### PR TITLE
[Bug Fix] Fix oauth2 token for widget didn't been setup when login

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -402,10 +402,10 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     NSNumber *siteId    = defaultBlog.dotComID;
     NSString *blogName  = defaultBlog.settings.name;
     NSString *blogUrl   = defaultBlog.displayURL;
-    
+    NSString *oauth2Token = defaultAccount.authToken;
+    TodayExtensionService *service = [TodayExtensionService new];
     if (defaultBlog == nil || defaultBlog.isDeleted) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            TodayExtensionService *service = [TodayExtensionService new];
             [service removeTodayWidgetConfiguration];
 
             [ShareExtensionService removeShareExtensionConfiguration];
@@ -415,9 +415,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         });
     } else {
         // Required Attributes
-
-        NSString *oauth2Token       = defaultAccount.authToken;
-
         // For the Today Extensions, if the user has set a non-primary site, use that.
         NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppGroupName];
         NSNumber *todayExtensionSiteID = [sharedDefaults objectForKey:AppConfigurationWidgetStatsToday.userDefaultsSiteIdKey];
@@ -441,8 +438,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
             [service configureTodayWidgetWithSiteID:todayExtensionSiteID
                                            blogName:todayExtensionBlogName
                                             blogUrl:todayExtensionBlogUrl
-                                       siteTimeZone:timeZone
-                                     andOAuth2Token:oauth2Token];
+                                       siteTimeZone:timeZone];
 
             [ShareExtensionService configureShareExtensionDefaultSiteID:siteId.integerValue defaultSiteName:blogName];
             [ShareExtensionService configureShareExtensionToken:defaultAccount.authToken];
@@ -456,7 +452,11 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
             [NotificationSupportService insertServiceExtensionUserID:defaultAccount.userID.stringValue];
         });
     }
-    
+    if (oauth2Token.length > 0) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [service configureTodayWidgetOAuth2Token:oauth2Token];
+        });
+    }
 }
 
 - (void)purgeAccountIfUnused:(WPAccount *)account

--- a/WordPress/Classes/Services/TodayExtensionService.h
+++ b/WordPress/Classes/Services/TodayExtensionService.h
@@ -2,11 +2,12 @@
 
 @interface TodayExtensionService : NSObject
 
+- (void)configureTodayWidgetOAuth2Token:(NSString *)oauth2Token;
+
 - (void)configureTodayWidgetWithSiteID:(NSNumber *)siteID
                               blogName:(NSString *)blogName
                                blogUrl:(NSString *)blogUrl
-                          siteTimeZone:(NSTimeZone *)timeZone
-                        andOAuth2Token:(NSString *)oauth2Token;
+                          siteTimeZone:(NSTimeZone *)timeZone;
 
 - (void)removeTodayWidgetConfiguration;
 

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -5,16 +5,29 @@
 
 @implementation TodayExtensionService
 
+- (void)configureTodayWidgetOAuth2Token:(NSString *)oauth2Token {
+    NSParameterAssert(oauth2Token.length > 0);
+
+    NSError *error;
+    [SFHFKeychainUtils storeUsername:AppConfigurationWidgetStats.keychainTokenKey
+                         andPassword:oauth2Token
+                      forServiceName:AppConfigurationWidgetStats.keychainServiceName
+                         accessGroup:WPAppKeychainAccessGroup
+                      updateExisting:YES
+                               error:&error];
+    if (error) {
+        DDLogError(@"Today Widget OAuth2Token error: %@", error);
+    }
+}
+
 - (void)configureTodayWidgetWithSiteID:(NSNumber *)siteID
                               blogName:(NSString *)blogName
                                blogUrl:(NSString *)blogUrl
                           siteTimeZone:(NSTimeZone *)timeZone
-                        andOAuth2Token:(NSString *)oauth2Token
 {
     NSParameterAssert(siteID != nil);
     NSParameterAssert(blogName != nil);
     NSParameterAssert(timeZone != nil);
-    NSParameterAssert(oauth2Token.length > 0);
 
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppGroupName];
     
@@ -30,18 +43,6 @@
     [sharedDefaults setObject:siteID forKey:AppConfigurationWidgetStatsToday.userDefaultsSiteIdKey];
     [sharedDefaults setObject:blogName forKey:AppConfigurationWidgetStatsToday.userDefaultsSiteNameKey];
     [sharedDefaults setObject:blogUrl forKey:AppConfigurationWidgetStatsToday.userDefaultsSiteUrlKey];
-    
-    NSError *error;
-    
-    [SFHFKeychainUtils storeUsername:AppConfigurationWidgetStats.keychainTokenKey
-                         andPassword:oauth2Token
-                      forServiceName:AppConfigurationWidgetStats.keychainServiceName
-                         accessGroup:WPAppKeychainAccessGroup
-                      updateExisting:YES
-                               error:&error];
-    if (error) {
-        DDLogError(@"Today Widget OAuth2Token error: %@", error);
-    }
 }
 
 - (void)removeTodayWidgetConfiguration

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -159,11 +159,11 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 {
     TodayExtensionService *service = [TodayExtensionService new];
 
+    [service configureTodayWidgetOAuth2Token:SiteStatsInformation.sharedInstance.oauth2Token];
     [service configureTodayWidgetWithSiteID:SiteStatsInformation.sharedInstance.siteID
                                    blogName:self.blog.settings.name
                                     blogUrl:self.blog.displayURL
-                               siteTimeZone:SiteStatsInformation.sharedInstance.siteTimeZone
-                             andOAuth2Token:SiteStatsInformation.sharedInstance.oauth2Token];
+                               siteTimeZone:SiteStatsInformation.sharedInstance.siteTimeZone];
 }
 
 


### PR DESCRIPTION
## Description
The widget extension shares the auth token through the keychain that is configured in the `TodayExtensionService`. The auth token is obtained when:

1. The app is launched
2. The account is changed 

The issue happens when the account is changed, because in `AccountService` -> `updateAccountWithID` -> `updateDefaultBlogIfNeeded`, we only configure the token if the account has a `defaultBlog`.

However, the defaultBlog is empty when the user just logs in, which means the widget service API token is lost until the next time the token sync-up, resulting in the error response: "The operation couldn't be completed. (Foundation_GenericObjCError error 0.)"

## Impact
This issue causes inconsistent results for users, they will see a value of 0 until the app is launched again.

Users may try to click on the widget and be redirected to the stats insight page. The widget value will update at this time, but won't autorefresh because the token is not yet synced. The current time updated value comes from the cache, and the next auto fetch after 30 minutes will keep failing.

It is not severe because it can be recovered when the app is launched again. However, it may be a problem for users with multiple accounts.

## Reproduce Steps 
1. Log in to an account that has at least one website
2. Add any widget to the home screen
3. The widget value is always 0 due to the API request missing token error (fall back to use the initial model)

## Solution
Separate configure widget and configure token, I think it makes sense always configure the token for logged-in users.
For the chase that users without websites, we have checked another config `AppConfiguration.Widget.Stats.userDefaultsSiteIdKey` in the timeline provider to present another status.

## Testing Instructions
Given logged in account with at least one website and has stats value (not 0)
1. Add any widget to the home screen
2. Choose the website to have the value > 0
3. Log out to clear the token
4. Log in to the same account
5. The widget should display the correct value as `step 2` instead of the default 0 value

## Regression Notes
1. Potential unintended areas of impact
Home screen widgets data fetch

2. What I did to test those areas of impact (or what existing automated tests I relied on)
As same as Testing Instructions

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
