### PR TITLE
Improve site creation error handling in the site assembly step 

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -207,6 +207,7 @@ final class SiteAssemblyWizardContent: UIViewController {
             guard let self else {
                 return
             }
+            self.contentView.status = .inProgress
             self.attemptDomainPurchasing(domain: domain, site: site)
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -252,9 +252,8 @@ final class SiteAssemblyWizardContent: UIViewController {
 private extension SiteAssemblyWizardContent {
     func contactSupportTapped() {
         // TODO : capture analytics event via #10335
-
         let supportVC = SupportTableViewController()
-        supportVC.showFromTabBar()
+        supportVC.show(from: self)
     }
 
     func dismissTapped(viaDone: Bool = false, completion: (() -> Void)? = nil) {

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -235,6 +235,15 @@ final class SiteAssemblyWizardContent: UIViewController {
             }
         }
 
+        // Remove previous error state view controller
+        if let errorStateViewController {
+            errorStateViewController.willMove(toParent: nil)
+            errorStateViewController.view?.removeFromSuperview()
+            errorStateViewController.removeFromParent()
+            errorStateViewController.didMove(toParent: nil)
+        }
+
+        // Install new error state view controller
         let errorStateViewController = ErrorStateViewController(with: configuration)
 
         self.contentView.errorStateView = errorStateViewController.view

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -159,12 +159,17 @@ final class SiteAssemblyWizardContent: UIViewController {
             case .success(let domain):
                 self.contentView.siteName = domain
                 self.contentView.isFreeDomain = false
-            case .failure:
+                self.contentView.status = .succeeded
+            case .failure(let error):
                 self.contentView.isFreeDomain = true
-                // TODO: We should discuss how to handle domain purchasing errors
-                break
+                switch error {
+                case .unsupportedRedirect, .internal, .invalidInput, .other:
+                    self.installErrorStateViewController(with: .domainCheckoutFailed)
+                    self.contentView.status = .failed
+                case .canceled:
+                    self.contentView.status = .succeeded
+                }
             }
-            self.contentView.status = .succeeded
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewConfiguration.swift
@@ -13,6 +13,7 @@ enum ErrorStateViewType {
     case general
     case networkUnreachable
     case siteLoading
+    case domainCheckoutFailed
 }
 
 // MARK: ErrorViewConfiguration
@@ -53,7 +54,7 @@ struct ErrorStateViewConfiguration {
 extension ErrorStateViewType {
     var localizedTitle: String {
         switch self {
-        case .general, .siteLoading:
+        case .general, .siteLoading, .domainCheckoutFailed:
             return NSLocalizedString("There was a problem",
                                      comment: "This primary message message is displayed if a user encounters a general error.")
         case .networkUnreachable:
@@ -69,6 +70,12 @@ extension ErrorStateViewType {
                                      comment: "This secondary message is displayed if a user encounters a general error.")
         case .networkUnreachable:
             return nil
+        case .domainCheckoutFailed:
+            return NSLocalizedString(
+                "site.creation.assembly.step.domain.checkout.error.subtitle",
+                value: "Your website has been created successfully, but we encountered an issue while preparing your custom domain for checkout. Please try again or contact support for assistance.",
+                comment: "The error message to show in the 'Site Creation > Assembly Step' when the domain checkout fails for unknown reasons."
+            )
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -71,6 +71,18 @@ class SupportTableViewController: UITableViewController {
         createUserActivity()
     }
 
+    func show(from presentingViewController: UIViewController) {
+        let navigationController = UINavigationController.init(rootViewController: self)
+
+        if WPDeviceIdentification.isiPad() {
+            navigationController.modalTransitionStyle = .crossDissolve
+            navigationController.modalPresentationStyle = .formSheet
+        }
+
+        presentingViewController.present(navigationController, animated: true)
+    }
+
+    // TODO: Refactor this method to use the general `show(from:)` method
     @objc func showFromTabBar() {
         let navigationController = UINavigationController.init(rootViewController: self)
 


### PR DESCRIPTION
Ref p1682428923526859/1681907249.388189-slack-C04M1NX8YCR

## Description

This PR shows an error screen when the domain checkout web view fails to appear.

| Light | Dark | 
| ----- | ----- |
| ![light](https://user-images.githubusercontent.com/9609223/235544929-d597f04a-021d-4822-88b4-868c91b61f9e.png) | ![dark](https://user-images.githubusercontent.com/9609223/235544926-23665207-e10c-4768-a4de-c67841c376c3.png) |

## Test Instructions

### Domain Checkout Error

```
💡 The user should see an error message if the domain checkout web view fails to appear.
```

1. Force the domain purchasing to fail by changing the following code:

Change the code in `DomainPurchasingWebFlowController.swift` line 173.

```swift
// Before
let canOpenNewURL = newURL.absoluteString.starts(with: Constants.checkoutWebAddress)

// After
let canOpenNewURL = newURL.absoluteString.starts(with: "https://google.com")
```

2. Build and run the Jetpack app.
3. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`.
4. Go through the site creation flow until you reach the final step.
    - Select a paid domain in the "Choose a domain" step.
5. **Expect** the domain checkout to fail. The error message should be exactly like the one in the screenshots above.
6. **Verify** that the "Contact support" button brings the support screen.
7. **Verify** that the "Retry" button retries the domain purchasing. But it's expected to fail again.
8. **Verify** that the "X" button at the top-left corner dismisses the modal.

### Regression: Site Creation Error

```
💡 The user should see an error message if the site creation request fails.
```

1. Build and run the Jetpack app.
2. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`.
3. Go through the site creation flow until you reach the final step.
    1. Disable Wifi.
    2. Select a free domain in the "Choose a domain" step.
4.  **Expect** the site creation to fail. The error message should be:
    - **Title**: There was a problem.
    - **Description**: Error communicating with the server, please try again.
5. **Verify** that the "Contact support" button brings the support screen.
6. **Verify** that the "Retry" button retries the site creation request.
7. **Verify** that the "X" button at the top-left corner dismisses the modal.

## Regression Notes
1. Potential unintended areas of impact
This could impact the error handling for the site creation. See Test Instructions.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests and manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)