### PR TITLE
Site Editor: Fetch the editor settings on `PageListViewController`

### DIFF
--- a/WordPress/Classes/Services/BlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/BlockEditorSettingsService.swift
@@ -51,6 +51,15 @@ class BlockEditorSettingsService {
             fetchTheme(completion)
         }
     }
+
+    @MainActor
+    func fetchSettings() async -> Result<SettingsServiceResult, Error> {
+        await withCheckedContinuation { continuation in
+            fetchSettings { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
 }
 
 // MARK: Editor `theme_supports` support


### PR DESCRIPTION
Closes #20643

> **Note**
> This PR is pointing to the branch in #20640. It will be updated to `trunk` when that PR is merged.

## Description

Adds fetching the editor settings to the "Pages" screen. This overrides the `syncHelper` method to call the editor settings. Adding it here means it will fetch when the screen is loaded, a filter changes, and the user pulls to refresh.

## Testing

There isn't a great way to test this outside of using the debugger.

To test:

- Launch Jetpack and login
- Add a breakpoint to this function: https://github.com/wordpress-mobile/WordPress-iOS/blob/dfaa43cc8c9d05097e7006621990f0688d639910/WordPress/Classes/Services/BlockEditorSettingsService.swift#L47
- Navigate to the "Pages" screen
- **Verify** the breakpoint hits and a fetch settings call is made
- Pull-to-refresh the pages
- **Verify** the breakpoint hits and a fetch settings call is made

## Regression Notes
1. Potential unintended areas of impact
The sync pages call in the parent class

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
