### PR TITLE
Replace all `case _:` with `default:`

### DIFF
--- a/WordPress/UITestsFoundation/XCTestCase+Utils.swift
+++ b/WordPress/UITestsFoundation/XCTestCase+Utils.swift
@@ -12,7 +12,7 @@ public extension XCTestCase {
         switch app.state {
         case .unknown, .notRunning:
             app.launch()
-        case _:
+        default:
             break
         }
 


### PR DESCRIPTION
While `case _` works, `default` is the recommended syntax.

See conversation at https://github.com/wordpress-mobile/WordPress-iOS/pull/20128#discussion_r1155616461

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
