### PR TITLE
Turn on Parallel Testing for UI Tests

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -52,6 +52,6 @@ else
   echo "The UI Tests, ran during the '🔬 Testing' step above, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
-annotate_test_failures "build/results/report.junit"
+annotate_test_failures "build/results/JetpackUITests.xml"
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -36,6 +36,6 @@ else
   echo "The Unit Tests, ran during the '🔬 Testing' step above, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
-annotate_test_failures "build/results/report.junit"
+annotate_test_failures "build/results/WordPress.xml"
 
 exit $TESTS_EXIT_STATUS

--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -20,6 +20,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -114,10 +114,14 @@ platform :ios do
       output_directory: File.join(PROJECT_ROOT_FOLDER, 'build', 'results'),
       reset_simulator: true,
       result_bundle: true,
+      output_types: '',
+      fail_build: false,
       parallel_testing: parallel_testing_value,
       concurrent_workers: CONCURRENT_SIMULATORS,
       max_concurrent_simulators: CONCURRENT_SIMULATORS
     )
+
+    trainer(path: lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH], fail_build: true)
   end
 
   # Builds the WordPress app and uploads it to TestFlight, for beta-testing or final release

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -5,6 +5,7 @@ SENTRY_PROJECT_SLUG_WORDPRESS = 'wordpress-ios'
 SENTRY_PROJECT_SLUG_JETPACK = 'jetpack-ios'
 APPCENTER_OWNER_NAME = 'automattic'
 APPCENTER_OWNER_TYPE = 'organization'
+CONCURRENT_SIMULATORS = 2
 
 # Shared options to use when invoking `gym` / `build_app`.
 #
@@ -98,6 +99,10 @@ platform :ios do
     # Because we only support those two modes, we can infer the scheme name from the xctestrun name
     scheme = options[:name].include?('Jetpack') ? 'JetpackUITests' : 'WordPress'
 
+    # Only run Jetpack UI tests in parallel.
+    # At the time of writing, we need to explicitly set this value despite using test plans that configure parallelism.
+    parallel_testing_value = options[:name].include?('Jetpack')
+
     run_tests(
       workspace: WORKSPACE_PATH,
       scheme: scheme,
@@ -108,7 +113,10 @@ platform :ios do
       xctestrun: xctestrun_path,
       output_directory: File.join(PROJECT_ROOT_FOLDER, 'build', 'results'),
       reset_simulator: true,
-      result_bundle: true
+      result_bundle: true,
+      parallel_testing: parallel_testing_value,
+      concurrent_workers: CONCURRENT_SIMULATORS,
+      max_concurrent_simulators: CONCURRENT_SIMULATORS
     )
   end
 


### PR DESCRIPTION
### Description
~(This branch was created based on [`refactor-to-turn-on-parallel-testing`](https://github.com/wordpress-mobile/WordPress-iOS/pull/20655), once that's merged there should be less changes on this PR) - PR merged~

This PR turns on parallel testing for UI tests (JPiOS), running on 2 simulators. There is one issue I couldn't figure out, so I am putting this here for discussion if we want to continue with this or not. 

For reasons I still don't understand, the first test on the first runner will always fail on the first try but passes on the retry (the same behavior that @tiagomar noticed a few months back). Here's an example when the first test suite is `StatsTest`:
![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/46ac3938-94ff-4427-852f-9f6e42a2a392)

I tried disabling that test to see if it was test related and the results were worse, both "first" tests on the runners failed:
![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/95d7a666-5e51-4ecc-91ad-44d80fe73e97)

And the failures all happen at the same place, after tapping on the Continue button after entering the password to log in, this is the screenshot from the failures:
![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/2b828b69-ba3a-4032-8f8f-20f4688ee8be)

You can see that the spinner icon is still displayed on the Continue button, so it doesn't continue to show the next screen. I tried updating the timeout to wait as long as 90 seconds but the results were the same - it would still fail on the first run. 

### Example Results
Before change - ~23m 23s ([example](https://buildkite.com/automattic/wordpress-ios/builds/14117#018803ad-5ecc-4ca0-ace1-39f0e5ed95b3))
After change (including that 1 consistent failure) - ~14m 35s ([example](https://buildkite.com/automattic/wordpress-ios/builds/14116#01880393-2e53-4248-8772-be9a8901d0d7))

Even with the consistent failing test, the time taken to complete the test run is already much faster. Is this a trade-off we're willing to take? I think we should, but open to feedback and thoughts from the team. 

### Testing
CI should be green, and tests should run in parallel on 2 simulators. To validate, check (should be generated in the UI test steps) the test plan log and ensure that they are two runners:
![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/d7c913a4-dfbb-4270-bb41-8529f90c29b6)
