### PR TITLE
Fix Domain Dashboard Card appearing while domains information is still loading 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DomainsDashboardCardHelper.swift
@@ -12,10 +12,15 @@ import Foundation
             return false
         }
 
+        /// If this propery is empty, it indicates that domain information is not yet loaded
+        let hasLoadedDomains = blog.freeDomain != nil
         let hasOtherDomains = blog.domainsList.count > 0
         let hasDomainCredit = blog.hasDomainCredit
 
-        return blog.supports(.domains) && !hasOtherDomains && !hasDomainCredit
+        return blog.supports(.domains)
+            && hasLoadedDomains
+            && !hasOtherDomains
+            && !hasDomainCredit
     }
 
     static func hideCard(for blog: Blog?) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -477,21 +477,25 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 self?.refreshControl.endRefreshing()
             }
 
-            blogService.syncBlogAndAllMetadata(blog) { [weak self] in
-                guard let self = self else {
-                    return
-                }
-
-                self.updateNavigationTitle(for: blog)
-                self.sitePickerViewController?.blogDetailHeaderView.blog = blog
-                self.blogDashboardViewController?.reloadCardsLocally()
-            }
+            syncBlogAndAllMetadata(blog)
 
             /// Update today's prompt if the blog has blogging prompts enabled.
             fetchPrompt(for: blog)
         }
 
         WPAnalytics.track(.mySitePullToRefresh, properties: [WPAppAnalyticsKeyTabSource: section.analyticsDescription])
+    }
+
+    private func syncBlogAndAllMetadata(_ blog: Blog) {
+        blogService.syncBlogAndAllMetadata(blog) { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.updateNavigationTitle(for: blog)
+            self.sitePickerViewController?.blogDetailHeaderView.blog = blog
+            self.blogDashboardViewController?.reloadCardsLocally()
+        }
     }
 
     // MARK: - Segmented Control
@@ -850,6 +854,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             blogDetailsViewController?.preloadMetadata()
             blogDetailsViewController?.showInitialDetailsForBlog()
         case .dashboard:
+            syncBlogAndAllMetadata(blog)
             blogDashboardViewController?.update(blog: blog)
         }
     }

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -125,15 +125,15 @@ final class BlogBuilder {
         return self
     }
 
-    func with(registeredDomainCount: Int) -> Self {
+    func with(domainCount: Int, of type: DomainType) -> Self {
         var domains: [ManagedDomain] = []
-        for _ in 0..<registeredDomainCount {
+        for _ in 0..<domainCount {
             let domain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain
-            domain.domainType = .registered
+            domain.domainType = type
             domains.append(domain)
         }
 
-        blog.domains = Set(domains)
+        blog.domains = Set(domains).union(Set(blog.domains ?? []))
         return self
     }
 

--- a/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
@@ -64,7 +64,7 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
 
         let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
 
-        XCTAssertFalse(result, "Card should not show for blogs with domain credit")
+        XCTAssertFalse(result, "Card should not until domain information is loaded")
     }
 
     func testShouldNotShowCardFeatureFlagDisabled() {

--- a/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DomainsDashboardCardHelperTests.swift
@@ -5,7 +5,8 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
     func testShouldShowCardBlogSupportsDomains() {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: true)
-            .with(registeredDomainCount: 0)
+            .with(domainCount: 1, of: .wpCom)
+            .with(domainCount: 0, of: .registered)
             .with(hasDomainCredit: false)
             .build()
 
@@ -17,7 +18,8 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
     func testShouldNotShowCardBlogDoesNotSupportDomains() {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: false)
-            .with(registeredDomainCount: 0)
+            .with(domainCount: 1, of: .wpCom)
+            .with(domainCount: 0, of: .registered)
             .with(hasDomainCredit: false)
             .build()
 
@@ -29,7 +31,8 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
     func testShouldNotShowCardHasOtherDomains() {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: true)
-            .with(registeredDomainCount: 2)
+            .with(domainCount: 1, of: .wpCom)
+            .with(domainCount: 2, of: .registered)
             .with(hasDomainCredit: false)
             .build()
 
@@ -41,8 +44,22 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
     func testShouldNotShowCardHasDomainCredit() {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: true)
-            .with(registeredDomainCount: 0)
+            .with(domainCount: 1, of: .wpCom)
+            .with(domainCount: 0, of: .registered)
             .with(hasDomainCredit: true)
+            .build()
+
+        let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show for blogs with domain credit")
+    }
+
+    func testShouldNotShowCardWhenDomainInformationIsNotLoaded() {
+        let blog = BlogBuilder(mainContext)
+            .with(supportsDomains: true)
+            .with(domainCount: 0, of: .wpCom)
+            .with(domainCount: 0, of: .registered)
+            .with(hasDomainCredit: false)
             .build()
 
         let result = DomainsDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
@@ -53,7 +70,8 @@ final class DomainsDashboardCardHelperTests: CoreDataTestCase {
     func testShouldNotShowCardFeatureFlagDisabled() {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: true)
-            .with(registeredDomainCount: 0)
+            .with(domainCount: 1, of: .wpCom)
+            .with(domainCount: 0, of: .registered)
             .with(hasDomainCredit: false)
             .build()
 


### PR DESCRIPTION
## ℹ️ Milestone information

 Since the issue only happens during the first load, it can be moved to 22.4 if the review doesn't pass on time.

## Description

Fixes #20620

- Don't show the domain dashboard card while domain information hasn't been loaded to avoid the card appearing momentarily and then disappearing
- Load domain information when switching sites, otherwise the domain information is not loaded for non-default domain sites

## Testing instructions

Log into an admin account with at least two sites (pc8eDl-NP-p2):
- dotCom site without a domain
- dotCom site with a domain

### Case 1: Only show the card when the domains are loaded (site without a domain)
1. Launch Jetpack
2. Log into a given account
3. Select a site **without a domain after login**
4. The card appears after a moment

### Case 2 Don't show the card before domains are loaded (site with a domain)
1. Launch Jetpack
2. Log into a given account
3. Select a site **with a domain after login**
4. The card never appears

### Case 3 Switch sites
1. Launch Jetpack
2. Log into a given account
3. Select a site **with a domain after login**
4. The card doesn't appear
5. Switch to a site **without a domain**
6. The card appears after a moment


## Regression Notes

1. Potential unintended areas of impact

2. What I did to test those areas of impact (or what existing automated tests I relied on)

7. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before
https://user-images.githubusercontent.com/4062343/235092318-313bbf25-d920-48c7-b1c2-2731fbbe9456.mp4

### After
https://user-images.githubusercontent.com/4062343/235122569-d00f5f49-c0e2-4bb6-83b9-3b1ca169ea24.mp4