### PR TITLE
Hiding dashboard cards: remove prompts from site settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -503,10 +503,12 @@ private extension DashboardPromptsCardCell {
         WPAnalytics.track(.promptsDashboardCardMenuRemove)
         let service = BlogDashboardPersonalizationService(siteID: siteID)
         service.setEnabled(false, for: .prompts)
-        let notice = Notice(title: Strings.promptRemovedTitle, message: Strings.promptRemovedSubtitle, feedbackType: .success, actionTitle: Strings.undoSkipTitle) { _ in
-            service.setEnabled(true, for: .prompts)
+        if !FeatureFlag.personalizeHomeTab.enabled {
+            let notice = Notice(title: Strings.promptRemovedTitle, message: Strings.promptRemovedSubtitle, feedbackType: .success, actionTitle: Strings.undoSkipTitle) { _ in
+                service.setEnabled(true, for: .prompts)
+            }
+            ActionDispatcher.dispatch(NoticeAction.post(notice))
         }
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     func learnMoreTapped() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
@@ -38,7 +38,7 @@ private extension SiteSettingsViewController {
         if blog.areBloggingRemindersAllowed() {
             rows.append(.reminders)
         }
-        if blog.isAccessibleThroughWPCom() && FeatureFlag.bloggingPromptsEnhancements.enabled {
+        if blog.isAccessibleThroughWPCom() && FeatureFlag.bloggingPromptsEnhancements.enabled && !FeatureFlag.personalizeHomeTab.enabled {
             rows.append(.prompts)
         }
         return rows
@@ -56,7 +56,6 @@ private extension SiteSettingsViewController {
         cell?.textValue = schedule(for: blog)
         return cell ?? SettingTableViewCell()
     }
-
 
     func schedule(for blog: Blog) -> String {
         guard let scheduler = try? ReminderScheduleCoordinator() else {


### PR DESCRIPTION
Related issue: #20296

## Changes

- Remove prompts from site settings
- Remove a notice when disabling prompts

> Cards visibility is now controlled using a new Personalize Home Tab screen added in #20369 that replaced the item in Site Settings

## To test

- Enable "Personalize Home Tab" screen and open Dashboard
- Open the Prompts card context menu and select "Turn off prompts"
- Verify that the card got removed but not notice (snackbar) was shown
- Open site settings
- Verify that the "Prompts" row is not there

## Regression Notes
1. Potential unintended areas of impact. **n/a** (changes only affect what's in the description)
2. What I did to test those areas of impact (or what existing automated tests I relied on). **Manual testing**
3. What automated tests I added (or what prevented me from doing so). **n/a**

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
