### PR TITLE
Workaround Core Data concurrency issues in the Gutenberg editor

### DIFF
--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -189,7 +189,7 @@ class MediaThumbnailService: NSObject {
             return
         }
 
-        let download = AuthenticatedImageDownload(url: imageURL, blog: media.blog, callbackQueue: callbackQueue, onSuccess: onCompletion, onFailure: onError)
+        let download = AuthenticatedImageDownload(url: imageURL, blogObjectID: media.blog.objectID, callbackQueue: callbackQueue, onSuccess: onCompletion, onFailure: onError)
 
         download.start()
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -576,11 +576,15 @@ extension GutenbergViewController {
 extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidGetRequestFetch(path: String, completion: @escaping (Result<Any, NSError>) -> Void) {
-        GutenbergNetworkRequest(path: path, blog: post.blog, method: .get).request(completion: completion)
+        workaroundCoreDataConcurrencyIssue(accessing: post) {
+            GutenbergNetworkRequest(path: path, blog: post.blog, method: .get).request(completion: completion)
+        }
     }
 
     func gutenbergDidPostRequestFetch(path: String, data: [String: AnyObject]?, completion: @escaping (Result<Any, NSError>) -> Void) {
-        GutenbergNetworkRequest(path: path, blog: post.blog, method: .post, data: data).request(completion: completion)
+        workaroundCoreDataConcurrencyIssue(accessing: post) {
+            GutenbergNetworkRequest(path: path, blog: post.blog, method: .post, data: data).request(completion: completion)
+        }
     }
 
     func editorDidAutosave() {
@@ -1071,7 +1075,9 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidRequestSendEventToHost(_ eventName: String, properties: [AnyHashable: Any]) -> Void {
-        WPAnalytics.trackBlockEditorEvent(eventName, properties: properties, blog: post.blog)
+        workaroundCoreDataConcurrencyIssue(accessing: post) {
+            WPAnalytics.trackBlockEditorEvent(eventName, properties: properties, blog: self.post.blog)
+        }
     }
 }
 
@@ -1181,12 +1187,14 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     }
 
     func gutenbergMediaSources() -> [Gutenberg.MediaSource] {
-        return [
-            post.blog.supports(.stockPhotos) ? .stockPhotos : nil,
-            post.blog.supports(.tenor) ? .tenor : nil,
-            .otherApps,
-            .allFiles,
-        ].compactMap { $0 }
+        workaroundCoreDataConcurrencyIssue(accessing: post) {
+            [
+                post.blog.supports(.stockPhotos) ? .stockPhotos : nil,
+                post.blog.supports(.tenor) ? .tenor : nil,
+                .otherApps,
+                .allFiles,
+            ].compactMap { $0 }
+        }
     }
 
     func gutenbergCapabilities() -> [Capabilities: Bool] {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -576,14 +576,14 @@ extension GutenbergViewController {
 extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidGetRequestFetch(path: String, completion: @escaping (Result<Any, NSError>) -> Void) {
-        workaroundCoreDataConcurrencyIssue(accessing: post) {
-            GutenbergNetworkRequest(path: path, blog: post.blog, method: .get).request(completion: completion)
+        post.managedObjectContext!.perform {
+            GutenbergNetworkRequest(path: path, blog: self.post.blog, method: .get).request(completion: completion)
         }
     }
 
     func gutenbergDidPostRequestFetch(path: String, data: [String: AnyObject]?, completion: @escaping (Result<Any, NSError>) -> Void) {
-        workaroundCoreDataConcurrencyIssue(accessing: post) {
-            GutenbergNetworkRequest(path: path, blog: post.blog, method: .post, data: data).request(completion: completion)
+        post.managedObjectContext!.perform {
+            GutenbergNetworkRequest(path: path, blog: self.post.blog, method: .post, data: data).request(completion: completion)
         }
     }
 
@@ -1075,7 +1075,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidRequestSendEventToHost(_ eventName: String, properties: [AnyHashable: Any]) -> Void {
-        workaroundCoreDataConcurrencyIssue(accessing: post) {
+        post.managedObjectContext!.perform {
             WPAnalytics.trackBlockEditorEvent(eventName, properties: properties, blog: self.post.blog)
         }
     }

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -5,7 +5,7 @@ class EditorGutenbergTests: XCTestCase {
     private var editorScreen: BlockEditorScreen!
 
     override func setUpWithError() throws {
-        setUpTestSuite(crashOnCoreDataConcurrencyIssues: false)
+        setUpTestSuite()
 
         _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = try EditorFlow


### PR DESCRIPTION
## Goal
Enabling the Core Data concurrency debug option ([the `-com.apple.CoreData.ConcurrencyDebug 1` launch argument](https://developer.apple.com/documentation/coredata/synchronizing_a_local_store_to_the_cloud#4039168)) will greatly help us catching Core Data related bugs during development. I have been fixing relevant issues in the app for a while. However, even though I tried to find and resolve these concurrency issues, there is _nothing_ preventing new issues from appearing again. So one of my ultimate goals of the Core Data Modernization project is enabling this launch argument in both WordPress and Jetpack schemes.

## Issue

One major "side effect" with this launch argument is, the app crashes upon encountering Core Data concurrency issues. This crash of course will become a blocker to our day-to-day feature development work, which isn't ideal. And resolving the Core Data concurrency issues properly may require relatively large refactor. That's why I propose a temporary workaround in this PR so that we can enable the launch argument.

Once the launch argument is enabled (for which I'll open a dedicated PR), developers may see seemly unrelated crash with backtrace looking like this:

```
* thread #35, queue = 'com.facebook.react.RNReactNativeGutenbergBridgeQueue', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1844751b8)
    frame #0: 0x00000001844751b8 CoreData`_PFAssertSafeMultiThreadedAccess_impl + 520
    frame #1: 0x0000000184474810 CoreData`_pvfk_header + 92
    frame #2: 0x000000018446f520 CoreData`_sharedIMPL_pvfk_core + 28
  * frame #3: 0x00000001011a3770 Jetpack`GutenbergViewController.gutenbergDidGetRequestFetch(path="/wp/v2/blocks?per_page=100&_locale=user", completion=0x00000001024f6a70 Jetpack`partial apply forwarder for closure #1 (Swift.Result<Any, __C.NSError>) -> () in Gutenberg.RNReactNativeGutenbergBridge.fetchRequest(_: Swift.String, resolver: (Swift.Optional<Any>) -> (), rejecter: (Swift.Optional<Swift.String>, Swift.Optional<Swift.String>, Swift.Optional<Swift.Error>) -> ()) -> () at <compiler-generated>, self=0x0000000127054e00) at GutenbergViewController.swift:580:65
    frame #4: 0x00000001011ac070 Jetpack`protocol witness for GutenbergBridgeDelegate.gutenbergDidGetRequestFetch(path:completion:) in conformance GutenbergViewController at <compiler-generated>:0
```

## Resolution

It's of course _highly recommended_ to investigate the crash and find a proper fix, to make sure the `NSManagedObject` is used in the context it's bound to. But I can totally see that the developer experiences the crash might not be familiar with the crash site. And, that's what this workaround is for, to temporarily resolve the crash, by wrapping the crashing code into a `workaroundCoreDataConcurrencyIssue` function call. Ideally, the developers who work on the crash site would be informed about this crash, so that they can choose to investigate further.

As mentioned in this new workaround function's API doc, this workaround does not apply to release builds, since it's meant for workaround a crash that's only reproducible when launching from Xcode.

This PR happens to contain a "proper fix" of Core Data concurrency issue, which is in `AuthenticatedImageDownload`. The class access a `Blog` instance directly, in a random background thread managed by Foundation's `Operation` implementation. The fix is storing `Blog.objectID` (instead of the instance itself) as instance property and re-query the `Blog` instance within a queue managed by a Core Data context object.

## Regression Notes

I don't think regression is needed, since the new code does not change the app's behaviour.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
