### PR TITLE
[UI Tests] Make crash reports available in CI

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,8 +40,9 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 💥 Collecting Crash reports"
+mkdir -p build/results/crashes
 find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
-  cp "$file" "build/results/[CRASH]$(basename "$file")"
+  cp "$file" "build/results/crashes/$(basename "$file")"
 done
 
 echo "--- 🚦 Report Tests Status"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -39,6 +39,9 @@ fi
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
+echo "--- 💥 Collecting Crash reports"
+for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]]; then cp "$f" "build/results/[CRASH]$(basename "$f")"; fi; done
+
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
   echo "UI Tests seems to have passed (exit code 0). All good 👍"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -40,7 +40,9 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 💥 Collecting Crash reports"
-for f in ~/Library/Logs/DiagnosticReports/*; do if [[ "$f" == *.ips* ]]; then cp "$f" "build/results/[CRASH]$(basename "$f")"; fi; done
+find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
+  cp "$file" "build/results/[CRASH]$(basename "$file")"
+done
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,6 +90,7 @@ steps:
         plugins: *common_plugins
         artifact_paths:
           - "build/results/*"
+          - "build/results/crashes/*"
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
@@ -105,6 +106,7 @@ steps:
         plugins: *common_plugins
         artifact_paths:
           - "build/results/*"
+          - "build/results/crashes/*"
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"


### PR DESCRIPTION
### Description 

The objective of this PR is to make crash reports available in CI, under `Artifacts` tab to support the investigation of eventual app crashes caught by UI Tests, [some times not easily reproducible](pcdRpT-2d5-p2).

### To Test
1. CI must be green.

2. This [Test PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20564) has the changes introduced here and a few hacks to test the crash scenario.

![image](https://user-images.githubusercontent.com/42008628/236969111-12ab9e52-7c08-478c-bf95-9af8da364cfd.png)
