### PR TITLE
[Tooling] Use Buildkite emojis for Prototype Builds

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -263,6 +263,7 @@ platform :ios do
       scheme: 'WordPress Alpha',
       output_app_name: 'WordPress Alpha',
       appcenter_app_name: 'WPiOS-One-Offs',
+      app_icon: ':wordpress:', # Use Buildkite emoji
       sentry_project_slug: SENTRY_PROJECT_SLUG_WORDPRESS
     )
   end
@@ -281,6 +282,7 @@ platform :ios do
       scheme: 'Jetpack',
       output_app_name: 'Jetpack Alpha',
       appcenter_app_name: 'jetpack-installable-builds',
+      app_icon: ':jetpack:', # Use Buildkite emoji
       sentry_project_slug: SENTRY_PROJECT_SLUG_JETPACK
     )
   end
@@ -313,7 +315,7 @@ platform :ios do
   # Builds a Prototype Build for WordPress or Jetpack, then uploads it to App Center and comment with a link to it on the PR.
   #
   # rubocop:disable Metrics/AbcSize
-  def build_and_upload_prototype_build(scheme:, output_app_name:, appcenter_app_name:, sentry_project_slug:)
+  def build_and_upload_prototype_build(scheme:, output_app_name:, appcenter_app_name:, app_icon:, sentry_project_slug:)
     configuration = 'Release-Alpha'
 
     # Get the current build version, and update it if needed
@@ -371,6 +373,7 @@ platform :ios do
     # Post PR Comment
     comment_body = prototype_build_details_comment(
       app_display_name: output_app_name,
+      app_icon: app_icon,
       app_center_org_name: APPCENTER_OWNER_NAME,
       metadata: { Configuration: configuration },
       fold: true


### PR DESCRIPTION
## Why?

If we don't provide an explicit `app_icon` to the call to `prototype_build_details_comment` action, this action uses the URL of the icon returned by the App Center API as a fallback.

This works well in general, except that this URL contains a signed token in its query parameter, that is only valid for a certain amount of time. Thus this ends up making that icon URL invalid (and the icon image unreachable) after some time has passed (e.g. when you go back on older PRs, like [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/20435#issuecomment-1490478619)).

## How?

To fix this, we now specify the [Buildkite emoji](https://github.com/buildkite/emojis) (`:wordpress:` or `:jetpack:`) explicitly to use as `app_icon`.

## Testing

 - Check that the PR comments about WP and JP prototypes builds show the right icon for each case
 - Hover over the ![:wordpress:](https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/wordpress.png) and ![:jetpack:](https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/jetpack.png) emojis that are embedded in those comments—both for the emoji at the start of the comment before the 📲 , and the one in front of the "App Name" row—and verify that all 4 of them use a URL like `https://raw.githubusercontent.com/buildkite/emojis/main/img-buildkite-64/*.png` (instead of a URL to App Center servers with a token in query)

<img width="1450" alt="pr-20667-prototype-pr-comment-icon" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/216089/5fc2f9f4-0baf-4f78-a2a7-e867271b0c04">
