### PR TITLE
Blogging Prompts: Update prompt's responses string on the dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -128,6 +128,10 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     }
 
     private var answerInfoText: String {
+        if FeatureFlag.bloggingPromptsSocial.enabled {
+            return Strings.viewAllResponses
+        }
+
         let stringFormat = (answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat)
         return String(format: stringFormat, answerCount)
     }
@@ -550,6 +554,9 @@ private extension DashboardPromptsCardCell {
                                                                 + "that answered the blogging prompt.")
         static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users "
                                                               + "that answered the blogging prompt.")
+        static let viewAllResponses = NSLocalizedString("prompts.card.viewprompts.title",
+                                                        value: "View all responses",
+                                                        comment: "Title for a tappable string that opens the reader with a prompts tag")
         static let errorTitle = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
         static let promptSkippedTitle = NSLocalizedString("Prompt skipped", comment: "Title of the notification presented when a prompt is skipped")
         static let undoSkipTitle = NSLocalizedString("Undo", comment: "Button in the notification presented when a prompt is skipped")


### PR DESCRIPTION
## Description

Changes the `X answer(s)` string to `View all responses` when the prompts social flag is enabled.

## Testing

To test:
- Launch Jetpack and login if necessary
- Select a site which has blogging prompts
- On the prompts dashboard card, **verify** the answers string is: `X answer(s)`
- Navigate to Me > App Settings > Debug
- Enable the feature flag `Blogging Prompts Social`
- Navigate back to the dashboard
- Pull to refresh (Usually works, you may have to switch sites for it to update)
- **Verify** the string changed to `View all responses`


## Regression Notes
1. Potential unintended areas of impact
Current prompts dashboard card without the feature flag enabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + testing instructions in the PR

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
