### PR TITLE
Fix a few warnings in unit tests

### DIFF
--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -274,7 +274,7 @@ class AccountServiceTests: CoreDataTestCase {
                     "email": "jim@wptestaccounts.com",
                     "primary_blog": 55555551,
                     "primary_blog_url": "https://test1.wordpress.com",
-                ],
+                ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
@@ -291,7 +291,7 @@ class AccountServiceTests: CoreDataTestCase {
 
     func testChangingBlogVisiblity() throws {
         stub(condition: isPath("/rest/v1.1/me/sites") && isMethodPOST()) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
 
         let account = try createAccount(withUsername: "username", authToken: "token")

--- a/WordPress/WordPressTest/AccountSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/AccountSettingsServiceTests.swift
@@ -49,7 +49,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
 
     func testUpdateSuccess() throws {
         stub(condition: isPath("/rest/v1.1/me/settings")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
         waitUntil { done in
             self.service.saveChange(.firstName("Updated"), finished: { success in
@@ -62,7 +62,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
 
     func testUpdateFailure() throws {
         stub(condition: isPath("/rest/v1.1/me/settings")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
         }
         waitUntil { done in
             self.service.saveChange(.firstName("Updated"), finished: { success in
@@ -83,7 +83,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
             // Simulate a slow HTTP response, so that the test code below has a chance to
             // cancel this API request
             sleep(2)
-            return HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+            return HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
         }
         service.getSettingsAttempt()
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -435,6 +435,6 @@ class BlogDashboardPostsParserMock: BlogDashboardPostsParser {
             return postsDictionary
         }
 
-        return ["has_published": false, "draft": [[:]], "scheduled": [[:]]]
+        return ["has_published": false, "draft": [[String: Any]()], "scheduled": [[String: Any]()]]
     }
 }

--- a/WordPress/WordPressTest/LikeUserHelperTests.swift
+++ b/WordPress/WordPressTest/LikeUserHelperTests.swift
@@ -22,7 +22,7 @@ class LikeUserHelperTests: CoreDataTestCase {
                 "icon": [
                     "img": "someimage.jpg",
                 ]
-            ]
+            ] as [String: Any]
         }
 
         return remoteUserDictionary

--- a/WordPress/WordPressTest/PeopleServiceTests.swift
+++ b/WordPress/WordPressTest/PeopleServiceTests.swift
@@ -47,9 +47,9 @@ class PeopleServiceTests: CoreDataTestCase {
                             "ID": 1,
                             "nice_name": "Name",
                             "name": "username"
-                        ]
+                        ] as [String: Any]
                     ]
-                ],
+                ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
@@ -71,7 +71,7 @@ class PeopleServiceTests: CoreDataTestCase {
 
     func testLoadUsersFailure() {
         stub(condition: isPath("/rest/v1.1/sites/\(siteID)/users")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
         }
 
         waitUntil { done in
@@ -98,9 +98,9 @@ class PeopleServiceTests: CoreDataTestCase {
                             "ID": 1,
                             "nice_name": "Nice Name",
                             "name": "name"
-                        ]
+                        ] as [String: Any]
                     ]
-                ],
+                ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
@@ -126,9 +126,9 @@ class PeopleServiceTests: CoreDataTestCase {
                             "ID": 1,
                             "nice_name": "Name",
                             "name": "username"
-                        ]
+                        ] as [String: Any]
                     ]
-                ],
+                ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
@@ -161,9 +161,9 @@ class PeopleServiceTests: CoreDataTestCase {
                             "ID": 1,
                             "nice_name": "Nice Name",
                             "name": "name"
-                        ]
+                        ] as [String: Any]
                     ]
-                ],
+                ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
@@ -182,7 +182,7 @@ class PeopleServiceTests: CoreDataTestCase {
 
         // Make API call to delete the loaded follower
         stub(condition: isPath("/rest/v1.1/sites/\(siteID)/followers/\(follower.userID)/delete")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
         }
 
         waitUntil { done in
@@ -204,7 +204,7 @@ class PeopleServiceTests: CoreDataTestCase {
 
     func testLoadFollowersFailure() {
         stub(condition: isPath("/rest/v1.1/sites/123/follows")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
         }
 
         waitUntil { done in

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -411,8 +411,8 @@ private extension PromptRemindersSchedulerTests {
                 "date": Self.dateFormatter.string(from: date),
                 "answered": false,
                 "answered_users_count": 0,
-                "answered_users_sample": []
-            ])
+                "answered_users_sample": [String: Any]()
+            ] as [String: Any])
         }
 
         return ["prompts": objects]

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -411,7 +411,7 @@ private extension PromptRemindersSchedulerTests {
                 "date": Self.dateFormatter.string(from: date),
                 "answered": false,
                 "answered_users_count": 0,
-                "answered_users_sample": [String: Any]()
+                "answered_users_sample": [[String: Any]]()
             ] as [String: Any])
         }
 

--- a/WordPress/WordPressTest/ReaderSiteServiceTests.swift
+++ b/WordPress/WordPressTest/ReaderSiteServiceTests.swift
@@ -28,14 +28,14 @@ class ReaderSiteServiceTests: CoreDataTestCase {
             HTTPStubsResponse(jsonObject: ["is_following": false], statusCode: 200, headers: nil)
         }
         stub(condition: isPath("/rest/v1.1/sites/42/follows/new")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
         stub(condition: isPath("/rest/v1.2/read/sites/42")) { _ in
             HTTPStubsResponse(jsonObject: [
                 "feed_ID": 100,
                 "feed_URL": "https://test.blog/feed",
                 "post_count": 0,
-            ], statusCode: 200, headers: nil)
+            ] as [String: Any], statusCode: 200, headers: nil)
         }
 
         let success = expectation(description: "The success block should be called")
@@ -48,14 +48,14 @@ class ReaderSiteServiceTests: CoreDataTestCase {
             HTTPStubsResponse(jsonObject: ["is_following": false], statusCode: 200, headers: nil)
         }
         stub(condition: isPath("/rest/v1.1/sites/42/follows/new")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
         stub(condition: isPath("/rest/v1.2/read/sites/42")) { _ in
             HTTPStubsResponse(jsonObject: [
                 "feed_ID": 100,
                 "feed_URL": "https://test.blog/feed",
                 "post_count": 0,
-            ], statusCode: 200, headers: nil)
+            ] as [String: Any], statusCode: 200, headers: nil)
         }
 
         let success = expectation(description: "The success block should be called")
@@ -65,7 +65,7 @@ class ReaderSiteServiceTests: CoreDataTestCase {
 
     func testUnfollowSiteByID() {
         stub(condition: isPath("/rest/v1.1/sites/42/follows/mine/delete")) { _ in
-            HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
 
         let success = expectation(description: "The success block should be called")


### PR DESCRIPTION
A version of https://github.com/wordpress-mobile/WordPress-iOS/pull/20530 on the latest `trunk`, `a3d645da00`, with a fix for a empty collection that didn't have the expected type.