### PR TITLE
Social: Add deprecated section in connection list

### DIFF
--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -5,6 +5,7 @@ open class PublicizeService: NSManagedObject {
     @objc static let googlePlusServiceID = "google_plus"
     @objc static let facebookServiceID = "facebook"
     @objc static let defaultStatus = "ok"
+    @objc static let unsupportedStatus = "unsupported"
 
     @NSManaged open var connectURL: String
     @NSManaged open var detail: String

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -18,7 +18,14 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 @interface SharingViewController ()
 
 @property (nonatomic, strong, readonly) Blog *blog;
-@property (nonatomic, strong) NSArray *publicizeServices;
+@property (nonatomic, strong) NSArray<PublicizeService *> *publicizeServices;
+
+// Contains Publicize services that are currently available for use.
+@property (nonatomic, strong) NSArray<PublicizeService *> *supportedServices;
+
+// Contains unsupported Publicize services that are deprecated or temporarily disabled.
+@property (nonatomic, strong) NSArray<PublicizeService *> *unsupportedServices;
+
 @property (nonatomic, weak) id delegate;
 @property (nonatomic) PublicizeServicesState *publicizeServicesState;
 @property (nonatomic) JetpackModuleHelper *jetpackModuleHelper;
@@ -34,6 +41,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if (self) {
         _blog = blog;
         _publicizeServices = [NSMutableArray new];
+        _supportedServices = @[];
+        _unsupportedServices = @[];
         _delegate = delegate;
         _publicizeServicesState = [PublicizeServicesState new];
     }
@@ -91,6 +100,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (void)refreshPublicizers
 {
     self.publicizeServices = [PublicizeService allPublicizeServicesInContext:[self managedObjectContext] error:nil];
+
+    NSPredicate *supportedPredicate = [NSPredicate predicateWithFormat:@"status == %@", PublicizeService.defaultStatus];
+    self.supportedServices = [self.publicizeServices filteredArrayUsingPredicate:supportedPredicate];
+
+    NSPredicate *unsupportedPredicate = [NSPredicate predicateWithFormat:@"status == %@", PublicizeService.unsupportedStatus];
+    self.unsupportedServices = [self.publicizeServices filteredArrayUsingPredicate:unsupportedPredicate];
 
     [self.tableView reloadData];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -177,8 +177,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
             return NSLocalizedString(@"Jetpack Social Connections", @"Section title for Publicize services in Sharing screen");
 
         case SharingSectionUnsupported:
-            return NSLocalizedString(@"Twitter Auto-sharing Is No Longer Available",
-                                     @"Section title for the disabled Twitter service in the Social screen");
+            return NSLocalizedStringWithDefaultValue(
+                                              @"social.section.disabledTwitter.header",
+                                              nil,
+                                              [NSBundle mainBundle],
+                                              @"Twitter Auto-Sharing Is No Longer Available",
+                                              @"Section title for the disabled Twitter service in the Social screen");
 
         case SharingSectionSharingButtons:
             return NSLocalizedString(@"Sharing Buttons", @"Section title for the sharing buttons section in the Sharing screen");

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -110,7 +110,16 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     self.supportedServices = [self.publicizeServices filteredArrayUsingPredicate:supportedPredicate];
 
     NSPredicate *unsupportedPredicate = [NSPredicate predicateWithFormat:@"status == %@", PublicizeService.unsupportedStatus];
-    self.unsupportedServices = [self.publicizeServices filteredArrayUsingPredicate:unsupportedPredicate];
+    NSArray<PublicizeService *> *unsupportedList = [self.publicizeServices filteredArrayUsingPredicate:unsupportedPredicate];
+
+    // only list unsupported services with existing connections.
+    NSMutableArray<PublicizeService *> *unsupportedServicesWithConnections = [NSMutableArray new];
+    for (PublicizeService *service in unsupportedList) {
+        if ([self connectionsForService:service].count > 0) {
+            [unsupportedServicesWithConnections addObject:service];
+        }
+    }
+    self.unsupportedServices = unsupportedServicesWithConnections;
 
     // Refresh table sections in case anything changes.
     [self refreshSections];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -90,13 +90,13 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [self.tableView reloadData];
 }
 
--(void)viewWillDisappear:(BOOL)animated
+- (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
     [ReachabilityUtils dismissNoInternetConnectionNotice];
 }
 
--(void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
     [self notifyDelegatePublicizeServicesChangedIfNeeded];
 }
@@ -238,7 +238,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     }
 
     SharingSectionType sectionType = [self sectionTypeForIndex:indexPath.section];
-    switch(sectionType) {
+    switch (sectionType) {
         case SharingSectionAvailableServices: // fallthrough
         case SharingSectionUnsupported:
             [self configurePublicizeCell:cell atIndexPath:indexPath];
@@ -260,7 +260,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (PublicizeService *)publicizeServiceForIndexPath:(NSIndexPath *)indexPath
 {
     SharingSectionType sectionType = [self sectionTypeForIndex:indexPath.section];
-    switch(sectionType) {
+    switch (sectionType) {
         case SharingSectionAvailableServices:
             return self.supportedServices[indexPath.row];
         case SharingSectionUnsupported:


### PR DESCRIPTION
Refs #20675, Th1ahHKq53k5JT1PNDMavY-fi-880_16225
Depends on #20707 

> **Note**:
> This PR is targeting 22.4 and contains cherry-picked commits from #20696 .

Here's the summary of the changes:

- Twitter is now displayed in a separate section.
- Without an existing Twitter connection, Twitter will be hidden.
- Some refactoring is done to the table section logic, to make it easier to work with.
- Unsupported connections will no longer show the orange exclamation icon (as per the design).

Before | After (with connections) | After (without connections)
-|-|-
![20675_before](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c444a316-362c-4536-b898-0f6d6aa61202) | ![20675_after](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/18582ae9-0ed8-4371-8309-b1fa6acd69da) |  ![20675_after_no_connection](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/7fed06c4-03ff-4b9b-9403-7327336291b1)

> **Warning**:
> The footer part is not implemented yet and will be included in the next PR.

## To test

- Prepare a site that has an existing Twitter connection.
- Launch the Jetpack app.
- Go to Site Menu > Social.
- 🔎 Verify that Twitter is displayed in a separate section.
- Switch to a site without Twitter connections. 
- Go to Site Menu > Social.
- 🔎 Verify that Twitter is not displayed.

## Regression Notes
1. Potential unintended areas of impact
This introduces some changes & light refactoring in the Site menu > Social screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)