### PR TITLE
Hiding dashboard cards: make quick start cards personalizable

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -107,8 +107,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
         let activitySubmenu = UIMenu(title: String(), options: .displayInline, children: [activityAction])
 
 
-        let hideThisAction = BlogDashboardHelpers.makeHideCardAction(for: .activityLog,
-                                                                     siteID: blog.dotComID?.intValue ?? 0)
+        let hideThisAction = BlogDashboardHelpers.makeHideCardAction(for: .activityLog, blog: blog)
 
         cardFrameView.ellipsisButton.menu = UIMenu(title: String(), options: .displayInline, children: [
             activitySubmenu,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
@@ -78,7 +78,7 @@ final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
         }
         WPAnalytics.track(.dashboardCardItemTapped, properties: ["type": DashboardCard.personalize.rawValue], blog: blog)
         let viewController = UIHostingController(rootView: NavigationView {
-            BlogDashboardPersonalizationView(viewModel: .init(service: .init(siteID: siteID)))
+            BlogDashboardPersonalizationView(viewModel: .init(service: .init(siteID: siteID), quickStartType: blog.quickStartType))
         }.navigationViewStyle(.stack)) // .stack is required for iPad
         if UIDevice.isPad() {
             viewController.modalPresentationStyle = .formSheet

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
@@ -103,7 +103,10 @@ extension DashboardPagesListCardCell {
         }
         cardFrameView.ellipsisButton.showsMenuAsPrimaryAction = true
 
-        let children = [makeAllPagesAction(), makeHideCardAction(blog: blog)].compactMap { $0 }
+        let children = [
+            makeAllPagesAction(),
+            BlogDashboardHelpers.makeHideCardAction(for: .pages, blog: blog)
+        ].compactMap { $0 }
 
         cardFrameView.ellipsisButton.menu = UIMenu(title: String(), options: .displayInline, children: children)
     }
@@ -117,13 +120,6 @@ extension DashboardPagesListCardCell {
         // https://developer.apple.com/documentation/uikit/uimenu/options/3261455-displayinline
         let allPagesSubmenu = UIMenu(title: String(), options: .displayInline, children: [allPagesAction])
         return allPagesSubmenu
-    }
-
-    private func makeHideCardAction(blog: Blog) -> UIMenuElement? {
-        guard let siteID = blog.dotComID?.intValue else {
-            return nil
-        }
-        return BlogDashboardHelpers.makeHideCardAction(for: .pages, siteID: siteID)
     }
 
     // MARK: Actions

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -183,6 +183,15 @@ class BlogDashboardCardFrameView: UIView {
         buttonContainerStackView.removeFromSuperview()
     }
 
+    /// Adds the "more" button with the given actions to the corner of the cell.
+    func addMoreMenu(items: [UIMenuElement], card: DashboardCard) {
+        onEllipsisButtonTap = {
+            BlogDashboardAnalytics.trackContextualMenuAccessed(for: card)
+        }
+        ellipsisButton.showsMenuAsPrimaryAction = true
+        ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: items)
+    }
+
     private func updateEllipsisButtonState() {
         ellipsisButton.isHidden = onEllipsisButtonTap == nil
         let headerPadding = ellipsisButton.isHidden ?

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -110,13 +110,9 @@ extension DashboardPostsListCardCell {
     private func addContextMenu(card: DashboardCard, blog: Blog) {
         guard FeatureFlag.personalizeHomeTab.enabled else { return }
 
-        frameView.onEllipsisButtonTap = {
-            BlogDashboardAnalytics.trackContextualMenuAccessed(for: card)
-        }
-        frameView.ellipsisButton.showsMenuAsPrimaryAction = true
-        frameView.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: [
-            BlogDashboardHelpers.makeHideCardAction(for: card, siteID: blog.dotComID?.intValue ?? 0)
-        ])
+        frameView.addMoreMenu(items: [
+            BlogDashboardHelpers.makeHideCardAction(for: card, blog: blog)
+        ], card: card)
     }
 
     private func configureDraftsList(blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -51,12 +51,12 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
             fallthrough
 
         case .newSite:
-            configureOnEllipsisButtonTap(sourceRect: cardFrameView.ellipsisButton.frame)
+            configureOnEllipsisButtonTap(sourceRect: cardFrameView.ellipsisButton.frame, blog: blog)
             cardFrameView.showHeader()
 
         case .existingSite:
             cardFrameView.configureButtonContainerStackView()
-            configureOnEllipsisButtonTap(sourceRect: cardFrameView.buttonContainerStackView.frame)
+            configureOnEllipsisButtonTap(sourceRect: cardFrameView.buttonContainerStackView.frame, blog: blog)
             cardFrameView.hideHeader()
 
         }
@@ -64,14 +64,24 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         cardFrameView.setTitle(Strings.title(for: blog.quickStartType))
     }
 
-    private func configureOnEllipsisButtonTap(sourceRect: CGRect) {
-        cardFrameView.onEllipsisButtonTap = { [weak self] in
-            guard let self = self,
-                  let viewController = self.viewController,
-                  let blog = self.blog else {
-                return
+    private func configureOnEllipsisButtonTap(sourceRect: CGRect, blog: Blog) {
+        if FeatureFlag.personalizeHomeTab.enabled {
+            cardFrameView.onEllipsisButtonTap = {
+                BlogDashboardAnalytics.trackContextualMenuAccessed(for: .quickStart)
             }
-            viewController.removeQuickStart(from: blog, sourceView: self.cardFrameView, sourceRect: sourceRect)
+            cardFrameView.ellipsisButton.showsMenuAsPrimaryAction = true
+            cardFrameView.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: [
+                BlogDashboardHelpers.makeHideCardAction(for: .quickStart, siteID: blog.dotComID?.intValue ?? 0)
+            ])
+        } else {
+            cardFrameView.onEllipsisButtonTap = { [weak self] in
+                guard let self = self,
+                      let viewController = self.viewController,
+                      let blog = self.blog else {
+                    return
+                }
+                viewController.removeQuickStart(from: blog, sourceView: self.cardFrameView, sourceRect: sourceRect)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -66,13 +66,9 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
 
     private func configureOnEllipsisButtonTap(sourceRect: CGRect, blog: Blog) {
         if FeatureFlag.personalizeHomeTab.enabled {
-            cardFrameView.onEllipsisButtonTap = {
-                BlogDashboardAnalytics.trackContextualMenuAccessed(for: .quickStart)
-            }
-            cardFrameView.ellipsisButton.showsMenuAsPrimaryAction = true
-            cardFrameView.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: [
-                BlogDashboardHelpers.makeHideCardAction(for: .quickStart, siteID: blog.dotComID?.intValue ?? 0)
-            ])
+            cardFrameView.addMoreMenu(items: [
+                BlogDashboardHelpers.makeHideCardAction(for: .quickStart, blog: blog)
+            ], card: .quickStart)
         } else {
             cardFrameView.onEllipsisButtonTap = { [weak self] in
                 guard let self = self,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -75,13 +75,9 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         }
 
         if FeatureFlag.personalizeHomeTab.enabled {
-            frameView.onEllipsisButtonTap = {
-                BlogDashboardAnalytics.trackContextualMenuAccessed(for: .todaysStats)
-            }
-            frameView.ellipsisButton.showsMenuAsPrimaryAction = true
-            frameView.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: [
-                BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, siteID: blog.dotComID?.intValue ?? 0)
-            ])
+            frameView.addMoreMenu(items: [
+                BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, blog: blog)
+            ], card: .todaysStats)
         }
 
         statsStackView?.views = viewModel?.todaysViews

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -154,9 +154,9 @@ enum DashboardCard: String, CaseIterable {
         .scheduledPosts,
         .blaze,
         .prompts,
+        .quickStart,
         .pages,
         .activityLog
-        .quickStart
     ]
 
     /// Includes all cards that should be fetched from the backend

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -156,6 +156,7 @@ enum DashboardCard: String, CaseIterable {
         .prompts,
         .pages,
         .activityLog
+        .quickStart
     ]
 
     /// Includes all cards that should be fetched from the backend

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 struct BlogDashboardHelpers {
-    static func makeHideCardAction(for card: DashboardCard, siteID: Int) -> UIAction {
+    static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
         UIAction(
             title: Strings.hideThis,
             image: UIImage(systemName: "minus.circle"),
             attributes: [.destructive],
             handler: { _ in
                 BlogDashboardAnalytics.trackHideTapped(for: card)
-                BlogDashboardPersonalizationService(siteID: siteID)
+                BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
                     .setEnabled(false, for: card)
             })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -62,7 +62,9 @@ private func makeKey(for card: DashboardCard) -> String? {
         return "activity-log-card-enabled-site-settings"
     case .pages:
         return "pages-card-enabled-site-settings"
-    case .quickStart, .jetpackBadge, .jetpackInstall, .nextPost, .createPost, .failure, .ghost, .personalize, .empty:
+    case .quickStart:
+        return "quick-start-card-enabled-site-settings"
+    case .jetpackBadge, .jetpackInstall, .nextPost, .createPost, .failure, .ghost, .personalize, .empty:
         return nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationView.swift
@@ -52,7 +52,7 @@ private extension BlogDashboardPersonalizationView {
 struct BlogDashboardPersonalizationView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            BlogDashboardPersonalizationView(viewModel: .init(service: .init(repository: UserDefaults.standard, siteID: 1)))
+            BlogDashboardPersonalizationView(viewModel: .init(service: .init(repository: UserDefaults.standard, siteID: 1), quickStartType: .newSite))
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -3,9 +3,13 @@ import SwiftUI
 final class BlogDashboardPersonalizationViewModel: ObservableObject {
     let cards: [BlogDashboardPersonalizationCardCellViewModel]
 
-    init(service: BlogDashboardPersonalizationService) {
-        self.cards = DashboardCard.personalizableCards.map {
-            BlogDashboardPersonalizationCardCellViewModel(card: $0, service: service)
+    init(service: BlogDashboardPersonalizationService, quickStartType: QuickStartType) {
+        self.cards = DashboardCard.personalizableCards.compactMap {
+            if $0 == .quickStart && quickStartType == .undefined {
+                return nil
+            }
+            let title = $0.getLocalizedTitle(quickStartType: quickStartType)
+            return BlogDashboardPersonalizationCardCellViewModel(card: $0, title: title, service: service)
         }
     }
 }
@@ -15,7 +19,7 @@ final class BlogDashboardPersonalizationCardCellViewModel: ObservableObject, Ide
     private let service: BlogDashboardPersonalizationService
 
     var id: DashboardCard { card }
-    var title: String { card.localizedTitle }
+    let title: String
 
     var isOn: Bool {
         get { service.isEnabled(card) }
@@ -25,14 +29,15 @@ final class BlogDashboardPersonalizationCardCellViewModel: ObservableObject, Ide
         }
     }
 
-    init(card: DashboardCard, service: BlogDashboardPersonalizationService) {
+    init(card: DashboardCard, title: String, service: BlogDashboardPersonalizationService) {
         self.card = card
+        self.title = title
         self.service = service
     }
 }
 
 private extension DashboardCard {
-    var localizedTitle: String {
+    func getLocalizedTitle(quickStartType: QuickStartType) -> String {
         switch self {
         case .prompts:
             return NSLocalizedString("personalizeHome.dashboardCard.prompts", value: "Blogging prompts", comment: "Card title for the pesonalization menu")
@@ -48,7 +53,17 @@ private extension DashboardCard {
             return NSLocalizedString("personalizeHome.dashboardCard.activityLog", value: "Recent activity", comment: "Card title for the pesonalization menu")
         case .pages:
             return NSLocalizedString("personalizeHome.dashboardCard.pages", value: "Pages", comment: "Card title for the pesonalization menu")
-        case .quickStart, .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .domainsDashboardCard, .freeToPaidPlansDashboardCard, .domainRegistration, .empty:
+        case .quickStart:
+            switch quickStartType {
+            case .undefined:
+                assertionFailure(".quickStart card should only appear in the personalization menu if there are remaining steps")
+                return ""
+            case .existingSite:
+                return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Get to know the app", comment: "Card title for the pesonalization menu")
+            case .newSite:
+                return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Next steps", comment: "Card title for the pesonalization menu")
+            }
+        case .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .domainsDashboardCard:
             assertionFailure("\(self) card should not appear in the personalization menus")
             return "" // These cards don't appear in the personalization menus
         }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -63,7 +63,7 @@ private extension DashboardCard {
             case .newSite:
                 return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Next steps", comment: "Card title for the pesonalization menu")
             }
-        case .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .domainsDashboardCard:
+        case .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .domainsDashboardCard, .freeToPaidPlansDashboardCard, .domainRegistration:
             assertionFailure("\(self) card should not appear in the personalization menus")
             return "" // These cards don't appear in the personalization menus
         }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -59,7 +59,7 @@ private extension DashboardCard {
                 assertionFailure(".quickStart card should only appear in the personalization menu if there are remaining steps")
                 return ""
             case .existingSite:
-                return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Get to know the app", comment: "Card title for the pesonalization menu")
+                return NSLocalizedString("personalizeHome.dashboardCard.getToKnowTheApp", value: "Get to know the app", comment: "Card title for the pesonalization menu")
             case .newSite:
                 return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Next steps", comment: "Card title for the pesonalization menu")
             }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -44,4 +44,12 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         // Then settings for site 1 are ignored
         XCTAssertTrue(service.isEnabled(.quickStart))
     }
+
+    func testThatUserDefaultsKeysAreSpecifiedForAllPersonalizableCards() {
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        for card in DashboardCard.personalizableCards {
+            service.setEnabled(false, for: card)
+            XCTAssertFalse(service.isEnabled(card))
+        }
+    }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
@@ -12,7 +12,7 @@ final class BlogDashboardPersonalizationViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        viewModel = BlogDashboardPersonalizationViewModel(service: service)
+        viewModel = BlogDashboardPersonalizationViewModel(service: service, quickStartType: .undefined)
     }
 
     func testThatCardStateIsToggled() throws {
@@ -29,5 +29,24 @@ final class BlogDashboardPersonalizationViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(cardViewModel.isOn)
         XCTAssertFalse(service.isEnabled(card), "Service wasn't updated")
+    }
+
+    func testThatAllCardsHaveTitles() {
+        for card in viewModel.cards {
+            XCTAssertTrue(!card.title.isEmpty)
+        }
+    }
+
+
+    func testThatQuickStartCardsIsNotDisplayedWhenTourIsActive() {
+        // Given
+        viewModel = BlogDashboardPersonalizationViewModel(service: service, quickStartType: .newSite)
+
+        // Then
+        XCTAssertTrue(viewModel.cards.contains(where: { $0.id == .quickStart }))
+    }
+
+    func testThatQuickStartCardsIsNotDisplayedWhenNoTourIsActive() {
+        XCTAssertFalse(viewModel.cards.contains(where: { $0.id == .quickStart }))
     }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
@@ -37,7 +37,6 @@ final class BlogDashboardPersonalizationViewModelTests: XCTestCase {
         }
     }
 
-
     func testThatQuickStartCardsIsNotDisplayedWhenTourIsActive() {
         // Given
         viewModel = BlogDashboardPersonalizationViewModel(service: service, quickStartType: .newSite)


### PR DESCRIPTION
Related issue: #20296

Previous PRs (dependencies):
1. #20365
2. #20369
3. #20384

> I can't set the previous PR #20385 as a target because it only exists in my fork. If you want to review only the changes from this PR, see the following [diff](https://github.com/wordpress-mobile/WordPress-iOS/pull/20393/files/9d2cd357e32f18eaa52b693a054d4aded460d4a5..672ee148ba223d8d0eb2296f5b869b1df1bceec0).

Add personalization support for "Next steps" and "Get to know the app" cards. Previously, tapping "Remove next steps" on the Home tab worked by removing all active tours and setting `quickStartType` to `.undefined`. And now it's just a matter of setting a flag in the personalization service introduced in #20365. It allows the user to continue the tour or revisit a completed one.

## Changes:

- Add "Next steps" and "Get to know the app" cards to the Personalize Home Tab screen.
- Update the design of the context menu for the quick start card (use a context menu instead of an action sheet)
- Add unit test to make sure all personalizable cards have a predefined UserDefaults key and titles for menus to catch regressions in case someone make an existing card personalizable without updating the other places

## Testing

*Prerequisites:*

- Feature Flag "Personalize Home Tab" enabled

**Test 1**

- Install the app (fresh install)
- Log in and select "Not sure, show me around" on the "What would you like to focus on first" page
- Complete one of the Quick Start steps
- On the Home tab, open the context menu for the "Get to know the app" card
- Verify that the context menu uses the new design (context menu instead of an action sheet)
- Tap "Hide this"
- Verify that the "Get to know the app" card was removed from the Home tab
- Tap "Personalize Home Tab" at the bottom of the Home tab
- Verify that the "Get to know the app" switch is displayed and it's disabled
- Toggle the switch and close the screen
- Verify that the "Get to know the app" is again displayed on the Home tab 
- Verify that the Quick Start is restarted from the previous state
- Try going through one of the next steps and verify that it works

**Test 2**

- Repeat test 1, but instead of completing only one step, complete all of them
- Verify that you can still show/hide the "Get to know the app" card at any time to revisit the completed steps

**Test 3**

- Repeat tests 1 and 2 for the "Next steps" card. An easy way to enable it is by using the "Enable Quick Start for New Site" button from the Debug menu.

**Test 4**

- Install the app (fresh install)
- Login and tap "Skip" on the "What would you like to focus on first" page to make sure no Quick Start guides are added
- Tap "Personalize Home Tab" at the bottom of the Home tab
- Verify that neither the "Next steps" nor "Get to know the app" cards are displayed in the list

## Screenshots

![Screenshot 2023-03-23 at 7 56 16 PM](https://user-images.githubusercontent.com/1567433/227389798-7701b420-d2c3-4573-8247-fb5e66fe3d60.png) ![Screenshot 2023-03-23 at 7 56 31 PM](https://user-images.githubusercontent.com/1567433/227389800-9057f42a-d29c-4d0d-8ec7-15105e3cf1bc.png)

## Regression Notes

1. Potential unintended areas of impact: 
Anything that's related to the quick start guides ("Next steps" or "What would you like to focus on first")
4. What I did to test those areas of impact (or what existing automated tests I relied on):
I performed manual testing and verified that the guides still work
5. What automated tests I added (or what prevented me from doing so)
I covered new changes with unit tests (making sure that the switch is displayed in the "Personalize Home Tab" screen)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
