### PR TITLE
Dashboard Cards: Add remote feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -14,6 +14,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case blaze
     case wordPressIndividualPluginSupport
     case directDomainsPurchaseDashboardCard
+    case pagesDashboardCard
+    case activityLogDashboardCard
 
     var defaultValue: Bool {
         switch self {
@@ -40,6 +42,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .wordPressIndividualPluginSupport:
             return AppConfiguration.isWordPress
         case .directDomainsPurchaseDashboardCard:
+            return false
+        case .pagesDashboardCard:
+            return false
+        case .activityLogDashboardCard:
             return false
         }
     }
@@ -71,6 +77,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "wp_individual_plugin_overlay"
         case .directDomainsPurchaseDashboardCard:
             return "direct_domain_purchase_dashboard_card"
+        case .pagesDashboardCard:
+            return "dashboard_card_pages"
+        case .activityLogDashboardCard:
+            return "dashboard_card_activity_log"
         }
     }
 
@@ -100,6 +110,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Jetpack Individual Plugin Support for WordPress"
         case .directDomainsPurchaseDashboardCard:
             return "Direct Domains Purchase Dashboard Card"
+        case .pagesDashboardCard:
+            return "Pages Dashboard Cards"
+        case .activityLogDashboardCard:
+            return "Activity Log Dashboard Card"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -111,7 +111,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .directDomainsPurchaseDashboardCard:
             return "Direct Domains Purchase Dashboard Card"
         case .pagesDashboardCard:
-            return "Pages Dashboard Cards"
+            return "Pages Dashboard Card"
         case .activityLogDashboardCard:
             return "Activity Log Dashboard Card"
         }


### PR DESCRIPTION
Fixes #20437

## Description
Adds a new remote feature flag for the pages and activity log dashboard cards. 

## How to test
1. Go to the debug menu from App Settings
2. ✅ Verify: the "Pages Dashboard Card" and the "Activity Log Dashboard Card" feature flags are displayed in the Remote Feature Flags section

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
