### PR TITLE
Scheduled Posts: Fix date modified being set to future date

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -268,11 +268,30 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
         if (forceDraftIfCreating) {
             remotePost.status = PostStatusDraft;
         }
-
-        [remote createPost:remotePost
-                   success:successBlock
-                   failure:failureBlock];
+        [self createPost:remotePost
+                  remote:remote
+                 success:successBlock
+                 failure:failureBlock];
     }
+}
+
+
+/// Creates new post on the server.
+/// If the post type is scheduled, another call to update the post is made after creation to fix the modified date.
+- (void)createPost:(RemotePost *)post
+            remote:(id<PostServiceRemote>)remote
+           success:(void (^)(RemotePost *post))success
+           failure:(void (^)(NSError *error))failure;
+{
+    [remote createPost:post success:^(RemotePost *post) {
+        if ([post.status isEqualToString:PostStatusScheduled]) {
+            [remote updatePost:post success:success failure:failure];
+        }
+        else {
+            success(post);
+        }
+        
+    } failure:failure];
 }
 
 #pragma mark - Autosave Related


### PR DESCRIPTION
Fixes #20521

## Description

Fixes an issue where scheduled posts and pages would have a future modified date on creation.

## Testing Instructions

1. Run the Jetpack app
2. Log into a site that has at least one page
3. Enable the Pages Card Remote Feature Flag from the debug menu
4. Navigate to the dashboard
5. Tap on the floating button
6. Tap on "Site Page"
7. Tap on "Create Blank Page"
8. Fill in the title and content
9. Tap on the More button
10. Tap on "Page Settings"
11. Tap on "Published on"
12. Choose a date in the future
13. Go back to the editor
14. Tap "Schedule"
15. The created page should be the first page in the Pages card
16. Tap on any other existing page
17. Change anything
18. Tap "Update"
19. Close the editor
20. Make sure that the updated page is now the first page in the Pages card 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.