### PR TITLE
Dashboard cards: Activity log context menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -135,17 +135,6 @@ class BaseActivityListViewController: UIViewController, TableViewContainer, Immu
         fatalError("init(coder:) has not been implemented")
     }
 
-    @objc convenience init?(blog: Blog) {
-        precondition(blog.dotComID != nil)
-        guard let siteRef = JetpackSiteRef(blog: blog) else {
-            return nil
-        }
-
-
-        let isFreeWPCom = blog.isHostedAtWPcom && !blog.hasPaidPlan
-        self.init(site: siteRef, store: StoreContainer.shared.activity, isFreeWPCom: isFreeWPCom)
-    }
-
     // MARK: - View lifecycle
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -31,6 +31,16 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    @objc convenience init?(blog: Blog) {
+        precondition(blog.dotComID != nil)
+        guard let siteRef = JetpackSiteRef(blog: blog) else {
+            return nil
+        }
+
+        let isFreeWPCom = blog.isHostedAtWPcom && !blog.hasPaidPlan
+        self.init(site: siteRef, store: StoreContainer.shared.activity, isFreeWPCom: isFreeWPCom)
+    }
+
     // MARK: - View lifecycle
 
     override func viewDidLoad() {


### PR DESCRIPTION
Fixes #20450

## Description
- Design ref: YSMw2nbFAgPpjZLLbYvTfT-fi-96_3834
- Adds a context menu to the ellipsis
- Adds a "All activity" action that navigates to the activity log on tap
- Adds a "Hide this" action that hides the activity log dashboard card

## How to test
1. Run the Jetpack app
2. Enable the Activity Log Card Remote Feature Flag from the debug menu
3. Enable the Personalize Home Tab Feature Flag from the debug menu
4. Navigate to the dashboard
5. Tap on the ellipsis icon of the Activity Log card
6. ✅ A context menu is displayed with  "All activity" and "Hide this" actions
7. Tap on "All activity"
8. ✅ The Activity Log screen is displayed
9. Navigate back to the dashboard
10. Tap on the ellipsis icon of the Activity Log card then tap on "Hide this"
11. ✅ The Activity Log card is hidden
12. Tap on "Personalize your home tab"
13. ✅ The Activity Log card is disabled
14. Enable the Activity Log card and close the screen
15. ✅ The Activity Log card is displayed


https://user-images.githubusercontent.com/6711616/230075518-ab533d45-164d-4e40-958c-11a00f0202f6.mp4


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.