### PR TITLE
Make UI tests dismiss prompt to save password

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -38,6 +38,13 @@ public class PasswordScreen: ScreenObject {
         let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
 
+        // The Simulator might as to save the password which, of course, we don't want to do
+        if app.buttons["Save Password"].waitForExistence(timeout: 5) {
+            // There should be no need to wait for this button to exist since it's part of the same
+            // alert where "Save Password" is.
+            app.buttons["Not Now"].tap()
+        }
+
         return self
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -38,7 +38,7 @@ public class PasswordScreen: ScreenObject {
         let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
 
-        // The Simulator might as to save the password which, of course, we don't want to do
+        // The Simulator might ask to save the password which, of course, we don't want to do
         if app.buttons["Save Password"].waitForExistence(timeout: 5) {
             // There should be no need to wait for this button to exist since it's part of the same
             // alert where "Save Password" is.

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackUITests.xcscheme
@@ -29,7 +29,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:WordPressUITests/JetpackUITests.xctestplan"
+            reference = "container:UITests/JetpackUITests.xctestplan"
             default = "YES">
          </TestPlanReference>
       </TestPlans>


### PR DESCRIPTION
I don't know why this happens only to me, it clearly doesn't happen in CI, but when I run the UI tests locally they always get stuck because my Simulator is asking for input on saving the password.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**