### PR TITLE
Dashboard Cards: Fixes card header flashes on launch

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -10,7 +10,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
-        frameView.title = Strings.title
+        frameView.setTitle(Strings.title)
         return frameView
     }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
@@ -43,7 +43,7 @@ class DashboardDomainsCardCell: DashboardCollectionViewCell {
         frameView.onEllipsisButtonTap = cardViewModel.onEllipsisTap
         frameView.ellipsisButton.showsMenuAsPrimaryAction = true
         frameView.ellipsisButton.menu = contextMenu
-        frameView.title = Strings.title
+        frameView.setTitle(Strings.title)
         frameView.clipsToBounds = true
         frameView.translatesAutoresizingMaskIntoConstraints = false
         return frameView

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesCardCell.swift
@@ -10,7 +10,7 @@ final class DashboardPagesCardCell: DashboardCollectionViewCell {
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
-        frameView.title = Strings.title
+        frameView.setTitle(Strings.title)
         return frameView
     }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -68,20 +68,6 @@ class BlogDashboardCardFrameView: UIView {
 
     weak var currentView: UIView?
 
-    /// The title at the header
-    var title: String? {
-        didSet {
-            self.setNeedsDisplay()
-        }
-    }
-
-    /// The part in the title that needs to be highlighted
-    var titleHint: String? {
-        didSet {
-            self.setNeedsDisplay()
-        }
-    }
-
     /// Closure to be called when anywhere in the view is tapped.
     /// If set, the chevron image is displayed.
     var onViewTap: (() -> Void)? {
@@ -123,11 +109,6 @@ class BlogDashboardCardFrameView: UIView {
         // Update view background
         self.layer.masksToBounds = true
         self.layer.cornerRadius = Constants.cornerRadius
-
-        // Update title label
-        if let title {
-            self.titleLabel.attributedText = Self.titleAttributedText(title: title, hint: titleHint, font: titleLabel.font)
-        }
     }
 
     /// Add a subview inside the card frame
@@ -152,6 +133,18 @@ class BlogDashboardCardFrameView: UIView {
         buttonContainerStackView.isHidden = true
 
         mainStackViewTrailingConstraint?.constant = 0
+    }
+
+
+    /// Set's the title displayed in the card's header
+    /// - Parameters:
+    ///   - title: Title to be displayed
+    ///   - titleHint: The part in the title that needs to be highlighted
+    func setTitle(_ title: String?, titleHint: String? = nil) {
+        guard let title else {
+            return
+        }
+        self.titleLabel.attributedText = Self.titleAttributedText(title: title, hint: titleHint, font: titleLabel.font)
     }
 
     private func configureMainStackView() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -120,15 +120,14 @@ extension DashboardPostsListCardCell {
     }
 
     private func configureDraftsList(blog: Blog) {
-        frameView.title = Strings.draftsTitle
-        frameView.titleHint = Strings.draftsTitleHint
+        frameView.setTitle(Strings.draftsTitle, titleHint: Strings.draftsTitleHint)
         frameView.onHeaderTap = { [weak self] in
             self?.presentPostList(with: .draft)
         }
     }
 
     private func configureScheduledList(blog: Blog) {
-        frameView.title = Strings.scheduledTitle
+        frameView.setTitle(Strings.scheduledTitle)
         frameView.onHeaderTap = { [weak self] in
             self?.presentPostList(with: .scheduled)
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -10,7 +10,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     private(set) lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
-        frameView.title = Strings.cardFrameTitle
+        frameView.setTitle(Strings.cardFrameTitle)
 
         // NOTE: Remove the logic when support for iOS 14 is dropped
         if #available (iOS 15.0, *) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -61,7 +61,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
 
         }
 
-        cardFrameView.title = Strings.title(for: blog.quickStartType)
+        cardFrameView.setTitle(Strings.title(for: blog.quickStartType))
     }
 
     private func configureOnEllipsisButtonTap(sourceRect: CGRect) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -39,8 +39,7 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
     }
 
     private func addSubviews() {
-        frameView.title = Strings.statsTitle
-        frameView.titleHint = Strings.statsTitleHint
+        frameView.setTitle(Strings.statsTitle, titleHint: Strings.statsTitleHint)
 
         let statsStackview = DashboardStatsStackView()
         frameView.add(subview: statsStackview)


### PR DESCRIPTION
Fixes #20534

## Description

Fixes an issue where the dashboard card headers would flash for a split second on launch.

## Recordings

|Before|After|
|-|-|
|<video src="https://user-images.githubusercontent.com/25306722/231878043-faf3c3ac-dad6-4a0b-9d8d-3937ca9302ae.mp4">|<video src="https://user-images.githubusercontent.com/25306722/231878073-6e4dd570-7674-4491-9717-eae08cec6a30.mp4">|

## Testing Instructions

1. Run the Jetpack app
2. Make sure that the dashboard card titles are set straight away, and they don't flash

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.