### PR TITLE
Notify to reload the timelines for lock screen widget

### DIFF
--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -22,6 +22,7 @@ class StatsWidgetsStore {
         if let newTodayData = refreshStats(type: HomeWidgetTodayData.self) {
             HomeWidgetTodayData.write(items: newTodayData)
             WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
         }
 
         if let newAllTimeData = refreshStats(type: HomeWidgetAllTimeData.self) {
@@ -43,6 +44,7 @@ class StatsWidgetsStore {
             DDLogInfo("StatsWidgets: Writing initialization data into HomeWidgetTodayData.plist")
             HomeWidgetTodayData.write(items: initializeHomeWidgetData(type: HomeWidgetTodayData.self))
             WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
         }
 
         if !HomeWidgetThisWeekData.cacheDataExists() {
@@ -115,6 +117,9 @@ class StatsWidgetsStore {
 
         T.write(items: homeWidgetCache)
         WidgetCenter.shared.reloadTimelines(ofKind: widgetKind)
+        if widgetKind == AppConfiguration.Widget.Stats.todayKind {
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
+        }
     }
 }
 
@@ -273,6 +278,7 @@ private extension StatsWidgetsStore {
                 WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
                 WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
                 WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
+                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
             }
         }
     }


### PR DESCRIPTION
This is the PR for implementing the reload lockscreen widgets.

1.  https://github.com/wordpress-mobile/WordPress-iOS/pull/20309 (✅ Approved)
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/20312 (✅ Approved) 
3. https://github.com/wordpress-mobile/WordPress-iOS/pull/20342 (TBD) 
4. https://github.com/wordpress-mobile/WordPress-iOS/pull/20353 (✅ Approved)
5. https://github.com/wordpress-mobile/WordPress-iOS/pull/20371 (✅ Approved)
6. https://github.com/wordpress-mobile/WordPress-iOS/pull/20317 (✅ Approved)
7. https://github.com/wordpress-mobile/WordPress-iOS/pull/20368 (✅ Approved)
8. https://github.com/wordpress-mobile/WordPress-iOS/pull/20399 (✅ Approved)
9. https://github.com/wordpress-mobile/WordPress-iOS/pull/20405 (✅ Approved)  👈 you're here!
(Confirm the data display on UI correctly in this phase)
10. https://github.com/wordpress-mobile/WordPress-iOS/pull/20422 (✅ Approved)
11. https://github.com/wordpress-mobile/WordPress-iOS/pull/20427 (In Reviewing)

## Descrption
To reload the lockscreen today views widget at the same time as the homescreen today widget.

## Testing Instructions
Because the issue about token sync-up: https://github.com/wordpress-mobile/WordPress-iOS/pull/20404
after the account is switched, we can see the status changed but with an incorrect value (default 0) until the app launch again to get the correct token.
### Log In
Given user logged out and added the widget to the lockscreen, displayed `logged-out` status view
1. Log in
2. The widget should automatically update to the success status with views count of today
### Log Out
Given user logged in and added the widget to the lockscreen, displayed `site-selected` status view
1. Log out 
2. The widget should automatically update to the `logged-out` message
### Stats data update
Given user logged in and added the widget to the lockscreen, displayed `site-selected` status view
1. Click the widget and redirect to the stats insights page
2. The widget should automatically update due to the stats data changed

## Regression Notes
1. Potential unintended areas of impact
No change existing codes

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
