### PR TITLE
Dashboard Cards: Hide activity log card if a site doesn't have activities

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -129,7 +129,7 @@ enum DashboardCard: String, CaseIterable {
         case .pages:
             return true
         case .activityLog:
-            return true // FIXME: hide card if there's no activities
+            return apiResponse.hasActivities
         default:
             return false
         }
@@ -172,4 +172,8 @@ private extension BlogDashboardRemoteEntity {
      var hasPublished: Bool {
          return self.posts?.hasPublished ?? true
      }
+
+    var hasActivities: Bool {
+        return (self.activity?.count ?? 0) > 0
+    }
  }


### PR DESCRIPTION
Fixes #20448

## Description
Hides the activity log card if the dashboard endpoint doesn't return any activities for a site

## How to test
1. Enable the activity log card remote feature flag via the debug menu
2. Switch to a site that has no activities
3. ✅ The activity log card should not be displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
