### PR TITLE
Social: Show Twitter deprecation notice in Post Settings

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -150,6 +150,15 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
                                                 dispatch_group_leave(syncGroup);
                                             }];
 
+    SharingService *publicizeService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
+    dispatch_group_enter(syncGroup);
+    [publicizeService syncPublicizeServicesForBlog:blog success:^{
+        dispatch_group_leave(syncGroup);
+    } failure:^(NSError * _Nullable error) {
+        DDLogError(@"Failed syncing publicize services for blog %@: %@", blog.url, error);
+        dispatch_group_leave(syncGroup);
+    }];
+
     dispatch_group_enter(syncGroup);
     [remote getAllAuthorsWithSuccess:^(NSArray<RemoteUser *> *users) {
         [self updateMultiAuthor:users forBlog:blogObjectID];

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -204,7 +204,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     PublicizeConnection *connection = [[self connectionsForService] objectAtIndex:indexPath.row];
     cell.textLabel.text = connection.externalDisplay;
 
-    if ([connection requiresUserAction] && self.publicizeService.isSupported) {
+    if (![self.publicizeService isSupported]) {
+        cell.accessoryView = [WPStyleGuide sharingCellErrorAccessoryImageView];
+    } else if ([connection requiresUserAction]) {
         cell.accessoryView = [WPStyleGuide sharingCellWarningAccessoryImageView];
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -313,9 +313,14 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     cell.detailTextLabel.text = str;
 
+    if (![publicizer isSupported]) {
+        cell.accessoryView = [WPStyleGuide sharingCellErrorAccessoryImageView];
+        return;
+    }
+
     // Check if any of the connections are broken.
     for (PublicizeConnection *pubConn in connections) {
-        if ([pubConn requiresUserAction] && [publicizer.status isEqualToString:PublicizeService.defaultStatus]) {
+        if ([pubConn requiresUserAction]) {
             cell.accessoryView = [WPStyleGuide sharingCellWarningAccessoryImageView];
             break;
         }

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
@@ -11,13 +11,27 @@ extension WPStyleGuide {
     /// - Returns: A UIImageView
     ///
     @objc public class func sharingCellWarningAccessoryImageView() -> UIImageView {
-
         let imageSize = 20.0
         let horizontalPadding = 8.0
         let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: imageSize + horizontalPadding, height: imageSize))
 
         imageView.image = UIImage(named: "sharing-notice")
         imageView.tintColor = jazzyOrange()
+        imageView.contentMode = .right
+        return imageView
+    }
+
+    /// Create an UIImageView showing the notice gridicon.
+    ///
+    /// - Returns: A UIImageView
+    ///
+    @objc public class func sharingCellErrorAccessoryImageView() -> UIImageView {
+        let imageSize = 20.0
+        let horizontalPadding = 8.0
+        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: imageSize + horizontalPadding, height: imageSize))
+
+        imageView.image = UIImage(named: "sharing-notice")
+        imageView.tintColor = .systemRed
         imageView.contentMode = .right
         return imageView
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
@@ -7,6 +7,7 @@ typedef enum {
     PostSettingsSectionFeaturedImage,
     PostSettingsSectionStickyPost,
     PostSettingsSectionShare,
+    PostSettingsSectionDisabledTwitter, // NOTE: Clean up when Twitter has been removed from Publicize services.
     PostSettingsSectionGeolocation,
     PostSettingsSectionMoreOptions
 } PostSettingsSection;


### PR DESCRIPTION
Resolves #20674 and #20721 

This PR implements the Twitter deprecation notice in Post Settings. 

- To ensure that the PublicizeService is up to date, we'll also sync Publicize services when calling `syncBlogAndAllMetadata`. This is only temporary, though. We can remove the sync call once Twitter is fully removed.
- Tapping the Twitter account in Post Settings now brings you to the Share Detail screen. 
  - To account for changes when the user decides to disconnect, `setupPublicizeConnections` is called to ensure that the table rows are up to date after returning from Share Detail.

Some previews:

Before | After (with connections) | After (without connections)
-|-|-
![IMG_4520](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f68a186e-e67b-4658-8fee-2e9ba959465a) | ![after_with_conn](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/d03ff627-0777-484b-b811-166bbcf777a7) | ![after_without_conn](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/e4554600-f949-4bb6-8941-6080d8497e8e)

Additionally, based on p1684748137475819-slack-C05362VSXFU, I've added error icons in the Sharing & Sharing Connection screens. Here's another preview:

Sharing | Sharing Connection
-|-
![after_icon_sharing](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/3bb60280-20b8-4ef4-9778-ff025786d5f4) | ![after_icon_sharing_conn](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/62dcb5a7-c16a-45bb-b580-3ab4e3ab724b)

## To test

### Verifying changes in Post Settings

- Switch to a site where you have existing Twitter connections.
- Go to any post draft > tap the ellipsis menu > Post Settings.
- 🔎 Verify that the Twitter connections are displayed in a separate section, below Jetpack Social.
- Tap the Twitter account.
- 🔎 Verify that tapping the account brings you to the Sharing Detail screen.
- Switch to a site where you **don't** have any Twitter connections.
- Go to the Post Settings screen.
- 🔎 Verify that the Twitter section is not shown.

### Verifying icon updates in the Sharing screens

- Switch to a site where you have existing Twitter connections.
- Go to Site menu > Social.
- 🔎  Verify that the error icon is shown for the Twitter service.
- Tap the Twitter service.
- 🔎  Verify that the error icon is shown for all Twitter connections.

## Regression Notes
1. Potential unintended areas of impact
This PR affects the logic related to Jetpack Social in Post Settings.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)