### PR TITLE
Use WordPressKit 8.0.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,8 +47,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 7.2-beta'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
+  # pod 'WordPressKit', '~> 7.2-beta'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'release/8.0.0'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
@@ -231,8 +231,8 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  pod 'WordPressAuthenticator', '~> 6.0-beta'
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
+  # pod 'WordPressAuthenticator', '~> 6.0-beta'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'release/6.1.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -47,8 +47,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  # pod 'WordPressKit', '~> 7.2-beta'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'release/8.0.0'
+  pod 'WordPressKit', '~> 8.0-beta'
+  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
@@ -231,8 +231,8 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  # pod 'WordPressAuthenticator', '~> 6.0-beta'
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'release/6.1.0'
+  pod 'WordPressAuthenticator', '~> 6.1-beta'
+  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -501,15 +501,15 @@ PODS:
   - WordPress-Aztec-iOS (1.19.8)
   - WordPress-Editor-iOS (1.19.8):
     - WordPress-Aztec-iOS (= 1.19.8)
-  - WordPressAuthenticator (6.0.0):
+  - WordPressAuthenticator (6.1.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 7.0-beta)
+    - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (7.2.0):
+  - WordPressKit (8.0.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -608,8 +608,8 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (~> 6.0-beta)
-  - WordPressKit (~> 7.2-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `release/6.1.0`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `release/8.0.0`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `trunk`)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.7)
@@ -655,8 +655,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
-    - WordPressKit
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -771,6 +769,12 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.93.0
+  WordPressAuthenticator:
+    :branch: release/6.1.0
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :branch: release/8.0.0
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -789,6 +793,12 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.93.0
+  WordPressAuthenticator:
+    :commit: 49e437f0a4fd1fb3d78fa9c0f54d0ec644df4856
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :commit: b50380fef16a692cfe3475e3195a6f771d2e3be6
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: d86b274e1d06964317c430b4e434d37b2a9891a7
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -878,8 +888,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: e6a801d25f4f178de5bdf475ffe29050d0148176
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
-  WordPressKit: b88fc8a8229366c2aace623eb3612318514faa34
+  WordPressAuthenticator: 9956582dabc0e98fc6f22ef960c52d8a3480b2d8
+  WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
@@ -894,6 +904,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 15716f375a35c835b61fed1e6c54a3f4ac968c30
+PODFILE CHECKSUM: d4304203a2c442612402bd66c49afe066aed0fa2
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -608,8 +608,8 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `release/6.1.0`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `release/8.0.0`)
+  - WordPressAuthenticator (~> 6.1-beta)
+  - WordPressKit (~> 8.0-beta)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `trunk`)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.7)
@@ -618,6 +618,9 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
+    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -769,12 +772,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.93.0
-  WordPressAuthenticator:
-    :branch: release/6.1.0
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WordPressKit:
-    :branch: release/8.0.0
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -793,12 +790,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.93.0
-  WordPressAuthenticator:
-    :commit: 49e437f0a4fd1fb3d78fa9c0f54d0ec644df4856
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WordPressKit:
-    :commit: b50380fef16a692cfe3475e3195a6f771d2e3be6
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: d86b274e1d06964317c430b4e434d37b2a9891a7
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -888,8 +879,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: e6a801d25f4f178de5bdf475ffe29050d0148176
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: 9956582dabc0e98fc6f22ef960c52d8a3480b2d8
-  WordPressKit: 8e1c5a64645a59493a7316f38468ac036de9c79b
+  WordPressAuthenticator: 0d2db316896beeb31d2c8b368c8e2b33ff0001af
+  WordPressKit: b65a51863982d8166897bea8b753f1fc51732aad
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
@@ -904,6 +895,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: d4304203a2c442612402bd66c49afe066aed0fa2
+PODFILE CHECKSUM: 9bbdc48682ae729d84ac66e292d448e81200d728
 
 COCOAPODS: 1.11.3

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -35,11 +35,11 @@ class ActivityListViewModelTests: XCTestCase {
 
     // Check if `loadMore` dispatchs the correct offset
     //
-    func testLoadMoreOffset() {
+    func testLoadMoreOffset() throws {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
         let activityStoreMock = ActivityStoreMock()
         let activityListViewModel = ActivityListViewModel(site: jetpackSiteRef, store: activityStoreMock, configuration: activityListConfiguration)
-        activityStoreMock.state.activities[jetpackSiteRef] = [Activity.mock(), Activity.mock(), Activity.mock()]
+        activityStoreMock.state.activities[jetpackSiteRef] = try [Activity.mock(), Activity.mock(), Activity.mock()]
 
         activityListViewModel.loadMore()
         activityListViewModel.loadMore()
@@ -51,11 +51,11 @@ class ActivityListViewModelTests: XCTestCase {
 
     // Check if `loadMore` dispatchs the correct after/before date and groups
     //
-    func testLoadMoreAfterBeforeDate() {
+    func testLoadMoreAfterBeforeDate() throws {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
         let activityStoreMock = ActivityStoreMock()
         let activityListViewModel = ActivityListViewModel(site: jetpackSiteRef, store: activityStoreMock, configuration: activityListConfiguration)
-        activityStoreMock.state.activities[jetpackSiteRef] = [Activity.mock(), Activity.mock(), Activity.mock()]
+        activityStoreMock.state.activities[jetpackSiteRef] = try [Activity.mock(), Activity.mock(), Activity.mock()]
         let afterDate = Date()
         let beforeDate = Date(timeIntervalSinceNow: 86400)
         let activityGroup = ActivityGroup.mock()
@@ -133,8 +133,16 @@ class ActivityStoreMock: ActivityStore {
 }
 
 extension Activity {
-    static func mock(isRewindable: Bool = false) -> Activity {
-        let dictionary = ["activity_id": "1", "summary": "", "is_rewindable": isRewindable, "rewind_id": "1", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String: AnyObject]
-        return try! Activity(dictionary: dictionary)
+    static func mock(isRewindable: Bool = false) throws -> Activity {
+        let dictionary = [
+            "activity_id": "1",
+            "summary": "",
+            "is_rewindable": isRewindable,
+            "rewind_id": "1",
+            "content": ["text": ""],
+            "published": "2020-11-09T13:16:43.701+00:00"
+        ] as [String: AnyObject]
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: .prettyPrinted)
+        return try JSONDecoder().decode(Activity.self, from: data)
     }
 }

--- a/WordPress/WordPressTest/ActivityContentRouterTests.swift
+++ b/WordPress/WordPressTest/ActivityContentRouterTests.swift
@@ -15,8 +15,8 @@ final class ActivityContentRouterTests: XCTestCase {
         super.tearDown()
     }
 
-    func testRouteToComment() {
-        let commentActivity = getCommentActivity()
+    func testRouteToComment() throws {
+        let commentActivity = try getCommentActivity()
         let router = ActivityContentRouter(activity: commentActivity, coordinator: testCoordinator)
 
         router.routeTo(commentURL)
@@ -26,8 +26,8 @@ final class ActivityContentRouterTests: XCTestCase {
         XCTAssertEqual(testCoordinator.commentSiteID?.intValue, testData.testSiteID)
     }
 
-    func testRouteToPost() {
-        let activity = getPostActivity()
+    func testRouteToPost() throws {
+        let activity = try getPostActivity()
         let router = ActivityContentRouter(activity: activity, coordinator: testCoordinator)
 
         router.routeTo(postURL)
@@ -49,13 +49,15 @@ extension ActivityContentRouterTests {
         return URL(string: testData.testCommentURL)!
     }
 
-    func getCommentActivity() -> FormattableActivity {
-        let activity = try! Activity(dictionary: testData.getCommentEventDictionary())
+    func getCommentActivity() throws -> FormattableActivity {
+        let data = try JSONSerialization.data(withJSONObject: testData.getCommentEventDictionary())
+        let activity = try JSONDecoder().decode(Activity.self, from: data)
         return FormattableActivity(with: activity)
     }
 
-    func getPostActivity() -> FormattableActivity {
-        let activity = try! Activity(dictionary: testData.getPostEventDictionary())
+    func getPostActivity() throws -> FormattableActivity {
+        let data = try JSONSerialization.data(withJSONObject: testData.getPostEventDictionary())
+        let activity = try JSONDecoder().decode(Activity.self, from: data)
         return FormattableActivity(with: activity)
     }
 }

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -61,10 +61,10 @@ class ActivityStoreTests: CoreDataTestCase {
 
     // Check if loadMoreActivities keep the activies and add the new retrieved ones
     //
-    func testLoadMoreActivitiesKeepTheExistent() {
+    func testLoadMoreActivitiesKeepTheExistent() throws {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
-        store.state.activities[jetpackSiteRef] = [Activity.mock()]
-        activityServiceMock.activitiesToReturn = [Activity.mock(), Activity.mock()]
+        store.state.activities[jetpackSiteRef] = [try Activity.mock()]
+        activityServiceMock.activitiesToReturn = [try Activity.mock(), try Activity.mock()]
         activityServiceMock.hasMore = true
 
         dispatch(.loadMoreActivities(site: jetpackSiteRef, quantity: 10, offset: 20, afterDate: nil, beforeDate: nil, group: []))
@@ -75,10 +75,10 @@ class ActivityStoreTests: CoreDataTestCase {
 
     // resetActivities remove all activities
     //
-    func testResetActivities() {
+    func testResetActivities() throws {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
-        store.state.activities[jetpackSiteRef] = [Activity.mock()]
-        activityServiceMock.activitiesToReturn = [Activity.mock(), Activity.mock()]
+        store.state.activities[jetpackSiteRef] = [try Activity.mock()]
+        activityServiceMock.activitiesToReturn = [try Activity.mock(), try Activity.mock()]
         activityServiceMock.hasMore = true
 
         dispatch(.resetActivities(site: jetpackSiteRef))
@@ -90,10 +90,10 @@ class ActivityStoreTests: CoreDataTestCase {
 
     // Check if loadMoreActivities keep the activies and add the new retrieved ones
     //
-    func testReturnOnlyRewindableActivities() {
+    func testReturnOnlyRewindableActivities() throws {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
-        store.state.activities[jetpackSiteRef] = [Activity.mock()]
-        activityServiceMock.activitiesToReturn = [Activity.mock(isRewindable: true), Activity.mock()]
+        store.state.activities[jetpackSiteRef] = [try Activity.mock()]
+        activityServiceMock.activitiesToReturn = [try Activity.mock(isRewindable: true), try Activity.mock()]
         activityServiceMock.hasMore = true
 
         store.onlyRestorableItems = true

--- a/WordPress/WordPressTest/Test Data/activity-log-comment.json
+++ b/WordPress/WordPressTest/Test Data/activity-log-comment.json
@@ -1,4 +1,5 @@
 {
+    "activityId": "id-123",
     "summary": "Comment approved",
     "content": {
         "text": "Comment by aaaaaaaaaa on Hola Lima! 🇵🇪: Great post! True talent!",

--- a/WordPress/WordPressTest/Test Data/activity-log-post.json
+++ b/WordPress/WordPressTest/Test Data/activity-log-post.json
@@ -1,4 +1,5 @@
 {
+    "activityId": "id-123",
     "summary": "Post published",
     "content": {
         "text": "Tren de Machu Picchu a Cusco",


### PR DESCRIPTION
I updated WordPressKit to 7.2.0 as part of the 22.2 code freeze, but that turned out to break the unit tests build. Once I updated the tests to build, they showed failures, see 47ba771a7842ac613c21bee1a67591b0ab88a40a.

After some investigation, it became clear that 7.2.0 introduced a breaking change (hence it should have been 8.0.0) and that it required a fix (https://github.com/wordpress-mobile/WordPressKit-iOS/pull/596).

Notice that, as far as I can see, the changes from 7.2.0/8.0.0 are not required by 22.2, so I could have just as well reverted the WordPressKit update. I decided to move on instead to address the breaking change while I was at it, without splitting the work into two chunks (finish code freeze, address breaking change then update versions on `trunk`).