### PR TITLE
Domains Dashboard Card: Hide card from P2 (WP for teams) sites

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -579,7 +579,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureSiteManagement:
             return [self supportsSiteManagementServices];
         case BlogFeatureDomains:
-            return ([self isHostedAtWPcom] || [self isAtomic]) && [self isAdmin] && ![self isWPForTeams];
+            return [self isHostedAtWPcom] && [self supportsSiteManagementServices];
         case BlogFeatureNoncePreviews:
             return [self supportsRestApi] && ![self isHostedAtWPcom];
         case BlogFeatureMediaMetadataEditing:

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -579,7 +579,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureSiteManagement:
             return [self supportsSiteManagementServices];
         case BlogFeatureDomains:
-            return [self isHostedAtWPcom] && [self supportsSiteManagementServices];
+            return ([self isHostedAtWPcom] || [self isAtomic]) && [self isAdmin] && ![self isWPForTeams];
         case BlogFeatureNoncePreviews:
             return [self supportsRestApi] && ![self isHostedAtWPcom];
         case BlogFeatureMediaMetadataEditing:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -12,10 +12,14 @@ final class DomainsDashboardCardHelper {
             return false
         }
 
+        let isHostedAtWPcom = blog.isHostedAtWPcom
+        let isAtomic = blog.isAtomic()
+        let isAdmin = blog.isAdmin
         let hasOtherDomains = blog.domainsList.count > 0
         let hasDomainCredit = blog.hasDomainCredit
+        let isWPForTeamsSite = blog.isWPForTeams() // P2 site
 
-        return blog.supports(.domains) && !hasOtherDomains && !hasDomainCredit
+        return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit && !isWPForTeamsSite
     }
 
     static func hideCard(for blog: Blog?) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -17,8 +17,9 @@ final class DomainsDashboardCardHelper {
         let isAdmin = blog.isAdmin
         let hasOtherDomains = blog.domainsList.count > 0
         let hasDomainCredit = blog.hasDomainCredit
+        let isWPForTeamsSite = blog.isWPForTeams() // P2 site
 
-        return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit
+        return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit && !isWPForTeamsSite
     }
 
     static func hideCard(for blog: Blog?) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -12,14 +12,10 @@ final class DomainsDashboardCardHelper {
             return false
         }
 
-        let isHostedAtWPcom = blog.isHostedAtWPcom
-        let isAtomic = blog.isAtomic()
-        let isAdmin = blog.isAdmin
         let hasOtherDomains = blog.domainsList.count > 0
         let hasDomainCredit = blog.hasDomainCredit
-        let isWPForTeamsSite = blog.isWPForTeams() // P2 site
 
-        return (isHostedAtWPcom || isAtomic) && isAdmin && !hasOtherDomains && !hasDomainCredit && !isWPForTeamsSite
+        return blog.supports(.domains) && !hasOtherDomains && !hasDomainCredit
     }
 
     static func hideCard(for blog: Blog?) {

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -137,6 +137,10 @@ final class BlogBuilder {
         return self
     }
 
+    func with(isWPForTeamsSite: Bool) -> Self {
+        return set(blogOption: "is_wpforteams_site", value: isWPForTeamsSite)
+    }
+
     @discardableResult
     func build() -> Blog {
         return blog

--- a/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
@@ -85,4 +85,19 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
 
         XCTAssertFalse(result, "Card should not show when the feature flag is disabled")
     }
+
+    func testShouldNotShowCardForP2s() {
+        let blog = BlogBuilder(mainContext)
+            .isHostedAtWPcom()
+            .with(atomic: false)
+            .with(isAdmin: true)
+            .with(registeredDomainCount: 0)
+            .with(hasDomainCredit: false)
+            .with(isWPForTeamsSite: true)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show when the site is P2 site")
+    }
 }


### PR DESCRIPTION
Fixes #20572

## Description

Hide domain dashboard card from  P2 (WP for teams) sites

## Testing instructions

### Case 1:
1. Open Jetpack
2. Log into an account that [has access to a P2 (WP for teams) site](https://wordpress.com/p2/)
3. Enable `Domain Dashboard Card` feature flag
4. Confirm that domains dashboard card doesn't appear

## Regression Notes

1. Potential unintended areas of impact

Only affects `DomainDashboardCard`, makes sure previous appearance criteria continue to be satisfied

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- `DomainsDashboardCardHelperTests`
- `DashboardTests`

5. What automated tests I added (or what prevented me from doing so)

- Expanded `DomainsDashboardCardHelperTests`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos




