### PR TITLE
Use the default link behavior when counterpart app exists

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -69,7 +69,15 @@ class PreviewWebKitViewController: WebKitViewController {
         let isPage = post is Page
 
         let configuration = WebViewControllerConfiguration(url: url)
-        configuration.linkBehavior = isPage ? .hostOnly(url) : .urlOnly(url)
+
+        /// When the counterpart app is installed, revert to the default link behavior from `WebKitViewController`
+        /// to prevent links from being opened through the `externalLinkHandler`.
+        ///
+        /// This can be removed once the universal link routes for the WP app is removed.
+        if !MigrationAppDetection.isCounterpartAppInstalled {
+            configuration.linkBehavior = isPage ? .hostOnly(url) : .urlOnly(url)
+        }
+
         configuration.opensNewInSafari = true
         configuration.authenticate(blog: post.blog)
         configuration.analyticsSource = source


### PR DESCRIPTION
Resolves #20390 

## Description

This handles the universal link issue under scenarios where `PreviewWebKitViewController` is used to drive the webview.

When using `.urlOnly` or `.hostOnly` link behaviors, the webview will call its `externalLinkHandler` when the requested link contains a different URL (for `.urlOnly`) or different host (for `.hostOnly`), which simply calls `UIApplication.shared.open`. This is what caused the deeplink into the other app.

Adding a guard & early return in the `externalLinkHandler` doesn't work, because the link behavior returns a `.cancel` navigation policy, which will cause the webview to ignore the link.

The temporary workaround is to allow all links to be opened within the webview. More context about the previous implementation is detailed in paCL20-dF-p2 (from a 2019 project). The `.urlOnly` and `.hostOnly` bit is [added in this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/13226/files#diff-007e2da00f79be71c5e0cd7d5563b52bac8a4ec19cacc06e7b2decca7720497c).

## To test

> **Note**:
> Refer to p5T066-3VZ-p2#comment-1456 for prepared test links.

- Launch the app (can be WordPress or Jetpack). 
- Go to My Site > Posts.
- Tap 'View' on the post that contains a link to other `*.wordpress.com` sites.
- Click on the link.
- 🔎  Verify that the link now opens in the in-app browser instead of deeplinking to the other app.

## Regression Notes
1. Potential unintended areas of impact
External links (to other `*.wordpress.com` sites) will be opened in the in-app browser.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.