### PR TITLE
Social: Track when Twitter notice footer link is tapped

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -483,6 +483,9 @@ import Foundation
     case directDomainsPurchaseDashboardCardTapped
     case directDomainsPurchaseDashboardCardHidden
 
+    // Jetpack Social - Twitter Deprecation Notice
+    case jetpackSocialTwitterNoticeLinkTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1313,6 +1316,10 @@ import Foundation
             return "direct_domains_purchase_dashboard_card_hidden"
         case .directDomainsPurchaseDashboardCardTapped:
             return "direct_domains_purchase_dashboard_card_tapped"
+
+        // Jetpack Social - Twitter Deprecation Notice
+        case .jetpackSocialTwitterNoticeLinkTapped:
+            return "twitter_notice_link_tapped"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TwitterDeprecationTableFooterView.swift
@@ -95,7 +95,7 @@ private extension TwitterDeprecationTableFooterView {
             return
         }
 
-        // TODO: Tracking
+        WPAnalytics.track(.jetpackSocialTwitterNoticeLinkTapped, properties: ["source": source])
 
         // Ideally this shouldn't be the responsibility of this class, but I'm keeping it simple since it's temporary.
         let webViewController = WebViewControllerFactory.controller(url: attachmentURL, source: source)


### PR DESCRIPTION
Resolves #20677 
Depends on #20723 

As titled, this PR implements tracking whenever the footer link is tapped.

## To test

- Launch the Jetpack app.
- Switch to a site with existing Twitter connections.
- Go to Site menu > Social.
- Tap 'Find out more' in the Sharing screen.
- 🔎 Verify that `🔵 Tracked: twitter_notice_link_tapped <source: social_connection_list>` is sent.
- Tap the Twitter service to go into the Sharing Connections screen.
- Tap 'Find out more'.
- 🔎 Verify that `🔵 Tracked: twitter_notice_link_tapped <source: social_connection_detail>` is sent.
- Go back to Site menu > Posts > Drafts and go to Post Settings.
- Tap 'Find out more'.
- 🔎 Verify that `🔵 Tracked: twitter_notice_link_tapped <source: post_settings>` is sent.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
