### PR TITLE
Enable the Core Data Concurrency Debug launch argument

### DIFF
--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -92,7 +92,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-com.apple.CoreData.ConcurrencyDebug 1"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-wpcom-api-base-url http://localhost:8282/"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -93,7 +93,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-com.apple.CoreData.ConcurrencyDebug 1"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-wpcom-api-base-url http://localhost:8282/"


### PR DESCRIPTION
Pretty much what says in the title. Xcode now crashes at any code that has [Core Data concurrency issue](https://github.com/wordpress-mobile/WordPress-iOS/blob/d2c9b1a699a357e390b76f06562ecd6964d4fe86/WordPress/Classes/Utility/ContextManager.swift#L343-L347), which we should fix if possible or use [the new workaround function](https://github.com/wordpress-mobile/WordPress-iOS/blob/d2c9b1a699a357e390b76f06562ecd6964d4fe86/WordPress/Classes/Utility/ContextManager.swift#L358) introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/20480 when necessary.

## Regression Notes

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
