### PR TITLE
Fix failing unit test in testShowShareSheet

### DIFF
--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -138,7 +138,11 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         coordinator.share(fromView: button)
 
         expect(postSharingControllerMock.didCallShareReaderPostWith).to(equal(post))
-        expect(postSharingControllerMock.didCallShareReaderPostWithView).to(equal(button))
+        if case let .view(view) = postSharingControllerMock.didCallShareReaderPostWithView {
+            expect(view).to(equal(button))
+        } else {
+            fail("`postSharingControllerMock.didCallShareReaderPostWithView` should equal .view(button)")
+        }
         expect(postSharingControllerMock.didCallShareReaderPostWithViewController).to(equal(viewMock))
     }
 
@@ -350,12 +354,12 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
 
 private class PostSharingControllerMock: PostSharingController {
     var didCallShareReaderPostWith: ReaderPost?
-    var didCallShareReaderPostWithView: UIView?
+    var didCallShareReaderPostWithView: PostSharingController.PopoverAnchor?
     var didCallShareReaderPostWithViewController: UIViewController?
 
-    override func shareReaderPost(_ post: ReaderPost, fromView anchorView: UIView, inViewController viewController: UIViewController) {
+    override func shareReaderPost(_ post: ReaderPost, fromAnchor anchor: PostSharingController.PopoverAnchor, inViewController viewController: UIViewController) {
         didCallShareReaderPostWith = post
-        didCallShareReaderPostWithView = anchorView
+        didCallShareReaderPostWithView = anchor
         didCallShareReaderPostWithViewController = viewController
     }
 }


### PR DESCRIPTION
Ref p1681302734155419/1681301548.381489-slack-C5ALGJYEP

This PR fixes a failing unit test that was merged in `release/22.1`.

## Test Instructions
Ensure Unit Tests are green.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.