### PR TITLE
Social: Show deprecation notice in detail screens

### DIFF
--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -19,4 +19,8 @@ open class PublicizeService: NSManagedObject {
     @NSManaged open var serviceID: String
     @NSManaged open var type: String
     @NSManaged open var status: String
+
+    @objc open var isSupported: Bool {
+        status == Self.defaultStatus
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -97,7 +97,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         } else {
             return 0;
         }
-    } else if ([self hasConnectedAccounts]) {
+    } else if ([self hasConnectedAccounts] && self.publicizeService.isSupported) {
         return 2;
     }
     
@@ -128,6 +128,19 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
     [WPStyleGuide configureTableViewSectionFooter:view];
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    if (self.publicizeService.isSupported) {
+        return nil;
+    }
+
+    TwitterDeprecationTableFooterView *footerView = [TwitterDeprecationTableFooterView new];
+    footerView.presentingViewController = self;
+    footerView.source = @"social_connection_detail";
+
+    return footerView;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
@@ -191,7 +204,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     PublicizeConnection *connection = [[self connectionsForService] objectAtIndex:indexPath.row];
     cell.textLabel.text = connection.externalDisplay;
 
-    if ([connection requiresUserAction]) {
+    if ([connection requiresUserAction] && self.publicizeService.isSupported) {
         cell.accessoryView = [WPStyleGuide sharingCellWarningAccessoryImageView];
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -15,6 +15,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 @property (nonatomic, strong, readonly) Blog *blog;
 @property (nonatomic, strong) PublicizeConnection *publicizeConnection;
+@property (nonatomic, strong) PublicizeService *publicizeService;
 @property (nonatomic, strong) SharingAuthorizationHelper *helper;
 @end
 
@@ -40,6 +41,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
                                                                                 blog:self.blog
                                                                     publicizeService:publicizeService];
             self.helper.delegate = self;
+            self.publicizeService = publicizeService;
         }
     }
     return self;
@@ -103,12 +105,18 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return self.blog.managedObjectContext;
 }
 
+/// Returns true if the service is supported by Jetpack Social, but the connection is broken.
+- (BOOL)isSupportedConnectionBroken
+{
+    return [self.publicizeConnection isBroken] && self.publicizeService.isSupported;
+}
+
 
 #pragma mark - TableView Delegate Methods
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-    if ([self.publicizeConnection requiresUserAction]) {
+    if ([self.publicizeConnection requiresUserAction] && self.publicizeService.isSupported) {
         return 3;
     }
 
@@ -135,7 +143,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
             return [self textForFacebookFooter];
         }
 
-        if ([self.publicizeConnection isBroken]) {
+        if ([self isSupportedConnectionBroken]) {
             return [self textForBrokenConnectionFooter];
         }
     }
@@ -159,7 +167,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if (indexPath.section == 0) {
         cell = [self switchTableViewCell];
 
-    } else if (indexPath.section == 1 && [self.publicizeConnection isBroken]) {
+    } else if (indexPath.section == 1 && [self isSupportedConnectionBroken]) {
         [self configureReconnectCell:cell];
 
     } else if (indexPath.section == 1 && [self.publicizeConnection mustDisconnectFacebook]) {
@@ -176,7 +184,14 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    if (indexPath.section == 1 && [self.publicizeConnection isBroken]) {
+    // Do nothing when the service is unsupported.
+    // The first section's cell has a tap recognizer applied on the entire cell, preventing touch events from
+    // bubbling up to the table view delegate. But when the cell's interaction is disabled, this method will be called.
+    if (indexPath.section == 0 && !self.publicizeService.isSupported) {
+        return;
+    }
+
+    if (indexPath.section == 1 && [self isSupportedConnectionBroken]) {
         [self reconnectPublicizeConnection];
     } else if (indexPath.section == 1 && [self.publicizeConnection mustDisconnectFacebook]) {
             [self openFacebookFAQ];
@@ -190,6 +205,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     SwitchTableViewCell *cell = [[SwitchTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:nil];
     cell.textLabel.text = NSLocalizedString(@"Available to all users", @"");
     cell.on = self.publicizeConnection.shared;
+
+    // disable interaction if the service is unsupported.
+    if (!self.publicizeService.isSupported) {
+        [cell.textLabel setTextColor:[UIColor secondaryLabelColor]];
+        cell.userInteractionEnabled = NO;
+    }
 
     __weak __typeof(self) weakSelf = self;
     cell.onChange = ^(BOOL value) {
@@ -275,7 +296,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         alert.modalPresentationStyle = UIModalPresentationPopover;
         [self presentViewController:alert animated:YES completion:nil];
 
-        NSUInteger section = [self.publicizeConnection isBroken] ? 2 : 1;
+        NSUInteger section = [self isSupportedConnectionBroken] ? 2 : 1;
         UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section]];
         UIPopoverPresentationController *presentationController = alert.popoverPresentationController;
         presentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;

--- a/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
@@ -17,7 +17,7 @@
         label.textColor = .secondaryLabel
 
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = 0.9
+        paragraphStyle.lineHeightMultiple = Constants.lineHeightMultiple
 
         let attributedString = NSMutableAttributedString(string: "\(Constants.deprecationNoticeText) ", attributes: [
             .paragraphStyle: paragraphStyle
@@ -60,12 +60,7 @@ private extension TwitterDeprecationTableFooterView {
         label.addGestureRecognizer(tapGesture)
 
         contentView.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
-            label.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor),
-            label.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor)
-        ])
+        contentView.pinSubviewToAllEdgeMargins(label)
     }
 
     @objc func labelTapped(_ sender: UITapGestureRecognizer) {
@@ -95,9 +90,7 @@ private extension TwitterDeprecationTableFooterView {
             return
         }
 
-        let range = NSMakeRange(characterIndex, 1)
         let attributes = attributedText.attributes(at: characterIndex, effectiveRange: nil)
-
         guard let attachmentURL = attributes[.attachment] as? URL else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
@@ -16,9 +16,16 @@
         label.font = WPStyleGuide.tableviewSectionFooterFont()
         label.textColor = .secondaryLabel
 
-        let attributedString = NSMutableAttributedString(string: "\(Constants.deprecationNoticeText) ")
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 0.9
+
+        let attributedString = NSMutableAttributedString(string: "\(Constants.deprecationNoticeText) ", attributes: [
+            .paragraphStyle: paragraphStyle
+        ])
+
         if let attachmentURL = Constants.blogPostURL {
             let hyperlinkText = NSAttributedString(string: Constants.hyperlinkText, attributes: [
+                .paragraphStyle: paragraphStyle,
                 .attachment: attachmentURL,
                 .foregroundColor: UIColor.brand
             ])
@@ -106,6 +113,9 @@ private extension TwitterDeprecationTableFooterView {
     // MARK: Constants
 
     enum Constants {
+        // adjust attributedText's line height. The default settings look slightly stretched.
+        static let lineHeightMultiple = 0.9
+
         static let blogPostURL = URL(string: "https://wordpress.com/blog/2023/04/29/why-twitter-auto-sharing-is-coming-to-an-end/")
 
         static let deprecationNoticeText = NSLocalizedString(


### PR DESCRIPTION
Refs #20675 
Depends on #20709 👈🏼 Please review this first.

- Disable adding new connections in the Sharing Connection screen when the service is unsupported.
- Disable actions in the Sharing Detail screen when the service is unsupported.
- Fixed some UI issues with the footer view:
  - Decreased the line height so it looks more similar to the system footer view. Somehow the attributed text uses a slightly bigger line height.
  - Fixed constraints. The label is now pinned to layout margins instead of the readable content guide.

Some previews:

• | Sharing | Connections | Detail
-|-|-|-
Before | ![before_sharing](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/643f261f-0ab3-4033-9ba5-3b140d9aa9e8) | ![before_connections](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8d984ea6-5f89-4bf4-a9b0-bad1154f7073) | ![before_detail](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/226dec94-652c-46b9-910e-1069521b5534)
After | ![after_sharing](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/77e8161d-be0d-4c0f-a12d-7477b73b75ac) | ![after_connections](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/82a14489-a248-4b37-b3b7-f1c2b2b16076) | ![after_detail](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/93aeaa6e-5e13-4712-bd7f-36d4af125d94)

FYI @osullivanchris: 
- in the last screen, I intentionally used the `secondary label` color for the "Available to all users" text to communicate that the row is disabled.
- Also, apparently, there's supposed to be a Reconnect button for broken accounts. I've also removed them for Twitter.

## To test

### Verify that the unsupported state is as expected

- Launch the Jetpack app.
- Switch to a site with an existing Twitter connection.
- Go to Site menu > Social.
- Tap the Twitter account to enter the Connection screen.
- 🔎 Verify that:
  - The 'Connect another account' button is not displayed.
  - The account is displayed without the orange ❕ icon.
- Tap the account to enter the Detail screen.
- 🔎 Verify that:
  - The "Available to all users" row is disabled. Nothing happens when you tap this row.
  - Tapping "Disconnect" shows a confirmation sheet.
  - Using an iPad, tapping "Disconnect" should show a PopOver anchored to the "Disconnect" row.

### Verify that the supported services remain unaffected

- Launch the Jetpack app.
- Go to Site menu > Social.
- Tap any service (except Twitter) that doesn't have a connection.
- 🔎 Verify that the "Connect another account" button is displayed.
- Go back, and select another with an existing account.
- 🔎 Verify that both the username row and the "Connect another account" button are displayed.
- Tap on the username.
- 🔎 Verify that:
  - you can interact with the "Available to all users" row.
  - Tapping "Disconnect" shows a confirmation sheet.

## Regression Notes
1. Potential unintended areas of impact
Changes are scoped within the Social screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
