### PR TITLE
Hiding dashboard cards: fix scroll position

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -147,16 +147,7 @@ private extension BlogDashboardViewModel {
 
     func applySnapshot(for cards: [DashboardCardModel]) {
         let snapshot = createSnapshot(from: cards)
-        let scrollView = viewController?.mySiteScrollView
-        let position = scrollView?.contentOffset
-
-        dataSource?.apply(snapshot, animatingDifferences: false) { [weak self] in
-            guard let scrollView = scrollView, let position = position else {
-                return
-            }
-
-            self?.scroll(scrollView, to: position)
-        }
+        dataSource?.apply(snapshot, animatingDifferences: false)
     }
 
     func createSnapshot(from cards: [DashboardCardModel]) -> DashboardSnapshot {
@@ -173,12 +164,6 @@ private extension BlogDashboardViewModel {
         snapshot.appendItems([.quickActions(dotComID)], toSection: .quickActions)
         snapshot.appendItems(items, toSection: .cards)
         return snapshot
-    }
-
-    func scroll(_ scrollView: UIScrollView, to position: CGPoint) {
-        if position.y > 0 {
-            scrollView.setContentOffset(position, animated: false)
-        }
     }
 
     // In case a draft is saved and the drafts card


### PR DESCRIPTION
Related issue: #20296

Fixes an issue with an incorrect scroll position after hiding multiple cards in the Personalize Home Tab screen and then turning them back on. The issue was reported by @guarani [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/20369#pullrequestreview-1357343984) (see the linked comment for the video).

To test:

- Open Jetpack and enable the "Personalize Home Tab" flag
- Tap "Personalize Home Tab" on the bottom of the site's Dashboard
- Turn all cards off, then turn some of them back off
- Go back the Dashboard
- Verify that the scroll view has _normal_ scroll position: cards are visible

## Regression Notes
1. Potential unintended areas of impact. 
Site Dashboard.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing
4. What automated tests I added (or what prevented me from doing so)
No

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
