### PR TITLE
[Domain Purchasing] Add A/B Experiment

### DIFF
--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -51,7 +51,10 @@ final class DomainsServiceAdapter: SiteAddressService {
 
     // MARK: Properties
 
-    private let domainPurchasingEnabled = FeatureFlag.siteCreationDomainPurchasing.enabled
+    /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
+    private var domainPurchasingEnabled: Bool {
+        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+    }
 
     /**
      Corresponds to:

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -10,6 +10,14 @@ enum ABTest: String, CaseIterable {
     var variation: Variation {
         return ExPlat.shared?.experiment(self.rawValue) ?? .control
     }
+
+    ///
+    var isTreatmentVariation: Bool {
+        switch variation {
+        case .treatment: return true
+        default: return false
+        }
+    }
 }
 
 extension ABTest {

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -11,7 +11,7 @@ enum ABTest: String, CaseIterable {
         return ExPlat.shared?.experiment(self.rawValue) ?? .control
     }
 
-    ///
+    /// Flag indicating whether the experiment's variation is treament or not.
     var isTreatmentVariation: Bool {
         switch variation {
         case .treatment: return true

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -4,6 +4,7 @@ import AutomatticTracks
 // Jetpack is not supported
 enum ABTest: String, CaseIterable {
     case unknown = "unknown"
+    case siteCreationDomainPurchasing = "jpios_site_creation_domain_purchasing_v1"
 
     /// Returns a variation for the given experiment
     var variation: Variation {

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -14,8 +14,8 @@ enum ABTest: String, CaseIterable {
     /// Flag indicating whether the experiment's variation is treament or not.
     var isTreatmentVariation: Bool {
         switch variation {
-        case .treatment: return true
-        default: return false
+        case .treatment, .customTreatment: return true
+        case .control: return false
         }
     }
 }

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -15,14 +15,15 @@ extension ABTest {
     /// Start the AB Testing platform if any experiment exists
     ///
     static func start() {
-        guard ABTest.allCases.count > 1, AccountHelper.isLoggedIn,
-              AppConfiguration.isWordPress else {
+        guard ABTest.allCases.count > 1,
+              AccountHelper.isLoggedIn,
+              AppConfiguration.isJetpack,
+              let exPlat = ExPlat.shared
+        else {
             return
         }
-
         let experimentNames = ABTest.allCases.filter { $0 != .unknown }.map { $0.rawValue }
-        ExPlat.shared?.register(experiments: experimentNames)
-
-        ExPlat.shared?.refresh()
+        exPlat.register(experiments: experimentNames)
+        exPlat.refresh()
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension WPAnalytics {
+
+    /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
+    private static var domainPurchasingEnabled: Bool {
+        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+    }
+
     static func domainsProperties(for blog: Blog) -> [AnyHashable: Any] {
         // For now we do not have the `siteCreation` route implemented so hardcoding `menu`
         domainsProperties(usingCredit: blog.canRegisterDomainWithPaidPlan, origin: .menu)
@@ -11,7 +17,7 @@ extension WPAnalytics {
         origin: DomainPurchaseWebViewViewOrigin?
     ) -> [AnyHashable: Any] {
         var dict: [AnyHashable: Any] = ["using_credit": usingCredit.stringLiteral]
-        if FeatureFlag.siteCreationDomainPurchasing.enabled,
+        if Self.domainPurchasingEnabled,
            let origin = origin {
             dict["origin"] = origin.rawValue
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
@@ -13,7 +13,7 @@ extension BlogListViewController {
                 return
             }
             self.present(wizard, animated: true)
-            WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
+            SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: source)
         })
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -734,7 +734,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 return
             }
             self.present(wizard, animated: true)
-            WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
+            SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: source)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -395,7 +395,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 }
 
                 navigationController.present(wizard, animated: true)
-                WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
+                SiteCreationAnalyticsHelper.trackSiteCreationAccessed(source: source)
             })
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -158,7 +158,7 @@ final class SiteAssemblyContentView: UIView {
             label.font = WPStyleGuide.fontForTextStyle(.title1, fontWeight: .bold)
             label.textColor = .text
 
-            if FeatureFlag.siteCreationDomainPurchasing.enabled {
+            if siteCreator.domainPurchasingEnabled {
                 label.textAlignment = .natural
             } else {
                 label.textAlignment = .center

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsEvent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum SiteCreationAnalyticsEvent: String {
+    case domainPurchasingExperiment = "site_creation_domain_purchasing_experiment"
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -25,28 +25,22 @@ class SiteCreationAnalyticsHelper {
     private static let variationKey = "variation"
     private static let siteNameKey = "site_name"
     private static let recommendedKey = "recommended"
-    private static let treatmentVariationValue = "treatment_variation_value"
+    private static let customTreatmentNameKey = "custom_treatment_variation_name"
 
     // MARK: - Lifecycle
     static func trackSiteCreationAccessed(source: String) {
         WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
 
         if FeatureFlag.siteCreationDomainPurchasing.enabled {
-
             let domainPurchasingExperimentProperties: [String: String] = {
-                var dict: [String: String]
-                switch ABTest.siteCreationDomainPurchasing.variation {
-                case .control:
-                    dict = [Self.variationKey: "control"]
-                case .treatment(let val):
-                    dict = [Self.variationKey: "treatment"]
-                    if let val {
-                        dict[Self.treatmentVariationValue] = val
-                    }
+                var dict: [String: String] = [Self.variationKey: ABTest.siteCreationDomainPurchasing.variation.tracksProperty]
+
+                if case let .customTreatment(name) = ABTest.siteCreationDomainPurchasing.variation {
+                    dict[Self.customTreatmentNameKey] = name
                 }
+
                 return dict
             }()
-
             Self.track(.domainPurchasingExperiment, properties: domainPurchasingExperimentProperties)
         }
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -26,6 +26,11 @@ class SiteCreationAnalyticsHelper {
     private static let siteNameKey = "site_name"
     private static let recommendedKey = "recommended"
 
+    // MARK: - Lifecycle
+    static func trackSiteCreationAccessed(source: String) {
+        WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
+    }
+
     // MARK: - Site Intent
     static func trackSiteIntentViewed() {
         WPAnalytics.track(.enhancedSiteCreationIntentQuestionViewed)

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -5,7 +5,9 @@ final class AddressTableViewCell: UITableViewCell {
 
     // MARK: - Dependencies
 
-    private let domainPurchasingEnabled = FeatureFlag.siteCreationDomainPurchasing.enabled
+    private var domainPurchasingEnabled: Bool {
+        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+    }
 
     // MARK: - Views
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
@@ -20,8 +20,10 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
         return .hidden
     }
 
-    /// Checks if the Domain Purchasing Feature Flag is enabled
-    private let domainPurchasingEnabled = FeatureFlag.siteCreationDomainPurchasing.enabled
+    /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
+    private var domainPurchasingEnabled: Bool {
+        return siteCreator.domainPurchasingEnabled
+    }
 
     /// The creator collects user input as they advance through the wizard flow.
     private let siteCreator: SiteCreator
@@ -146,7 +148,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     }
 
     private func configureUIIfNeeded() {
-        guard FeatureFlag.siteCreationDomainPurchasing.enabled else {
+        guard domainPurchasingEnabled else {
             return
         }
 
@@ -160,7 +162,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
 
     private func loadHeaderView() {
 
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+        if domainPurchasingEnabled {
             searchBar.searchBarStyle = UISearchBar.Style.default
             searchBar.translatesAutoresizingMaskIntoConstraints = false
             WPStyleGuide.configureSearchBar(searchBar, backgroundColor: .clear, returnKeyType: .search)
@@ -217,7 +219,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
         coordinator.animate(alongsideTransition: nil) { [weak self] (_) in
             guard let `self` = self else { return }
 
-            if FeatureFlag.siteCreationDomainPurchasing.enabled {
+            if domainPurchasingEnabled {
                 if !self.siteTemplateHostingController.view.isHidden {
                     self.updateTitleViewVisibility(true)
                 }
@@ -332,7 +334,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     }
 
     private func restoreSearchIfNeeded() {
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+        if domainPurchasingEnabled {
             search(searchBar.text)
         } else {
             search(query(from: searchTextField))
@@ -422,7 +424,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
             "search_term": lastSearchQuery as AnyObject
         ]
 
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+        if domainPurchasingEnabled {
             domainSuggestionProperties["domain_cost"] = domainSuggestion.costString
         }
 
@@ -447,7 +449,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     // MARK: - Search logic
 
     private func setAddressHintVisibility(isHidden: Bool) {
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+        if domainPurchasingEnabled {
             siteTemplateHostingController.view?.isHidden = isHidden
         } else {
             sitePromptView.isHidden = isHidden
@@ -455,7 +457,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     }
 
     private func addAddressHintView() {
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+        if domainPurchasingEnabled {
             guard let siteCreationView = siteTemplateHostingController.view else {
                 return
             }
@@ -661,7 +663,7 @@ extension WebAddressWizardContent: UITableViewDelegate {
         let domainSuggestion = data[indexPath.row]
         self.selectedDomain = domainSuggestion
 
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+        if domainPurchasingEnabled {
             searchBar.resignFirstResponder()
         } else {
             searchTextField.resignFirstResponder()

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
@@ -217,9 +217,9 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
         updateNoResultsLabelTopInset()
 
         coordinator.animate(alongsideTransition: nil) { [weak self] (_) in
-            guard let `self` = self else { return }
+            guard let self else { return }
 
-            if domainPurchasingEnabled {
+            if self.domainPurchasingEnabled {
                 if !self.siteTemplateHostingController.view.isHidden {
                     self.updateTitleViewVisibility(true)
                 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -55,9 +55,14 @@ final class SiteCreator {
         information?.title != nil
     }
 
+    /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
+    var domainPurchasingEnabled: Bool {
+        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+    }
+
     /// Flag indicating whether the domain checkout flow should appear or not.
     var shouldShowDomainCheckout: Bool {
-        return FeatureFlag.siteCreationDomainPurchasing.enabled && !(address?.isFree ?? false)
+        domainPurchasingEnabled && !(address?.isFree ?? false)
     }
 
     /// Returns the domain suggestion if there's one,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3532,6 +3532,8 @@
 		F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */; };
 		F44FB6CD287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */; };
 		F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = F44FB6D02878A1020001E3CE /* user-suggestions.json */; };
+		F45326D829F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */; };
+		F45326D929F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */; };
 		F4552086299D147B00D9F6A8 /* BlockedSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48D44B5298992C30051EAA6 /* BlockedSite.swift */; };
 		F465976E28E4669200D5F49A /* cool-green-icon-app-76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */; };
 		F465976F28E4669200D5F49A /* cool-green-icon-app-76.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */; };
@@ -8890,6 +8892,7 @@
 		F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsListViewModelTests.swift; sourceTree = "<group>"; };
 		F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewMockDelegate.swift; sourceTree = "<group>"; };
 		F44FB6D02878A1020001E3CE /* user-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-suggestions.json"; sourceTree = "<group>"; };
+		F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationAnalyticsEvent.swift; sourceTree = "<group>"; };
 		F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76@2x.png"; sourceTree = "<group>"; };
 		F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76.png"; sourceTree = "<group>"; };
 		F465976B28E4669200D5F49A /* cool-green-icon-app-60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-60@3x.png"; sourceTree = "<group>"; };
@@ -12520,6 +12523,7 @@
 				738B9A5D21B8632E0005062B /* UITableView+Header.swift */,
 				738B9A5B21B85EB00005062B /* UIView+ContentLayout.swift */,
 				46D6114E2555DAED00B0B7BB /* SiteCreationAnalyticsHelper.swift */,
+				F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -21083,6 +21087,7 @@
 				80A2154629D15B88002FE8EB /* RemoteConfigOverrideStore.swift in Sources */,
 				F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */,
 				4629E4212440C5B20002E15C /* GutenbergCoverUploadProcessor.swift in Sources */,
+				F45326D829F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */,
 				FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */,
 				982DDF94263238A6002B3904 /* LikeUserPreferredBlog+CoreDataClass.swift in Sources */,
 				F5844B6B235EAF3D007C6557 /* PartScreenPresentationController.swift in Sources */,
@@ -23804,6 +23809,7 @@
 				8B55F9EE2614D977007D618E /* UnifiedPrologueStatsContentView.swift in Sources */,
 				FABB21932602FC2C00C8785C /* GutenbergTenorMediaPicker.swift in Sources */,
 				3F8B45A029283D6C00730FA4 /* DashboardMigrationSuccessCell.swift in Sources */,
+				F45326D929F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */,
 				FA98B61A29A3BF050071AAE8 /* BlazeCardView.swift in Sources */,
 				FABB21942602FC2C00C8785C /* AztecPostViewController.swift in Sources */,
 				F1585442267D3BF900A2E966 /* CalendarDayToggleButton.swift in Sources */,


### PR DESCRIPTION
Fixes #20074

This PR adds the following:

1. Adds A/B experiment in code:
2. Integrates the experiment with the feature config:
   - The feature is enabled when the feature flag is `ON` and the experiment variation is `treatment`
3. Tracks the experiment variation at the start of Site Creation:
   - event: `enhanced_site_creation_domain_purchasing_experiment`
   - properties: `variation`: `control`, `treatment`
   - timing: fires immediately after event `enhanced_site_creation_accessed`

## Test Instructions

#### Prerequisites:

<details><summary>Toggle the Site Creation Domain Purchasing feature (<code>Site Creation Domain Purchasing</code>)</summary>

1. Go to `Me` → `App Settings` → `Debug settings.`
2. Scroll down until you find `Site Creation Domain Purchasing` flag.
3. Tap the switch on or off to toggle the `Site Creation Domain Purchasing` flag.
4. Go to **Abacus** (internal ref:  21064-explat-experiment) and assign to your test a8c-user the treatment variation.
---
</details>

### 🅰️ Control Variation

1. Open the Jetpack app and login
2. Toggle the `Site Creation Domain Purchasing` feature flag `ON` and `control` variation.
3. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`.
4. **Verify** The tracking event is fired (in the debugger output the following line should appear):
   ```
   🔵 Tracked: enhanced_site_creation_domain_purchasing_experiment <variation: control>
   ```

### 🅱️ Treatment Variation

1. Toggle the `Site Creation Domain Purchasing` feature flag `ON` and `treatment` variation.
2. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`.
4. **Verify** The tracking event is fired (in the debugger output the following line should appear):
   ```
   🔵 Tracked: enhanced_site_creation_domain_purchasing_experiment <variation: treatment>
   ```

### Regression: Feature Disabled

1. Open the Jetpack app and login
2. Toggle the `Site Creation Domain Purchasing` feature flag `OFF`
3. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`
4. **Verify** The tracking event is **not fired**.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)