### PR TITLE
My Site Dashboard: Hide unsupported quick action buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -68,6 +68,16 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable {
 extension DashboardQuickActionsCardCell {
 
     func configureQuickActionButtons(for blog: Blog, with sourceController: UIViewController) {
+        hideUnsupportedActionIfNeeded(for: blog)
+        configureTapEvents(for: blog, with: sourceController)
+    }
+
+    private func hideUnsupportedActionIfNeeded(for blog: Blog) {
+        statsButton.isHidden = !blog.supports(.stats)
+        pagesButton.isHidden = !blog.supports(.pages)
+    }
+
+    private func configureTapEvents(for blog: Blog, with sourceController: UIViewController) {
         statsButton.onTap = { [weak self] in
             self?.showStats(for: blog, from: sourceController)
         }


### PR DESCRIPTION
Fixes #20595 

## Description
Contributors do not have the capability to view stats or pages, yet we show quick action buttons for both features in the dashboard. This PR removes the unsupported quick action buttons.

## Testing Instructions

1. Run the Jetpack app
2. Log in using an account that's added as a contributor to Site A
3. Switch to site A
4. Navigate to the Dashboard
5. Make sure that the Stats and Pages Quick Action buttons are not displayed ✅ 

## Regression Notes
1. Potential unintended areas of impact
Quick action buttons for other user roles

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
