### PR TITLE
Site Editor: Create theme template homepage cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -12,8 +12,18 @@ final class PageListTableViewHandler: WPTableViewHandler {
         return status == .scheduled
     }
 
+    var showEditorHomepage: Bool {
+        guard FeatureFlag.siteEditorMVP.enabled else {
+            return false
+        }
+
+        let isFSETheme = blog.blockEditorSettings?.isFSETheme ?? false
+        return isFSETheme && status == .published && !groupResults
+    }
+
     private var pages: [Page] = []
     private let blog: Blog
+
     private lazy var publishedResultController: NSFetchedResultsController<NSFetchRequestResult> = {
         let publishedFilter = PostListFilter.publishedFilter()
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Page.entityName())
@@ -120,7 +130,8 @@ final class PageListTableViewHandler: WPTableViewHandler {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return groupResults ? super.tableView(tableView, numberOfRowsInSection: section) : pages.count
+        let additionalPage = showEditorHomepage ? 1 : 0
+        return groupResults ? super.tableView(tableView, numberOfRowsInSection: section) : pages.count + additionalPage
     }
 
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -435,6 +435,15 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             predicates.append(searchPredicate)
         }
 
+        if FeatureFlag.siteEditorMVP.enabled,
+           blog.blockEditorSettings?.isFSETheme ?? false,
+           let homepageID = blog.homepagePageID,
+           let homepageType = blog.homepageType,
+           homepageType == .page {
+            let homepagePredicate = NSPredicate(format: "postID != %i", homepageID)
+            predicates.append(homepagePredicate)
+        }
+
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         return predicate
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -397,9 +397,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             // Since we're adding a fake homepage cell, we need to adjust the index path to match
             let adjustedIndexPath = IndexPath(row: indexPath.row - 1, section: indexPath.section)
             return _tableViewHandler.page(at: adjustedIndexPath)
-        } else {
-            return _tableViewHandler.page(at: indexPath)
         }
+        return _tableViewHandler.page(at: indexPath)
     }
 
     // MARK: - TableView Handler Delegate Methods
@@ -499,15 +498,15 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             let identifier = Constant.Identifiers.templatePageCellIdentifier
             let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
             return cell
-        } else {
-            let page = pageAtIndexPath(indexPath)
-
-            let identifier = cellIdentifierForPage(page)
-            let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
-
-            configureCell(cell, at: indexPath)
-            return cell
         }
+
+        let page = pageAtIndexPath(indexPath)
+
+        let identifier = cellIdentifierForPage(page)
+        let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
+
+        configureCell(cell, at: indexPath)
+        return cell
     }
 
     override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {

--- a/WordPress/Classes/ViewRelated/Pages/TemplatePageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/TemplatePageTableViewCell.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+class TemplatePageTableViewCell: UITableViewCell {
+
+    private let hostViewController: UIHostingController<TemplatePageView>
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        hostViewController = UIHostingController(rootView: TemplatePageView())
+        hostViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(hostViewController.view)
+        contentView.pinSubviewToAllEdges(hostViewController.view)
+        applyStyles()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func applyStyles() {
+        backgroundColor = .neutral(.shade5)
+        separatorInset = .zero
+    }
+
+}
+
+private struct TemplatePageView: View {
+    var body: some View {
+        HStack {
+            text
+            icon
+        }
+        .padding(EdgeInsets(top: 4.0, leading: 16.0, bottom: 8.0, trailing: 16.0))
+        .background(Color(UIColor.listForeground))
+    }
+
+    private var text: some View {
+        VStack(alignment: .leading, spacing: 2.0) {
+            Text(Constants.title)
+                .font(Font(WPStyleGuide.notoBoldFontForTextStyle(.headline)))
+                .foregroundColor(Color(UIColor.text))
+            Text(Constants.subtitle)
+                .font(.subheadline)
+                .foregroundColor(Color(UIColor.textSubtle))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var icon: some View {
+        Image(uiImage: .gridicon(.infoOutline))
+            .resizable()
+            .frame(width: 24.0, height: 24.0)
+            .foregroundColor(Color(UIColor.textSubtle))
+            .onTapGesture {
+                guard let url = URL(string: Constants.supportUrl) else {
+                    return
+                }
+                UIApplication.shared.open(url)
+            }
+    }
+}
+
+private struct Constants {
+    static let supportUrl = "https://wordpress.com/support/templates/"
+    static let title = NSLocalizedString("pages.template.title",
+                                         value: "Homepage",
+                                         comment: "Title of the theme template homepage cell")
+    static let subtitle = NSLocalizedString("pages.template.subtitle",
+                                            value: "Your homepage is using a Theme template and will open in the web editor.",
+                                            comment: "Subtitle of the theme template homepage cell")
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1996,6 +1996,8 @@
 		8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
 		8332DD2529259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
 		8332DD2829259BEB00802F7D /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2729259BEB00802F7D /* DataMigratorTests.swift */; };
+		834A49D22A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834A49D12A0C23A90042ED3D /* TemplatePageTableViewCell.swift */; };
+		834A49D32A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834A49D12A0C23A90042ED3D /* TemplatePageTableViewCell.swift */; };
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
@@ -7334,6 +7336,7 @@
 		8332DD2729259BEB00802F7D /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
 		833AF25A114575A50016DE8F /* PostAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostAnnotation.m; sourceTree = "<group>"; };
+		834A49D12A0C23A90042ED3D /* TemplatePageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatePageTableViewCell.swift; sourceTree = "<group>"; };
 		834CE7331256D0DE0046A4A3 /* CFNetwork.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		834CE7371256D0F60046A4A3 /* CoreGraphics.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		8350E15911D28B4A00A7B073 /* WordPress.xcdatamodel */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = wrapper.xcdatamodel; path = WordPress.xcdatamodel; sourceTree = "<group>"; };
@@ -12368,14 +12371,15 @@
 			children = (
 				59A3CADB1CD2FF0C009BFA1B /* BasePageListCell.h */,
 				59A3CADC1CD2FF0C009BFA1B /* BasePageListCell.m */,
+				8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */,
+				5D13FA561AF99C2100F06492 /* PageListSectionHeaderView.xib */,
 				5DFA7EC41AF814E40072023B /* PageListTableViewCell.h */,
 				5DFA7EC51AF814E40072023B /* PageListTableViewCell.m */,
 				5DFA7EC61AF814E40072023B /* PageListTableViewCell.xib */,
-				5D13FA561AF99C2100F06492 /* PageListSectionHeaderView.xib */,
 				5D18FE9C1AFBB17400EFEED0 /* RestorePageTableViewCell.h */,
 				5D18FE9D1AFBB17400EFEED0 /* RestorePageTableViewCell.m */,
 				5D18FE9E1AFBB17400EFEED0 /* RestorePageTableViewCell.xib */,
-				8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */,
+				834A49D12A0C23A90042ED3D /* TemplatePageTableViewCell.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -20882,6 +20886,7 @@
 				4388FEFE20A4E0B900783948 /* NotificationsViewController+AppRatings.swift in Sources */,
 				93C1148518EDF6E100DAC95C /* BlogService.m in Sources */,
 				2F668B62255DD11400D0038A /* JetpackSettingsViewController.swift in Sources */,
+				834A49D22A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */,
 				981C986821B9BDF300A7C0C8 /* PostingActivityViewController.swift in Sources */,
 				FA4B203529A786460089FE68 /* BlazeEventsTracker.swift in Sources */,
 				FAD2538F26116A1600EDAF88 /* AppStyleGuide.swift in Sources */,
@@ -25024,6 +25029,7 @@
 				FABB25022602FC2C00C8785C /* NotificationTextContent.swift in Sources */,
 				FABB25032602FC2C00C8785C /* PostEditor+Publish.swift in Sources */,
 				FABB25042602FC2C00C8785C /* MediaCoordinator.swift in Sources */,
+				834A49D32A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */,
 				FABB25052602FC2C00C8785C /* StatsStackViewCell.swift in Sources */,
 				C79C307E26EA970200E88514 /* ReferrerDetailsHeaderRow.swift in Sources */,
 				98AA9F2227EA890800B3A98C /* FeatureIntroductionViewController.swift in Sources */,


### PR DESCRIPTION
Closes #20644 

## Description

- Adds UI for the theme template homepage cell
- Filters out the existing homepage cell for block based themes

## Screenshots

| Light | Dark |
|------|------|
| ![Screenshot 2023-05-12 at 8 19 58 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/4a215c5d-379f-434b-aa4f-7df31367839d) | ![Screenshot 2023-05-12 at 8 20 55 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/daf0cb62-c32d-4de4-ac7c-bc2dc905ad96) |

## Testing

### Homepage cell
- Launch Jetpack and login
- Select a blog which is using a block based theme
- On the Home dashboard, tap on "Pages"
- **Verify** UI matches p1683798908177459/1683649202.214889-slack-C04STEB172L (with the info icon)
- Tap on the info icon
- **Verify** https://wordpress.com/support/templates/ opens

### Existing homepage gets filtered

- On a blog which has a block based theme, set a static homepage on the web by going to: `Appearance > Customize > Homepage settings`
- Pull to refresh on the home dashboard (or any other way to update the `blog` object)
- Tap on "Pages" on the home dashboard
- **Verify** whatever post you selected as your homepage is filtered
- Search for that post's title
- **Verify** it does not show up in the search results

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)