### PR TITLE
Domains Dashboard Card: Card UI v2

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
@@ -60,34 +60,21 @@ class DashboardDomainsCardCell: DashboardCollectionViewCell {
         return label
     }()
 
+    private lazy var dashboardDomainsCardSearchView: UIView = {
+        let searchView = UIView.embedSwiftUIView(DashboardDomainsCardSearchVew())
+        searchView.translatesAutoresizingMaskIntoConstraints = false
+        return searchView
+    }()
+
     private lazy var containerStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [dashboardIconView, descriptionLabel])
-        stackView.axis = .horizontal
+        let stackView = UIStackView(arrangedSubviews: [dashboardDomainsCardSearchView, descriptionLabel])
+        stackView.axis = .vertical
         stackView.spacing = Metrics.stackViewSpacing
-        stackView.alignment = .center
+        stackView.alignment = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.directionalLayoutMargins = Metrics.contentDirectionalLayoutMargins
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
-    }()
-
-    private lazy var dashboardIconView: UIView = {
-        let circleView = UIView(frame: .zero)
-        circleView.backgroundColor = .jetpackGreen
-        circleView.layer.cornerRadius = Metrics.iconSize / 2
-        circleView.layer.masksToBounds = true
-        circleView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            circleView.widthAnchor.constraint(equalToConstant: Metrics.iconSize),
-            circleView.heightAnchor.constraint(equalToConstant: Metrics.iconSize)
-        ])
-
-        circleView.addSubview(dashboardIcon)
-        NSLayoutConstraint.activate([
-            dashboardIcon.centerXAnchor.constraint(equalTo: circleView.centerXAnchor),
-            dashboardIcon.centerYAnchor.constraint(equalTo: circleView.centerYAnchor)
-        ])
-        return circleView
     }()
 
     private lazy var dashboardIcon: UIImageView = {
@@ -148,14 +135,12 @@ extension DashboardDomainsCardCell {
     }
 
     private enum Style {
-        static let titleLabelFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
         static let descriptionLabelFont = WPStyleGuide.fontForTextStyle(.subheadline)
         static let hideThisImage = UIImage(systemName: "minus.circle")
     }
 
     private enum Metrics {
-        static let stackViewSpacing = 16.0
-        static let iconSize = 40.0
+        static let stackViewSpacing: CGFloat = -20 // Negative since the views should overlap
         static let contentDirectionalLayoutMargins = NSDirectionalEdgeInsets(top: 8.0,
                                                                              leading: 16.0,
                                                                              bottom: 8.0,
@@ -163,8 +148,8 @@ extension DashboardDomainsCardCell {
     }
 
     private enum Strings {
-        static let title = NSLocalizedString("domain.dashboard.card.title",
-                                             value: "Own your online identity with a custom domain",
+        static let title = NSLocalizedString("domain.dashboard.card.shortTitle",
+                                             value: "Find a custom domain",
                                              comment: "Title for the Domains dashboard card.")
         static let description = NSLocalizedString("domain.dashboard.card.description",
                                                    value: "Stake your claim on your corner of the web with a site address that’s easy to find, share and follow.",

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
@@ -61,7 +61,7 @@ class DashboardDomainsCardCell: DashboardCollectionViewCell {
     }()
 
     private lazy var dashboardDomainsCardSearchView: UIView = {
-        let searchView = UIView.embedSwiftUIView(DashboardDomainsCardSearchVew())
+        let searchView = UIView.embedSwiftUIView(DashboardDomainsCardSearchView())
         searchView.translatesAutoresizingMaskIntoConstraints = false
         return searchView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardSearchView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardSearchView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct DashboardDomainsCardSearchVew: View {
+struct DashboardDomainsCardSearchView: View {
     @SwiftUI.Environment(\.colorScheme) var colorScheme: ColorScheme
 
     var body: some View {
@@ -45,7 +45,7 @@ struct DashboardDomainsCardSearchVew: View {
     }
 }
 
-private extension DashboardDomainsCardSearchVew {
+private extension DashboardDomainsCardSearchView {
     enum Metrics {
         static let padding: CGFloat = 8
         static let cornerRadius: CGFloat = 16

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardSearchView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardSearchView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct DashboardDomainsCardSearchVew: View {
+    @SwiftUI.Environment(\.colorScheme) var colorScheme: ColorScheme
+
+    var body: some View {
+        VStack(alignment: .center) {
+            HStack {
+                Image(systemName: Constants.iconName)
+                    .foregroundColor(Colors.icon)
+                    .font(.system(size: Metrics.iconSize))
+                Text(Constants.searchBarPlaceholder)
+                    .foregroundColor(Colors.text)
+                    .font(.system(size: Metrics.fontSize))
+                Spacer()
+            }
+            .padding(.horizontal, Metrics.padding)
+            .frame(height: Metrics.searchBarHeight)
+            .background(
+                RoundedRectangle(cornerRadius: Metrics.containerCornerRadius)
+                    .foregroundColor(Colors.containerBackground)
+            )
+            Spacer()
+            RoundedRectangle(cornerRadius: Metrics.containerCornerRadius)
+                .foregroundColor(Colors.containerBackground)
+        }
+        .padding([.leading, .trailing, .top], Metrics.padding)
+        .frame(height: Metrics.height)
+        .background(
+            ZStack {
+                LinearGradient(
+                    gradient: Gradient(
+                        colors: [
+                            colorScheme == .light ? Colors.gradientTopLight : Colors.gradientTopDark,
+                            Color.clear
+                        ]
+                    ),
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            }
+        )
+        .cornerRadius(Metrics.cornerRadius)
+        .accessibilityHidden(true)
+    }
+}
+
+private extension DashboardDomainsCardSearchVew {
+    enum Metrics {
+        static let padding: CGFloat = 8
+        static let cornerRadius: CGFloat = 16
+        static let containerCornerRadius: CGFloat = 8
+        static let iconSize: CGFloat = 20
+        static let fontSize: CGFloat = 15 // fixed .footnote style size
+        static let height: CGFloat = 110
+        static let searchBarHeight: CGFloat = 40
+    }
+
+    enum Constants {
+        static let iconName = "globe"
+        static let searchBarPlaceholder = "domain.blog"
+    }
+
+    enum Colors {
+        static let gradientTopLight = Color(UIColor.secondarySystemBackground)
+        static let gradientTopDark = Color(UIColor.tertiarySystemBackground)
+        static let containerBackground = Color(UIColor.secondarySystemGroupedBackground)
+        static let icon = Color(UIColor.jetpackGreen)
+        static let text = Color(UIColor.textSubtle)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -167,6 +167,8 @@
 		01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
 		01DBFD8729BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01DBFD8829BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
+		01E61E5A29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */; };
+		01E61E5B29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */; };
 		01E78D1D296EA54F00FB6863 /* StatsPeriodHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */; };
 		02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */; };
 		02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */; };
@@ -5754,6 +5756,7 @@
 		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
+		01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainsCardSearchView.swift; sourceTree = "<group>"; };
 		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
 		02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+SectionHelpers.swift"; sourceTree = "<group>"; };
 		02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSubsectionToSectionCategoryTests.swift; sourceTree = "<group>"; };
@@ -9602,6 +9605,7 @@
 				DCFC097229D3549C00277ECB /* DashboardDomainsCardCell.swift */,
 				0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */,
 				0118969E29D30CAD00D34BA9 /* DomainsDashboardCardTracker.swift */,
+				01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */,
 			);
 			path = Domains;
 			sourceTree = "<group>";
@@ -21555,6 +21559,7 @@
 				931F312C2714302A0075433B /* PublicizeServicesState.swift in Sources */,
 				8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */,
 				FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */,
+				01E61E5A29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */,
 				803C493B283A7C0C00003E9B /* QuickStartChecklistHeader.swift in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
 				FF945F701B28242300FB8AC4 /* MediaLibraryPickerDataSource.m in Sources */,
@@ -25263,6 +25268,7 @@
 				FABB26012602FC2C00C8785C /* ReaderShareAction.swift in Sources */,
 				C7124E4F2638528F00929318 /* JetpackPrologueViewController.swift in Sources */,
 				FE341706275FA157005D5CA7 /* RichCommentContentRenderer.swift in Sources */,
+				01E61E5B29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */,
 				FABB26022602FC2C00C8785C /* PostingActivityMonth.swift in Sources */,
 				0107E15D28FFE99300DE87DB /* WidgetConfiguration.swift in Sources */,
 				FABB26032602FC2C00C8785C /* StreakStatsRecordValue+CoreDataClass.swift in Sources */,


### PR DESCRIPTION
Fixes #20550

## Description

Updated the UI to use "a placeholder search bar view" indicating to users the possibility to look for the domain.

## Testing instructions

1. Run the Jetpack app
2. Log into free .com website without a domain
3. Enable Domain Dashboard Card feature flag
4. Confirm that the domain dashboard card appears
5. Switch between Light / Dark mode - confirm that UI adapts
6. Increase/Decrease text size - confirm that title and description adapts and the search view remains static as an image
7. Change from vertical to horizontal orientation - confirm that UI adapts
8. Test voiceover - confirm that title, more button, and description are correctly indicated by voiceover


## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

- [x] Wait for https://github.com/wordpress-mobile/WordPress-iOS/pull/20562 to be merge and confirm that the tests continue to be working

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

https://user-images.githubusercontent.com/4062343/233357083-be98dce9-39dc-4d9a-992e-5217090286e0.mp4

| Light | Dark | iPad |
|-------|-------|------|
| ![Simulator Screen Shot - iPhone 14 - 2023-04-20 at 14 37 19](https://user-images.githubusercontent.com/4062343/233357127-fbc9f6ca-b90e-47e8-85d4-f6bbc0182134.png) | ![Simulator Screen Shot - iPhone 14 - 2023-04-20 at 14 37 11](https://user-images.githubusercontent.com/4062343/233357133-bb9e5111-29c4-49b6-b905-b77f45ddf1bf.png) | ![Simulator Screen Shot - iPad Air (5th generation) - 2023-04-20 at 14 28 13](https://user-images.githubusercontent.com/4062343/233357134-b4369703-2955-473a-95ee-fae25803165e.png) |
