### PR TITLE
Disable lockScreenWidget feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -76,7 +76,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .todayWidget:
             return true
         case .lockScreenWidget:
-            return true
+            return false
         case .milestoneNotifications:
             return true
         case .bloggingReminders:


### PR DESCRIPTION
This is the PR to turn off the feature flag for preparing the merge feature branch PR to the trunk

1.  https://github.com/wordpress-mobile/WordPress-iOS/pull/20309 (✅ Approved)
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/20312 (✅ Approved) 
3. https://github.com/wordpress-mobile/WordPress-iOS/pull/20342 (Closed) 
4. https://github.com/wordpress-mobile/WordPress-iOS/pull/20353 (✅ Approved)
5. https://github.com/wordpress-mobile/WordPress-iOS/pull/20371 (✅ Approved)
6. https://github.com/wordpress-mobile/WordPress-iOS/pull/20317 (✅ Approved)
7. https://github.com/wordpress-mobile/WordPress-iOS/pull/20368 (✅ Approved)
8. https://github.com/wordpress-mobile/WordPress-iOS/pull/20399 (✅ Approved)
9. https://github.com/wordpress-mobile/WordPress-iOS/pull/20405 (✅ Approved)
(Confirm the data display on UI correctly in this phase)
10. https://github.com/wordpress-mobile/WordPress-iOS/pull/20422 (✅ Approved)
11. https://github.com/wordpress-mobile/WordPress-iOS/pull/20427 (In Reviewing)  👈 you're here!

## Description
The first widget in the lock screen feature is ready for merge, disable the feature flag to wait for the release decision.

## Testing Instructions
Enter the lock screen editor page, shouldn't see the Jetpack in the selection page
(If added widget in the lock screen before, the widget will be removed after the app is upgraded)

## Regression Notes
1. Potential unintended areas of impact
Home screen widget

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing widget in home screen won't be impacted, and able to add the widget to home screen

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
