### PR TITLE
Cover more user paths where UI tests ask to save password

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -87,6 +87,8 @@ public class LoginUsernamePasswordScreen: ScreenObject {
             passwordTextField.typeText(password)
         }
         nextButton.tap()
+
+        app.dismissSavePasswordPrompt()
     }
 
     private func dismissQuickStartPromptIfNeeded() throws {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -15,6 +15,8 @@ public class PasswordScreen: ScreenObject {
     public func proceedWithValidPassword() throws -> LoginEpilogueScreen {
         try tryProceed(password: "pw")
 
+        app.dismissSavePasswordPrompt()
+
         return try LoginEpilogueScreen()
     }
 
@@ -48,12 +50,7 @@ public class PasswordScreen: ScreenObject {
         let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
 
-        // The Simulator might ask to save the password which, of course, we don't want to do
-        if app.buttons["Save Password"].waitForExistence(timeout: 5) {
-            // There should be no need to wait for this button to exist since it's part of the same
-            // alert where "Save Password" is.
-            app.buttons["Not Now"].tap()
-        }
+        app.dismissSavePasswordPrompt()
     }
 
     public func verifyLoginError() -> PasswordScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -25,6 +25,8 @@ public class PrologueScreen: ScreenObject {
     public func selectContinue() throws -> GetStartedScreen {
         continueButton.tap()
 
+        app.dismissSavePasswordPrompt()
+
         return try GetStartedScreen()
     }
 

--- a/WordPress/UITestsFoundation/XCUIApplication+SavePassword.swift
+++ b/WordPress/UITestsFoundation/XCUIApplication+SavePassword.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+extension XCUIApplication {
+
+    // Starting with iOS 16.4, the Simulator might ask to save the password with a modal sheet.
+    // This method encapsulates the logic to dimiss the prompt.
+    func dismissSavePasswordPrompt() {
+        XCTContext.runActivity(named: "Dismiss save password prompt if needed.") { _ in
+            guard buttons["Save Password"].waitForExistence(timeout: 5) else { return  }
+
+            // There should be no need to wait for this button to exist since it's part of the same
+            // alert where "Save Password" is.
+            buttons["Not Now"].tap()
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -813,6 +813,7 @@
 		3F685B6A26D431FA001C6808 /* DomainSuggestionViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAF9CC426D03C7400268EA2 /* DomainSuggestionViewControllerWrapper.swift */; };
 		3F6975FF242D941E001F1807 /* ReaderTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6975FE242D941E001F1807 /* ReaderTabViewModel.swift */; };
 		3F6A7E92251BC1DC005B6A61 /* RootViewCoordinator+WhatIsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6A7E91251BC1DC005B6A61 /* RootViewCoordinator+WhatIsNew.swift */; };
+		3F6A8CE02A246357009DBC2B /* XCUIApplication+SavePassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6A8CDF2A246357009DBC2B /* XCUIApplication+SavePassword.swift */; };
 		3F6AD0562502A91400080F3B /* AnnouncementsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6AD0552502A91400080F3B /* AnnouncementsCache.swift */; };
 		3F6BC04B25B2474C007369D3 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		3F6BC05C25B24773007369D3 /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A09B98238FE13B0022AE0D /* FeatureFlagOverrideStore.swift */; };
@@ -6498,6 +6499,7 @@
 		3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewController.swift; sourceTree = "<group>"; };
 		3F6975FE242D941E001F1807 /* ReaderTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewModel.swift; sourceTree = "<group>"; };
 		3F6A7E91251BC1DC005B6A61 /* RootViewCoordinator+WhatIsNew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RootViewCoordinator+WhatIsNew.swift"; sourceTree = "<group>"; };
+		3F6A8CDF2A246357009DBC2B /* XCUIApplication+SavePassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+SavePassword.swift"; sourceTree = "<group>"; };
 		3F6AD0552502A91400080F3B /* AnnouncementsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsCache.swift; sourceTree = "<group>"; };
 		3F6DA04025646F96002AB88F /* HomeWidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetData.swift; sourceTree = "<group>"; };
 		3F720C2028899DD900519938 /* JetpackBrandingVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingVisibility.swift; sourceTree = "<group>"; };
@@ -11504,6 +11506,7 @@
 				3FA640592670CCD40064401E /* UITestsFoundation.h */,
 				3F762E9426784B540088CD45 /* WireMock.swift */,
 				3F107B1829B6F7E0009B3658 /* XCTestCase+Utils.swift */,
+				3F6A8CDF2A246357009DBC2B /* XCUIApplication+SavePassword.swift */,
 				3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */,
 				3F762E9A26784D2A0088CD45 /* XCUIElement+Utils.swift */,
 				3F762E9826784CC90088CD45 /* XCUIElementQuery+Utils.swift */,
@@ -22779,6 +22782,7 @@
 				3F2F855D26FAF227000FCDA5 /* LoginCheckMagicLinkScreen.swift in Sources */,
 				EA78189427596B2F00554DFA /* ContactUsScreen.swift in Sources */,
 				D82E087829EEB7AF0098F500 /* DomainsScreen.swift in Sources */,
+				3F6A8CE02A246357009DBC2B /* XCUIApplication+SavePassword.swift in Sources */,
 				3F2F855626FAF227000FCDA5 /* LoginEmailScreen.swift in Sources */,
 				FA9276AF2888557500C323BB /* SiteIntentScreen.swift in Sources */,
 				3FE39A3926F837E1006E2B3A /* ActivityLogScreen.swift in Sources */,


### PR DESCRIPTION
@jostnes and @tiagomar have done great work recently tidying up UI tests. Still, I keep experiencing CI failures. _Maybe I'm jinxed_ 😅 

For example, I was doing [experiments](https://github.com/wordpress-mobile/WordPress-iOS/pull/20834) to try understand what could have introduced all the "could not launch app" CI logs and I got a [string of failures](https://buildkite.com/automattic/wordpress-ios/builds?branch=mokagio%2Fdisable-ui-tests-parallelism). These changes were the only ones that resulted in a green build.

Note: I didn't try more launches. Given I've only experienced failures recently, this seems like an improvement already.

Keen to hear what you think!

