### PR TITLE
Social: Show Twitter deprecation footer in connection list screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -352,11 +352,19 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
 {
     SharingSectionType sectionType = [self sectionTypeForIndex:section];
-    if (sectionType == SharingSectionSharingButtons && [SharingViewController jetpackBrandingVisibile]) {
-        return [self makeJetpackBadge];
-    }
+    switch (sectionType) {
+        case SharingSectionUnsupported:
+            return [self makeTwitterDeprecationFooterView];
 
-    // TODO: Show footer view for unsupported section.
+        case SharingSectionSharingButtons:
+            if ([SharingViewController jetpackBrandingVisibile]) {
+                return [self makeJetpackBadge];
+            }
+            break;
+
+        default:
+            break;
+    }
 
     return nil;
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
@@ -25,4 +25,15 @@ extension SharingViewController {
         JetpackBrandingCoordinator.presentOverlay(from: self)
         JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .sharing)
     }
+
+    // MARK: Twitter Deprecation
+
+    @objc
+    func makeTwitterDeprecationFooterView() -> TwitterDeprecationTableFooterView {
+        let footerView = TwitterDeprecationTableFooterView()
+        footerView.presentingViewController = self
+        footerView.source = "social_connection_list"
+
+        return footerView
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
@@ -1,0 +1,101 @@
+@objc class TwitterDeprecationTableFooterView: UITableViewHeaderFooterView {
+
+    private let label: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.font = WPStyleGuide.tableviewSectionFooterFont()
+        label.textColor = .secondaryLabel
+
+        let attributedString = NSMutableAttributedString(string: "\(Constants.deprecationNoticeText) ")
+
+        if let destinationURL = Constants.blogPostURL {
+            let hyperlinkText = NSAttributedString(string: Constants.hyperlinkText, attributes: [
+                .link: destinationURL,
+                .foregroundColor: UIColor.brand
+            ])
+            attributedString.append(hyperlinkText)
+        }
+
+        label.attributedText = attributedString
+        label.isUserInteractionEnabled = true
+
+        return label
+    }()
+
+    override public init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setupSubviews()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupSubviews()
+    }
+
+    private func setupSubviews() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
+        label.addGestureRecognizer(tapGesture)
+
+        contentView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
+            label.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor),
+            label.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor)
+        ])
+    }
+
+    @objc private func labelTapped(_ sender: UITapGestureRecognizer) {
+        guard let attributedText = label.attributedText else {
+            return
+        }
+
+        // detect the tap location within the attributed text.
+        let location = sender.location(in: label)
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        let textContainer = NSTextContainer(size: label.bounds.size)
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+
+        textContainer.lineFragmentPadding = 0
+        textContainer.lineBreakMode = label.lineBreakMode
+        textContainer.maximumNumberOfLines = label.numberOfLines
+
+        let characterIndex = layoutManager.characterIndex(for: location,
+                                                          in: textContainer,
+                                                          fractionOfDistanceBetweenInsertionPoints: nil)
+
+        guard characterIndex < textStorage.length else {
+            return
+        }
+
+        let range = NSMakeRange(characterIndex, 1)
+        let attributes = attributedText.attributes(at: characterIndex, effectiveRange: nil)
+
+        guard let link = attributes[.link] as? URL else {
+            return
+        }
+
+        // TODO: Tracking
+
+        UIApplication.shared.open(link)
+    }
+
+    private enum Constants {
+        static let blogPostURL = URL(string: "https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/")
+
+        static let deprecationNoticeText = NSLocalizedString(
+            "social.twitterDeprecation.text",
+            value: "Twitter auto-sharing is no longer available due to Twitter's changes in terms and pricing.",
+            comment: "A smallprint that hints the reason behind why Twitter is deprecated."
+        )
+
+        static let hyperlinkText = NSLocalizedString(
+            "social.twitterDeprecation.link",
+            value: "Find out more",
+            comment: "Text for a hyperlink that allows the user to learn more about the Twitter deprecation."
+        )
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
@@ -1,3 +1,6 @@
+/// A subclass implementation of `UITableViewHeaderFooterView` that displays a text with a tappable link.
+/// Specifically used for Twitter deprecation purposes.
+///
 @objc class TwitterDeprecationTableFooterView: UITableViewHeaderFooterView {
 
     private let label: UILabel = {
@@ -8,10 +11,9 @@
         label.textColor = .secondaryLabel
 
         let attributedString = NSMutableAttributedString(string: "\(Constants.deprecationNoticeText) ")
-
-        if let destinationURL = Constants.blogPostURL {
+        if let linkURL = Constants.blogPostURL {
             let hyperlinkText = NSAttributedString(string: Constants.hyperlinkText, attributes: [
-                .link: destinationURL,
+                .attachment: linkURL,
                 .foregroundColor: UIColor.brand
             ])
             attributedString.append(hyperlinkText)
@@ -22,6 +24,8 @@
 
         return label
     }()
+
+    // MARK: Methods
 
     override public init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
@@ -74,7 +78,7 @@
         let range = NSMakeRange(characterIndex, 1)
         let attributes = attributedText.attributes(at: characterIndex, effectiveRange: nil)
 
-        guard let link = attributes[.link] as? URL else {
+        guard let link = attributes[.attachment] as? URL else {
             return
         }
 
@@ -82,6 +86,8 @@
 
         UIApplication.shared.open(link)
     }
+
+    // MARK: Constants
 
     private enum Constants {
         static let blogPostURL = URL(string: "https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5491,6 +5491,8 @@
 		FE4DC5A7293A79F1008F322F /* WordPressExportRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4DC5A6293A79F1008F322F /* WordPressExportRoute.swift */; };
 		FE4DC5A8293A84E6008F322F /* MigrationDeepLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4DC5A2293A75FC008F322F /* MigrationDeepLinkRouter.swift */; };
 		FE4DC5AA293A84F8008F322F /* WordPressExportRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4DC5A6293A79F1008F322F /* WordPressExportRoute.swift */; };
+		FE5096592A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5096582A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift */; };
+		FE50965A2A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5096582A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift */; };
 		FE6BB143293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
 		FE6BB144293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
 		FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */; };
@@ -9252,6 +9254,7 @@
 		FE4DC5A2293A75FC008F322F /* MigrationDeepLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationDeepLinkRouter.swift; sourceTree = "<group>"; };
 		FE4DC5A6293A79F1008F322F /* WordPressExportRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressExportRoute.swift; sourceTree = "<group>"; };
 		FE5096572A13D5BA00DDD071 /* WordPress 149.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 149.xcdatamodel"; sourceTree = "<group>"; };
+		FE5096582A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterDeprecationTableFooterView.swift; sourceTree = "<group>"; };
 		FE59DA9527D1FD0700624D26 /* WordPress 138.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 138.xcdatamodel"; sourceTree = "<group>"; };
 		FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinator.swift; sourceTree = "<group>"; };
 		FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -16693,6 +16696,7 @@
 				E64384821C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift */,
 				E60BD230230A3DD400727E82 /* KeyringAccountHelper.swift */,
 				931F312B2714302A0075433B /* PublicizeServicesState.swift */,
+				FE5096582A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift */,
 			);
 			name = Sharing;
 			sourceTree = "<group>";
@@ -21270,6 +21274,7 @@
 				1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */,
 				FEA088052696F7AA00193358 /* WPStyleGuide+List.swift in Sources */,
 				17C2FF0925D4852400CDB712 /* UnifiedProloguePages.swift in Sources */,
+				FE5096592A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift in Sources */,
 				400A2C882217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift in Sources */,
 				08D345561CD7FBA900358E8C /* MenuHeaderViewController.m in Sources */,
 				088CC594282BEC41007B9421 /* TooltipPresenter.swift in Sources */,
@@ -23700,6 +23705,7 @@
 				93F72150271831820021A09F /* SiteStatsPinnedItemStore.swift in Sources */,
 				FABB212A2602FC2C00C8785C /* BadgeLabel.swift in Sources */,
 				FABB212B2602FC2C00C8785C /* ReaderTagsTableViewController.swift in Sources */,
+				FE50965A2A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift in Sources */,
 				FABB212C2602FC2C00C8785C /* NotificationsViewController+AppRatings.swift in Sources */,
 				FABB212D2602FC2C00C8785C /* BlogService.m in Sources */,
 				DC9AF76A285DF8A300EA2A0D /* StatsFollowersChartViewModel.swift in Sources */,


### PR DESCRIPTION
Refs #20675 
Depends on #20708 👈🏼  Please review this first.

This PR adds a somewhat reusable footer view for the Twitter deprecation notice since it's going to be used in two other places. Furthermore, tapping on 'Find out more' displays the blog post in a web view. This is so the user stays in the app.

Here are some previews:

Footer text | Web view
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2023-05-19 at 20 57 36](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/13a1ea55-4444-463f-94f4-4edc8a8b5112) |  ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-19 at 20 57 42](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f5168c14-95b1-478a-8b8e-475feca1ea1d)

FYI: @osullivanchris 

## To test

- Prepare a site with an existing Twitter connection. 
- Launch the Jetpack app, and go to Site menu > Social.
- 🔎 Verify that the footer for the Twitter section is now displayed.
- Tap on "Find out more".
- 🔎 Verify that the blog post is now displayed.

## Regression Notes
1. Potential unintended areas of impact
Should be none. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
