### PR TITLE
Blaze Manage Campaigns: Add skeleton UI for the campaigns list screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -8,7 +8,7 @@ final class BlazeCampaignsViewController: UIViewController {
         let button = UIBarButtonItem(image: UIImage(systemName: "plus"),
                                      style: .plain,
                                      target: self,
-                                     action: #selector(promotePostButtonTapped))
+                                     action: #selector(plusButtonTapped))
         return button
     }()
 
@@ -47,7 +47,7 @@ final class BlazeCampaignsViewController: UIViewController {
         navigationItem.rightBarButtonItem = dismissButton
     }
 
-    @objc private func promotePostButtonTapped() {
+    @objc private func plusButtonTapped() {
         // TODO: Track event
         BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignsList, blog: blog)
     }

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -1,0 +1,61 @@
+import UIKit
+
+final class BlazeCampaignsViewController: UIViewController {
+
+    // MARK: - Views
+
+    private lazy var dismissButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: UIImage(systemName: "plus"),
+                                     style: .plain,
+                                     target: self,
+                                     action: #selector(promotePostButtonTapped))
+        return button
+    }()
+
+    // MARK: - Properties
+
+    private var blog: Blog
+
+    // MARK: - Initializers
+
+    init(blog: Blog) {
+        self.blog = blog
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        // This VC is designed to be initialized programmatically.
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        setupNavBar()
+    }
+
+    // MARK: - Private helpers
+
+    private func setupView() {
+        view.backgroundColor = .DS.Background.primary
+    }
+
+    private func setupNavBar() {
+        title = Strings.navigationTitle
+        navigationItem.rightBarButtonItem = dismissButton
+    }
+
+    @objc private func promotePostButtonTapped() {
+        // TODO: Track event
+        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignsList, blog: blog)
+    }
+}
+
+extension BlazeCampaignsViewController {
+
+    private enum Strings {
+        static let navigationTitle = NSLocalizedString("blaze.campaigns.title", value: "Blaze Campaigns", comment: "Title for the screen that allows users to manage their Blaze campaigns.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -44,7 +44,7 @@ final class BlazeCampaignsViewController: UIViewController {
 
     private func setupNavBar() {
         title = Strings.navigationTitle
-        navigationItem.rightBarButtonItem = dismissButton
+        navigationItem.rightBarButtonItem = plusButton
     }
 
     @objc private func plusButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -4,7 +4,7 @@ final class BlazeCampaignsViewController: UIViewController {
 
     // MARK: - Views
 
-    private lazy var dismissButton: UIBarButtonItem = {
+    private lazy var plusButton: UIBarButtonItem = {
         let button = UIBarButtonItem(image: UIImage(systemName: "plus"),
                                      style: .plain,
                                      target: self,

--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewModel.swift
@@ -18,6 +18,8 @@ struct BlazeOverlayViewModel {
         switch source {
         case .dashboardCard:
             fallthrough
+        case .campaignsList:
+            fallthrough
         case .menuItem:
             return buttonTitleWithIcon(title: Strings.blazeButtonTitle)
         case .postsList:

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -6,6 +6,7 @@ import UIKit
     case menuItem
     case postsList
     case pagesList
+    case campaignsList
 
     var description: String {
         switch self {
@@ -17,6 +18,8 @@ import UIKit
             return "posts_list"
         case .pagesList:
             return "pages_list"
+        case .campaignsList:
+            return "campaigns_list"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -69,10 +69,10 @@ import UIKit
     ///   - delegate: The delegate gets notified of changes happening in the web view. Default value is `nil`
     @objc(presentBlazeWebFlowInViewController:source:blog:postID:delegate:)
     static func presentBlazeWebFlow(in viewController: UIViewController,
-                                 source: BlazeSource,
-                                 blog: Blog,
-                                 postID: NSNumber? = nil,
-                                 delegate: BlazeWebViewControllerDelegate? = nil) {
+                                    source: BlazeSource,
+                                    blog: Blog,
+                                    postID: NSNumber? = nil,
+                                    delegate: BlazeWebViewControllerDelegate? = nil) {
         let blazeViewController = BlazeWebViewController(source: source, blog: blog, postID: postID, delegate: delegate)
         let navigationViewController = UINavigationController(rootViewController: blazeViewController)
         navigationViewController.overrideUserInterfaceStyle = .light
@@ -96,5 +96,16 @@ import UIKit
         let navigationController = UINavigationController(rootViewController: overlayViewController)
         navigationController.modalPresentationStyle = .formSheet
         viewController.present(navigationController, animated: true)
+    }
+
+    /// Used to display the blaze campaigns screen.
+    /// - Parameters:
+    ///   - viewController: The view controller where the screen should be presented in.
+    ///   - blog: `Blog` object representing the site with Blaze campaigns.
+    @objc(presentBlazeCampaignsInViewController:blog:)
+    static func presentBlazeCampaigns(in viewController: UIViewController,
+                                      blog: Blog) {
+        let campaignsViewController = BlazeCampaignsViewController(blog: blog)
+        viewController.navigationController?.pushViewController(campaignsViewController, animated: true)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3773,6 +3773,8 @@
 		F9C47A6B238C7CFD00AAD9ED /* LoginFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED4D8321FF11E3800A11345 /* LoginFlow.swift */; };
 		F9C47A78238C7DAC00AAD9ED /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4E9E1FD664F5007AE3E4 /* BaseScreen.swift */; };
 		FA00863D24EB68B100C863F2 /* FollowCommentsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */; };
+		FA111E382A2F38FC00896FCE /* BlazeCampaignsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */; };
+		FA111E392A2F474600896FCE /* BlazeCampaignsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */; };
 		FA1A543E25A6E2F60033967D /* RestoreWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */; };
 		FA1A544025A6E3080033967D /* RestoreWarningView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1A543F25A6E3080033967D /* RestoreWarningView.xib */; };
 		FA1A55EF25A6F0740033967D /* RestoreStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */; };
@@ -9134,6 +9136,7 @@
 		F9C47A8B238C801600AAD9ED /* PostsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostsScreen.swift; sourceTree = "<group>"; };
 		F9C47A8E238C9D6400AAD9ED /* StatsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsScreen.swift; sourceTree = "<group>"; };
 		FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsService.swift; sourceTree = "<group>"; };
+		FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsViewController.swift; sourceTree = "<group>"; };
 		FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWarningView.swift; sourceTree = "<group>"; };
 		FA1A543F25A6E3080033967D /* RestoreWarningView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreWarningView.xib; sourceTree = "<group>"; };
 		FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreStatusView.swift; sourceTree = "<group>"; };
@@ -13391,6 +13394,7 @@
 				82FC61181FA8ADAC00A1757E /* Activity */,
 				B50C0C441EF429D500372C65 /* Aztec */,
 				80C5239F2995977100B1C14B /* Blaze */,
+				FA111E362A2F38E200896FCE /* Blaze Campaigns */,
 				AC34397B0E11443300E5D79B /* Blog */,
 				8320B5CF11FCA3EA00607422 /* Cells */,
 				C533CF320E6D3AB3000C3DE8 /* Comments */,
@@ -17596,6 +17600,14 @@
 			path = Logging;
 			sourceTree = "<group>";
 		};
+		FA111E362A2F38E200896FCE /* Blaze Campaigns */ = {
+			isa = PBXGroup;
+			children = (
+				FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */,
+			);
+			path = "Blaze Campaigns";
+			sourceTree = "<group>";
+		};
 		FA1A563825A708BF0033967D /* Restore Options */ = {
 			isa = PBXGroup;
 			children = (
@@ -21215,6 +21227,7 @@
 				FFD12D5E1FE1998D00F20A00 /* Progress+Helpers.swift in Sources */,
 				FAFC065127D27241002F0483 /* BlogDetailsViewController+Dashboard.swift in Sources */,
 				0A9610F928B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */,
+				FA111E382A2F38FC00896FCE /* BlazeCampaignsViewController.swift in Sources */,
 				170CE7402064478600A48191 /* PostNoticeNavigationCoordinator.swift in Sources */,
 				740516892087B73400252FD0 /* SearchableActivityConvertable.swift in Sources */,
 				F4D36AD5298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */,
@@ -24674,6 +24687,7 @@
 				FAC1B81F29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */,
 				FABB23AF2602FC2C00C8785C /* TopCommentedPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB23B02602FC2C00C8785C /* Data.swift in Sources */,
+				FA111E392A2F474600896FCE /* BlazeCampaignsViewController.swift in Sources */,
 				FABB23B12602FC2C00C8785C /* AccountSettingsViewController.swift in Sources */,
 				FABB23B22602FC2C00C8785C /* StatsChildRowsView.swift in Sources */,
 				FABB23B32602FC2C00C8785C /* Menu.m in Sources */,


### PR DESCRIPTION
Part of #20762

## Description
- Adds a blank screen for the campaigns list screen (UI refinement, data hookup, navigation hookup will be addressed in future PRs)

## How to test

1. Replace `DashboardBlazeCardCell.swift` L18 with
```
BlazeFlowCoordinator.presentBlazeCampaigns(in: presentingViewController, blog: blog)
```
2. Run the app
3. Tap on the Blaze dashboard card
4. ✅ A blank screen called "Blaze Campaigns" is displayed

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f0eeaaf3-64c3-4895-97c3-5a428402e7f4" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
