### PR TITLE
Plans on JP: Show free for first year offer on domain selection screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -8,7 +8,7 @@ import UIKit
     ) {
         let domainSuggestionsViewController = RegisterDomainSuggestionsViewController.instance(
             site: blog,
-            domainType: .mapped,
+            domainSelectionType: .purchaseWithPaidPlan,
             includeSupportButton: false
         )
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+@objc final class FreeToPaidPlansCoordinator: NSObject {
+    static func presentFreeDomainWithAnnualPlanFlow(
+        in dashboardViewController: BlogDashboardViewController,
+        source: String,
+        blog: Blog
+    ) {
+        let domainSuggestionsViewController = RegisterDomainSuggestionsViewController.instance(
+            site: blog,
+            domainType: .mapped,
+            includeSupportButton: false
+        )
+
+        domainSuggestionsViewController.domainAddedToCartCallback = {
+            // TODO: Present Plans Selection and Checkout Flow
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20688
+        }
+
+        dashboardViewController.show(domainSuggestionsViewController, sender: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardCell.swift
@@ -7,8 +7,17 @@ final class FreeToPaidPlansDashboardCardCell: BaseDashboardDomainsCardCell {
 
     private lazy var cardViewModel: DashboardDomainsCardViewModel = {
         let onViewTap: () -> Void = { [weak self] in
-            // TODO: Present Domain Selection
-            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20686
+            guard let self,
+                  let presentingViewController = self.presentingViewController,
+                  let blog = self.blog else {
+                return
+            }
+
+            FreeToPaidPlansCoordinator.presentFreeDomainWithAnnualPlanFlow(
+                in: presentingViewController,
+                source: Strings.source,
+                blog: blog
+            )
 
             // TODO: Analytics
             // https://github.com/wordpress-mobile/WordPress-iOS/issues/20692

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
@@ -22,7 +22,7 @@ extension BlogDetailsViewController {
 
     @objc func showDomainCreditRedemption() {
         let controller = RegisterDomainSuggestionsViewController
-            .instance(site: blog, domainPurchasedCallback: { [weak self] domain in
+            .instance(site: blog, domainSelectionType: .registerWithPaidPlan, domainPurchasedCallback: { [weak self] domain in
                 WPAnalytics.track(.domainCreditRedemptionSuccess)
                 self?.presentDomainCreditRedemptionSuccess(domain: domain)
             })

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
@@ -6,16 +6,20 @@ import WordPressKit
 struct DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable {
 
     private let blog: Blog
-    private let domainType: DomainType
+    private let domainSelectionType: DomainSelectionType
     private let onDismiss: () -> Void
 
     private var domainSuggestionViewController: RegisterDomainSuggestionsViewController
 
-    init(blog: Blog, domainType: DomainType, onDismiss: @escaping () -> Void) {
+    init(blog: Blog, domainSelectionType: DomainSelectionType, onDismiss: @escaping () -> Void) {
         self.blog = blog
-        self.domainType = domainType
+        self.domainSelectionType = domainSelectionType
         self.onDismiss = onDismiss
-        self.domainSuggestionViewController = DomainsDashboardFactory.makeDomainsSuggestionViewController(blog: blog, domainType: domainType, onDismiss: onDismiss)
+        self.domainSuggestionViewController = DomainsDashboardFactory.makeDomainsSuggestionViewController(
+            blog: blog,
+            domainSelectionType: domainSelectionType,
+            onDismiss: onDismiss
+        )
     }
 
     func makeUIViewController(context: Context) -> LightNavigationController {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -387,15 +387,16 @@ extension DomainSuggestionsTableViewController {
         let attributedString = NSMutableAttributedString()
 
         let hasDomainCredit = blog?.hasDomainCredit ?? false
+        let freeForFirstYear = hasDomainCredit || domainType == .mapped
 
-        if hasDomainCredit {
+        if freeForFirstYear {
             attributedString.append(attributedFreeForTheFirstYear())
         } else if let saleCost = attributedSaleCost(for: suggestion) {
             attributedString.append(saleCost)
         }
 
-        attributedString.append(attributedSuggestionCost(for: suggestion, hasDomainCredit: hasDomainCredit))
-        attributedString.append(attributedPerYearPostfix(for: suggestion, hasDomainCredit: hasDomainCredit))
+        attributedString.append(attributedSuggestionCost(for: suggestion, freeForFirstYear: freeForFirstYear))
+        attributedString.append(attributedPerYearPostfix(for: suggestion, freeForFirstYear: freeForFirstYear))
 
         return attributedString
     }
@@ -418,22 +419,22 @@ extension DomainSuggestionsTableViewController {
             attributes: suggestionSaleCostAttributes())
     }
 
-    private func attributedSuggestionCost(for suggestion: FullyQuotedDomainSuggestion, hasDomainCredit: Bool) -> NSAttributedString {
+    private func attributedSuggestionCost(for suggestion: FullyQuotedDomainSuggestion, freeForFirstYear: Bool) -> NSAttributedString {
         NSAttributedString(
             string: suggestion.costString,
-            attributes: suggestionCostAttributes(striked: mustStrikeRegularPrice(suggestion, hasDomainCredit: hasDomainCredit)))
+            attributes: suggestionCostAttributes(striked: mustStrikeRegularPrice(suggestion, freeForFirstYear: freeForFirstYear)))
     }
 
-    private func attributedPerYearPostfix(for suggestion: FullyQuotedDomainSuggestion, hasDomainCredit: Bool) -> NSAttributedString {
+    private func attributedPerYearPostfix(for suggestion: FullyQuotedDomainSuggestion, freeForFirstYear: Bool) -> NSAttributedString {
         NSAttributedString(
             string: NSLocalizedString(" / year", comment: "Per-year postfix shown after a domain's cost."),
-            attributes: perYearPostfixAttributes(striked: mustStrikeRegularPrice(suggestion, hasDomainCredit: hasDomainCredit)))
+            attributes: perYearPostfixAttributes(striked: mustStrikeRegularPrice(suggestion, freeForFirstYear: freeForFirstYear)))
     }
 
     // MARK: - Attributed partial string attributes
 
-    private func mustStrikeRegularPrice(_ suggestion: FullyQuotedDomainSuggestion, hasDomainCredit: Bool) -> Bool {
-        suggestion.saleCostString != nil || hasDomainCredit
+    private func mustStrikeRegularPrice(_ suggestion: FullyQuotedDomainSuggestion, freeForFirstYear: Bool) -> Bool {
+        suggestion.saleCostString != nil || freeForFirstYear
     }
 
     private func suggestionSaleCostAttributes() -> [NSAttributedString.Key: Any] {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -32,7 +32,7 @@ class DomainSuggestionsTableViewController: UITableViewController {
     var siteName: String?
     var delegate: DomainSuggestionsTableViewControllerDelegate?
     var domainSuggestionType: DomainsServiceRemote.DomainSuggestionType = .noWordpressDotCom
-    var domainType: DomainType?
+    var domainSelectionType: DomainSelectionType?
     var freeSiteAddress: String = ""
 
     var useFadedColorForParentDomains: Bool {
@@ -319,8 +319,7 @@ extension DomainSuggestionsTableViewController {
     }
 
     private var shouldShowTopBanner: Bool {
-        if let domainType = domainType,
-           domainType == .siteRedirect {
+        if domainSelectionType == .purchaseSeparately {
             return true
         }
 
@@ -387,7 +386,7 @@ extension DomainSuggestionsTableViewController {
         let attributedString = NSMutableAttributedString()
 
         let hasDomainCredit = blog?.hasDomainCredit ?? false
-        let freeForFirstYear = hasDomainCredit || domainType == .mapped
+        let freeForFirstYear = hasDomainCredit || domainSelectionType == .purchaseWithPaidPlan
 
         if freeForFirstYear {
             attributedString.append(attributedFreeForTheFirstYear())

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -23,7 +23,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     private var domain: FullyQuotedDomainSuggestion?
     private var siteName: String?
     private var domainsTableViewController: DomainSuggestionsTableViewController?
-    private var domainSelectionType: DomainSelectionType = .purchaseSeparately
+    private var domainSelectionType: DomainSelectionType = .registerWithPaidPlan
     private var includeSupportButton: Bool = true
 
     private var webViewURLChangeObservation: NSKeyValueObservation?
@@ -51,7 +51,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     }()
 
     static func instance(site: Blog,
-                         domainSelectionType: DomainSelectionType = .purchaseSeparately,
+                         domainSelectionType: DomainSelectionType = .registerWithPaidPlan,
                          includeSupportButton: Bool = true,
                          domainPurchasedCallback: ((String) -> Void)? = nil) -> RegisterDomainSuggestionsViewController {
         let storyboard = UIStoryboard(name: Constants.storyboardIdentifier, bundle: Bundle.main)

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardCoordinator.swift
@@ -14,8 +14,8 @@ import UIKit
     static func presentDomainsSuggestions(in dashboardViewController: BlogDashboardViewController,
                                           source: String,
                                           blog: Blog) {
-        let domainType: DomainType = blog.canRegisterDomainWithPaidPlan ? .registered : .siteRedirect
-        let controller = DomainsDashboardFactory.makeDomainsSuggestionViewController(blog: blog, domainType: domainType) {
+        let domainSelectionType: DomainSelectionType = blog.canRegisterDomainWithPaidPlan ? .registerWithPaidPlan : .purchaseSeparately
+        let controller = DomainsDashboardFactory.makeDomainsSuggestionViewController(blog: blog, domainSelectionType: domainSelectionType) {
             dashboardViewController.navigationController?.popViewController(animated: true)
         }
         controller.navigationItem.largeTitleDisplayMode = .never

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardFactory.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardFactory.swift
@@ -8,10 +8,10 @@ struct DomainsDashboardFactory {
         return viewController
     }
 
-    static func makeDomainsSuggestionViewController(blog: Blog, domainType: DomainType, onDismiss: @escaping () -> Void) -> RegisterDomainSuggestionsViewController {
+    static func makeDomainsSuggestionViewController(blog: Blog, domainSelectionType: DomainSelectionType, onDismiss: @escaping () -> Void) -> RegisterDomainSuggestionsViewController {
         let viewController = RegisterDomainSuggestionsViewController.instance(
             site: blog,
-            domainType: domainType,
+            domainSelectionType: domainSelectionType,
             includeSupportButton: false)
 
         viewController.domainPurchasedCallback = { domain in

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
@@ -138,7 +138,11 @@ struct DomainsDashboardView: View {
 
     /// Instantiates the proper search depending if it's for claiming a free domain with a paid plan or purchasing a new one
     private func makeDomainSearch(for blog: Blog, onDismiss: @escaping () -> Void) -> some View {
-        return DomainSuggestionViewControllerWrapper(blog: blog, domainType: blog.canRegisterDomainWithPaidPlan ? .registered : .siteRedirect, onDismiss: onDismiss)
+        return DomainSuggestionViewControllerWrapper(
+            blog: blog,
+            domainSelectionType: blog.canRegisterDomainWithPaidPlan ? .registerWithPaidPlan : .purchaseSeparately,
+            onDismiss: onDismiss
+        )
     }
 
     private func updateDomainsList() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		011F52C32A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */; };
 		011F52C42A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */; };
 		011F52C62A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */; };
+		011F52C82A16551A00B04114 /* FreeToPaidPlansCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C72A16551A00B04114 /* FreeToPaidPlansCoordinator.swift */; };
+		011F52C92A16551A00B04114 /* FreeToPaidPlansCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C72A16551A00B04114 /* FreeToPaidPlansCoordinator.swift */; };
 		01281E9A2A0456CB00464F8F /* DomainsSuggestionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */; };
 		01281E9C2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
 		01281E9D2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
@@ -5789,6 +5791,7 @@
 		011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardCell.swift; sourceTree = "<group>"; };
 		011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardHelper.swift; sourceTree = "<group>"; };
 		011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardHelperTests.swift; sourceTree = "<group>"; };
+		011F52C72A16551A00B04114 /* FreeToPaidPlansCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansCoordinator.swift; sourceTree = "<group>"; };
 		01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsSuggestionsScreen.swift; sourceTree = "<group>"; };
 		01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigationTests.swift; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
@@ -9678,6 +9681,7 @@
 			children = (
 				011F52BF2A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift */,
 				011F52C22A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift */,
+				011F52C72A16551A00B04114 /* FreeToPaidPlansCoordinator.swift */,
 			);
 			path = "Free to Paid Plans";
 			sourceTree = "<group>";
@@ -21146,6 +21150,7 @@
 				E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */,
 				7E4123C120F4097B00DF8486 /* FormattableContentRange.swift in Sources */,
 				08D978581CD2AF7D0054F19A /* MenuItemSourceHeaderView.m in Sources */,
+				011F52C82A16551A00B04114 /* FreeToPaidPlansCoordinator.swift in Sources */,
 				FA1A543E25A6E2F60033967D /* RestoreWarningView.swift in Sources */,
 				1E4F2E712458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift in Sources */,
 				98E0829F2637545C00537BF1 /* PostService+Likes.swift in Sources */,
@@ -24906,6 +24911,7 @@
 				FABB24922602FC2C00C8785C /* PingHubManager.swift in Sources */,
 				FABB24932602FC2C00C8785C /* MediaVideoExporter.swift in Sources */,
 				FABB24942602FC2C00C8785C /* PluginViewController.swift in Sources */,
+				011F52C92A16551A00B04114 /* FreeToPaidPlansCoordinator.swift in Sources */,
 				179A70F12729834B006DAC0A /* Binding+OnChange.swift in Sources */,
 				17F11EDC268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */,
 				FABB24952602FC2C00C8785C /* ReaderSiteTopic.swift in Sources */,


### PR DESCRIPTION
Fixes #20686

Configure Domain Suggestions View Controller for Free to Paid plans flow:
1. Specify domains being free for the first year
2. Present from the dashboard card
3. Create a structure for the flow that can be used for integrating plan selection and checkout

📒 Domain selection does not show any premium domains that would not be eligible to appear for free (premium domains). We could consider improving the domain selection view or integrating a new domain selection view used in site creation as a task outside the project. The current domain selection view is quite basic on iOS and lags behind the user experience on the web.

## To test:

1. Log into free .com account
2. Enable "Free to Paid Plans Dashboard Card" feature flag
3. Tap on the dashboard card
5. Confirm that domains view is opened
6. Confirm that "free for the first year" offer appears

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/dd784916-649d-46a2-92fc-8869da29b939
