### PR TITLE
PoC: Use a HTML file served by WireMock to test different types of links

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/__files/links.html
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/__files/links.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>TESTING LINKS</title>
+</head>
+<body>
+    <h1>TESTING LINKS</h1>
+    <h2>Web Links</h2>
+    <p><a href="https://wordpress.com/stats">Stats</a></p>
+    <p><a href="https://wordpress.com/read">Reader</a></p>
+    <p><a href="https://wordpress.com/notifications">Notifications</a></p>
+    <p><a href="https://wordpress.com/me">Me</a></p>
+</body>
+</html>

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/files.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/files.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPattern": "/.*([a-z0-9]*\\.[a-z]{2,6})"
+        "urlPattern": "/.*([A-z0-9]*\\.[A-z]{1,6})"
     },
     "response": {
         "status": 200,

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/files.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/files.json
@@ -5,7 +5,7 @@
     },
     "response": {
         "status": 200,
-        "body": "../__files{{request.url}}",
+        "bodyFileName": "../__files{{request.url}}",
         "headers": {
             "Content-Type": "text/html"
         }

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/files.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/files.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": "/.*([a-z0-9]*\\.[a-z]{2,6})"
+    },
+    "response": {
+        "status": 200,
+        "body": "../__files{{request.url}}",
+        "headers": {
+            "Content-Type": "text/html"
+        }
+    }
+}


### PR DESCRIPTION
### Description
This is a PoC for using a HTML page served by WireMock with different types of links for automating universal and deep links tests.

Under `API-Mocks/WordPressMocks/src/main/assets/mocks/` we have a couple folders, `__files` and `mappings`, we use `mappings` to store our regular mock files in json format while `__files` would  serve.... files and any file under this folder would be accessed by the relative path, i.e. to reach `__files/hello-world.html` we can navigate to `localhost:8282/hello-world.html` an so on. In this PR's case we should visit `localhost:8282/links.html`.

Despite the files being properly saved this way, we would still see unmatched requests on WireMock logs like:

```
2023-04-06 07:52:37.644 
                                               Request was not matched
                                               =======================

-----------------------------------------------------------------------------------------------------------------------
| Closest stub                                             | Request                                                  |
-----------------------------------------------------------------------------------------------------------------------
                                                           |
GET                                                        | GET
/wpcom/v2/plans/mobile                                     | /links.html                                         <<<<< URL does not match
                                                           |
                                                           |
-----------------------------------------------------------------------------------------------------------------------
```

To deal with that I added a regular json mock file to capture file requests and referencing them in the response, using the `bodyFileName` property.

#### Demo video
  <video width="300" src="https://user-images.githubusercontent.com/42008628/230388913-0c325008-56df-491e-853e-ae880f935f27.mov
">

### How to test
1. `rake mocks`
2. Choose a UI Test and add a breakpoint right after the log in.
3. Run the test and wait for it to reach the breakpoint.
4. Open Safari and visit `localhost:8282/links.html`.
5. Tap the links in on the web pages and notice the redirection to the app.