### PR TITLE
Updates the copy of the Jetpack static poster

### DIFF
--- a/WordPress/Classes/Extensions/String+NonbreakingSpace.swift
+++ b/WordPress/Classes/Extensions/String+NonbreakingSpace.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension String {
+    var replacingLastSpaceWithNonBreakingSpace: String {
+        if let lastSpace = range(of: " ", options: .backwards, locale: .current) {
+            return replacingCharacters(in: lastSpace, with: "\u{00a0}")
+        }
+        return self
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
@@ -76,7 +76,7 @@ final class MovedToJetpackViewController: UIViewController {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = viewModel.title
+        label.text = viewModel.title.replacingLastSpaceWithNonBreakingSpace
         label.font = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .bold)
         label.adjustsFontForContentSizeCategory = true
         label.adjustsFontSizeToFitWidth = true

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewModel.swift
@@ -87,25 +87,25 @@ extension MovedToJetpackViewModel {
 
         static let statsTitle = NSLocalizedString(
             "movedToJetpack.stats.title",
-            value: "Stats have moved to the Jetpack app.",
+            value: "Use WordPress with Stats in the Jetpack pp.",
             comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
         )
 
         static let readerTitle = NSLocalizedString(
             "movedToJetpack.reader.title",
-            value: "Reader has moved to the Jetpack app.",
+            value: "Use WordPress with Reader in the Jetpack app.",
             comment: "Title for the static screen displayed in the Reader screen prompting users to switch to the Jetpack app."
         )
 
         static let notificationsTitle = NSLocalizedString(
             "movedToJetpack.notifications.title",
-            value: "Notifications have moved to the Jetpack app.",
+            value: "Use WordPress with Notifications in the Jetpack app.",
             comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
         )
 
         static let description = NSLocalizedString(
             "movedToJetpack.description",
-            value: "Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app, and can now only be found in the Jetpack app.",
+            value: "The Jetpack app has all the WordPress app’s functionality, and now exclusive access to Stats, Reader, Notifications and more.",
             comment: "Description for the static screen displayed prompting users to switch the Jetpack app."
         )
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewModel.swift
@@ -65,7 +65,7 @@ extension MovedToJetpackViewModel {
 
         static let statsTitle = NSLocalizedString(
             "movedToJetpack.stats.title",
-            value: "Use WordPress with Stats in the Jetpack pp.",
+            value: "Use WordPress with Stats in the Jetpack app.",
             comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
         )
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewModel.swift
@@ -21,27 +21,9 @@ struct MovedToJetpackViewModel {
 
     let source: MovedToJetpackSource
 
-    var animationLtr: String {
-        switch source {
-        case .stats:
-            return Constants.statsLogoAnimationLtr
-        case .reader:
-            return Constants.readerLogoAnimationLtr
-        case .notifications:
-            return Constants.notificationsLogoAnimationLtr
-        }
-    }
+    let animationLtr: String = Constants.wpJetpackLogoAnimationLtr
 
-    var animationRtl: String {
-        switch source {
-        case .stats:
-            return Constants.statsLogoAnimationRtl
-        case .reader:
-            return Constants.readerLogoAnimationRtl
-        case .notifications:
-            return Constants.notificationsLogoAnimationRtl
-        }
-    }
+    let animationRtl: String = Constants.wpJetpackLogoAnimationRtl
 
     var title: String {
         switch source {
@@ -75,12 +57,8 @@ struct MovedToJetpackViewModel {
 extension MovedToJetpackViewModel {
 
     private enum Constants {
-        static let statsLogoAnimationLtr = "JetpackStatsLogoAnimation_ltr"
-        static let statsLogoAnimationRtl = "JetpackStatsLogoAnimation_rtl"
-        static let readerLogoAnimationLtr = "JetpackReaderLogoAnimation_ltr"
-        static let readerLogoAnimationRtl = "JetpackReaderLogoAnimation_rtl"
-        static let notificationsLogoAnimationLtr = "JetpackNotificationsLogoAnimation_ltr"
-        static let notificationsLogoAnimationRtl = "JetpackNotificationsLogoAnimation_rtl"
+        static let wpJetpackLogoAnimationLtr = "JetpackWordPressLogoAnimation_ltr"
+        static let wpJetpackLogoAnimationRtl = "JetpackWordPressLogoAnimation_rtl"
     }
 
     private enum Strings {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5386,6 +5386,8 @@
 		FAC1B82729B1F1EE00E0C542 /* BlazePostPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC1B82629B1F1EE00E0C542 /* BlazePostPreviewView.swift */; };
 		FAC1B82829B1F1EE00E0C542 /* BlazePostPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC1B82629B1F1EE00E0C542 /* BlazePostPreviewView.swift */; };
 		FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */; };
+		FAD1263C2A0CF2F50004E24C /* String+NonbreakingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1263B2A0CF2F50004E24C /* String+NonbreakingSpace.swift */; };
+		FAD1263D2A0CF2F50004E24C /* String+NonbreakingSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1263B2A0CF2F50004E24C /* String+NonbreakingSpace.swift */; };
 		FAD2538F26116A1600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD2539026116A1600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD2539126116A1600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
@@ -9176,6 +9178,7 @@
 		FAC1B81D29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeOverlayViewModel.swift; sourceTree = "<group>"; };
 		FAC1B82629B1F1EE00E0C542 /* BlazePostPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePostPreviewView.swift; sourceTree = "<group>"; };
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
+		FAD1263B2A0CF2F50004E24C /* String+NonbreakingSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+NonbreakingSpace.swift"; sourceTree = "<group>"; };
 		FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyleGuide.swift; sourceTree = "<group>"; };
 		FAD2544126116CEA00EDAF88 /* AppStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyleGuide.swift; sourceTree = "<group>"; };
 		FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+WordPressColors.swift"; sourceTree = "<group>"; };
@@ -15069,6 +15072,7 @@
 				E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */,
 				7360018E20A265C7001E5E31 /* String+Files.swift */,
 				C737553D27C80DD500C6E9A1 /* String+CondenseWhitespace.swift */,
+				FAD1263B2A0CF2F50004E24C /* String+NonbreakingSpace.swift */,
 				B55FFCF91F034F1A0070812C /* String+Ranges.swift */,
 				B54C02231F38F50100574572 /* String+RegEx.swift */,
 				B5969E2120A49E86005E9DF1 /* UIAlertController+Helpers.swift */,
@@ -22250,6 +22254,7 @@
 				326E281B250AC4A50029EBF0 /* ImageDimensionFetcher.swift in Sources */,
 				7435CE7320A4B9170075A1B9 /* AnimatedImageCache.swift in Sources */,
 				43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */,
+				FAD1263C2A0CF2F50004E24C /* String+NonbreakingSpace.swift in Sources */,
 				CE46018B21139E8300F242B6 /* FooterTextContent.swift in Sources */,
 				E6D6A1302683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
 				F1BC842E27035A1800C39993 /* BlogService+Domains.swift in Sources */,
@@ -23594,6 +23599,7 @@
 				FABB20EF2602FC2C00C8785C /* QuickStartTourGuide.swift in Sources */,
 				FABB20F02602FC2C00C8785C /* ReaderDetailToolbar.swift in Sources */,
 				80A2154429D1177A002FE8EB /* RemoteConfigDebugViewController.swift in Sources */,
+				FAD1263D2A0CF2F50004E24C /* String+NonbreakingSpace.swift in Sources */,
 				FABB20F12602FC2C00C8785C /* RecentSitesService.swift in Sources */,
 				FA332AD129C1F97A00182FBB /* MovedToJetpackViewController.swift in Sources */,
 				8BD66ED52787530C00CCD95A /* PostsCardViewModel.swift in Sources */,


### PR DESCRIPTION
## Description
Updates the copy of the Jetpack static poster

Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18388

### Internal refs
* pbArwn-650-p2#comment-7637
* p1683628287128089-slack-C0180B5PRJ4

## To test:
1. Delete the Jetpack app (of the current build flavour) if present or delete the local data of the app
2. Run the WP app from this branch or the CI build
3. Visit the Stats, Reader, and Notifications page
4. **Verify** that the updated copy is displayed

**Note:** The [nitpick reported on the Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/18388#pullrequestreview-1420833385) regarding the line break issue (e.g. the Stats screenshot below) is not handled. I've tried using a [Non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space) or setting the `lineBreakStrategy` for the label. Any suggestions on this are more than welcome :)

|Reader Before|Reader After|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 19 47 40](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/c2066e13-6450-4529-bd30-c7fee53c7d06)|![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 19 44 17](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/b81129cc-b64b-4cdd-9ee2-7e816c510435)|

|Notifications Before|Notifications After|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 19 47 44](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/d5443b89-4d52-4066-b866-7392e0aa6e7d)|![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 19 44 21](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/70e3852e-b930-4814-bfda-29c82ea0f18c)|

|Stats Before|Stats After|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 19 47 34](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/a848ec80-5ddd-43ad-be9a-afe5e93b9763)|![Simulator Screen Shot - iPhone 14 - 2023-05-10 at 19 44 07](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/2cc2829b-7b59-4989-9390-ba3f29a9380a)|

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
