### PR TITLE
Add accessibility identifier to comments text field and adapt UI Test

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -745,6 +745,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         NSString *placeholderFormat = NSLocalizedString(@"Reply to %1$@", @"Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.");
         self.replyTextView.placeholder = [NSString stringWithFormat:placeholderFormat, [comment authorForDisplay]];
     } else {
+        self.replyTextView.accessibilityIdentifier = @"reply-to-post-text-field";
         self.replyTextView.placeholder = NSLocalizedString(@"Reply to post", @"Placeholder text for replying to a post");
     }
 }

--- a/WordPress/UITestsFoundation/Screens/CommentsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/CommentsScreen.swift
@@ -7,8 +7,8 @@ public class CommentsScreen: ScreenObject {
         $0.navigationBars["Comments"]
     }
 
-    private let replyTextViewGetter: (XCUIApplication) -> XCUIElement = {
-        $0.textViews["ReplyText"]
+    private let replyFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements["reply-to-post-text-field"]
     }
 
     private let backButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -19,7 +19,7 @@ public class CommentsScreen: ScreenObject {
         $0.buttons["Reply"]
     }
 
-    var replyTextView: XCUIElement { replyTextViewGetter(app) }
+    var replyField: XCUIElement { replyFieldGetter(app) }
     var backButton: XCUIElement { backButtonGetter(app) }
     var replyButton: XCUIElement { replyButtonGetter(app) }
 
@@ -27,7 +27,7 @@ public class CommentsScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [
                 navigationBarTitleGetter,
-                replyTextViewGetter
+                replyFieldGetter
             ],
             app: app,
             waitTimeout: 7
@@ -45,8 +45,8 @@ public class CommentsScreen: ScreenObject {
 
     @discardableResult
     public func replyToPost(_ comment: String) -> CommentsScreen {
-        app.otherElements.containing(.staticText, identifier: "Reply to post").lastMatch?.tap()
-        replyTextView.typeText(comment)
+        replyField.tap()
+        replyField.typeText(comment)
         replyButton.tap()
         return self
     }


### PR DESCRIPTION
### Description
This PR's objective is to add accessibility identifier to the comments text field in order to provide a more reliable locator for the recently added ui test to cover adding new comments, and also a better code readability with simpler element queries. 

### Testing
If CI is green, we're good to go.
