### PR TITLE
[Gutenberg] Fix range out of bounds exception in block upload processor

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -162,8 +162,10 @@ private extension GutenbergBlockProcessor {
     ///         - text: The string that the following parameter is found in.
     ///     - Returns: True if the block tag is self-closing.
     func isSelfClosingTag(forMatch openTag: NSTextCheckingResult, in text: String) -> Bool {
-        let tagRange = text.range(from: openTag.range)
-        let tagSubstring = text[tagRange]
+        guard let tagRange = Range(openTag.range, in: text) else {
+            return false
+        }
+        let tagSubstring = String(text[tagRange])
         return tagSubstring.hasSuffix("/-->")
     }
 

--- a/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
@@ -41,4 +41,23 @@ class GutenbergVideoPressUploadProcessorTests: XCTestCase {
 
         XCTAssertEqual(resultContent, blockWithAttrsResultContent, "Post content should be updated correctly")
     }
+
+    let blockWithEmojiContent = """
+    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":-181231834,"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title 🙂","useAverageColor":false} /-->
+    """
+
+    let blockWithEmojiResultContent = """
+    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","guid":"AbCdE","id":100,"loop":true,"muted":true,"playsinline":true,"poster":"https:\\/\\/test.files.wordpress.com\\/2022\\/02\\/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title 🙂","useAverageColor":false} /-->
+    """
+
+    func testVideoPressBlockWithEmojiProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let videoPressGUID = "AbCdE"
+
+        let gutenbergVideoPressUploadProcessor = GutenbergVideoPressUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, videoPressGUID: videoPressGUID)
+        let resultContent = gutenbergVideoPressUploadProcessor.process(blockWithEmojiContent)
+
+        XCTAssertEqual(resultContent, blockWithEmojiResultContent, "Post content should be updated correctly")
+    }
 }


### PR DESCRIPTION
**Sentry report:** https://a8c.sentry.io/issues/4114698271/events/f9c6f32f642d4b7f9da004506289e989/

This PR updates the substring calculation made on the `isSelfClosingTag` function (introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/20563) when processing uploads. Seems when an emoji was present on any of the block attributes, the calculation was failing and throwing a `String index is out of bounds` exception.

## To test:

### Emoji case (cause of the crash)
1. Create/open a post.
2. Add a VideoPress block.
3. Add a video.
4. Open the block settings.
5. Add text to the title including at least one emoji.
6. Save the post.
7. Observe that the post is saved successfully and that the app doesn't crash.

### Potential regressions
This change shouldn't impact the rest of the upload processors, however, it would be great to double-check it.

1. Create/open a post.
2. Add a Video block.
3. Select the "Choose from device" option.
4. Select a video.
5. While there’s an ongoing upload, close the post with publishing changes.
6. Verify that you see the upload progress in the post summary.
7. Re-open the post.
8. Verify that the Video block shows the video.
9. Preview the post and observe that the video can be played.

### VideoPress block
**NOTE:** Use the changes from this PR to test this section.

1. Create/open a post.
2. Add a VideoPress block.
3. Select the "Choose from device" option.
4. Select a video.
5. While there’s an ongoing upload, close the post with publishing changes.
6. Verify that you see the upload progress in the post summary.
7. Re-open the post.
8. Preview the post and observe that the video can be played.

## Regression Notes
1. Potential unintended areas of impact
`isSelfClosingTag` function is only used in VideoPress blocks, which haven't been released yet. This block is only intended area of impact.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually testing the VideoPress upload processor.

9. What automated tests I added (or what prevented me from doing so)
I added a new unit test to cover the emoji case.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
