### PR TITLE
Reader: Missing Report and Block actions from the Post Menu Sheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 22.5
 -----
+* [*] [Jetpack-only] Reader: Fixed an issue that was causing the Report and Block actions to be missing from Post Menu actions sheet. [#20705]
 
 
 22.4

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
@@ -13,7 +13,15 @@ final class ReaderMenuAction {
                  source: ReaderPostMenuSource,
                  followCommentsService: FollowCommentsService
     ) {
-        self.execute(post: post, context: context, anchor: .view(anchor), vc: vc, source: source, followCommentsService: followCommentsService)
+        self.execute(
+            post: post,
+            context: context,
+            readerTopic: readerTopic,
+            anchor: .view(anchor),
+            vc: vc,
+            source: source,
+            followCommentsService: followCommentsService
+        )
     }
 
     func execute(post: ReaderPost,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3652,6 +3652,7 @@
 		F4D9AF53288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */; };
 		F4DD58322A095210009A772D /* DataMigrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DD58312A095210009A772D /* DataMigrationError.swift */; };
 		F4DD58332A095210009A772D /* DataMigrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DD58312A095210009A772D /* DataMigrationError.swift */; };
+		F4DD58362A168229009A772D /* ReaderPostCellActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DD58352A168229009A772D /* ReaderPostCellActionsTests.swift */; };
 		F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */; };
 		F4DDE2C329C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */; };
 		F4E79301296EEE320025E8E0 /* MigrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E79300296EEE320025E8E0 /* MigrationState.swift */; };
@@ -9007,6 +9008,7 @@
 		F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTableViewTests.swift; sourceTree = "<group>"; };
 		F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewDelegateMock.swift; sourceTree = "<group>"; };
 		F4DD58312A095210009A772D /* DataMigrationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrationError.swift; sourceTree = "<group>"; };
+		F4DD58352A168229009A772D /* ReaderPostCellActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCellActionsTests.swift; sourceTree = "<group>"; };
 		F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashLogging+Singleton.swift"; sourceTree = "<group>"; };
 		F4E79300296EEE320025E8E0 /* MigrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationState.swift; sourceTree = "<group>"; };
 		F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostService.swift; sourceTree = "<group>"; };
@@ -16736,6 +16738,7 @@
 				3F5094592454EC7A00C4470B /* Tabbed Reader */,
 				08C42C30281807880034720B /* ReaderSubscribeCommentsActionTests.swift */,
 				08B954F228535EE800B07185 /* FeatureHighlightStoreTests.swift */,
+				F4DD58352A168229009A772D /* ReaderPostCellActionsTests.swift */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -23349,6 +23352,7 @@
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
 				17FC0032264D728E00FCBD37 /* SharingServiceTests.swift in Sources */,
 				D88A649C208D7D81008AE9BC /* StockPhotosDataSourceTests.swift in Sources */,
+				F4DD58362A168229009A772D /* ReaderPostCellActionsTests.swift in Sources */,
 				3236F7A124B61B950088E8F3 /* ReaderInterestsDataSourceTests.swift in Sources */,
 				40E7FEC52211DF790032834E /* StatsRecordTests.swift in Sources */,
 				8BDA5A74247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import WordPress
+
+final class ReaderPostCellActionsTests: CoreDataTestCase {
+
+    // MARK: - Tests
+
+    /// Tests the block and report actions are visible for posts in the Following feed.
+    func testActionSheetContainsReportAndBlockActions() throws {
+        // Given
+        let viewController = MockViewController()
+        let post = makePost()
+        let cell = makeCell()
+        let actionsHandler = makePostCellActionsWithFollowingTopic(origin: viewController)
+        let expectedActions = ["Block this site", "Block this user", "Report this post", "Report this user"]
+
+        // When
+        actionsHandler.readerCell(cell, menuActionForProvider: post, fromView: cell)
+
+        // Then
+        let presentedAlertController = try XCTUnwrap(viewController.presentedAlertController)
+        let actions = presentedAlertController.actions.compactMap { $0.title }
+        XCTAssertTrue(Set(expectedActions).isSubset(of: actions))
+    }
+
+    // MARK: - Helpers
+
+    private func makePostCellActionsWithFollowingTopic(origin: UIViewController) -> ReaderPostCellActions {
+        let topic = makeFollowingTopic()
+        let actions = ReaderPostCellActions(context: mainContext, origin: origin, topic: topic, visibleConfirmation: false)
+        actions.isLoggedIn = true
+        return actions
+    }
+
+    private func makeFollowingTopic() -> ReaderAbstractTopic {
+        let topic = NSEntityDescription.insertNewObject(forEntityName: ReaderDefaultTopic.entityName(), into: mainContext) as! ReaderDefaultTopic
+        topic.inUse = true
+        topic.following = true
+        topic.path = "https://wordpress.com/read/following"
+        return topic
+    }
+
+    private func makeCell() -> ReaderPostCardCell {
+        return Bundle.loadRootViewFromNib(type: ReaderPostCardCell.self)!
+    }
+
+    private func makePost() -> ReaderPost {
+        let builder = ReaderPostBuilder()
+        let post: ReaderPost = builder.build()
+        post.isWPCom = true
+        return post
+    }
+}
+
+// MARK: - Mocks
+
+private class MockViewController: UIViewController {
+
+    var presentedAlertController: UIAlertController?
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        self.presentedAlertController = viewControllerToPresent as? UIAlertController
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+}


### PR DESCRIPTION
Fixes #20706

## Description

This PR fixes an issue in Reader that was causing the Report and Block actions to be missing from Post Menu actions sheet.

| Before | After |
| ------ | ------ |
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/4acd88f5-3c69-4d1f-b5f4-bba01f3c6c72) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/359ff356-675e-4f18-9eb1-05b992549e33) |

## Test Instructions

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests to verify that the Report / Block actions are present when certain conditions are fulfilled.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes testing checklist:
N/A
