### PR TITLE
My Site: Hide the Stats row if it is unsupported

### DIFF
--- a/WordPress/Classes/Categories/NSMutableArray+NullableObjects.h
+++ b/WordPress/Classes/Categories/NSMutableArray+NullableObjects.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSMutableArray<ObjectType> (NullableObjects)
+
+- (void)addNullableObject:(nullable ObjectType)anObject;
+
+@end

--- a/WordPress/Classes/Categories/NSMutableArray+NullableObjects.m
+++ b/WordPress/Classes/Categories/NSMutableArray+NullableObjects.m
@@ -1,0 +1,11 @@
+#import "NSMutableArray+NullableObjects.h"
+
+@implementation NSMutableArray (NullableObjects)
+
+- (void)addNullableObject:(nullable id)anObject {
+    if (anObject != nil) {
+        [self addObject:anObject];
+    }
+}
+
+@end

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -79,7 +79,6 @@ public class MySiteScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [
                 switchSiteButtonGetter,
-                statsButtonGetter,
                 postsButtonGetter,
                 mediaButtonGetter,
                 createButtonGetter

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1894,6 +1894,8 @@
 		80D9D00429EF4C7F00FE3400 /* DashboardPageCreationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9D00229EF4C7F00FE3400 /* DashboardPageCreationCell.swift */; };
 		80D9D04629F760C400FE3400 /* FailableDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9D04529F760C400FE3400 /* FailableDecodable.swift */; };
 		80D9D04729F765C900FE3400 /* FailableDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D9D04529F760C400FE3400 /* FailableDecodable.swift */; };
+		80D9D04A29FC0D9000FE3400 /* NSMutableArray+NullableObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = 80D9D04929FC0D9000FE3400 /* NSMutableArray+NullableObjects.m */; };
+		80D9D04B29FC118900FE3400 /* NSMutableArray+NullableObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = 80D9D04929FC0D9000FE3400 /* NSMutableArray+NullableObjects.m */; };
 		80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
@@ -7261,6 +7263,8 @@
 		80D9CFFF29E85EBF00FE3400 /* PageEditorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageEditorPresenter.swift; sourceTree = "<group>"; };
 		80D9D00229EF4C7F00FE3400 /* DashboardPageCreationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPageCreationCell.swift; sourceTree = "<group>"; };
 		80D9D04529F760C400FE3400 /* FailableDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailableDecodable.swift; sourceTree = "<group>"; };
+		80D9D04829FC0D9000FE3400 /* NSMutableArray+NullableObjects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableArray+NullableObjects.h"; sourceTree = "<group>"; };
+		80D9D04929FC0D9000FE3400 /* NSMutableArray+NullableObjects.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableArray+NullableObjects.m"; sourceTree = "<group>"; };
 		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
 		80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCustomAnnouncementCell.swift; sourceTree = "<group>"; };
 		80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsStackView.swift; sourceTree = "<group>"; };
@@ -15637,6 +15641,8 @@
 				31EC15071A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m */,
 				8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */,
 				8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */,
+				80D9D04829FC0D9000FE3400 /* NSMutableArray+NullableObjects.h */,
+				80D9D04929FC0D9000FE3400 /* NSMutableArray+NullableObjects.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -22236,6 +22242,7 @@
 				F1BC842E27035A1800C39993 /* BlogService+Domains.swift in Sources */,
 				80C740FB2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift in Sources */,
 				B5EEDB971C91F10400676B2B /* Blog+Interface.swift in Sources */,
+				80D9D04A29FC0D9000FE3400 /* NSMutableArray+NullableObjects.m in Sources */,
 				982DDF96263238A6002B3904 /* LikeUserPreferredBlog+CoreDataProperties.swift in Sources */,
 				5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */,
 				C7BB601F2863B9E800748FD9 /* QRLoginCameraSession.swift in Sources */,
@@ -23746,6 +23753,7 @@
 				DC8F61F827032B3F0087AC5D /* TimeZoneFormatter.swift in Sources */,
 				FABB216B2602FC2C00C8785C /* WPRichTextEmbed.swift in Sources */,
 				80EF928E280E83110064A971 /* QuickStartToursCollection.swift in Sources */,
+				80D9D04B29FC118900FE3400 /* NSMutableArray+NullableObjects.m in Sources */,
 				FABB216C2602FC2C00C8785C /* PostSignUpInterstitialViewController.swift in Sources */,
 				FABB216D2602FC2C00C8785C /* StatsGhostTableViewRows.swift in Sources */,
 				FABB216E2602FC2C00C8785C /* ActivityContentRouter.swift in Sources */,


### PR DESCRIPTION
Fixes #20594

## Description
Contributors do not have the permissions to view stats, yet we show the stats button in the My Site Menu. This PR removes the stats button when unsupported.

## Testing Instructions

1. Run the Jetpack app
2. Log in using an account that's added as a contributor to Site A
3. Switch to site A
4. Navigate to the Menu
5. Make sure that the Stats button is not displayed ✅ 
6. Make sure that the whole Traffic section is not displayed ✅ 

## Regression Notes
1. Potential unintended areas of impact
My Site menu for other user roles

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
