### PR TITLE
[UI Tests] Added a UI Test for "Pages" dashboard card navigation.

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/activity/wpcom_v2_site_activity.json
@@ -6,727 +6,114 @@
   "response": {
     "status": 200,
     "jsonBody": {
+
       "@context": "https://www.w3.org/ns/activitystreams",
       "summary": "Activity log",
       "type": "OrderedCollection",
-      "totalItems": 300,
+      "totalItems": 3,
       "page": 1,
-      "totalPages": 15,
+      "totalPages": 1,
       "itemsPerPage": 20,
-      "id": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/185124945/activity?number=20&page=1",
-      "nextAfter": [
-        1620221875793
-      ],
-      "oldestItemTs": 1604484582203,
-      "first": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/185124945/activity?number=20&page=1",
-      "last": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/185124945/activity?number=20&page=15",
+      "id": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?number=20&page=1",
+      "oldestItemTs": 1654043700542,
+      "first": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?number=20&page=1",
+      "last": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?number=20&page=1",
       "current": {
         "type": "OrderedCollectionPage",
-        "id": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/185124945/activity?number=20&page=1",
-        "prev": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/185124945/activity?number=20&page=0",
-        "next": "{{request.requestLine.baseUrl}}/wpcom/v2/sites/185124945/activity?number=20&page=2",
-        "totalItems": 20,
+        "id": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?number=20&page=1",
+        "prev": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?number=20&page=0",
+        "totalItems": 3,
         "orderedItems": [
           {
-            "summary": "Backup and scan complete",
-            "content": {
-              "text": "4 plugins, 2 themes, 3 uploads, 2 posts"
-            },
-            "name": "rewind__backup_complete_full",
-            "actor": {
-              "type": "Application",
-              "name": "Jetpack"
-            },
-            "type": "Announce",
-            "published": "{{now format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": true,
-            "rewind_id": "1620282190.798",
-            "gridicon": "cloud",
-            "status": "success",
-            "activity_id": "AXlAWDctEdwdUqNpZHlC",
-            "object": {
-              "type": "Backup",
-              "backup_type": "full",
-              "rewind_id": "1620282190.798",
-              "backup_stats": "{\"themes\":{\"count\":2,\"list\":[\"twentynineteen\",\"twentytwenty\"]},\"plugins\":{\"count\":4,\"list\":[\"akismet\",\"calendar\",\"jetpack\",\"jetpack-threat-tester-master\"]},\"uploads\":{\"count\":3,\"images\":2,\"movies\":0,\"audio\":0,\"archives\":0},\"tables\":{\"wp_calendar\":{\"rows\":0},\"wp_calendar_categories\":{\"rows\":1},\"wp_calendar_config\":{\"rows\":10},\"wp_commentmeta\":{\"rows\":0},\"wp_comments\":{\"rows\":1},\"wp_links\":{\"rows\":0},\"wp_options\":{\"rows\":221},\"wp_postmeta\":{\"rows\":6},\"wp_posts\":{\"rows\":6,\"published\":2},\"wp_term_relationships\":{\"rows\":2},\"wp_term_taxonomy\":{\"rows\":1},\"wp_termmeta\":{\"rows\":0},\"wp_terms\":{\"rows\":1},\"wp_usermeta\":{\"rows\":48},\"wp_users\":{\"rows\":3}},\"prefix\":\"wp_\",\"wp_version\":\"5.7.1\"}",
-              "backup_period": 1620282173
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Threat resolved",
-            "content": {
-              "text": "The threat known as URL_BlockList_1 is no longer present in wp_posts: File is now clean",
-              "ranges": [
-                {
-                  "type": "em",
-                  "indices": [
-                    20,
-                    35
-                  ],
-                  "id": "3",
-                  "parent": null
-                }
-              ]
-            },
-            "name": "rewind__scan_result_fixed",
-            "actor": {
-              "type": "Application",
-              "name": "Jetpack"
-            },
-            "type": "Announce",
-            "published": "{{now format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620282185.3564",
-            "gridicon": "checkmark",
-            "status": "success",
-            "activity_id": "AXlAWCuCHPpm8Jl5QV_X",
-            "object": {
-              "type": "Security",
-              "file": "wp_posts",
-              "signature": "URL_BlockList_1",
-              "fixed_ts": 1620282185208,
-              "reason": "File is now clean"
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Threat resolved",
-            "content": {
-              "text": "The threat known as EICAR_AV_Test is no longer present in /htdocs/wp-content/uploads/jptt_eicar.php: File is now clean",
-              "ranges": [
-                {
-                  "type": "em",
-                  "indices": [
-                    20,
-                    33
-                  ],
-                  "id": "7",
-                  "parent": null
-                }
-              ]
-            },
-            "name": "rewind__scan_result_fixed",
-            "actor": {
-              "type": "Application",
-              "name": "Jetpack"
-            },
-            "type": "Announce",
-            "published": "{{now format='yyyy-MM-dd'}}T{{now format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620282178.7763",
-            "gridicon": "checkmark",
-            "status": "success",
-            "activity_id": "AXlAWAOxC0Gvh1USAs-0",
-            "object": {
-              "type": "Security",
-              "file": "/htdocs/wp-content/uploads/jptt_eicar.php",
-              "signature": "EICAR_AV_Test",
-              "fixed_ts": 1620282178649,
-              "reason": "File is now clean"
-            },
-            "is_discarded": false
-          },
-          {
             "summary": "Setting changed",
             "content": {
-              "text": "Default post format changed to \"Standard\"",
-              "ranges": [
-                {
-                  "type": "em",
-                  "indices": [
-                    32,
-                    40
-                  ],
-                  "id": "11",
-                  "parent": null
-                }
-              ]
+              "text": "Enabled Jetpack Social for automatic social sharing"
             },
-            "name": "setting__changed_default_post_format",
+            "name": "setting__changed_jetpack_module_publicize",
             "actor": {
               "type": "Person",
-              "name": "emilylaguna",
-              "external_user_id": 2,
-              "wpcom_user_id": 175698209,
+              "name": "demo",
+              "external_user_id": 1,
+              "wpcom_user_id": 195654479,
               "icon": {
                 "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/6d1fe505117c34cd81af4b6572b55f56?s=96&d=mm&r=g",
+                "url": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=mm&r=g",
                 "width": 96,
                 "height": 96
               },
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
+            "published": "2023-04-04T10:33:09.300+00:00",
             "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
+              "jetpack_version": 0,
+              "blog_id": 106707880
             },
-            "is_rewindable": true,
-            "rewind_id": "1620230363.1081",
+            "is_rewindable": false,
+            "rewind_id": "1680604388.4567",
             "gridicon": "cog",
             "status": null,
-            "activity_id": "AXk9QWGUekSREqZdrE0M",
+            "activity_id": "6gjTS4cBfytF4jpL6MFT",
             "is_discarded": false
           },
           {
-            "summary": "Setting changed",
+            "summary": "Site owner connected",
             "content": {
-              "text": "Timezone changed to \"UTC+0\"",
-              "ranges": [
-                {
-                  "type": "em",
-                  "indices": [
-                    21,
-                    26
-                  ],
-                  "id": "15",
-                  "parent": null
-                }
-              ]
+              "text": "The Jetpack connection is now complete. Welcome!"
             },
-            "name": "setting__changed_timezone",
+            "name": "jetpack__site_owner_connected",
             "actor": {
               "type": "Person",
-              "name": "pressable-jetpack-complete",
+              "name": "Kevin Jorge",
               "external_user_id": 1,
-              "wpcom_user_id": 196051067,
+              "wpcom_user_id": 11111111,
               "icon": {
                 "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
+                "url": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=mm&r=g",
                 "width": 96,
                 "height": 96
               },
               "role": "administrator"
             },
             "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
+            "published": "2023-04-04T10:33:05.614+00:00",
             "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
+              "jetpack_version": 0,
+              "blog_id": 106707880
             },
             "is_rewindable": false,
-            "rewind_id": "1620226323.2004",
-            "gridicon": "cog",
-            "status": null,
-            "activity_id": "AXk9A7jxC0Gvh1USarVK",
-            "is_discarded": false
-          },
-          {
-            "summary": "Plugin updated",
-            "content": {
-              "text": "Jetpack by WordPress.com 9.7",
-              "ranges": [
-                {
-                  "type": "plugin",
-                  "indices": [
-                    0,
-                    28
-                  ],
-                  "id": "18",
-                  "parent": null,
-                  "slug": "jetpack",
-                  "version": "9.7",
-                  "site_slug": "pressable-jetpack-complete.mystagingwebsite.com"
-                }
-              ]
-            },
-            "name": "plugin__updated",
-            "actor": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": "administrator"
-            },
-            "type": "Update",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620226323.198",
-            "gridicon": "plugins",
+            "rewind_id": "1680604385.6144",
+            "gridicon": "plans",
             "status": "success",
-            "activity_id": "AXk9A7jxC0Gvh1USarVA",
-            "items": [
-              {
-                "type": "Plugin",
-                "name": "Jetpack by WordPress.com",
-                "object_version": "9.7",
-                "object_slug": "jetpack/jetpack.php",
-                "object_previous_version": "9.6.1"
-              }
-            ],
-            "totalItems": 1,
+            "activity_id": "avfTS4cB98Gh8vy65ZU4",
             "is_discarded": false
           },
           {
-            "summary": "Setting changed",
+            "summary": "Site connected",
             "content": {
-              "text": "Site icon changed (icon.png)",
-              "ranges": [
-                {
-                  "url": "https://wordpress.com/media/185124945/8",
-                  "indices": [
-                    0,
-                    28
-                  ],
-                  "id": 8,
-                  "parent": null,
-                  "type": "a",
-                  "site_id": 185124945,
-                  "section": "media",
-                  "intent": "edit",
-                  "context": "single"
-                }
-              ]
+              "text": "This site is connected to Jetpack."
             },
-            "name": "setting__changed_site_icon",
-            "actor": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": "administrator"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620226281.4911",
-            "gridicon": "cog",
-            "status": null,
-            "activity_id": "AXk9AzWAHPpm8Jl5qY7t",
-            "image": {
-              "available": true,
-              "type": "Image",
-              "name": "Site icon changed (icon.png)",
-              "url": "https://i2.wp.com/pressable-jetpack-complete.mystagingwebsite.com/wp-content/uploads/2021/05/icon.png?ssl=1",
-              "thumbnail_url": "https://i2.wp.com/pressable-jetpack-complete.mystagingwebsite.com/wp-content/uploads/2021/05/icon.png?fit=96%2C96&#038;ssl=1"
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Setting changed",
-            "content": {
-              "text": "Site description was changed from \"Just another WordPress site\" to \"Site with everything enabled\"",
-              "ranges": [
-                {
-                  "type": "em",
-                  "indices": [
-                    35,
-                    62
-                  ],
-                  "id": "23",
-                  "parent": null
-                },
-                {
-                  "type": "em",
-                  "indices": [
-                    68,
-                    96
-                  ],
-                  "id": "26",
-                  "parent": null
-                }
-              ]
-            },
-            "name": "setting__changed_blogdescription",
-            "actor": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": "administrator"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620226281.4705",
-            "gridicon": "cog",
-            "status": null,
-            "activity_id": "AXk9Ay97ekSREqZdnq2n",
-            "is_discarded": false
-          },
-          {
-            "summary": "Setting changed",
-            "content": {
-              "text": "Site title was changed from \"My WordPress Site\" to \"Jetpack - Complete\"",
-              "ranges": [
-                {
-                  "type": "em",
-                  "indices": [
-                    29,
-                    46
-                  ],
-                  "id": "30",
-                  "parent": null
-                },
-                {
-                  "type": "em",
-                  "indices": [
-                    52,
-                    70
-                  ],
-                  "id": "33",
-                  "parent": null
-                }
-              ]
-            },
-            "name": "setting__changed_blogname",
-            "actor": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": "administrator"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": true,
-            "rewind_id": "1620226281.462",
-            "gridicon": "cog",
-            "status": null,
-            "activity_id": "AXk9Ay97ekSREqZdnq2e",
-            "is_discarded": false
-          },
-          {
-            "summary": "Image uploaded",
-            "content": {
-              "text": "icon.png",
-              "ranges": [
-                {
-                  "url": "https://wordpress.com/media/185124945/8",
-                  "indices": [
-                    0,
-                    8
-                  ],
-                  "id": 8,
-                  "parent": null,
-                  "type": "a",
-                  "site_id": 185124945,
-                  "section": "media",
-                  "intent": "edit",
-                  "context": "single"
-                }
-              ]
-            },
-            "name": "attachment__uploaded",
-            "actor": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": "administrator"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": true,
-            "rewind_id": "1620226276.8479",
-            "gridicon": "image",
-            "status": "success",
-            "activity_id": "AXk9AwVyC0Gvh1USao1z",
-            "image": {
-              "available": true,
-              "type": "Image",
-              "name": "icon.png",
-              "url": "https://i2.wp.com/pressable-jetpack-complete.mystagingwebsite.com/wp-content/uploads/2021/05/icon.png?ssl=1",
-              "thumbnail_url": "https://i2.wp.com/pressable-jetpack-complete.mystagingwebsite.com/wp-content/uploads/2021/05/icon.png?fit=96%2C96&#038;ssl=1",
-              "medium_url": "https://i2.wp.com/pressable-jetpack-complete.mystagingwebsite.com/wp-content/uploads/2021/05/icon.png?w=846&#038;ssl=1"
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Login succeeded",
-            "content": {
-              "text": "pressable-jetpack-complete successfully logged in from IP Address 73.159.235.239",
-              "ranges": [
-                {
-                  "url": "https://wordpress.com/people/edit/185124945/pressable-jetpack-complete",
-                  "indices": [
-                    0,
-                    26
-                  ],
-                  "id": 1,
-                  "parent": null,
-                  "type": "a",
-                  "site_id": 185124945,
-                  "section": "user",
-                  "intent": "edit"
-                }
-              ]
-            },
-            "name": "user__login",
-            "actor": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/9eac9665a4c900eeb9ba5ceb211b0f62?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": "administrator"
-            },
-            "type": "Join",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620226253.9047",
-            "gridicon": "lock",
-            "status": null,
-            "activity_id": "AXk9ArAGC0Gvh1USan6F",
-            "object": {
-              "type": "Person",
-              "name": "pressable-jetpack-complete",
-              "external_user_id": 1,
-              "wpcom_user_id": 196051067
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Backup and scan complete",
-            "content": {
-              "text": "4 plugins, 2 themes, 1 upload, 2 posts"
-            },
-            "name": "rewind__backup_complete_full",
+            "name": "jetpack__site_connected",
             "actor": {
               "type": "Application",
               "name": "Jetpack"
             },
             "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
+            "published": "2023-04-04T10:32:54.647+00:00",
             "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": true,
-            "rewind_id": "1620223139.141",
-            "gridicon": "cloud",
-            "status": "success",
-            "activity_id": "AXk80zD9HPpm8Jl5nqOO",
-            "object": {
-              "type": "Backup",
-              "backup_type": "full",
-              "rewind_id": "1620223139.141",
-              "backup_stats": "{\"themes\":{\"count\":2,\"list\":[\"twentynineteen\",\"twentytwenty\"]},\"plugins\":{\"count\":4,\"list\":[\"akismet\",\"calendar\",\"jetpack\",\"jetpack-threat-tester-master\"]},\"uploads\":{\"count\":1,\"images\":0,\"movies\":0,\"audio\":0,\"archives\":0},\"tables\":{\"wp_calendar\":{\"rows\":0},\"wp_calendar_categories\":{\"rows\":1},\"wp_calendar_config\":{\"rows\":10},\"wp_commentmeta\":{\"rows\":0},\"wp_comments\":{\"rows\":1},\"wp_links\":{\"rows\":0},\"wp_options\":{\"rows\":350},\"wp_postmeta\":{\"rows\":2},\"wp_posts\":{\"rows\":4,\"published\":2},\"wp_term_relationships\":{\"rows\":2},\"wp_term_taxonomy\":{\"rows\":1},\"wp_termmeta\":{\"rows\":0},\"wp_terms\":{\"rows\":1},\"wp_usermeta\":{\"rows\":48},\"wp_users\":{\"rows\":3}},\"prefix\":\"wp_\",\"wp_version\":\"5.7.1\"}",
-              "backup_period": 1620223121
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Backup and scan complete",
-            "content": {
-              "text": "4 plugins, 2 themes, 1 upload, 2 posts"
-            },
-            "name": "rewind__backup_complete_full",
-            "actor": {
-              "type": "Application",
-              "name": "Jetpack"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": true,
-            "rewind_id": "1620223112.797",
-            "gridicon": "cloud",
-            "status": "success",
-            "activity_id": "AXk80rw-C0Gvh1USX6QQ",
-            "object": {
-              "type": "Backup",
-              "backup_type": "full",
-              "rewind_id": "1620223112.797",
-              "backup_stats": "{\"themes\":{\"count\":2,\"list\":[\"twentynineteen\",\"twentytwenty\"]},\"plugins\":{\"count\":4,\"list\":[\"akismet\",\"calendar\",\"jetpack\",\"jetpack-threat-tester-master\"]},\"uploads\":{\"count\":1,\"images\":0,\"movies\":0,\"audio\":0,\"archives\":0},\"tables\":{\"wp_calendar\":{\"rows\":0},\"wp_calendar_categories\":{\"rows\":1},\"wp_calendar_config\":{\"rows\":10},\"wp_commentmeta\":{\"rows\":0},\"wp_comments\":{\"rows\":1},\"wp_links\":{\"rows\":0},\"wp_options\":{\"rows\":350},\"wp_postmeta\":{\"rows\":2},\"wp_posts\":{\"rows\":4,\"published\":2},\"wp_term_relationships\":{\"rows\":2},\"wp_term_taxonomy\":{\"rows\":1},\"wp_termmeta\":{\"rows\":0},\"wp_terms\":{\"rows\":1},\"wp_usermeta\":{\"rows\":48},\"wp_users\":{\"rows\":3}},\"prefix\":\"wp_\",\"wp_version\":\"5.7.1\"}",
-              "backup_period": 1620223090
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Threat resolved",
-            "content": {
-              "text": "The extension in /htdocs/wp-content/plugins/calendar/calendar.php is no longer vulnerable: Applied threat fixer"
-            },
-            "name": "rewind__scan_result_fixed",
-            "actor": {
-              "type": "Application",
-              "name": "Jetpack"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
+              "jetpack_version": 0,
+              "blog_id": 106707880
             },
             "is_rewindable": false,
-            "rewind_id": "1620223082.8809",
-            "gridicon": "checkmark",
+            "rewind_id": "1680604374.6466",
+            "gridicon": "plans",
             "status": "success",
-            "activity_id": "AXk80lkJekSREqZdlA-f",
-            "object": {
-              "type": "Security",
-              "file": "/htdocs/wp-content/plugins/calendar/calendar.php",
-              "signature": "Vulnerable.WP.Extension",
-              "fixed_ts": 1620223082559,
-              "reason": "Applied threat fixer"
-            },
-            "is_discarded": false
-          },
-          {
-            "summary": "Plugin updated",
-            "content": {
-              "text": "Calendar 1.3.14",
-              "ranges": [
-                {
-                  "type": "plugin",
-                  "indices": [
-                    0,
-                    15
-                  ],
-                  "id": "44",
-                  "parent": null,
-                  "slug": "calendar",
-                  "version": "1.3.14",
-                  "site_slug": "pressable-jetpack-complete.mystagingwebsite.com"
-                }
-              ]
-            },
-            "name": "plugin__updated",
-            "actor": {
-              "type": "Person",
-              "name": "",
-              "external_user_id": 0,
-              "wpcom_user_id": 0,
-              "icon": {
-                "type": "Image",
-                "url": "https://secure.gravatar.com/avatar/?s=96&d=mm&r=g",
-                "width": 96,
-                "height": 96
-              },
-              "role": ""
-            },
-            "type": "Update",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": false,
-            "rewind_id": "1620223082.5373",
-            "gridicon": "plugins",
-            "status": "success",
-            "activity_id": "AXk87CWqEdwdUqNpxIhq",
-            "items": [
-              {
-                "type": "Plugin",
-                "name": "Calendar",
-                "object_version": "1.3.14",
-                "object_slug": "calendar/calendar.php",
-                "object_previous_version": "1.3.1"
-              }
-            ],
-            "totalItems": 1,
-            "is_discarded": false
-          },
-          {
-            "summary": "Backup and scan complete",
-            "content": {
-              "text": "4 plugins, 2 themes, 1 upload, 2 posts"
-            },
-            "name": "rewind__backup_complete_full",
-            "actor": {
-              "type": "Application",
-              "name": "Jetpack"
-            },
-            "type": "Announce",
-            "published": "{{now offset='-1 days' format='yyyy-MM-dd'}}T{{now offset='-1 days' format='HH:mm:ss.SSSZ'}}",
-            "generator": {
-              "jetpack_version": 9.7,
-              "blog_id": 185124945
-            },
-            "is_rewindable": true,
-            "rewind_id": "1620222944.83",
-            "gridicon": "cloud",
-            "status": "success",
-            "activity_id": "AXk80DZxEdwdUqNpvgLh",
-            "object": {
-              "type": "Backup",
-              "backup_type": "full",
-              "rewind_id": "1620222944.83",
-              "backup_stats": "{\"themes\":{\"count\":2,\"list\":[\"twentynineteen\",\"twentytwenty\"]},\"plugins\":{\"count\":4,\"list\":[\"akismet\",\"calendar\",\"jetpack\",\"jetpack-threat-tester-master\"]},\"uploads\":{\"count\":1,\"images\":0,\"movies\":0,\"audio\":0,\"archives\":0},\"tables\":{\"wp_calendar\":{\"rows\":0},\"wp_calendar_categories\":{\"rows\":1},\"wp_commentmeta\":{\"rows\":0},\"wp_calendar_config\":{\"rows\":10},\"wp_comments\":{\"rows\":1},\"wp_links\":{\"rows\":0},\"wp_options\":{\"rows\":334},\"wp_postmeta\":{\"rows\":2},\"wp_posts\":{\"rows\":4,\"published\":2},\"wp_term_relationships\":{\"rows\":2},\"wp_term_taxonomy\":{\"rows\":1},\"wp_termmeta\":{\"rows\":0},\"wp_terms\":{\"rows\":1},\"wp_usermeta\":{\"rows\":48},\"wp_users\":{\"rows\":3}},\"prefix\":\"wp_\",\"wp_version\":\"5.7.1\"}",
-              "backup_period": 1620222920
-            },
+            "activity_id": "XvfTS4cB98Gh8vy6sI2-",
             "is_discarded": false
           }
         ]
       }
+      
     },
     "headers": {
       "Content-Type": "application/json",

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/dashboard.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/dashboard.json
@@ -7,7 +7,7 @@
           "matches": "(.*)"
       },
       "cards": {
-          "equalTo": "todays_stats,posts,pages"
+          "equalTo": "todays_stats,posts,pages,activity"
       }
     }
   },
@@ -50,7 +50,116 @@
           "modified": "2023-02-03 09:46:32",
           "date": "2023-02-03 09:46:32"
         }
-      ]
+      ],
+
+      "activity": {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "summary": "Activity log",
+        "type": "OrderedCollection",
+        "totalItems": 3,
+        "page": 1,
+        "totalPages": 1,
+        "itemsPerPage": 5,
+        "id": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity",
+        "oldestItemTs": 1654043700542,
+        "first": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?page=1",
+        "last": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity?page=1",
+        "current": {
+          "type": "OrderedCollectionPage",
+          "id": "https://public-api.wordpress.com/wpcom/v2/sites/106707880/activity",
+          "totalItems": 1,
+          "orderedItems": [
+            {
+              "summary": "Setting changed",
+              "content": {
+                "text": "Enabled Jetpack Social for automatic social sharing"
+              },
+              "name": "setting__changed_jetpack_module_publicize",
+              "actor": {
+                "type": "Person",
+                "name": "demo",
+                "external_user_id": 1,
+                "wpcom_user_id": 195654479,
+                "icon": {
+                  "type": "Image",
+                  "url": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=mm&r=g",
+                  "width": 96,
+                  "height": 96
+                },
+                "role": "administrator"
+              },
+              "type": "Announce",
+              "published": "2023-04-04T10:33:09.300+00:00",
+              "generator": {
+                "jetpack_version": 0,
+                "blog_id": 106707880
+              },
+              "is_rewindable": false,
+              "rewind_id": "1680604388.4567",
+              "gridicon": "cog",
+              "status": null,
+              "activity_id": "6gjTS4cBfytF4jpL6MFT",
+              "is_discarded": false
+            },
+            {
+              "summary": "Site owner connected",
+              "content": {
+                "text": "The Jetpack connection is now complete. Welcome!"
+              },
+              "name": "jetpack__site_owner_connected",
+              "actor": {
+                "type": "Person",
+                "name": "Kevin Jorge",
+                "external_user_id": 1,
+                "wpcom_user_id": 11111111,
+                "icon": {
+                  "type": "Image",
+                  "url": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=mm&r=g",
+                  "width": 96,
+                  "height": 96
+                },
+                "role": "administrator"
+              },
+              "type": "Announce",
+              "published": "2023-04-04T10:33:05.614+00:00",
+              "generator": {
+                "jetpack_version": 0,
+                "blog_id": 106707880
+              },
+              "is_rewindable": false,
+              "rewind_id": "1680604385.6144",
+              "gridicon": "plans",
+              "status": "success",
+              "activity_id": "avfTS4cB98Gh8vy65ZU4",
+              "is_discarded": false
+            },
+            {
+              "summary": "Site connected",
+              "content": {
+                "text": "This site is connected to Jetpack."
+              },
+              "name": "jetpack__site_connected",
+              "actor": {
+                "type": "Application",
+                "name": "Jetpack"
+              },
+              "type": "Announce",
+              "published": "2023-04-04T10:32:54.647+00:00",
+              "generator": {
+                "jetpack_version": 0,
+                "blog_id": 106707880
+              },
+              "is_rewindable": false,
+              "rewind_id": "1680604374.6466",
+              "gridicon": "plans",
+              "status": "success",
+              "activity_id": "XvfTS4cB98Gh8vy6sI2-",
+              "is_discarded": false
+            }
+          ]
+        }
+      }
+
     }
   }
 }

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/dashboard.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/dashboard.json
@@ -1,30 +1,56 @@
 {
-    "request": {
-      "method": "GET",
-      "urlPath": "/wpcom/v2/sites/106707880/dashboard/cards-data/",
-      "queryParameters": {
-        "_locale": {
-            "matches": "(.*)"
-        },
-        "cards": {
-            "equalTo": "todays_stats,posts"
-        }
-      }
-    },
-    "response": {
-      "status": 200,
-      "jsonBody": {
-        "todays_stats": {
-            "views": 56,
-            "visitors": 44,
-            "likes": 19,
-            "comments": 0
-        },
-        "posts": {
-            "has_published": true,
-            "draft": [],
-            "scheduled": []
-        }
+  "request": {
+    "method": "GET",
+    "urlPath": "/wpcom/v2/sites/106707880/dashboard/cards-data/",
+    "queryParameters": {
+      "_locale": {
+          "matches": "(.*)"
+      },
+      "cards": {
+          "equalTo": "todays_stats,posts,pages"
       }
     }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "todays_stats": {
+          "views": 56,
+          "visitors": 44,
+          "likes": 19,
+          "comments": 0
+      },
+      "posts": {
+          "has_published": true,
+          "draft": [],
+          "scheduled": []
+      },
+      "pages": [
+        {
+          "id": 51,
+          "title": "Blog",
+          "content": "Introduce yourself and your blog My Latest Posts • • • • • •",
+          "status": "publish",
+          "modified": "2023-05-18 10:33:38",
+          "date": "2023-05-18 10:33:38"
+        },
+        {
+          "id": 30,
+          "title": "Cart",
+          "content": "",
+          "status": "publish",
+          "modified": "2023-02-03 09:46:32",
+          "date": "2023-02-03 09:46:32"
+        },
+        {
+          "id": 31,
+          "title": "Checkout",
+          "content": "",
+          "status": "publish",
+          "modified": "2023-02-03 09:46:32",
+          "date": "2023-02-03 09:46:32"
+        }
+      ]
+    }
   }
+}

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/publisize.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/publisize.json
@@ -1,0 +1,87 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/wpcom/v2/sites/106707880/external-services",
+    "queryParameters": {
+      "locale": {
+          "matches": "(.*)"
+      },
+      "type": {
+          "equalTo": "publicize"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+
+      "services": {
+        "facebook": {
+          "ID": "facebook",
+          "label": "Facebook",
+          "type": "publicize",
+          "description": "Publish your posts to your Facebook timeline or page.",
+          "genericon": {
+            "class": "facebook-alt",
+            "unicode": "\\f203"
+          },
+          "icon": "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-fb-2x.png",
+          "connect_URL": "https://public-api.wordpress.com/connect/?action=request&kr_nonce=c98be927cc&nonce=31e8eb987b&for=connect&service=facebook&blog=215224204&kr_blog_nonce=3d5d1f5eff&magic=keyring",
+          "multiple_external_user_ID_support": true,
+          "external_users_only": true,
+          "jetpack_support": true,
+          "jetpack_module_required": "publicize"
+        },
+        "twitter": {
+          "ID": "twitter",
+          "label": "Twitter",
+          "type": "publicize",
+          "description": "Publish your posts to your Twitter account.",
+          "genericon": {
+            "class": "twitter",
+            "unicode": "\\f202"
+          },
+          "icon": "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-twitter-2x.png",
+          "connect_URL": "https://public-api.wordpress.com/connect/?action=request&kr_nonce=c98be927cc&nonce=49e6f85e72&for=connect&service=twitter&blog=215224204&kr_blog_nonce=3d5d1f5eff&magic=keyring",
+          "multiple_external_user_ID_support": false,
+          "external_users_only": false,
+          "jetpack_support": true,
+          "jetpack_module_required": "publicize",
+          "status": "unsupported"
+        },
+        "linkedin": {
+          "ID": "linkedin",
+          "label": "LinkedIn",
+          "type": "publicize",
+          "description": "Publish your posts to your LinkedIn profile.",
+          "genericon": {
+            "class": "linkedin",
+            "unicode": "\\f207"
+          },
+          "icon": "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-linkedin-2x.png",
+          "connect_URL": "https://public-api.wordpress.com/connect/?action=request&kr_nonce=c98be927cc&nonce=9ed430da6c&for=connect&service=linkedin&blog=215224204&kr_blog_nonce=3d5d1f5eff&magic=keyring",
+          "multiple_external_user_ID_support": false,
+          "external_users_only": false,
+          "jetpack_support": true,
+          "jetpack_module_required": "publicize"
+        },
+        "tumblr": {
+          "ID": "tumblr",
+          "label": "Tumblr",
+          "type": "publicize",
+          "description": "Publish your posts to your Tumblr blog.",
+          "genericon": {
+            "class": "tumblr",
+            "unicode": "\\f214"
+          },
+          "icon": "http://i.wordpress.com/wp-content/admin-plugins/publicize/assets/publicize-tumblr-2x.png",
+          "multiple_external_user_ID_support": true,
+          "external_users_only": false,
+          "connect_URL": "https://public-api.wordpress.com/connect/?action=request&kr_nonce=c98be927cc&nonce=99d8ed4fcc&for=connect&service=tumblr&blog=215224204&kr_blog_nonce=3d5d1f5eff&magic=keyring",
+          "jetpack_support": true,
+          "jetpack_module_required": "publicize"
+        }
+      }
+    }
+  }
+}

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/feature-flags.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/feature-flags.json
@@ -12,7 +12,8 @@
     "status": 200,
     "jsonBody": {
       "dashboard_card_domain": false,
-      "dashboard_card_free_to_paid_plans": true
+      "dashboard_card_free_to_paid_plans": true,
+      "dashboard_card_pages": true
     }
   }
 }

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/feature-flags.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/feature-flags.json
@@ -11,6 +11,7 @@
   "response": {
     "status": 200,
     "jsonBody": {
+      "dashboard_card_activity_log": true,
       "dashboard_card_domain": false,
       "dashboard_card_free_to_paid_plans": true,
       "dashboard_card_pages": true

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/pages/pages_offset_0.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/pages/pages_offset_0.json
@@ -1,0 +1,295 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/rest/v1.2/sites/106707880/posts",
+    "queryParameters": {
+      "locale": {
+        "matches": "(.*)"
+      },
+      "type": {
+        "equalTo": "page"
+      },
+      "offset" : {
+        "absent" : true
+      }        
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "found": 6,
+      "posts": [
+        {
+          "ID": 51,
+          "site_ID": 106707880,
+          "author": {
+            "ID": 152748359,
+            "login": "kkevin",
+            "email": "test@automattic.com",
+            "name": "Kevin Jorge",
+            "first_name": "Kevin",
+            "last_name": "Jorge",
+            "nice_name": "kkevin",
+            "URL": "",
+            "avatar_URL": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=identicon&r=g",
+            "profile_URL": "https://en.gravatar.com/eea057209f5e29d6ca4103bc165d645b"
+          },
+          "date": "2023-05-18T13:33:38+03:00",
+          "modified": "2023-05-18T13:33:38+03:00",
+          "title": "Blog",
+          "URL": "https://infocusphotographers.wpcomstaging.com/blog-2/",
+          "short_URL": "https://wp.me/Pez3E8-P",
+          "content": "<!-- wp:image {\"align\":\"full\",\"sizeSlug\":\"large\",\"linkDestination\":\"none\"} -->\n<figure class=\"wp-block-image alignfull size-large\"><img src=\"https://dotcompatterns.files.wordpress.com/2021/02/pexels-photo-3954635.jpeg?w=1024\" alt=\"\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"level\":1} -->\n<h1 class=\"wp-block-heading has-text-align-center\"><strong>Introduce yourself and your blog</strong></h1>\n<!-- /wp:heading -->\n\n<!-- wp:spacer {\"height\":\"30px\"} -->\n<div style=\"height:30px\" aria-hidden=\"true\" class=\"wp-block-spacer\"></div>\n<!-- /wp:spacer -->\n\n<!-- wp:heading {\"textAlign\":\"center\"} -->\n<h2 class=\"wp-block-heading has-text-align-center\">My Latest Posts</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">• • •</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:latest-posts {\"postsToShow\":2,\"displayPostContent\":true,\"excerptLength\":30,\"displayPostDate\":true,\"featuredImageSizeSlug\":\"large\"} /-->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\">• • •</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:image {\"id\":50,\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://infocusphotographers.wpcomstaging.com/wp-content/uploads/2023/05/wp-16844059886575706661464159925646-771x1024.jpg\" alt=\"\" class=\"wp-image-50\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:image {\"id\":27,\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://infocusphotographers.wpcomstaging.com/wp-content/uploads/2023/02/wiser-by-the-mile-ofhkpckhyey-unsplash-e1669859194158-1.jpg\" alt=\"\" class=\"wp-image-27\"/></figure>\n<!-- /wp:image -->",
+          "excerpt": "",
+          "slug": "blog-2",
+          "guid": "https://infocusphotographers.wpcomstaging.com/blog-2/",
+          "status": "publish",
+          "sticky": false,
+          "password": "",
+          "parent": false,
+          "type": "page",
+          "discussion": {
+            "comments_open": false,
+            "comment_status": "closed",
+            "pings_open": false,
+            "ping_status": "closed",
+            "comment_count": 0
+          },
+          "likes_enabled": true,
+          "sharing_enabled": true,
+          "like_count": 0,
+          "i_like": false,
+          "is_reblogged": false,
+          "is_following": true,
+          "global_ID": "97e31e7dc1c0c1ef55ff252025cc55b3",
+          "featured_image": "",
+          "format": "standard",
+          "geo": false,
+          "menu_order": 0,
+          "page_template": "",
+          "publicize_URLs": [],
+          "terms": {},
+          "tags": {},
+          "categories": {
+            "Uncategorized": {
+              "ID": 1,
+              "name": "Uncategorized",
+              "slug": "uncategorized",
+              "description": "",
+              "post_count": 6,
+              "meta": {
+                "links": {
+                  "self": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/categories/slug:uncategorized",
+                  "help": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/categories/slug:uncategorized/help",
+                  "site": "https://public-api.wordpress.com/rest/v1.2/sites/106707880"
+                }
+              },
+              "parent": 0
+            }
+          },
+          "attachments": {},
+          "attachment_count": 0,
+          "metadata": [],
+          "meta": {
+            "links": {
+              "self": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/posts/51",
+              "help": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/posts/51/help",
+              "site": "https://public-api.wordpress.com/rest/v1.2/sites/106707880",
+              "replies": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/posts/51/replies/",
+              "likes": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/posts/51/likes/"
+            }
+          },
+          "capabilities": {
+            "publish_post": true,
+            "delete_post": true,
+            "edit_post": true
+          },
+          "other_URLs": {}
+        },
+        {
+          "ID": 6,
+          "site_ID": 106707880,
+          "author": {
+            "ID": 152748359,
+            "login": "kkevin",
+            "email": "test@automattic.com",
+            "name": "Kevin Jorge",
+            "first_name": "Kevin",
+            "last_name": "Jorge",
+            "nice_name": "kkevin",
+            "URL": "",
+            "avatar_URL": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=identicon&r=g",
+            "profile_URL": "https://en.gravatar.com/eea057209f5e29d6ca4103bc165d645b"
+          },
+          "date": "2023-02-03T11:39:21+02:00",
+          "modified": "2023-02-03T11:39:21+02:00",
+          "title": "Shop",
+          "URL": "https://infocusphotographers.wpcomstaging.com/shop/",
+          "short_URL": "https://wp.me/Pez3E8-6",
+          "content": "",
+          "excerpt": "",
+          "slug": "shop",
+          "guid": "https://infocusphotographers.wpcomstaging.com/shop/",
+          "status": "publish",
+          "sticky": false,
+          "password": "",
+          "parent": false,
+          "type": "page",
+          "discussion": {
+            "comments_open": false,
+            "comment_status": "closed",
+            "pings_open": false,
+            "ping_status": "closed",
+            "comment_count": 0
+          },
+          "likes_enabled": true,
+          "sharing_enabled": false,
+          "like_count": 0,
+          "i_like": false,
+          "is_reblogged": false,
+          "is_following": true,
+          "global_ID": "3a97ffe84953f0deaa2fe6bfc2ba0e58",
+          "featured_image": "",
+          "format": "standard",
+          "geo": false,
+          "menu_order": 0,
+          "page_template": "",
+          "publicize_URLs": [],
+          "terms": {},
+          "tags": {},
+          "categories": {},
+          "attachments": {},
+          "attachment_count": 0,
+          "metadata": [
+            {
+              "id": "36",
+              "key": "switch_like_status",
+              "value": [
+                null
+              ]
+            },
+            {
+              "id": "37",
+              "key": "_starter_page_template",
+              "value": ""
+            },
+            {
+              "id": "39",
+              "key": "_wpas_skip_all_services",
+              "value": "1"
+            }
+          ],
+          "meta": {
+            "links": {
+              "self": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/posts/6",
+              "help": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/posts/6/help",
+              "site": "https://public-api.wordpress.com/rest/v1.2/sites/106707880",
+              "replies": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/posts/6/replies/",
+              "likes": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/posts/6/likes/"
+            }
+          },
+          "capabilities": {
+            "publish_post": true,
+            "delete_post": true,
+            "edit_post": true
+          },
+          "other_URLs": {}
+        },
+        {
+          "ID": 7,
+          "site_ID": 106707880,
+          "author": {
+            "ID": 152748359,
+            "login": "kkevin",
+            "email": "test@automattic.com",
+            "name": "Kevin Jorge",
+            "first_name": "Kevin",
+            "last_name": "Jorge",
+            "nice_name": "kkevin",
+            "URL": "",
+            "avatar_URL": "https://secure.gravatar.com/avatar/eea057209f5e29d6ca4103bc165d645b?s=96&d=identicon&r=g",
+            "profile_URL": "https://en.gravatar.com/eea057209f5e29d6ca4103bc165d645b"
+          },
+          "date": "2023-02-03T11:39:20+02:00",
+          "modified": "2023-02-03T11:39:20+02:00",
+          "title": "Cart",
+          "URL": "https://infocusphotographers.wpcomstaging.com/cart/",
+          "short_URL": "https://wp.me/Pez3E8-7",
+          "content": "<!-- wp:woocommerce/cart -->\n<div class=\"wp-block-woocommerce-cart is-loading\"><!-- wp:woocommerce/filled-cart-block -->\n<div class=\"wp-block-woocommerce-filled-cart-block\"><!-- wp:woocommerce/cart-items-block -->\n<div class=\"wp-block-woocommerce-cart-items-block\"><!-- wp:woocommerce/cart-line-items-block -->\n<div class=\"wp-block-woocommerce-cart-line-items-block\"></div>\n<!-- /wp:woocommerce/cart-line-items-block -->\n\n<!-- wp:woocommerce/cart-cross-sells-block -->\n<div class=\"wp-block-woocommerce-cart-cross-sells-block\"><!-- wp:heading {\"level\":3} -->\n<h3>You may be interested in…</h3>\n<!-- /wp:heading -->\n\n<!-- wp:woocommerce/cart-cross-sells-products-block -->\n<div class=\"wp-block-woocommerce-cart-cross-sells-products-block\"></div>\n<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>\n<!-- /wp:woocommerce/cart-cross-sells-block --></div>\n<!-- /wp:woocommerce/cart-items-block -->\n\n<!-- wp:woocommerce/cart-totals-block -->\n<div class=\"wp-block-woocommerce-cart-totals-block\"><!-- wp:woocommerce/cart-order-summary-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-block\"><!-- wp:woocommerce/cart-order-summary-heading-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-heading-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-heading-block -->\n\n<!-- wp:woocommerce/cart-order-summary-subtotal-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-subtotal-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-subtotal-block -->\n\n<!-- wp:woocommerce/cart-order-summary-fee-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-fee-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-fee-block -->\n\n<!-- wp:woocommerce/cart-order-summary-discount-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-discount-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-discount-block -->\n\n<!-- wp:woocommerce/cart-order-summary-coupon-form-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-coupon-form-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-coupon-form-block -->\n\n<!-- wp:woocommerce/cart-order-summary-shipping-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-shipping-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-shipping-block -->\n\n<!-- wp:woocommerce/cart-order-summary-taxes-block -->\n<div class=\"wp-block-woocommerce-cart-order-summary-taxes-block\"></div>\n<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>\n<!-- /wp:woocommerce/cart-order-summary-block -->\n\n<!-- wp:woocommerce/cart-express-payment-block -->\n<div class=\"wp-block-woocommerce-cart-express-payment-block\"></div>\n<!-- /wp:woocommerce/cart-express-payment-block -->\n\n<!-- wp:woocommerce/proceed-to-checkout-block -->\n<div class=\"wp-block-woocommerce-proceed-to-checkout-block\"></div>\n<!-- /wp:woocommerce/proceed-to-checkout-block -->\n\n<!-- wp:woocommerce/cart-accepted-payment-methods-block -->\n<div class=\"wp-block-woocommerce-cart-accepted-payment-methods-block\"></div>\n<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>\n<!-- /wp:woocommerce/cart-totals-block --></div>\n<!-- /wp:woocommerce/filled-cart-block -->\n\n<!-- wp:woocommerce/empty-cart-block -->\n<div class=\"wp-block-woocommerce-empty-cart-block\"><!-- wp:image {\"align\":\"center\",\"sizeSlug\":\"small\"} -->\n<figure class=\"wp-block-image aligncenter size-small\"><img src=\"image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE5IDBDOC41MDQwMyAwIDAgOC41MDQwMyAwIDE5QzAgMjkuNDk2IDguNTA0MDMgMzggMTkgMzhDMjkuNDk2IDM4IDM4IDI5LjQ5NiAzOCAxOUMzOCA4LjUwNDAzIDI5LjQ5NiAwIDE5IDBaTTI1LjEyOSAxMi44NzFDMjYuNDg1MSAxMi44NzEgMjcuNTgwNiAxMy45NjY1IDI3LjU4MDYgMTUuMzIyNkMyNy41ODA2IDE2LjY3ODYgMjYuNDg1MSAxNy43NzQyIDI1LjEyOSAxNy43NzQyQzIzLjc3MyAxNy43NzQyIDIyLjY3NzQgMTYuNjc4NiAyMi42Nzc0IDE1LjMyMjZDMjIuNjc3NCAxMy45NjY1IDIzLjc3MyAxMi44NzEgMjUuMTI5IDEyLjg3MVpNMTEuNjQ1MiAzMS4yNTgxQzkuNjE0OTIgMzEuMjU4MSA3Ljk2Nzc0IDI5LjY0OTIgNy45Njc3NCAyNy42NTczQzcuOTY3NzQgMjYuMTI1IDEwLjE1MTIgMjMuMDI5OCAxMS4xNTQ4IDIxLjY5NjhDMTEuNCAyMS4zNjczIDExLjg5MDMgMjEuMzY3MyAxMi4xMzU1IDIxLjY5NjhDMTMuMTM5MSAyMy4wMjk4IDE1LjMyMjYgMjYuMTI1IDE1LjMyMjYgMjcuNjU3M0MxNS4zMjI2IDI5LjY0OTIgMTMuNjc1NCAzMS4yNTgxIDExLjY0NTIgMzEuMjU4MVpNMTIuODcxIDE3Ljc3NDJDMTEuNTE0OSAxNy43NzQyIDEwLjQxOTQgMTYuNjc4NiAxMC40MTk0IDE1LjMyMjZDMTAuNDE5NCAxMy45NjY1IDExLjUxNDkgMTIuODcxIDEyLjg3MSAxMi44NzFDMTQuMjI3IDEyLjg3MSAxNS4zMjI2IDEzLjk2NjUgMTUuMzIyNiAxNS4zMjI2QzE1LjMyMjYgMTYuNjc4NiAxNC4yMjcgMTcuNzc0MiAxMi44NzEgMTcuNzc0MlpNMjUuOTEwNSAyOS41ODc5QzI0LjE5NDQgMjcuNTM0NyAyMS42NzM4IDI2LjM1NDggMTkgMjYuMzU0OEMxNy4zNzU4IDI2LjM1NDggMTcuMzc1OCAyMy45MDMyIDE5IDIzLjkwMzJDMjIuNDAxNiAyMy45MDMyIDI1LjYxMTcgMjUuNDA0OCAyNy43ODc1IDI4LjAyNUMyOC44NDQ4IDI5LjI4MTUgMjYuOTI5NCAzMC44MjE0IDI1LjkxMDUgMjkuNTg3OVoiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=\" alt=\"\" /></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading {\"textAlign\":\"center\",\"className\":\"wc-block-cart__empty-cart__title\"} -->\n<h2 class=\"has-text-align-center wc-block-cart__empty-cart__title\">Your cart is currently empty!</h2>\n<!-- /wp:heading -->\n\n<!-- wp:paragraph {\"align\":\"center\"} -->\n<p class=\"has-text-align-center\"><a href=\"https://zainodemo.wpcomstaging.com/shop/\">Browse store</a>.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:separator {\"className\":\"is-style-dots\"} -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity is-style-dots\" />\n<!-- /wp:separator -->\n\n<!-- wp:heading {\"textAlign\":\"center\"} -->\n<h2 class=\"has-text-align-center\">New in store</h2>\n<!-- /wp:heading -->\n\n<!-- wp:woocommerce/product-new {\"rows\":1} /--></div>\n<!-- /wp:woocommerce/empty-cart-block --></div>\n<!-- /wp:woocommerce/cart -->",
+          "excerpt": "",
+          "slug": "cart",
+          "guid": "https://infocusphotographers.wpcomstaging.com/cart/",
+          "status": "publish",
+          "sticky": false,
+          "password": "",
+          "parent": false,
+          "type": "page",
+          "discussion": {
+            "comments_open": false,
+            "comment_status": "closed",
+            "pings_open": false,
+            "ping_status": "closed",
+            "comment_count": 0
+          },
+          "likes_enabled": true,
+          "sharing_enabled": false,
+          "like_count": 0,
+          "i_like": false,
+          "is_reblogged": false,
+          "is_following": true,
+          "global_ID": "5a697a759e1d595fddd5cdfcd64f00a0",
+          "featured_image": "",
+          "format": "standard",
+          "geo": false,
+          "menu_order": 0,
+          "page_template": "",
+          "publicize_URLs": [],
+          "terms": {},
+          "tags": {},
+          "categories": {},
+          "attachments": {},
+          "attachment_count": 0,
+          "metadata": [
+            {
+              "id": "43",
+              "key": "switch_like_status",
+              "value": [
+                null
+              ]
+            },
+            {
+              "id": "44",
+              "key": "_starter_page_template",
+              "value": ""
+            },
+            {
+              "id": "46",
+              "key": "_wpas_skip_all_services",
+              "value": "1"
+            }
+          ],
+          "meta": {
+            "links": {
+              "self": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/posts/7",
+              "help": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/posts/7/help",
+              "site": "https://public-api.wordpress.com/rest/v1.2/sites/106707880",
+              "replies": "https://public-api.wordpress.com/rest/v1.1/sites/106707880/posts/7/replies/",
+              "likes": "https://public-api.wordpress.com/rest/v1.2/sites/106707880/posts/7/likes/"
+            }
+          },
+          "capabilities": {
+            "publish_post": true,
+            "delete_post": true,
+            "edit_post": true
+          },
+          "other_URLs": {}
+        }
+      ],
+      "meta": {
+        "links": {
+          "counts": "https://public-api.wordpress.com/rest/v1.2/sites/1/post-counts/page"
+        }
+      }
+    }
+  }
+}

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/pages/pages_offset_6.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/pages/pages_offset_6.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/rest/v1.2/sites/106707880/posts",
+    "queryParameters": {
+      "locale": {
+        "matches": "(.*)"
+      },
+      "type": {
+        "equalTo": "page"
+      },
+      "offset": {
+        "equalTo": "3"
+      }        
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "found": 0,
+      "posts": [],
+      "meta": {
+        "links": {
+          "counts": "https://public-api.wordpress.com/rest/v1.2/sites/1/post-counts/page"
+        }
+      }
+    }
+  }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -21,6 +21,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.setTitle(Strings.title)
+        frameView.accessibilityIdentifier = "dashboard-activity-log-card-frameview"
         return frameView
     }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPagesListCardCell.swift
@@ -16,6 +16,7 @@ final class DashboardPagesListCardCell: DashboardCollectionViewCell, PagesCardVi
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.setTitle(Strings.title)
+        frameView.accessibilityIdentifier = "dashboard-pages-card-frameview"
         return frameView
     }()
 

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -39,4 +39,15 @@ class DashboardTests: XCTestCase {
             .tapPagesCardHeader()
             .verifyPagesScreenLoaded()
     }
+
+    func testActivityLogCardHeaderNavigation() throws {
+        try MySiteScreen()
+            .scrollToActivityLogCard()
+            .verifyActivityLogCard()
+            .verifyActivityLogCard(hasActivityPartial: "Enabled Jetpack Social for")
+            .verifyActivityLogCard(hasActivityPartial: "The Jetpack connection is")
+            .verifyActivityLogCard(hasActivityPartial: "This site is connected to J")
+            .tapActivityLogCardHeader()
+            .verifyActivityLogScreenLoaded()
+    }
 }

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -44,9 +44,9 @@ class DashboardTests: XCTestCase {
         try MySiteScreen()
             .scrollToActivityLogCard()
             .verifyActivityLogCard()
-            .verifyActivityLogCard(hasActivityPartial: "Enabled Jetpack Social for")
-            .verifyActivityLogCard(hasActivityPartial: "The Jetpack connection is")
-            .verifyActivityLogCard(hasActivityPartial: "This site is connected to J")
+            .verifyActivityLogCard(hasActivityPartial: "Enabled Jetpack Social")
+            .verifyActivityLogCard(hasActivityPartial: "The Jetpack connection")
+            .verifyActivityLogCard(hasActivityPartial: "This site is connected to")
             .tapActivityLogCardHeader()
             .verifyActivityLogScreenLoaded()
     }

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -1,6 +1,7 @@
 import UITestsFoundation
 import XCTest
 
+// These tests are Jetpack only.
 class DashboardTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
@@ -17,7 +18,7 @@ class DashboardTests: XCTestCase {
         removeApp()
     }
 
-    // This test is JP only.
+
     func testFreeToPaidCardNavigation() throws {
         try MySiteScreen()
             .scrollToFreeToPaidPlansCard()

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -49,5 +49,8 @@ class DashboardTests: XCTestCase {
             .verifyActivityLogCard(hasActivityPartial: "This site is connected to")
             .tapActivityLogCardHeader()
             .verifyActivityLogScreenLoaded()
+            .verifyActivityLogScreen(hasActivityPartial: "Enabled Jetpack Social")
+            .verifyActivityLogScreen(hasActivityPartial: "The Jetpack connection")
+            .verifyActivityLogScreen(hasActivityPartial: "This site is connected to")
     }
 }

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -28,4 +28,15 @@ class DashboardTests: XCTestCase {
             .goToPlanSelection()
             .verifyPlanSelectionScreenLoaded()
     }
+
+    func testPagesCardHeaderNavigation() throws {
+        try MySiteScreen()
+            .scrollToPagesCard()
+            .verifyPagesCard()
+            .verifyPagesCard(hasPage: "Blog")
+            .verifyPagesCard(hasPage: "Shop")
+            .verifyPagesCard(hasPage: "Cart")
+            .tapPagesCardHeader()
+            .verifyPagesScreenLoaded()
+    }
 }

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -18,7 +18,6 @@ class DashboardTests: XCTestCase {
         removeApp()
     }
 
-
     func testFreeToPaidCardNavigation() throws {
         try MySiteScreen()
             .scrollToFreeToPaidPlansCard()

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -39,5 +39,8 @@ class DashboardTests: XCTestCase {
             .verifyPagesCard(hasPage: "Cart")
             .tapPagesCardHeader()
             .verifyPagesScreenLoaded()
+            .verifyPagesScreen(hasPage: "Blog")
+            .verifyPagesScreen(hasPage: "Shop")
+            .verifyPagesScreen(hasPage: "Cart")
     }
 }

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -34,4 +34,12 @@ public class ActivityLogScreen: ScreenObject {
         XCTAssertTrue(ActivityLogScreen.isLoaded(), "\"Activity\" screen isn't loaded.")
         return self
     }
+
+    @discardableResult
+    public func verifyActivityLogScreen(hasActivityPartial activityTitle: String) -> Self {
+        XCTAssertTrue(
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", activityTitle)).firstMatch.waitForIsHittable(),
+            "Activity Log Screen: \"\(activityTitle)\" activity not displayed.")
+        return self
+    }
 }

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -2,12 +2,36 @@ import ScreenObject
 import XCTest
 
 public class ActivityLogScreen: ScreenObject {
+    public let tabBar: TabNavComponent
+
+    let dateRangeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Date Range"].firstMatch
+    }
+
+    let activityTypeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Activity Type"].firstMatch
+    }
+
+    var dateRangeButton: XCUIElement { dateRangeButtonGetter(app) }
+    var activityTypeButton: XCUIElement { activityTypeButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        tabBar = try TabNavComponent()
+
         try super.init(
-            expectedElementGetters: [ { $0.otherElements.firstMatch } ],
+            expectedElementGetters: [ dateRangeButtonGetter, activityTypeButtonGetter ],
             app: app,
             waitTimeout: 7
         )
+    }
+
+    public static func isLoaded() -> Bool {
+        (try? ActivityLogScreen().isLoaded) ?? false
+    }
+
+    @discardableResult
+    public func verifyActivityLogScreenLoaded() -> Self {
+        XCTAssertTrue(ActivityLogScreen.isLoaded(), "\"Activity\" screen isn't loaded.")
+        return self
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -26,6 +26,9 @@ private struct ElementStringIDs {
     static let pagesCardId = "dashboard-pages-card-frameview"
     static let pagesCardHeaderButton = "Pages"
     static let pagesCardCreatePageButton = "Create another page"
+    // "Activity Log" Card
+    static let activityLogCardId = "dashboard-activity-log-card-frameview"
+    static let activityLogCardHeaderButton = "Recent activity"
 }
 
 /// The home-base screen for an individual site. Used in many of our UI tests.
@@ -87,10 +90,20 @@ public class MySiteScreen: ScreenObject {
         $0.cells[ElementStringIDs.domainsButton]
     }
 
+    let activityLogCardGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements[ElementStringIDs.activityLogCardId]
+    }
+
+    let activityLogCardHeaderButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements[ElementStringIDs.activityLogCardId].buttons[ElementStringIDs.activityLogCardHeaderButton]
+    }
+
     var freeToPaidPlansCardButton: XCUIElement { freeToPaidPlansCardButtonGetter(app) }
     var pagesCard: XCUIElement { pagesCardGetter(app) }
     var pagesCardHeaderButton: XCUIElement { pagesCardHeaderButtonGetter(app) }
     var pagesCardCreatePageButton: XCUIElement { pagesCardCreatePageButtonGetter(app) }
+    var activityLogCard: XCUIElement { activityLogCardGetter(app) }
+    var activityLogCardHeaderButton: XCUIElement { activityLogCardHeaderButtonGetter(app) }
 
     static var isVisible: Bool {
         let app = XCUIApplication()
@@ -232,6 +245,21 @@ public class MySiteScreen: ScreenObject {
     }
 
     @discardableResult
+    public func verifyActivityLogCard() -> Self {
+        XCTAssertTrue(activityLogCardHeaderButton.waitForIsHittable(), "Activity Log card: header not displayed.")
+        XCTAssertTrue(activityLogCard.buttons["More"].waitForIsHittable(), "Activity Log card: context menu not displayed.")
+        return self
+    }
+
+    @discardableResult
+    public func verifyActivityLogCard(hasActivityPartial activityTitle: String) -> Self {
+        XCTAssertTrue(
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", activityTitle)).firstMatch.waitForIsHittable(),
+            "Activity Log card: \"\(activityTitle)\" activity not displayed.")
+        return self
+    }
+
+    @discardableResult
     public func tapFreeToPaidPlansCard() throws -> DomainsSuggestionsScreen {
         freeToPaidPlansCardButton.tap()
         return try DomainsSuggestionsScreen()
@@ -253,6 +281,18 @@ public class MySiteScreen: ScreenObject {
     public func tapPagesCardHeader() throws -> PagesScreen {
         pagesCardHeaderButton.tap()
         return try PagesScreen()
+    }
+
+    @discardableResult
+    public func scrollToActivityLogCard() throws -> Self {
+        scrollToCard(withId: ElementStringIDs.activityLogCardId)
+        return self
+    }
+
+    @discardableResult
+    public func tapActivityLogCardHeader() throws -> ActivityLogScreen {
+        activityLogCardHeaderButton.tap()
+        return try ActivityLogScreen()
     }
 
     func scrollToCard(withId id: String) {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -19,7 +19,13 @@ private struct ElementStringIDs {
     static let switchSiteButton = "SwitchSiteButton"
     static let dashboardButton = "Home"
     static let segmentedControlMenuButton = "Menu"
+    // "Free To Paid Plans" Card
+    static let freeToPaidPlansCardId = "dashboard-free-to-paid-plans-card-contentview"
     static let freeToPaidPlansCardHeaderButton = "Free domain with an annual plan"
+    // "Pages" Card
+    static let pagesCardId = "dashboard-pages-card-frameview"
+    static let pagesCardHeaderButton = "Pages"
+    static let pagesCardCreatePageButton = "Create another page"
 }
 
 /// The home-base screen for an individual site. Used in many of our UI tests.
@@ -65,11 +71,26 @@ public class MySiteScreen: ScreenObject {
         $0.buttons[ElementStringIDs.freeToPaidPlansCardHeaderButton]
     }
 
+    let pagesCardGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements[ElementStringIDs.pagesCardId]
+    }
+
+    let pagesCardHeaderButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements[ElementStringIDs.pagesCardId].buttons[ElementStringIDs.pagesCardHeaderButton]
+    }
+
+    let pagesCardCreatePageButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements[ElementStringIDs.pagesCardId].buttons[ElementStringIDs.pagesCardCreatePageButton]
+    }
+
     let domainsButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells[ElementStringIDs.domainsButton]
     }
 
     var freeToPaidPlansCardButton: XCUIElement { freeToPaidPlansCardButtonGetter(app) }
+    var pagesCard: XCUIElement { pagesCardGetter(app) }
+    var pagesCardHeaderButton: XCUIElement { pagesCardHeaderButtonGetter(app) }
+    var pagesCardCreatePageButton: XCUIElement { pagesCardCreatePageButtonGetter(app) }
 
     static var isVisible: Bool {
         let app = XCUIApplication()
@@ -197,6 +218,20 @@ public class MySiteScreen: ScreenObject {
     }
 
     @discardableResult
+    public func verifyPagesCard() -> Self {
+        XCTAssertTrue(pagesCardHeaderButton.waitForIsHittable(), "Pages card: header not displayed.")
+        XCTAssertTrue(pagesCard.buttons["More"].waitForIsHittable(), "Pages card: context menu not displayed.")
+        XCTAssertTrue(pagesCardCreatePageButton.waitForIsHittable(), "Pages card: Create Page button not displayed.")
+        return self
+    }
+
+    @discardableResult
+    public func verifyPagesCard(hasPage pageTitle: String) -> Self {
+        XCTAssertTrue(pagesCard.staticTexts[pageTitle].waitForIsHittable(), "Pages card: \"\(pageTitle)\" page not displayed.")
+        return self
+    }
+
+    @discardableResult
     public func tapFreeToPaidPlansCard() throws -> DomainsSuggestionsScreen {
         freeToPaidPlansCardButton.tap()
         return try DomainsSuggestionsScreen()
@@ -204,9 +239,25 @@ public class MySiteScreen: ScreenObject {
 
     @discardableResult
     public func scrollToFreeToPaidPlansCard() throws -> Self {
-        let collectionView = app.collectionViews.firstMatch
-        let cardCell = collectionView.cells.containing(.other, identifier: "dashboard-free-to-paid-plans-card-contentview").firstMatch
-        cardCell.scrollIntoView(within: collectionView)
+        scrollToCard(withId: ElementStringIDs.freeToPaidPlansCardId)
         return self
+    }
+
+    @discardableResult
+    public func scrollToPagesCard() throws -> Self {
+        scrollToCard(withId: ElementStringIDs.pagesCardId)
+        return self
+    }
+
+    @discardableResult
+    public func tapPagesCardHeader() throws -> PagesScreen {
+        pagesCardHeaderButton.tap()
+        return try PagesScreen()
+    }
+
+    func scrollToCard(withId id: String) {
+        let collectionView = app.collectionViews.firstMatch
+        let cardCell = collectionView.cells.containing(.any, identifier: id).firstMatch
+        app.scrollDownToElement(element: cardCell)
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -25,6 +25,7 @@ private struct ElementStringIDs {
     // "Pages" Card
     static let pagesCardId = "dashboard-pages-card-frameview"
     static let pagesCardHeaderButton = "Pages"
+    static let pagesCardMoreButton = "More"
     static let pagesCardCreatePageButton = "Create another page"
 }
 
@@ -79,8 +80,12 @@ public class MySiteScreen: ScreenObject {
         $0.otherElements[ElementStringIDs.pagesCardId].buttons[ElementStringIDs.pagesCardHeaderButton]
     }
 
+    let pagesCardMoreButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements[ElementStringIDs.pagesCardId].buttons[ElementStringIDs.pagesCardHeaderButton]
+    }
+
     let pagesCardCreatePageButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.otherElements[ElementStringIDs.pagesCardId].buttons[ElementStringIDs.pagesCardCreatePageButton]
+        $0.otherElements[ElementStringIDs.pagesCardId].buttons[ElementStringIDs.pagesCardMoreButton]
     }
 
     let domainsButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -90,6 +95,7 @@ public class MySiteScreen: ScreenObject {
     var freeToPaidPlansCardButton: XCUIElement { freeToPaidPlansCardButtonGetter(app) }
     var pagesCard: XCUIElement { pagesCardGetter(app) }
     var pagesCardHeaderButton: XCUIElement { pagesCardHeaderButtonGetter(app) }
+    var pagesCardMoreButton: XCUIElement { pagesCardMoreButtonGetter(app) }
     var pagesCardCreatePageButton: XCUIElement { pagesCardCreatePageButtonGetter(app) }
 
     static var isVisible: Bool {
@@ -219,9 +225,9 @@ public class MySiteScreen: ScreenObject {
 
     @discardableResult
     public func verifyPagesCard() -> Self {
-        XCTAssertTrue(pagesCardHeaderButton.waitForIsHittable(), "Pages card: header not displayed.")
-        XCTAssertTrue(pagesCard.buttons["More"].waitForIsHittable(), "Pages card: context menu not displayed.")
-        XCTAssertTrue(pagesCardCreatePageButton.waitForIsHittable(), "Pages card: Create Page button not displayed.")
+        XCTAssertTrue(pagesCardHeaderButton.waitForIsHittable(), "Pages card: Header not displayed.")
+        XCTAssertTrue(pagesCardMoreButton.waitForIsHittable(), "Pages card: Context menu button not displayed.")
+        XCTAssertTrue(pagesCardCreatePageButton.waitForIsHittable(), "Pages card: \"Create Page\" button not displayed.")
         return self
     }
 

--- a/WordPress/UITestsFoundation/Screens/PagesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PagesScreen.swift
@@ -29,4 +29,10 @@ public class PagesScreen: ScreenObject {
         XCTAssertTrue(PagesScreen.isLoaded(), "\"Pages\" screen isn't loaded.")
         return self
     }
+
+    @discardableResult
+    public func verifyPagesScreen(hasPage pageTitle: String) -> Self {
+        XCTAssertTrue(pagesTable.staticTexts[pageTitle].waitForIsHittable(), "Pages Screen: \"\(pageTitle)\" page not displayed.")
+        return self
+    }
 }

--- a/WordPress/UITestsFoundation/Screens/PagesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PagesScreen.swift
@@ -1,0 +1,32 @@
+import ScreenObject
+import XCTest
+
+public class PagesScreen: ScreenObject {
+    public let tabBar: TabNavComponent
+
+    let pagesTableGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["PagesTable"]
+    }
+
+    var pagesTable: XCUIElement { pagesTableGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        tabBar = try TabNavComponent()
+
+        try super.init(
+            expectedElementGetters: [ pagesTableGetter ],
+            app: app,
+            waitTimeout: 7
+        )
+    }
+
+    public static func isLoaded() -> Bool {
+        (try? PagesScreen().isLoaded) ?? false
+    }
+
+    @discardableResult
+    public func verifyPagesScreenLoaded() -> Self {
+        XCTAssertTrue(PagesScreen.isLoaded(), "\"Pages\" screen isn't loaded.")
+        return self
+    }
+}

--- a/WordPress/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
+++ b/WordPress/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
@@ -3,11 +3,11 @@ import XCTest
 // Taken from https://stackoverflow.com/a/46943935
 extension XCUIApplication {
     private struct Constants {
-        // Half way accross the screen and 10% from top
-        static let topOffset = CGVector(dx: 0.5, dy: 0.1)
+        // Half way accross the screen and 40% from top
+        static let topOffset = CGVector(dx: 0.5, dy: 0.4)
 
-        // Half way accross the screen and 90% from top
-        static let bottomOffset = CGVector(dx: 0.5, dy: 0.9)
+        // Half way accross the screen and 70% from top
+        static let bottomOffset = CGVector(dx: 0.5, dy: 0.7)
     }
 
     var screenTopCoordinate: XCUICoordinate {
@@ -20,18 +20,20 @@ extension XCUIApplication {
 
     /// Scrolls down to element until it becomes hittable.
     /// After that attempts to scroll it to the screen top.
-    func scrollDownToElement(element: XCUIElement, maxScrolls: Int = 5) {
+    func scrollDownToElement(element: XCUIElement, maxScrolls: Int = 10) {
         for _ in 0..<maxScrolls {
-            if element.exists && element.isHittable {
-                element.scrollToTop()
-                break
+            if !element.isFullyVisibleOnScreen() {
+                scrollDown()
             }
-
-            scrollDown()
         }
     }
 
     func scrollDown() {
-        screenBottomCoordinate.press(forDuration: 0.1, thenDragTo: screenTopCoordinate)
+        screenBottomCoordinate.press(
+            forDuration: 0.1,
+            thenDragTo: screenTopCoordinate,
+            withVelocity: XCUIGestureVelocity.slow,
+            thenHoldForDuration: 0.1
+        )
     }
 }

--- a/WordPress/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
+++ b/WordPress/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+// Taken from https://stackoverflow.com/a/46943935
+extension XCUIApplication {
+    private struct Constants {
+        // Half way accross the screen and 10% from top
+        static let topOffset = CGVector(dx: 0.5, dy: 0.1)
+
+        // Half way accross the screen and 90% from top
+        static let bottomOffset = CGVector(dx: 0.5, dy: 0.9)
+    }
+
+    var screenTopCoordinate: XCUICoordinate {
+        return windows.firstMatch.coordinate(withNormalizedOffset: Constants.topOffset)
+    }
+
+    var screenBottomCoordinate: XCUICoordinate {
+        return windows.firstMatch.coordinate(withNormalizedOffset: Constants.bottomOffset)
+    }
+
+    /// Scrolls down to element until it becomes hittable.
+    /// After that attempts to scroll it to the screen top.
+    func scrollDownToElement(element: XCUIElement, maxScrolls: Int = 5) {
+        for _ in 0..<maxScrolls {
+            if element.exists && element.isHittable {
+                element.scrollToTop()
+                break
+            }
+
+            scrollDown()
+        }
+    }
+
+    func scrollDown() {
+        screenBottomCoordinate.press(forDuration: 0.1, thenDragTo: screenTopCoordinate)
+    }
+}

--- a/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
@@ -21,18 +21,4 @@ extension XCUIElement {
             XCTFail("Unable to scroll element into view")
         }
     }
-
-    // Taken from https://stackoverflow.com/a/46943935
-    /// Scroll an element to the screen top.
-    func scrollToTop() {
-        let topCoordinate = XCUIApplication().screenTopCoordinate
-        let elementCoordinate = coordinate(withNormalizedOffset: .zero)
-
-        // Adjust coordinate so that the drag is straight up, otherwise
-        // an embedded horizontal scrolling element will get scrolled instead
-        let delta = topCoordinate.screenPoint.x - elementCoordinate.screenPoint.x
-        let deltaVector = CGVector(dx: delta, dy: 0.0)
-
-        elementCoordinate.withOffset(deltaVector).press(forDuration: 0.1, thenDragTo: topCoordinate)
-    }
 }

--- a/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
@@ -21,4 +21,18 @@ extension XCUIElement {
             XCTFail("Unable to scroll element into view")
         }
     }
+
+    // Taken from https://stackoverflow.com/a/46943935
+    /// Scroll an element to the screen top.
+    func scrollToTop() {
+        let topCoordinate = XCUIApplication().screenTopCoordinate
+        let elementCoordinate = coordinate(withNormalizedOffset: .zero)
+
+        // Adjust coordinate so that the drag is straight up, otherwise
+        // an embedded horizontal scrolling element will get scrolled instead
+        let delta = topCoordinate.screenPoint.x - elementCoordinate.screenPoint.x
+        let deltaVector = CGVector(dx: delta, dy: 0.0)
+
+        elementCoordinate.withOffset(deltaVector).press(forDuration: 0.1, thenDragTo: topCoordinate)
+    }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3055,6 +3055,7 @@
 		D858F2FD20E1F09F007E8A1C /* NotificationActionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D858F2FC20E1F09F007E8A1C /* NotificationActionParser.swift */; };
 		D858F30120E20106007E8A1C /* LikePost.swift in Sources */ = {isa = PBXBuildFile; fileRef = D858F30020E20106007E8A1C /* LikePost.swift */; };
 		D858F30320E201F4007E8A1C /* EditComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D858F30220E201F4007E8A1C /* EditComment.swift */; };
+		D8599FEA2A2930CE00065193 /* PagesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8599FE92A2930CE00065193 /* PagesScreen.swift */; };
 		D865721221869C590023A99C /* WizardStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = D865721021869C590023A99C /* WizardStep.swift */; };
 		D865721321869C590023A99C /* Wizard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D865721121869C590023A99C /* Wizard.swift */; };
 		D86572172186C3600023A99C /* WizardDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86572162186C3600023A99C /* WizardDelegate.swift */; };
@@ -3093,6 +3094,7 @@
 		D8C31CC72188490000A33B35 /* SiteSegmentsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D8C31CC52188490000A33B35 /* SiteSegmentsCell.xib */; };
 		D8CB56202181A8CE00554EAE /* SiteSegmentsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB561F2181A8CE00554EAE /* SiteSegmentsService.swift */; };
 		D8D7DF5A20AD18A400B40A2D /* ImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFE20A33BDB0010EB6E /* ImgUploadProcessor.swift */; };
+		D8E7529B2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E7529A2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift */; };
 		D8EB1FD121900810002AE1C4 /* BlogListViewController+SiteCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EB1FD021900810002AE1C4 /* BlogListViewController+SiteCreation.swift */; };
 		DC06DFF927BD52BE00969974 /* WeeklyRoundupBackgroundTaskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC06DFF827BD52BE00969974 /* WeeklyRoundupBackgroundTaskTests.swift */; };
 		DC06DFFC27BD679700969974 /* BlogTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC06DFFB27BD679700969974 /* BlogTitleTests.swift */; };
@@ -8402,6 +8404,7 @@
 		D858F2FC20E1F09F007E8A1C /* NotificationActionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationActionParser.swift; sourceTree = "<group>"; };
 		D858F30020E20106007E8A1C /* LikePost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikePost.swift; sourceTree = "<group>"; };
 		D858F30220E201F4007E8A1C /* EditComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditComment.swift; sourceTree = "<group>"; };
+		D8599FE92A2930CE00065193 /* PagesScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesScreen.swift; sourceTree = "<group>"; };
 		D865721021869C590023A99C /* WizardStep.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WizardStep.swift; path = Classes/ViewRelated/Wizards/WizardStep.swift; sourceTree = SOURCE_ROOT; };
 		D865721121869C590023A99C /* Wizard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Wizard.swift; path = Classes/ViewRelated/Wizards/Wizard.swift; sourceTree = SOURCE_ROOT; };
 		D86572162186C3600023A99C /* WizardDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WizardDelegate.swift; path = Classes/ViewRelated/Wizards/WizardDelegate.swift; sourceTree = SOURCE_ROOT; };
@@ -8440,6 +8443,7 @@
 		D8C31CC42188490000A33B35 /* SiteSegmentsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSegmentsCell.swift; sourceTree = "<group>"; };
 		D8C31CC52188490000A33B35 /* SiteSegmentsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SiteSegmentsCell.xib; sourceTree = "<group>"; };
 		D8CB561F2181A8CE00554EAE /* SiteSegmentsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSegmentsService.swift; sourceTree = "<group>"; };
+		D8E7529A2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+ScrollDownToElement.swift"; sourceTree = "<group>"; };
 		D8EB1FD021900810002AE1C4 /* BlogListViewController+SiteCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogListViewController+SiteCreation.swift"; sourceTree = "<group>"; };
 		DA67DF58196D8F6A005B5BC8 /* WordPress 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 20.xcdatamodel"; sourceTree = "<group>"; };
 		DB915AD54243A8AE0039B0C7 /* Pods-WordPressScreenshotGeneration.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release.xcconfig"; sourceTree = "<group>"; };
@@ -11471,6 +11475,7 @@
 				3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */,
 				3F762E9A26784D2A0088CD45 /* XCUIElement+Utils.swift */,
 				3F762E9826784CC90088CD45 /* XCUIElementQuery+Utils.swift */,
+				D8E7529A2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift */,
 			);
 			path = UITestsFoundation;
 			sourceTree = "<group>";
@@ -11552,6 +11557,7 @@
 				D82E087729EEB7AF0098F500 /* DomainsScreen.swift */,
 				01281E992A0456CB00464F8F /* DomainsSuggestionsScreen.swift */,
 				011F52D72A1BECA200B04114 /* PlanSelectionScreen.swift */,
+				D8599FE92A2930CE00065193 /* PagesScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -22743,6 +22749,7 @@
 				011F52D82A1BECA200B04114 /* PlanSelectionScreen.swift in Sources */,
 				3F2F854026FAE9DC000FCDA5 /* BlockEditorScreen.swift in Sources */,
 				3FB5C2B327059AC8007D0ECE /* XCUIElement+Scroll.swift in Sources */,
+				D8599FEA2A2930CE00065193 /* PagesScreen.swift in Sources */,
 				3F2F854726FAED51000FCDA5 /* MediaPickerAlbumListScreen.swift in Sources */,
 				3FE39A3626F8370D006E2B3A /* MySitesScreen.swift in Sources */,
 				3F762E9926784CC90088CD45 /* XCUIElementQuery+Utils.swift in Sources */,
@@ -22758,6 +22765,7 @@
 				3F2F855C26FAF227000FCDA5 /* LinkOrPasswordScreen.swift in Sources */,
 				3F2F855226FAF227000FCDA5 /* SignupCheckMagicLinkScreen.swift in Sources */,
 				3FE39A4026F8386A006E2B3A /* SiteSettingsScreen.swift in Sources */,
+				D8E7529B2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift in Sources */,
 				3FE39A3526F83701006E2B3A /* LoginEpilogueScreen.swift in Sources */,
 				3FE39A3826F837CB006E2B3A /* MySiteScreen.swift in Sources */,
 			);


### PR DESCRIPTION
### Description
This PR adds a UI test for the "Pages" dashboard card:

<img width="348" alt="Screenshot 2023-06-02 at 11 27 37" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/73365754/14417053-c6eb-4579-8446-a25d5a01d53d">

**What it does:**
- Checks that that card with expected header, context menu button, pages list and `Create Page` button is available at `Home` screen.
- Taps the card header and checks that the redirect to `Pages` screen takes place

I hope the code is pretty self-explanatory, so I'm not providing a lot of notes on it. There are 12 changed files, however most of them are mocks, accessibility identifiers addition, and extensions for scrolling to an element.

### To test
- All tests are green on CI, including the new `testPagesCardHeaderNavigation`

### Regression Notes
I'm not filling the regression notes since the PR adds a UI test, it does not change the app behaviour in any way.