### PR TITLE
Check if object id is a temporary object id

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,12 +1,12 @@
 22.4
 -----
-* [**] [internal] Attempt to fix an image loading crash in post editor. [#20633]
 
 
 22.3
 -----
 * [*] [internal] Allow updating specific fields when updating media details. [#20606]
 * [**] Block Editor: Enable VideoPress block (only on Simple WPCOM sites) [#20580]
+* [**] [internal] Attempt to fix an image loading crash in post editor. [#20633]
 
 22.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 22.4
 -----
+* [**] [internal] Attempt to fix an image loading crash in post editor. [#20633]
 
 
 22.3


### PR DESCRIPTION
This is an attempt to fix #20630.

The crash message says "NSInvalidArgumentException: nil is not a valid object ID", but the `blogObjectID` is a non-optional object, so I'm not exactly sure what the `nil` references and what's the cause of the crash.

Considering this is an attempt to fix a crash, @mokagio do you think we should target this change to the code freeze branch?

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Viewed a post with images, and confirmed the image can be loaded and displayed.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A