### PR TITLE
Plans on JP: Remove unnecessary analytics events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -496,12 +496,6 @@ import Foundation
     case freeToPaidPlansDashboardCardMenuTapped
     case freeToPaidPlansDashboardCardHidden
 
-    // Plan Selection
-    case planSelectionWebViewViewed
-
-    // Checkout
-    case checkoutWebViewViewed
-
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1355,13 +1349,6 @@ import Foundation
         case .freeToPaidPlansDashboardCardMenuTapped:
             return "free_to_paid_plan_dashboard_card_menu_tapped"
 
-        // Plan Selection
-        case .planSelectionWebViewViewed:
-            return "plan_selection_webview_viewed"
-
-        // Checkout
-        case .checkoutWebViewViewed:
-            return "checkout_webview_viewed"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -39,8 +39,6 @@ import SwiftUI
             checkoutViewController.configureSandboxStore {
                 navigationController.pushViewController(checkoutViewController, animated: true)
             }
-
-            PlansTracker.trackCheckoutWebViewViewed(source: "plan_selection")
         }
 
         let domainAddedToCart = { (domainName: String) in
@@ -50,8 +48,6 @@ import SwiftUI
                 planSelected(domainName, checkoutURL)
             }
             navigationController.pushViewController(planSelectionViewController, animated: true)
-
-            PlansTracker.trackPlanSelectionWebViewViewed(.domainAndPlanPackage, source: "domains_register")
         }
         domainSuggestionsViewController.domainAddedToCartCallback = domainAddedToCart
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/PlansTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/PlansTracker.swift
@@ -30,20 +30,6 @@ struct PlansTracker {
         WPAnalytics.track(.freeToPaidPlansDashboardCardMenuTapped, properties: properties)
     }
 
-    // MARK: - Plan Selection
-
-    static func trackPlanSelectionWebViewViewed(_ type: PlanSelectionType, source: String) {
-        let properties = ["source": source, planSelectionTypeKey: type.rawValue]
-        WPAnalytics.track(.planSelectionWebViewViewed, properties: properties)
-    }
-
-    // MARK: - Checkout
-
-    static func trackCheckoutWebViewViewed(source: String) {
-        let properties = ["source": source]
-        WPAnalytics.track(.checkoutWebViewViewed, properties: properties)
-    }
-
     // MARK: - Purchase Result
 
     static func trackPurchaseResult(source: String) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/PlansTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/PlansTracker.swift
@@ -6,7 +6,6 @@ struct PlansTracker {
     }
 
     private static let positionKey = "position_index"
-    private static let planSelectionTypeKey = "plan_selection_type"
 
     // MARK: - Dashboard Card
 


### PR DESCRIPTION
Rely on Calypso events instead of native events to track web view access:

pc8eDl-Vv-p2#comment-779

### To test:

No new functionality added, just confirm CI builds

## Regression Notes
1. Potential unintended areas of impact

None


2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.