### PR TITLE
Dashboard Card: Implement Pages card actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
@@ -128,7 +128,17 @@ extension DashboardPagesListCardCell {
 // MARK: - UITableViewDelegate
 extension DashboardPagesListCardCell: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO: Open editor for selected page
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let page = viewModel?.pageAt(indexPath),
+              let presentingViewController else {
+            return
+        }
+        let didOpenEditor = PageEditorPresenter.handle(page: page,
+                                                       in: presentingViewController,
+                                                       entryPoint: .dashboard)
+        if didOpenEditor {
+            // TODO: Track editor opened
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
@@ -51,6 +51,7 @@ final class DashboardPagesListCardCell: DashboardCollectionViewCell, PagesCardVi
 
     private func commonInit() {
         setupView()
+        configureHeaderAction()
         tableView.delegate = self
     }
 
@@ -59,6 +60,12 @@ final class DashboardPagesListCardCell: DashboardCollectionViewCell, PagesCardVi
 
         contentView.addSubview(cardFrameView)
         contentView.pinSubviewToAllEdges(cardFrameView, priority: .defaultHigh)
+    }
+
+    private func configureHeaderAction() {
+        cardFrameView.onHeaderTap = { [weak self] in
+            self?.showPagesList()
+        }
     }
 }
 
@@ -85,15 +92,15 @@ extension DashboardPagesListCardCell {
         }
         cardFrameView.ellipsisButton.showsMenuAsPrimaryAction = true
 
-        let children = [makeAllPagesAction(blog: blog), makeHideCardAction(blog: blog)].compactMap { $0 }
+        let children = [makeAllPagesAction(), makeHideCardAction(blog: blog)].compactMap { $0 }
 
         cardFrameView.ellipsisButton.menu = UIMenu(title: String(), options: .displayInline, children: children)
     }
 
-    private func makeAllPagesAction(blog: Blog) -> UIMenuElement {
+    private func makeAllPagesAction() -> UIMenuElement {
         let allPagesAction = UIAction(title: Strings.allPages,
                                       image: Style.allPagesImage,
-                                      handler: { _ in self.showPagesList(for: blog) })
+                                      handler: { _ in self.showPagesList() })
 
         // Wrap the pages action in a menu to display a divider between the pages action and hide this action.
         // https://developer.apple.com/documentation/uikit/uimenu/options/3261455-displayinline
@@ -110,8 +117,8 @@ extension DashboardPagesListCardCell {
 
     // MARK: Actions
 
-    private func showPagesList(for blog: Blog) {
-        guard let presentingViewController else {
+    private func showPagesList() {
+        guard let blog, let presentingViewController else {
             return
         }
         PageListViewController.showForBlog(blog, from: presentingViewController)

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 class EditPageViewController: UIViewController {
+    var entryPoint: PostEditorEntryPoint = .unknown
     fileprivate var page: Page?
     fileprivate var blog: Blog
     fileprivate var postTitle: String?
@@ -90,6 +91,7 @@ class EditPageViewController: UIViewController {
     }
 
     private func show(_ editor: EditorViewController) {
+        editor.entryPoint = entryPoint
         editor.onClose = { [weak self] _, _ in
             // Dismiss navigation controller
             self?.dismiss(animated: true) {

--- a/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
@@ -1,0 +1,43 @@
+import Foundation
+import WordPressFlux
+
+struct PageEditorPresenter {
+    static func handle(page: Page, in presentingViewController: UIViewController, entryPoint: PostEditorEntryPoint) -> Bool {
+        guard !page.isSitePostsPage else {
+            showSitePostPageUneditableNotice()
+            return false
+        }
+
+        guard page.status != .trash else {
+            return false
+        }
+
+        guard !PostCoordinator.shared.isUploading(post: page) else {
+            presentAlertForPageBeingUploaded()
+            return false
+        }
+
+        QuickStartTourGuide.shared.endCurrentTour()
+
+        let editorViewController = EditPageViewController(page: page)
+        editorViewController.entryPoint = entryPoint
+        presentingViewController.present(editorViewController, animated: false)
+        return true
+    }
+
+    private static func showSitePostPageUneditableNotice() {
+        let sitePostPageUneditableNotice =  NSLocalizedString("The content of your latest posts page is automatically generated and cannot be edited.", comment: "Message informing the user that posts page cannot be edited")
+        let notice = Notice(title: sitePostPageUneditableNotice, feedbackType: .warning)
+        ActionDispatcher.global.dispatch(NoticeAction.post(notice))
+    }
+
+    private static func presentAlertForPageBeingUploaded() {
+        let message = NSLocalizedString("This page is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the page is being uploaded and cannot be edited while that process is ongoing.")
+
+        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        alertController.presentFromRootViewController()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -419,20 +419,14 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.deselectRow(at: indexPath, animated: true)
 
         let page = pageAtIndexPath(indexPath)
-        if page.isSiteHomepage {
-            tableView.reloadRows(at: [indexPath], with: .automatic)
-        } else if page.isSitePostsPage {
+        if page.isSitePostsPage {
             showSitePostPageUneditableNotice()
             return
-        } else {
-            QuickStartTourGuide.shared.endCurrentTour()
-            tableView.reloadData()
         }
 
         guard page.status != .trash else {
             return
         }
-
         editPage(page)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -152,6 +152,7 @@ extension PostEditor {
 enum PostEditorEntryPoint: String {
     case unknown
     case postsList
+    case pagesList
     case dashboard
     case bloggingPromptsFeatureIntroduction = "blogging_prompts_introduction"
     case bloggingPromptsActionSheetHeader = "add_new_sheet_answer_prompt"

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1881,6 +1881,8 @@
 		80D9CFFB29E5E6FE00FE3400 /* DashboardCardTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9CFF929E5E6FE00FE3400 /* DashboardCardTableView.swift */; };
 		80D9CFFD29E711E200FE3400 /* DashboardPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9CFFC29E711E200FE3400 /* DashboardPageCell.swift */; };
 		80D9CFFE29E711E200FE3400 /* DashboardPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9CFFC29E711E200FE3400 /* DashboardPageCell.swift */; };
+		80D9D00029E85EBF00FE3400 /* PageEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9CFFF29E85EBF00FE3400 /* PageEditorPresenter.swift */; };
+		80D9D00129E85EBF00FE3400 /* PageEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9CFFF29E85EBF00FE3400 /* PageEditorPresenter.swift */; };
 		80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
@@ -7228,6 +7230,7 @@
 		80D9CFF629E5010300FE3400 /* PagesCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesCardViewModel.swift; sourceTree = "<group>"; };
 		80D9CFF929E5E6FE00FE3400 /* DashboardCardTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTableView.swift; sourceTree = "<group>"; };
 		80D9CFFC29E711E200FE3400 /* DashboardPageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPageCell.swift; sourceTree = "<group>"; };
+		80D9CFFF29E85EBF00FE3400 /* PageEditorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageEditorPresenter.swift; sourceTree = "<group>"; };
 		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
 		80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCustomAnnouncementCell.swift; sourceTree = "<group>"; };
 		80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsStackView.swift; sourceTree = "<group>"; };
@@ -16685,6 +16688,7 @@
 				5DFA7EBE1AF7CB3A0072023B /* Views */,
 				5D62BAD518AA88210044E5F7 /* PageSettingsViewController.h */,
 				5D62BAD618AA88210044E5F7 /* PageSettingsViewController.m */,
+				80D9CFFF29E85EBF00FE3400 /* PageEditorPresenter.swift */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -21275,6 +21279,7 @@
 				C81CCD80243BF7A600A83E27 /* TenorPicker.swift in Sources */,
 				74EFB5C8208674250070BD4E /* BlogListViewController+Activity.swift in Sources */,
 				738B9A5721B85CF20005062B /* TableDataCoordinator.swift in Sources */,
+				80D9D00029E85EBF00FE3400 /* PageEditorPresenter.swift in Sources */,
 				FA73D7E52798765B00DF24B3 /* SitePickerViewController.swift in Sources */,
 				B541276B1C0F7D610015CA80 /* SettingsMultiTextViewController.m in Sources */,
 				3F810A5A2616870C00ADDCC2 /* UnifiedPrologueIntroContentView.swift in Sources */,
@@ -24321,6 +24326,7 @@
 				FABB23492602FC2C00C8785C /* MenuItemSourceCell.m in Sources */,
 				FABB234A2602FC2C00C8785C /* BlogDetailsViewController.m in Sources */,
 				FABB234B2602FC2C00C8785C /* UIBarButtonItem+MeBarButton.swift in Sources */,
+				80D9D00129E85EBF00FE3400 /* PageEditorPresenter.swift in Sources */,
 				FABB234C2602FC2C00C8785C /* PostSettingsViewController+FeaturedImageUpload.swift in Sources */,
 				F158542E267D3B8A00A2E966 /* BloggingRemindersFlowSettingsViewController.swift in Sources */,
 				8332DD2529259AE300802F7D /* DataMigrator.swift in Sources */,


### PR DESCRIPTION
Closes #20442

## Description
- Adds action that navigates the user to the pages list when tapping the card's header
- Adds action that opens up the editor when the user taps on the page

## Testing Instructions

### Card Header Action
1. Run the Jetpack app
2. Enable the Pages Card Remote Feature Flag from the debug menu
3. Navigate to the dashboard
4. Tap on the card header
5. Make sure you get navigated to the pages list screen

### Edit Page Action

1. Run the Jetpack app
2. Enable the Pages Card Remote Feature Flag from the debug menu
3. Navigate to the dashboard
4. Navigate to the Pages card
5. Tap on a normal page
6. Make sure the editor opens up with the correct content
7. Dismiss the editor
8. Tap on a page marked as the Homepage
9. Make sure the editor opens up with the correct content
10. Dismiss the editor
11. Tap on a page marked as a Posts list
12. Make sure the editor is not displayed and a notice is displayed explaining the page can't be edited

### Pages List Actions

1. Run the Jetpack app
2. Navigate to the Pages list
3. Tap on a normal page
4. Make sure the editor opens up with the correct content
5. Dismiss the editor
6. Tap on a page marked as the Homepage
7. Make sure the editor opens up with the correct content
8. Dismiss the editor
9. Tap on a page marked as a Posts list
10. Make sure the editor is not displayed and a notice is displayed explaining the page can't be edited
11. Tap on the More button for any page
12. Tap on Edit
13. Make sure the editor opens up with the correct content
14. Dismiss the editor
15. Navigate to Trashed Pages
16. Tap on any page
17. Make sure the editor is not displayed

## Regression Notes
1. Potential unintended areas of impact
Pages list editor actions

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.