### PR TITLE
Fix event name for plugin installation failures

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
@@ -77,7 +77,7 @@ extension WPComJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
         case .initial, .loading:
             tracker.track(.jetpackInstallFullPluginViewed, properties: ["status": state.statusForTracks])
         case .failed(let description, _):
-            tracker.track(.jetpackInstallPluginModalViewed,
+            tracker.track(.jetpackInstallFullPluginViewed,
                           properties: ["status": state.statusForTracks, "description": description])
         case .cancel:
             tracker.track(.jetpackInstallFullPluginCancelTapped, properties: ["status": state.statusForTracks])


### PR DESCRIPTION
## Description

> **Warning**:
> Auto-merge is turned on!

As titled, this fixes an error from #20436 where the wrong event name was used to track when the plugin installation fails. The correct event should be `jp_install_full_plugin_flow_viewed` instead of `jp_install_full_plugin_onboarding_modal_viewed`. 🤦🏼 

## To test

- Prepare an individual site that's connected to your WordPress.com account.
- Install the full Jetpack plugin from wp-admin, and then deactivate it.
- Launch the Jetpack app, and switch to your individual site.
- Go through the Jetpack plugin installation flow. The installation flow should fail.
- Verify that this is tracked:
- `🔵 Tracked: jp_install_full_plugin_flow_viewed <description: Destination folder already exists., status: error>`

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes. And double-checked the actual event name this time.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
