### PR TITLE
Plans on JP: Use a single modal for the entire flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -17,7 +17,9 @@ import UIKit
         let planSelected = { checkoutURL in
             let viewModel = CheckoutViewModel(url: checkoutURL)
             let checkoutViewController = CheckoutViewController(viewModel: viewModel)
-            navigationController.pushViewController(checkoutViewController, animated: true)
+            checkoutViewController.configureSandboxStore {
+                navigationController.pushViewController(checkoutViewController, animated: true)
+            }
 
             PlansTracker.trackCheckoutWebViewViewed(source: "plan_selection")
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -12,14 +12,16 @@ import UIKit
             includeSupportButton: false
         )
 
+        let navigationController = UINavigationController(rootViewController: domainSuggestionsViewController)
+
         domainSuggestionsViewController.domainAddedToCartCallback = {
             guard let viewModel = PlanSelectionViewModel(blog: blog) else { return }
             let planSelectionViewController = PlanSelectionViewController(viewModel: viewModel)
-            domainSuggestionsViewController.show(planSelectionViewController, sender: nil)
+            navigationController.pushViewController(planSelectionViewController, animated: true)
 
             PlansTracker.trackPlanSelectionWebViewViewed(.domainAndPlanPackage, source: "domains_register")
         }
 
-        dashboardViewController.show(domainSuggestionsViewController, sender: nil)
+        dashboardViewController.present(navigationController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -14,13 +14,23 @@ import UIKit
 
         let navigationController = UINavigationController(rootViewController: domainSuggestionsViewController)
 
-        domainSuggestionsViewController.domainAddedToCartCallback = {
+        let planSelected = { checkoutURL in
+            let viewModel = CheckoutViewModel(url: checkoutURL)
+            let checkoutViewController = CheckoutViewController(viewModel: viewModel)
+            navigationController.pushViewController(checkoutViewController, animated: true)
+
+            PlansTracker.trackCheckoutWebViewViewed(source: "plan_selection")
+        }
+
+        let domainAddedToCart = {
             guard let viewModel = PlanSelectionViewModel(blog: blog) else { return }
             let planSelectionViewController = PlanSelectionViewController(viewModel: viewModel)
+            planSelectionViewController.planSelectedCallback = planSelected
             navigationController.pushViewController(planSelectionViewController, animated: true)
 
             PlansTracker.trackPlanSelectionWebViewViewed(.domainAndPlanPackage, source: "domains_register")
         }
+        domainSuggestionsViewController.domainAddedToCartCallback = domainAddedToCart
 
         dashboardViewController.present(navigationController, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/CheckoutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/CheckoutViewController.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+struct CheckoutViewModel {
+    let url: URL
+}
+
+final class CheckoutViewController: WebKitViewController {
+    let viewModel: CheckoutViewModel
+
+    init(viewModel: CheckoutViewModel) {
+        self.viewModel = viewModel
+
+        let configuration = WebViewControllerConfiguration(url: viewModel.url)
+        configuration.authenticateWithDefaultAccount()
+        configuration.secureInteraction = true
+        super.init(configuration: configuration)
+    }
+
+    // MARK: - Required Init
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -47,7 +47,6 @@ class DomainSuggestionsTableViewController: UITableViewController {
     }
 
     private var noResultsViewController: NoResultsViewController?
-    private var siteTitleSuggestions: [FullyQuotedDomainSuggestion] = []
     private var searchSuggestions: [FullyQuotedDomainSuggestion] = [] {
         didSet {
             tableView.reloadSections(IndexSet(integer: Sections.suggestions.rawValue), with: .automatic)
@@ -99,15 +98,12 @@ class DomainSuggestionsTableViewController: UITableViewController {
 
         // only procede with initial search if we don't have site title suggestions yet
         // (hopefully only the first time)
-        guard siteTitleSuggestions.count < 1,
+        guard searchSuggestions.count < 1,
             let nameToSearch = siteName else {
             return
         }
 
-        suggestDomains(for: nameToSearch) { [weak self] (suggestions) in
-            self?.siteTitleSuggestions = suggestions
-            self?.tableView.reloadSections(IndexSet(integer: Sections.suggestions.rawValue), with: .automatic)
-        }
+        suggestDomains(for: nameToSearch)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -128,7 +124,7 @@ class DomainSuggestionsTableViewController: UITableViewController {
     /// - Parameters:
     ///   - searchTerm: string to base suggestions on
     ///   - addSuggestions: function to call when results arrive
-    private func suggestDomains(for searchTerm: String, addSuggestions: @escaping (_: [FullyQuotedDomainSuggestion]) ->()) {
+    private func suggestDomains(for searchTerm: String) {
         guard !isSearching else {
             return
         }
@@ -213,7 +209,7 @@ extension DomainSuggestionsTableViewController {
             if noSuggestions == true {
                 return 1
             }
-            return searchSuggestions.count > 0 ? searchSuggestions.count : siteTitleSuggestions.count
+            return searchSuggestions.count
         default:
             return 0
         }
@@ -233,11 +229,7 @@ extension DomainSuggestionsTableViewController {
                 cell = noResultsCell()
             } else {
                 let suggestion: FullyQuotedDomainSuggestion
-                if searchSuggestions.count > 0 {
-                    suggestion = searchSuggestions[indexPath.row]
-                } else {
-                    suggestion = siteTitleSuggestions[indexPath.row]
-                }
+                suggestion = searchSuggestions[indexPath.row]
                 cell = suggestionCell(suggestion)
             }
         }
@@ -497,11 +489,7 @@ extension DomainSuggestionsTableViewController {
 
         switch indexPath.section {
         case Sections.suggestions.rawValue:
-            if searchSuggestions.count > 0 {
-                selectedDomain = searchSuggestions[indexPath.row]
-            } else {
-                selectedDomain = siteTitleSuggestions[indexPath.row]
-            }
+            selectedDomain = searchSuggestions[indexPath.row]
         default:
             return
         }
@@ -541,9 +529,7 @@ extension DomainSuggestionsTableViewController: SearchTableViewCellDelegate {
             return
         }
 
-        suggestDomains(for: searchTerm) { [weak self] (suggestions) in
-            self?.searchSuggestions = suggestions
-        }
+        suggestDomains(for: searchTerm)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -344,25 +344,8 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
 
         WPAnalytics.track(.domainsPurchaseWebviewViewed, properties: WPAnalytics.domainsProperties(for: site), blog: site)
 
-        if let storeSandboxCookie = (HTTPCookieStorage.shared.cookies?.first {
-
-            $0.properties?[.name] as? String == Constants.storeSandboxCookieName &&
-            $0.properties?[.domain] as? String == Constants.storeSandboxCookieDomain
-        }) {
-            // this code will only run if a store sandbox cookie has been set
-            let webView = webViewController.webView
-            let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
-            cookieStore.getAllCookies { [weak self] cookies in
-
-                    var newCookies = cookies
-                    newCookies.append(storeSandboxCookie)
-
-                    cookieStore.setCookies(newCookies) {
-                        self?.present(navController, animated: true)
-                    }
-            }
-        } else {
-            present(navController, animated: true)
+        webViewController.configureSandboxStore { [weak self] in
+            self?.present(navController, animated: true)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Utility/WebKitViewController+SandboxStore.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Utility/WebKitViewController+SandboxStore.swift
@@ -1,0 +1,30 @@
+import UIKit
+import WebKit
+
+extension WebKitViewController {
+    func configureSandboxStore(_ completion: @escaping () -> Void) {
+        let storeSandboxCookieName = "store_sandbox"
+        let storeSandboxCookieDomain = ".wordpress.com"
+
+        if let storeSandboxCookie = (HTTPCookieStorage.shared.cookies?.first {
+
+            $0.properties?[.name] as? String == storeSandboxCookieName &&
+            $0.properties?[.domain] as? String == storeSandboxCookieDomain
+        }) {
+            // this code will only run if a store sandbox cookie has been set
+            let webView = self.webView
+            let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+            cookieStore.getAllCookies { cookies in
+
+                    var newCookies = cookies
+                    newCookies.append(storeSandboxCookie)
+
+                    cookieStore.setCookies(newCookies) {
+                        completion()
+                    }
+            }
+        } else {
+            completion()
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -171,6 +171,8 @@
 		0147D651294B6EA600AA6410 /* StatsRevampStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0147D650294B6EA600AA6410 /* StatsRevampStoreTests.swift */; };
 		0148CC292859127F00CF5D96 /* StatsWidgetsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */; };
 		0148CC2B2859C87000CF5D96 /* BlogServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */; };
+		014ACD142A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */; };
+		014ACD152A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */; };
 		015BA4EB29A788A300920F4B /* StatsTotalInsightsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */; };
 		01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
 		01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
@@ -5809,6 +5811,7 @@
 		0147D650294B6EA600AA6410 /* StatsRevampStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRevampStoreTests.swift; sourceTree = "<group>"; };
 		0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsStoreTests.swift; sourceTree = "<group>"; };
 		0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceMock.swift; sourceTree = "<group>"; };
+		014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebKitViewController+SandboxStore.swift"; sourceTree = "<group>"; };
 		015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTotalInsightsCellTests.swift; sourceTree = "<group>"; };
 		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
@@ -11108,6 +11111,7 @@
 			children = (
 				3F3DD0B526FD18EB00F5F121 /* Blog+DomainsDashboardView.swift */,
 				175CC16F2720548700622FB4 /* DomainExpiryDateFormatter.swift */,
+				014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -21745,6 +21749,7 @@
 				E66EB6F91C1B7A76003DABC5 /* ReaderSpacerView.swift in Sources */,
 				AE2F3125270B6DA000B2A9C2 /* Scanner+QuotedText.swift in Sources */,
 				B560914C208A671F00399AE4 /* WPStyleGuide+SiteCreation.swift in Sources */,
+				014ACD142A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */,
 				B0960C8727D14BD400BC9717 /* SiteIntentStep.swift in Sources */,
 				9801E682274EEBC4002FDDB6 /* ReaderDetailCommentsHeader.swift in Sources */,
 				C352870527FDD35C004E2E51 /* SiteNameStep.swift in Sources */,
@@ -25260,6 +25265,7 @@
 				FABB25792602FC2C00C8785C /* Blog+Files.swift in Sources */,
 				FABB257A2602FC2C00C8785C /* RevisionDiffsBrowserViewController.swift in Sources */,
 				46F583AE2624CE790010A723 /* BlockEditorSettingElement+CoreDataClass.swift in Sources */,
+				014ACD152A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */,
 				80D9CFF829E5010300FE3400 /* PagesCardViewModel.swift in Sources */,
 				FADFBD3C265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift in Sources */,
 				FABB257B2602FC2C00C8785C /* WPAccount.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		011F52C92A16551A00B04114 /* FreeToPaidPlansCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52C72A16551A00B04114 /* FreeToPaidPlansCoordinator.swift */; };
 		011F52D32A1B84FF00B04114 /* PlansTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52D22A1B84FF00B04114 /* PlansTracker.swift */; };
 		011F52D42A1B84FF00B04114 /* PlansTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52D22A1B84FF00B04114 /* PlansTracker.swift */; };
+		011F52DA2A1CA53300B04114 /* CheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52D92A1CA53300B04114 /* CheckoutViewController.swift */; };
+		011F52DB2A1CA53300B04114 /* CheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011F52D92A1CA53300B04114 /* CheckoutViewController.swift */; };
 		01281E9A2A0456CB00464F8F /* DomainsSuggestionsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */; };
 		01281E9C2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
 		01281E9D2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */; };
@@ -5798,6 +5800,7 @@
 		011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansDashboardCardHelperTests.swift; sourceTree = "<group>"; };
 		011F52C72A16551A00B04114 /* FreeToPaidPlansCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeToPaidPlansCoordinator.swift; sourceTree = "<group>"; };
 		011F52D22A1B84FF00B04114 /* PlansTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlansTracker.swift; sourceTree = "<group>"; };
+		011F52D92A1CA53300B04114 /* CheckoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutViewController.swift; sourceTree = "<group>"; };
 		01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsSuggestionsScreen.swift; sourceTree = "<group>"; };
 		01281E9B2A051EEA00464F8F /* MenuNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuNavigationTests.swift; sourceTree = "<group>"; };
 		0141929B2983F0A300CAEDB0 /* SupportConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportConfiguration.swift; sourceTree = "<group>"; };
@@ -11887,6 +11890,7 @@
 				43D74AD220FB5A82004AD934 /* Views */,
 				F47E154929E84A9300B6E426 /* DomainPurchasingWebFlowController.swift */,
 				B07F133D2A16C69800AF7FCF /* PlanSelectionViewController.swift */,
+				011F52D92A1CA53300B04114 /* CheckoutViewController.swift */,
 			);
 			path = "Domain registration";
 			sourceTree = "<group>";
@@ -21219,6 +21223,7 @@
 				088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */,
 				C3C2F84828AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift in Sources */,
 				F181EDE526B2AC7200C61241 /* BackgroundTasksCoordinator.swift in Sources */,
+				011F52DA2A1CA53300B04114 /* CheckoutViewController.swift in Sources */,
 				8B93412F257029F60097D0AC /* FilterChipButton.swift in Sources */,
 				40A71C68220E1952002E3D25 /* StatsRecordValue+CoreDataClass.swift in Sources */,
 				4A1E77C6298897F6006281CC /* SharingSyncService.swift in Sources */,
@@ -24945,6 +24950,7 @@
 				FABB24972602FC2C00C8785C /* JetpackLoginViewController.swift in Sources */,
 				DC772AF2282009BA00664C02 /* InsightsLineChart.swift in Sources */,
 				176CE91727FB44C100F1E32B /* StatsBaseCell.swift in Sources */,
+				011F52DB2A1CA53300B04114 /* CheckoutViewController.swift in Sources */,
 				934098C12719577D00B3E77E /* InsightType.swift in Sources */,
 				FABB24992602FC2C00C8785C /* StreakStatsRecordValue+CoreDataProperties.swift in Sources */,
 				46F583AA2624CE790010A723 /* BlockEditorSettings+CoreDataClass.swift in Sources */,


### PR DESCRIPTION
Fixes #20727

- [x] On the entry point into this the Plans on JP flow, use a modal screen to house the Domains screen.
- [x] Make the transition from the Domains screen to the Plans screen a push transition within the same modal (similar to the flow in the app after you tap the profile button and then tap My Profile and the app transitions to the next screen). Change the X close button to a Back button to account for this.
- [x] Use a push transition from the Plans screen to the Checkout screen and use a Back button on the Checkout screen to show users they can go back to Plans.

## Technical details

The potentially tricky part is to make a native push navigation from Plans to Checkout view. It required me to manually stop the web view Plans page from navigating to the Checkout page, and instead push a new ViewController that presents Checkout. That allows to come back natively from Checkout to Plans views.

## To test:

On both iPad and iPhone:

1. Use free .com account
2. Enable `Free to Paid Plans Dashboard Card` feature flag
3. Select a card
4. Confirm that domain selection appears modally, and "Cancel" closes the domain selection
5. Select a domain
6. Confirm that Plans view is pushed into navigation stack, and "Back" comes back to Domain view
7. Select a plan
8. Confirm that Checkout view is pushed into navigation stack, and "Back" comes back to Plans view

## Regression Notes
1. Potential unintended areas of impact

I did some refactoring on the Domain selection view that could unintentionally break domain selection flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Code analysis (I removed the unused code) and manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)


## Videos

ℹ️ Note, "< Back" navigation will disappear from within the web view once https://github.com/Automattic/wp-calypso/pull/77029 is merged

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/49129ecd-06d0-4473-b110-60b7dde7a86f

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/25b8f8ac-4e93-4261-ad46-8b41c37df80d
