### PR TITLE
Activity Log: Fetch backup status only if site has backup capabilities

### DIFF
--- a/WordPress/Classes/Models/JetpackSiteRef.swift
+++ b/WordPress/Classes/Models/JetpackSiteRef.swift
@@ -16,7 +16,7 @@ struct JetpackSiteRef: Hashable, Codable {
     /// The homeURL string  for a site.
     let homeURL: String
 
-    private var hasBackup = false
+    private(set) var hasBackup = false
     private var hasPaidPlan = false
 
     // Self Hosted Non Jetpack Support

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -300,6 +300,10 @@ extension ActivityStore {
     }
 
     func fetchBackupStatus(site: JetpackSiteRef) {
+        guard site.hasBackup else {
+            return
+        }
+
         state.fetchingBackupStatus[site] = true
 
         backupService.getAllBackupStatus(for: site, success: { [actionDispatcher] backupsStatus in


### PR DESCRIPTION
Fixes #20769

## Description

Fixes an issue where sites without backup capabilities were calling the `/rewind/downloads` endpoint.

Slack ref: p1685031889517599/1685030191.657229-slack-CS8UYNPEE

## Notes

This issue doesn't seem to be a regression. On Sentry there's an uptick starting on May 15, which coincides with the 22.3 release. I checked out the 22.2 tag but I was able to reproduce the 500 error. 

While I'm not sure what caused the significant uptick in errors (maybe a change in backend implmentation?), avoiding calls to the `/rewind/downloads` endpoint if the site doesn't have backup capabilities resolves this issue.

## How to test

### Sites without Jetpack Backup

1. Use Charles to see the network traffic; make sure to disable the Automattic Proxy
2. Run the Jetpack app
3. Switch to a site without Jetpack Backup capabilities (e.g. wp.com sites on a free Personal plan)
4. Go to the activity log
5. ✅ On Charles, verify that the `/rewind/downloads` endpoint isn't called

### Sites with Jetpack Backup

1. Use Charles to see the network traffic; make sure to disable the Automattic Proxy
2. Run the Jetpack app
3. Switch to a site with Jetpack Backup capabilities (e.g. wp.com sites on a Business plan)
4. Go to the activity log
5. ✅ On Charles, verify that the `/rewind/downloads` endpoint is called

## Regression Notes
1. Potential unintended areas of impact
Checking the backup status for sites with backup capabilities

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified via the Sites with Jetpack Backup case above

8. What automated tests I added (or what prevented me from doing so)
n/a
