### PR TITLE
Activity Log: Add missing icons

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
@@ -159,6 +159,7 @@ extension WPStyleGuide {
             "themes": GridiconType.themes,
             "trash": GridiconType.trash,
             "user": GridiconType.user,
+            "video": GridiconType.video
         ]
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
@@ -159,7 +159,12 @@ extension WPStyleGuide {
             "themes": GridiconType.themes,
             "trash": GridiconType.trash,
             "user": GridiconType.user,
-            "video": GridiconType.video
+            "video": GridiconType.video,
+            "status": GridiconType.status,
+            "cart": GridiconType.cart,
+            "custom-post-type": GridiconType.customPostType,
+            "multiple-users": GridiconType.multipleUsers,
+            "audio": GridiconType.audio
         ]
     }
 }


### PR DESCRIPTION
Closes #20597 

## Description
Adds mapping for videopress icon on the activity log

## How to test
1. Switch to a site that has activity log enabled
2. Upload a video via videopress
3. Go to the activity log
4. ✅ The video upload event has an icon

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/234225734-f46b4e05-9679-4bb4-b05f-ef684a45e659.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/234225136-f29302d2-26ca-4d53-98b0-85584a24897a.png" width=200> 

## Regression Notes
1. Potential unintended areas of impact
n/a

5. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
