### PR TITLE
Jetpack Social: Add Jetpack Social feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,6 +40,7 @@ enum FeatureFlag: Int, CaseIterable {
     case readerUserBlocking
     case personalizeHomeTab
     case commentModerationUpdate
+    case jetpackSocial
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -128,6 +129,8 @@ enum FeatureFlag: Int, CaseIterable {
             return false
         case .commentModerationUpdate:
             return false
+        case .jetpackSocial:
+            return AppConfiguration.isJetpack && BuildConfiguration.current == .localDeveloper
         }
     }
 
@@ -226,6 +229,8 @@ extension FeatureFlag {
             return "Personalize Home Tab"
         case .commentModerationUpdate:
             return "Comments Moderation Update"
+        case .jetpackSocial:
+            return "Jetpack Social"
         }
     }
 }


### PR DESCRIPTION
Closes #20781

## Description

Adds a feature flag for the Jetpack Social changes.

## Testing

Since the feature flag isn't being used yet, there is no easy way to test it. The changes are also small enough to where it is clear what it is doing.

But if you really want to test, the following can be done:
- Add the feature flag somewhere in code
- Add a breakpoint
- Verify it's only true when the app is Jetpack and in debug mode

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
