### PR TITLE
Update domain purchasing in site creation analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -7,9 +7,8 @@ extension WPAnalytics {
         FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
     }
 
-    static func domainsProperties(for blog: Blog) -> [AnyHashable: Any] {
-        // For now we do not have the `siteCreation` route implemented so hardcoding `menu`
-        domainsProperties(usingCredit: blog.canRegisterDomainWithPaidPlan, origin: .menu)
+    static func domainsProperties(for blog: Blog, origin: DomainPurchaseWebViewViewOrigin? = .menu) -> [AnyHashable: Any] {
+        domainsProperties(usingCredit: blog.canRegisterDomainWithPaidPlan, origin: origin)
     }
 
     static func domainsProperties(

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -231,6 +231,7 @@ import Foundation
     case domainsRegistrationFormViewed
     case domainsRegistrationFormSubmitted
     case domainsPurchaseWebviewViewed
+    case domainsPurchaseSucceeded
 
     // My Site
     case mySitePullToRefresh
@@ -890,6 +891,8 @@ import Foundation
             return "domains_registration_form_submitted"
         case .domainsPurchaseWebviewViewed:
             return "domains_purchase_webview_viewed"
+        case .domainsPurchaseSucceeded:
+            return "domains_purchase_domain_success"
 
         // My Site
         case .mySitePullToRefresh:

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -18,7 +18,7 @@ final class SiteAssemblyWizardContent: UIViewController {
     private let service: SiteAssemblyService
 
     /// Displays the domain checkout web view.
-    private lazy var domainPurchasingController = DomainPurchasingWebFlowController(viewController: self)
+    private lazy var domainPurchasingController = DomainPurchasingWebFlowController(viewController: self, origin: .siteCreation)
 
     /// The new `Blog`, if successfully created; `nil` otherwise.
     private var createdBlog: Blog?

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/EnhancedSiteCreationAnalyticsEvent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/EnhancedSiteCreationAnalyticsEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum EnhancedSiteCreationAnalyticsEvent: String {
+    case domainPurchasingExperiment = "enhanced_site_creation_domain_purchasing_experiment"
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsEvent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsEvent.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-enum SiteCreationAnalyticsEvent: String {
-    case domainPurchasingExperiment = "site_creation_domain_purchasing_experiment"
-}

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -156,7 +156,7 @@ class SiteCreationAnalyticsHelper {
     }
 
     // MARK: - Common
-    private static func track(_ event: SiteCreationAnalyticsEvent, properties: [String: String] = [:]) {
+    private static func track(_ event: EnhancedSiteCreationAnalyticsEvent, properties: [String: String] = [:]) {
         let event = AnalyticsEvent(name: event.rawValue, properties: properties)
         WPAnalytics.track(event)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3537,8 +3537,8 @@
 		F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */; };
 		F44FB6CD287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */; };
 		F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = F44FB6D02878A1020001E3CE /* user-suggestions.json */; };
-		F45326D829F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */; };
-		F45326D929F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */; };
+		F45326D829F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */; };
+		F45326D929F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */; };
 		F4552086299D147B00D9F6A8 /* BlockedSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48D44B5298992C30051EAA6 /* BlockedSite.swift */; };
 		F465976E28E4669200D5F49A /* cool-green-icon-app-76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */; };
 		F465976F28E4669200D5F49A /* cool-green-icon-app-76.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */; };
@@ -8906,7 +8906,7 @@
 		F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsListViewModelTests.swift; sourceTree = "<group>"; };
 		F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewMockDelegate.swift; sourceTree = "<group>"; };
 		F44FB6D02878A1020001E3CE /* user-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-suggestions.json"; sourceTree = "<group>"; };
-		F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationAnalyticsEvent.swift; sourceTree = "<group>"; };
+		F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedSiteCreationAnalyticsEvent.swift; sourceTree = "<group>"; };
 		F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76@2x.png"; sourceTree = "<group>"; };
 		F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76.png"; sourceTree = "<group>"; };
 		F465976B28E4669200D5F49A /* cool-green-icon-app-60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-60@3x.png"; sourceTree = "<group>"; };
@@ -12541,7 +12541,7 @@
 				738B9A5D21B8632E0005062B /* UITableView+Header.swift */,
 				738B9A5B21B85EB00005062B /* UIView+ContentLayout.swift */,
 				46D6114E2555DAED00B0B7BB /* SiteCreationAnalyticsHelper.swift */,
-				F45326D729F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift */,
+				F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -21111,7 +21111,7 @@
 				80A2154629D15B88002FE8EB /* RemoteConfigOverrideStore.swift in Sources */,
 				F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */,
 				4629E4212440C5B20002E15C /* GutenbergCoverUploadProcessor.swift in Sources */,
-				F45326D829F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */,
+				F45326D829F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */,
 				FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */,
 				982DDF94263238A6002B3904 /* LikeUserPreferredBlog+CoreDataClass.swift in Sources */,
 				F5844B6B235EAF3D007C6557 /* PartScreenPresentationController.swift in Sources */,
@@ -23841,7 +23841,7 @@
 				8B55F9EE2614D977007D618E /* UnifiedPrologueStatsContentView.swift in Sources */,
 				FABB21932602FC2C00C8785C /* GutenbergTenorMediaPicker.swift in Sources */,
 				3F8B45A029283D6C00730FA4 /* DashboardMigrationSuccessCell.swift in Sources */,
-				F45326D929F6B8A6005F9F31 /* SiteCreationAnalyticsEvent.swift in Sources */,
+				F45326D929F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */,
 				FA98B61A29A3BF050071AAE8 /* BlazeCardView.swift in Sources */,
 				FABB21942602FC2C00C8785C /* AztecPostViewController.swift in Sources */,
 				F1585442267D3BF900A2E966 /* CalendarDayToggleButton.swift in Sources */,


### PR DESCRIPTION
Fixes #20652

This PR:
- Updates events tracking to ensure proper analysis can be done on the performance of the experimental feature.

## Test Instructions

#### Prerequisites:

<details><summary>Toggle the Site Creation Domain Purchasing feature (<code>Site Creation Domain Purchasing</code>)</summary>

1. Go to `Me` → `App Settings` → `Debug settings.`
2. Scroll down until you find `Site Creation Domain Purchasing` flag.
3. Tap the switch on or off to toggle the `Site Creation Domain Purchasing` flag.
4. Go to **Abacus** (internal ref:  21064-explat-experiment) and assign to your test a8c-user the treatment variation.
---
</details>

###  Treatment Variation

1. **Verify** the following sequence of events is tracked for **free** domains:

```python
🔵 Tracked: enhanced_site_creation_accessed <source: my_sites>
🔵 Tracked: enhanced_site_creation_domain_purchasing_experiment <variation: treatment>
…
🔵 Tracked: enhanced_site_creation_domains_accessed
🔵 Tracked: enhanced_site_creation_domains_selected <chosen_domain: *, domain_cost: Free, search_term: *>
…
🔵 Tracked: site_created <template: *>
…
🔵 Tracked: enhanced_site_creation_preview_ok_button_tapped
```

2. **Verify** the following sequence of events is tracked for **paid** domains:

```python
🔵 Tracked: enhanced_site_creation_accessed <source: my_sites>
🔵 Tracked: enhanced_site_creation_domain_purchasing_experiment <variation: treatment>
…
🔵 Tracked: enhanced_site_creation_domains_accessed
🔵 Tracked: enhanced_site_creation_domains_selected <chosen_domain: *, domain_cost: *, search_term: *>
…
🔵 Tracked: site_created <template: *>
🔵 Tracked: domains_purchase_webview_viewed <blog_id: *, origin: site_creation, site_type: blog, using_credit: *>
🔵 Tracked: webview_displayed
🔵 Tracked: domains_purchase_domain_success <blog_id: *, origin: site_creation, site_type: blog, using_credit: *>
…
🔵 Tracked: enhanced_site_creation_preview_ok_button_tapped
```

### Control Variation

1. **Verify** the same sequence of events is tracked as for **free** domains:

```python
🔵 Tracked: enhanced_site_creation_accessed <source: my_sites>
🔵 Tracked: enhanced_site_creation_domain_purchasing_experiment <variation: control>
…
🔵 Tracked: enhanced_site_creation_domains_accessed
🔵 Tracked: enhanced_site_creation_domains_selected <chosen_domain: *, domain_cost: Free, search_term: *>
…
🔵 Tracked: site_created <template: *>
…
🔵 Tracked: enhanced_site_creation_preview_ok_button_tapped
```

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
