### PR TITLE
Fix Domains Service initializer crash when wordPressComRestApi is nil

### DIFF
--- a/WordPress/Classes/Services/BlogService+Domains.swift
+++ b/WordPress/Classes/Services/BlogService+Domains.swift
@@ -6,6 +6,7 @@ extension BlogService {
     enum BlogServiceDomainError: Error {
         case noAccountForSpecifiedBlog(blog: Blog)
         case noSiteIDForSpecifiedBlog(blog: Blog)
+        case noWordPressComRestApi(blog: Blog)
     }
 
     /// Convenience method to be able to refresh the blogs from ObjC.
@@ -14,6 +15,11 @@ extension BlogService {
     func refreshDomains(for blog: Blog, success: (() -> Void)?, failure: ((Error) -> Void)?) {
         guard let account = blog.account else {
             failure?(BlogServiceDomainError.noAccountForSpecifiedBlog(blog: blog))
+            return
+        }
+
+        guard account.wordPressComRestApi != nil else {
+            failure?(BlogServiceDomainError.noWordPressComRestApi(blog: blog))
             return
         }
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -192,13 +192,15 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         dispatch_group_leave(syncGroup);
     }];
     
-    dispatch_group_enter(syncGroup);
-    [self refreshDomainsFor:blog success:^{
-        dispatch_group_leave(syncGroup);
-    } failure:^(NSError * _Nonnull error) {
-        DDLogError(@"Failed refreshing domains: %@", error);
-        dispatch_group_leave(syncGroup);
-    }];
+    if ([DomainsDashboardCardHelper isFeatureEnabled]) {
+        dispatch_group_enter(syncGroup);
+        [self refreshDomainsFor:blog success:^{
+            dispatch_group_leave(syncGroup);
+        } failure:^(NSError * _Nonnull error) {
+            DDLogError(@"Failed refreshing domains: %@", error);
+            dispatch_group_leave(syncGroup);
+        }];
+    }
     
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class DomainsDashboardCardHelper {
+@objc final class DomainsDashboardCardHelper: NSObject {
 
     /// Checks conditions for showing domain dashboard cards
     static func shouldShowCard(
@@ -30,5 +30,9 @@ final class DomainsDashboardCardHelper {
 
         BlogDashboardPersonalizationService(siteID: siteID)
             .setEnabled(false, for: .domainsDashboardCard)
+    }
+
+    @objc static func isFeatureEnabled() -> Bool {
+        return AppConfiguration.isJetpack && RemoteFeatureFlag.domainsDashboardCard.enabled()
     }
 }


### PR DESCRIPTION
Fixes #20558

## Description

Domains Service initializer crashes when `wordPressComRestApi` is `nil`. 

This is at least [a 6 month issue](https://a8c.sentry.io/issues/3699671467/?environment=appStore&project=5716771&referrer=similar-issues&statsPeriod=14d) when refreshing domains from `BlogDetailsViewController`. 

However, with the introduction of the domains dashboard card, we also [refresh domains when refreshing blog metadata](https://github.com/wordpress-mobile/WordPress-iOS/pull/20423/commits/f19429836e1b726bd13f66174139808b6980b6c2). This created a second entry point for `DomainsService` initializer crash.

## Solution

1. Other service calls check for `wordPressComRestApi` since it can be `nil`. The long-term solution would be to make `wordPressComRestApi` nullable, which would force to handle `nil` scenarios in all the cases properly.
2. Additionally only refresh domains when the feature flag for the domains dashboard card is enabled, to avoid unnecessary refreshes.

## Testing

The easiest way to reproduce the issue is to return `nil` from `WPAccount.m` `wordPressComRestApi` (line 164). 

### Case 1:
1. Return `nil` from `WPAccount.m` `wordPressComRestApi` (line 164)
2. Launch Jetpack app
3. Log into .com account
4. Enable `Domain Dashboard Card` feature flag
5. Pull to refresh
6. There shouldn't be any crash

## Regression Notes

1. Potential unintended areas of impact

I tried to minimize the issue by moving it under the feature flag as well

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



