### PR TITLE
[UI Tests] - Small refactoring as prep to turn on parallel testing

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/sites_rewind_capabilities.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/sites_rewind_capabilities.json
@@ -1,0 +1,12 @@
+{
+    "request": {
+      "method": "GET",
+      "urlPattern": "/wpcom/v2/sites/.*/rewind/capabilities.*"
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": {
+            "capabilities": []
+      }
+    }
+  }

--- a/WordPress/UITests/Flows/LoginFlow.swift
+++ b/WordPress/UITests/Flows/LoginFlow.swift
@@ -7,7 +7,7 @@ class LoginFlow {
     static func login(email: String, password: String, selectedSiteTitle: String? = nil) throws -> MySiteScreen {
         return try PrologueScreen().selectContinue()
             .proceedWith(email: email)
-            .proceedWith(password: password)
+            .proceedWithValidPassword()
             .continueWithSelectedSite(title: selectedSiteTitle)
             .dismissNotificationAlertIfNeeded()
     }
@@ -20,15 +20,6 @@ class LoginFlow {
             .proceedWith(username: username, password: password)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
-
-        // TODO: remove when unifiedAuth is permanent.
-        // Leaving here for now in case unifiedAuth is disabled.
-//        return WelcomeScreen().selectLogin()
-//            .goToSiteAddressLogin()
-//            .proceedWith(siteUrl: siteUrl)
-//            .proceedWith(username: username, password: password)
-//            .continueWithSelectedSite()
-//            .dismissNotificationAlertIfNeeded()
     }
 
     // Login with WP site via Site Address.
@@ -37,7 +28,7 @@ class LoginFlow {
         return try PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: siteUrl)
             .proceedWith(email: email)
-            .proceedWith(password: password)
+            .proceedWithValidPassword()
         .continueWithSelectedSite()
         .dismissNotificationAlertIfNeeded()
     }

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -17,7 +17,7 @@ class LoginTests: XCTestCase {
     func testWPcomLoginLogout() throws {
         let prologueScreen = try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .proceedWithValidPassword()
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
@@ -61,7 +61,7 @@ class LoginTests: XCTestCase {
     func testWPcomInvalidPassword() throws {
         _ = try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .tryProceed(password: "invalidPswd")
+            .proceedWithInvalidPassword()
             .verifyLoginError()
     }
 
@@ -70,7 +70,7 @@ class LoginTests: XCTestCase {
     func testAddSelfHostedSiteAfterWPcomLogin() throws {
         try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .proceedWithValidPassword()
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite() //returns MySite screen
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -13,7 +13,7 @@ public class LoginEpilogueScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [loginEpilogueTableGetter],
             app: app,
-            waitTimeout: 7
+            waitTimeout: 60
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -8,7 +8,7 @@ public class PasswordScreen: ScreenObject {
             // swiftlint:disable:next opening_brace
             expectedElementGetters: [ { $0.secureTextFields["Password"] } ],
             app: app,
-            waitTimeout: 7
+            waitTimeout: 10
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -39,8 +39,10 @@ public class PasswordScreen: ScreenObject {
         //
         // Calling passwordTextField.doubleTap() prevents tests from failing by ensuring that the text field's
         // secureTextEntry property remains 'true'.
-        let passwordTextField = expectedElement
-        passwordTextField.doubleTap()
+
+        if Locale.current.identifier.contains("ar") {
+            passwordTextField.doubleTap()
+        }
 
         passwordTextField.typeText(password)
         let continueButton = app.buttons["Continue Button"]

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -12,13 +12,21 @@ public class PasswordScreen: ScreenObject {
         )
     }
 
-    public func proceedWith(password: String) throws -> LoginEpilogueScreen {
-        _ = tryProceed(password: password)
+    public func proceedWithValidPassword() throws -> LoginEpilogueScreen {
+        try tryProceed(password: "pw")
 
         return try LoginEpilogueScreen()
     }
 
-    public func tryProceed(password: String) -> PasswordScreen {
+    public func proceedWithInvalidPassword() throws -> PasswordScreen {
+        try tryProceed(password: "invalidPswd")
+
+        return try PasswordScreen()
+    }
+
+    public func tryProceed(password: String) throws {
+        let passwordTextField = expectedElement
+
         // A hack to make tests pass for RtL languages.
         //
         // An unintended side effect of calling passwordTextField.tap() while testing a RtL language is that the
@@ -44,8 +52,6 @@ public class PasswordScreen: ScreenObject {
             // alert where "Save Password" is.
             app.buttons["Not Now"].tap()
         }
-
-        return self
     }
 
     public func verifyLoginError() -> PasswordScreen {


### PR DESCRIPTION
## Description
This PR is for small refactoring changes before turning on parallel testing on JPiOS. I've decided to separate the two so that we can revert the changes separately if needed. The idea is that the changes introduced in this PR shouldn't affect existing test cases even if parallel testing is not turned on. The changes are:

1. Break the enter password flows to valid and invalid password. Currently, there is one flow for both, but the return value is different depending on the flow, valid password should return Login Epilogue Screen, an invalid password should return Password Screen. Because of that and the speed of the simulator, the test might end up in a state where it is waiting for an element on the wrong screen, causing a false negative. This is similar to the update done on [WCiOS](https://github.com/woocommerce/woocommerce-ios/pull/9560). Change in https://github.com/wordpress-mobile/WordPress-iOS/pull/20655/commits/037d05b9953687178c71e907f612e96e60a38219
2. Add missing mock file - there is a missing response during log in flow, added in https://github.com/wordpress-mobile/WordPress-iOS/pull/20655/commits/5c1e70facace5f12b05c8219c57cd6bf6ea9a3ac
3. Updated to only run the existing double tap hack for RTL language (I believe the RTL language used by the screenshot test is `ar` locale so using that as the condition). Change in https://github.com/wordpress-mobile/WordPress-iOS/pull/20655/commits/3870712b76126d6fb23d969d0029bce0393ef004
4. Updated timeouts. This is needed as some screens load slower when tests are running in parallel. Change made for only 2 screens: `LoginEpilogueScreen` and `PasswordScreen` in this PR. Change in https://github.com/wordpress-mobile/WordPress-iOS/pull/20655/commits/e31aa7e9515f926ab4874bb7437519eda2d27f04

## Testing
CI should be green
