### PR TITLE
Catch Objective-C exceptions from Core Data object query

### DIFF
--- a/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
@@ -2,7 +2,6 @@ import ScreenObject
 import XCTest
 
 public class DomainsSuggestionsScreen: ScreenObject {
-    public let tabBar: TabNavComponent
 
     let siteDomainsNavbarHeaderGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Search domains"]
@@ -11,8 +10,6 @@ public class DomainsSuggestionsScreen: ScreenObject {
     var siteDomainsNavbarHeader: XCUIElement { siteDomainsNavbarHeaderGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        tabBar = try TabNavComponent()
-
         try super.init(
             expectedElementGetters: [ siteDomainsNavbarHeaderGetter ],
             app: app,


### PR DESCRIPTION
Another attempt in fixing https://github.com/wordpress-mobile/WordPress-iOS/issues/20630.

I'm still not sure what's the root cause of the `nil is not a valid object ID` error. But catching the Objective-C exception _should_ prevent the app from crashing.

## Test Instructions

Open a few posts that have images from the post editor. Make sure images can be loaded.

## Regression Notes
1. Potential unintended areas of impact
None. The refactored `loadObject` function wasn't used anywhere, except the unit tests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What says in the "Test Instructions"

3. What automated tests I added (or what prevented me from doing so)
The existing ones have been updated.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ]x I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: **N/A**
~Portrait and landscape orientations.~
~Light and dark modes.~
~Fonts: Larger, smaller and bold text.~
~High contrast.~
~VoiceOver.~
~Languages with large words or with letters/accents not frequently used in English.~
~Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)~
~iPhone and iPad.~
~Multi-tasking: Split view and Slide over. (iPad)~
