### PR TITLE
My Site Dashboard: Fixes the dashboard not loading

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -152,7 +152,7 @@ enum DashboardCard: String, CaseIterable {
         case todaysStats = "todays_stats"
         case posts
         case pages
-        case activity
+//        case activity // TODO: Uncomment this when activity log support is added to the endpoint
     }
 }
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -45,7 +45,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
         service.fetch(blog: blog) { _ in
             XCTAssertEqual(self.remoteServiceMock.didCallWithBlogID, self.wpComID)
-            XCTAssertEqual(self.remoteServiceMock.didRequestCards, ["todays_stats", "posts", "pages", "activity"])
+            XCTAssertEqual(self.remoteServiceMock.didRequestCards, ["todays_stats", "posts", "pages"])
             expect.fulfill()
         }
 

--- a/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
@@ -309,7 +309,7 @@ class DashboardCardTests: CoreDataTestCase {
         let identifiers = DashboardCard.RemoteDashboardCard.allCases.map { $0.rawValue }
 
         // Then
-        XCTAssertEqual(identifiers, ["todays_stats", "posts", "pages", "activity"])
+        XCTAssertEqual(identifiers, ["todays_stats", "posts", "pages"])
     }
 
     // MARK: Helpers


### PR DESCRIPTION
Fixes #20491

## Description

Fixes an issue where dashboard cards are not loaded on startup. This was caused by marking the activity logs card as a remote card while it was not yet supported by the endpoint. Changes in this PR should be reverted once the endpoint is updated.

## Testing Instructions

1. Fresh install the Jetpack app
2. Log in
3. Make sure the dashboard loads normally

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.