### PR TITLE
Plans on JP: Success view

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
@@ -41,7 +41,7 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
         title.textAlignment = .center
         title.font = WPStyleGuide.serifFontForTextStyle(.largeTitle)
         title.textColor = .white
-        title.text = TextContent.title
+        title.text = TextContent.titleString
         title.adjustsFontForContentSizeCategory = true
         return title
     }()
@@ -186,7 +186,7 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
     }
 
     private func makeDomainDetailsString(domain: String) -> String {
-        String(format: TextContent.domainDetailsString, domain)
+        String(format: TextContent.descriptionString, domain)
     }
 
     // MARK: - Actions
@@ -200,9 +200,9 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
     private let subtitleFont = UIFont.preferredFont(forTextStyle: .title3)
 
     private enum TextContent {
-        static let title = NSLocalizedString("Congratulations on your purchase!", comment: "Title of domain name purchase success screen")
-        static let domainDetailsString = NSLocalizedString("Your new domain %@ is being set up. It may take up to 30 minutes for your domain to start working.",
-                                                           comment: "Details about recently acquired domain on domain credit redemption success screen")
+        static let titleString = NSLocalizedString("domainPurchase.success.title", value: "All ready to go!", comment: "Title of domain name purchase success screen")
+        static let descriptionString = NSLocalizedString("domainPurchase.success.description", value: "Your new domain %1$@ is being set up.", comment: "Description of the recently acquired domain.")
+        static let activationString = NSLocalizedString("domainPurchase.success.activationDetails", value: "It may take up to 30 minutes for your domain to start working properly", comment: "Explanation of the time it takes for domain to start working after the purchase")
         static let doneButtonTitle = NSLocalizedString("Done",
                                                        comment: "Done button title")
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
@@ -89,6 +89,36 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
         return view
     }()
 
+    private lazy var informationStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = Metrics.stackViewSpacing
+        stackView.alignment = .fill
+        stackView.backgroundColor = UIColor.secondarySystemBackground
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = Metrics.informationViewMargins
+        stackView.layer.cornerRadius = 8
+
+        let infoIconImage = UIImage(systemName: "info.circle")?.withTintColor(.textSubtle, renderingMode: .alwaysOriginal)
+        let infoIconImageView = UIImageView(image: infoIconImage)
+        infoIconImageView.contentMode = .scaleAspectFit
+        infoIconImageView.frame = CGRect(origin: .zero, size: Metrics.iconImageSize)
+
+        let informationLabel = UILabel()
+        informationLabel.translatesAutoresizingMaskIntoConstraints = false
+        informationLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
+        informationLabel.adjustsFontForContentSizeCategory = true
+        informationLabel.adjustsFontSizeToFitWidth = true
+        informationLabel.numberOfLines = 0
+        informationLabel.textColor = .textSubtle
+        informationLabel.text = TextContent.informationString
+
+        stackView.addArrangedSubviews([infoIconImageView, informationLabel])
+
+        return stackView
+    }()
+
     // MARK: - View lifecycle
 
     init(domain: String, continueButtonPressed: @escaping (String) -> Void) {
@@ -120,7 +150,9 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
     }
 
     private func setupViewHierarchy() {
-        stackView.addArrangedSubviews([illustration, titleLabel, subtitleLabel])
+        stackView.addArrangedSubviews([illustration, titleLabel, subtitleLabel, informationStackView])
+        stackView.setCustomSpacing(Metrics.stackViewSpacing * 2, after: illustration)
+        stackView.setCustomSpacing(Metrics.stackViewSpacing * 2, after: subtitleLabel)
         stackViewContainer.addSubview(stackView)
         scrollView.addSubview(stackViewContainer)
         view.addSubview(scrollView)
@@ -188,7 +220,7 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
     private enum TextContent {
         static let titleString = NSLocalizedString("domainPurchase.success.title", value: "All ready to go!", comment: "Title of domain name purchase success screen")
         static let descriptionString = NSLocalizedString("domainPurchase.success.description", value: "Your new domain %1$@ is being set up.", comment: "Description of the recently acquired domain.")
-        static let activationString = NSLocalizedString("domainPurchase.success.activationDetails", value: "It may take up to 30 minutes for your domain to start working properly", comment: "Explanation of the time it takes for domain to start working after the purchase")
+        static let informationString = NSLocalizedString("domainPurchase.success.information", value: "It may take up to 30 minutes for your domain to start working properly", comment: "Explanation of the time it takes for domain to start working after the purchase")
         static let doneButtonTitle = NSLocalizedString("Done",
                                                        comment: "Done button title")
     }
@@ -198,6 +230,8 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
         static let buttonControllerMinHeight: CGFloat = 84.0
         static let edgePadding: CGFloat = 20.0
         static let doneButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        static let informationViewMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        static let iconImageSize = CGSize(width: 24, height: 24)
     }
 
     private enum Accessibility {

--- a/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
@@ -36,23 +36,24 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
 
     private lazy var titleLabel: UILabel = {
         let title = UILabel()
-        title.numberOfLines = 0
-        title.lineBreakMode = .byWordWrapping
-        title.textAlignment = .center
-        title.font = WPStyleGuide.serifFontForTextStyle(.largeTitle)
-        title.textColor = .white
-        title.text = TextContent.titleString
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.font = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .bold)
         title.adjustsFontForContentSizeCategory = true
+        title.adjustsFontSizeToFitWidth = true
+        title.numberOfLines = 0
+        title.textColor = .text
+        title.text = TextContent.titleString
         return title
     }()
 
     private lazy var subtitleLabel: UILabel = {
         let subtitle = UILabel()
-        subtitle.numberOfLines = 0
-        subtitle.lineBreakMode = .byWordWrapping
-        subtitle.textAlignment = .center
-        subtitle.textColor = .white
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+        subtitle.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         subtitle.adjustsFontForContentSizeCategory = true
+        subtitle.adjustsFontSizeToFitWidth = true
+        subtitle.numberOfLines = 0
+        subtitle.textColor = .text
 
         let subtitleText = makeDomainDetailsString(domain: domain)
         subtitle.attributedText = applyDomainStyle(to: subtitleText, domain: domain)
@@ -68,14 +69,14 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
 
     private lazy var doneButton: FancyButton = {
         let button = FancyButton()
-        button.isPrimary = true
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(TextContent.doneButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(doneButtonTapped), for: .touchUpInside)
-        button.isPrimary = false
+        button.isPrimary = true
+        button.primaryNormalBackgroundColor = .jetpackGreen
+        button.primaryHighlightBackgroundColor = .muriel(color: .jetpackGreen, .shade80)
         button.accessibilityIdentifier = Accessibility.doneButtonIdentifier
         button.accessibilityHint = Accessibility.doneButtonHint
-        button.secondaryNormalBackgroundColor = UIColor(light: .white, dark: .muriel(name: .blue, .shade40))
         return button
     }()
 
@@ -87,14 +88,6 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
         view.setContentHuggingPriority(.defaultHigh, for: .vertical)
         return view
     }()
-
-    private lazy var divider: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = UIColor(white: 1.0, alpha: 0.3)
-        return view
-    }()
-
 
     // MARK: - View lifecycle
 
@@ -119,8 +112,7 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.view.backgroundColor = UIColor(light: .primary, dark: .secondarySystemBackground)
-
+        view.backgroundColor = .basicBackground
         navigationController?.setNavigationBarHidden(true, animated: false)
 
         setupViewHierarchy()
@@ -133,7 +125,6 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
         scrollView.addSubview(stackViewContainer)
         view.addSubview(scrollView)
         view.addSubview(doneButtonContainer)
-        view.addSubview(divider)
     }
 
     private func configureConstraints() {
@@ -161,11 +152,6 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
             doneButtonContainer.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor),
             doneButtonContainer.bottomAnchor.constraint(equalTo: view.safeBottomAnchor),
             doneButtonContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.buttonControllerMinHeight),
-
-            divider.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            divider.bottomAnchor.constraint(equalTo: doneButtonContainer.topAnchor),
-            divider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth)
         ])
     }
 


### PR DESCRIPTION
Fixes #20690

Editing the existing `DomainCreditRedemptionSuccessViewController`, since it has exactly the same copy and serves the same purpose.

⚠️ Still in progress. Missing functionality based on criteria:
- [x] Update fonts, spacing, and colors
- [x] Update copy
- [x] Add an informational container
- [ ] Change the top image
- [ ] Rename the class to better explain the purpose
- [ ] Integrate into the checkout view
- [ ] Complete UI Changes checklist

## To test:

TBD

## Regression Notes
1. Potential unintended areas of impact

Since already existing `DomainCreditRedemptionSuccessViewController` is edited, we need to make sure this success view continues to work in other flows.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

TBD

3. What automated tests I added (or what prevented me from doing so)

TBD

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
