### PR TITLE
[UI Tests] Simplify the command to copy crash reports into Artifacts

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -41,9 +41,7 @@ cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult
 
 echo "--- 💥 Collecting Crash reports"
 mkdir -p build/results/crashes
-find ~/Library/Logs/DiagnosticReports -name '*.ips' -print0 | while read -d $'\0' -r file; do
-  cp "$file" "build/results/crashes/$(basename "$file")"
-done
+find ~/Library/Logs/DiagnosticReports -name '*.ips' -exec cp "{}" "build/results/crashes/" \;
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then


### PR DESCRIPTION
This PR simplifies the command to copy crash reports files to a folder included in Artifacts path, in UI Tests step, by removing the `while` loop, no longer needed after deciding to copy the files into `build/results/crashes/` instead of copying them to `build/results/` with a `[CRASH]` prefix to the file name.

To test:
If CI is green, we're safe.