### PR TITLE
Enable feature flag for Jetpack individual plugin support in WordPress

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
+* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app.
 
 22.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
-* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app.
+* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
 
 22.0
 -----

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -37,7 +37,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .blaze:
             return false
         case .wordPressIndividualPluginSupport:
-            return false
+            return AppConfiguration.isWordPress
         }
     }
 


### PR DESCRIPTION
Refs pctCYC-HX-p2
Resolves #20407 

## Description

This PR enables the feature flag in WordPress, along with a release note.

In the WordPress app, when a WordPress.com account user owns at least one self-hosted site that's connected through Jetpack individual plugins, they will see a warning below upon switching to that site:

<img src="https://user-images.githubusercontent.com/1299411/227885834-19b68a9a-ea9b-43b9-80f1-8ca9ccb4b78e.png" width=250 />

This pop-up explains that a Jetpack connection through individual plugins currently does not support the core features of the app yet, and provides the user an option to switch to the Jetpack app where they can receive guidance to work around this limitation. 

Furthermore, this pop-up will be shown multiple times for each affected site, and there's also an increasing delay between each pop-up. The delay is configured to 1 day, then 3 days, then 7 days onwards.

> **Note**:
> This feature and the max display amount for the pop-up can be remotely configured.

For more details, please refer to pctCYC-HX-p2.

## Testing

### WordPress app

- Prepare two self-hosted sites with only Jetpack individual plugin(s), and connect them to your WordPress.com account.
- Launch the WordPress app.
- Switch to the self-hosted site.
- 🔎 Verify that the overlay is shown.
- 🔎 Verify that tapping "Switch to the Jetpack app" switches you to the Jetpack app (or the App Store page for Jetpack).
- Switch to an unaffected site (e.g. hosted on WordPress.com, pure self-hosted, self-hosted with full Jetpack plugin)
- 🔎 Verify that the Jetpack plugin overlay is not shown.
- Switch back to the previous self-hosted site.
- 🔎 Verify that the Jetpack plugin overlay is not shown.
- Switch to another self-hosted site with only individual plugins.
- 🔎 Verify that the overlay is shown.

#### Testing the overlay recurrence:

- After 24 hours have passed, open the app and switch to the self-hosted site again.
- 🔎 Verify that the overlay is shown.

An alternative to this is to make a slight code modification:

https://github.com/wordpress-mobile/WordPress-iOS/blob/a62e71c22796f83c6e81beead0ae3e3773541233/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift#L302

Change the value of this variable to `60`, to make the second overlay appear after 1 minute.

### Jetpack app

The goal is to ensure that the current plugin overlay logic in the Jetpack app remains unaffected:

- Launch the Jetpack app and log in using the same WordPress.com account as the above.
- Switch to the self-hosted site.
- 🔎 Verify that the overlay is shown, and make sure the copy and the CTA are different from the one shown in WordPress.

For more detailed testing in the Jetpack app, please refer to pctCYC-Gx-p2.

## Regression Notes
1. Potential unintended areas of impact
This feature modifies the plugin overlay logic for the Jetpack app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes in both the WordPress and Jetpack app.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.