### PR TITLE
Update blogging prompt card on pull-to-refresh

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -486,6 +486,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 self.sitePickerViewController?.blogDetailHeaderView.blog = blog
                 self.blogDashboardViewController?.reloadCardsLocally()
             }
+
+            /// Update today's prompt if the blog has blogging prompts enabled.
+            fetchPrompt(for: blog)
         }
 
         WPAnalytics.track(.mySitePullToRefresh, properties: [WPAppAnalyticsKeyTabSource: section.analyticsDescription])
@@ -961,7 +964,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         guard FeatureFlag.bloggingPrompts.enabled,
               let blog = blog,
               blog.isAccessibleThroughWPCom(),
-              let promptsService = BloggingPromptsService(blog: blog) else {
+              let promptsService = BloggingPromptsService(blog: blog),
+              let siteID = blog.dotComID?.intValue else {
+            return
+        }
+
+        let dashboardPersonalization = BlogDashboardPersonalizationService(siteID: siteID)
+        guard dashboardPersonalization.isEnabled(.prompts) else {
             return
         }
 


### PR DESCRIPTION
Fixes #18626 

## Description

This PR introduces two changes:
- Properly update the dashboard prompt card when a pull-to-refresh action is performed.
- Add an additional guard condition that skips fetching today's prompt when the prompt card has been disabled/hidden.

Since the prompt card already listens to managed object context changes, the remaining thing is to trigger the service to fetch today's prompt on pull-to-refresh.

## To Test

To test the pull-to-refresh behavior, apply this change temporarily in `BloggingPromptsService`'s `upsert` method that updates the prompt text to a random UUID string whenever a fetch is triggered:

```swift
    func upsert(with remotePrompts: [RemoteBloggingPrompt], completion: @escaping (Result<Void, Error>) -> Void) {
        if remotePrompts.isEmpty {
            completion(.success(()))
            return
        }

        // START TEST CODE
        let remotePrompts = remotePrompts.map { prompt in
            var mutablePrompt = prompt
            mutablePrompt.text = UUID().uuidString
            return mutablePrompt
        }
        // END TEST CODE

        ...
```

- Launch the Jetpack app and log in to your WordPress.com account.
- Switch to a site that has blogging prompts enabled.
- Perform a pull-to-refresh action.
- 🔎 Verify that the prompt text is updated.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
