### PR TITLE
Add an unit test for CommentService.updateRepliesVisibility

### DIFF
--- a/WordPress/Classes/Services/CommentService+Replies.swift
+++ b/WordPress/Classes/Services/CommentService+Replies.swift
@@ -71,10 +71,7 @@ extension CommentService {
                 childComment.visibleOnReader = isVisible
             }
 
-            self.coreDataStack.save(context)
-            DispatchQueue.main.async {
-                completion?()
-            }
+            self.coreDataStack.save(context, completion: completion, on: .main)
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1171,6 +1171,7 @@
 		4A526BE0296BE9A50007B5BA /* CoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A526BDD296BE9A50007B5BA /* CoreDataService.m */; };
 		4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */; };
 		4A76A4BD29D43BFD00AABF4B /* CommentService+MorderationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */; };
+		4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */; };
 		4A82C43128D321A300486CFF /* Blog+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82C43028D321A300486CFF /* Blog+Post.swift */; };
 		4A82C43228D321A300486CFF /* Blog+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82C43028D321A300486CFF /* Blog+Post.swift */; };
 		4A878550290F2C7D0083AB78 /* Media+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A87854F290F2C7D0083AB78 /* Media+Sync.swift */; };
@@ -6693,6 +6694,7 @@
 		4A526BDE296BE9A50007B5BA /* CoreDataService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreDataService.h; sourceTree = "<group>"; };
 		4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+LikesTests.swift"; sourceTree = "<group>"; };
 		4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+MorderationTests.swift"; sourceTree = "<group>"; };
+		4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-success.json"; sourceTree = "<group>"; };
 		4A82C43028D321A300486CFF /* Blog+Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog+Post.swift"; sourceTree = "<group>"; };
 		4A87854F290F2C7D0083AB78 /* Media+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+Sync.swift"; sourceTree = "<group>"; };
 		4A9314DB297790C300360232 /* PeopleServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleServiceTests.swift; sourceTree = "<group>"; };
@@ -16343,6 +16345,7 @@
 				93CD939219099BE70049096E /* authtoken.json */,
 				FE003F61282E73E6006F8D1D /* blogging-prompts-fetch-success.json */,
 				FEFC0F8D27313DCF001F7F1D /* comments-v2-success.json */,
+				4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */,
 				FEFC0F8F27315634001F7F1D /* empty-array.json */,
 				74585B9A1F0D591D00E7E667 /* domain-service-valid-domains.json */,
 				74585B9B1F0D591D00E7E667 /* domain-service-all-domain-types.json */,
@@ -19061,6 +19064,7 @@
 				7E4A772120F7BBBD001C706D /* activity-log-post-content.json in Resources */,
 				748437F01F1D4E9E00E8DDAF /* notifications-load-all.json in Resources */,
 				E11330511A13BAA300D36D84 /* me-sites-with-jetpack.json in Resources */,
+				4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */,
 				7E53AB0820FE6C9C005796FE /* activity-log-post.json in Resources */,
 				32110560250C027D0048446F /* invalid-gif.gif in Resources */,
 				D848CC0B20FF2D5D00A9038F /* notifications-user-range.json in Resources */,

--- a/WordPress/WordPressTest/Test Data/reader-post-comments-success.json
+++ b/WordPress/WordPressTest/Test Data/reader-post-comments-success.json
@@ -1,0 +1,1090 @@
+{
+  "found": 24,
+  "site_ID": 3584907,
+  "comments": [
+    {
+      "ID": 428602,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 228172339,
+        "login": "",
+        "email": false,
+        "name": "thisness",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://thisnessart.wordpress.com",
+        "avatar_URL": "https://2.gravatar.com/avatar/84a56c859a787eeed67ec4dd2f9388e8?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/84a56c859a787eeed67ec4dd2f9388e8",
+        "ip_address": false
+      },
+      "date": "2023-03-17T19:27:43+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428602",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428602",
+      "content": "<p>This is great news! Any plans for adding this capability to WordPress.com blogs?</p>\n",
+      "raw_content": "This is great news! Any plans for adding this capability to Wordpress.com blogs?",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 7,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428602",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428602/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428602/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428602/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428627,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 998857,
+        "login": "",
+        "email": false,
+        "name": "Steve Sawczyn",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://steves.life",
+        "avatar_URL": "https://2.gravatar.com/avatar/eea57818a25081563cdd49ee44b11b57?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/eea57818a25081563cdd49ee44b11b57",
+        "ip_address": false
+      },
+      "date": "2023-03-17T21:09:25+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428627",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428627",
+      "content": "<p>I have waited a long time for an announcement like this, but it seems that this functionality may only be available for WordPress Business and above?  When I tried to install this on my Premium plan, I was told that I would need a plan upgrade, but not what that upgrade might be: it&#8217;s presumably an upgrade to business as I don&#8217;t find any other options that would support plugin installation.  I&#8217;d absolutely love to incorporate ActivityPub into my blog as I truly believe in the open web, but I&#8217;m not willing to pay 3X what I&#8217;m already paying just to gain access to a single plugin.  Is there some other way to add this to accounts lower than Business tier?  If not, I truly hope that Automattic will consider merging this somehow into Jetpack, so that all of us can truly take part in the open web.</p>\n",
+      "raw_content": "I have waited a long time for an announcement like this, but it seems that this functionality may only be available for WordPress Business and above?  When I tried to install this on my Premium plan, I was told that I would need a plan upgrade, but not what that upgrade might be: it's presumably an upgrade to business as I don't find any other options that would support plugin installation.  I'd absolutely love to incorporate ActivityPub into my blog as I truly believe in the open web, but I'm not willing to pay 3X what I'm already paying just to gain access to a single plugin.  Is there some other way to add this to accounts lower than Business tier?  If not, I truly hope that Automattic will consider merging this somehow into Jetpack, so that all of us can truly take part in the open web.",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 7,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428627",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428627/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428627/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428627/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428664,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 28155716,
+        "login": "",
+        "email": false,
+        "name": "Jerry B",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://theboundlesshorizon.com/",
+        "avatar_URL": "https://1.gravatar.com/avatar/4c69dba70ef25cc957d880ee565fb6e2?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/4c69dba70ef25cc957d880ee565fb6e2",
+        "ip_address": false
+      },
+      "date": "2023-03-19T18:43:32+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428664",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428664",
+      "content": "<p>Hi there, for the moment this plugin is in beta, so it has not been incorporated with the WordPress.com platform directly.  For now, the only way to use this feature is to upgrade to the Business Plan or use a self-hosted WordPress site with a &#8220;traditional web host.&#8221;</p>\n<p>We don&#8217;t have a specific timeline for adding this functionality for all WordPress.com sites, but we would announce it here in our blog.  Thanks for your patience!</p>\n",
+      "raw_content": "Hi there, for the moment this plugin is in beta, so it has not been incorporated with the WordPress.com platform directly.  For now, the only way to use this feature is to upgrade to the Business Plan or use a self-hosted WordPress site with a \"traditional web host.\"\r\n\r\nWe don't have a specific timeline for adding this functionality for all WordPress.com sites, but we would announce it here in our blog.  Thanks for your patience!",
+      "status": "approved",
+      "parent": {
+        "ID": 428627,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428627"
+      },
+      "type": "comment",
+      "like_count": 6,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428664",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428664/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428664/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428664/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428629,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 233004886,
+        "login": "",
+        "email": false,
+        "name": "Affiliated Madness",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://affiliatedmadnessbusiness.wordpress.com",
+        "avatar_URL": "https://2.gravatar.com/avatar/5f25a84336080d9c62934bc170de97f6?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/5f25a84336080d9c62934bc170de97f6",
+        "ip_address": false
+      },
+      "date": "2023-03-18T06:16:06+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428629",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428629",
+      "content": "<p>First comment \ud83d\ude01. This is really cool actually, thank you for making such a great post. Once I get some things in place I&#8217;m definitely going to have to make use of this awesome plugin!</p>\n",
+      "raw_content": "First comment \ud83d\ude01. This is really cool actually, thank you for making such a great post. Once I get some things in place I'm definitely going to have to make use of this awesome plugin!",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 3,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428629",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428629/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428629/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428629/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428633,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 223648874,
+        "login": "",
+        "email": false,
+        "name": "scribblans",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "",
+        "avatar_URL": "https://0.gravatar.com/avatar/90e5b99bcd5ab90eca0bc15a7b56bdc4?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/90e5b99bcd5ab90eca0bc15a7b56bdc4",
+        "ip_address": false
+      },
+      "date": "2023-03-18T10:00:30+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428633",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428633",
+      "content": "<p>It should be understood that installing this plug-in &#8212; that democratises publishing and makes the web a better place &#8212; requires your subscription to be on the Business plan or higher, so is not for Personal or Premium accounts.</p>\n",
+      "raw_content": "It should be understood that installing this plug-in -- that democratises publishing and makes the web a better place -- requires your subscription to be on the Business plan or higher, so is not for Personal or Premium accounts.",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428633",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428633/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428633/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428633/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428646,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 198177542,
+        "login": "",
+        "email": false,
+        "name": "minecraftchest1",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://minecraftchest1.wordpress.com",
+        "avatar_URL": "https://2.gravatar.com/avatar/27b4b30c8412f92d0e9e59ca59f1d66a?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/27b4b30c8412f92d0e9e59ca59f1d66a",
+        "ip_address": false
+      },
+      "date": "2023-03-18T12:13:00+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428646",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428646",
+      "content": "<p>Now for it to be available for all users, not just buisness.</p>\n",
+      "raw_content": "Now for it to be available for all users, not just buisness.",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 3,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428646",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428646/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428646/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428646/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428678,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 42251266,
+        "login": "",
+        "email": false,
+        "name": "Carolyn S.",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://wordpress.com/learn/",
+        "avatar_URL": "https://2.gravatar.com/avatar/561be467af56cefa58e02782b7ac7510?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/561be467af56cefa58e02782b7ac7510",
+        "ip_address": false
+      },
+      "date": "2023-03-20T18:54:56+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428678",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428678",
+      "content": "<p>We&#8217;re working on it! Since it hasn&#8217;t been integrated into WordPress.com yet (which will take some time), the only way to use this feature at the moment is to upgrade to the Business Plan or use a self-hosted WordPress site with a \u201ctraditional web host.\u201d</p>\n<p>We don\u2019t have a specific timeline for adding this functionality for all WordPress.com sites, but we would announce it here in our blog. Thanks for your patience!</p>\n",
+      "raw_content": "We're working on it! Since it hasn't been integrated into WordPress.com yet (which will take some time), the only way to use this feature at the moment is to upgrade to the Business Plan or use a self-hosted WordPress site with a \u201ctraditional web host.\u201d\r\n\r\nWe don\u2019t have a specific timeline for adding this functionality for all WordPress.com sites, but we would announce it here in our blog. Thanks for your patience!",
+      "status": "approved",
+      "parent": {
+        "ID": 428646,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428646"
+      },
+      "type": "comment",
+      "like_count": 0,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428678",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428678/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428678/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428678/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428647,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 143775722,
+        "login": "",
+        "email": false,
+        "name": "Lou Carreras",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://loucarrerascarver.wordpress.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/481440a83d9023669f982a5eb249310f?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/481440a83d9023669f982a5eb249310f",
+        "ip_address": false
+      },
+      "date": "2023-03-18T12:35:55+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428647",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428647",
+      "content": "<p>You were right installing the plugin was amazingly easy. but I couldn&#8217;t find the entry for manage plugin which would allow me to to set things up. Have I missed something here?</p>\n",
+      "raw_content": "You were right installing the plugin was amazingly easy. but I couldn't find the entry for manage plugin which would allow me to to set things up. Have I missed something here?",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 5,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428647",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428647/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428647/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428647/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428663,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 28155716,
+        "login": "",
+        "email": false,
+        "name": "Jerry B",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://theboundlesshorizon.com/",
+        "avatar_URL": "https://1.gravatar.com/avatar/4c69dba70ef25cc957d880ee565fb6e2?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/4c69dba70ef25cc957d880ee565fb6e2",
+        "ip_address": false
+      },
+      "date": "2023-03-19T18:39:58+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428663",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428663",
+      "content": "<p>Hi there, the settings for the plugin are found in your site admin area.  In the sidebar on the right, look for Settings &gt; ActivityPub</p>\n<p>You can find a full explanation of how the plugin works, as well as a few examples to help clarify, by reading the the info provided by the plugin author here:  <a href=\"https://github.com/pfefferle/wordpress-activitypub#description\" rel=\"nofollow ugc\">https://github.com/pfefferle/wordpress-activitypub#description</a></p>\n<p>Hope this helps!</p>\n",
+      "raw_content": "Hi there, the settings for the plugin are found in your site admin area.  In the sidebar on the right, look for Settings &gt; ActivityPub\r\n\r\nYou can find a full explanation of how the plugin works, as well as a few examples to help clarify, by reading the the info provided by the plugin author here:  https://github.com/pfefferle/wordpress-activitypub#description\r\n\r\nHope this helps!",
+      "status": "approved",
+      "parent": {
+        "ID": 428647,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428647"
+      },
+      "type": "comment",
+      "like_count": 5,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428663",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428663/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428663/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428663/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428649,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 37703838,
+        "login": "",
+        "email": false,
+        "name": "Maho-Art",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://eyeof1.wordpress.com",
+        "avatar_URL": "https://0.gravatar.com/avatar/c6c6a7f29e8ee3f0926e5cbfc1f566d7?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/c6c6a7f29e8ee3f0926e5cbfc1f566d7",
+        "ip_address": false
+      },
+      "date": "2023-03-18T14:30:17+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428649",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428649",
+      "content": "<p>It is not very clear to me when someone make a statement that they are demonstrating a product or access when they are busy buying up independent related businesses and determining to use factor of those products.</p>\n<p>I\u2019ve always understood the \u201cmarket\u201d to be an amalgamation of varied interests in a field interactions, buying, selling and trading. Today all portals of such activities are being owned and influenced by fewer and fewer minds, in an arena of slavish drones waiting for the next offering. In such a case how can we believe the market is free, or the processes democratic? This is truly a quandary of perception.</p>\n",
+      "raw_content": "It is not very clear to me when someone make a statement that they are demonstrating a product or access when they are busy buying up independent related businesses and determining to use factor of those products.\n\nI\u2019ve always understood the \u201cmarket\u201d to be an amalgamation of varied interests in a field interactions, buying, selling and trading. Today all portals of such activities are being owned and influenced by fewer and fewer minds, in an arena of slavish drones waiting for the next offering. In such a case how can we believe the market is free, or the processes democratic? This is truly a quandary of perception.",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 3,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428649",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428649/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428649/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428649/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428906,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 130920716,
+        "login": "",
+        "email": false,
+        "name": "revelation316",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://revelation316.wordpress.com",
+        "avatar_URL": "https://0.gravatar.com/avatar/96d7a93f80f9998864aaadfad0431e94?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/96d7a93f80f9998864aaadfad0431e94",
+        "ip_address": false
+      },
+      "date": "2023-03-27T11:32:35+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428906",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428906",
+      "content": "<p>Hi  Maho-Art, this is all sounding a bit strange to me as well. Not sure what to do about it. Let me know if     you choose another option? Would  ya.<br />\nAre they saying they own our work, can send it off to any of the options they listed above, and make money? We get nothing? This is the part that\u2019s confusing me. Help!</p>\n",
+      "raw_content": "Hi  Maho-Art, this is all sounding a bit strange to me as well. Not sure what to do about it. Let me know if     you choose another option? Would  ya.\nAre they saying they own our work, can send it off to any of the options they listed above, and make money? We get nothing? This is the part that\u2019s confusing me. Help!",
+      "status": "approved",
+      "parent": {
+        "ID": 428649,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428649"
+      },
+      "type": "comment",
+      "like_count": 1,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428906",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428906/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428906/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428906/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428650,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 215503140,
+        "login": "",
+        "email": false,
+        "name": "Ana Daksina",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://troubadorofversepoetry.wordpress.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/4c7a151b7b18ff4a58b9578e7f3221fe?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/4c7a151b7b18ff4a58b9578e7f3221fe",
+        "ip_address": false
+      },
+      "date": "2023-03-18T15:09:42+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428650",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428650",
+      "content": "<p>Open source, transparency and collaboration, empowering, user control, diversity and inclusiveness ~ what wonderful words! \ud83d\udc4f\ud83d\udc4f\ud83d\udc4f</p>\n",
+      "raw_content": "Open source, transparency and collaboration, empowering, user control, diversity and inclusiveness ~ what wonderful words! \ud83d\udc4f\ud83d\udc4f\ud83d\udc4f",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 4,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428650",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428650/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428650/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428650/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428652,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 233096405,
+        "login": "",
+        "email": false,
+        "name": "Shine\u2728",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://shinelight8.wordpress.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/15162221324d4b2aac50f32af5da6f71?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/15162221324d4b2aac50f32af5da6f71",
+        "ip_address": false
+      },
+      "date": "2023-03-18T20:10:33+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428652",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428652",
+      "content": "<p>\ud83d\udc4d</p>\n",
+      "raw_content": "\ud83d\udc4d",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428652",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428652/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428652/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428652/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428657,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 184244113,
+        "login": "",
+        "email": false,
+        "name": "Shuvo Azam",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://shuvoart.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/4ef0296d99aa0b7d268b37bc7929a522?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/4ef0296d99aa0b7d268b37bc7929a522",
+        "ip_address": false
+      },
+      "date": "2023-03-19T09:51:39+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428657",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428657",
+      "content": "<p>\ud83d\udc4d</p>\n",
+      "raw_content": "\ud83d\udc4d",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428657",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428657/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428657/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428657/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428658,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 231768058,
+        "login": "",
+        "email": false,
+        "name": "hamadalikhan776",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://haadittinfo.wordpress.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/ab10ed57c0c4d917ce35fe622530ab44?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/ab10ed57c0c4d917ce35fe622530ab44",
+        "ip_address": false
+      },
+      "date": "2023-03-19T15:57:11+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428658",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428658",
+      "content": "<p>Fantastic effort, Nice idea </p>\n",
+      "raw_content": "Fantastic effort, Nice idea ",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 5,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428658",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428658/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428658/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428658/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428659,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 233115586,
+        "login": "",
+        "email": false,
+        "name": "Oftaane Asaffa",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://oftaanedata.wordpress.com",
+        "avatar_URL": "https://2.gravatar.com/avatar/b272d9679558047d88a8739174305535?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/b272d9679558047d88a8739174305535",
+        "ip_address": false
+      },
+      "date": "2023-03-19T16:42:25+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428659",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428659",
+      "content": "<p>Awesome</p>\n",
+      "raw_content": "Awesome",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 3,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428659",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428659/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428659/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428659/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428668,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 171783,
+        "login": "",
+        "email": false,
+        "name": "Chris Till",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://cjtill.com",
+        "avatar_URL": "https://0.gravatar.com/avatar/c5c026eda0c03b4a38da5ceaad7433a0?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/c5c026eda0c03b4a38da5ceaad7433a0",
+        "ip_address": false
+      },
+      "date": "2023-03-20T09:02:11+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428668",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428668",
+      "content": "<p>Pretty ridiculous to announce that it\u2019s available and not mention that it\u2019s in beta and only available to business customers at this time. So we all went to install it and were confused.</p>\n",
+      "raw_content": "Pretty ridiculous to announce that it\u2019s available and not mention that it\u2019s in beta and only available to business customers at this time. So we all went to install it and were confused.",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428668",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428668/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428668/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428668/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428679,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 42251266,
+        "login": "",
+        "email": false,
+        "name": "Carolyn S.",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://wordpress.com/learn/",
+        "avatar_URL": "https://2.gravatar.com/avatar/561be467af56cefa58e02782b7ac7510?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/561be467af56cefa58e02782b7ac7510",
+        "ip_address": false
+      },
+      "date": "2023-03-20T18:55:31+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428679",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428679",
+      "content": "<p>We&#8217;re working on it! Since it hasn&#8217;t been integrated into WordPress.com yet (which will take some time), the only way to use this feature at the moment is to upgrade to the Business Plan or use a self-hosted WordPress site with a \u201ctraditional web host.\u201d</p>\n<p>We don\u2019t have a specific timeline for adding this functionality for all WordPress.com sites, but we would announce it here in our blog. Thanks for your patience!</p>\n",
+      "raw_content": "We're working on it! Since it hasn't been integrated into WordPress.com yet (which will take some time), the only way to use this feature at the moment is to upgrade to the Business Plan or use a self-hosted WordPress site with a \u201ctraditional web host.\u201d\r\n\r\nWe don\u2019t have a specific timeline for adding this functionality for all WordPress.com sites, but we would announce it here in our blog. Thanks for your patience!",
+      "status": "approved",
+      "parent": {
+        "ID": 428668,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428668"
+      },
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428679",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428679/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428679/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428679/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428681,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 171783,
+        "login": "",
+        "email": false,
+        "name": "Chris Till",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://cjtill.com",
+        "avatar_URL": "https://0.gravatar.com/avatar/c5c026eda0c03b4a38da5ceaad7433a0?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/c5c026eda0c03b4a38da5ceaad7433a0",
+        "ip_address": false
+      },
+      "date": "2023-03-20T19:17:25+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428681",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428681",
+      "content": "<p>That\u2019s fair enough. Happy to wait. I used to have a self-hosted site when I was a kid, but found it to be quite a lot of hassle in the end compared to wp.com, which I guess is the whole idea. And it definitely seems like a good idea to embrace this kind of open social system after what we\u2019ve seen happen at Twitter.</p>\n<p>Also, re-reading my comment, it comes across as a lot less polite than was intended. So I apologise for that.</p>\n",
+      "raw_content": "That\u2019s fair enough. Happy to wait. I used to have a self-hosted site when I was a kid, but found it to be quite a lot of hassle in the end compared to wp.com, which I guess is the whole idea. And it definitely seems like a good idea to embrace this kind of open social system after what we\u2019ve seen happen at Twitter.\n\nAlso, re-reading my comment, it comes across as a lot less polite than was intended. So I apologise for that.",
+      "status": "approved",
+      "parent": {
+        "ID": 428679,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428679"
+      },
+      "type": "comment",
+      "like_count": 1,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428681",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428681/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428681/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428681/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428672,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 233157196,
+        "login": "",
+        "email": false,
+        "name": "isabella1892",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://filminginromania.com/",
+        "avatar_URL": "https://0.gravatar.com/avatar/0f5a9101e996fec29ee0a84853752a6a?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/0f5a9101e996fec29ee0a84853752a6a",
+        "ip_address": false
+      },
+      "date": "2023-03-20T11:39:03+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428672",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428672",
+      "content": "<p>Awesome!</p>\n",
+      "raw_content": "Awesome!",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428672",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428672/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428672/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428672/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428677,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 216048251,
+        "login": "",
+        "email": false,
+        "name": "Anthony Friday",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://de8blog.wordpress.com",
+        "avatar_URL": "https://0.gravatar.com/avatar/6ff6c930f1804f8fd552d0dabd878c17?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/6ff6c930f1804f8fd552d0dabd878c17",
+        "ip_address": false
+      },
+      "date": "2023-03-20T17:52:00+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428677",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428677",
+      "content": "<p>This is a good plug in.. Thanks so much for this. </p>\n",
+      "raw_content": "This is a good plug in.. Thanks so much for this. ",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428677",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428677/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428677/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428677/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428693,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 233176337,
+        "login": "",
+        "email": false,
+        "name": "Bonneywakgari",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://bonneyartcom.wordpress.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/aaae4b6ea83519538de1dd8427be861b?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/aaae4b6ea83519538de1dd8427be861b",
+        "ip_address": false
+      },
+      "date": "2023-03-21T10:25:47+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428693",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428693",
+      "content": "<p>Best</p>\n",
+      "raw_content": "Best",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 3,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428693",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428693/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428693/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428693/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428820,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 209800614,
+        "login": "",
+        "email": false,
+        "name": "butterflylovers2023@outlook.com",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://www.classicrock.wordpress.com",
+        "avatar_URL": "https://2.gravatar.com/avatar/51e3e8195bcca87501a234dc687a44ba?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/51e3e8195bcca87501a234dc687a44ba",
+        "ip_address": false
+      },
+      "date": "2023-03-24T09:29:34+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428820",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428820",
+      "content": "<p>How do we add it onto our website?  How much does it cost? Is it only in beta? Etc&#8230;</p>\n",
+      "raw_content": "How do we add it onto our website?  How much does it cost? Is it only in beta? Etc...",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 2,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428820",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428820/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428820/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428820/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    },
+    {
+      "ID": 428821,
+      "post": {
+        "ID": 51399,
+        "title": "Making the Social Web a Better Place: ActivityPub for WordPress Joins the Automattic Family\u00a0",
+        "type": "post",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399"
+      },
+      "author": {
+        "ID": 1485049,
+        "login": "",
+        "email": false,
+        "name": "Fotis",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "https://support.wordpress.com/",
+        "avatar_URL": "https://1.gravatar.com/avatar/75418515f7e3f3ca9728a5653aa2edef?s=96&d=retro",
+        "profile_URL": "https://en.gravatar.com/75418515f7e3f3ca9728a5653aa2edef",
+        "ip_address": false
+      },
+      "date": "2023-03-24T11:04:16+00:00",
+      "URL": "http://en.blog.wordpress.com/2023/03/17/making-the-social-web-a-better-place-activitypub-for-wordpress-joins-the-automattic-family/#comment-428821",
+      "short_URL": "https://wp.me/pf2B5-dn1%23comment-428821",
+      "content": "<p>Hi, you can install it from the Plugins Marketplace. Here&#8217;s a direct link: <a href=\"https://wordpress.com/plugins/activitypub\" rel=\"nofollow ugc\">https://wordpress.com/plugins/activitypub</a><br />\nThe plugin itself is free. However, to install it on your WordPress.com site, you&#8217;ll need to upgrade to the Business or eCommerce plan. Those are the only plans that allow the installation of plugins.</p>\n",
+      "raw_content": "Hi, you can install it from the Plugins Marketplace. Here's a direct link: https://wordpress.com/plugins/activitypub\nThe plugin itself is free. However, to install it on your WordPress.com site, you'll need to upgrade to the Business or eCommerce plan. Those are the only plans that allow the installation of plugins.",
+      "status": "approved",
+      "parent": {
+        "ID": 428820,
+        "type": "comment",
+        "link": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428820"
+      },
+      "type": "comment",
+      "like_count": 1,
+      "i_like": false,
+      "meta": {
+        "links": {
+          "self": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428821",
+          "help": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428821/help",
+          "site": "https://public-api.wordpress.com/rest/v1.1/sites/3584907",
+          "post": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/posts/51399",
+          "replies": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428821/replies/",
+          "likes": "https://public-api.wordpress.com/rest/v1.1/sites/3584907/comments/428821/likes/"
+        }
+      },
+      "can_moderate": false,
+      "i_replied": false
+    }
+  ]
+}


### PR DESCRIPTION
There is a small change to the tested function. The `completion` block should be called after the changes are saved, but the current implementation calls the completion block in parallels with saving the changes. I don't think there would be any issue with the current implementation, but thought the change in this PR would make it more correct.

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
