### PR TITLE
Fix: Use default value for nil sitenames when displaying a notice

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -368,9 +368,9 @@ struct ReaderPostMenuButtonTitles {
         let blogName = {
             guard let blogNameForDisplay = post.blogNameForDisplay() else {
                 if let siteID = post.siteID, let postID = post.postID {
-                    WordPressAppDelegate.crashLogging?.logMessage("Expected blogNameForDisplay() to exist",
-                                                                  properties: ["siteID": siteID, "postID": postID],
-                                                                  level: .error)
+                    CrashLogging.main.logMessage("Expected blogNameForDisplay() to exist",
+                                                 properties: ["siteID": siteID, "postID": postID],
+                                                 level: .error)
                 }
                 return NoticeMessages.unknownSiteText
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressShared
 import WordPressFlux
+import AutomatticTracks
 
 
 // MARK: - Reader Notifications

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -365,7 +365,18 @@ struct ReaderPostMenuButtonTitles {
     }
 
     class func dispatchToggleFollowSiteMessage(post: ReaderPost, follow: Bool, success: Bool) {
-        dispatchToggleFollowSiteMessage(siteTitle: post.blogNameForDisplay(), siteID: post.siteID, follow: follow, success: success)
+        let blogName = {
+            guard let blogNameForDisplay = post.blogNameForDisplay() else {
+                if let siteID = post.siteID, let postID = post.postID {
+                    WordPressAppDelegate.crashLogging?.logMessage("Expected blogNameForDisplay() to exist",
+                                                                  properties: ["siteID": siteID, "postID": postID],
+                                                                  level: .error)
+                }
+                return NoticeMessages.unknownSiteText
+            }
+            return blogNameForDisplay
+        }()
+        dispatchToggleFollowSiteMessage(siteTitle: blogName, siteID: post.siteID, follow: follow, success: success)
     }
 
     class func dispatchToggleFollowSiteMessage(site: ReaderSiteTopic, follow: Bool, success: Bool) {
@@ -526,6 +537,14 @@ struct ReaderPostMenuButtonTitles {
         static let commentUnfollowFail = NSLocalizedString("Failed to unfollow conversation", comment: "The app failed to unsubscribe from the comments for the post")
         static let commentFollowError = NSLocalizedString("Could not subscribe to comments", comment: "The app failed to subscribe to the comments for the post")
         static let commentUnfollowError = NSLocalizedString("Could not unsubscribe from comments", comment: "The app failed to unsubscribe from the comments for the post")
+        static let unknownSiteText = NSLocalizedString(
+            "reader.notice.follow.site.unknown",
+            value: "this site",
+            comment: """
+                A default value used to fill in the site name when the followed site somehow has missing site name or URL.
+                Example: given a notice format "Following %@" and empty site name, this will be "Following this site".
+                """
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #20565 

Sometimes the `post.blogNameForDisplay()` would return nil, which throws a fatal error. I haven't figured out the exact reason why that would return nil, but this adds some mitigation steps:

- Show "Following this site" instead of crashing
- Log the message to Sentry (so we can track the frequency)

## To test

Follow the reproduction steps from #20565:

1. Reader -> Search
2. Type "adafruit"
3. Followed hackaday.com and blog.adafruit.com from the top two posts

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A, no UI changes impacted or introduced.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)