### PR TITLE
Refactor the migration error handling logic to include the underlying error

### DIFF
--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -181,6 +181,19 @@ extension ContextManager {
     }
 }
 
+extension ContextManager.ContextManagerError: LocalizedError, CustomDebugStringConvertible {
+    var errorDescription: String? {
+        switch self {
+        case .missingCoordinatorOrStore: return "Missing coordinator or store"
+        case .missingDatabase: return "Missing database"
+        }
+    }
+
+    var debugDescription: String {
+        return localizedDescription
+    }
+}
+
 extension CoreDataStack {
     /// Perform a query using the `mainContext` and return the result.
     func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T) -> T {

--- a/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
@@ -37,7 +37,11 @@ extension DataMigrationError: LocalizedError, CustomNSError {
     var errorUserInfo: [String: Any] {
         switch self {
         case .databaseExportError(let error), .databaseImportError(let error):
-            return (error as NSError).userInfo
+            let nsError = error as NSError
+            return ["underlying-error-domain": nsError.domain,
+                    "underlying-error-code": nsError.code,
+                    "underlying-error-message": nsError.localizedDescription,
+                    "underlying-error-user-info": nsError.userInfo]
         default:
             var userInfo = [String: Any]()
             if let errorDescription {

--- a/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum DataMigrationError {
-    case databaseImportError
+    case databaseImportError(underlyingError: Error)
     case databaseExportError(underlyingError: Error)
     case backupLocationNil
     case sharedUserDefaultsNil
@@ -35,11 +35,16 @@ extension DataMigrationError: LocalizedError, CustomNSError {
     }
 
     var errorUserInfo: [String: Any] {
-        var userInfo = [String: Any]()
-        if let errorDescription {
-            userInfo[NSDebugDescriptionErrorKey] = errorDescription
+        switch self {
+        case .databaseExportError(let error), .databaseImportError(let error):
+            return (error as NSError).userInfo
+        default:
+            var userInfo = [String: Any]()
+            if let errorDescription {
+                userInfo[NSDebugDescriptionErrorKey] = errorDescription
+            }
+            return userInfo
         }
-        return userInfo
     }
 }
 

--- a/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
@@ -15,8 +15,8 @@ extension DataMigrationError: LocalizedError, CustomNSError {
         case .backupLocationNil: return "Database shared directory not found"
         case .sharedUserDefaultsNil: return "Shared user defaults not found"
         case .dataNotReadyToImport: return "The data wasn't ready to import"
-        case .databaseImportError(let error): return "Import Failed: \(error)"
-        case .databaseExportError(let error): return "Export Failed: \(error)"
+        case .databaseImportError(let error): return "Import Failed: \(error.localizedDescription)"
+        case .databaseExportError(let error): return "Export Failed: \(error.localizedDescription)"
         }
     }
 
@@ -43,22 +43,14 @@ extension DataMigrationError: LocalizedError, CustomNSError {
                     "underlying-error-message": nsError.localizedDescription,
                     "underlying-error-user-info": nsError.userInfo]
         default:
-            var userInfo = [String: Any]()
-            if let errorDescription {
-                userInfo[NSDebugDescriptionErrorKey] = errorDescription
-            }
-            return userInfo
+            return [:]
         }
     }
 }
 
 extension DataMigrationError: CustomDebugStringConvertible {
-
     var debugDescription: String {
-        guard let desc = errorDescription else {
-            return String(describing: self)
-        }
-        return "[\(Self.errorDomain)] \(desc)"
+        return "[\(Self.errorDomain)] \(localizedDescription)"
     }
 }
 

--- a/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+enum DataMigrationError {
+    case databaseImportError
+    case databaseExportError(underlyingError: Error)
+    case backupLocationNil
+    case sharedUserDefaultsNil
+    case dataNotReadyToImport
+}
+
+extension DataMigrationError: LocalizedError, CustomNSError {
+
+    var errorDescription: String? {
+        switch self {
+        case .databaseImportError: return "The database couldn't be copied from shared directory"
+        case .databaseExportError: return "The database couldn't be copied to shared directory"
+        case .backupLocationNil: return "Database shared directory not found"
+        case .sharedUserDefaultsNil: return "Shared user defaults not found"
+        case .dataNotReadyToImport: return "The data wasn't ready to import"
+        }
+    }
+
+    static var errorDomain: String {
+        return String(describing: DataMigrationError.self)
+    }
+
+    var errorCode: Int {
+        switch self {
+        case .dataNotReadyToImport: return 100
+        case .databaseImportError: return 200
+        case .databaseExportError: return 300
+        case .backupLocationNil: return 400
+        case .sharedUserDefaultsNil: return 401
+        }
+    }
+
+    var errorUserInfo: [String: Any] {
+        var userInfo = [String: Any]()
+        if let errorDescription {
+            userInfo[NSDebugDescriptionErrorKey] = errorDescription
+        }
+        return userInfo
+    }
+}
+
+extension DataMigrationError: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        guard let desc = errorDescription else {
+            return String(describing: self)
+        }
+        return "[\(Self.errorDomain)] \(desc)"
+    }
+}

--- a/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
@@ -61,3 +61,12 @@ extension DataMigrationError: CustomDebugStringConvertible {
         return "[\(Self.errorDomain)] \(desc)"
     }
 }
+
+extension DataMigrationError: Equatable {
+
+    static func ==(left: DataMigrationError, right: DataMigrationError) -> Bool {
+        let leftNSError = left as NSError
+        let rightNSError = right as NSError
+        return leftNSError == rightNSError
+    }
+}

--- a/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrationError.swift
@@ -12,11 +12,11 @@ extension DataMigrationError: LocalizedError, CustomNSError {
 
     var errorDescription: String? {
         switch self {
-        case .databaseImportError: return "The database couldn't be copied from shared directory"
-        case .databaseExportError: return "The database couldn't be copied to shared directory"
         case .backupLocationNil: return "Database shared directory not found"
         case .sharedUserDefaultsNil: return "Shared user defaults not found"
         case .dataNotReadyToImport: return "The data wasn't ready to import"
+        case .databaseImportError(let error): return "Import Failed: \(error)"
+        case .databaseExportError(let error): return "Export Failed: \(error)"
         }
     }
 
@@ -27,10 +27,10 @@ extension DataMigrationError: LocalizedError, CustomNSError {
     var errorCode: Int {
         switch self {
         case .dataNotReadyToImport: return 100
-        case .databaseImportError: return 200
-        case .databaseExportError: return 300
-        case .backupLocationNil: return 400
-        case .sharedUserDefaultsNil: return 401
+        case .backupLocationNil: return 200
+        case .sharedUserDefaultsNil: return 201
+        case .databaseImportError(let error): return 1000 + (error as NSError).code
+        case .databaseExportError(let error): return 2000 + (error as NSError).code
         }
     }
 

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -16,34 +16,6 @@ protocol ContentDataMigrating {
     func deleteExportedData()
 }
 
-enum DataMigrationError: LocalizedError, CustomNSError {
-    case databaseImportError
-    case databaseExportError
-    case sharedUserDefaultsNil
-    case dataNotReadyToImport
-
-    var errorDescription: String? {
-        switch self {
-        case .databaseImportError: return "The database couldn't be copied from shared directory"
-        case .databaseExportError: return "The database couldn't be copied to shared directory"
-        case .sharedUserDefaultsNil: return "Shared user defaults not found"
-        case .dataNotReadyToImport: return "The data wasn't ready to import"
-        }
-    }
-
-    static var errorDomain: String {
-        return String(describing: DataMigrationError.self)
-    }
-
-    var errorUserInfo: [String: Any] {
-        var userInfo = [String: Any]()
-        if let errorDescription {
-            userInfo[NSDebugDescriptionErrorKey] = errorDescription
-        }
-        return userInfo
-    }
-}
-
 final class DataMigrator {
     private let coreDataStack: CoreDataStack
     private let backupLocation: URL?

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -168,9 +168,15 @@ private extension DataMigrator {
         sharedDefaults.removeObject(forKey: DefaultsWrapper.dictKey)
     }
 
-    private func log(error: DataMigrationError, userInfo: [String: String]? = nil) {
+    private func log(error: DataMigrationError, userInfo: [String: Any] = [:]) {
+        let userInfo = userInfo.merging(self.userInfo(for: error)) { $1 }
         DDLogError(error)
         crashLogger.logError(error, userInfo: userInfo, level: .error)
+    }
+
+    private func userInfo(for error: DataMigrationError) -> [String: Any] {
+        let defaultUserInfo = ["backup-location": backupLocation?.absoluteString as Any]
+        return defaultUserInfo.merging(error.errorUserInfo) { $1 }
     }
 }
 

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -48,7 +48,7 @@ extension DataMigrator: ContentDataMigrating {
             try copyDatabase(to: backupLocation)
             try populateSharedDefaults()
         } catch {
-            let error = (error as? DataMigrationError) ?? .databaseExportError(underlyingError: error)
+            let error = DataMigrationError.databaseExportError(underlyingError: error)
             log(error: error)
             completion?(.failure(error))
             return
@@ -75,7 +75,7 @@ extension DataMigrator: ContentDataMigrating {
 
             try populateFromSharedDefaults()
         } catch {
-            let error = (error as? DataMigrationError) ?? DataMigrationError.databaseImportError(underlyingError: error)
+            let error = DataMigrationError.databaseImportError(underlyingError: error)
             log(error: error)
             completion?(.failure(error))
             return

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3646,6 +3646,8 @@
 		F4D9AF4F288AD2E300803D40 /* SuggestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */; };
 		F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */; };
 		F4D9AF53288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */; };
+		F4DD58322A095210009A772D /* DataMigrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DD58312A095210009A772D /* DataMigrationError.swift */; };
+		F4DD58332A095210009A772D /* DataMigrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DD58312A095210009A772D /* DataMigrationError.swift */; };
 		F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */; };
 		F4DDE2C329C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */; };
 		F4E79301296EEE320025E8E0 /* MigrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E79300296EEE320025E8E0 /* MigrationState.swift */; };
@@ -8994,6 +8996,7 @@
 		F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModelTests.swift; sourceTree = "<group>"; };
 		F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTableViewTests.swift; sourceTree = "<group>"; };
 		F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewDelegateMock.swift; sourceTree = "<group>"; };
+		F4DD58312A095210009A772D /* DataMigrationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrationError.swift; sourceTree = "<group>"; };
 		F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashLogging+Singleton.swift"; sourceTree = "<group>"; };
 		F4E79300296EEE320025E8E0 /* MigrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationState.swift; sourceTree = "<group>"; };
 		F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostService.swift; sourceTree = "<group>"; };
@@ -13211,6 +13214,7 @@
 			children = (
 				8332DD2329259AE300802F7D /* DataMigrator.swift */,
 				FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */,
+				F4DD58312A095210009A772D /* DataMigrationError.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -22328,6 +22332,7 @@
 				FA4F65A72594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift in Sources */,
 				7E14635720B3BEAB00B95F41 /* WPStyleGuide+Loader.swift in Sources */,
 				087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */,
+				F4DD58322A095210009A772D /* DataMigrationError.swift in Sources */,
 				08F8CD2A1EBD22EF0049D0C0 /* MediaExporter.swift in Sources */,
 				FAC086D725EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift in Sources */,
 				324780E1247F2E2A00987525 /* NoResultsViewController+FollowedSites.swift in Sources */,
@@ -24659,6 +24664,7 @@
 				FABB24092602FC2C00C8785C /* DiffAbstractValue+Attributes.swift in Sources */,
 				FABB240A2602FC2C00C8785C /* Environment.swift in Sources */,
 				FABB240B2602FC2C00C8785C /* AbstractPostListViewController.swift in Sources */,
+				F4DD58332A095210009A772D /* DataMigrationError.swift in Sources */,
 				FABB240C2602FC2C00C8785C /* ManagedAccountSettings.swift in Sources */,
 				FA88EAD6260AE69C001D232B /* TemplatePreviewViewController.swift in Sources */,
 				F41BDD7B29114E2400B7F2B0 /* MigrationStep.swift in Sources */,

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -70,7 +70,8 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
     }
 
     func test_startAndDo_givenExportError_shouldInvokeClosureWithError() {
-        mockDataMigrator.exportErrorToReturn = .databaseExportError
+        let error: DataMigrationError = .databaseExportError(underlyingError: ContextManager.ContextManagerError.missingCoordinatorOrStore)
+        mockDataMigrator.exportErrorToReturn = error
 
         let expect = expectation(description: "Content migration should fail")
         coordinator.startAndDo { result in

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -71,7 +71,7 @@ class DataMigratorTests: XCTestCase {
         let migratorError = getExportDataMigratorError(migrator)
 
         // Then
-        XCTAssertEqual(migratorError, .sharedUserDefaultsNil)
+        XCTAssertEqual(migratorError, DataMigrationError.databaseExportError(underlyingError: DataMigrationError.sharedUserDefaultsNil))
     }
 
     func test_importData_givenDataIsNotExported_shouldFail() {


### PR DESCRIPTION
Related to #20650

We got this [error](https://a8c.sentry.io/issues/4101495100/?referrer=github_integration) on Sentry, but it's unclear what caused the issue:
```
WordPress.DataMigrationError.databaseExportError
```
This PR will improve the Sentry error message. So instead of the error message above, we should expect to see something like this:
```
[DataMigrationError] Export Failed: Database shared directory not found
```
To achieve this result, I added an `underlyingError` param to `databaseExportError` and `databaseImportError` enum cases.
```swift
enum DataMigrationError {
    case databaseImportError(underlyingError: Error)
    case databaseExportError(underlyingError: Error)
    case backupLocationNil
    case sharedUserDefaultsNil
    case dataNotReadyToImport
}
```

## Test Instructions

To properly test this PR, we should cause the migration to fail and see the error event reported in Sentry. But the reported migration error is hard to reproduce, and Sentry is disabled in the development environment. 

But there is a workaround:

1. Set a breakpoint in `CrashLogging.swift` file line 161.
```swift
    func logError(_ error: Error, userInfo: [String: Any]? = nil, level: SentryLevel = .error) {

        let userInfo = userInfo ?? (error as NSError).userInfo

        let event = Event.from(
            error: error as NSError,
            level: level,
            extra: userInfo
        )
🔵      SentrySDK.capture(event: event)
        dataProvider.didLogErrorCallback?(event)
    }
```
2. Pick an error from the table below.
3. Add the following code snippet in the AppDelegate line 122.
```swift
let error = DataMigrationError.databaseExportError(underlyingError: DataMigrationError.backupLocationNil)
CrashLogging.main.logError(error)
```
4. Build and Run the Jetpack app, then wait for the breakpoint.
5. Execute the following LLDB command `po event.message`
6. Expect the output to match the values in `Event Message` and `Event Extra` columns.

| Error | Event Message |
| ---- | ---------------- |
| `.databaseExportError(.backupLocationNil)` | [DataMigrationError] Export Failed: Database shared directory not found | 
| `.databaseExportError(.sharedUserDefaultsNil)` | [DataMigrationError] Export Failed: Shared user defaults not found | 
| `.databaseExportError(systemError)` | The message should start with `[DataMigrationError] Export Failed:` followed by the `systemError` description. | 
| `.databaseImportError(.backupLocationNil)` | [DataMigrationError] Import Failed: Database shared directory not found | 
| `.databaseImportError(.sharedUserDefaultsNil)` | [DataMigrationError] Import Failed: Shared user defaults not found |
| `.databaseImportError(systemError)` | The message should start with `[DataMigrationError] Import Failed:` followed by the `systemError` description.  |

8. Execute the following LLDB command `po event.extra`.
9. **Exepect** the output to include the following keys:
   - error-domain
   - error-code
   - underlying-error-domain
   - underlying-error-code
   - underlying-error-message
   - underlying-error-user-info

## Regression Notes
1. Potential unintended areas of impact
Although not the purpose of this PR, the migration logic could be impacted. Better smoke-test the migration feature to ensure it works as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests and manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
