### PR TITLE
Site Editor: Open authenticated web view to site editor on homepage tap

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -26,6 +26,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         struct Events {
             static let source = "page_list"
             static let pagePostType = "page"
+            static let editHomepageSource = "page_list_edit_homepage"
         }
 
         static let editorUrl = "site-editor.php?canvas=edit"
@@ -490,7 +491,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
             let webViewController = WebViewControllerFactory.controller(url: editorUrl,
                                                                         blog: blog,
-                                                                        source: Constant.Events.source)
+                                                                        source: Constant.Events.editHomepageSource)
             let navigationController = UINavigationController(rootViewController: webViewController)
             present(navigationController, animated: true)
         } else {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -27,6 +27,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             static let source = "page_list"
             static let pagePostType = "page"
         }
+
+        static let editorUrl = "site-editor.php?canvas=edit"
     }
 
     fileprivate lazy var sectionFooterSeparatorView: UIView = {
@@ -482,7 +484,15 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.deselectRow(at: indexPath, animated: true)
 
         if indexPath.row == 0 && _tableViewHandler.showEditorHomepage {
-            // TODO: Open editor web view
+            guard let editorUrl = URL(string: blog.adminUrl(withPath: Constant.editorUrl)) else {
+                return
+            }
+
+            let webViewController = WebViewControllerFactory.controller(url: editorUrl,
+                                                                        blog: blog,
+                                                                        source: Constant.Events.source)
+            let navigationController = UINavigationController(rootViewController: webViewController)
+            present(navigationController, animated: true)
         } else {
             let page = pageAtIndexPath(indexPath)
             editPage(page)


### PR DESCRIPTION
Closes #20645 

## Description

Opens the site editor when tapping on the "Homepage" cell in the "Pages" screen.

## Testing

To test:
- Launch Jetpack and login
- Select a site which has a block based theme
- On the Home dashboard, tap on "Pages"
- Tap on the "Homepage" cell
- **Verify** the site editor opens and is already editing the homepage

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
