### PR TITLE
[JP Plugin] Track error reason when installation fails

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -86,7 +86,7 @@ private extension JetpackRemoteInstallViewController {
 
             case .failure(let error):
                 let blogURLString = self.blog.url ?? "unknown"
-                self.viewModel.track(.failed(description: error.type.rawValue, siteURLString: blogURLString))
+                self.viewModel.track(.failed(description: error.description, siteURLString: blogURLString))
 
                 let title = error.title ?? "no error message"
                 let type = error.type.rawValue
@@ -164,5 +164,18 @@ extension JetpackRemoteInstallViewController: JetpackRemoteInstallStateViewDeleg
         let supportViewController = SupportTableViewController()
         supportViewController.sourceTag = viewModel.supportSourceTag
         navigationController?.pushViewController(supportViewController, animated: true)
+    }
+}
+
+// MARK: - Error Helpers
+
+extension JetpackInstallError {
+    /// When the error is unknown, return the error title (if it exists) to get a more descriptive reason.
+    var description: String {
+        if let title,
+           type == .unknown {
+            return title
+        }
+        return type.rawValue
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
@@ -66,15 +66,19 @@ extension WPComJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
                 self?.state = .success
             case .failure(let error):
                 DDLogError("Error: Jetpack plugin installation via proxy failed. \(error.localizedDescription)")
-                self?.state = .failure(.unknown)
+                let installError = JetpackInstallError(title: error.localizedDescription, type: .unknown)
+                self?.state = .failure(installError)
             }
         }
     }
 
     func track(_ event: JetpackRemoteInstallEvent) {
         switch event {
-        case .initial, .loading, .failed:
+        case .initial, .loading:
             tracker.track(.jetpackInstallFullPluginViewed, properties: ["status": state.statusForTracks])
+        case .failed(let description, _):
+            tracker.track(.jetpackInstallPluginModalViewed,
+                          properties: ["status": state.statusForTracks, "description": description])
         case .cancel:
             tracker.track(.jetpackInstallFullPluginCancelTapped, properties: ["status": state.statusForTracks])
         case .start:

--- a/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
+++ b/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
@@ -103,7 +103,12 @@ final class WPComJetpackRemoteInstallViewModelTests: CoreDataTestCase {
         api.failureBlockPassedIn?(mockError, nil) // call the failure block to trigger Result.failure
 
         // assert
-        XCTAssertTrue(viewModel.state == .failure(.unknown))
+        guard case .failure(let error) = viewModel.state else {
+            XCTFail("Expected a failure state")
+            return
+        }
+
+        XCTAssertTrue(error.type == .unknown)
     }
 }
 


### PR DESCRIPTION
Refs p1679941373337129-slack-C01CW1VMLAF

This is a small improvement that tracks the error's `localizedDescription` for `.unknown` error types.

## To test

- Prepare an individual site that's connected to your WordPress.com account.
- Install the full Jetpack plugin from wp-admin, and then deactivate it.
- Launch the Jetpack app, and switch to your individual site.
- Go through the Jetpack plugin installation flow. The installation flow should fail.
- Verify that this is tracked: `🔵 Tracked: jp_install_full_plugin_onboarding_modal_viewed <description: Destination folder already exists., status: error>`

## Regression Notes
1. Potential unintended areas of impact
Self-hosted Jetpack plugin installation may be impacted when the error is also `unknown`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.