### PR TITLE
UGC: Fix an edge case where the app could crash when blocking a post author

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] [internal] Refactor uploading media assets. [#20294]
 * [*] Block editor: Allow new block transforms for most blocks. [https://github.com/WordPress/gutenberg/pull/48792]
 * [*] Visual improvements were made to the in-app survey along with updated text to differentiate between the WordPress and Jetpack apps. [#20276]
+* [*] Reader: Resolve an issue that could cause the app to crash when blocking a post author. [#20421]
 
 21.9
 -----


### PR DESCRIPTION
Fixes #20387

This PR resolves an issue where the app could crash when blocking a Post Author. 

**Root Cause**
1. Part of the User Blocking implementation is to read the `post.authorID` to check whether it's blocked or not. 
2. The type of `post.authorID` is `NSNumber!`
3. The code accessed `post.authorID` without safely unwrapping it. ( I thought `authorID` property would never be `nil` ) 
4. There is a case where `post.authorID` could be `nil` I don't know how to reproduce that case, though.

**Solution**
Safely unwrap that property before using it.
```swift
guard let authorID = post.authorID else {
    return true
}
// Use authorID
```

## Test Instructions

I don't know how to reproduce a case where `post.authorID` is `nil` but I think we should test **User Blocking** feature for regression.

Since the code changes are minor and are unlikely to cause a regression issue, feel free to test only 1 one of the following use cases:

[User Blocking Test Instructions](https://github.com/wordpress-mobile/WordPress-iOS/pull/20193)

## Regression Notes
1. Potential unintended areas of impact
Smoke test **User Blocking** feature.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

7. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
