### PR TITLE
Blogging Prompts: Enable the blogging prompts social feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [*] [internal] [Jetpack-only] Redesigned the migration success card. [#20515]
 * [**] [internal] Refactored Google SignIn implementation to not use the Google SDK [#20128]
 * [***] Block Editor: Resolved scroll-jump issues and enhanced caret focus management [https://github.com/WordPress/gutenberg/pull/48791]
-* [**] [Jetpack-only] Blogging Prompts: adds the ability to view other users' responses to a prompt. [#]
+* [**] [Jetpack-only] Blogging Prompts: adds the ability to view other users' responses to a prompt. [#20540]
 
 22.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] [internal] [Jetpack-only] Redesigned the migration success card. [#20515]
 * [**] [internal] Refactored Google SignIn implementation to not use the Google SDK [#20128]
 * [***] Block Editor: Resolved scroll-jump issues and enhanced caret focus management [https://github.com/WordPress/gutenberg/pull/48791]
+* [**] [Jetpack-only] Blogging Prompts: adds the ability to view other users' responses to a prompt. [#]
 
 22.1
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int, CaseIterable {
     case bloggingPrompts
     case bloggingPromptsEnhancements
-    case bloggingPromptsSocial
     case jetpackDisconnect
     case debugMenu
     case readerCSS
@@ -52,8 +51,6 @@ enum FeatureFlag: Int, CaseIterable {
             return AppConfiguration.isJetpack
         case .bloggingPromptsEnhancements:
             return AppConfiguration.isJetpack
-        case .bloggingPromptsSocial:
-            return false
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .debugMenu:
@@ -154,8 +151,6 @@ extension FeatureFlag {
             return "Blogging Prompts"
         case .bloggingPromptsEnhancements:
             return "Blogging Prompts Enhancements"
-        case .bloggingPromptsSocial:
-            return "Blogging Prompts Social"
         case .jetpackDisconnect:
             return "Jetpack disconnect"
         case .debugMenu:

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -17,6 +17,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case pagesDashboardCard
     case activityLogDashboardCard
     case sdkLessGoogleSignIn
+    case bloggingPromptsSocial
 
     var defaultValue: Bool {
         switch self {
@@ -50,6 +51,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .sdkLessGoogleSignIn:
             return false
+        case .bloggingPromptsSocial:
+            return AppConfiguration.isJetpack
         }
     }
 
@@ -86,6 +89,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "dashboard_card_activity_log"
         case .sdkLessGoogleSignIn:
             return "google_signin_without_sdk"
+        case .bloggingPromptsSocial:
+            return "blogging_prompts_social_enabled"
         }
     }
 
@@ -121,6 +126,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Activity Log Dashboard Card"
         case .sdkLessGoogleSignIn:
             return "Sign-In with Google without the Google SDK"
+        case .bloggingPromptsSocial:
+            return "Blogging Prompts Social"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -130,7 +130,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     }
 
     private var answerInfoText: String {
-        if FeatureFlag.bloggingPromptsSocial.enabled {
+        if RemoteFeatureFlag.bloggingPromptsSocial.enabled() {
             return Strings.viewAllResponses
         }
 
@@ -174,7 +174,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         button.setTitle(answerInfoText, for: .normal)
         button.titleLabel?.font = WPStyleGuide.BloggingPrompts.answerInfoButtonFont
         button.setTitleColor(
-            FeatureFlag.bloggingPromptsSocial.enabled
+            RemoteFeatureFlag.bloggingPromptsSocial.enabled()
             ? WPStyleGuide.BloggingPrompts.buttonTitleColor
             : WPStyleGuide.BloggingPrompts.answerInfoButtonColor,
             for: .normal
@@ -187,8 +187,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     @objc
     private func didTapAnswerInfoButton() {
-        guard FeatureFlag.bloggingPromptsSocial.enabled,
-        let promptID = prompt?.promptID else {
+        guard RemoteFeatureFlag.bloggingPromptsSocial.enabled(),
+              let promptID = prompt?.promptID else {
             return
         }
         RootViewCoordinator.sharedPresenter.readerCoordinator?.showTag(named: "\(Constants.dailyPromptTag)-\(promptID)")


### PR DESCRIPTION
Closes #20539

## Description

- Enables the blogging prompts social feature flag
- Converts the local feature flag to a remote feature flag

## Testing

To test:

- Install and launch Jetpack
- Sign in if necessary
- Select a site which has blogging prompts
- Navigate to the home dashboard
- **Verify**:
  -  The prompt's dashboard card now has `View all responses`
  - `View all responses` is the app's primary color
- Tap on `View all responses`
- **Verify** the reader appears with the tag `dailyprompt-#` where `#` is the current day's prompt

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
