### PR TITLE
Send Slack notification for UI/Unit test failures

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.1
+    - automattic/a8c-ci-toolkit#2.17.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -50,6 +50,11 @@ else
   echo "The UI Tests, ran during the '🔬 Testing' step above, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
-annotate_test_failures "build/results/JetpackUITests.xml"
+
+if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
+    annotate_test_failures "build/results/JetpackUITests.xml" --slack "build-and-ship"
+else
+    annotate_test_failures "build/results/JetpackUITests.xml"
+fi
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -36,6 +36,11 @@ else
   echo "The Unit Tests, ran during the '🔬 Testing' step above, have failed."
   echo "For more details about the failed tests, check the Buildkite annotation, the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
-annotate_test_failures "build/results/WordPress.xml"
+
+if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
+    annotate_test_failures "build/results/WordPress.xml" --slack "build-and-ship"
+else
+    annotate_test_failures "build/results/WordPress.xml"
+fi
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.1
+    - automattic/a8c-ci-toolkit#2.17.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"
@@ -73,10 +73,6 @@ steps:
     notify:
       - github_commit_status:
           context: "Unit Tests"
-      - slack:
-          channels:
-            - "#mobile-apps-tests-notif"
-        if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # UI Tests
@@ -94,10 +90,6 @@ steps:
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
-          - slack:
-              channels:
-                - "#mobile-apps-tests-notif"
-            if: build.state == "failed" && build.branch == "trunk"
 
       - label: "🔬 :jetpack: UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh 'iPad Air (5th generation)'
@@ -110,10 +102,6 @@ steps:
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"
-          - slack:
-              channels:
-                - "#mobile-apps-tests-notif"
-            if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # Linters

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.15.1
+    - automattic/a8c-ci-toolkit#2.17.0
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"


### PR DESCRIPTION
### Description
Same changes as This PR updates the `a8c-ci-toolkit` to v2.17.0 to get the updated version of `annotate_test_failures` utility. With this change, any test failures (UI and Unit) on merges to `trunk` or `release/*` branches will send a slack notification to `build-and-ship` channel.

I also removed Buildkite's Slack notification for UI and Unit test steps that was previously added via https://github.com/wordpress-mobile/WordPress-iOS/pull/19181/ and https://github.com/wordpress-mobile/WordPress-iOS/pull/19120/ as this new notification will replace that.

Similar PR for WCiOS: https://github.com/woocommerce/woocommerce-ios/pull/9853