### PR TITLE
Fix a crash when dashboard is reloaded from a background thread

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -26,7 +26,9 @@ struct BlogDashboardPersonalizationService {
         settings[siteID] = isEnabled
         repository.set(settings, forKey: key)
 
-        NotificationCenter.default.post(name: .blogDashboardPersonalizationSettingsChanged, object: self)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .blogDashboardPersonalizationSettingsChanged, object: self)
+        }
     }
 
     private func getSettings(for card: DashboardCard) -> [String: Bool] {


### PR DESCRIPTION
Fixes #20592

## Description

Fix a crash during blog synchronization when a dashboard is reloaded from a background thread and we try to access a core data entity from another context. [More information on an issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/20592#issuecomment-1521702746).

Regression from [personalization changes](https://github.com/wordpress-mobile/WordPress-iOS/pull/20365).

## Solution

BlogDashboardPersonalizationService may be used on a background thread and called inside a core data perform the block. Go to the main thread before notifying about the settings change.

## Testing instructions

### Case 0: (Easier testing in the debug environment)
1. In the app `BloggingPromptSettings updatePromptSettingsIfNecessary`, comment out `if !service.hasPreference(for: .prompts)` so `service.setEnabled(enabled, for: .prompts)` would be always called
2. Open Jetpack app
3. Log into an account / pull to refresh the blog
4. Confirm that the crash doesn't happen

### Case 1:
1. On the web, add a new site into account (join a P2)
2. Open the Jetpack app
3. Log into the same account
4. Confirm that the crash doesn't happen

## Regression Notes

1. Potential unintended areas of impact

None, as far as I could tell

2. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




