### PR TITLE
[Reader] Add --color-neutral-5 to ReaderWebView CSS colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -178,7 +178,9 @@ class ReaderWebView: WKWebView {
             :root {
               --color-text: #\(UIColor.text.color(for: trait).hexString() ?? "");
               --color-neutral-0: #\(UIColor.listForegroundUnread.color(for: trait).hexString() ?? "");
-            --color-neutral-10: #\(UIColor(light: .muriel(color: .gray, .shade10),
+              --color-neutral-5: #\(UIColor(light: .muriel(color: .gray, .shade5),
+                            dark: .muriel(color: .gray, .shade80)).color(for: trait).hexString() ?? "");
+              --color-neutral-10: #\(UIColor(light: .muriel(color: .gray, .shade10),
                             dark: .muriel(color: .gray, .shade30)).color(for: trait).hexString() ?? "");
               --color-neutral-40: #\(UIColor(light: .muriel(color: .gray, .shade40),
               dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString() ?? "");


### PR DESCRIPTION
The CSS for supporting "Daily Prompt" blocks on Reader [(this PR)](https://github.com/Automattic/wp-calypso/pull/76092#pullrequestreview-1400696306) originally included `--color-neutral-5`, which is not currently supported by the app in the `ReaderWebView`. 

I was able to talk with the author of the Calypso PR to use the closest color which is already supported by the apps for now (`--color-neutral-10`), so once that PR is merged and deployed we should have the Prompt block working correctly in Reader, but I figured it would be nice to implement `--color-neutral-5` anyway for future-proofing.

## To test
Since nothing uses this color at the moment, it is not possible to test this change, but it should be very straightforward to review it. 

**I was able to test it however by downloading the `/calypso/reader-mobile.css` from that PR, saving it locally, setting something to `--color-neutral-5` (like the prompt block border), and using Charles Proxy _Map Local_ feature to proxy requests to `/calypso/reader-mobile.css` to deliver my local CSS. This internal ref has a brief explanation of how to set up Charles Proxy: pctCYC-Mc-p2#comment-846, in case anyone wants to do it.**

Demo of the CSS fix, but using `--color-neutral-5` instead of `--color-neutral-10` via the proxy method mentioned above:

https://user-images.githubusercontent.com/5091503/234419466-cbf06093-0bbe-4956-825a-353ab7345e83.mp4


## Regression Notes
1. Potential unintended areas of impact
Other colors stop working.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)