### PR TITLE
Dashboard Cards: Add "new" label for dashboard cards

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -65,6 +65,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
         contentView.pinSubviewToAllEdges(cardFrameView, priority: .defaultHigh)
 
         cardFrameView.add(subview: tableView)
+        cardFrameView.isNew = true
         tableView.delegate = self
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
@@ -57,6 +57,7 @@ final class DashboardPagesListCardCell: DashboardCollectionViewCell, PagesCardVi
 
     private func setupView() {
         cardFrameView.add(subview: tableView)
+        cardFrameView.isNew = true
 
         contentView.addSubview(cardFrameView)
         contentView.pinSubviewToAllEdges(cardFrameView, priority: .defaultHigh)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -65,7 +65,7 @@ class BlogDashboardCardFrameView: UIView {
     }()
 
     /// Button displayed to the left of the ellipsis button.
-    /// Displayed when isNew is set to true. Use interaction is disabled.
+    /// Displayed when isNew is set to true. User interaction is disabled.
     private(set) lazy var newButton: UIButton = {
         let button = UIButton()
         button.setTitle("\(Strings.newLabel) ✨", for: .normal)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -71,7 +71,7 @@ class BlogDashboardCardFrameView: UIView {
         button.setTitle("\(Strings.newLabel) ✨", for: .normal)
         button.setTitleColor(.text, for: .normal)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         button.backgroundColor = Colors.newButtonBackgroundColor
         button.layer.cornerRadius = Constants.newButtonCornerRadius
         button.contentEdgeInsets = Constants.newButtonInsets
@@ -272,7 +272,7 @@ class BlogDashboardCardFrameView: UIView {
         static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
-        static let newButtonInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 4).flippedForRightToLeft
+        static let newButtonInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 6).flippedForRightToLeft
         static let newButtonCornerRadius: CGFloat = 4
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -272,7 +272,7 @@ class BlogDashboardCardFrameView: UIView {
         static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
-        static let newButtonInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 6).flippedForRightToLeft
+        static let newButtonInsets = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 8)
         static let newButtonCornerRadius: CGFloat = 4
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -77,6 +77,7 @@ class BlogDashboardCardFrameView: UIView {
         button.contentEdgeInsets = Constants.newButtonInsets
         button.isUserInteractionEnabled = false
         button.accessibilityTraits = .staticText
+        button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return button
     }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -64,9 +64,32 @@ class BlogDashboardCardFrameView: UIView {
         return containerStackView
     }()
 
+    /// Button displayed to the left of the ellipsis button.
+    /// Displayed when isNew is set to true. Use interaction is disabled.
+    private(set) lazy var newButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("\(Strings.newLabel) ✨", for: .normal)
+        button.setTitleColor(.text, for: .normal)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
+        button.backgroundColor = Colors.newButtonBackgroundColor
+        button.layer.cornerRadius = Constants.newButtonCornerRadius
+        button.contentEdgeInsets = Constants.newButtonInsets
+        button.isUserInteractionEnabled = false
+        button.accessibilityTraits = .staticText
+        return button
+    }()
+
     private var mainStackViewTrailingConstraint: NSLayoutConstraint?
 
     weak var currentView: UIView?
+
+    /// Shows or hides the new button
+    var isNew: Bool = false {
+        didSet {
+            newButton.isHidden = !isNew
+        }
+    }
 
     /// Closure to be called when anywhere in the view is tapped.
     /// If set, the chevron image is displayed.
@@ -161,7 +184,9 @@ class BlogDashboardCardFrameView: UIView {
         ])
 
         mainStackView.addArrangedSubview(headerStackView)
-        headerStackView.addArrangedSubviews([titleLabel, ellipsisButton])
+        headerStackView.addArrangedSubviews([titleLabel, newButton, ellipsisButton])
+
+        newButton.isHidden = !isNew
     }
 
     /// Configures button container stack view
@@ -247,9 +272,17 @@ class BlogDashboardCardFrameView: UIView {
         static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
+        static let newButtonInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 4).flippedForRightToLeft
+        static let newButtonCornerRadius: CGFloat = 4
+    }
+
+    private enum Colors {
+        private static let darkModeBackgroundColor = UIColor(red: 0.173, green: 0.173, blue: 0.18, alpha: 1)
+        static let newButtonBackgroundColor = UIColor(light: .secondarySystemBackground, dark: darkModeBackgroundColor)
     }
 
     private enum Strings {
         static let ellipsisButtonAccessibilityLabel = NSLocalizedString("More", comment: "Accessibility label for more button in dashboard quick start card.")
+        static let newLabel = NSLocalizedString("dashboardCard.newLabel", value: "New", comment: "Label for new dashboard cards.")
     }
 }


### PR DESCRIPTION
Closes #20660

## Description
Adds a "new" label to the pages and activity log cares

## How to test
1. Enable the pages card and activity log card via the debug menu
2. Go to the dashboard
3. ✅ The "new" label is displayed on the pages and activity log card, but not the other cards

Light | Dark
-- | --
<img src="https://user-images.githubusercontent.com/6711616/234250609-02191b3a-6963-4910-b0ab-f3e26789d63a.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/234250604-00beca16-e3fe-454c-ac4d-8580a5162f52.png" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
