### PR TITLE
Dashboard Cards: Deduplicate activities before rendering the Activity Log card

### DIFF
--- a/WordPress/Classes/Extensions/Array.swift
+++ b/WordPress/Classes/Extensions/Array.swift
@@ -18,6 +18,11 @@ extension Array where Element: Hashable {
     public var unique: [Element] {
         return Array(Set(self))
     }
+
+    public func deduplicated() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
 }
 
 extension Array where Element: Equatable {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -12,6 +12,7 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
     private(set) var blog: Blog?
     private(set) weak var presentingViewController: BlogDashboardViewController?
     private(set) lazy var dataSource = createDataSource()
+    private var viewModel: DashboardActivityLogViewModel?
 
     let store = StoreContainer.shared.activity
 
@@ -71,11 +72,16 @@ final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
     // MARK: - BlogDashboardCardConfigurable
 
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        guard let apiResponse else {
+            return
+        }
+
         self.blog = blog
         self.presentingViewController = viewController
+        self.viewModel = DashboardActivityLogViewModel(apiResponse: apiResponse)
 
         tableView.dataSource = dataSource
-        updateDataSource(with: apiResponse?.activity?.value?.current?.orderedItems ?? [])
+        updateDataSource(with: viewModel?.activitiesToDisplay ?? [])
 
         configureHeaderAction(for: blog)
         configureContextMenu(for: blog)
@@ -151,10 +157,7 @@ extension DashboardActivityLogCardCell {
     private func updateDataSource(with activities: [Activity]) {
         var snapshot = Snapshot()
         snapshot.appendSections(ActivityLogSection.allCases)
-
-        let activitiesToDisplay = Array(activities.prefix(Constants.maxActivitiesCount))
-        snapshot.appendItems(activitiesToDisplay, toSection: .activities)
-
+        snapshot.appendItems(activities, toSection: .activities)
         dataSource.apply(snapshot)
     }
 }
@@ -190,7 +193,6 @@ extension DashboardActivityLogCardCell {
 extension DashboardActivityLogCardCell {
 
     private enum Constants {
-        static let maxActivitiesCount = 3
         static let headerTapSource = "activity_card_header"
         static let contextMenuTapSource = "activity_card_context_menu"
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class DashboardActivityLogViewModel {
+
+    // MARK: Private Variables
+
+    private var apiResponse: BlogDashboardRemoteEntity
+
+    // MARK: Initializer
+
+    init(apiResponse: BlogDashboardRemoteEntity) {
+        self.apiResponse = apiResponse
+    }
+
+    // MARK: Public Variables
+
+    var activitiesToDisplay: [Activity] {
+        let uniqueActivities = apiResponse.activity?.value?.current?.orderedItems?.deduplicated() ?? []
+        return Array(uniqueActivities.prefix(Constants.maxActivitiesCount))
+    }
+
+    private enum Constants {
+        static let maxActivitiesCount = 3
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3791,6 +3791,8 @@
 		FA347AF226EB7A420096604B /* StatsGhostGrowAudienceCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA347AF126EB7A420096604B /* StatsGhostGrowAudienceCell.xib */; };
 		FA347AF326EB7A420096604B /* StatsGhostGrowAudienceCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA347AF126EB7A420096604B /* StatsGhostGrowAudienceCell.xib */; };
 		FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */; };
+		FA3FBF8B2A2772340012FC90 /* DashboardActivityLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */; };
+		FA3FBF8C2A2772340012FC90 /* DashboardActivityLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
 		FA4B202F29A619130089FE68 /* BlazeFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B202E29A619130089FE68 /* BlazeFlowCoordinator.swift */; };
@@ -9145,6 +9147,7 @@
 		FA347AEC26EB6E300096604B /* GrowAudienceCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GrowAudienceCell.xib; sourceTree = "<group>"; };
 		FA347AF126EB7A420096604B /* StatsGhostGrowAudienceCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsGhostGrowAudienceCell.xib; sourceTree = "<group>"; };
 		FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreCompleteViewController.swift; sourceTree = "<group>"; };
+		FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardActivityLogViewModel.swift; sourceTree = "<group>"; };
 		FA41044C263932AC00E90EBF /* ActivityLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLogScreen.swift; sourceTree = "<group>"; };
 		FA4104732639393700E90EBF /* JetpackScanScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanScreen.swift; sourceTree = "<group>"; };
 		FA4104BE26393F1A00E90EBF /* JetpackBackupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupScreen.swift; sourceTree = "<group>"; };
@@ -17712,6 +17715,7 @@
 			children = (
 				FA70024B29DC3B5500E874FD /* DashboardActivityLogCardCell.swift */,
 				FAD7626329F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift */,
+				FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */,
 			);
 			path = "Activity Log";
 			sourceTree = "<group>";
@@ -20926,6 +20930,7 @@
 				400A2C842217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */,
 				FA332AD429C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */,
+				FA3FBF8B2A2772340012FC90 /* DashboardActivityLogViewModel.swift in Sources */,
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,
 				E16A76F31FC4766900A661E3 /* CredentialsService.swift in Sources */,
 				F9B862C92478170A008B093C /* EncryptedLogTableViewController.swift in Sources */,
@@ -25315,6 +25320,7 @@
 				FABB25902602FC2C00C8785C /* SharingViewController.m in Sources */,
 				FABB25912602FC2C00C8785C /* FormattableActivity.swift in Sources */,
 				FABB25922602FC2C00C8785C /* RevisionPreviewTextViewManager.swift in Sources */,
+				FA3FBF8C2A2772340012FC90 /* DashboardActivityLogViewModel.swift in Sources */,
 				FABB25932602FC2C00C8785C /* StatsChartLegendView.swift in Sources */,
 				C7B7CC712812FDCE007B9807 /* MySiteViewController+OnboardingPrompt.swift in Sources */,
 				C3FF78E928354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3793,6 +3793,7 @@
 		FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */; };
 		FA3FBF8B2A2772340012FC90 /* DashboardActivityLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */; };
 		FA3FBF8C2A2772340012FC90 /* DashboardActivityLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */; };
+		FA3FBF8E2A2777E00012FC90 /* DashboardActivityLogViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3FBF8D2A2777E00012FC90 /* DashboardActivityLogViewModelTests.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
 		FA4B202F29A619130089FE68 /* BlazeFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B202E29A619130089FE68 /* BlazeFlowCoordinator.swift */; };
@@ -9148,6 +9149,7 @@
 		FA347AF126EB7A420096604B /* StatsGhostGrowAudienceCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsGhostGrowAudienceCell.xib; sourceTree = "<group>"; };
 		FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreCompleteViewController.swift; sourceTree = "<group>"; };
 		FA3FBF8A2A2772340012FC90 /* DashboardActivityLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardActivityLogViewModel.swift; sourceTree = "<group>"; };
+		FA3FBF8D2A2777E00012FC90 /* DashboardActivityLogViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardActivityLogViewModelTests.swift; sourceTree = "<group>"; };
 		FA41044C263932AC00E90EBF /* ActivityLogScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityLogScreen.swift; sourceTree = "<group>"; };
 		FA4104732639393700E90EBF /* JetpackScanScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanScreen.swift; sourceTree = "<group>"; };
 		FA4104BE26393F1A00E90EBF /* JetpackBackupScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupScreen.swift; sourceTree = "<group>"; };
@@ -13661,6 +13663,7 @@
 				0118969029D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift */,
 				0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */,
 				011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */,
+				FA3FBF8D2A2777E00012FC90 /* DashboardActivityLogViewModelTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -23483,6 +23486,7 @@
 				FE32E7F12844971000744D80 /* ReminderScheduleCoordinatorTests.swift in Sources */,
 				4688E6CC26AB571D00A5D894 /* RequestAuthenticatorTests.swift in Sources */,
 				7E442FC720F677CB00DEACA5 /* ActivityLogRangesTest.swift in Sources */,
+				FA3FBF8E2A2777E00012FC90 /* DashboardActivityLogViewModelTests.swift in Sources */,
 				938466B92683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift in Sources */,
 				FECA44322836647100D01F15 /* PromptRemindersSchedulerTests.swift in Sources */,
 				FE3D057E26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift in Sources */,

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -133,9 +133,9 @@ class ActivityStoreMock: ActivityStore {
 }
 
 extension Activity {
-    static func mock(isRewindable: Bool = false) throws -> Activity {
+    static func mock(id: String = "1", isRewindable: Bool = false) throws -> Activity {
         let dictionary = [
-            "activity_id": "1",
+            "activity_id": id,
             "summary": "",
             "is_rewindable": isRewindable,
             "rewind_id": "1",

--- a/WordPress/WordPressTest/Dashboard/DashboardActivityLogViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardActivityLogViewModelTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import WordPress
+
+final class DashboardActivityLogViewModelTests: XCTestCase {
+
+    func testReturnMaxThreeItems() {
+        // Given
+        let activities = try? [
+            Activity.mock(id: "1"),
+            Activity.mock(id: "2"),
+            Activity.mock(id: "3"),
+            Activity.mock(id: "4"),
+            Activity.mock(id: "5"),
+        ]
+
+        let currentActivity = BlogDashboardRemoteEntity.BlogDashboardActivity.CurrentActivity(orderedItems: activities)
+        let activityData = BlogDashboardRemoteEntity.BlogDashboardActivity(current: currentActivity)
+        let activity = FailableDecodable(value: activityData)
+        let apiResponse = BlogDashboardRemoteEntity(activity: activity)
+        let viewModel = DashboardActivityLogViewModel(apiResponse: apiResponse)
+
+        // When & Then
+        XCTAssertEqual(viewModel.activitiesToDisplay.count, 3)
+        XCTAssertEqual(viewModel.activitiesToDisplay[0].activityID, "1")
+        XCTAssertEqual(viewModel.activitiesToDisplay[1].activityID, "2")
+        XCTAssertEqual(viewModel.activitiesToDisplay[2].activityID, "3")
+    }
+
+    func testReturnUniqueItems() {
+        // Given
+        let activities = try? [
+            Activity.mock(id: "1"),
+            Activity.mock(id: "1"),
+            Activity.mock(id: "1"),
+            Activity.mock(id: "2"),
+            Activity.mock(id: "2"),
+            Activity.mock(id: "3"),
+            Activity.mock(id: "4")
+        ]
+
+        let currentActivity = BlogDashboardRemoteEntity.BlogDashboardActivity.CurrentActivity(orderedItems: activities)
+        let activityData = BlogDashboardRemoteEntity.BlogDashboardActivity(current: currentActivity)
+        let activity = FailableDecodable(value: activityData)
+        let apiResponse = BlogDashboardRemoteEntity(activity: activity)
+        let viewModel = DashboardActivityLogViewModel(apiResponse: apiResponse)
+
+        // When & Then
+        XCTAssertEqual(viewModel.activitiesToDisplay.count, 3)
+        XCTAssertEqual(viewModel.activitiesToDisplay[0].activityID, "1")
+        XCTAssertEqual(viewModel.activitiesToDisplay[1].activityID, "2")
+        XCTAssertEqual(viewModel.activitiesToDisplay[2].activityID, "3")
+    }
+}


### PR DESCRIPTION
Fixes  #20729

## Description
- Adds a check to deduplicate activities before rendering the Activity Log card

## Background
- Crash caused by diffable data source not being able to differentiate items - duplicate activity items were being returned in the `/dashboard/cards-data` endpoint as well as the `sites/{site-id}/activity` endpoint
- Mobile investigation: p1684971925814679-slack-C0180B5PRJ4
- Jetpack crew investigation: p1685611256986159-slack-C011BCGRMBR

## How to test
1. Make sure the tests in `DashboardActivityLogViewModelTests` pass

## Regression Notes
1. Potential unintended areas of impact
Activity Log dashboard card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit tests

3. What automated tests I added (or what prevented me from doing so)
`DashboardActivityLogViewModelTests`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
