### PR TITLE
Fix: App crashes when tapping more and share button in the Reader Details screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
 * [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
 * [**] Add a "Personalize Home Tab" button to the bottom of the Home tab that allows changing cards visibility. [#20369]
+* [*] [Reader] Fix an issue that was causing the app to crash when tapping the More or Share buttons in Reader Detail screen. [#20490]
 
 22.0
 -----

--- a/WordPress/Classes/Extensions/UIPopoverPresentationController+PopoverAnchor.swift
+++ b/WordPress/Classes/Extensions/UIPopoverPresentationController+PopoverAnchor.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+extension UIPopoverPresentationController {
+
+    enum PopoverAnchor {
+        case view(UIView)
+        case barButtonItem(UIBarButtonItem)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -44,6 +44,10 @@ import SVProgressHUD
     }
 
     @objc func sharePost(_ title: String, summary: String, link: String?, fromView anchorView: UIView, inViewController viewController: UIViewController) {
+        sharePost(title, summary: summary, link: link, fromAnchor: .view(anchorView), inViewController: viewController)
+    }
+
+    private func sharePost(_ title: String, summary: String, link: String?, fromAnchor anchor: PopoverAnchor, inViewController viewController: UIViewController) {
         let controller = shareController(
             title,
             summary: summary,
@@ -59,8 +63,13 @@ import SVProgressHUD
         viewController.present(controller, animated: true)
         if let presentationController = controller.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
-            presentationController.sourceView = anchorView
-            presentationController.sourceRect = anchorView.bounds
+            switch anchor {
+            case .barButtonItem(let item):
+                presentationController.barButtonItem = item
+            case .view(let anchorView):
+                presentationController.sourceView = anchorView
+                presentationController.sourceRect = anchorView.bounds
+            }
         }
     }
 
@@ -81,6 +90,16 @@ import SVProgressHUD
             summary: post.contentPreviewForDisplay(),
             link: post.permaLink,
             fromView: anchorView,
+            inViewController: viewController)
+    }
+
+    func shareReaderPost(_ post: ReaderPost, fromAnchor anchor: PopoverAnchor, inViewController viewController: UIViewController) {
+
+        sharePost(
+            post.titleForDisplay(),
+            summary: post.contentPreviewForDisplay(),
+            link: post.permaLink,
+            fromAnchor: anchor,
             inViewController: viewController)
     }
 
@@ -114,4 +133,6 @@ import SVProgressHUD
         }
 
     }
+
+    typealias PopoverAnchor = UIPopoverPresentationController.PopoverAnchor
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -400,7 +400,7 @@ class ReaderDetailCoordinator {
 
     /// Show a menu with options for the current post's site
     ///
-    private func showMenu(_ anchorView: UIView) {
+    private func showMenu(_ anchor: UIPopoverPresentationController.PopoverAnchor) {
         guard let post = post,
               let context = post.managedObjectContext,
               let viewController = viewController,
@@ -415,6 +415,7 @@ class ReaderDetailCoordinator {
             context: context,
             readerTopic: readerTopic,
             anchor: anchorView,
+            anchor: anchor,
             vc: viewController,
             source: ReaderPostMenuSource.details,
             followCommentsService: followCommentsService
@@ -680,8 +681,12 @@ extension ReaderDetailCoordinator: ReaderDetailHeaderViewDelegate {
         previewSite()
     }
 
+    func didTapMenuButton(_ sender: UIBarButtonItem) {
+        showMenu(.barButtonItem(sender))
+    }
+
     func didTapMenuButton(_ sender: UIView) {
-        showMenu(sender)
+        showMenu(.view(sender))
     }
 
     func didTapTagButton() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -213,11 +213,17 @@ class ReaderDetailCoordinator {
     /// Share the current post
     ///
     func share(fromView anchorView: UIView) {
+        self.share(fromAnchor: .view(anchorView))
+    }
+
+    /// Share the current post
+    ///
+    func share(fromAnchor anchor: UIPopoverPresentationController.PopoverAnchor) {
         guard let post = post, let view = viewController else {
             return
         }
 
-        sharingController.shareReaderPost(post, fromView: anchorView, inViewController: view)
+        sharingController.shareReaderPost(post, fromAnchor: anchor, inViewController: view)
 
         WPAnalytics.trackReader(.readerSharedItem)
     }
@@ -414,7 +420,6 @@ class ReaderDetailCoordinator {
             post: post,
             context: context,
             readerTopic: readerTopic,
-            anchor: anchorView,
             anchor: anchor,
             vc: viewController,
             source: ReaderPostMenuSource.details,

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -708,7 +708,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         coordinator?.share(fromView: sender)
     }
 
-    @objc func didTapMenuButton(_ sender: UIButton) {
+    @objc func didTapMenuButton(_ sender: UIBarButtonItem) {
         coordinator?.didTapMenuButton(sender)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -704,15 +704,15 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Ask the coordinator to present the share sheet
     ///
-    @objc func didTapShareButton(_ sender: UIButton) {
-        coordinator?.share(fromView: sender)
+    @objc func didTapShareButton(_ sender: UIBarButtonItem) {
+        coordinator?.share(fromAnchor: .barButtonItem(sender))
     }
 
     @objc func didTapMenuButton(_ sender: UIBarButtonItem) {
         coordinator?.didTapMenuButton(sender)
     }
 
-    @objc func didTapBrowserButton(_ sender: UIButton) {
+    @objc func didTapBrowserButton(_ sender: UIBarButtonItem) {
         coordinator?.openInBrowser()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
@@ -13,6 +13,17 @@ final class ReaderMenuAction {
                  source: ReaderPostMenuSource,
                  followCommentsService: FollowCommentsService
     ) {
+        self.execute(post: post, context: context, anchor: .view(anchor), vc: vc, source: source, followCommentsService: followCommentsService)
+    }
+
+    func execute(post: ReaderPost,
+                 context: NSManagedObjectContext,
+                 readerTopic: ReaderAbstractTopic? = nil,
+                 anchor: ReaderShowMenuAction.PopoverAnchor,
+                 vc: UIViewController,
+                 source: ReaderPostMenuSource,
+                 followCommentsService: FollowCommentsService
+    ) {
         let siteTopic: ReaderSiteTopic? = post.isFollowing ? (try? ReaderSiteTopic.lookup(withSiteID: post.siteID, in: context)) : nil
 
         ReaderShowMenuAction(loggedIn: isLoggedIn).execute(

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
@@ -1,11 +1,15 @@
 /// Encapsulates a command share a post
 final class ReaderShareAction {
     func execute(with post: ReaderPost, context: NSManagedObjectContext, anchor: UIView, vc: UIViewController) {
+        self.execute(with: post, context: context, anchor: .view(anchor), vc: vc)
+    }
+
+    func execute(with post: ReaderPost, context: NSManagedObjectContext, anchor: UIPopoverPresentationController.PopoverAnchor, vc: UIViewController) {
         let postID = post.objectID
         if let post: ReaderPost = ReaderActionHelpers.existingObject(for: postID, in: context) {
             let sharingController = PostSharingController()
 
-            sharingController.shareReaderPost(post, fromView: anchor, inViewController: vc)
+            sharingController.shareReaderPost(post, fromAnchor: anchor, inViewController: vc)
             WPAnalytics.trackReader(.itemSharedReader, properties: ["blogId": post.siteID as Any])
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -11,7 +11,7 @@ final class ReaderShowMenuAction {
                  context: NSManagedObjectContext,
                  siteTopic: ReaderSiteTopic? = nil,
                  readerTopic: ReaderAbstractTopic? = nil,
-                 anchor: UIView,
+                 anchor: PopoverAnchor,
                  vc: UIViewController,
                  source: ReaderPostMenuSource,
                  followCommentsService: FollowCommentsService
@@ -194,8 +194,13 @@ final class ReaderShowMenuAction {
             vc.present(alertController, animated: true)
             if let presentationController = alertController.popoverPresentationController {
                 presentationController.permittedArrowDirections = .any
-                presentationController.sourceView = anchor
-                presentationController.sourceRect = anchor.bounds
+                switch anchor {
+                case .barButtonItem(let item):
+                    presentationController.barButtonItem = item
+                case .view(let anchor):
+                    presentationController.sourceView = anchor
+                    presentationController.sourceRect = anchor.bounds
+                }
             }
         } else {
             vc.present(alertController, animated: true)
@@ -283,4 +288,8 @@ final class ReaderShowMenuAction {
         let userInfo: [String: Any] = [ReaderNotificationKeys.post: post, ReaderNotificationKeys.result: result]
         center.post(name: .ReaderUserBlockingDidEnd, object: nil, userInfo: userInfo)
     }
+
+    // MARK: - Types
+
+    typealias PopoverAnchor = UIPopoverPresentationController.PopoverAnchor
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3584,6 +3584,8 @@
 		F49B9A08293A21F4000CEFCE /* MigrationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A07293A21F4000CEFCE /* MigrationEvent.swift */; };
 		F49B9A09293A3243000CEFCE /* MigrationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A07293A21F4000CEFCE /* MigrationEvent.swift */; };
 		F49B9A0A293A3249000CEFCE /* MigrationAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */; };
+		F49D7BEB29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */; };
+		F49D7BEC29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */; };
 		F4BECD1B288EE5220078391A /* SuggestionsViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */; };
 		F4BECD1C288EE5220078391A /* SuggestionsViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */; };
 		F4CBE3D429258AE1004FFBB6 /* MeHeaderViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB0ACC292587D500F651F9 /* MeHeaderViewConfiguration.swift */; };
@@ -8907,6 +8909,7 @@
 		F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
 		F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F49B9A07293A21F4000CEFCE /* MigrationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationEvent.swift; sourceTree = "<group>"; };
+		F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPopoverPresentationController+PopoverAnchor.swift"; sourceTree = "<group>"; };
 		F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuggestionsViewModelType.swift; sourceTree = "<group>"; };
 		F4CBE3D329258AD6004FFBB6 /* MeHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeHeaderView.h; sourceTree = "<group>"; };
 		F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewControllerConfiguration.swift; sourceTree = "<group>"; };
@@ -14989,6 +14992,7 @@
 				FA20751327A86B73001A644D /* UIScrollView+Helpers.swift */,
 				C7AFF873283C0ADC000E01DF /* UIApplication+Helpers.swift */,
 				C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */,
+				F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -21745,6 +21749,7 @@
 				BE87E1A01BD4054F0075D45B /* WP3DTouchShortcutCreator.swift in Sources */,
 				742B7F3A209CB2B6002E3CC9 /* GIFPlaybackStrategy.swift in Sources */,
 				8B6214E327B1B2F3001DF7B6 /* BlogDashboardService.swift in Sources */,
+				F49D7BEB29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift in Sources */,
 				F1D8C6E926BA94DF002E3323 /* WordPressBackgroundTaskEventHandler.swift in Sources */,
 				D8212CC520AA83F9008E8AE8 /* ReaderCommentAction.swift in Sources */,
 				FAD954B825B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift in Sources */,
@@ -23923,6 +23928,7 @@
 				FABB22512602FC2C00C8785C /* TabbedTotalsCell.swift in Sources */,
 				B084E61F27E3B79F007BF7A8 /* SiteIntentStep.swift in Sources */,
 				FABB22522602FC2C00C8785C /* ActivityTableViewCell.swift in Sources */,
+				F49D7BEC29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift in Sources */,
 				FABB22532602FC2C00C8785C /* BlogDetailsViewController+FancyAlerts.swift in Sources */,
 				FABB22542602FC2C00C8785C /* StoriesIntroDataSource.swift in Sources */,
 				FABB22552602FC2C00C8785C /* StoreContainer.swift in Sources */,


### PR DESCRIPTION
Fixes #20487

## Description

This PR fixed a bug that crashed the app when the user taps the more or share button in the Reader Details screen. This bug is only affecting iPad users.

## Root Cause

This is the exact change in https://github.com/wordpress-mobile/WordPress-iOS/pull/20363 that caused the crash.

```diff
    func barButtonItem(with image: UIImage, action: Selector) -> UIBarButtonItem {
        let image = image.withRenderingMode(.alwaysTemplate)
-      let button = UIButton(frame: CGRect(x: 0, y: 0, width: 44.0, height: image.size.height))
-      button.setImage(image, for: UIControl.State())
-      button.addTarget(self, action: action, for: .touchUpInside)
- 
-       return UIBarButtonItem(customView: button)
+      return UIBarButtonItem(image: image, style: .plain, target: self, action: action)
    }
```

The code above removes usage of `UIButton` when creating a `UIBarButtonItem`, so the `action` param is now passed to a `UIBarButtonItem` instead of a `UIButton`. But the `sender` param of the action handlers was not updated accordingly.

```swift
// This method can be found in "ReaderDetailViewController.swift".
@objc private func didTapMenuButton(_ sender: UIButton) {
   // ...
}
```
The type of `sender` param type should be `UIBarButtonItem` instead of `UIButton`. The compiler didn't catch this, and I didn't either.

At runtime, however, the `sender` param type was `UIBarButtonItem`, which passed through several methods until it reached the following code.

```swift
// Can be found in `ReaderShowMenuAction.swift` and `PostSharingController.swift`.
if let presentationController = alertController.popoverPresentationController {
    presentationController.permittedArrowDirections = .any
    presentationController.sourceView = anchor
    presentationController.sourceRect = anchor.bounds
}
```
The `presentationController.sourceView`'s type is `UIView` and `anchor`'s type at runtime is `UIBarButtonItem`, thus the crash.

## Screenshots

| More Button | Share Button |
| ------------ | -------------- |
| ![](https://user-images.githubusercontent.com/9609223/230513978-8f98f39e-22bc-4ced-8457-7ea197516388.png) | ![](https://user-images.githubusercontent.com/9609223/230513984-351ca370-3872-4fc4-94df-4dc1b3e2d92a.png) |

## Test Instructions

Please perform the following tests on iPhone and iPad.

1. Install the Jetpack app and log in.
2. Head to **Reader > Following** or **Reader > Discover**
3. Tap the More Button on any post.
4. **Expect** a sheet to show up on iPhone and a popover to show up on iPad.
5. Tap the post itself to reach the Reader Detail screen.
6. Tap the More button.
7. **Expect** a sheet/popover to appear.
8. Tap the Share button.
9. **Expect** a sheet/popover to appear.

## Regression Notes
1. Potential unintended areas of impact
Double check the More and Share buttons work as expected in Reader Details and Reader Following / Discover screens.

| | Reader Details | Reader Following & Discover Feeds |
| - | -------------- | ----------------------------------- |
| iPad | ✅ | ✅ |
| iPhone | ✅ | ✅ |

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
