### PR TITLE
Dashboard Cards: Activity log skeleton UI

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -5,6 +5,18 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
     private var blog: Blog?
     private weak var presentingViewController: BlogDashboardViewController?
 
+    // MARK: - Views
+
+    private lazy var cardFrameView: BlogDashboardCardFrameView = {
+        let frameView = BlogDashboardCardFrameView()
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        frameView.title = Strings.title
+        frameView.onEllipsisButtonTap = {
+            // FIXME: Track event
+        }
+        return frameView
+    }()
+
     // MARK: - Initializers
 
     override init(frame: CGRect) {
@@ -19,7 +31,8 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
     // MARK: - View setup
 
     private func setupView() {
-        // FIXME: setup view
+        contentView.addSubview(cardFrameView)
+        contentView.pinSubviewToAllEdges(cardFrameView, priority: .defaultHigh)
     }
 
     // MARK: - BlogDashboardCardConfigurable
@@ -43,5 +56,14 @@ extension DashboardActivityLogCardCell {
         }
 
         return true
+    }
+}
+
+extension DashboardActivityLogCardCell {
+
+    private enum Strings {
+        static let title = NSLocalizedString("activityLog.dashboard.card.title",
+                                             value: "Recent activity",
+                                             comment: "Title for the Activity Log dashboard card.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -32,3 +32,16 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
         // Expecting a list of type [Activity]
     }
 }
+
+extension DashboardActivityLogCardCell {
+
+    static func shouldShowCard(for blog: Blog) -> Bool {
+        guard RemoteFeatureFlag.activityLogDashboardCard.enabled(),
+              blog.supports(.activity),
+              !blog.isWPForTeams() else {
+            return false
+        }
+
+        return true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
+
+    private var blog: Blog?
+    private weak var presentingViewController: BlogDashboardViewController?
+
+    // MARK: - Initializers
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View setup
+
+    private func setupView() {
+        // FIXME: setup view
+    }
+
+    // MARK: - BlogDashboardCardConfigurable
+
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        self.blog = blog
+        self.presentingViewController = viewController
+
+        // FIXME: configure card using api response
+        // Expecting a list of type [Activity]
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -15,6 +15,7 @@ enum DashboardCard: String, CaseIterable {
     case todaysStats = "todays_stats"
     case draftPosts
     case scheduledPosts
+    case activityLog
     case nextPost = "create_next"
     case createPost = "create_first"
     case jetpackBadge
@@ -58,6 +59,8 @@ enum DashboardCard: String, CaseIterable {
             return BlogDashboardEmptyStateCell.self
         case .personalize:
             return BlogDashboardPersonalizeCardCell.self
+        case .activityLog:
+            return DashboardActivityLogCardCell.self
         }
     }
 
@@ -98,6 +101,8 @@ enum DashboardCard: String, CaseIterable {
             return false // Controlled manually based on other cards visibility
         case .personalize:
             return FeatureFlag.personalizeHomeTab.enabled
+        case .activityLog:
+            return DashboardActivityLogCardCell.shouldShowCard(for: blog) && shouldShowRemoteCard(apiResponse: apiResponse)
         }
     }
 
@@ -116,6 +121,8 @@ enum DashboardCard: String, CaseIterable {
             return apiResponse.hasNoDraftsOrScheduled && !apiResponse.hasPublished
         case .todaysStats:
             return true
+        case .activityLog:
+            return true // FIXME: hide card if there's no activities
         default:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -134,7 +134,8 @@ enum DashboardCard: String, CaseIterable {
         .draftPosts,
         .scheduledPosts,
         .blaze,
-        .prompts
+        .prompts,
+        .activityLog
     ]
 
     /// Includes all cards that should be fetched from the backend

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -52,6 +52,8 @@ private func makeKey(for card: DashboardCard) -> String? {
         return "prompts-enabled-site-settings"
     case .domainsDashboardCard:
         return "domains-dashboard-card-enabled-site-settings"
+    case .activityLog:
+        return "activity-log-card-enabled-site-settings"
     case .quickStart, .jetpackBadge, .jetpackInstall, .nextPost, .createPost, .failure, .ghost, .personalize, .empty:
         return nil
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -44,6 +44,8 @@ private extension DashboardCard {
             return NSLocalizedString("personalizeHome.dashboardCard.draftPosts", value: "Draft posts", comment: "Card title for the pesonalization menu")
         case .scheduledPosts:
             return NSLocalizedString("personalizeHome.dashboardCard.scheduledPosts", value: "Scheduled posts", comment: "Card title for the pesonalization menu")
+        case .activityLog:
+            return NSLocalizedString("personalizeHome.dashboardCard.activityLog", value: "Recent activity", comment: "Card title for the pesonalization menu")
         case .quickStart, .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .domainsDashboardCard, .empty:
             assertionFailure("\(self) card should not appear in the personalization menus")
             return "" // These cards don't appear in the personalization menus

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -303,7 +303,6 @@
 		0A9610F928B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
-		0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */; };
 		0C35FFF129CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */; };
 		0C35FFF229CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */; };
 		0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */; };
@@ -3746,6 +3745,8 @@
 		FA681F8A25CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA681F8825CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift */; };
 		FA6FAB3525EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */; };
 		FA6FAB4725EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */; };
+		FA70024C29DC3B5500E874FD /* DashboardActivityLogCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA70024B29DC3B5500E874FD /* DashboardActivityLogCardCell.swift */; };
+		FA70024D29DC3B5500E874FD /* DashboardActivityLogCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA70024B29DC3B5500E874FD /* DashboardActivityLogCardCell.swift */; };
 		FA73D7D6278D9E5D00DF24B3 /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
 		FA73D7E52798765B00DF24B3 /* SitePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7E42798765B00DF24B3 /* SitePickerViewController.swift */; };
 		FA73D7E62798765B00DF24B3 /* SitePickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7E42798765B00DF24B3 /* SitePickerViewController.swift */; };
@@ -5928,7 +5929,6 @@
 		0A69300A28B5AA5E00E98DE1 /* FullScreenCommentReplyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelTests.swift; sourceTree = "<group>"; };
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
-		0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModelTests.swift; sourceTree = "<group>"; };
 		0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardHelpers.swift; sourceTree = "<group>"; };
 		0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModelTests.swift; sourceTree = "<group>"; };
 		0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardEmptyStateCell.swift; sourceTree = "<group>"; };
@@ -9049,6 +9049,7 @@
 		FA681F8825CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreStatusFailedViewController.swift; sourceTree = "<group>"; };
 		FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderRelatedPostsSectionHeaderView.swift; sourceTree = "<group>"; };
 		FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderRelatedPostsSectionHeaderView.xib; sourceTree = "<group>"; };
+		FA70024B29DC3B5500E874FD /* DashboardActivityLogCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardActivityLogCardCell.swift; sourceTree = "<group>"; };
 		FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardViewController.swift; sourceTree = "<group>"; };
 		FA73D7E42798765B00DF24B3 /* SitePickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePickerViewController.swift; sourceTree = "<group>"; };
 		FA73D7E827987BA500DF24B3 /* SitePickerViewController+SiteIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePickerViewController+SiteIcon.swift"; sourceTree = "<group>"; };
@@ -13427,6 +13428,7 @@
 		8B4DDF23278F3AED0022494D /* Cards */ = {
 			isa = PBXGroup;
 			children = (
+				FA70024E29DC3B6100E874FD /* Activity Log */,
 				0118968D29D1EAC900D34BA9 /* Domains */,
 				FA98B61429A3B71E0071AAE8 /* Blaze */,
 				DCFC097129D3544600277ECB /* Domains */,
@@ -17525,6 +17527,14 @@
 			path = "Restore Status Failed";
 			sourceTree = "<group>";
 		};
+		FA70024E29DC3B6100E874FD /* Activity Log */ = {
+			isa = PBXGroup;
+			children = (
+				FA70024B29DC3B5500E874FD /* DashboardActivityLogCardCell.swift */,
+			);
+			path = "Activity Log";
+			sourceTree = "<group>";
+		};
 		FA73D7D7278D9E6300DF24B3 /* Blog Dashboard */ = {
 			isa = PBXGroup;
 			children = (
@@ -20652,6 +20662,7 @@
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				9874767321963D330080967F /* SiteStatsInformation.swift in Sources */,
 				738B9A5821B85CF20005062B /* TitleSubtitleHeader.swift in Sources */,
+				FA70024C29DC3B5500E874FD /* DashboardActivityLogCardCell.swift in Sources */,
 				17C64BD2248E26A200AF09D7 /* AppAppearance.swift in Sources */,
 				3F09CCA82428FF3300D00A8C /* ReaderTabViewController.swift in Sources */,
 				8B1E62D625758AAF009A0F80 /* ActivityTypeSelectorViewController.swift in Sources */,
@@ -25086,6 +25097,7 @@
 				837B49DE283C2AE80061A657 /* BloggingPromptSettingsReminderDays+CoreDataProperties.swift in Sources */,
 				FABB25BD2602FC2C00C8785C /* OtherAndTotalViewsCount+CoreDataProperties.swift in Sources */,
 				3FAF9CC326D02FC500268EA2 /* DomainsDashboardView.swift in Sources */,
+				FA70024D29DC3B5500E874FD /* DashboardActivityLogCardCell.swift in Sources */,
 				F48D44BB2989A9070051EAA6 /* ReaderSiteService.swift in Sources */,
 				FABB25BE2602FC2C00C8785C /* SettingsPickerViewController.swift in Sources */,
 				FABB25BF2602FC2C00C8785C /* WPTableImageSource.m in Sources */,


### PR DESCRIPTION
Fixes #20446 

## Description
Adds a skeleton activity log card to the dashboard.

<img src="https://user-images.githubusercontent.com/6711616/229799402-3fad5439-fff9-4b10-aeb1-f8f06f6692a9.png" width=200>


## How to test
0. Enable the Activity Log Dashboard Card remote feature flag via the debug menu
1. Switch to a site that has activity log enabled - the site must be a non-P2 Jetpack-connected site that supports the REST API, and the user must be an admin
2. ✅ The activity log card is displayed below the draft posts, scheduled posts, and stats cards
3. Switch to a site that doesn't have activity log enabled
4. ✅ The activity log card isn't displayed

## Regression Notes
6. Potential unintended areas of impact
n/a

7. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

8. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
