### PR TITLE
Editor: Fix crash when adding images when permissions are missing

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -141,9 +141,9 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-  # pod 'WPMediaPicker', '~> 1.8.7'
+  pod 'WPMediaPicker', '~> 1.8.8-beta.1'
   ## while PR is in review:
-  pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: 'fix/19965-classic-block-media-crash'
+  # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: 'fix/19965-classic-block-media-crash'
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
   pod 'Gridicons', '~> 1.1.0'

--- a/Podfile
+++ b/Podfile
@@ -141,9 +141,9 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-#  pod 'WPMediaPicker', '~> 1.8.7'
+  # pod 'WPMediaPicker', '~> 1.8.7'
   ## while PR is in review:
-   pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: 'fix/19965-classic-block-media-crash'
+  pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: 'fix/19965-classic-block-media-crash'
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
   pod 'Gridicons', '~> 1.1.0'

--- a/Podfile
+++ b/Podfile
@@ -141,9 +141,9 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-  pod 'WPMediaPicker', '~> 1.8.7'
+#  pod 'WPMediaPicker', '~> 1.8.7'
   ## while PR is in review:
-  # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
+   pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: 'fix/19965-classic-block-media-crash'
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
   pod 'Gridicons', '~> 1.1.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -520,7 +520,7 @@ PODS:
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.2.0)
   - WordPressUI (1.12.5)
-  - WPMediaPicker (1.8.7)
+  - WPMediaPicker (1.8.8-beta.1)
   - wpxmlrpc (0.10.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.2)
@@ -615,7 +615,7 @@ DEPENDENCIES:
   - WordPressKit (~> 8.1.0-beta)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `trunk`)
   - WordPressUI (~> 1.12.5)
-  - WPMediaPicker (~> 1.8.7)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, branch `fix/19965-classic-block-media-crash`)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.94.0/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -663,7 +663,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressKit
     - WordPressUI
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
     - ZendeskCoreSDK
@@ -779,6 +778,9 @@ EXTERNAL SOURCES:
   WordPressShared:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
+  WPMediaPicker:
+    :branch: fix/19965-classic-block-media-crash
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.94.0/third-party-podspecs/Yoga.podspec.json
 
@@ -797,6 +799,9 @@ CHECKOUT OPTIONS:
   WordPressShared:
     :commit: 9a010fdab8d31f9e1fa0511f231e7068ef0170b1
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
+  WPMediaPicker:
+    :commit: cab8e939b9e6c8b9ed7877c6b1bbbfd25d30b884
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -888,7 +893,7 @@ SPEC CHECKSUMS:
   WordPressKit: 707e723428027ac0aa9d514807e391117588dd5d
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
-  WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
+  WPMediaPicker: 3b0d7272bec6eb0d8bc267daa5606c9b259e6cbb
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   Yoga: 5e12f4deb20582f86f6323e1cdff25f07afc87f6
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
@@ -900,6 +905,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: e50160a649d94dcab9a9727eab8d626d4c9a7f51
+PODFILE CHECKSUM: 8ee86fddf87bdb9bd0441aa5530166860187cc4d
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -520,7 +520,7 @@ PODS:
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.2.0)
   - WordPressUI (1.12.5)
-  - WPMediaPicker (1.8.7)
+  - WPMediaPicker (1.8.8-beta.1)
   - wpxmlrpc (0.10.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.2)
@@ -615,7 +615,7 @@ DEPENDENCIES:
   - WordPressKit (~> 8.1.0-beta)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `trunk`)
   - WordPressUI (~> 1.12.5)
-  - WPMediaPicker (~> 1.8.7)
+  - WPMediaPicker (~> 1.8.8-beta.1)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.95.0/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -888,7 +888,7 @@ SPEC CHECKSUMS:
   WordPressKit: 707e723428027ac0aa9d514807e391117588dd5d
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
-  WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
+  WPMediaPicker: 3b0d7272bec6eb0d8bc267daa5606c9b259e6cbb
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   Yoga: 5e12f4deb20582f86f6323e1cdff25f07afc87f6
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
@@ -900,6 +900,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: e50160a649d94dcab9a9727eab8d626d4c9a7f51
+PODFILE CHECKSUM: 9b3422afb7a22d84b6de0fdb51bc1f8900efb80e
 
 COCOAPODS: 1.11.3

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3301,6 +3301,12 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
         updateFormatBarInsertAssetCount()
     }
 
+    func mediaPickerController(_ picker: WPMediaPickerViewController, handleError error: Error) -> Bool {
+        let alert = WPMediaPickerAlertHelper.buildAlertControllerWithError(error)
+        present(alert, animated: true)
+        return true
+    }
+
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
         if let phAssets = assets as? [PHAsset], phAssets.allSatisfy({ $0.mediaType == .image }) {
             edit(fromMediaPicker: picker, assets: phAssets)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -125,9 +125,7 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
     }
 
     open func mediaPickerController(_ picker: WPMediaPickerViewController, handleError error: Error) -> Bool {
-        guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController else {
-            return true
-        }
+        let presenter = context.topmostPresentedViewController
         let alert = WPMediaPickerAlertHelper.buildAlertControllerWithError(error)
         presenter.present(alert, animated: true)
         return true

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -125,8 +125,11 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
     }
 
     open func mediaPickerController(_ picker: WPMediaPickerViewController, handleError error: Error) -> Bool {
+        guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController else {
+            return true
+        }
         let alert = WPMediaPickerAlertHelper.buildAlertControllerWithError(error)
-        context.present(alert, animated: true)
+        presenter.present(alert, animated: true)
         return true
     }
 


### PR DESCRIPTION
Fixes #19965 
[MediaPicker-iOS PR](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/409)

## Description

- Fixes a crash that happens when attempting to add media to a classic block while the library permissions are missing.
- The PR adds an alert prompting users to give the app access to the device library.
- The PR also fixes an issue where the alert prompting users to give the app access to the device library was not being displayed from Gutenberg blocks.

## Testing Instructions

### Classic Block

1. Ensure the JP app has photo permissions set to None
2. Try to edit a page that has a classic block on it.
3. Press the '+' button to add an image
4. Make sure the app doesn't crash ✅ 
5. Make sure an alert is displayed ✅ 

### Gutenberg Block

1. Ensure the JP/WP app has photo permissions set to None
2. Tap on any page
3. The editor will show up
4. Add an Image block
5. Tap on "Add Image"
6. Tap on "Choose from device"
7. Make sure an alert is displayed ✅ 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
