### PR TITLE
Blaze: Update blaze instance from the correct thread

### DIFF
--- a/WordPress/Classes/Services/BlazeService.swift
+++ b/WordPress/Classes/Services/BlazeService.swift
@@ -3,12 +3,12 @@ import WordPressKit
 
 @objc final class BlazeService: NSObject {
 
-    private let contextManager: CoreDataStack
+    private let contextManager: CoreDataStackSwift
     private let remote: BlazeServiceRemote
 
     // MARK: - Init
 
-    required init?(contextManager: CoreDataStack = ContextManager.shared,
+    required init?(contextManager: CoreDataStackSwift = ContextManager.shared,
                    remote: BlazeServiceRemote? = nil) {
         guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext) else {
             return nil
@@ -28,7 +28,7 @@ import WordPressKit
     ///
     /// - Parameters:
     ///   - blog: A blog
-    ///   - completion: Closure to be called on success
+    ///   - completion: Closure to be called on completion
     @objc func getStatus(for blog: Blog,
                          completion: (() -> Void)? = nil) {
 
@@ -58,16 +58,12 @@ import WordPressKit
                                   isBlazeApproved: Bool,
                                   completion: (() -> Void)? = nil) {
         contextManager.performAndSave({ context in
-
-            guard let blog = context.object(with: objectID) as? Blog else {
-                DDLogError("Unable to update isBlazeApproved value for blog")
-                completion?()
+            guard let blog = try? context.existingObject(with: objectID) as? Blog else {
+                DDLogError("Unable to fetch blog and update isBlazedApproved value")
                 return
             }
-
             blog.isBlazeApproved = isBlazeApproved
             DDLogInfo("Successfully updated isBlazeApproved value for blog: \(isBlazeApproved)")
-
         }, completion: {
             completion?()
         }, on: .main)


### PR DESCRIPTION
Fixes #20397 

## Description
Fixes an issue where Blog managed object was being updated from the wrong thread.

Queries the Blog managed object using the context provided by the `performAndSave` closure to ensure the managed object is updated correctly.

Ref: pbArwn-602-p2

## How to test
0. Switch to trunk
1. Add `-com.apple.CoreData.ConcurrencyDebug 1` to your launch arguments
2. Build and run the Jetpack app
3. The app crashes
<img width="672" alt="Screenshot 2023-03-27 at 11 52 23" src="https://user-images.githubusercontent.com/6711616/227921783-9be776dd-f0d0-4055-a393-bef9b5b89946.png">

4. Switch to this branch
5. Build and run the Jetpack app
6. The app doesn't crash 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

7. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.