### PR TITLE
Hiding dashboard cards: register cards automatically

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -121,15 +121,6 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    /// A list of cards that can be shown/hidden on a "Personalize Home Tab" screen.
-    static let personalizableCards: [DashboardCard] = [
-        .todaysStats,
-        .draftPosts,
-        .scheduledPosts,
-        .blaze,
-        .prompts
-    ]
-
     /// Includes all cards that should be fetched from the backend
     /// The `String` should match its identifier on the backend.
     enum RemoteDashboardCard: String, CaseIterable {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -20,7 +20,7 @@ struct BlogDashboardPersonalizationService {
     }
 
     func setEnabled(_ isEnabled: Bool, for card: DashboardCard) {
-        guard let key = makeKey(for: card) else { return }
+        guard let key = card.isEnabledKey else { return }
 
         var settings = getSettings(for: card)
         settings[siteID] = isEnabled
@@ -30,30 +30,36 @@ struct BlogDashboardPersonalizationService {
     }
 
     private func getSettings(for card: DashboardCard) -> [String: Bool] {
-        guard let key = makeKey(for: card) else { return [:] }
+        guard let key = card.isEnabledKey else { return [:] }
         return repository.dictionary(forKey: key) as? [String: Bool] ?? [:]
+    }
+
+    /// Returns all cards that can by hidden/shown by `BlogDashboardPersonalizationService`.
+    static var personalizableCards: [DashboardCard] {
+        DashboardCard.allCases.filter { $0.isEnabledKey != nil }
     }
 }
 
-private func makeKey(for card: DashboardCard) -> String? {
-    switch card {
-    case .todaysStats:
-        return "todays-stats-card-enabled-site-settings"
-    case .draftPosts:
-        return "draft-posts-card-enabled-site-settings"
-    case .scheduledPosts:
-        return "scheduled-posts-card-enabled-site-settings"
-    case .blaze:
-        return "blaze-card-enabled-site-settings"
-    case .prompts:
-        // Warning: there is an irregularity with the prompts key that doesn't
-        // have a "-card" component in the key name. Keeping it like this to
-        // avoid having to migrate data.
-        return "prompts-enabled-site-settings"
-    case .domainsDashboardCard:
-        return "domains-dashboard-card-enabled-site-settings"
-    case .quickStart, .jetpackBadge, .jetpackInstall, .nextPost, .createPost, .failure, .ghost, .personalize, .empty:
-        return nil
+private extension DashboardCard {
+    var isEnabledKey: String? {
+        switch card {
+        case .todaysStats:
+            return "todays-stats-card-enabled-site-settings"
+        case .draftPosts:
+            return "draft-posts-card-enabled-site-settings"
+        case .scheduledPosts:
+            return "scheduled-posts-card-enabled-site-settings"
+        case .blaze:
+            return "blaze-card-enabled-site-settings"
+        case .prompts:
+            // Warning: there is an irregularity with the prompts key that doesn't
+            // have a "-card" component in the key name. Keeping it like this to
+            // avoid having to migrate data.
+            return "prompts-enabled-site-settings"
+        case .domainsDashboardCard:
+            return "domains-dashboard-card-enabled-site-settings"
+        case .quickStart, .jetpackBadge, .jetpackInstall, .nextPost, .createPost, .failure, .ghost, .personalize, .empty:
+            return nil
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -4,7 +4,9 @@ final class BlogDashboardPersonalizationViewModel: ObservableObject {
     let cards: [BlogDashboardPersonalizationCardCellViewModel]
 
     init(service: BlogDashboardPersonalizationService) {
-        self.cards = DashboardCard.personalizableCards.map {
+        self.cards = BlogDashboardPersonalizationService.personalizableCards.filter {
+            $0 != .domainsDashboardCard
+        }.map {
             BlogDashboardPersonalizationCardCellViewModel(card: $0, service: service)
         }
     }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
@@ -19,7 +19,6 @@ final class BlogDashboardPersonalizationViewModelTests: XCTestCase {
         // Given
         let cardViewModel = try XCTUnwrap(viewModel.cards.first)
         let card = cardViewModel.id
-        XCTAssertEqual(card, .todaysStats)
         XCTAssertTrue(cardViewModel.isOn, "By default, the cards are enabled")
         XCTAssertTrue(service.isEnabled(card))
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -132,7 +132,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     func testThatWhenAllCardsAreHiddenEmptyStateIsShown() {
         // Given
         let personalizationService = BlogDashboardPersonalizationService(repository: repositoryMock, siteID: wpComID)
-        for card in DashboardCard.personalizableCards {
+        for card in BlogDashboardPersonalizationService.personalizableCards {
             personalizationService.setEnabled(false, for: card)
         }
 


### PR DESCRIPTION
Related issue: #20296

Addresses the [feedback](https://github.com/wordpress-mobile/WordPress-iOS/pull/20369#issuecomment-1488538703) by @staskus and @hassaanelgarem about simplifying how the cards are added to the Personalize Home Tab screen. 

Please note that it also changes the order of cards as they appear in the Personalize Home Tab. It was previously based on  Figma and is now based on how they appear on Dashboard. I confirmed this change [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/20369#issuecomment-1488661970).

## To test:

Follow the test instructions from #20369 (regression testing needed).

## Regression Notes
1. Potential unintended areas of impact
The new Personalize Home Tab screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I performed manual testing

3. What automated tests I added (or what prevented me from doing so)
It has existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
