### PR TITLE
Plans on JP: Add plan step to free-to-paid purchase flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -13,8 +13,9 @@ import UIKit
         )
 
         domainSuggestionsViewController.domainAddedToCartCallback = {
-            // TODO: Present Plans Selection and Checkout Flow
-            // https://github.com/wordpress-mobile/WordPress-iOS/issues/20688
+            guard let viewModel = PlanSelectionViewModel(blog: blog) else { return }
+            let planSelectionViewController = PlanSelectionViewController(viewModel: viewModel)
+            domainSuggestionsViewController.show(planSelectionViewController, sender: nil)
         }
 
         dashboardViewController.show(domainSuggestionsViewController, sender: nil)

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/PlanSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/PlanSelectionViewController.swift
@@ -1,0 +1,51 @@
+import UIKit
+
+struct PlanSelectionViewModel {
+
+    let blog: Blog
+    let url: URL
+
+    init?(blog: Blog) {
+        self.blog = blog
+
+        guard let homeUrl = blog.homeURL, let siteUrl = URL(string: homeUrl as String), let host = siteUrl.host else {
+            return nil
+        }
+
+        var components = URLComponents(string: Constants.plansWebAddress)!
+
+        components.queryItems = [
+            URLQueryItem(name: Constants.domainAndPlanPackageParameter, value: "true"),
+            URLQueryItem(name: Constants.jetpackAppPlansParameter, value: "true")
+        ]
+
+        components.path += "/" + host
+        guard let url = components.url else { return nil }
+        self.url = url
+    }
+
+    enum Constants {
+        static let plansWebAddress = "https://wordpress.com/plans/yearly"
+        static let domainAndPlanPackageParameter = "domainAndPlanPackage"
+        static let jetpackAppPlansParameter = "jetpackAppPlans"
+    }
+}
+
+final class PlanSelectionViewController: WebKitViewController {
+    let viewModel: PlanSelectionViewModel
+
+    init(viewModel: PlanSelectionViewModel) {
+        self.viewModel = viewModel
+
+        let configuration = WebViewControllerConfiguration(url: viewModel.url)
+        configuration.authenticateWithDefaultAccount()
+        configuration.secureInteraction = true
+        super.init(configuration: configuration)
+    }
+
+    // MARK: - Required Init
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2588,6 +2588,8 @@
 		B0637543253E7E7A00FD45D2 /* GutenbergSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0637542253E7E7A00FD45D2 /* GutenbergSuggestionsViewController.swift */; };
 		B06378C0253F639D00FD45D2 /* SiteSuggestion+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06378BE253F639D00FD45D2 /* SiteSuggestion+CoreDataClass.swift */; };
 		B06378C1253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06378BF253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift */; };
+		B07F133E2A16C69800AF7FCF /* PlanSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07F133D2A16C69800AF7FCF /* PlanSelectionViewController.swift */; };
+		B07F133F2A16C69800AF7FCF /* PlanSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07F133D2A16C69800AF7FCF /* PlanSelectionViewController.swift */; };
 		B084E61F27E3B79F007BF7A8 /* SiteIntentStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0960C8627D14BD400BC9717 /* SiteIntentStep.swift */; };
 		B084E62027E3B7A4007BF7A8 /* SiteIntentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B089140C27E1255D00CF468B /* SiteIntentViewController.swift */; };
 		B089140D27E1255D00CF468B /* SiteIntentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B089140C27E1255D00CF468B /* SiteIntentViewController.swift */; };
@@ -7910,6 +7912,7 @@
 		B06378AE253F619500FD45D2 /* WordPress 103.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 103.xcdatamodel"; sourceTree = "<group>"; };
 		B06378BE253F639D00FD45D2 /* SiteSuggestion+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SiteSuggestion+CoreDataClass.swift"; sourceTree = "<group>"; };
 		B06378BF253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SiteSuggestion+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		B07F133D2A16C69800AF7FCF /* PlanSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanSelectionViewController.swift; sourceTree = "<group>"; };
 		B089140C27E1255D00CF468B /* SiteIntentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentViewController.swift; sourceTree = "<group>"; };
 		B0960C8627D14BD400BC9717 /* SiteIntentStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentStep.swift; sourceTree = "<group>"; };
 		B0A6DEBE2626335F00B5B8EF /* AztecPostViewController+MenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AztecPostViewController+MenuTests.swift"; path = "Aztec/AztecPostViewController+MenuTests.swift"; sourceTree = "<group>"; };
@@ -11879,6 +11882,7 @@
 				436D560B2117312600CEAA33 /* RegisterDomainSuggestions */,
 				43D74AD220FB5A82004AD934 /* Views */,
 				F47E154929E84A9300B6E426 /* DomainPurchasingWebFlowController.swift */,
+				B07F133D2A16C69800AF7FCF /* PlanSelectionViewController.swift */,
 			);
 			path = "Domain registration";
 			sourceTree = "<group>";
@@ -22391,6 +22395,7 @@
 				FAC086D725EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift in Sources */,
 				324780E1247F2E2A00987525 /* NoResultsViewController+FollowedSites.swift in Sources */,
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
+				B07F133E2A16C69800AF7FCF /* PlanSelectionViewController.swift in Sources */,
 				9822A8412624CFB900FD8A03 /* UserProfileSiteCell.swift in Sources */,
 				9A38DC6D218899FB006A409B /* DiffAbstractValue.swift in Sources */,
 				17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */,
@@ -23618,6 +23623,7 @@
 				FE29EFCE29A91160007CE034 /* WPAdminConvertibleRouter.swift in Sources */,
 				FABB20D22602FC2C00C8785C /* AztecNavigationController.swift in Sources */,
 				FABB20D32602FC2C00C8785C /* Notification+Interface.swift in Sources */,
+				B07F133F2A16C69800AF7FCF /* PlanSelectionViewController.swift in Sources */,
 				FABB20D42602FC2C00C8785C /* ReaderSaveForLater+Analytics.swift in Sources */,
 				FABB20D52602FC2C00C8785C /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB20D62602FC2C00C8785C /* RevisionOperation.swift in Sources */,


### PR DESCRIPTION
Addresses #20688

This integrates plan selection into the domain purchase flow.
- Plan selection is the step after domain selection and is shown in a modal.
- This PR doesn't include any web view customization (limit plans to Personal & Premium, remove back button, etc) because it depends on the new `jetpackAppPlans` query parameter in https://github.com/Automattic/wp-calypso/pull/77029.

### Screenshots

| Step 1: Dashboard card entry point | Step 2: Domain selection | Step 3: Plan selection | 
| - | - | - |
| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/20475a69-21da-44c0-bd30-d812de12c7ea" width="250"> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/9ad9018e-b128-4d08-b5cd-5b5d8640574c" width="250"> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/ec4934db-a87d-40d8-921e-02763c11c54f" width="250"> |
### To test

I've only been able to test that the web view opens the current production plans screen. When https://github.com/Automattic/wp-calypso/pull/77029 is merged, we can test that just the Personal and Premium plans are shown in the web view. I think it's OK to merge this as-is and I couldn't find a way to test the app against the [Calypso build URL](https://github.com/Automattic/wp-calypso/pull/77029#issuecomment-1551535572)(suggestions welcome!).

1. Log into the JP app
2. Locate a Simple non-P2 site on the Free plan
3. Turn on the feature flag: tap profile pic > App Settings > Debug and turn ON `Free to Paid Plans Dashboard Card` and turn OFF `Domains Dashboard Card`
4. Return to the My Site dashboard 
5. Tap the "Free domain with an annual plan" card
6. Select a domain
7. Expect a web view to open showing a list of plans (as noted above, once https://github.com/Automattic/wp-calypso/pull/77029 is merged this will show the correct list of plans)

## Regression Notes
1. Potential unintended areas of impact

This could break the existing Domain dashboard card or the older domain flow (My Site > Menu > Domains)

9. What I did to test those areas of impact (or what existing automated tests I relied on)

I did manual testing of the first few steps of the above to make sure they still work.

10. What automated tests I added (or what prevented me from doing so)

Given this step is a UI change, I think a UI test of the happy path of this flow could be the best option. This could be an update to `DashboardTests`. I'm not sure it's worthwhile to implement this before the feature flag is turned on, otherwise the test needs to turn the flag on before doing the test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
