### PR TITLE
[Domain Purchase] Update final UI strings

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -136,12 +136,12 @@ final class SiteAssemblyContentView: UIView {
     let siteCreator: SiteCreator
 
     var isFreeDomain: Bool?
-    private lazy var shouldShowDomainPurchase: Bool = {
+    private func shouldShowDomainPurchase() -> Bool {
         if let isFreeDomain = isFreeDomain {
             return !isFreeDomain
         }
         return siteCreator.shouldShowDomainCheckout
-    }()
+    }
 
     // MARK: SiteAssemblyContentView
 
@@ -366,7 +366,7 @@ final class SiteAssemblyContentView: UIView {
         self.assembledSiteWidthConstraint = assembledSiteWidthConstraint
 
         let assembledSiteViewBottomConstraint: NSLayoutConstraint
-        if shouldShowDomainPurchase {
+        if shouldShowDomainPurchase() {
             assembledSiteView.layer.cornerRadius = 12
             assembledSiteView.layer.masksToBounds = true
             assembledSiteViewBottomConstraint = footnoteLabel.topAnchor.constraint(
@@ -510,7 +510,9 @@ final class SiteAssemblyContentView: UIView {
 
                     self.completionLabel.isHidden = false
                     self.completionDescription.isHidden = false
-                    self.footnoteLabel.isHidden = !self.shouldShowDomainPurchase
+                    self.completionLabel.text = self.shouldShowDomainPurchase() ? Strings.Paid.completionTitle : Strings.Free.completionTitle
+                    self.completionDescription.text = self.shouldShowDomainPurchase() ? Strings.Paid.description : Strings.Free.description
+                    self.footnoteLabel.isHidden = !self.shouldShowDomainPurchase()
 
 
                     if let buttonView = self.buttonContainerView {

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -138,7 +138,7 @@ final class SiteAssemblyContentView: UIView {
     var isFreeDomain: Bool?
     private lazy var shouldShowDomainPurchase: Bool = {
         if let isFreeDomain = isFreeDomain {
-            return isFreeDomain
+            return !isFreeDomain
         }
         return siteCreator.shouldShowDomainCheckout
     }()

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -33,12 +33,6 @@ final class SiteAssemblyContentView: UIView {
         $0.numberOfLines = 0
         $0.font = WPStyleGuide.fontForTextStyle(.body)
         $0.textColor = .text
-        let createdDescription = NSLocalizedString(
-            "domain.purchase.preview.description",
-            value: "We’ve emailed a receipt to your address on file.",
-            comment: "Domain Purchase Completion description."
-        )
-        $0.text = createdDescription
         return $0
     }(UILabel())
 
@@ -57,7 +51,7 @@ final class SiteAssemblyContentView: UIView {
         $0.textColor = .text
         let footerText = NSLocalizedString(
             "domain.purchase.preview.footer",
-            value: "It may take up to a day for your blog and your new domain to be fully connected.",
+            value: "It may take up to 30 minutes for your custom domain to start working.",
             comment: "Domain Purchase Completion footer"
         )
         $0.text = footerText
@@ -166,13 +160,8 @@ final class SiteAssemblyContentView: UIView {
                 label.textAlignment = .center
             }
 
-            let createdText = NSLocalizedString(
-                "Your site has been created!",
-                comment: "User-facing string, presented to reflect that site assembly completed successfully."
-            )
-
-            label.text = createdText
-            label.accessibilityLabel = createdText
+            label.text = Strings.Free.completionTitle
+            label.accessibilityLabel = Strings.Free.completionTitle
 
             return label
         }()
@@ -381,18 +370,14 @@ final class SiteAssemblyContentView: UIView {
                 constant: 24
             )
 
-            let createdText = NSLocalizedString(
-                "domain.purchase.preview.title",
-                value: "Domain Purchase Complete",
-                comment: "User-facing string, presented to reflect that site assembly completed successfully."
-            )
-            completionLabel.text = createdText
-            completionLabel.accessibilityLabel = createdText
-
+            completionLabel.text = Strings.Paid.completionTitle
+            completionLabel.accessibilityLabel = Strings.Paid.completionTitle
+            completionDescription.text = Strings.Paid.description
         } else {
             assembledSiteViewBottomConstraint = assembledSiteView.bottomAnchor.constraint(
                 equalTo: buttonContainerView?.topAnchor ?? bottomAnchor
             )
+            completionDescription.text = Strings.Free.description
         }
 
         NSLayoutConstraint.activate([
@@ -520,7 +505,7 @@ final class SiteAssemblyContentView: UIView {
                     }
 
                     self.completionLabel.isHidden = false
-                    self.completionDescription.isHidden = !self.shouldShowDomainPurchase
+                    self.completionDescription.isHidden = false
                     self.footnoteLabel.isHidden = !self.shouldShowDomainPurchase
 
 
@@ -533,5 +518,34 @@ final class SiteAssemblyContentView: UIView {
                     self.layoutIfNeeded()
                 })
             })
+    }
+}
+
+private enum Strings {
+    enum Paid {
+        static let completionTitle = NSLocalizedString(
+            "domain.purchase.preview.title",
+            value: "Kudos, your site is live!",
+            comment: "Reflects that site is live when domain purchase feature flag is ON."
+        )
+
+        static let description = NSLocalizedString(
+            "domain.purchase.preview.paid.description",
+            value: "We’ve emailed your receipt. Next, we'll help you get it ready for everyone.",
+            comment: "Domain Purchase Completion description (only for PAID domains)."
+        )
+    }
+
+    enum Free {
+        static let completionTitle = NSLocalizedString(
+            "Your site has been created!",
+            comment: "User-facing string, presented to reflect that site assembly completed successfully."
+        )
+        static let description = NSLocalizedString(
+            "domain.purchase.preview.free.description",
+            value: "Next, we'll help you get it ready to be browsed.",
+            comment: "Domain Purchase Completion description (only for FREE domains)."
+        )
+
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -135,8 +135,12 @@ final class SiteAssemblyContentView: UIView {
 
     let siteCreator: SiteCreator
 
+    var isFreeDomain: Bool?
     private lazy var shouldShowDomainPurchase: Bool = {
-        siteCreator.shouldShowDomainCheckout
+        if let isFreeDomain = isFreeDomain {
+            return isFreeDomain
+        }
+        return siteCreator.shouldShowDomainCheckout
     }()
 
     // MARK: SiteAssemblyContentView

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -158,7 +158,9 @@ final class SiteAssemblyWizardContent: UIViewController {
             switch result {
             case .success(let domain):
                 self.contentView.siteName = domain
+                self.contentView.isFreeDomain = false
             case .failure:
+                self.contentView.isFreeDomain = true
                 // TODO: We should discuss how to handle domain purchasing errors
                 break
             }


### PR DESCRIPTION
This PR matches the strings to the [Android Implementation](https://github.com/wordpress-mobile/WordPress-Android/pull/18305)

To test:
- Enable Site Creation Feature Flag

### Paid Domain
- Install Jetpack and log in.
- Head to "My Site" > "Chevron Down" button to display "My Sites" screen.
- Tap "+" button, then "Create WordPress.com site"
- Go through the flow until your reach the "Choose a domain" screen.
- Search for a domain and select a PAID domain.
- Tap "Create Site."
- Title, description and footer should match to the strings in screenshot from Android PR linked above.

### Free Domain
- Install Jetpack and log in.
- Head to "My Site" > "Chevron Down" button to display "My Sites" screen.
- Tap "+" button, then "Create WordPress.com site"
- Go through the flow until your reach the "Choose a domain" screen.
- Search for a domain and select a FREE domain.
- Tap "Create Site."
- Title, description and footer should match to the strings in screenshot from Android PR linked above.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.