### PR TITLE
[UI Test] Removed `tabBar` init from redesigned Domains Suggestions Screen

### DIFF
--- a/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
@@ -2,7 +2,6 @@ import ScreenObject
 import XCTest
 
 public class DomainsSuggestionsScreen: ScreenObject {
-    public let tabBar: TabNavComponent
 
     let siteDomainsNavbarHeaderGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Search domains"]
@@ -11,8 +10,6 @@ public class DomainsSuggestionsScreen: ScreenObject {
     var siteDomainsNavbarHeader: XCUIElement { siteDomainsNavbarHeaderGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        tabBar = try TabNavComponent()
-
         try super.init(
             expectedElementGetters: [ siteDomainsNavbarHeaderGetter ],
             app: app,


### PR DESCRIPTION
### Description

#20728 updates `testFreeToPaidCardNavigation` UI test, and includes an assertion for the screen that looked like this:

<img width="323" alt="Screenshot 2023-05-29 at 16 59 04" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/73365754/b0e66262-3cae-4915-ba6b-82d6d08eb183">

However, before #20728 was merged, another PR #20731 that redesigns this screen was merged to `trunk`:

<img width="325" alt="Screenshot 2023-05-29 at 16 59 45" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/73365754/990aa6ea-aadb-47d5-a6d6-75fc4d00cf3b">

As can be seen, the newer design uses an overlay style and makes the bottom navigation bar overlapped. Once #20728 was merged to `trunk` too, the test began to fail consistently, because `DomainsSuggestionsScreen` was initializing the `tabBar`, which no longer was visible in the app. The PR simply removes `tabBar` from screen `init`.


### To test
- CI is green.