### PR TITLE
Fix Activity Log and Plugins not working on Jetpack

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -159,7 +159,7 @@ static NSString * const JetpackComOAuthKeychainServiceName = @"jetpack.public-ap
 
 + (NSString *)authKeychainServiceName
 {
-    return [AppConfiguration authKeychainServiceName];
+    return [AppConstants authKeychainServiceName];
 }
 
 #pragma mark - API Helpers

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -159,7 +159,7 @@ static NSString * const JetpackComOAuthKeychainServiceName = @"jetpack.public-ap
 
 + (NSString *)authKeychainServiceName
 {
-    return [AppConfiguration isWordPress] ? WordPressComOAuthKeychainServiceName : JetpackComOAuthKeychainServiceName;
+    return [AppConfiguration authKeychainServiceName];
 }
 
 #pragma mark - API Helpers

--- a/WordPress/Classes/Services/CredentialsService.swift
+++ b/WordPress/Classes/Services/CredentialsService.swift
@@ -16,6 +16,6 @@ class CredentialsService {
     }
 
     func getOAuthToken(site: JetpackSiteRef) -> String? {
-        return provider.getPassword(username: site.username, service: AppConfiguration.authKeychainServiceName)
+        return provider.getPassword(username: site.username, service: AppConstants.authKeychainServiceName)
     }
 }

--- a/WordPress/Classes/Services/CredentialsService.swift
+++ b/WordPress/Classes/Services/CredentialsService.swift
@@ -10,13 +10,12 @@ struct KeychainCredentialsProvider: CredentialsProvider {
 
 class CredentialsService {
     private let provider: CredentialsProvider
-    private let dotComOAuthKeychainService = "public-api.wordpress.com"
 
     init(provider: CredentialsProvider = KeychainCredentialsProvider()) {
         self.provider = provider
     }
 
     func getOAuthToken(site: JetpackSiteRef) -> String? {
-        return provider.getPassword(username: site.username, service: dotComOAuthKeychainService)
+        return provider.getPassword(username: site.username, service: AppConfiguration.authKeychainServiceName)
     }
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -23,5 +23,4 @@ import Foundation
     @objc static let showsWhatIsNew: Bool = true
     @objc static let showsStatsRevampV2: Bool = false
     @objc static let qrLoginEnabled: Bool = false
-    @objc static let authKeychainServiceName: String = "public-api.wordpress.com"
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -4,7 +4,7 @@ import Foundation
  * WordPress Configuration
  * - Warning:
  * This configuration class has a **Jetpack** counterpart in the Jetpack bundle.
- * Make sure to keep them in sync to avoid build errors when builing the Jetpack target.
+ * Make sure to keep them in sync to avoid build errors when building the Jetpack target.
  */
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = false

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -23,4 +23,5 @@ import Foundation
     @objc static let showsWhatIsNew: Bool = true
     @objc static let showsStatsRevampV2: Bool = false
     @objc static let qrLoginEnabled: Bool = false
+    @objc static let authKeychainServiceName: String = "public-api.wordpress.com"
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -3,7 +3,7 @@ import WordPressAuthenticator
 
 /// - Warning:
 /// This configuration class has a **Jetpack** counterpart in the Jetpack bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the Jetpack target.
+/// Make sure to keep them in sync to avoid build errors when building the Jetpack target.
 @objc class AppConstants: NSObject {
     static let itunesAppID = "335703880"
     static let productTwitterHandle = "@WordPressiOS"

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -14,6 +14,7 @@ import WordPressAuthenticator
     static let shareAppName: ShareAppName = .wordpress
     static let mobileAnnounceAppId = "2"
     @objc static let eventNamePrefix = "wpios"
+    @objc static let authKeychainServiceName = "public-api.wordpress.com"
 
     /// Notifications Constants
     ///

--- a/WordPress/Classes/Utility/App Configuration/AppDependency.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppDependency.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// - Warning:
 /// This configuration class has a **Jetpack** counterpart in the Jetpack bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the Jetpack target.
+/// Make sure to keep them in sync to avoid build errors when building the Jetpack target.
 @objc class AppDependency: NSObject {
     static func authenticationManager(windowManager: WindowManager) -> WordPressAuthenticationManager {
         return WordPressAuthenticationManager(windowManager: windowManager)

--- a/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
@@ -3,7 +3,7 @@ import WordPressShared
 
 /// - Warning:
 /// This configuration struct has a **Jetpack** counterpart in the Jetpack bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the Jetpack target.
+/// Make sure to keep them in sync to avoid build errors when building the Jetpack target.
 struct AppStyleGuide {
     static let navigationBarStandardFont: UIFont = WPStyleGuide.fixedSerifFontForTextStyle(.headline, fontWeight: .semibold)
     static let navigationBarLargeFont: UIFont = WPStyleGuide.fixedSerifFontForTextStyle(.largeTitle, fontWeight: .semibold)

--- a/WordPress/Classes/Utility/App Configuration/ExtensionConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/ExtensionConfiguration.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// - Warning:
 /// This configuration extension has a **Jetpack** counterpart in the Jetpack bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the Jetpack target.
+/// Make sure to keep them in sync to avoid build errors when building the Jetpack target.
 @objc extension AppConfiguration {
 
     @objc(AppConfigurationExtension)

--- a/WordPress/Classes/Utility/KeychainTools.swift
+++ b/WordPress/Classes/Utility/KeychainTools.swift
@@ -42,7 +42,7 @@ final class KeychainTools: NSObject {
     static fileprivate func serviceForItem(_ item: String) -> String? {
         switch item {
         case "wordpress.com":
-            return "public-api.wordpress.com"
+            return AppConfiguration.authKeychainServiceName
         case "*", "all":
             return nil
         default:

--- a/WordPress/Classes/Utility/KeychainTools.swift
+++ b/WordPress/Classes/Utility/KeychainTools.swift
@@ -42,7 +42,7 @@ final class KeychainTools: NSObject {
     static fileprivate func serviceForItem(_ item: String) -> String? {
         switch item {
         case "wordpress.com":
-            return AppConfiguration.authKeychainServiceName
+            return AppConstants.authKeychainServiceName
         case "*", "all":
             return nil
         default:

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -23,4 +23,5 @@ import Foundation
     @objc static let showsWhatIsNew: Bool = true
     @objc static let showsStatsRevampV2: Bool = true
     @objc static let qrLoginEnabled: Bool = true
+    @objc static let authKeychainServiceName: String = "jetpack.public-api.wordpress.com"
 }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -23,5 +23,4 @@ import Foundation
     @objc static let showsWhatIsNew: Bool = true
     @objc static let showsStatsRevampV2: Bool = true
     @objc static let qrLoginEnabled: Bool = true
-    @objc static let authKeychainServiceName: String = "jetpack.public-api.wordpress.com"
 }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -4,7 +4,7 @@ import Foundation
  * Jetpack Configuration
  * - Warning:
  * This configuration class has a **WordPress** counterpart in the WordPress bundle.
- * Make sure to keep them in sync to avoid build errors when builing the WordPress target.
+ * Make sure to keep them in sync to avoid build errors when building the WordPress target.
  */
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = true

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -14,6 +14,7 @@ import WordPressKit
     static let shareAppName: ShareAppName = .jetpack
     static let mobileAnnounceAppId = "6"
     @objc static let eventNamePrefix = "jpios"
+    @objc static let authKeychainServiceName = "jetpack.public-api.wordpress.com"
 
     /// Notifications Constants
     ///

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -3,7 +3,7 @@ import WordPressKit
 
 /// - Warning:
 /// This configuration class has a **WordPress** counterpart in the WordPress bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the WordPress target.
+/// Make sure to keep them in sync to avoid build errors when building the WordPress target.
 @objc class AppConstants: NSObject {
     static let itunesAppID = "1565481562"
     static let productTwitterHandle = "@jetpack"

--- a/WordPress/Jetpack/AppDependency.swift
+++ b/WordPress/Jetpack/AppDependency.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// - Warning:
 /// This configuration class has a **WordPress** counterpart in the WordPress bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the WordPress target.
+/// Make sure to keep them in sync to avoid build errors when building the WordPress target.
 @objc class AppDependency: NSObject {
     static func authenticationManager(windowManager: WindowManager) -> WordPressAuthenticationManager {
         return WordPressAuthenticationManager(windowManager: windowManager, authenticationHandler: JetpackAuthenticationManager())

--- a/WordPress/Jetpack/AppStyleGuide.swift
+++ b/WordPress/Jetpack/AppStyleGuide.swift
@@ -4,7 +4,7 @@ import Gridicons
 
 /// - Warning:
 /// This configuration struct has a **WordPress** counterpart in the WordPress bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the WordPress target.
+/// Make sure to keep them in sync to avoid build errors when building the WordPress target.
 struct AppStyleGuide {
     static let navigationBarStandardFont: UIFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
     static let navigationBarLargeFont: UIFont = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)

--- a/WordPress/Jetpack/ExtensionConfiguration.swift
+++ b/WordPress/Jetpack/ExtensionConfiguration.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// - Warning:
 /// This configuration extension has a **WordPress** counterpart in the WordPress bundle.
-/// Make sure to keep them in sync to avoid build errors when builing the WordPress target.
+/// Make sure to keep them in sync to avoid build errors when building the WordPress target.
 @objc extension AppConfiguration {
 
     @objc(AppConfigurationExtension)


### PR DESCRIPTION
Fixes #20471
Ref: p1680581589932799/1680567166.180859-slack-C0180B5PRJ4

## Description
Fixes an issue where Activity Log and Plugins wouldn't load normally on Jetpack.

## Testing Instructions

1. Run the WordPress app
2. Log in to an account that has a connected self-hosted site
3. Logout
4. Run the Jetpack app
5. Log in to the same account from step 2
6. Navigate to the Menu
7. Navigate to Activity Log
8. Make sure the Activity Log list loads normally
9. Go back
10. Navigate to Plugins
11. Make sure the Installed Plugins section loads normally.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.