### PR TITLE
Activity Log: Check if route is valid before determining match

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -48,6 +48,15 @@ class RouteMatcher {
             let allValues = values.merging(placeholderValues,
                                            uniquingKeysWith: { (current, _) in current })
 
+            // If it's a wpcomPost reader route, then check if it's a valid wpcom url.
+            // Need to check since we have no guarantee that it's a valid wpcom url,
+            // other than the path having 4 components.
+            if let readerRoute = route as? ReaderRoute,
+               readerRoute == .wpcomPost,
+               !readerRoute.isValidWpcomUrl(allValues) {
+                return nil
+            }
+
             return route.matched(with: allValues)
         })
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -148,7 +148,7 @@ extension ReaderRoute: NavigationAction {
         return (blogID, postID)
     }
 
-    private func isValidWpcomUrl(_ values: [String: String]) -> Bool {
+    func isValidWpcomUrl(_ values: [String: String]) -> Bool {
         let year = Int(values["post_year"] ?? "") ?? 0
         let month = Int(values["post_month"] ?? "") ?? 0
         let day = Int(values["post_day"] ?? "") ?? 0


### PR DESCRIPTION
Fixes #19856

## Description
Fixes a bug where the incorrect route (`/:post_year/:post_month/:post_day/:post_name`) was being used to show post links in activity details.

## Notes
The link behavior matches Calypso - tapping on a post link in activity details opens up the editor. 

## How to test

1. Publish a post
2. Find the "post modified" activity in the activity log and tap the post title
3. ✅ The post opens up in a webview


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/0af33f6d-a66a-4042-b9fe-ef83c3dbc5ff



## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.