### PR TITLE
Use Xcode 14.3.1-rc.1 in pipeline that runs UI tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-14.3
+    IMAGE_ID: xcode-14.3.1-rc.1
 
 # This is the default pipeline – it will build and test the app
 steps:


### PR DESCRIPTION
This was a test to see if using the new Xcode image addressed what looks like a UI tests error. It did not.