### PR TITLE
Dashboard Cards: Handle Dark mode for the Pages Card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCell.swift
@@ -109,7 +109,7 @@ private extension DashboardPageCell {
     }
 
     enum Colors {
-        static let separatorColor = UIColor(red: 0.235, green: 0.235, blue: 0.263, alpha: 0.36)
+        static let separatorColor: UIColor = .separator
     }
 }
 
@@ -197,7 +197,7 @@ fileprivate class PageStatusView: UIView {
     }
 
     private func applyStyles() {
-        backgroundColor = .secondarySystemBackground
+        backgroundColor = Metrics.backgroundColor
         layer.cornerRadius = Metrics.cornerRadius
     }
 
@@ -222,6 +222,8 @@ fileprivate class PageStatusView: UIView {
         static let titleLabelMargins: NSDirectionalEdgeInsets = .init(top: 2, leading: 4, bottom: 2, trailing: 8)
         static let iconImageViewSize: CGFloat = 16
         static let cornerRadius: CGFloat = 2
+        private static let darkModeBackgroundColor = UIColor(red: 0.173, green: 0.173, blue: 0.18, alpha: 1)
+        static let backgroundColor: UIColor = .init(light: .secondarySystemBackground, dark: darkModeBackgroundColor)
     }
 
     private enum Strings {


### PR DESCRIPTION
Closes #20523
Design ref: YSMw2nbFAgPpjZLLbYvTfT-fi-96_3834

## Description
Applies dark mode style changes to the Pages card.

## Screenshots

|Light Mode|Dark Mode|
| - | - |
|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-13 at 22 12 14](https://user-images.githubusercontent.com/25306722/231873413-d21cb6ce-1481-42ec-9d74-291a74c6aa6d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-04-13 at 22 12 12](https://user-images.githubusercontent.com/25306722/231873425-5500f12e-5a78-4419-93ea-dc5a2594ee55.png)|

## Testing Instructions

1. Run the Jetpack app
2. Enable the Pages Card Remote Feature Flag from the debug menu
3. Navigate to the dashboard
4. Make sure that the Pages card matches the light mode design
5. Switch to Dark mode
6. Make sure that the Pages card matches the dark mode design

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.