### PR TITLE
Free to Paid Plans: Create a Dashboard Card with the presentation criteria

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -192,7 +192,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         dispatch_group_leave(syncGroup);
     }];
     
-    if ([DomainsDashboardCardHelper isFeatureEnabled]) {
+    if ([DomainsDashboardCardHelper isFeatureEnabled] || [FreeToPaidPlansDashboardCardHelper isFeatureEnabled]) {
         dispatch_group_enter(syncGroup);
         [self refreshDomainsFor:blog success:^{
             dispatch_group_leave(syncGroup);

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -14,6 +14,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case blaze
     case wordPressIndividualPluginSupport
     case domainsDashboardCard
+    case freeToPaidPlansDashboardCard
     case pagesDashboardCard
     case activityLogDashboardCard
     case sdkLessGoogleSignIn
@@ -44,6 +45,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .wordPressIndividualPluginSupport:
             return AppConfiguration.isWordPress
         case .domainsDashboardCard:
+            return false
+        case .freeToPaidPlansDashboardCard:
             return false
         case .pagesDashboardCard:
             return false
@@ -83,6 +86,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "wp_individual_plugin_overlay"
         case .domainsDashboardCard:
             return "dashboard_card_domain"
+        case .freeToPaidPlansDashboardCard:
+            return "dashboard_card_free_to_paid_plans"
         case .pagesDashboardCard:
             return "dashboard_card_pages"
         case .activityLogDashboardCard:
@@ -120,6 +125,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Jetpack Individual Plugin Support for WordPress"
         case .domainsDashboardCard:
             return "Domains Dashboard Card"
+        case .freeToPaidPlansDashboardCard:
+            return "Free to Paid Plans Dashboard Card"
         case .pagesDashboardCard:
             return "Pages Dashboard Card"
         case .activityLogDashboardCard:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/BaseDashboardDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/BaseDashboardDomainsCardCell.swift
@@ -1,0 +1,160 @@
+import UIKit
+
+class BaseDashboardDomainsCardCell: DashboardCollectionViewCell {
+    var blog: Blog?
+    weak var presentingViewController: BlogDashboardViewController?
+    private(set) var viewModel: DashboardDomainsCardViewModel = .empty
+
+    // MARK: - Views
+
+    private lazy var cardFrameView: BlogDashboardCardFrameView = {
+        let frameView = BlogDashboardCardFrameView()
+        frameView.onEllipsisButtonTap = viewModel.onEllipsisTap
+        frameView.ellipsisButton.showsMenuAsPrimaryAction = true
+        frameView.ellipsisButton.menu = contextMenu
+        frameView.setTitle(viewModel.strings.title)
+        frameView.clipsToBounds = true
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        return frameView
+    }()
+
+    private lazy var descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.font = Style.descriptionLabelFont
+        label.text = viewModel.strings.description
+        label.textColor = .textSubtle
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var dashboardDomainsCardSearchView: UIView = {
+        let searchView = UIView.embedSwiftUIView(DashboardDomainsCardSearchView())
+        searchView.translatesAutoresizingMaskIntoConstraints = false
+        return searchView
+    }()
+
+    private lazy var containerStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [dashboardDomainsCardSearchView, descriptionLabel])
+        stackView.axis = .vertical
+        stackView.spacing = Metrics.stackViewSpacing
+        stackView.alignment = .fill
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.directionalLayoutMargins = Metrics.contentDirectionalLayoutMargins
+        stackView.isLayoutMarginsRelativeArrangement = true
+        return stackView
+    }()
+
+    private lazy var dashboardIcon: UIImageView = {
+        let image = UIImage.gridicon(.domains).withTintColor(.white).withRenderingMode(.alwaysOriginal)
+        let imageView = UIImageView(image: image)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private lazy var contextMenu: UIMenu = {
+        let hideThisAction = UIAction(title: viewModel.strings.hideThis,
+                                      image: Style.hideThisImage,
+                                      attributes: [UIMenuElement.Attributes.destructive],
+                                      handler: viewModel.onHideThisTap)
+        return UIMenu(title: String(), options: .displayInline, children: [hideThisAction])
+    }()
+
+    // MARK: - Initializers
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View setup
+
+    private func setupView() {
+        contentView.addSubview(cardFrameView)
+        contentView.pinSubviewToAllEdges(cardFrameView, priority: Constants.cardFrameConstraintPriority)
+        contentView.accessibilityIdentifier = "dashboard-domains-card-contentview"
+        cardFrameView.add(subview: containerStackView)
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+        addGestureRecognizer(tap)
+    }
+
+    @objc private func viewTapped() {
+        viewModel.onViewTap()
+    }
+
+    // MARK: - BlogDashboardCardConfigurable
+
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        self.blog = blog
+        self.presentingViewController = viewController
+
+        DomainsDashboardCardTracker.trackDirectDomainsPurchaseDashboardCardShown(in: row)
+    }
+}
+
+extension BaseDashboardDomainsCardCell {
+
+    private enum Constants {
+        static let cardFrameConstraintPriority = UILayoutPriority(999)
+    }
+
+    private enum Style {
+        static let descriptionLabelFont = WPStyleGuide.fontForTextStyle(.subheadline)
+        static let hideThisImage = UIImage(systemName: "minus.circle")
+    }
+
+    private enum Metrics {
+        static let stackViewSpacing: CGFloat = -20 // Negative since the views should overlap
+        static let contentDirectionalLayoutMargins = NSDirectionalEdgeInsets(top: 8.0,
+                                                                             leading: 16.0,
+                                                                             bottom: 8.0,
+                                                                             trailing: 16.0)
+    }
+}
+
+// MARK: - DashboardCardViewModel
+
+struct DashboardDomainsCardViewModel {
+    struct Strings {
+        let title: String
+        let description: String
+        let hideThis: String
+        let source: String
+
+        init(title: String = "",
+             description: String = "",
+             hideThis: String = "",
+             source: String = "") {
+            self.title = title
+            self.description = description
+            self.hideThis = hideThis
+            self.source = source
+        }
+
+    }
+
+    let strings: DashboardDomainsCardViewModel.Strings
+    let onViewTap: () -> Void
+    let onEllipsisTap: () -> Void
+    let onHideThisTap: UIActionHandler
+
+    init(strings: DashboardDomainsCardViewModel.Strings,
+         onViewTap: @escaping () -> Void = {},
+         onEllipsisTap: @escaping () -> Void = {},
+         onHideThisTap: @escaping UIActionHandler = { _ in }) {
+        self.strings = strings
+        self.onViewTap = onViewTap
+        self.onEllipsisTap = onEllipsisTap
+        self.onHideThisTap = onHideThisTap
+    }
+
+    static var empty: DashboardDomainsCardViewModel {
+        DashboardDomainsCardViewModel(strings: .init())
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/DashboardDomainsCardCell.swift
@@ -1,14 +1,11 @@
 import UIKit
 
-class DashboardDomainsCardCell: DashboardCollectionViewCell {
+final class DashboardDomainsCardCell: BaseDashboardDomainsCardCell {
+    override var viewModel: DashboardDomainsCardViewModel {
+        return cardViewModel
+    }
 
-    private var blog: Blog?
-    private weak var presentingViewController: BlogDashboardViewController?
-
-    // MARK: - Views
-
-    private lazy var cardViewModel: DashboardCardViewModel = {
-
+    private lazy var cardViewModel: DashboardDomainsCardViewModel = {
         let onViewTap: () -> Void = { [weak self] in
             guard let self,
                   let presentingViewController = self.presentingViewController,
@@ -33,121 +30,21 @@ class DashboardDomainsCardCell: DashboardCollectionViewCell {
             self.presentingViewController?.reloadCardsLocally()
         }
 
-        return DashboardCardViewModel(onViewTap: onViewTap,
-                                      onEllipsisTap: onEllipsisTap,
-                                      onHideThisTap: onHideThisTap)
+        return DashboardDomainsCardViewModel(
+            strings: .init(
+                title: Strings.title,
+                description: Strings.description,
+                hideThis: Strings.hideThis,
+                source: Strings.source
+            ),
+            onViewTap: onViewTap,
+            onEllipsisTap: onEllipsisTap,
+            onHideThisTap: onHideThisTap
+        )
     }()
-
-    private lazy var cardFrameView: BlogDashboardCardFrameView = {
-        let frameView = BlogDashboardCardFrameView()
-        frameView.onEllipsisButtonTap = cardViewModel.onEllipsisTap
-        frameView.ellipsisButton.showsMenuAsPrimaryAction = true
-        frameView.ellipsisButton.menu = contextMenu
-        frameView.setTitle(Strings.title)
-        frameView.clipsToBounds = true
-        frameView.translatesAutoresizingMaskIntoConstraints = false
-        return frameView
-    }()
-
-    private lazy var descriptionLabel: UILabel = {
-        let label = UILabel()
-        label.font = Style.descriptionLabelFont
-        label.text = Strings.description
-        label.textColor = .textSubtle
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-        label.translatesAutoresizingMaskIntoConstraints = false
-        return label
-    }()
-
-    private lazy var dashboardDomainsCardSearchView: UIView = {
-        let searchView = UIView.embedSwiftUIView(DashboardDomainsCardSearchView())
-        searchView.translatesAutoresizingMaskIntoConstraints = false
-        return searchView
-    }()
-
-    private lazy var containerStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [dashboardDomainsCardSearchView, descriptionLabel])
-        stackView.axis = .vertical
-        stackView.spacing = Metrics.stackViewSpacing
-        stackView.alignment = .fill
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.directionalLayoutMargins = Metrics.contentDirectionalLayoutMargins
-        stackView.isLayoutMarginsRelativeArrangement = true
-        return stackView
-    }()
-
-    private lazy var dashboardIcon: UIImageView = {
-        let image = UIImage.gridicon(.domains).withTintColor(.white).withRenderingMode(.alwaysOriginal)
-        let imageView = UIImageView(image: image)
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        return imageView
-    }()
-
-    private lazy var contextMenu: UIMenu = {
-        let hideThisAction = UIAction(title: Strings.hideThis,
-                                      image: Style.hideThisImage,
-                                      attributes: [UIMenuElement.Attributes.destructive],
-                                      handler: cardViewModel.onHideThisTap)
-        return UIMenu(title: String(), options: .displayInline, children: [hideThisAction])
-    }()
-
-    // MARK: - Initializers
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setupView()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - View setup
-
-    private func setupView() {
-        contentView.addSubview(cardFrameView)
-        contentView.pinSubviewToAllEdges(cardFrameView, priority: Constants.cardFrameConstraintPriority)
-        contentView.accessibilityIdentifier = "dashboard-domains-card-contentview"
-        cardFrameView.add(subview: containerStackView)
-
-        let tap = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
-        addGestureRecognizer(tap)
-    }
-
-    @objc private func viewTapped() {
-        cardViewModel.onViewTap()
-    }
-
-    // MARK: - BlogDashboardCardConfigurable
-
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
-        self.blog = blog
-        self.presentingViewController = viewController
-
-        DomainsDashboardCardTracker.trackDirectDomainsPurchaseDashboardCardShown(in: row)
-    }
 }
 
 extension DashboardDomainsCardCell {
-
-    private enum Constants {
-        static let cardFrameConstraintPriority = UILayoutPriority(999)
-    }
-
-    private enum Style {
-        static let descriptionLabelFont = WPStyleGuide.fontForTextStyle(.subheadline)
-        static let hideThisImage = UIImage(systemName: "minus.circle")
-    }
-
-    private enum Metrics {
-        static let stackViewSpacing: CGFloat = -20 // Negative since the views should overlap
-        static let contentDirectionalLayoutMargins = NSDirectionalEdgeInsets(top: 8.0,
-                                                                             leading: 16.0,
-                                                                             bottom: 8.0,
-                                                                             trailing: 16.0)
-    }
-
     private enum Strings {
         static let title = NSLocalizedString("domain.dashboard.card.shortTitle",
                                              value: "Find a custom domain",
@@ -159,21 +56,5 @@ extension DashboardDomainsCardCell {
                                                 value: "Hide this",
                                                 comment: "Title for a menu action in the context menu on the Jetpack install card.")
         static let source = "domains_dashboard_card"
-    }
-}
-
-// MARK: - DashboardCardViewModel
-
-struct DashboardCardViewModel {
-    let onViewTap: () -> Void
-    let onEllipsisTap: () -> Void
-    let onHideThisTap: UIActionHandler
-
-    init(onViewTap: @escaping () -> Void = {},
-         onEllipsisTap: @escaping () -> Void = {},
-         onHideThisTap: @escaping UIActionHandler = { _ in }) {
-        self.onViewTap = onViewTap
-        self.onEllipsisTap = onEllipsisTap
-        self.onHideThisTap = onHideThisTap
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardCell.swift
@@ -1,0 +1,60 @@
+import UIKit
+
+final class FreeToPaidPlansDashboardCardCell: BaseDashboardDomainsCardCell {
+    override var viewModel: DashboardDomainsCardViewModel {
+        return cardViewModel
+    }
+
+    private lazy var cardViewModel: DashboardDomainsCardViewModel = {
+        let onViewTap: () -> Void = { [weak self] in
+            // TODO: Present Domain Selection
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20686
+
+            // TODO: Analytics
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20692
+        }
+
+        let onEllipsisTap: () -> Void = { [weak self] in
+            // TODO: Analytics
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20692
+        }
+
+        let onHideThisTap: UIActionHandler = { [weak self] _ in
+            guard let self else { return }
+
+            FreeToPaidPlansDashboardCardHelper.hideCard(for: self.blog)
+
+            // TODO: Analytics
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20692
+
+            self.presentingViewController?.reloadCardsLocally()
+        }
+
+        return DashboardDomainsCardViewModel(
+            strings: .init(
+                title: Strings.title,
+                description: Strings.description,
+                hideThis: Strings.hideThis,
+                source: Strings.source
+            ),
+            onViewTap: onViewTap,
+            onEllipsisTap: onEllipsisTap,
+            onHideThisTap: onHideThisTap
+        )
+    }()
+}
+
+extension FreeToPaidPlansDashboardCardCell {
+    private enum Strings {
+        static let title = NSLocalizedString("freeToPaidPlans.dashboard.card.shortTitle",
+                                             value: "Free domain with an annual plan",
+                                             comment: "Title for the Free to Paid plans dashboard card.")
+        static let description = NSLocalizedString("freeToPaidPlans.dashboard.card.description",
+                                                   value: "Get a free domain for the first year, remove ads on your site, and increase your storage.",
+                                                   comment: "Description for the Free to Paid plans dashboard card.")
+        static let hideThis = NSLocalizedString("freeToPaidPlans.dashboard.card.menu.hide",
+                                                value: "Hide this",
+                                                comment: "Title for a menu action in the context menu on the Free to Paid plans dashboard card.")
+        static let source = "free_to_paid_plans_dashboard_card"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+@objc final class FreeToPaidPlansDashboardCardHelper: NSObject {
+
+    /// Checks conditions for showing free to paid plans dashboard cards
+    static func shouldShowCard(
+        for blog: Blog,
+        isJetpack: Bool = AppConfiguration.isJetpack,
+        featureFlagEnabled: Bool = RemoteFeatureFlag.freeToPaidPlansDashboardCard.enabled()
+    ) -> Bool {
+        guard isJetpack, featureFlagEnabled else {
+            return false
+        }
+
+        return true
+    }
+
+    static func hideCard(for blog: Blog?) {
+        guard let blog,
+              let siteID = blog.dotComID?.intValue else {
+            DDLogError("Free to Paid Plans Dashboard Card: error hiding the card.")
+            return
+        }
+
+        BlogDashboardPersonalizationService(siteID: siteID)
+            .setEnabled(false, for: .freeToPaidPlansDashboardCard)
+    }
+
+    @objc static func isFeatureEnabled() -> Bool {
+        return AppConfiguration.isJetpack && RemoteFeatureFlag.freeToPaidPlansDashboardCard.enabled()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
@@ -12,7 +12,15 @@ import Foundation
             return false
         }
 
-        return true
+        /// If this propery is empty, it indicates that domain information is not yet loaded
+        let hasLoadedDomains = blog.freeDomain != nil
+        let hasMappedDomain = blog.hasMappedDomain()
+        let hasFreePlan = !blog.hasPaidPlan
+
+        return blog.supports(.domains)
+            && hasFreePlan
+            && hasLoadedDomains
+            && !hasMappedDomain
     }
 
     static func hideCard(for blog: Blog?) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
@@ -13,7 +13,7 @@ import Foundation
         }
 
         /// If this propery is empty, it indicates that domain information is not yet loaded
-        let hasLoadedDomains = blog.freeDomain != nil
+        let hasLoadedDomains = blog.domains?.isEmpty == false
         let hasMappedDomain = blog.hasMappedDomain()
         let hasFreePlan = !blog.hasPaidPlan
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -104,7 +104,7 @@ enum DashboardCard: String, CaseIterable {
         case .blaze:
             return BlazeHelper.shouldShowCard(for: blog)
         case .domainsDashboardCard:
-            return DomainsDashboardCardHelper.shouldShowCard(for: blog)
+            return DomainsDashboardCardHelper.shouldShowCard(for: blog) && !FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog)
         case .freeToPaidPlansDashboardCard:
             return FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog)
         case .empty:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -12,6 +12,7 @@ enum DashboardCard: String, CaseIterable {
     case prompts
     case blaze
     case domainsDashboardCard
+    case freeToPaidPlansDashboardCard
     case todaysStats = "todays_stats"
     case draftPosts
     case scheduledPosts
@@ -56,6 +57,8 @@ enum DashboardCard: String, CaseIterable {
             return DashboardBlazeCardCell.self
         case .domainsDashboardCard:
             return DashboardDomainsCardCell.self
+        case .freeToPaidPlansDashboardCard:
+            return FreeToPaidPlansDashboardCardCell.self
         case .empty:
             return BlogDashboardEmptyStateCell.self
         case .personalize:
@@ -102,6 +105,8 @@ enum DashboardCard: String, CaseIterable {
             return BlazeHelper.shouldShowCard(for: blog)
         case .domainsDashboardCard:
             return DomainsDashboardCardHelper.shouldShowCard(for: blog)
+        case .freeToPaidPlansDashboardCard:
+            return FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog)
         case .empty:
             return false // Controlled manually based on other cards visibility
         case .personalize:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -54,6 +54,8 @@ private func makeKey(for card: DashboardCard) -> String? {
         return "prompts-enabled-site-settings"
     case .domainsDashboardCard:
         return "domains-dashboard-card-enabled-site-settings"
+    case .freeToPaidPlansDashboardCard:
+        return "free-to-paid-plans-dashboard-card-enabled-site-settings"
     case .activityLog:
         return "activity-log-card-enabled-site-settings"
     case .pages:

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -48,7 +48,7 @@ private extension DashboardCard {
             return NSLocalizedString("personalizeHome.dashboardCard.activityLog", value: "Recent activity", comment: "Card title for the pesonalization menu")
         case .pages:
             return NSLocalizedString("personalizeHome.dashboardCard.pages", value: "Pages", comment: "Card title for the pesonalization menu")
-        case .quickStart, .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .domainsDashboardCard, .empty:
+        case .quickStart, .nextPost, .createPost, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .domainsDashboardCard, .freeToPaidPlansDashboardCard, .empty:
             assertionFailure("\(self) card should not appear in the personalization menus")
             return "" // These cards don't appear in the personalization menus
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		011F52C12A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */; };
 		011F52C32A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */; };
 		011F52C42A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */; };
+		011F52C62A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */; };
 		01281E9A2A0456CB00464F8F /* DomainsSuggestionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */; };
 		01281E9C2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
 		01281E9D2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
@@ -5787,6 +5788,7 @@
 		011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseDashboardDomainsCardCell.swift; sourceTree = "<group>"; };
 		011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardCell.swift; sourceTree = "<group>"; };
 		011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardHelper.swift; sourceTree = "<group>"; };
+		011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardHelperTests.swift; sourceTree = "<group>"; };
 		01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsSuggestionsScreen.swift; sourceTree = "<group>"; };
 		01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigationTests.swift; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
@@ -13626,6 +13628,7 @@
 				80EF9283280CFEB60064A971 /* DashboardPostsSyncManagerTests.swift */,
 				0118969029D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift */,
 				0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */,
+				011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -23331,6 +23334,7 @@
 				40ACCF14224E167900190713 /* FlagsTest.swift in Sources */,
 				E15027651E03E54100B847E3 /* PinghubTests.swift in Sources */,
 				E1B642131EFA5113001DC6D7 /* ModelTestHelper.swift in Sources */,
+				011F52C62A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift in Sources */,
 				FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */,
 				3F3D854B251E6418001CA4D2 /* AnnouncementsDataStoreTests.swift in Sources */,
 				F11023A1231863CE00C4E84A /* MediaServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		011896A629D5B72500D34BA9 /* DomainsDashboardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011896A429D5B72500D34BA9 /* DomainsDashboardCoordinator.swift */; };
 		011896A829D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */; };
 		011896A929D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */; };
+		011F52BD2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */; };
+		011F52BE2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */; };
 		01281E9A2A0456CB00464F8F /* DomainsSuggestionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */; };
 		01281E9C2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
 		01281E9D2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
@@ -5778,6 +5780,7 @@
 		011896A429D5B72500D34BA9 /* DomainsDashboardCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsDashboardCoordinator.swift; sourceTree = "<group>"; };
 		011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsDashboardFactory.swift; sourceTree = "<group>"; };
 		011A2815DB0DE7E3973CBC0E /* Pods-Apps-Jetpack.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release.xcconfig"; sourceTree = "<group>"; };
+		011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseDashboardDomainsCardCell.swift; sourceTree = "<group>"; };
 		01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsSuggestionsScreen.swift; sourceTree = "<group>"; };
 		01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigationTests.swift; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
@@ -9657,8 +9660,16 @@
 				0118968E29D1EB5E00D34BA9 /* DomainsDashboardCardHelper.swift */,
 				0118969E29D30CAD00D34BA9 /* DomainsDashboardCardTracker.swift */,
 				01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */,
+				011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */,
 			);
 			path = Domains;
+			sourceTree = "<group>";
+		};
+		011F52BB2A15324800B04114 /* Free to Paid Plans */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "Free to Paid Plans";
 			sourceTree = "<group>";
 		};
 		0141929E2983F5D900CAEDB0 /* Support */ = {
@@ -13551,8 +13562,9 @@
 		8B4DDF23278F3AED0022494D /* Cards */ = {
 			isa = PBXGroup;
 			children = (
-				FA70024E29DC3B6100E874FD /* Activity Log */,
+				011F52BB2A15324800B04114 /* Free to Paid Plans */,
 				0118968D29D1EAC900D34BA9 /* Domains */,
+				FA70024E29DC3B6100E874FD /* Activity Log */,
 				FA98B61429A3B71E0071AAE8 /* Blaze */,
 				80D9CFF229DCA51C00FE3400 /* Pages */,
 				FE18495627F5ACA400D26879 /* Prompts */,
@@ -21693,6 +21705,7 @@
 				B5EFB1C21B31B98E007608A3 /* NotificationSettingsService.swift in Sources */,
 				011896A829D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */,
 				5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */,
+				011F52BD2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
 				1717139F265FE59700F3A022 /* ButtonStyles.swift in Sources */,
 				C3FF78E828354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */,
 				803BB989295B80D300B3F6D6 /* RootViewPresenter+EditorNavigation.swift in Sources */,
@@ -23681,6 +23694,7 @@
 				803BB97D2959559500B3F6D6 /* RootViewPresenter.swift in Sources */,
 				FABB21192602FC2C00C8785C /* NotificationContentRangeFactory.swift in Sources */,
 				FABB211A2602FC2C00C8785C /* SiteInfo.swift in Sources */,
+				011F52BE2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
 				FABB211B2602FC2C00C8785C /* CredentialsService.swift in Sources */,
 				3F5AAC242877791900AEF5DD /* JetpackButton.swift in Sources */,
 				FABB211C2602FC2C00C8785C /* EncryptedLogTableViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -149,6 +149,10 @@
 		011896A929D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */; };
 		011F52BD2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */; };
 		011F52BE2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */; };
+		011F52C02A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */; };
+		011F52C12A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */; };
+		011F52C32A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */; };
+		011F52C42A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */; };
 		01281E9A2A0456CB00464F8F /* DomainsSuggestionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */; };
 		01281E9C2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
 		01281E9D2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
@@ -5781,6 +5785,8 @@
 		011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsDashboardFactory.swift; sourceTree = "<group>"; };
 		011A2815DB0DE7E3973CBC0E /* Pods-Apps-Jetpack.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release.xcconfig"; sourceTree = "<group>"; };
 		011F52BC2A15327700B04114 /* BaseDashboardDomainsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseDashboardDomainsCardCell.swift; sourceTree = "<group>"; };
+		011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardCell.swift; sourceTree = "<group>"; };
+		011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardHelper.swift; sourceTree = "<group>"; };
 		01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsSuggestionsScreen.swift; sourceTree = "<group>"; };
 		01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigationTests.swift; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
@@ -9668,6 +9674,8 @@
 		011F52BB2A15324800B04114 /* Free to Paid Plans */ = {
 			isa = PBXGroup;
 			children = (
+				011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */,
+				011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */,
 			);
 			path = "Free to Paid Plans";
 			sourceTree = "<group>";
@@ -21452,6 +21460,7 @@
 				3234BB342530EA980068DA40 /* ReaderRecommendedSiteCardCell.swift in Sources */,
 				93414DE51E2D25AE003143A3 /* PostEditorState.swift in Sources */,
 				1707CE421F3121750020B7FE /* UICollectionViewCell+Tint.swift in Sources */,
+				011F52C32A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */,
 				B5176CC31CDCE1C30083CF2D /* ManagedPerson+CoreDataProperties.swift in Sources */,
 				17C1D7DC26735631006C8970 /* EmojiRenderer.swift in Sources */,
 				C81CCD7B243BF7A600A83E27 /* TenorStrings.swift in Sources */,
@@ -21542,6 +21551,7 @@
 				FA1CEAC225CA9C2A005E7038 /* RestoreStatusFailedView.swift in Sources */,
 				9848DF8121B8BB5700B99DA4 /* PostingActivityLegend.swift in Sources */,
 				B5DB8AF41C949DC20059196A /* WPImmuTableRows.swift in Sources */,
+				011F52C02A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift in Sources */,
 				E192E78C22EF453C008D725D /* WordPress-87-88.xcmappingmodel in Sources */,
 				E6311C411EC9FF4A00122529 /* UsersService.swift in Sources */,
 				E125F1E71E8E59C800320B67 /* SharePost+UIActivityItemSource.swift in Sources */,
@@ -23693,6 +23703,7 @@
 				FABB21182602FC2C00C8785C /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				803BB97D2959559500B3F6D6 /* RootViewPresenter.swift in Sources */,
 				FABB21192602FC2C00C8785C /* NotificationContentRangeFactory.swift in Sources */,
+				011F52C12A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift in Sources */,
 				FABB211A2602FC2C00C8785C /* SiteInfo.swift in Sources */,
 				011F52BE2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
 				FABB211B2602FC2C00C8785C /* CredentialsService.swift in Sources */,
@@ -23802,6 +23813,7 @@
 				FABB21682602FC2C00C8785C /* NullBlogPropertySanitizer.swift in Sources */,
 				FABB21692602FC2C00C8785C /* StockPhotosStrings.swift in Sources */,
 				FABB216A2602FC2C00C8785C /* StatsViewController.m in Sources */,
+				011F52C42A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */,
 				DC8F61F827032B3F0087AC5D /* TimeZoneFormatter.swift in Sources */,
 				FABB216B2602FC2C00C8785C /* WPRichTextEmbed.swift in Sources */,
 				80EF928E280E83110064A971 /* QuickStartToursCollection.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -142,6 +142,23 @@ final class BlogBuilder {
         return self
     }
 
+    func with(hasPaidPlan: Bool) -> Self {
+        blog.hasPaidPlan = hasPaidPlan
+        return self
+    }
+
+    func with(hasMappedDomain: Bool) -> Self {
+        set(blogOption: "unmapped_url", value: "http://domain1.com")
+
+        if hasMappedDomain {
+            set(blogOption: "home_url", value: "http://domain2.com")
+        } else {
+            set(blogOption: "home_url", value: "http://domain1.com")
+        }
+
+        return self
+    }
+
     func with(isWPForTeamsSite: Bool) -> Self {
         return set(blogOption: "is_wpforteams_site", value: isWPForTeamsSite)
     }

--- a/WordPress/WordPressTest/Dashboard/FreeToPaidPlansDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/FreeToPaidPlansDashboardCardHelperTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import WordPress
+
+final class FreeToPaidPlansDashboardCardHelperTests: CoreDataTestCase {
+    func testShouldShowCardWithFreePlanAndNoMappedDomain() {
+        let blog = BlogBuilder(mainContext)
+            .with(supportsDomains: true)
+            .with(domainCount: 1, of: .wpCom)
+            .with(hasMappedDomain: false)
+            .with(hasPaidPlan: false)
+            .build()
+
+        let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertTrue(result, "Card should show for blogs with a free plan and a mapped domain")
+    }
+
+    func testShouldNotShowCardWithoutFreePlan() {
+        let blog = BlogBuilder(mainContext)
+            .with(supportsDomains: true)
+            .with(domainCount: 1, of: .wpCom)
+            .with(hasMappedDomain: false)
+            .with(hasPaidPlan: true)
+            .build()
+
+        let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show for blogs without a free plan")
+    }
+
+    func testShouldNotShowCardWithMappedDomain() {
+        let blog = BlogBuilder(mainContext)
+            .with(supportsDomains: true)
+            .with(domainCount: 1, of: .wpCom)
+            .with(hasMappedDomain: true)
+            .with(hasPaidPlan: false)
+            .build()
+
+        let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show for blogs with a mapped domain")
+    }
+
+    func testShouldNotShowCardWhenDomainInformationIsNotLoaded() {
+        let blog = BlogBuilder(mainContext)
+            .with(supportsDomains: true)
+            .with(domainCount: 0, of: .wpCom)
+            .with(hasMappedDomain: false)
+            .with(hasPaidPlan: false)
+            .build()
+
+        let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
+
+        XCTAssertFalse(result, "Card should not show until domain information is loaded")
+    }
+
+    func testShouldNotShowCardFeatureFlagDisabled() {
+        let blog = BlogBuilder(mainContext)
+            .with(supportsDomains: true)
+            .with(domainCount: 1, of: .wpCom)
+            .with(hasMappedDomain: false)
+            .with(hasPaidPlan: false)
+            .build()
+
+        let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: false)
+
+        XCTAssertFalse(result, "Card should not show when the feature flag is disabled")
+    }
+}

--- a/WordPress/WordPressTest/Dashboard/FreeToPaidPlansDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/FreeToPaidPlansDashboardCardHelperTests.swift
@@ -12,7 +12,7 @@ final class FreeToPaidPlansDashboardCardHelperTests: CoreDataTestCase {
 
         let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
 
-        XCTAssertTrue(result, "Card should show for blogs with a free plan and a mapped domain")
+        XCTAssertTrue(result, "Card should show for blogs with a free plan and no mapped domain")
     }
 
     func testShouldNotShowCardWithoutFreePlan() {
@@ -32,6 +32,7 @@ final class FreeToPaidPlansDashboardCardHelperTests: CoreDataTestCase {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: true)
             .with(domainCount: 1, of: .wpCom)
+            .with(domainCount: 1, of: .registered)
             .with(hasMappedDomain: true)
             .with(hasPaidPlan: false)
             .build()


### PR DESCRIPTION
Fixes #20685

The goal of this PR is to:
- Create a `Free to Paid Plans Dashboard Card` that would repurpose Domains Dashboard Card
- Define the presentation criteria for `Free to Paid Plans Dashboard Card`

ℹ️ For the moment, the codebase will support both `DomainsDashboardCard` and `FreeToPaidPlansDashboardCard` so they could be separately controlled by the feature flag. Later, we can keep only `FreeToPaidPlansDashboardCard`. 

## Implementation:

1. Implemented a remote feature flag
2. Made `DashboardDomainsCardCell` reusable by moving the layout to `BaseDashboardDomainsCardCell` and making it configurable through inheritance and overriding `DashboardDomainsCardViewModel`. I chose this particular method since it fits how `DashboardCard.swift` is loading cards by providing a class type of the cell
3. Created `FreeToPaidPlansDashboardCardHelper` implementing presentation conditions

## To test:

**Card Availability and Card Appearance** (pc8eDl-WC-p2) pc8eDl-WC-p2


## Regression Notes
1. Potential unintended areas of impact

Breaking current `DomainDashboardCard` functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Unit tests and manual testing

3. What automated tests I added (or what prevented me from doing so)

`FreeToPaidPlansDashboardCardHelperTests`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x]  High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)

## Video

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/3de17a54-06a2-4bc8-81e9-9000add6f2da


