### PR TITLE
Blaze Manage Campaigns: Add remote feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -12,6 +12,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case jetpackMigrationPreventDuplicateNotifications
     case wordPressSupportForum
     case blaze
+    case blazeManageCampaigns
     case wordPressIndividualPluginSupport
     case domainsDashboardCard
     case freeToPaidPlansDashboardCard
@@ -42,6 +43,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .wordPressSupportForum:
             return true
         case .blaze:
+            return false
+        case .blazeManageCampaigns:
             return false
         case .wordPressIndividualPluginSupport:
             return AppConfiguration.isWordPress
@@ -85,6 +88,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "wordpress_support_forum_remote_field"
         case .blaze:
             return "blaze"
+        case .blazeManageCampaigns:
+            return "blaze_manage_campaigns"
         case .wordPressIndividualPluginSupport:
             return "wp_individual_plugin_overlay"
         case .domainsDashboardCard:
@@ -126,6 +131,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Provide support through a forum"
         case .blaze:
             return "Blaze"
+        case .blazeManageCampaigns:
+            return "Blaze Manage Campaigns"
         case .wordPressIndividualPluginSupport:
             return "Jetpack Individual Plugin Support for WordPress"
         case .domainsDashboardCard:


### PR DESCRIPTION
Closes #20756 

## Description
Adds a new remote feature flag (pbArwn-60x-p2) for the Blaze manage campaigns project.

## How to test
1. Go to the debug menu from App Settings
2. ✅ Verify: the "Blaze Manage Campaigns" flag is displayed in the Remote Feature Flags section

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.