### PR TITLE
[DO NOT MERGE] Test PR for adding UI tests crash logs to CI

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,8 +40,9 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 💥 Collect Crash reports"
+mkdir -p build/results/crashes
 find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
-  cp  -p "$file" "build/results/crashes/$(basename "$file")"
+  cp "$file" "build/results/crashes/$(basename "$file")"
 done
 
 echo "--- 🚦 Report Tests Status"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,7 +40,7 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 💥 Collect Crash reports"
-for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]]; then cp "$f" "build/results/CRASH_$(basename "$f")"; fi; done
+for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]]; then cp "$f" "build/results/[CRASH]$(basename "$f")"; fi; done
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,7 +40,7 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 💥 Collect Crash reports"
-for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]] then; cp "$f" "build/results/CRASH_$(basename "$f")"; fi; done
+for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]]; then cp "$f" "build/results/CRASH_$(basename "$f")"; fi; done
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,10 +40,10 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- LISTING DIR ~/Library/Logs/CoreSimulator"
-cd ~/Library/Logs/CoreSimulator && ls -Rla && zip -rq core-simulator-crash-files.zip *.crash
+cd ~/Library/Logs/CoreSimulator && ls -Rla && zip -rq core-simulator-crash-files.zip * || true
 
 echo "--- LISTING DIR ~/Library/Logs/DiagnosticReports/"
-cd ~/Library/Logs/DiagnosticReports/ && ls -Rla && zip -rq diag-reports-crash-files.zip *.crash
+cd ~/Library/Logs/DiagnosticReports/ && ls -Rla && zip -rq diag-reports-crash-files.zip * || true
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,7 +40,9 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 💥 Collect Crash reports"
-for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]]; then cp "$f" "build/results/[CRASH]$(basename "$f")"; fi; done
+find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
+  cp "$file" "build/results/[CRASH] $(basename "$file")"
+done
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -39,11 +39,15 @@ fi
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
-echo "--- LISTING DIR ~/Library/Logs/CoreSimulator"
-ls -Rla ~/Library/Logs/CoreSimulator && zip -rq build/results/core-simulator-crash-files.zip ~/Library/Logs/CoreSimulator/* || true
+echo "--- FOR"
+for file in ~/Library/Logs/DiagnosticReports/*.ips; do cp "$file" "build/results/CRASH_$(basename "$file")"; done
+echo "--- CP"
+cp ~/Library/Logs/DiagnosticReports/*.ips build/results/
 
-echo "--- LISTING DIR ~/Library/Logs/DiagnosticReports/"
-ls -Rla ~/Library/Logs/DiagnosticReports/ && zip -rq build/results/diag-reports-crash-files.zip ~/Library/Logs/DiagnosticReports/* || true
+echo "--- FOR - NO FILES"
+for file in ~/Library/Logs/DiagnosticReports/*.X; do cp "$file" "build/results/CRASH_$(basename "$file")"; done
+echo "--- CP - NO FILES"
+cp ~/Library/Logs/DiagnosticReports/*.X build/results/
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -41,7 +41,7 @@ cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult
 
 echo "--- 💥 Collect Crash reports"
 find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
-  cp  -p "$file" "build/results/crashes/$file"
+  cp  -p "$file" "build/results/crashes/$(basename "$file")"
 done
 
 echo "--- 🚦 Report Tests Status"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,10 +40,10 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- LISTING DIR ~/Library/Logs/CoreSimulator"
-cd ~/Library/Logs/CoreSimulator && ls -Rla && zip -rq core-simulator-crash-files.zip * || true
+ls -Rla ~/Library/Logs/CoreSimulator && zip -rq build/results/core-simulator-crash-files.zip ~/Library/Logs/CoreSimulator/* || true
 
 echo "--- LISTING DIR ~/Library/Logs/DiagnosticReports/"
-cd ~/Library/Logs/DiagnosticReports/ && ls -Rla && zip -rq diag-reports-crash-files.zip * || true
+ls -Rla ~/Library/Logs/DiagnosticReports/ && zip -rq build/results/diag-reports-crash-files.zip ~/Library/Logs/DiagnosticReports/* || true
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -41,7 +41,7 @@ cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult
 
 echo "--- 💥 Collect Crash reports"
 find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
-  cp "$file" "build/results/[CRASH] $(basename "$file")"
+  cp  -p "$file" "build/results/crashes/$file"
 done
 
 echo "--- 🚦 Report Tests Status"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -41,9 +41,7 @@ cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult
 
 echo "--- 💥 Collect Crash reports"
 mkdir -p build/results/crashes
-find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
-  cp "$file" "build/results/crashes/$(basename "$file")"
-done
+find ~/Library/Logs/DiagnosticReports -name '*.ips' -exec cp "{}" "build/results/crashes/" \;
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -39,6 +39,12 @@ fi
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
+echo "--- LISTING DIR ~/Library/Logs/CoreSimulator"
+cd ~/Library/Logs/CoreSimulator && ls -Rla && zip -rq core-simulator-crash-files.zip *.crash
+
+echo "--- LISTING DIR ~/Library/Logs/DiagnosticReports/"
+cd ~/Library/Logs/DiagnosticReports/ && ls -Rla && zip -rq diag-reports-crash-files.zip *.crash
+
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
   echo "UI Tests seems to have passed (exit code 0). All good 👍"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -39,15 +39,8 @@ fi
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
-echo "--- FOR"
-for file in ~/Library/Logs/DiagnosticReports/*.ips; do cp "$file" "build/results/CRASH_$(basename "$file")"; done
-echo "--- CP"
-cp ~/Library/Logs/DiagnosticReports/*.ips build/results/
-
-echo "--- FOR - NO FILES"
-for file in ~/Library/Logs/DiagnosticReports/*.X; do cp "$file" "build/results/CRASH_$(basename "$file")"; done
-echo "--- CP - NO FILES"
-cp ~/Library/Logs/DiagnosticReports/*.X build/results/
+echo "--- 💥 Collect Crash reports"
+for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]] then; cp "$f" "build/results/CRASH_$(basename "$f")"; fi; done
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -106,6 +106,7 @@ steps:
         plugins: *common_plugins
         artifact_paths:
           - "build/results/*"
+          - "build/results/crashes/*"
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,7 +89,7 @@ steps:
         env: *common_env
         plugins: *common_plugins
         artifact_paths:
-          - "build/results/*"
+          - "build/results/**/**"
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
@@ -104,7 +104,7 @@ steps:
         env: *common_env
         plugins: *common_plugins
         artifact_paths:
-          - "build/results/*"
+          - "build/results/**/**"
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,7 +89,8 @@ steps:
         env: *common_env
         plugins: *common_plugins
         artifact_paths:
-          - "build/results/**/**"
+          - "build/results/*"
+          - "build/results/crashes/*"
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
@@ -104,7 +105,7 @@ steps:
         env: *common_env
         plugins: *common_plugins
         artifact_paths:
-          - "build/results/**/**"
+          - "build/results/*"
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,42 +14,42 @@ common_params:
 # This is the default pipeline – it will build and test the app
 steps:
 
-  #################
-  # Create Prototype Builds for WP and JP
-  #################
-  - group: "🛠 Prototype Builds"
-    steps:
-      - label: "🛠 WordPress Prototype Build"
-        command: ".buildkite/commands/prototype-build-wordpress.sh"
-        env: *common_env
-        plugins: *common_plugins
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "WordPress Prototype Build"
+  # #################
+  # # Create Prototype Builds for WP and JP
+  # #################
+  # - group: "🛠 Prototype Builds"
+  #   steps:
+  #     - label: "🛠 WordPress Prototype Build"
+  #       command: ".buildkite/commands/prototype-build-wordpress.sh"
+  #       env: *common_env
+  #       plugins: *common_plugins
+  #       if: "build.pull_request.id != null || build.pull_request.draft"
+  #       notify:
+  #         - github_commit_status:
+  #             context: "WordPress Prototype Build"
 
-      - label: "🛠 Jetpack Prototype Build"
-        command: ".buildkite/commands/prototype-build-jetpack.sh"
-        env: *common_env
-        plugins: *common_plugins
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "Jetpack Prototype Build"
+  #     - label: "🛠 Jetpack Prototype Build"
+  #       command: ".buildkite/commands/prototype-build-jetpack.sh"
+  #       env: *common_env
+  #       plugins: *common_plugins
+  #       if: "build.pull_request.id != null || build.pull_request.draft"
+  #       notify:
+  #         - github_commit_status:
+  #             context: "Jetpack Prototype Build"
 
   #################
   # Create Builds for Testing
   #################
   - group: "🛠 Builds for Testing"
     steps:
-      - label: "🛠 :wordpress: Build for Testing"
-        key: "build_wordpress"
-        command: ".buildkite/commands/build-for-testing.sh wordpress"
-        env: *common_env
-        plugins: *common_plugins
-        notify:
-          - github_commit_status:
-              context: "WordPress Build for Testing"
+      # - label: "🛠 :wordpress: Build for Testing"
+      #   key: "build_wordpress"
+      #   command: ".buildkite/commands/build-for-testing.sh wordpress"
+      #   env: *common_env
+      #   plugins: *common_plugins
+      #   notify:
+      #     - github_commit_status:
+      #         context: "WordPress Build for Testing"
 
       - label: "🛠 :jetpack: Build for Testing"
         key: "build_jetpack"
@@ -63,20 +63,20 @@ steps:
   #################
   # Run Unit Tests
   #################
-  - label: "🔬 :wordpress: Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh"
-    depends_on: "build_wordpress"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "Unit Tests"
-      - slack:
-          channels:
-            - "#mobile-apps-tests-notif"
-        if: build.state == "failed" && build.branch == "trunk"
+  # - label: "🔬 :wordpress: Unit Tests"
+  #   command: ".buildkite/commands/run-unit-tests.sh"
+  #   depends_on: "build_wordpress"
+  #   env: *common_env
+  #   plugins: *common_plugins
+  #   artifact_paths:
+  #     - "build/results/*"
+  #   notify:
+  #     - github_commit_status:
+  #         context: "Unit Tests"
+  #     - slack:
+  #         channels:
+  #           - "#mobile-apps-tests-notif"
+  #       if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # UI Tests
@@ -116,26 +116,26 @@ steps:
   #################
   # Linters
   #################
-  - group: "Linters"
-    steps:
-      - label: "🧹 Lint Translations"
-        command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
-        plugins:
-          - docker#v3.8.0:
-              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-        agents:
-          queue: "default"
-        notify:
-          - github_commit_status:
-              context: "Lint Translations"
-      # This step uses Danger to run RuboCop, but it's "agnostic" about it.
-      # That is, it outwardly only mentions RuboCop, not Danger
-      - label: ":rubocop: Lint Ruby Tooling"
-        command: .buildkite/commands/rubocop-via-danger.sh
-        plugins: *common_plugins
-        agents:
-          queue: "android"
-      - label: ":sleuth_or_spy: Lint Localized Strings Format"
-        command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: *common_plugins
-        env: *common_env
+  # - group: "Linters"
+  #   steps:
+  #     - label: "🧹 Lint Translations"
+  #       command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
+  #       plugins:
+  #         - docker#v3.8.0:
+  #             image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
+  #       agents:
+  #         queue: "default"
+  #       notify:
+  #         - github_commit_status:
+  #             context: "Lint Translations"
+  #     # This step uses Danger to run RuboCop, but it's "agnostic" about it.
+  #     # That is, it outwardly only mentions RuboCop, not Danger
+  #     - label: ":rubocop: Lint Ruby Tooling"
+  #       command: .buildkite/commands/rubocop-via-danger.sh
+  #       plugins: *common_plugins
+  #       agents:
+  #         queue: "android"
+  #     - label: ":sleuth_or_spy: Lint Localized Strings Format"
+  #       command: .buildkite/commands/lint-localized-strings-format.sh
+  #       plugins: *common_plugins
+  #       env: *common_env

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1048,7 +1048,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         ReaderPost *post = [context existingObjectWithID:postObjectID error:nil];
         Comment *comment = [self createHierarchicalCommentWithContent:content withParent:parentID postID:post.postID siteID:siteID inContext:context];
-        objectID = comment.objectID;
+//        objectID = comment.objectID;
         // This fixes an issue where the comment may not appear for some posts after a successful posting
         // More information: https://github.com/wordpress-mobile/WordPress-iOS/issues/13259
         comment.post = post;

--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -22,9 +22,16 @@
     {
       "skippedTests" : [
         "EditorAztecTests",
+        "EditorGutenbergTests",
+        "LoginTests",
         "LoginTests\/testEmailMagicLinkLogin()",
+        "MainNavigationTests",
+        "ReaderTests\/testViewPost()",
+        "ReaderTests\/testViewPostInSafari()",
         "SignupTests",
         "SignupTests\/testEmailSignup()",
+        "StatsTests",
+        "SupportScreenTests",
         "SupportScreenTests\/testSupportForumsCanBeLoadedDuringLogin()"
       ],
       "target" : {

--- a/WordPress/WordPressTest/CommentServiceTests.swift
+++ b/WordPress/WordPressTest/CommentServiceTests.swift
@@ -1,128 +1,128 @@
-import Foundation
-import Nimble
-import XCTest
-
-@testable import WordPress
-
-final class CommentServiceTests: CoreDataTestCase {
-
-    private var remoteMock: CommentServiceRemoteRESTMock!
-    private var service: CommentService!
-
-    // MARK: Lifecycle
-
-    override func setUp() {
-        super.setUp()
-
-        contextManager.useAsSharedInstance(untilTestFinished: self)
-        remoteMock = CommentServiceRemoteRESTMock()
-
-        let remoteFactory = CommentServiceRemoteFactoryMock()
-        remoteFactory.restRemote = remoteMock
-        service = CommentService(coreDataStack: contextManager, commentServiceRemoteFactory: remoteFactory)
-    }
-
-    override func tearDown() {
-        super.tearDown()
-
-        service = nil
-        remoteMock = nil
-    }
-
-    // MARK: Helpers
-
-    private func createRemoteLikeUser() -> RemoteLikeUser {
-        let userDict: [String: Any] = [ "ID": NSNumber(value: 123),
-                                        "login": "johndoe",
-                                        "name": "John Doe",
-                                        "site_ID": NSNumber(value: 456),
-                                        "avatar_URL": "avatar URL",
-                                        "date_liked": "2021-02-09 08:34:43"
-        ]
-
-        return RemoteLikeUser(dictionary: userDict, commentID: NSNumber(value: 1), siteID: NSNumber(value: 2))
-    }
-}
-
-// MARK: - Tests
-
-extension CommentServiceTests {
-
-    // MARK: Fetch Likes
-
-    func testFetchingCommentLikesSuccessfullyShouldCallSuccessBlock() {
-        // Arrange
-        let commentID = NSNumber(value: 1)
-        let siteID = NSNumber(value: 2)
-        let expectedUsers = [createRemoteLikeUser()]
-        try! mainContext.save()
-        remoteMock.remoteUsersToReturnOnGetLikes = expectedUsers
-
-        // Act
-        waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
-                // Assert
-                expect(users).toNot(beNil())
-                expect(users.count) == 1
-                expect(likesPerPage) > 0
-                done()
-            },
-            failure: { _ in
-                fail("This closure should not be called")
-            })
-        }
-    }
-
-    func testFailingFetchCommentLikesShouldCallFailureBlock() {
-        // Arrange
-        let commentID = NSNumber(value: 1)
-        let siteID = NSNumber(value: 2)
-        try! mainContext.save()
-        remoteMock.fetchLikesShouldSucceed = false
-
-        // Act
-        waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
-                fail("this closure should not be called")
-            },
-            failure: { _ in
-                done()
-            })
-        }
-    }
-}
-
-// MARK: - Mocks
-
-private class CommentServiceRemoteFactoryMock: CommentServiceRemoteFactory {
-
-    var restRemote: CommentServiceRemoteREST = CommentServiceRemoteRESTMock()
-
-    override func restRemote(siteID: NSNumber, api: WordPressComRestApi) -> CommentServiceRemoteREST {
-        return restRemote
-    }
-
-}
-
-private class CommentServiceRemoteRESTMock: CommentServiceRemoteREST {
-
-    // related to fetching likes
-    var fetchLikesShouldSucceed: Bool = true
-    var remoteUsersToReturnOnGetLikes = [RemoteLikeUser]()
-    var totalLikes: NSNumber = 3
-
-    override func getLikesForCommentID(_ commentID: NSNumber,
-                                       count: NSNumber,
-                                       before: String?,
-                                       excludeUserIDs: [NSNumber]?,
-                                       success: (([RemoteLikeUser], NSNumber) -> Void)!,
-                                       failure: ((Error?) -> Void)!) {
-        DispatchQueue.global().async {
-            if self.fetchLikesShouldSucceed {
-                success(self.remoteUsersToReturnOnGetLikes, self.totalLikes)
-            } else {
-                failure(nil)
-            }
-        }
-    }
-}
+//import Foundation
+//import Nimble
+//import XCTest
+//
+//@testable import WordPress
+//
+//final class CommentServiceTests: CoreDataTestCase {
+//
+//    private var remoteMock: CommentServiceRemoteRESTMock!
+//    private var service: CommentService!
+//
+//    // MARK: Lifecycle
+//
+//    override func setUp() {
+//        super.setUp()
+//
+//        contextManager.useAsSharedInstance(untilTestFinished: self)
+//        remoteMock = CommentServiceRemoteRESTMock()
+//
+//        let remoteFactory = CommentServiceRemoteFactoryMock()
+//        remoteFactory.restRemote = remoteMock
+//        service = CommentService(coreDataStack: contextManager, commentServiceRemoteFactory: remoteFactory)
+//    }
+//
+//    override func tearDown() {
+//        super.tearDown()
+//
+//        service = nil
+//        remoteMock = nil
+//    }
+//
+//    // MARK: Helpers
+//
+//    private func createRemoteLikeUser() -> RemoteLikeUser {
+//        let userDict: [String: Any] = [ "ID": NSNumber(value: 123),
+//                                        "login": "johndoe",
+//                                        "name": "John Doe",
+//                                        "site_ID": NSNumber(value: 456),
+//                                        "avatar_URL": "avatar URL",
+//                                        "date_liked": "2021-02-09 08:34:43"
+//        ]
+//
+//        return RemoteLikeUser(dictionary: userDict, commentID: NSNumber(value: 1), siteID: NSNumber(value: 2))
+//    }
+//}
+//
+//// MARK: - Tests
+//
+//extension CommentServiceTests {
+//
+//    // MARK: Fetch Likes
+//
+//    func testFetchingCommentLikesSuccessfullyShouldCallSuccessBlock() {
+//        // Arrange
+//        let commentID = NSNumber(value: 1)
+//        let siteID = NSNumber(value: 2)
+//        let expectedUsers = [createRemoteLikeUser()]
+//        try! mainContext.save()
+//        remoteMock.remoteUsersToReturnOnGetLikes = expectedUsers
+//
+//        // Act
+//        waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
+//            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
+//                // Assert
+//                expect(users).toNot(beNil())
+//                expect(users.count) == 1
+//                expect(likesPerPage) > 0
+//                done()
+//            },
+//            failure: { _ in
+//                fail("This closure should not be called")
+//            })
+//        }
+//    }
+//
+//    func testFailingFetchCommentLikesShouldCallFailureBlock() {
+//        // Arrange
+//        let commentID = NSNumber(value: 1)
+//        let siteID = NSNumber(value: 2)
+//        try! mainContext.save()
+//        remoteMock.fetchLikesShouldSucceed = false
+//
+//        // Act
+//        waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
+//            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
+//                fail("this closure should not be called")
+//            },
+//            failure: { _ in
+//                done()
+//            })
+//        }
+//    }
+//}
+//
+//// MARK: - Mocks
+//
+//private class CommentServiceRemoteFactoryMock: CommentServiceRemoteFactory {
+//
+//    var restRemote: CommentServiceRemoteREST = CommentServiceRemoteRESTMock()
+//
+//    override func restRemote(siteID: NSNumber, api: WordPressComRestApi) -> CommentServiceRemoteREST {
+//        return restRemote
+//    }
+//
+//}
+//
+//private class CommentServiceRemoteRESTMock: CommentServiceRemoteREST {
+//
+//    // related to fetching likes
+//    var fetchLikesShouldSucceed: Bool = true
+//    var remoteUsersToReturnOnGetLikes = [RemoteLikeUser]()
+//    var totalLikes: NSNumber = 3
+//
+//    override func getLikesForCommentID(_ commentID: NSNumber,
+//                                       count: NSNumber,
+//                                       before: String?,
+//                                       excludeUserIDs: [NSNumber]?,
+//                                       success: (([RemoteLikeUser], NSNumber) -> Void)!,
+//                                       failure: ((Error?) -> Void)!) {
+//        DispatchQueue.global().async {
+//            if self.fetchLikesShouldSucceed {
+//                success(self.remoteUsersToReturnOnGetLikes, self.totalLikes)
+//            } else {
+//                failure(nil)
+//            }
+//        }
+//    }
+//}


### PR DESCRIPTION
The objective of this PR is to make crash reports available in CI as an artifact. 
In order to test this
* the crash when replying to a post was reintroduced 
* pipeline was reduced to save time and resources
* all UI Tests, except for `testAddComments()` were disabled to save time and resources
