### PR TITLE
Plans on JP: Add analytics event source for domain selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -10,6 +10,17 @@ enum DomainSelectionType {
     case purchaseSeparately
 }
 
+private extension DomainSelectionType {
+    var analyticsSource: String {
+        switch self {
+        case .purchaseWithPaidPlan:
+            return "plan_selection"
+        case .registerWithPaidPlan, .purchaseSeparately:
+            return "domains_register"
+        }
+    }
+}
+
 class RegisterDomainSuggestionsViewController: UIViewController {
     @IBOutlet weak var buttonContainerBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var buttonContainerViewHeightConstraint: NSLayoutConstraint!
@@ -218,7 +229,9 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
             return
         }
 
-        WPAnalytics.track(.domainsSearchSelectDomainTapped, properties: WPAnalytics.domainsProperties(for: site), blog: site)
+        var properties = WPAnalytics.domainsProperties(for: site)
+        properties["source"] = domainSelectionType.analyticsSource
+        WPAnalytics.track(.domainsSearchSelectDomainTapped, properties: properties, blog: site)
 
         switch domainSelectionType {
         case .registerWithPaidPlan:


### PR DESCRIPTION
Fixes #20692

## To test

### "Free domain with annual plan" card 
1. Log into free WP.com site and enable `Free to Paid plans dashboard card` feature flag
2. Expect `domains_dashboard_select_domain_tapped` with event property `source: plan_selection` when domain selection is confirmed

Sample app log: 
```
🔵 Tracked: domains_dashboard_select_domain_tapped <blog_id: 217356180, origin: menu, site_type: blog, source: plan_selection, using_credit: false>
```

### "Find a custom domain" card
1. Log into free WP.com site and enable `Domains Dashboard Card` feature flag
2. Expect `domains_dashboard_select_domain_tapped` with event property `source: domains_register` when domain selection is confirmed

Sample app log: 
```
🔵 Tracked: domains_dashboard_select_domain_tapped <blog_id: 217356180, origin: menu, site_type: blog, source: domains_register, using_credit: false>
```


## Regression Notes
1. Potential unintended areas of impact: **At most, analytics on the domain selection screen could break**
2. What I did to test those areas of impact (or what existing automated tests I relied on): **Manually going through the various domain purchase flows and verifying analytics events are logged correctly**
4. What automated tests I added (or what prevented me from doing so): **We're not adding tests for analytics events at the moment**

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: Not applicable
