### PR TITLE
Dashboard Cards: Track activity log events

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -286,6 +286,8 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
             return "activity_log"
         } else if presenter is BackupListViewController {
             return "backup"
+        } else if presenter is DashboardActivityLogCardCell {
+            return "dashboard"
         } else {
             return "unknown"
         }

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -47,8 +47,6 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         super.viewDidLoad()
 
         extendedLayoutIncludesOpaqueBars = true
-
-        WPAnalytics.track(.activityLogViewed)
     }
 
     private func configureBanner() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
@@ -38,7 +38,7 @@ extension DashboardActivityLogCardCell: ActivityPresenter {
         }
 
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
-        backupOptionsVC.presentedFrom = from ?? Constants.tabSource
+        backupOptionsVC.presentedFrom = from ?? Constants.sourceIdentifier
         let navigationVC = UINavigationController(rootViewController: backupOptionsVC)
         presentingViewController.present(navigationVC, animated: true)
     }
@@ -60,7 +60,7 @@ extension DashboardActivityLogCardCell: ActivityPresenter {
                                                                    isAwaitingCredentials: store.isAwaitingCredentials(site: site))
 
         restoreOptionsVC.restoreStatusDelegate = self
-        restoreOptionsVC.presentedFrom = from ?? Constants.tabSource
+        restoreOptionsVC.presentedFrom = from ?? Constants.sourceIdentifier
         let navigationVC = UINavigationController(rootViewController: restoreOptionsVC)
         presentingViewController.present(navigationVC, animated: true)
     }
@@ -72,5 +72,12 @@ extension DashboardActivityLogCardCell: JetpackRestoreStatusViewControllerDelega
 
     func didFinishViewing(_ controller: JetpackRestoreStatusViewController) {
         controller.dismiss(animated: true)
+    }
+}
+
+extension DashboardActivityLogCardCell {
+
+    private enum Constants {
+        static let sourceIdentifier = "dashboard"
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
@@ -38,7 +38,7 @@ extension DashboardActivityLogCardCell: ActivityPresenter {
         }
 
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
-        backupOptionsVC.presentedFrom = from ?? Constants.sourceIdentifier
+        backupOptionsVC.presentedFrom = from ?? Constants.tabSource
         let navigationVC = UINavigationController(rootViewController: backupOptionsVC)
         presentingViewController.present(navigationVC, animated: true)
     }
@@ -60,7 +60,7 @@ extension DashboardActivityLogCardCell: ActivityPresenter {
                                                                    isAwaitingCredentials: store.isAwaitingCredentials(site: site))
 
         restoreOptionsVC.restoreStatusDelegate = self
-        restoreOptionsVC.presentedFrom = from ?? Constants.sourceIdentifier
+        restoreOptionsVC.presentedFrom = from ?? Constants.tabSource
         let navigationVC = UINavigationController(rootViewController: restoreOptionsVC)
         presentingViewController.present(navigationVC, animated: true)
     }
@@ -72,12 +72,5 @@ extension DashboardActivityLogCardCell: JetpackRestoreStatusViewControllerDelega
 
     func didFinishViewing(_ controller: JetpackRestoreStatusViewController) {
         controller.dismiss(animated: true)
-    }
-}
-
-extension DashboardActivityLogCardCell {
-
-    private enum Constants {
-        static let sourceIdentifier = "dashboard"
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
@@ -12,6 +12,10 @@ extension DashboardActivityLogCardCell: ActivityPresenter {
             return
         }
 
+        WPAnalytics.track(.dashboardCardItemTapped,
+                          properties: ["type": DashboardCard.activityLog.rawValue],
+                          blog: blog)
+
         let detailVC = ActivityDetailViewController.loadFromStoryboard()
         detailVC.site = site
         detailVC.rewindStatus = store.state.rewindStatus[site]

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -189,7 +189,7 @@ extension DashboardActivityLogCardCell {
 
 extension DashboardActivityLogCardCell {
 
-    enum Constants {
+    private enum Constants {
         static let maxActivitiesCount = 3
         static let headerTapSource = "activity_card_header"
         static let contextMenuTapSource = "activity_card_context_menu"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -79,6 +79,10 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
 
         configureHeaderAction(for: blog)
         configureContextMenu(for: blog)
+
+        BlogDashboardAnalytics.shared.track(.dashboardCardShown,
+                                            properties: ["type": DashboardCard.activityLog.rawValue],
+                                            blog: blog)
     }
 
     private func configureHeaderAction(for blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -87,7 +87,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
 
     private func configureHeaderAction(for blog: Blog) {
         cardFrameView.onHeaderTap = { [weak self] in
-            self?.showActivityLog(for: blog)
+            self?.showActivityLog(for: blog, tapSource: Constants.headerTapSource)
         }
     }
 
@@ -100,7 +100,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
 
         let activityAction = UIAction(title: Strings.allActivity,
                                       image: Style.allActivityImage,
-                                      handler: { [weak self] _ in self?.showActivityLog(for: blog) })
+                                      handler: { [weak self] _ in self?.showActivityLog(for: blog, tapSource: Constants.contextMenuTapSource) })
 
         // Wrap the activity action in a menu to display a divider between the activity action and hide this action.
         // https://developer.apple.com/documentation/uikit/uimenu/options/3261455-displayinline
@@ -118,7 +118,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
 
     // MARK: - Navigation
 
-    private func showActivityLog(for blog: Blog) {
+    private func showActivityLog(for blog: Blog, tapSource: String) {
         guard let activityLogController = JetpackActivityLogViewController(blog: blog) else {
             return
         }
@@ -126,8 +126,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
 
         WPAnalytics.track(.activityLogViewed,
                           withProperties: [
-                            WPAppAnalyticsKeyTabSource: Constants.tabSource,
-                            WPAppAnalyticsKeyTapSource: Constants.tapSource
+                            WPAppAnalyticsKeyTapSource: tapSource
                           ])
     }
 
@@ -192,8 +191,8 @@ extension DashboardActivityLogCardCell {
 
     enum Constants {
         static let maxActivitiesCount = 3
-        static let tabSource = "dashboard"
-        static let tapSource = "activity_log_card"
+        static let headerTapSource = "activity_card_header"
+        static let contextMenuTapSource = "activity_card_context_menu"
     }
 
     private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -123,6 +123,12 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
             return
         }
         presentingViewController?.navigationController?.pushViewController(activityLogController, animated: true)
+
+        WPAnalytics.track(.activityLogViewed,
+                          withProperties: [
+                            WPAppAnalyticsKeyTabSource: Constants.tabSource,
+                            WPAppAnalyticsKeyTapSource: Constants.tapSource
+                          ])
     }
 
 }
@@ -184,8 +190,10 @@ extension DashboardActivityLogCardCell {
 
 extension DashboardActivityLogCardCell {
 
-    private enum Constants {
+    enum Constants {
         static let maxActivitiesCount = 3
+        static let tabSource = "dashboard"
+        static let tapSource = "activity_log_card"
     }
 
     private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -16,7 +16,7 @@ enum DashboardCard: String, CaseIterable {
     case draftPosts
     case scheduledPosts
     case pages
-    case activityLog
+    case activityLog = "activity_log"
     case nextPost = "create_next"
     case createPost = "create_first"
     case jetpackBadge

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1969,6 +1969,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
+    
+    [WPAnalytics track:WPAnalyticsStatActivityLogViewed
+                 withProperties:@{WPAppAnalyticsKeyTabSource: @"site_menu"}];
 }
 
 - (void)showBlaze

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1971,7 +1971,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
     
     [WPAnalytics track:WPAnalyticsStatActivityLogViewed
-                 withProperties:@{WPAppAnalyticsKeyTabSource: @"site_menu"}];
+                 withProperties:@{WPAppAnalyticsKeyTapSource: @"site_menu"}];
 }
 
 - (void)showBlaze


### PR DESCRIPTION
Closes #20451

## Description
Adds tracking for the activity log dashboard card

## How to test
1. Enable the activity log card remote feature flag via the debug menu
2. Switch to a site that has activity log enabled
3. Run and build the app
4. ✅ `my_site_dashboard_card_shown <blog_id: id, site_type: blog, type: activity_log>` is tracked
5. Tap on the card header
6. ✅ `activity_log_list_opened <tap_source: activity_card_header>` is tracked
7. Go back to the dashboard
8. Tap on an activity item
9. ✅ `my_site_dashboard_card_item_tapped <blog_id: id, site_type: blog, type: activity_log>` is tracked
10. Go back to the dashboard
11. Tap on the ellipsis button
13. ✅ `my_site_dashboard_contextual_menu_accessed <card: activity_log>` is tracked
14. Tap on the "All activity" button
15. ✅ `activity_log_list_opened <tap_source: activity_card_context_menu>` is tracked
16. Go back to the dashboard
17. Tap on the ellipsis button
18. Tap on the "Hide this" button
19. ✅ `my_site_dashboard_card_hide_tapped <card: activity_log>` is tracked


## Regression Notes
1. Potential unintended areas of impact
n/a

20. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

21. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
