### PR TITLE
Site Editor: Add edit homepage analytics to the page list screen

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -254,6 +254,10 @@ import Foundation
     case postListSetAsPostsPageAction
     case postListSetHomePageAction
 
+    // Page List
+    case pageListEditHomepageTapped
+    case pageListEditHomepageInfoTapped
+
     // Reader: Filter Sheet
     case readerFilterSheetDisplayed
     case readerFilterSheetDismissed
@@ -918,12 +922,20 @@ import Foundation
             return "site_switcher_search_performed"
         case .siteSwitcherToggleBlogVisible:
             return "site_switcher_toggle_blog_visible"
+
+        // Post List
         case .postListShareAction:
             return "post_list_button_pressed"
         case .postListSetAsPostsPageAction:
             return "post_list_button_pressed"
         case .postListSetHomePageAction:
             return "post_list_button_pressed"
+
+        // Page List
+        case .pageListEditHomepageTapped:
+            return "page_list_edit_homepage_item_pressed"
+        case .pageListEditHomepageInfoTapped:
+            return "page_list_edit_homepage_info_pressed"
 
         // Reader: Filter Sheet
         case .readerFilterSheetDisplayed:

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -485,6 +485,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.deselectRow(at: indexPath, animated: true)
 
         if indexPath.row == 0 && _tableViewHandler.showEditorHomepage {
+            WPAnalytics.track(.pageListEditHomepageTapped)
             guard let editorUrl = URL(string: blog.adminUrl(withPath: Constant.editorUrl)) else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Pages/TemplatePageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/TemplatePageTableViewCell.swift
@@ -52,6 +52,7 @@ private struct TemplatePageView: View {
             .frame(width: 24.0, height: 24.0)
             .foregroundColor(Color(UIColor.textSubtle))
             .onTapGesture {
+                WPAnalytics.track(.pageListEditHomepageInfoTapped)
                 guard let url = URL(string: Constants.supportUrl) else {
                     return
                 }


### PR DESCRIPTION
## Description

Adds analytics when:
- The edit homepage cell is tapped
- The info icon on the edit homepage cell is tapped

## Testing

To test:
- Launch Jetpack and login
- Select a site which has a block theme template
- Tap on "Pages" on the Home dashboard
- Perform the following actions and **verify** the analytic is tracked:

| Action | Analytic |
|-------|----------|
| Tap on the info icon "i" on the edit homepage cell | `🔵 Tracked: page_list_edit_homepage_info_pressed <>`
| Tap on the edit homepage cell | `🔵 Tracked: page_list_edit_homepage_item_pressed <>` |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
