### PR TITLE
Notifications: Fixes a crash when tapping the notifications tab multiple times right after launch

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -2071,7 +2071,9 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
 extension NotificationsViewController: WPScrollableViewController {
     // Used to scroll view to top when tapping on tab bar item when VC is already visible.
     func scrollViewToTop() {
-        tableView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: true)
+        if isViewLoaded {
+            tableView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: true)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #20519

## Description
Fixes a crash when tapping the notifications tab bar button multiple times on launch. The crash is rare and not easily reproducible, but the stack trace shows that the tab bar button is tapped a second time before the notifications view is loaded. This causes `scrollViewToTop` to crash because it accesses `tableView`, which is still nil as the view isn't loaded yet.

## Testing Instructions

Since the crash isn't reproducible, there are no testing instructions.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.