### PR TITLE
Fix Reader Crash on iPad after tapping more/share button in the details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1049,7 +1049,11 @@ private extension ReaderDetailViewController {
 
     func barButtonItem(with image: UIImage, action: Selector) -> UIBarButtonItem {
         let image = image.withRenderingMode(.alwaysTemplate)
-        return UIBarButtonItem(image: image, style: .plain, target: self, action: action)
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 44.0, height: image.size.height))
+        button.setImage(image, for: UIControl.State())
+        button.addTarget(self, action: action, for: .touchUpInside)
+
+        return UIBarButtonItem(customView: button)
     }
 
     /// Checks if the view is visible in the viewport.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -79,13 +79,29 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     /// Listens for contentOffset changes to track when the user scrolls
     private var scrollViewObserver: NSKeyValueObservation?
 
+    /// Flag indicating whether the navigation bar appearance needs restoration when the view disappears. Default is `false`.
+    ///
+    /// Flag changes to `true` when this view changes the navigation bar tint color. In other words, when the `navBarTintColor` setter is called.
+    private var navigationBarAppearanceNeedsRestoration = false
+
+    /// The original navigation bar tint color.
+    ///
+    /// This property is used to restore the navigation bar tint color to its original value.
+    private var previousNavBarTintColor: UIColor?
+
     /// The navigation bar tint color changes depending on whether the featured image is visible or not.
     private var navBarTintColor: UIColor? {
         get {
             return navigationBar?.tintColor
         }
         set(newValue) {
-            self.navigationItem?.setTintColor(useCompatibilityMode ? .textInverted : newValue)
+            // Ideally, we should be setting the navigationItem's tint color, but for some reason that didn't work.
+            // self.navigationItem?.setTintColor(.red)
+            if previousNavBarTintColor == nil {
+                self.previousNavBarTintColor = navigationBar?.tintColor
+            }
+            self.navigationBar?.tintColor = useCompatibilityMode ? .textInverted : newValue
+            self.navigationBarAppearanceNeedsRestoration = true
         }
     }
 
@@ -110,6 +126,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     func viewWillDisappear() {
         scrollViewObserver?.invalidate()
         scrollViewObserver = nil
+        restoreNavigationBarAppearanceIfNeeded()
     }
 
     // MARK: - Public: Configuration
@@ -286,6 +303,13 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
         updateNavigationBar(with: offsetY)
     }
 
+    private func restoreNavigationBarAppearanceIfNeeded() {
+        guard navigationBarAppearanceNeedsRestoration else {
+            return
+        }
+        self.navigationBar?.tintColor = previousNavBarTintColor
+    }
+
     private func hideLoading() {
         UIView.animate(withDuration: 0.3, animations: {
             self.loadingView.alpha = 0.0
@@ -379,7 +403,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     private func reset() {
-        navigationItem?.setTintColor(useCompatibilityMode ? .appBarTint : Styles.endTintColor)
+        navigationBar?.tintColor = useCompatibilityMode ? .appBarTint : Styles.endTintColor
 
         resetStatusBarStyle()
         heightConstraint.constant = 0
@@ -436,21 +460,5 @@ extension ReaderDetailFeaturedImageView: UIGestureRecognizerDelegate {
 
         /// Do not accept the touch if outside the featured image view
         return isOutsideView == false
-    }
-}
-
-// MARK: - Private: Navigation Item Extension
-
-private extension UINavigationItem {
-
-    func setTintColor(_ color: UIColor?) {
-        self.leftBarButtonItem?.tintColor = color
-        self.rightBarButtonItem?.tintColor = color
-        self.leftBarButtonItems?.forEach {
-            $0.tintColor = color
-        }
-        self.rightBarButtonItems?.forEach {
-            $0.tintColor = color
-        }
     }
 }


### PR DESCRIPTION
Fixes #20487

This reverts commit 78b9db9d58cac91cce49825c3ba28c148bf0bb70 made in https://github.com/wordpress-mobile/WordPress-iOS/pull/20363

## Test

1. Launch Jetpack App on iPad
2. Select the Reader tab
3. Select any post
4. Click the top right ellipsis "more" or share button
5. No crash should happen

## Regression Notes
1. Potential unintended areas of impact

Breaking what the last commit of https://github.com/wordpress-mobile/WordPress-iOS/pull/20363 was trying to address [Update the navigation bar tintColor using its navigation item](https://github.com/wordpress-mobile/WordPress-iOS/pull/20363/commits/78b9db9d58cac91cce49825c3ba28c148bf0bb70). Although the tint color seems to work for me.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
