### PR TITLE
Dashboard Cards: Configure Pages card context menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
@@ -38,8 +38,50 @@ final class DashboardPagesCardCell: DashboardCollectionViewCell {
         self.blog = blog
         self.presentingViewController = viewController
 
+        configureContextMenu(blog: blog)
+
         // FIXME: configure card using api response
         // Expecting a list of pages
+    }
+
+    // MARK: Context Menu
+
+    private func configureContextMenu(blog: Blog) {
+        cardFrameView.onEllipsisButtonTap = {
+            BlogDashboardAnalytics.trackContextualMenuAccessed(for: .pages)
+        }
+        cardFrameView.ellipsisButton.showsMenuAsPrimaryAction = true
+
+        let children = [makeAllPagesAction(blog: blog), makeHideCardAction(blog: blog)].compactMap { $0 }
+
+        cardFrameView.ellipsisButton.menu = UIMenu(title: String(), options: .displayInline, children: children)
+    }
+
+    private func makeAllPagesAction(blog: Blog) -> UIMenuElement {
+        let allPagesAction = UIAction(title: Strings.allPages,
+                                      image: Style.allPagesImage,
+                                      handler: { _ in self.showPagesList(for: blog) })
+
+        // Wrap the activity action in a menu to display a divider between the activity action and hide this action.
+        // https://developer.apple.com/documentation/uikit/uimenu/options/3261455-displayinline
+        let allPagesSubmenu = UIMenu(title: String(), options: .displayInline, children: [allPagesAction])
+        return allPagesSubmenu
+    }
+
+    private func makeHideCardAction(blog: Blog) -> UIMenuElement? {
+        guard let siteID = blog.dotComID?.intValue else {
+            return nil
+        }
+        return BlogDashboardHelpers.makeHideCardAction(for: .pages, siteID: siteID)
+    }
+
+    // MARK: Actions
+
+    private func showPagesList(for blog: Blog) {
+        guard let presentingViewController else {
+            return
+        }
+        PageListViewController.showForBlog(blog, from: presentingViewController)
     }
 }
 
@@ -58,8 +100,15 @@ extension DashboardPagesCardCell {
 extension DashboardPagesCardCell {
 
     private enum Strings {
-        static let title = NSLocalizedString("pages.dashboard.card.title",
+        static let title = NSLocalizedString("dashboardCard.Pages.title",
                                              value: "Pages",
                                              comment: "Title for the Pages dashboard card.")
+        static let allPages = NSLocalizedString("dashboardCard.Pages.contextMenu.allPages",
+                                                   value: "All Pages",
+                                                   comment: "Title for an action that opens the full pages list.")
+    }
+
+    private enum Style {
+        static let allPagesImage = UIImage(systemName: "doc.text")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
@@ -104,7 +104,7 @@ extension DashboardPagesCardCell {
                                              value: "Pages",
                                              comment: "Title for the Pages dashboard card.")
         static let allPages = NSLocalizedString("dashboardCard.Pages.contextMenu.allPages",
-                                                   value: "All Pages",
+                                                   value: "All pages",
                                                    comment: "Title for an action that opens the full pages list.")
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
@@ -62,7 +62,7 @@ final class DashboardPagesCardCell: DashboardCollectionViewCell {
                                       image: Style.allPagesImage,
                                       handler: { _ in self.showPagesList(for: blog) })
 
-        // Wrap the activity action in a menu to display a divider between the activity action and hide this action.
+        // Wrap the pages action in a menu to display a divider between the pages action and hide this action.
         // https://developer.apple.com/documentation/uikit/uimenu/options/3261455-displayinline
         let allPagesSubmenu = UIMenu(title: String(), options: .displayInline, children: [allPagesAction])
         return allPagesSubmenu


### PR DESCRIPTION
Closes #20443 

## Description
- Design ref: YSMw2nbFAgPpjZLLbYvTfT-fi-96_3834
- Adds a context menu to the ellipsis
- Adds an "All Pages" action that navigates to the pages list screen
- Adds a "Hide this" action that hides the Pages dashboard card

## Screenshots

|Light Mode|Dark Mode|
| - | - |
|![lightMode](https://user-images.githubusercontent.com/25306722/230812000-8e7f2b72-6e6e-42e9-b756-7373e51b1231.png)|![darkMode](https://user-images.githubusercontent.com/25306722/230812003-64df165a-e7cb-4faf-95b1-060c30efb085.png)|

## How to test
1. Run the Jetpack app
2. Enable the Pages Card Remote Feature Flag from the debug menu
3. Enable the Personalize Home Tab Feature Flag from the debug menu
4. Navigate to the dashboard
5. Tap on the ellipsis icon of the Pages card
6. Makes sure a context menu is displayed with  "All Pages" and "Hide this" actions
7. Tap on "All Pages"
8. Make sure that the Pages list screen is displayed
9. Navigate back to the dashboard
10. Tap on the ellipsis icon of the Pages card then tap on "Hide this"
11. Make sure the Pages card is hidden
12. Tap on "Personalize your home tab"
13. Make sure the Pages card is disabled
14. Enable the Pages card and close the screen
15. Make sure that the Pages card is displayed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.