### PR TITLE
Add SPM caching in CI

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -17,7 +17,7 @@ echo "--- :writing_hand: Copy Files"
 mkdir -pv ~/.configure/wordpress-ios/secrets
 cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
 
-echo "--- Installing Secrets"
+echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :swift: Setting up Swift Packages"

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -20,6 +20,9 @@ cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/projec
 echo "--- Installing Secrets"
 bundle exec fastlane run configure_apply
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_${APP}_for_testing
 

--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -12,5 +12,8 @@ install_cocoapods
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_jetpack_prototype_build

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -12,5 +12,8 @@ install_cocoapods
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_wordpress_prototype_build

--- a/.buildkite/commands/release-build-jetpack.sh
+++ b/.buildkite/commands/release-build-jetpack.sh
@@ -11,6 +11,9 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 

--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -12,6 +12,9 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -12,6 +12,9 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -19,6 +19,9 @@ tar -xf build-products-jetpack.tar
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -19,9 +19,6 @@ tar -xf build-products-jetpack.tar
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :cocoapods: Setting up Pods"
-install_cocoapods
-
 echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -11,6 +11,9 @@ tar -xf build-products-wordpress.tar
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
+echo "--- :swift: Setting up Swift Packages"
+install_swiftpm_dependencies
+
 echo "--- 🔬 Testing"
 set +e
 bundle exec fastlane test_without_building name:WordPressUnitTests


### PR DESCRIPTION
What it says in the title 😄 

Side by side of the first build that made the cache vs the second that downloaded it: ~15 mins saved 🎉 

<img width="2551" alt="image" src="https://user-images.githubusercontent.com/1218433/236746911-8a0acf28-c6a3-44bf-b7d4-a208162e4114.png">


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

UI Changes testing checklist: N.A.
