### PR TITLE
Add explanation of priority indicators to release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+> [***] High Priority, e.g., Major Enhancements, Widespread Crash Fixes, etc.
+> [**] Medium Priority, e.g., Minor Enhancements Users Will Notice, etc.
+> [*] Low Priority, e.g., Minor Enhancements Users May Miss, etc.
+
 22.1
 -----
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]


### PR DESCRIPTION
This proposal documents the release note priority indicators.

To test:

Ensure that no bots break with the addition of this change. 🤖 

I recall that scripts could break if the release notes don't follow a specific format, but I'm not sure which scripts or how. I'm requesting a review from someone familiar with the release process to help clarify this.

## Regression Notes
1. Potential unintended areas of impact

Scripts relating to this repo could break due to this change.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I'm requesting a review from release wranglers to help verify if this could break a script.

3. What automated tests I added (or what prevented me from doing so)

Not applicable since this is a documentation change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
