### PR TITLE
Dashboard Cards: Update title font weight to semibold

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -24,6 +24,8 @@ open class ActivityTableViewCell: WPTableViewCell, NibReusable {
             return
         }
 
+        configureFonts()
+
         dateLabel.isHidden = !displaysDate
         bulletLabel.isHidden = !displaysDate
 
@@ -50,6 +52,16 @@ open class ActivityTableViewCell: WPTableViewCell, NibReusable {
         actionButton.setImage(actionGridicon, for: .normal)
         actionButton.tintColor = .listIcon
         actionButton.accessibilityIdentifier = "activity-cell-action-button"
+    }
+
+    private func configureFonts() {
+        contentLabel.adjustsFontForContentSizeCategory = true
+        contentLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+
+        [summaryLabel, bulletLabel, dateLabel].forEach {
+            $0.adjustsFontForContentSizeCategory = true
+            $0.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+        }
     }
 
     @IBAction func didTapActionButton(_ sender: UIButton) {
@@ -88,6 +100,8 @@ open class RewindStatusTableViewCell: ActivityTableViewCell {
     open func configureCell(title: String,
                             summary: String,
                             progress: Float) {
+        configureFonts()
+
         self.title = title
         self.summary = summary
         self.progress = progress
@@ -103,5 +117,13 @@ open class RewindStatusTableViewCell: ActivityTableViewCell {
         progressView.progressTintColor = .primary
         progressView.trackTintColor = UIColor(light: (.primary(.shade5)), dark: (.primary(.shade80)))
         progressView.setProgress(progress, animated: true)
+    }
+
+    private func configureFonts() {
+        contentLabel.adjustsFontForContentSizeCategory = true
+        contentLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+
+        summaryLabel.adjustsFontForContentSizeCategory = true
+        summaryLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCell.swift
@@ -20,7 +20,7 @@ class DashboardPageCell: UITableViewCell, Reusable {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.adjustsFontForContentSizeCategory = true
-        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .bold)
+        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         label.numberOfLines = 1
         label.textColor = .text
         return label


### PR DESCRIPTION
Ref: p1684229058807289-slack-C0290FLA0RM

## Description
Updates the title font weight to semibold for the:
- Pages cell (dashboard)
- Activity cell (dashboard, activity log)

| Before | After |
|--------|--------|
| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/b4593c92-1c1f-46ff-95dd-e187e50c1f7c" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/7579b16d-96ab-417a-95db-584ee50db938" width=200> |
| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/eb715cde-15f2-4389-b34d-3d151b64e048" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/bc863f7f-5a81-47fa-85a0-4728da2c4526" width=200> |

## How to test
1. Go to the dashboard
2. ✅ Verify that the font weight for the pages cell title is semibold
3. ✅ Verify that the font weight for the activity cell title is semibold
4. Go to the activity log by tapping on "Recent activity" in the activity card
5. ✅ Verify that the font weight for the activity cell title is semibold

## Regression Notes
1. Potential unintended areas of impact
n/a

6. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

7. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.