### PR TITLE
Activity Log: Explicitly set Activity Store to return all items

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -6,6 +6,8 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
     let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
+        store.onlyRestorableItems = false
+
         let activityListConfiguration = ActivityListConfiguration(
             identifier: "activity_log",
             title: NSLocalizedString("Activity", comment: "Title for the activity list"),


### PR DESCRIPTION
Fixes #20581 

## Description
- Fixes a bug where the Activity Log was displaying only restorable items after visiting the Backup screen

## How to test

1. Switch to an account that has backups enabled (i.e. Business plan)
2. Go to the activity log and note the activities that are displayed
3. Go to the backup list and note the activities that are dipslayed
4. Go back to the activity log
5. ✅ The same activities from when you first visited the activity log should be displayed (i.e. all activities, not just restorable ones)

### Before

https://user-images.githubusercontent.com/6711616/233630751-3b956fab-0fe3-40cf-b06b-9ea367a0365b.mp4

### After 

https://user-images.githubusercontent.com/6711616/233630786-9f0ab106-3ad0-403f-a854-204c3a4c8bf0.mp4


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
