### PR TITLE
Blaze Manage Campaigns: Add Blaze campaigns dashboard card

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,8 +50,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  # pod 'WordPressKit', '~> 8.2-beta'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'feature/add-blaze-campaigns-endpoints'
+  pod 'WordPressKit', '~> 8.3-beta'
+  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile
+++ b/Podfile
@@ -50,8 +50,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 8.2-beta'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
+  # pod 'WordPressKit', '~> 8.2-beta'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'feature/add-blaze-campaigns-endpoints'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -512,7 +512,7 @@ PODS:
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.2.0):
+  - WordPressKit (8.3.0-beta.1):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -612,7 +612,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 6.1-beta)
-  - WordPressKit (~> 8.2-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/add-blaze-campaigns-endpoints`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `trunk`)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8-beta)
@@ -661,7 +661,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -776,6 +775,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.97.0-alpha1
+  WordPressKit:
+    :branch: feature/add-blaze-campaigns-endpoints
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -794,6 +796,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.97.0-alpha1
+  WordPressKit:
+    :commit: efdf32d8ba5ecf18c4e49f08209cf1ef8756387d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 9a010fdab8d31f9e1fa0511f231e7068ef0170b1
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -885,7 +890,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: b0b900696de5129a215adcd1e9ae6eb89da36ac8
-  WordPressKit: d9015b097a58096033775dd8fc026d7d42005ae2
+  WordPressKit: eab8f16472a869721b3c5ecce0089f467cf6602d
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
@@ -900,6 +905,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: c4bdcbac21a417ad5d771fc6fe99602db67b4fa8
+PODFILE CHECKSUM: d2bc1efbb0c1760c24438c6dd6c89be1150c617f
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -797,7 +797,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.97.0-alpha1
   WordPressKit:
-    :commit: efdf32d8ba5ecf18c4e49f08209cf1ef8756387d
+    :commit: f1baac023f83089b39bb0396b1851a555b8c1566
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 9a010fdab8d31f9e1fa0511f231e7068ef0170b1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -612,7 +612,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 6.1-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/add-blaze-campaigns-endpoints`)
+  - WordPressKit (~> 8.3-beta)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `trunk`)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8-beta)
@@ -623,6 +623,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -775,9 +776,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.97.0-alpha1
-  WordPressKit:
-    :branch: feature/add-blaze-campaigns-endpoints
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :branch: trunk
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -796,9 +794,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.97.0-alpha1
-  WordPressKit:
-    :commit: f1baac023f83089b39bb0396b1851a555b8c1566
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 9a010fdab8d31f9e1fa0511f231e7068ef0170b1
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -890,7 +885,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: b0b900696de5129a215adcd1e9ae6eb89da36ac8
-  WordPressKit: eab8f16472a869721b3c5ecce0089f467cf6602d
+  WordPressKit: eecc7eaaafb96e739327a0623376cbdca04f29c1
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
@@ -905,6 +900,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: d2bc1efbb0c1760c24438c6dd6c89be1150c617f
+PODFILE CHECKSUM: 8d45f149d70efe7560994bad2b7d40816dfc12b0
 
 COCOAPODS: 1.12.1

--- a/WordPress/Classes/Services/BlazeService.swift
+++ b/WordPress/Classes/Services/BlazeService.swift
@@ -68,4 +68,18 @@ import WordPressKit
             completion?()
         }, on: .main)
     }
+
+    func getRecentCampaigns(for blog: Blog,
+                            completion: @escaping (Result<BlazeCampaignsSearchResponse, Error>) -> Void) {
+        guard let siteId = blog.dotComID?.intValue else {
+            DDLogError("Invalid site ID for Blaze")
+            completion(.failure(BlazeServiceError.missingBlogId))
+            return
+        }
+        remote.searchCampaigns(forSiteId: siteId, callback: completion)
+    }
+}
+
+enum BlazeServiceError: Error {
+    case missingBlogId
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -66,7 +66,7 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
         let viewModel = DashboardBlazeCampaignCardCellViewModel(response: mockResponse)!
         campaignView.configure(with: viewModel.campaign, blog: blog)
         buttonShowMoreCampaigns.isHidden = viewModel.isButtonShowMoreHidden
-        buttonShowMoreCampaigns.setTitle(String(format: "+ \(Strings.showMoreCampaigns)", viewModel.totalCampaignCount), for: .normal)
+        buttonShowMoreCampaigns.setTitle(viewModel.buttonShowMoreTitle, for: .normal)
     }
 
     // MARK: - Actions
@@ -79,7 +79,14 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
 private extension DashboardBlazeCampaignCardCell {
     enum Strings {
         static let cardTitle = NSLocalizedString("my-sites.blazeCampaigns.title", value: "Blaze campaign", comment: "Title for the card displaying blaze campaigns.")
-        static let showMoreCampaigns = NSLocalizedString("my-sites.blazeCampaigns.showMoreCampaigns", value: "%d active campaigns", comment: "Title for button that shows more campaigns. Takes the number of campaigns as a parameter.")
+
+        static func buttonShowMoreText(forCampaignCount count: Int) -> String {
+            let format = count == 1 ? showMoreCampaignsOne : showMoreCampaignsTwoOrMore
+            return String(format: "+ \(format)", count)
+        }
+
+        static let showMoreCampaignsOne = NSLocalizedString("my-sites.blazeCampaigns.showMoreCampaignsOne", value: "%d active campaign", comment: "Title for button that shows more campaigns. Takes the number of campaigns as a parameter.")
+        static let showMoreCampaignsTwoOrMore = NSLocalizedString("my-sites.blazeCampaigns.showMoreCampaignsTwoOrMore", value: "%d active campaigns", comment: "Title for button that shows more campaigns. Takes the number of campaigns as a parameter.")
     }
 }
 
@@ -87,6 +94,7 @@ final class DashboardBlazeCampaignCardCellViewModel {
     let campaign: DashboardBlazeCampaignViewModel
     let totalCampaignCount: Int
     var isButtonShowMoreHidden: Bool { totalCampaignCount < 2 }
+    let buttonShowMoreTitle: String
 
     init?(response: BlazeCampaignsSearchResponse) {
         guard let campaign = response.campaigns?.first else {
@@ -94,6 +102,7 @@ final class DashboardBlazeCampaignCardCellViewModel {
         }
         self.campaign = DashboardBlazeCampaignViewModel(campaign: campaign)
         self.totalCampaignCount = response.totalItems ?? 1
+        self.buttonShowMoreTitle = DashboardBlazeCampaignCardCell.Strings.buttonShowMoreText(forCampaignCount: totalCampaignCount - 1)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -9,21 +9,21 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
     private lazy var buttonShowMoreCampaigns: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.heightAnchor.constraint(greaterThanOrEqualToConstant: 40).isActive = true
         button.setTitleColor(UIColor.primary, for: .normal)
         button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.contentHorizontalAlignment = .leading
         button.addTarget(self, action: #selector(buttonShowMoreTapped), for: .touchUpInside)
-
         return button
     }()
 
     private lazy var contentStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16)
-        stackView.spacing = 16
+        stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 16)
+        stackView.spacing = 4
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
@@ -83,7 +83,7 @@ private extension DashboardBlazeCampaignCardCell {
     }
 }
 
-private final class DashboardBlazeCampaignCardCellViewModel {
+final class DashboardBlazeCampaignCardCellViewModel {
     let campaign: DashboardBlazeCampaignViewModel
     let totalCampaignCount: Int
     var isButtonShowMoreHidden: Bool { totalCampaignCount < 2 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -1,0 +1,131 @@
+import UIKit
+import SwiftUI
+import WordPressKit
+
+final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
+    private let frameView = BlogDashboardCardFrameView()
+    private let campaignView = DashboardBlazeCampaignView()
+
+    private lazy var buttonShowMoreCampaigns: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitleColor(UIColor.primary, for: .normal)
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        button.contentHorizontalAlignment = .leading
+        button.addTarget(self, action: #selector(buttonShowMoreTapped), for: .touchUpInside)
+
+        return button
+    }()
+
+    private lazy var contentStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16)
+        stackView.spacing = 16
+        stackView.isLayoutMarginsRelativeArrangement = true
+        return stackView
+    }()
+
+    private var blog: Blog?
+    private weak var presentingViewController: BlogDashboardViewController?
+
+    // MARK: - Initializers
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View setup
+
+    private func setupView() {
+        contentView.addSubview(frameView)
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.pinSubviewToAllEdges(frameView, priority: UILayoutPriority(999))
+
+        frameView.add(subview: contentStackView)
+        contentStackView.addArrangedSubview(campaignView)
+        contentStackView.addArrangedSubview(buttonShowMoreCampaigns)
+    }
+
+    // MARK: - BlogDashboardCardConfigurable
+
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        self.blog = blog
+        self.presentingViewController = viewController
+
+
+        frameView.setTitle(Strings.cardTitle)
+
+        let viewModel = DashboardBlazeCampaignCardCellViewModel(response: mockResponse)!
+        campaignView.configure(with: viewModel.campaign, blog: blog)
+        buttonShowMoreCampaigns.isHidden = viewModel.isButtonShowMoreHidden
+        buttonShowMoreCampaigns.setTitle(String(format: "+ \(Strings.showMoreCampaigns)", viewModel.totalCampaignCount), for: .normal)
+    }
+
+    // MARK: - Actions
+
+    @objc private func buttonShowMoreTapped() {
+        // TODO: Show campaign list
+    }
+}
+
+private extension DashboardBlazeCampaignCardCell {
+    enum Strings {
+        static let cardTitle = NSLocalizedString("my-sites.blazeCampaigns.title", value: "Blaze campaign", comment: "Title for the card displaying blaze campaigns.")
+        static let showMoreCampaigns = NSLocalizedString("my-sites.blazeCampaigns.showMoreCampaigns", value: "%d active campaigns", comment: "Title for button that shows more campaigns. Takes the number of campaigns as a parameter.")
+    }
+}
+
+private final class DashboardBlazeCampaignCardCellViewModel {
+    let campaign: DashboardBlazeCampaignViewModel
+    let totalCampaignCount: Int
+    var isButtonShowMoreHidden: Bool { totalCampaignCount < 2 }
+
+    init?(response: BlazeCampaignsSearchResponse) {
+        guard let campaign = response.campaigns?.first else {
+            return nil
+        }
+        self.campaign = DashboardBlazeCampaignViewModel(campaign: campaign)
+        self.totalCampaignCount = response.totalItems ?? 1
+    }
+}
+
+private let mockResponse: BlazeCampaignsSearchResponse = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    decoder.dateDecodingStrategy = .iso8601
+    return try! decoder.decode(BlazeCampaignsSearchResponse.self, from: """
+    {
+        "totalItems": 3,
+        "campaigns": [
+            {
+                "campaign_id": 26916,
+                "name": "Test Post - don't approve",
+                "start_date": "2023-06-13T00:00:00Z",
+                "end_date": "2023-06-01T19:15:45Z",
+                "status": "finished",
+                "avatar_url": "https://0.gravatar.com/avatar/614d27bcc21db12e7c49b516b4750387?s=96&amp;d=identicon&amp;r=G",
+                "budget_cents": 500,
+                "target_url": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
+                "content_config": {
+                    "title": "Test Post - don't approve",
+                    "snippet": "Test Post Empty Empty",
+                    "clickUrl": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
+                    "imageUrl": "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"
+                },
+                "campaign_stats": {
+                    "impressions_total": 1000,
+                    "clicks_total": 235
+                }
+            }
+        ]
+    }
+    """.data(using: .utf8)!)
+}()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignStatusView.swift
@@ -1,0 +1,86 @@
+import Foundation
+import UIKit
+import WordPressKit
+
+final class DashboardBlazeCampaignStatusView: UIView {
+    let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.caption2, fontWeight: .semibold)
+
+        addSubview(titleLabel)
+        pinSubviewToAllEdges(titleLabel, insets: .init(top: 4, left: 4, bottom: 3, right: 4))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with viewModel: DashboardBlazeCampaignViewStatusViewModel) {
+        self.isHidden = viewModel.isHidden
+        self.titleLabel.text = viewModel.title.uppercased()
+        self.titleLabel.textColor = viewModel.textColor
+        self.backgroundColor = viewModel.backgroundColor
+        self.layer.masksToBounds = true
+        self.layer.cornerRadius = 4
+    }
+}
+
+struct DashboardBlazeCampaignViewStatusViewModel {
+    let isHidden: Bool
+    let title: String
+    let textColor: UIColor
+    let backgroundColor: UIColor
+
+    init(status: BlazeCampaign.Status) {
+        self.isHidden = status == .unknown
+        self.title = status.localizedTitle
+
+        switch status {
+        case .created, .processing, .scheduled, .canceled:
+            self.textColor = UIColor(fromHex: 0x4F3500)
+            self.backgroundColor = UIColor(fromHex: 0xF5E6B3)
+        case .rejected:
+            self.textColor = UIColor(fromHex: 0x8A2424)
+            self.backgroundColor = UIColor(fromHex: 0xFACFD2)
+        case .active, .approved:
+            self.textColor = UIColor(fromHex: 0x00450C)
+            self.backgroundColor = UIColor(fromHex: 0xB8E6BF)
+        case .finished:
+            self.textColor = UIColor(fromHex: 0x02395C)
+            self.backgroundColor = UIColor(fromHex: 0xBBE0FA)
+        case .unknown:
+            self.textColor = .label
+            self.backgroundColor = .secondarySystemBackground
+        }
+    }
+}
+
+extension BlazeCampaign.Status {
+    var localizedTitle: String {
+        switch self {
+        case .scheduled:
+            return NSLocalizedString("blazeCampaign.status.finished", value: "Scheduled", comment: "Short status description")
+        case .created:
+            return NSLocalizedString("blazeCampaign.status.finished", value: "Created", comment: "Short status description")
+        case .approved:
+            return NSLocalizedString("blazeCampaign.status.finished", value: "Approved", comment: "Short status description")
+        case .processing:
+            return NSLocalizedString("blazeCampaign.status.finished", value: "In Moderation", comment: "Short status description")
+        case .rejected:
+            return NSLocalizedString("blazeCampaign.status.rejected", value: "Rejected", comment: "Short status description")
+        case .active:
+            return NSLocalizedString("blazeCampaign.status.active", value: "Active", comment: "Short status description")
+        case .canceled:
+            return NSLocalizedString("blazeCampaign.status.finished", value: "Cancelled", comment: "Short status description")
+        case .finished:
+            return NSLocalizedString("blazeCampaign.status.finished", value: "Completed", comment: "Short status description")
+        case .unknown:
+            return "–"
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignStatusView.swift
@@ -13,7 +13,7 @@ final class DashboardBlazeCampaignStatusView: UIView {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.caption2, fontWeight: .semibold)
 
         addSubview(titleLabel)
-        pinSubviewToAllEdges(titleLabel, insets: .init(top: 4, left: 4, bottom: 3, right: 4))
+        pinSubviewToAllEdges(titleLabel, insets: Constants.titleInsets)
     }
 
     required init?(coder: NSCoder) {
@@ -26,7 +26,14 @@ final class DashboardBlazeCampaignStatusView: UIView {
         self.titleLabel.textColor = viewModel.textColor
         self.backgroundColor = viewModel.backgroundColor
         self.layer.masksToBounds = true
-        self.layer.cornerRadius = 4
+        self.layer.cornerRadius = Constants.cornerRadius
+    }
+}
+
+private extension DashboardBlazeCampaignStatusView {
+    enum Constants {
+        static let titleInsets = UIEdgeInsets(top: 4, left: 4, bottom: 3, right: 4)
+        static let cornerRadius: CGFloat = 4
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -70,7 +70,7 @@ final class DashboardBlazeCampaignView: UIView {
 
         statsView.isHidden = !viewModel.isShowingStats
         if viewModel.isShowingStats {
-            statsView.arrangedSubviews.forEach(statsView.removeArrangedSubview)
+            statsView.arrangedSubviews.forEach { $0.removeFromSuperview() }
             makeStatsViews(for: viewModel).forEach(statsView.addArrangedSubview)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -88,11 +88,11 @@ final class DashboardBlazeCampaignView: UIView {
 
 private extension DashboardBlazeCampaignView {
     enum Strings {
-        static let impressions = NSLocalizedString("my-sites.blazeCampaigns.impressions", value: "Impressions", comment: "Title for impressions stats view")
-        static let clicks = NSLocalizedString("my-sites.blazeCampaigns.clicks", value: "Clicks", comment: "Title for impressions stats view")
+        static let impressions = NSLocalizedString("dashboardCard.blazeCampaigns.impressions", value: "Impressions", comment: "Title for impressions stats view")
+        static let clicks = NSLocalizedString("dashboardCard.blazeCampaigns.clicks", value: "Clicks", comment: "Title for impressions stats view")
     }
 
-    private struct Constants {
+    enum Constants {
         static let imageSize = CGSize(width: 44, height: 44)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -1,0 +1,125 @@
+import Foundation
+import UIKit
+import WordPressKit
+
+final class DashboardBlazeCampaignView: UIView {
+    private let statusView = DashboardBlazeCampaignStatusView()
+    private let titleLabel = UILabel()
+    private let imageView = CachedAnimatedImageView()
+
+    private lazy var statsView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+
+    private lazy var imageLoader = ImageLoader(imageView: imageView)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 2
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.layer.masksToBounds = true
+        imageView.layer.cornerRadius = 4
+
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 44),
+            imageView.heightAnchor.constraint(equalToConstant: 44),
+        ])
+
+        let headerView = UIStackView(arrangedSubviews: [titleLabel, imageView])
+        headerView.alignment = .top
+        headerView.spacing = 12
+
+        let contentView = UIStackView(arrangedSubviews: [
+            UIStackView(arrangedSubviews: [statusView, UIView()]), // Leading alignment
+            headerView,
+            statsView
+        ])
+        contentView.axis = .vertical
+        contentView.spacing = 8
+        contentView.setCustomSpacing(12, after: headerView)
+
+        addSubview(contentView)
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        pinSubviewToAllEdges(contentView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with viewModel: DashboardBlazeCampaignViewModel, blog: Blog) {
+        statusView.configure(with: viewModel.status)
+
+        titleLabel.text = viewModel.title
+
+        imageLoader.prepareForReuse()
+        imageView.isHidden = viewModel.imageURL == nil
+        if let imageURL = viewModel.imageURL {
+            let host = MediaHost(with: blog, failure: { error in
+                WordPressAppDelegate.crashLogging?.logError(error)
+            })
+            imageLoader.loadImage(with: imageURL, from: host, preferredSize: Constants.imageSize)
+        }
+
+        statsView.isHidden = !viewModel.isShowingStats
+        if viewModel.isShowingStats {
+            statsView.arrangedSubviews.forEach(statsView.removeArrangedSubview)
+            makeStatsViews(for: viewModel).forEach(statsView.addArrangedSubview)
+        }
+    }
+
+    private func makeStatsViews(for viewModel: DashboardBlazeCampaignViewModel) -> [UIView] {
+        let impressionsView = DashboardSingleStatView(title: Strings.impressions)
+        impressionsView.countString = "\(viewModel.impressions)"
+
+        let clicksView = DashboardSingleStatView(title: Strings.clicks)
+        clicksView.countString = "\(viewModel.clicks)"
+
+        return [impressionsView, clicksView]
+    }
+}
+
+private extension DashboardBlazeCampaignView {
+    enum Strings {
+        static let impressions = NSLocalizedString("my-sites.blazeCampaigns.impressions", value: "Impressions", comment: "Title for impressions stats view")
+        static let clicks = NSLocalizedString("my-sites.blazeCampaigns.clicks", value: "Clicks", comment: "Title for impressions stats view")
+    }
+
+    private struct Constants {
+        static let imageSize = CGSize(width: 44, height: 44)
+    }
+}
+
+struct DashboardBlazeCampaignViewModel {
+    let title: String
+    let imageURL: URL?
+    let impressions: Int
+    let clicks: Int
+    var status: DashboardBlazeCampaignViewStatusViewModel { .init(status: campaign.status) }
+
+    var isShowingStats: Bool {
+        switch campaign.status {
+        case .created, .processing, .canceled, .approved, .rejected, .scheduled, .unknown:
+            return false
+        case .active, .finished:
+            return true
+        }
+    }
+
+    private let campaign: BlazeCampaign
+
+    init(campaign: BlazeCampaign) {
+        self.campaign = campaign
+        self.title = campaign.name ?? "–"
+        self.imageURL = campaign.contentConfig?.imageURL.flatMap(URL.init)
+        self.impressions = campaign.stats?.impressionsTotal ?? 0
+        self.clicks = campaign.stats?.clicksTotal ?? 0
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -55,7 +55,9 @@ enum DashboardCard: String, CaseIterable {
         case .jetpackBadge:
             return DashboardBadgeCell.self
         case .blaze:
-            return DashboardBlazeCardCell.self
+            #warning("TEMP")
+            return DashboardBlazeCampaignCardCell.self
+//            return DashboardBlazeCardCell.self
         case .domainsDashboardCard:
             return DashboardDomainsCardCell.self
         case .freeToPaidPlansDashboardCard:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -55,9 +55,7 @@ enum DashboardCard: String, CaseIterable {
         case .jetpackBadge:
             return DashboardBadgeCell.self
         case .blaze:
-            #warning("TEMP")
-            return DashboardBlazeCampaignCardCell.self
-//            return DashboardBlazeCardCell.self
+            return DashboardBlazeCardCell.self
         case .domainsDashboardCard:
             return DashboardDomainsCardCell.self
         case .freeToPaidPlansDashboardCard:

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		0C391E5F2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */; };
 		0C391E612A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */; };
 		0C391E622A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */; };
+		0C391E642A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E632A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -6047,6 +6048,7 @@
 		0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardEmptyStateCell.swift; sourceTree = "<group>"; };
 		0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignView.swift; sourceTree = "<group>"; };
 		0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignStatusView.swift; sourceTree = "<group>"; };
+		0C391E632A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignViewModelTests.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
@@ -13691,6 +13693,7 @@
 				0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */,
 				011F52C52A15413800B04114 /* FreeToPaidPlansDashboardCardHelperTests.swift */,
 				FA3FBF8D2A2777E00012FC90 /* DashboardActivityLogViewModelTests.swift */,
+				0C391E632A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -23397,6 +23400,7 @@
 				436D5655212209D600CEAA33 /* RegisterDomainDetailsServiceProxyMock.swift in Sources */,
 				F1450CF92437EEBB00A28BFE /* MediaRequestAuthenticatorTests.swift in Sources */,
 				FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */,
+				0C391E642A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift in Sources */,
 				D821C817210036D9002ED995 /* ActivityContentFactoryTests.swift in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
 				B5772AC61C9C84900031F97E /* GravatarServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -341,6 +341,10 @@
 		0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */; };
 		0C35FFF629CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */; };
 		0C35FFF729CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */; };
+		0C391E5E2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */; };
+		0C391E5F2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */; };
+		0C391E612A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */; };
+		0C391E622A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -350,6 +354,8 @@
 		0CB4057A29C8DDEE008EED0A /* BlogDashboardPersonalizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */; };
 		0CB4057D29C8DF83008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
 		0CB4057E29C8DF84008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
+		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */; };
+		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */; };
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
 		17039225282E6D2800F602E9 /* ViewsVisitorsLineChartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC772B0728201F5300664C02 /* ViewsVisitorsLineChartCell.swift */; };
@@ -6039,11 +6045,14 @@
 		0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardHelpers.swift; sourceTree = "<group>"; };
 		0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModelTests.swift; sourceTree = "<group>"; };
 		0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardEmptyStateCell.swift; sourceTree = "<group>"; };
+		0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignView.swift; sourceTree = "<group>"; };
+		0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignStatusView.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
 		0CB4057229C8DD01008EED0A /* BlogDashboardPersonalizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationView.swift; sourceTree = "<group>"; };
 		0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizeCardCell.swift; sourceTree = "<group>"; };
+		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignCardCell.swift; sourceTree = "<group>"; };
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		150B6590614A28DF9AD25491 /* Pods-Apps-Jetpack.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		152F25D5C232985E30F56CAC /* Pods-Apps-Jetpack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.debug.xcconfig"; sourceTree = "<group>"; };
@@ -17792,6 +17801,9 @@
 			children = (
 				FA98B61529A3B76A0071AAE8 /* DashboardBlazeCardCell.swift */,
 				FA98B61829A3BF050071AAE8 /* BlazeCardView.swift */,
+				0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */,
+				0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */,
+				0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -21545,6 +21557,7 @@
 				93414DE51E2D25AE003143A3 /* PostEditorState.swift in Sources */,
 				1707CE421F3121750020B7FE /* UICollectionViewCell+Tint.swift in Sources */,
 				011F52C32A153A3400B04114 /* FreeToPaidPlansDashboardCardHelper.swift in Sources */,
+				0C391E612A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */,
 				B5176CC31CDCE1C30083CF2D /* ManagedPerson+CoreDataProperties.swift in Sources */,
 				17C1D7DC26735631006C8970 /* EmojiRenderer.swift in Sources */,
 				C81CCD7B243BF7A600A83E27 /* TenorStrings.swift in Sources */,
@@ -22332,6 +22345,7 @@
 				F17A2A1E23BFBD72001E96AC /* UIView+ExistingConstraints.swift in Sources */,
 				400A2C892217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift in Sources */,
 				F1450CF32437DA3E00A28BFE /* MediaRequestAuthenticator.swift in Sources */,
+				0C391E5E2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift in Sources */,
 				9881296E219CF1310075FF33 /* StatsCellHeader.swift in Sources */,
 				E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */,
 				5D18FE9F1AFBB17400EFEED0 /* RestorePageTableViewCell.m in Sources */,
@@ -22549,6 +22563,7 @@
 				329F8E5824DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift in Sources */,
 				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */,
+				0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */,
 				FAD7626429F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift in Sources */,
 				24351254264DCA08009BB2B6 /* Secrets.swift in Sources */,
 				03216EC6279946CA00D444CA /* SchedulingDatePickerViewController.swift in Sources */,
@@ -24380,6 +24395,7 @@
 				FABB22C12602FC2C00C8785C /* DomainsService.swift in Sources */,
 				98BAA7C426F925F70073A2F9 /* InlineEditableSingleLineCell.swift in Sources */,
 				FABB22C22602FC2C00C8785C /* PasswordAlertController.swift in Sources */,
+				0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */,
 				4A1E77CD2989F2F7006281CC /* WPAccount+DeduplicateBlogs.swift in Sources */,
 				FA98B61D29A3DB840071AAE8 /* BlazeHelper.swift in Sources */,
 				FABB22C32602FC2C00C8785C /* ReaderTagsFooter.swift in Sources */,
@@ -24424,6 +24440,7 @@
 				F49B9A06293A21BF000CEFCE /* MigrationAnalyticsTracker.swift in Sources */,
 				E62CE58F26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,
 				FABB22DE2602FC2C00C8785C /* KeyboardInfo.swift in Sources */,
+				0C391E622A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */,
 				FABB22DF2602FC2C00C8785C /* PlanDetailViewModel.swift in Sources */,
 				FABB22E02602FC2C00C8785C /* DebugMenuViewController.swift in Sources */,
 				9801E683274EEBC4002FDDB6 /* ReaderDetailCommentsHeader.swift in Sources */,
@@ -24969,6 +24986,7 @@
 				837B49DC283C2AE80061A657 /* BloggingPromptSettingsReminderDays+CoreDataClass.swift in Sources */,
 				FABB247C2602FC2C00C8785C /* RegisterDomainDetailsViewController+LocalizedStrings.swift in Sources */,
 				FABB247D2602FC2C00C8785C /* GutenbergLayoutPickerViewController.swift in Sources */,
+				0C391E5F2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift in Sources */,
 				011896A929D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */,
 				FABB247E2602FC2C00C8785C /* SiteInformation.swift in Sources */,
 				FABB247F2602FC2C00C8785C /* StockPhotosPageable.swift in Sources */,

--- a/WordPress/WordPressTest/Dashboard/DashboardBlazeCampaignViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardBlazeCampaignViewModelTests.swift
@@ -5,53 +5,43 @@ import XCTest
 final class DashboardBlazeCampaignViewModelTests: XCTestCase {
     func testViewModel() throws {
         // Given
-        let viewModel = try XCTUnwrap(DashboardBlazeCampaignCardCellViewModel(response: response))
+        let viewModel = DashboardBlazeCampaignViewModel(campaign: campaign)
 
         // Then campaign is displayed
-        let campaign = viewModel.campaign
-        XCTAssertEqual(campaign.title, "Test Post - don't approve")
-        XCTAssertEqual(campaign.imageURL, URL(string: "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"))
+        XCTAssertEqual(viewModel.title, "Test Post - don't approve")
+        XCTAssertEqual(viewModel.imageURL, URL(string: "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"))
 
         // Then stats are displayed
-        XCTAssertEqual(campaign.impressions, 1000)
-        XCTAssertEqual(campaign.clicks, 235)
-        XCTAssertTrue(campaign.isShowingStats)
-
-        // Then "show more" button is displayed
-        XCTAssertEqual(viewModel.totalCampaignCount, 3)
-        XCTAssertFalse(viewModel.isButtonShowMoreHidden)
+        XCTAssertEqual(viewModel.impressions, 1000)
+        XCTAssertEqual(viewModel.clicks, 235)
+        XCTAssertTrue(viewModel.isShowingStats)
     }
 }
 
-private let response: BlazeCampaignsSearchResponse = {
+private let campaign: BlazeCampaign = {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     decoder.dateDecodingStrategy = .iso8601
-    return try! decoder.decode(BlazeCampaignsSearchResponse.self, from: """
+    return try! decoder.decode(BlazeCampaign.self, from: """
     {
-        "totalItems": 3,
-        "campaigns": [
-            {
-                "campaign_id": 26916,
-                "name": "Test Post - don't approve",
-                "start_date": "2023-06-13T00:00:00Z",
-                "end_date": "2023-06-01T19:15:45Z",
-                "status": "finished",
-                "avatar_url": "https://0.gravatar.com/avatar/614d27bcc21db12e7c49b516b4750387?s=96&amp;d=identicon&amp;r=G",
-                "budget_cents": 500,
-                "target_url": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
-                "content_config": {
-                    "title": "Test Post - don't approve",
-                    "snippet": "Test Post Empty Empty",
-                    "clickUrl": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
-                    "imageUrl": "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"
-                },
-                "campaign_stats": {
-                    "impressions_total": 1000,
-                    "clicks_total": 235
-                }
-            }
-        ]
+        "campaign_id": 26916,
+        "name": "Test Post - don't approve",
+        "start_date": "2023-06-13T00:00:00Z",
+        "end_date": "2023-06-01T19:15:45Z",
+        "status": "finished",
+        "avatar_url": "https://0.gravatar.com/avatar/614d27bcc21db12e7c49b516b4750387?s=96&amp;d=identicon&amp;r=G",
+        "budget_cents": 500,
+        "target_url": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
+        "content_config": {
+            "title": "Test Post - don't approve",
+            "snippet": "Test Post Empty Empty",
+            "clickUrl": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
+            "imageUrl": "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"
+        },
+        "campaign_stats": {
+            "impressions_total": 1000,
+            "clicks_total": 235
+        }
     }
     """.data(using: .utf8)!)
 }()

--- a/WordPress/WordPressTest/Dashboard/DashboardBlazeCampaignViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardBlazeCampaignViewModelTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import WordPress
+
+final class DashboardBlazeCampaignViewModelTests: XCTestCase {
+    func testViewModel() throws {
+        // Given
+        let viewModel = try XCTUnwrap(DashboardBlazeCampaignCardCellViewModel(response: response))
+
+        // Then campaign is displayed
+        let campaign = viewModel.campaign
+        XCTAssertEqual(campaign.title, "Test Post - don't approve")
+        XCTAssertEqual(campaign.imageURL, URL(string: "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"))
+
+        // Then stats are displayed
+        XCTAssertEqual(campaign.impressions, 1000)
+        XCTAssertEqual(campaign.clicks, 235)
+        XCTAssertTrue(campaign.isShowingStats)
+
+        // Then "show more" button is displayed
+        XCTAssertEqual(viewModel.totalCampaignCount, 3)
+        XCTAssertFalse(viewModel.isButtonShowMoreHidden)
+    }
+}
+
+private let response: BlazeCampaignsSearchResponse = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    decoder.dateDecodingStrategy = .iso8601
+    return try! decoder.decode(BlazeCampaignsSearchResponse.self, from: """
+    {
+        "totalItems": 3,
+        "campaigns": [
+            {
+                "campaign_id": 26916,
+                "name": "Test Post - don't approve",
+                "start_date": "2023-06-13T00:00:00Z",
+                "end_date": "2023-06-01T19:15:45Z",
+                "status": "finished",
+                "avatar_url": "https://0.gravatar.com/avatar/614d27bcc21db12e7c49b516b4750387?s=96&amp;d=identicon&amp;r=G",
+                "budget_cents": 500,
+                "target_url": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
+                "content_config": {
+                    "title": "Test Post - don't approve",
+                    "snippet": "Test Post Empty Empty",
+                    "clickUrl": "https://alextest9123.wordpress.com/2023/06/01/test-post/",
+                    "imageUrl": "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"
+                },
+                "campaign_stats": {
+                    "impressions_total": 1000,
+                    "clicks_total": 235
+                }
+            }
+        ]
+    }
+    """.data(using: .utf8)!)
+}()


### PR DESCRIPTION
Related Issue: #20745

This PR adds the views, but none of the backend logic (is TBD) or user interactions yet.

To test:

1. In DashboardCard.swift replace `DashboardBlazeCardCell.self` with `DashboardBlazeCampaignCardCell.self`
2. Open dashboard on any site that supports Blaze and verify that the recent (mocked) campaign is displayed, along with its stats, and the button to show the remaining campaigns

<img width="302" alt="Screenshot 2023-06-07 at 5 04 12 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/baf6da8b-b231-4af8-84e2-e4dcdb41be04"> <img width="302" alt="Screenshot 2023-06-07 at 5 06 49 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/51c62e91-f923-4977-aafe-ac29d42e2497">

## Regression Notes
1. Potential unintended areas of impact: n/a (the card isn't fully integrated into the app yet)
4. What I did to test those areas of impact (or what existing automated tests I relied on): test manually
5. What automated tests I added (or what prevented me from doing so): ViewModel unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.