### PR TITLE
[Gutenberg] Update VideoPress upload processor (support self-closing block tag)

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -162,9 +162,9 @@ private extension GutenbergBlockProcessor {
     ///         - text: The string that the following parameter is found in.
     ///     - Returns: True if the block tag is self-closing.
     func isSelfClosingTag(forMatch openTag: NSTextCheckingResult, in text: String) -> Bool {
-        let range = openTag.range
-        let substring = text[Range(range, in: text)!]
-        return substring.hasSuffix("/-->")
+        let tagRange = text.range(from: openTag.range)
+        let tagSubstring = text[tagRange]
+        return tagSubstring.hasSuffix("/-->")
     }
 
     /// Determines if there are an equal number of opening and closing block tags in the provided text.

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -44,7 +44,7 @@ public class GutenbergBlockProcessor: Processor {
     /// 2. The block attributes
     ///
     var openTagRegex: NSRegularExpression {
-        let pattern = "\\<!--[ ]?(\(name))([\\s\\S]*?)-->"
+        let pattern = "\\<!--[ ]?(\(name))([\\s\\S]*?)\\/?-->"
         return try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
     }
 
@@ -107,7 +107,15 @@ private extension GutenbergBlockProcessor {
     private func process(_ match: NSTextCheckingResult, in text: String) -> (NSRange, String)? {
 
         var result: (NSRange, String)? = nil
-        if let closingRange = locateClosingTag(forMatch: match, in: text) {
+        if isSelfClosingTag(forMatch: match, in: text) {
+            let attributes = readAttributes(from: match, in: text)
+            let block = GutenbergBlock(name: name, attributes: attributes, content: "")
+
+            if let replacement = replacer(block) {
+                result = (match.range, replacement)
+            }
+        }
+        else if let closingRange = locateClosingTag(forMatch: match, in: text) {
             let attributes = readAttributes(from: match, in: text)
             let content = readContent(from: match, withClosingRange: closingRange, in: text)
             let parsedContent = process(content) // Recurrsively parse nested blocks and process those seperatly
@@ -145,6 +153,18 @@ private extension GutenbergBlockProcessor {
         }
 
         return nil
+    }
+
+    /// Determines if the block tag is self-closing.
+    /// E.g.: <!-- wp:videopress/video {"guid":"AbCdE","id":100} /-->
+    ///     - Parameters:
+    ///         - openTag: The match reperesenting an opening block tag
+    ///         - text: The string that the following parameter is found in.
+    ///     - Returns: True if the block tag is self-closing.
+    func isSelfClosingTag(forMatch openTag: NSTextCheckingResult, in text: String) -> Bool {
+        let range = openTag.range
+        let substring = text[Range(range, in: text)!]
+        return substring.hasSuffix("/-->")
     }
 
     /// Determines if there are an equal number of opening and closing block tags in the provided text.

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
@@ -6,42 +6,11 @@ class GutenbergVideoPressUploadProcessor: Processor {
     let mediaUploadID: Int32
     let serverMediaID: Int
     let videoPressGUID: String
-    private var videoPressURL: VideoPressURL?
 
     private enum VideoPressBlockKeys: String {
         case name = "wp:videopress/video"
         case id
         case guid
-        case resizeToParent
-        case cover
-        case autoplay
-        case controls
-        case loop
-        case muted
-        case playsinline
-        case poster
-        case preload
-        case seekbarColor
-        case seekbarPlayedColor
-        case seekbarLoadingColor
-        case useAverageColor
-    }
-
-    private enum VideoPressURLQueryParams: String {
-        case resizeToParent
-        case cover
-        case autoPlay
-        case controls
-        case loop
-        case muted
-        case persistVolume
-        case playsinline
-        case posterUrl
-        case preloadContent
-        case sbc
-        case sbpc
-        case sblc
-        case useAverageColor
     }
 
     init(mediaUploadID: Int32, serverMediaID: Int, videoPressGUID: String) {
@@ -49,18 +18,6 @@ class GutenbergVideoPressUploadProcessor: Processor {
         self.serverMediaID = serverMediaID
         self.videoPressGUID = videoPressGUID
     }
-
-    lazy var videoPressHtmlProcessor = HTMLProcessor(for: "figure", replacer: { (figure) in
-        let url = self.videoPressURL?.getURLString() ?? ""
-        var attributes = figure.attributes
-        var html = "<figure "
-        let attributeSerializer = ShortcodeAttributeSerializer()
-        html += attributeSerializer.serialize(figure.attributes)
-        html += "><div class=\"jetpack-videopress-player__wrapper\">"
-        html += "\n\(url.escapeHtmlNamedEntities())\n"
-        html += "</div></figure>"
-        return html
-    })
 
     lazy var videoPressBlockProcessor = GutenbergBlockProcessor(for: VideoPressBlockKeys.name.rawValue, replacer: { videoPressBlock in
         guard let mediaID = videoPressBlock.attributes[VideoPressBlockKeys.id.rawValue] as? Int, mediaID == self.mediaUploadID else {
@@ -74,168 +31,9 @@ class GutenbergVideoPressUploadProcessor: Processor {
             let jsonString = String(data: jsonData, encoding: .utf8) {
             block += jsonString
         }
-        block += " -->"
-
-        self.videoPressURL = VideoPressURL(attributes: attributes, guid: self.videoPressGUID)
-        block += self.videoPressHtmlProcessor.process(videoPressBlock.content)
-
-        block += "<!-- /\(VideoPressBlockKeys.name.rawValue) -->"
+        block += " /-->"
         return block
     })
-
-    /// The VideoPress URL is built using the same logic we have in Jetpack:
-    /// https://github.com/Automattic/jetpack/blob/b1b826ab38690c5fad18789301ac81297a458878/projects/packages/videopress/src/client/lib/url/index.ts#L19-L67
-    private struct VideoPressURL {
-        let attributes: [String: Any]
-        let guid: String
-        private var options: [URLQueryItem]
-
-        init(attributes: [String: Any], guid: String) {
-            self.attributes = attributes
-            self.guid = guid
-            self.options = [URLQueryItem]()
-
-            // Populate options
-            addDefaultOptions()
-            addAutoPlayOption()
-            addControlsOption()
-            addLoopOption()
-            addVolumeOptions()
-            addPlaysInlineOption()
-            addPosterOption()
-            addPreloadOption()
-            addSeekbarOptions()
-            addUseAverageColorOption()
-        }
-
-        /// Returns the string of the VideoPress URL.
-        func getURLString() -> String {
-            guard let url = URL(string: "https://videopress.com/v/\(guid)"), var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-                return ""
-            }
-            urlComponents.queryItems = options
-            guard
-                let query = urlComponents.query,
-                /// In web, the query parameters are encoded using `encodeURIComponent` that percent encodes reserved characters (like `/` and `:`) that are not strictly necessary to be encoded based on RFC 3986.
-                /// In the spirit of generating an URL with the same encoding, we encode using `urlHostAllowed` which percent encodes all reserved characters.
-                ///
-                /// References:
-                /// - https://en.wikipedia.org/wiki/URL_encoding#Reserved_characters
-                /// - https://www.ietf.org/rfc/rfc3986.txt
-                /// - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
-                /// - https://github.com/WordPress/gutenberg/blob/1dfec0ab5f0977dcce2722bdfbe823926903e2a6/packages/url/src/build-query-string.js#L53
-                let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
-                return url.absoluteString
-            }
-            return "\(url.absoluteString)?\(encodedQuery)"
-        }
-
-        /// Adds default options.
-        private mutating func addDefaultOptions() {
-            options += [
-                URLQueryItem(name: VideoPressURLQueryParams.resizeToParent.rawValue, value: true.stringLiteral),
-                URLQueryItem(name: VideoPressURLQueryParams.cover.rawValue, value: true.stringLiteral),
-            ]
-        }
-
-        /// Adds AutoPlay option.
-        ///
-        /// Turned OFF by default.
-        private mutating func addAutoPlayOption() {
-            if let autoplay = attributes[VideoPressBlockKeys.autoplay.rawValue] as? Bool, autoplay == true {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.autoPlay.rawValue, value: autoplay.stringLiteral))
-            }
-        }
-
-        /// Adds Controls option.
-        ///
-        /// Turned ON by default.
-        private mutating func addControlsOption() {
-            if let controls = attributes[VideoPressBlockKeys.controls.rawValue] as? Bool, controls == false {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.controls.rawValue, value: controls.stringLiteral))
-            }
-        }
-
-        /// Adds Loop option.
-        ///
-        /// Turned OFF by default.
-        private mutating func addLoopOption() {
-            if let loop = attributes[VideoPressBlockKeys.loop.rawValue] as? Bool, loop == true {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.loop.rawValue, value: loop.stringLiteral))
-            }
-        }
-
-        /// Adds Volume-related options.
-        ///
-        /// - Muted: Turned OFF by default.
-        private mutating func addVolumeOptions() {
-            if let muted = attributes[VideoPressBlockKeys.muted.rawValue] as? Bool, muted == true {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.muted.rawValue, value: muted.stringLiteral))
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.persistVolume.rawValue, value: false.stringLiteral))
-            }
-        }
-
-        /// Adds PlaysInline option.
-        ///
-        /// Turned OFF by default.
-        private mutating func addPlaysInlineOption() {
-            if let playinline = attributes[VideoPressBlockKeys.playsinline.rawValue] as? Bool, playinline == true {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.playsinline.rawValue, value: playinline.stringLiteral))
-            }
-        }
-
-        /// Adds Poster option.
-        ///
-        /// No image by default.
-        private mutating func addPosterOption() {
-            if let poster = attributes[VideoPressBlockKeys.poster.rawValue] as? String, !poster.isEmpty {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.posterUrl.rawValue, value: poster))
-            }
-        }
-
-        /// Adds Preload option.
-        ///
-        /// Metadata by default.
-        private mutating func addPreloadOption() {
-            if let preload = attributes[VideoPressBlockKeys.preload.rawValue] as? String, !preload.isEmpty {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: preload))
-            }
-            else {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: "metadata"))
-            }
-        }
-
-        /// Adds Seekbar options.
-        ///
-        /// - SeekbarColor: No color by default.
-        /// - SeekbarPlayerColor: No color by default.
-        /// - SeekbarLoadingColor: No color by default.
-        private mutating func addSeekbarOptions() {
-            if let seekbarColor = attributes[VideoPressBlockKeys.seekbarColor.rawValue] as? String, !seekbarColor.isEmpty {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.sbc.rawValue, value: seekbarColor))
-            }
-            if let seekbarPlayedColor = attributes[VideoPressBlockKeys.seekbarPlayedColor.rawValue] as? String, !seekbarPlayedColor.isEmpty {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.sbpc.rawValue, value: seekbarPlayedColor))
-            }
-            if let seekbarLoadingColor = attributes[VideoPressBlockKeys.seekbarLoadingColor.rawValue] as? String, !seekbarLoadingColor.isEmpty {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.sblc.rawValue, value: seekbarLoadingColor))
-            }
-        }
-
-        /// Adds UseAverageColor option.
-        ///
-        /// Turned ON by default.
-        private mutating func addUseAverageColorOption() {
-            if let useAverageColor = attributes[VideoPressBlockKeys.useAverageColor.rawValue] as? Bool {
-                if useAverageColor == true {
-                    options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: useAverageColor.stringLiteral))
-                }
-            }
-            else {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: true.stringLiteral))
-            }
-        }
-    }
 
     func process(_ text: String) -> String {
         return videoPressBlockProcessor.process(text)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
@@ -11,6 +11,7 @@ class GutenbergVideoPressUploadProcessor: Processor {
         case name = "wp:videopress/video"
         case id
         case guid
+        case src
     }
 
     init(mediaUploadID: Int32, serverMediaID: Int, videoPressGUID: String) {
@@ -27,6 +28,10 @@ class GutenbergVideoPressUploadProcessor: Processor {
         var attributes = videoPressBlock.attributes
         attributes[VideoPressBlockKeys.id.rawValue] = self.serverMediaID
         attributes[VideoPressBlockKeys.guid.rawValue] = self.videoPressGUID
+        // Removing `src` attribute if it points to a local file.
+        if let srcAttribute = attributes[VideoPressBlockKeys.src.rawValue] as? String, srcAttribute.starts(with: "file:") {
+            attributes.removeValue(forKey: VideoPressBlockKeys.src.rawValue)
+        }
         if let jsonData = try? JSONSerialization.data(withJSONObject: attributes, options: .sortedKeys),
             let jsonString = String(data: jsonData, encoding: .utf8) {
             block += jsonString

--- a/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
@@ -5,17 +5,11 @@ import XCTest
 class GutenbergVideoPressUploadProcessorTests: XCTestCase {
 
     let blockWithDefaultAttrsContent = """
-    <!-- wp:videopress/video {"id":-181231834} -->
-    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"></figure>
-    <!-- /wp:videopress/video -->
+    <!-- wp:videopress/video {"id":-181231834} /-->
     """
 
     let blockWithDefaultAttrsResultContent = """
-    <!-- wp:videopress/video {"guid":"AbCdE","id":100} -->
-    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">
-    https://videopress.com/v/AbCdE?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
-    </div></figure>
-    <!-- /wp:videopress/video -->
+    <!-- wp:videopress/video {"guid":"AbCdE","id":100} /-->
     """
 
     func testVideoPressBlockWithDefaultAttrsProcessor() {
@@ -30,17 +24,11 @@ class GutenbergVideoPressUploadProcessorTests: XCTestCase {
     }
 
     let blockWithAttrsContent = """
-    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":-181231834,"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} -->
-    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"></figure>
-    <!-- /wp:videopress/video -->
+    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":-181231834,"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} /-->
     """
 
     let blockWithAttrsResultContent = """
-    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","guid":"AbCdE","id":100,"loop":true,"muted":true,"playsinline":true,"poster":"https:\\/\\/test.files.wordpress.com\\/2022\\/02\\/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} -->
-    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">
-    https://videopress.com/v/AbCdE?resizeToParent=true&amp;cover=true&amp;autoPlay=true&amp;controls=false&amp;loop=true&amp;muted=true&amp;persistVolume=false&amp;playsinline=true&amp;posterUrl=https%3A%2F%2Ftest.files.wordpress.com%2F2022%2F02%2F265-5000x5000-1.jpeg&amp;preloadContent=none&amp;sbc=%23abb8c3&amp;sbpc=%239b51e0&amp;sblc=%23cf2e2e
-    </div></figure>
-    <!-- /wp:videopress/video -->
+    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","guid":"AbCdE","id":100,"loop":true,"muted":true,"playsinline":true,"poster":"https:\\/\\/test.files.wordpress.com\\/2022\\/02\\/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} /-->
     """
 
     func testVideoPressBlockWithAttrsProcessor() {

--- a/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class GutenbergVideoPressUploadProcessorTests: XCTestCase {
 
     let blockWithDefaultAttrsContent = """
-    <!-- wp:videopress/video {"id":-181231834} /-->
+    <!-- wp:videopress/video {"id":-181231834, "src":"file:///LocalFolder/181231834.mp4"} /-->
     """
 
     let blockWithDefaultAttrsResultContent = """


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5678.

This PR updates the VideoPress upload processor following [a recent change in the block format](https://github.com/Automattic/jetpack/pull/30134). Additionally, the upload processor logic has been updated to support the self-closing block tag (e.g. `<!-- wp:videopress/video {"id":"1234","guid":"AbCdE" /-->`), as the VideoPress block uses this format. Note that most of the changes are reverting the modifications introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/20380 (https://github.com/wordpress-mobile/WordPress-iOS/pull/20563/commits/b5b5c1a7edad8d17b86e3e6d90b87b7678510806).

## To test

_Testing instructions copied from https://github.com/wordpress-mobile/WordPress-iOS/pull/20380._

### Potential regressions
This change shouldn't impact the rest of the upload processors, however, it would be great to double-check it.

1. Create/open a post.
2. Add a Video block.
3. Select the "Choose from device" option.
4. Select a video.
5. While there’s an ongoing upload, close the post with publishing changes.
6. Verify that you see the upload progress in the post summary.
7. Re-open the post.
8. Verify that the Video block shows the video.
9. Preview the post and observe that the video can be played.

### VideoPress block
**NOTE:** Use the changes from this PR to test this section.

1. Create/open a post.
2. Add a VideoPress block.
3. Select the "Choose from device" option.
4. Select a video.
5. While there’s an ongoing upload, close the post with publishing changes.
6. Verify that you see the upload progress in the post summary.
7. Re-open the post.
8. Preview the post and observe that the video can be played.

## Regression Notes
1. Potential unintended areas of impact

This change could impact other upload processors due to the change related to supporting the self-closing tag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested the VideoPress upload processor and checked the unit tests of other upload processors.

3. What automated tests I added (or what prevented me from doing so)

I haven't added automated tests but updated the ones related to VideoPress upload processor.


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
