### PR TITLE
Site Editor: Update site editor MVP to a remote feature flag and enable it

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 22.5
 -----
 * [*] [Jetpack-only] Reader: Fixed an issue that was causing the Report and Block actions to be missing from Post Menu actions sheet. [#20705]
-* [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [#]
+* [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [#20713]
 
 22.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 22.5
 -----
 * [*] [Jetpack-only] Reader: Fixed an issue that was causing the Report and Block actions to be missing from Post Menu actions sheet. [#20705]
-
+* [***] Enables editing of the site homepage for sites using block-based themes directly from the pages list. [#]
 
 22.4
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -39,7 +39,6 @@ enum FeatureFlag: Int, CaseIterable {
     case siteCreationDomainPurchasing
     case readerUserBlocking
     case personalizeHomeTab
-    case siteEditorMVP
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -126,8 +125,6 @@ enum FeatureFlag: Int, CaseIterable {
             return true
         case .personalizeHomeTab:
             return false
-        case .siteEditorMVP:
-            return BuildConfiguration.current != .appStore
         }
     }
 
@@ -224,8 +221,6 @@ extension FeatureFlag {
             return "Reader User Blocking"
         case .personalizeHomeTab:
             return "Personalize Home Tab"
-        case .siteEditorMVP:
-            return "Site Editor MVP"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -19,6 +19,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case activityLogDashboardCard
     case sdkLessGoogleSignIn
     case bloggingPromptsSocial
+    case siteEditorMVP
 
     var defaultValue: Bool {
         switch self {
@@ -56,6 +57,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .bloggingPromptsSocial:
             return AppConfiguration.isJetpack
+        case .siteEditorMVP:
+            return true
         }
     }
 
@@ -96,6 +99,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "google_signin_without_sdk"
         case .bloggingPromptsSocial:
             return "blogging_prompts_social_enabled"
+        case .siteEditorMVP:
+            return "site_editor_mvp"
         }
     }
 
@@ -135,6 +140,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Sign-In with Google without the Google SDK"
         case .bloggingPromptsSocial:
             return "Blogging Prompts Social"
+        case .siteEditorMVP:
+            return "Site Editor MVP"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -13,7 +13,7 @@ final class PageListTableViewHandler: WPTableViewHandler {
     }
 
     var showEditorHomepage: Bool {
-        guard FeatureFlag.siteEditorMVP.enabled else {
+        guard RemoteFeatureFlag.siteEditorMVP.enabled() else {
             return false
         }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -255,7 +255,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     private func fetchEditorSettings(success: ((Bool) -> ())?, failure: ((NSError) -> ())?) -> (success: (_ hasMore: Bool) -> (), failure: (NSError) -> ()) {
         let fetchTask = Task { @MainActor [weak self] in
-            guard FeatureFlag.siteEditorMVP.enabled,
+            guard RemoteFeatureFlag.siteEditorMVP.enabled(),
                   let result = await editorSettingsService?.fetchSettings() else {
                 return
             }
@@ -437,7 +437,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             predicates.append(searchPredicate)
         }
 
-        if FeatureFlag.siteEditorMVP.enabled,
+        if RemoteFeatureFlag.siteEditorMVP.enabled(),
            blog.blockEditorSettings?.isFSETheme ?? false,
            let homepageID = blog.homepagePageID,
            let homepageType = blog.homepageType,


### PR DESCRIPTION
## Description

Moves the site editor MVP feature flag to a remote feature flag and enables it by default.

## Testing

To test:
- Launch Jetpack and login
- Select a blog with a block based theme
- Tap on "Pages" on the Home dashboard
- **Verify** the block based theme homepage cell appears in the "Published" pages

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
