### PR TITLE
Fix crash when initializing SupportTableViewController from WPError alert

### DIFF
--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -136,7 +136,7 @@ NSInteger const SupportButtonIndex = 0;
             UIAlertAction *action = [UIAlertAction actionWithTitle:supportText
                                                              style:UIAlertActionStyleCancel
                                                            handler:^(UIAlertAction * _Nonnull __unused action) {
-                                                               SupportTableViewController *supportVC = [SupportTableViewController new];
+                                                               SupportTableViewController *supportVC = [[SupportTableViewController alloc] init];
                                                                [supportVC showFromTabBar];
                                                                [WPError internalInstance].alertShowing = NO;
                                                            }];

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -33,9 +33,13 @@ class SupportTableViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    required convenience init(dismissTapped: (() -> ())? = nil) {
-        self.init(style: .grouped)
+    required convenience init(dismissTapped: (() -> ())?) {
+        self.init(configuration: .init(), style: .grouped)
         self.dismissTapped = dismissTapped
+    }
+
+    @objc public convenience init() {
+        self.init(configuration: .init(), style: .grouped)
     }
 
     // MARK: - View


### PR DESCRIPTION
Fixes #20733

## Description

When initializing SupportTableViewController from an Obj-C file, `self.init(style:)` was being invoked causing the app to crash.

To resolve this issue I've defined a convenience init with an objc annotation, which calls `self.init(configuration: style:)` under the hood.

## How to test

1. Switch to trunk
2. In MeViewController, replace L274-277 with the following:
``` swift
WPError.showAlert(withTitle: "title", message: "message", withSupportButton: true)
```
3. Run the app
4. Go to Me > Help & Support > Need Help?
5. ✅ The app crashes
6. Switch to this branch
7. Run the app
8. Go to Me > Help & Support > Need Help?
9. ✅ The support screen is displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

10. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
