### PR TITLE
Enable Core Data concurrency debug option in UI tests

### DIFF
--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -5,7 +5,7 @@ class EditorGutenbergTests: XCTestCase {
     private var editorScreen: BlockEditorScreen!
 
     override func setUpWithError() throws {
-        setUpTestSuite()
+        setUpTestSuite(crashOnCoreDataConcurrencyIssues: false)
 
         _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = try EditorFlow

--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -3,13 +3,21 @@ import XCTest
 
 extension XCTestCase {
 
-    public func setUpTestSuite(for app: XCUIApplication = XCUIApplication(), removeBeforeLaunching: Bool = false) {
+    public func setUpTestSuite(
+        for app: XCUIApplication = XCUIApplication(),
+        removeBeforeLaunching: Bool = false,
+        crashOnCoreDataConcurrencyIssues: Bool = true
+    ) {
         super.setUp()
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
         app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing"]
+
+        if crashOnCoreDataConcurrencyIssues {
+            app.launchArguments.append(contentsOf: ["-com.apple.CoreData.ConcurrencyDebug", "1"])
+        }
 
         if removeBeforeLaunching {
             removeApp(app)


### PR DESCRIPTION
The app crashes during UI tests when a Core Data concurrency issue occurs.

A Core Data concurrency issue is typically where a managed object is accessed outside of the context (or the queue managed by the context). Currently there are still many such issues in the app, post editing being the most impacted one, which is why the new
`crashOnCoreDataConcurrencyIssue` option is disabled in `EditorGutenbergTests`.

But, I think it's still valuable to ensure that those areas that don't have any Core Data concurrency issues to be maintained. And we should expose the new issue if one does occur. Doing that in UI tests is one easy way I can think of, which doesn't have a "blocking" factor—we can always disable the check for specific test(s).

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
