### PR TITLE
Accessibility Labels for Reader Navigation Buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -89,6 +89,7 @@ class ReaderTabViewController: UIViewController {
                                            target: self,
                                            action: #selector(didTapSearchButton))
         searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
+        searchButton.accessibilityLabel = ReaderTabConstants.searchButtonAccessibilityLabel
 
         // Settings Button
         settingsButton.spotlightOffset = ReaderTabConstants.spotlightOffset
@@ -96,6 +97,7 @@ class ReaderTabViewController: UIViewController {
         settingsButton.setImage(.gridicon(.readerFollowing), for: .normal)
         settingsButton.addTarget(self, action: #selector(didTapSettingsButton), for: .touchUpInside)
         settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
+        settingsButton.accessibilityLabel = ReaderTabConstants.settingsButtonAccessibilityLabel
         let settingsButton = UIBarButtonItem(customView: settingsButton)
 
         navigationItem.rightBarButtonItems = [searchButton, settingsButton]
@@ -191,7 +193,17 @@ extension ReaderTabViewController {
     private enum ReaderTabConstants {
         static let title = NSLocalizedString("Reader", comment: "The default title of the Reader")
         static let settingsButtonIdentifier = "ReaderSettingsButton"
+        static let settingsButtonAccessibilityLabel = NSLocalizedString(
+            "reader.navigation.settings.button.label",
+            value: "Reader Settings",
+            comment: "Reader settings button accessibility label."
+        )
         static let searchButtonAccessibilityIdentifier = "ReaderSearchBarButton"
+        static let searchButtonAccessibilityLabel = NSLocalizedString(
+            "reader.navigation.search.button.label",
+            value: "Search",
+            comment: "Reader search button accessibility label."
+        )
         static let storyBoardInitError = "Storyboard instantiation not supported"
         static let restorationIdentifier = "WPReaderTabControllerRestorationID"
         static let encodedIndexKey = "WPReaderTabControllerIndexRestorationKey"


### PR DESCRIPTION
Fixes #20152 

To test:
- Install & Login Jetpack
- Enable Voiceover
- Open Reader
- Select the navigation buttons (settings & search). Their accessibility labels should now be "Reader Settings" and "Search" respectively instead of "button".

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
Changes are not affecting the UI.