### PR TITLE
[Gutenberg] Avoid sending HTML to the editor when closing

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -100,6 +100,8 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     var postIsReblogged: Bool = false
 
+    var isEditorClosing: Bool = false
+
     // MARK: - Editor Media actions
 
     var isUploadingMedia: Bool {
@@ -205,7 +207,12 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         }
 
         self.html = html
-        gutenberg.updateHtml(html)
+
+        // Avoid sending the HTML back to the editor if it's closing.
+        // Otherwise, it will cause the editor to recreate all blocks.
+        if !isEditorClosing {
+            gutenberg.updateHtml(html)
+        }
     }
 
     func getHTML() -> String {
@@ -912,6 +919,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                     showAlertForEmptyPostPublish()
                 }
             case .close:
+                isEditorClosing = true
                 cancelEditing()
             case .more:
                 displayMoreSheet()


### PR DESCRIPTION
Sending the HTML when closing the editor was causing the editor to recreate all blocks. Some of these blocks might be executing logic during their initialization that would be affected by the editor closing process. This in combination with destroying/deallocating the editor and the libraries used (like Reanimated), might be the cause of the following issues:
* https://github.com/wordpress-mobile/WordPress-iOS/issues/20499
* https://github.com/wordpress-mobile/WordPress-iOS/issues/20647
* https://github.com/WordPress/gutenberg/issues/41686

I couldn't verify the above as I'm not able to reproduce them. Hence, we'd need to check in production if any of those issues are solved by this change.

**To test:**
This change can only be tested by incorporating logs into the React Native code.

1. Apply the following patch in the editor:
```patch
diff --git forkSrcPrefix/packages/block-library/src/paragraph/edit.native.js forkDstPrefix/packages/block-library/src/paragraph/edit.native.js
index 98662ba21c88410e8eb6291e18399ef979933f8a..f6963d277386f84097100298b75c52cd0b04b95c 100644
--- forkSrcPrefix/packages/block-library/src/paragraph/edit.native.js
+++ forkDstPrefix/packages/block-library/src/paragraph/edit.native.js
@@ -9,7 +9,7 @@ import {
 	RichText,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 const name = 'core/paragraph';
@@ -25,6 +25,10 @@ function ParagraphBlock( {
 	clientId,
 	parentBlockAlignment,
 } ) {
+	useEffect( () => {
+		console.log( `Paragraph block ${ clientId } mounted` );
+		return () => console.log( `Paragraph block ${ clientId } unmounted` );
+	}, [] );
 	const isRTL = useSelect( ( select ) => {
 		return !! select( blockEditorStore ).getSettings().isRTL;
 	}, [] );
```
2. Build the app and connect it to your local Metro server.
3. Create a post/page.
4. Add a Paragraph block with some text.
5. Close the editor and save the post/page.
6. Open the post again.
7. Observe in the console that the message `Paragraph block ${ clientId } mounted` is printed.
8. Close the editor.
9. Observe in the console that the message `Paragraph block ${ clientId } unmounted` is NOT printed.

**NOTE:** Previously, when closing the editor blocks were being unmounted and mounted.

## Regression Notes
1. Potential unintended areas of impact
This change is very specific so I don't foresee any unintended areas that could be impacted.

11. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

12. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
