### PR TITLE
Remove personalizing dashboard from release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
 * [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
-* [**] Add a "Personalize Home Tab" button to the bottom of the Home tab that allows changing cards visibility. [#20369]
 * [**] [internal] Refactored Google SignIn implementation to not use the Google SDK [#20128]
 
 22.0

--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -1,3 +1,2 @@
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
-* [**] Add a "Personalize Home Tab" button to the bottom of the Home tab that allows changing cards visibility. [#20369]


### PR DESCRIPTION
@Gio2018, today @tiagomar called attention to the personalize dashboard release notes in 22.1. This feature is still a work-in-progress, so this shouldn't be in 22.1's release notes. Instead we can add it back once we're confident which release this will ship in.

Related Slack discussion to remove this from the final release notes: p1680719118039509/1680571332.933819-slack-C02S5P5MBGA

## Regression Notes
1. Potential unintended areas of impact

Non-code change, no risk.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Non-code change, no testing required.

3. What automated tests I added (or what prevented me from doing so)

Non-code change, automated testing not applicable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.