### PR TITLE
Domains Dashboard Card: Presentation Criteria

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -191,7 +191,15 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
     [blazeService getStatusFor:blog completion:^{
         dispatch_group_leave(syncGroup);
     }];
-
+    
+    dispatch_group_enter(syncGroup);
+    [self refreshDomainsFor:blog success:^{
+        dispatch_group_leave(syncGroup);
+    } failure:^(NSError * _Nonnull error) {
+        DDLogError(@"Failed refreshing domains: %@", error);
+        dispatch_group_leave(syncGroup);
+    }];
+    
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler
     dispatch_group_notify(syncGroup, dispatch_get_main_queue(),^{

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -13,6 +13,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case wordPressSupportForum
     case blaze
     case wordPressIndividualPluginSupport
+    case directDomainsPurchaseDashboardCard
 
     var defaultValue: Bool {
         switch self {
@@ -38,6 +39,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .wordPressIndividualPluginSupport:
             return AppConfiguration.isWordPress
+        case .directDomainsPurchaseDashboardCard:
+            return false
         }
     }
 
@@ -66,6 +69,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "blaze"
         case .wordPressIndividualPluginSupport:
             return "wp_individual_plugin_overlay"
+        case .directDomainsPurchaseDashboardCard:
+            return "direct_domain_purchase_dashboard_card"
         }
     }
 
@@ -93,6 +98,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Blaze"
         case .wordPressIndividualPluginSupport:
             return "Jetpack Individual Plugin Support for WordPress"
+        case .directDomainsPurchaseDashboardCard:
+            return "Direct Domains Purchase Dashboard Card"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -20,4 +20,15 @@ final class DomainsDashboardCardHelper {
 
         return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit
     }
+
+    static func hideCard(for blog: Blog?) {
+        guard let blog,
+              let siteID = blog.dotComID?.intValue else {
+            DDLogError("Domains Dashboard Card: error hiding the card.")
+            return
+        }
+
+        BlogDashboardPersonalizationService(siteID: siteID)
+            .setEnabled(false, for: .domainsDashboardCard)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -1,0 +1,9 @@
+//
+//  DomainsDashboardCardHelper.swift
+//  WordPress
+//
+//  Created by Povilas Staskus on 2023-03-27.
+//  Copyright © 2023 WordPress. All rights reserved.
+//
+
+import Foundation

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -1,9 +1,23 @@
-//
-//  DomainsDashboardCardHelper.swift
-//  WordPress
-//
-//  Created by Povilas Staskus on 2023-03-27.
-//  Copyright © 2023 WordPress. All rights reserved.
-//
-
 import Foundation
+
+final class DomainsDashboardCardHelper {
+
+    /// Checks conditions for showing domain dashboard cards
+    static func shouldShowCard(
+        for blog: Blog,
+        isJetpack: Bool = AppConfiguration.isJetpack,
+        featureFlagEnabled: Bool = RemoteFeatureFlag.directDomainsPurchaseDashboardCard.enabled()
+    ) -> Bool {
+        guard isJetpack, featureFlagEnabled else {
+            return false
+        }
+
+        let isHostedAtWPcom = blog.isHostedAtWPcom
+        let isAtomic = blog.isAtomic()
+        let isAdmin = blog.isAdmin
+        let hasOtherDomains = blog.domains?.count ?? 0 > 1
+        let hasDomainCredit = blog.hasDomainCredit
+
+        return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -15,7 +15,7 @@ final class DomainsDashboardCardHelper {
         let isHostedAtWPcom = blog.isHostedAtWPcom
         let isAtomic = blog.isAtomic()
         let isAdmin = blog.isAdmin
-        let hasOtherDomains = blog.domains?.count ?? 0 > 1
+        let hasOtherDomains = blog.domainsList.count > 0
         let hasDomainCredit = blog.hasDomainCredit
 
         return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -11,6 +11,7 @@ enum DashboardCard: String, CaseIterable {
     case quickStart
     case prompts
     case blaze
+    case domainsDashboardCard
     case todaysStats = "todays_stats"
     case draftPosts
     case scheduledPosts
@@ -48,6 +49,9 @@ enum DashboardCard: String, CaseIterable {
             return DashboardBadgeCell.self
         case .blaze:
             return DashboardBlazeCardCell.self
+        case .domainsDashboardCard:
+            /// TODO
+            return DashboardFailureCardCell.self
         }
     }
 
@@ -82,6 +86,8 @@ enum DashboardCard: String, CaseIterable {
             return JetpackBrandingVisibility.all.enabled
         case .blaze:
             return BlazeHelper.shouldShowCard(for: blog)
+        case .domainsDashboardCard:
+            return DomainsDashboardCardHelper.shouldShowCard(for: blog)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -50,6 +50,8 @@ private func makeKey(for card: DashboardCard) -> String? {
         // have a "-card" component in the key name. Keeping it like this to
         // avoid having to migrate data.
         return "prompts-enabled-site-settings"
+    case .domainsDashboardCard:
+        return "domains-dashboard-enabled-site-settings"
     case .quickStart, .jetpackBadge, .jetpackInstall, .nextPost, .createPost, .failure, .ghost:
         return nil
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		0107E18F29000EA200DE87DB /* UIColor+MurielColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435B762122973D0600511813 /* UIColor+MurielColors.swift */; };
 		0118968F29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */; };
 		0118969129D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0118969029D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift */; };
+		0118969229D2CA6F00D34BA9 /* DomainsDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */; };
 		0141929C2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */; };
 		0141929D2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */; };
 		014192A02983F5E800CAEDB0 /* SupportConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929F2983F5E800CAEDB0 /* SupportConfigurationTests.swift */; };
@@ -25080,6 +25081,7 @@
 				F1C740C026B1D4D2005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
 				801D94F02919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift in Sources */,
 				FABB25FF2602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowDefinitions.swift in Sources */,
+				0118969229D2CA6F00D34BA9 /* DomainsDashboardCardHelper.swift in Sources */,
 				98E082A02637545C00537BF1 /* PostService+Likes.swift in Sources */,
 				FABB26002602FC2C00C8785C /* GravatarProfile.swift in Sources */,
 				FABB26012602FC2C00C8785C /* ReaderShareAction.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		0107E18D29000E3300DE87DB /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		0107E18E29000EA100DE87DB /* UIColor+MurielColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435B762122973D0600511813 /* UIColor+MurielColors.swift */; };
 		0107E18F29000EA200DE87DB /* UIColor+MurielColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435B762122973D0600511813 /* UIColor+MurielColors.swift */; };
+		0118968F29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */; };
 		0141929C2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */; };
 		0141929D2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */; };
 		014192A02983F5E800CAEDB0 /* SupportConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929F2983F5E800CAEDB0 /* SupportConfigurationTests.swift */; };
@@ -5688,6 +5689,7 @@
 		0107E1832900043200DE87DB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0107E1842900059300DE87DB /* LocalizationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationConfiguration.swift; sourceTree = "<group>"; };
 		0107E1862900065400DE87DB /* LocalizationConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizationConfiguration.swift; sourceTree = "<group>"; };
+		0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsDashboardCardHelper.swift; sourceTree = "<group>"; };
 		011A2815DB0DE7E3973CBC0E /* Pods-Apps-Jetpack.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release.xcconfig"; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
 		0141929F2983F5E800CAEDB0 /* SupportConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfigurationTests.swift; sourceTree = "<group>"; };
@@ -9517,6 +9519,14 @@
 				0107E1842900059300DE87DB /* LocalizationConfiguration.swift */,
 			);
 			path = JetpackStatsWidgets;
+			sourceTree = "<group>";
+		};
+		0118968D29D1EAC900D34BA9 /* Domains */ = {
+			isa = PBXGroup;
+			children = (
+				0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */,
+			);
+			path = Domains;
 			sourceTree = "<group>";
 		};
 		0141929E2983F5D900CAEDB0 /* Support */ = {
@@ -13358,6 +13368,7 @@
 		8B4DDF23278F3AED0022494D /* Cards */ = {
 			isa = PBXGroup;
 			children = (
+				0118968D29D1EAC900D34BA9 /* Domains */,
 				FA98B61429A3B71E0071AAE8 /* Blaze */,
 				FE18495627F5ACA400D26879 /* Prompts */,
 				8B92D69427CD51CE001F5371 /* Ghost */,
@@ -21323,6 +21334,7 @@
 				08E39B4528A3DEB200874CB8 /* UserPersistentStoreFactory.swift in Sources */,
 				C81CCD67243AECA200A83E27 /* TenorGIFCollection.swift in Sources */,
 				4AD5656C28E3D0670054C676 /* ReaderPost+Helper.swift in Sources */,
+				0118968F29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift in Sources */,
 				E137B1661F8B77D4006AC7FC /* WebNavigationDelegate.swift in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
 				803DE81328FFAE36007D4E9C /* RemoteConfigStore.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		0107E18E29000EA100DE87DB /* UIColor+MurielColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435B762122973D0600511813 /* UIColor+MurielColors.swift */; };
 		0107E18F29000EA200DE87DB /* UIColor+MurielColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435B762122973D0600511813 /* UIColor+MurielColors.swift */; };
 		0118968F29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */; };
+		0118969129D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0118969029D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift */; };
 		0141929C2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */; };
 		0141929D2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */; };
 		014192A02983F5E800CAEDB0 /* SupportConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0141929F2983F5E800CAEDB0 /* SupportConfigurationTests.swift */; };
@@ -5690,6 +5691,7 @@
 		0107E1842900059300DE87DB /* LocalizationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationConfiguration.swift; sourceTree = "<group>"; };
 		0107E1862900065400DE87DB /* LocalizationConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalizationConfiguration.swift; sourceTree = "<group>"; };
 		0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsDashboardCardHelper.swift; sourceTree = "<group>"; };
+		0118969029D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsDashboardCardHelperTests.swift; sourceTree = "<group>"; };
 		011A2815DB0DE7E3973CBC0E /* Pods-Apps-Jetpack.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release.xcconfig"; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
 		0141929F2983F5E800CAEDB0 /* SupportConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfigurationTests.swift; sourceTree = "<group>"; };
@@ -13416,6 +13418,7 @@
 				806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */,
 				80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */,
 				80EF9283280CFEB60064A971 /* DashboardPostsSyncManagerTests.swift */,
+				0118969029D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -23204,6 +23207,7 @@
 				933D1F471EA64108009FB462 /* TestingAppDelegate.m in Sources */,
 				5789E5C822D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift in Sources */,
 				0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */,
+				0118969129D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift in Sources */,
 				400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */,
 				C8567498243F41CA001A995E /* MockTenorService.swift in Sources */,
 				1D19C56629C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -120,10 +120,13 @@ final class BlogBuilder {
         return self
     }
 
-    func with(domainsCount: Int) -> Self {
+    func with(registeredDomainCount: Int) -> Self {
         var domains: [ManagedDomain] = []
-        for _ in 0..<domainsCount {
-            domains.append(NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain)
+        for _ in 0..<registeredDomainCount {
+            let domain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain
+            domain.domainType = .registered
+            domains.append(domain)
+
         }
 
         blog.domains = Set(domains)

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -126,7 +126,6 @@ final class BlogBuilder {
             let domain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain
             domain.domainType = .registered
             domains.append(domain)
-
         }
 
         blog.domains = Set(domains)

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -120,6 +120,21 @@ final class BlogBuilder {
         return self
     }
 
+    func with(domainsCount: Int) -> Self {
+        var domains: [ManagedDomain] = []
+        for _ in 0..<domainsCount {
+            domains.append(NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain)
+        }
+
+        blog.domains = Set(domains)
+        return self
+    }
+
+    func with(hasDomainCredit: Bool) -> Self {
+        blog.hasDomainCredit = hasDomainCredit
+        return self
+    }
+
     @discardableResult
     func build() -> Blog {
         return blog

--- a/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import WordPress
+
+final class DomainsDashboardCardHelperTests: CoreDataTestCase {
+    func testShouldShowCardEnabledFeatureFlagAndHostedAtWPcom() {
+        let blog = BlogBuilder(mainContext)
+            .isHostedAtWPcom()
+            .with(atomic: false)
+            .with(isAdmin: true)
+            .with(domainsCount: 0)
+            .with(hasDomainCredit: false)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertTrue(result, "Card should show for WPcom hosted blogs")
+    }
+
+    func testShouldShowCardEnabledFeatureFlagAndAtomic() {
+        let blog = BlogBuilder(mainContext)
+            .isNotHostedAtWPcom()
+            .with(atomic: true)
+            .with(isAdmin: true)
+            .with(domainsCount: 0)
+            .with(hasDomainCredit: false)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertTrue(result, "Card should show for Atomic blogs")
+    }
+
+    func testShouldNotShowCardNotAdmin() {
+        let blog = BlogBuilder(mainContext)
+            .isHostedAtWPcom()
+            .with(atomic: false)
+            .with(isAdmin: false)
+            .with(domainsCount: 0)
+            .with(hasDomainCredit: false)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show for non-admin users")
+    }
+
+    func testShouldNotShowCardHasOtherDomains() {
+        let blog = BlogBuilder(mainContext)
+            .isHostedAtWPcom()
+            .with(atomic: false)
+            .with(isAdmin: true)
+            .with(domainsCount: 2)
+            .with(hasDomainCredit: false)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show for blogs with more than one domain")
+    }
+
+    func testShouldNotShowCardHasDomainCredit() {
+        let blog = BlogBuilder(mainContext)
+            .isHostedAtWPcom()
+            .with(atomic: false)
+            .with(isAdmin: true)
+            .with(domainsCount: 0)
+            .with(hasDomainCredit: true)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show for blogs with domain credit")
+    }
+
+    func testShouldNotShowCardFeatureFlagDisabled() {
+        let blog = BlogBuilder(mainContext)
+            .isHostedAtWPcom()
+            .with(atomic: false)
+            .with(isAdmin: true)
+            .with(domainsCount: 0)
+            .with(hasDomainCredit: false)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: false)
+
+        XCTAssertFalse(result, "Card should not show when the feature flag is disabled")
+    }
+}

--- a/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
@@ -7,7 +7,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
             .isHostedAtWPcom()
             .with(atomic: false)
             .with(isAdmin: true)
-            .with(domainsCount: 0)
+            .with(registeredDomainCount: 0)
             .with(hasDomainCredit: false)
             .build()
 
@@ -21,7 +21,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
             .isNotHostedAtWPcom()
             .with(atomic: true)
             .with(isAdmin: true)
-            .with(domainsCount: 0)
+            .with(registeredDomainCount: 0)
             .with(hasDomainCredit: false)
             .build()
 
@@ -35,7 +35,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
             .isHostedAtWPcom()
             .with(atomic: false)
             .with(isAdmin: false)
-            .with(domainsCount: 0)
+            .with(registeredDomainCount: 0)
             .with(hasDomainCredit: false)
             .build()
 
@@ -49,7 +49,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
             .isHostedAtWPcom()
             .with(atomic: false)
             .with(isAdmin: true)
-            .with(domainsCount: 2)
+            .with(registeredDomainCount: 2)
             .with(hasDomainCredit: false)
             .build()
 
@@ -63,7 +63,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
             .isHostedAtWPcom()
             .with(atomic: false)
             .with(isAdmin: true)
-            .with(domainsCount: 0)
+            .with(registeredDomainCount: 0)
             .with(hasDomainCredit: true)
             .build()
 
@@ -77,7 +77,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
             .isHostedAtWPcom()
             .with(atomic: false)
             .with(isAdmin: true)
-            .with(domainsCount: 0)
+            .with(registeredDomainCount: 0)
             .with(hasDomainCredit: false)
             .build()
 


### PR DESCRIPTION
Fixes #20411

## Description

- [x] direct_domain_purchase_dashboard_card remote feature flag
- [x] Blog dashboard card presentation conditions
- [x] Card hiding logic
- [x] Improved blog domains refreshing
- [ ] Domains view presentation, leaving it for another PR  

A card UI will be implemented in https://github.com/wordpress-mobile/WordPress-iOS/issues/20409

## Testing instructions

### Before all:
1. Launch Jetpack app
2. Go to AppSettings -> Debug and enable `Direct Domains Purchase Dashboard` feature flag

### Case 1 Self-Hosted site:
1. Log into a self-hosted site
2. Dashboard should not display a placeholder card

### Case 2 free/personal .com site without registered domain:
1. Log into a .com site without registered domain
2. Dashboard should display a placeholder card above today's stats and under the blaze card

### Case 3 .com atomic (business) site without registered domain and without domain credits:
1. Log into a .com atomic site without registered domain and without domain credits
2. Dashboard should display a placeholder card above today's stats and under the blaze card

### Case 4 .com site with registered domain:
1. Log into a .com site with a registered domain
2. Dashboard should not display a placeholder card

## Regression Notes

1. Potential unintended areas of impact

None identified. I was trying to understand what additional blog syncing could cause, [there was a PR that would refresh domains in blog details view](https://github.com/wordpress-mobile/WordPress-iOS/pull/18124).

4. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing. Logging out, logging in, pull-to-refresh, seeing if there're any errors with domain refreshing

5. What automated tests I added (or what prevented me from doing so)

I added `DomainsDashboardCardHelperTests` to verify blog domain eligibility conditions

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos


| Self-Hosted | .com with registered domain | .com without registered domain |
|---------|---------|---------|
| No placeholder card | No placeholder card | Placeholder card |
| ![Simulator Screen Shot - iPhone 14 - 2023-03-28 at 11 19 19](https://user-images.githubusercontent.com/4062343/228174201-6a9604ef-de2a-4c31-b3ae-4c91a12d9fe4.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-28 at 11 19 13](https://user-images.githubusercontent.com/4062343/228174218-a181f0bc-ba34-435e-90fd-66f222ace024.png) | ![Simulator Screen Shot - iPhone 14 - 2023-03-28 at 11 19 08](https://user-images.githubusercontent.com/4062343/228174223-eb62c058-22e0-41a4-be21-9d951a384c63.png) |





