### PR TITLE
Blaze Manage Campaigns: Show loading and empty view in campaigns screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class BlazeCampaignsViewController: UIViewController {
+final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Views
 
@@ -15,6 +15,14 @@ final class BlazeCampaignsViewController: UIViewController {
     // MARK: - Properties
 
     private var blog: Blog
+
+    private var isLoading: Bool = false {
+        didSet {
+            if isLoading != oldValue {
+                showNoResultsViewIfNeeded()
+            }
+        }
+    }
 
     // MARK: - Initializers
 
@@ -34,6 +42,12 @@ final class BlazeCampaignsViewController: UIViewController {
         super.viewDidLoad()
         setupView()
         setupNavBar()
+        setupNoResults()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchCampaigns()
     }
 
     // MARK: - Private helpers
@@ -47,15 +61,70 @@ final class BlazeCampaignsViewController: UIViewController {
         navigationItem.rightBarButtonItem = dismissButton
     }
 
+    private func setupNoResults() {
+        noResultsViewController.delegate = self
+    }
+
+    private func fetchCampaigns() {
+        isLoading = true
+
+        // FIXME: Call BlazeService
+    }
+
     @objc private func promotePostButtonTapped() {
         // TODO: Track event
         BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignsList, blog: blog)
     }
 }
 
+// MARK: - No results
+
+extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
+
+    private func showNoResultsViewIfNeeded() {
+        guard !isLoading else {
+            showLoadingView()
+            return
+        }
+
+        // FIXME: if results aren't empty, hide the no results view and return
+
+        showNoResultsView()
+    }
+
+    private func showNoResultsView() {
+        hideNoResults()
+        noResultsViewController.hideImageView()
+        configureAndDisplayNoResults(on: view,
+                                     title: NoResults.emptyTitle,
+                                     subtitle: NoResults.emptySubtitle,
+                                     buttonTitle: Strings.promoteButtonTitle)
+    }
+
+    private func showLoadingView() {
+        hideNoResults()
+        configureAndDisplayNoResults(on: view,
+                                     title: NoResults.loadingTitle,
+                                     accessoryView: NoResultsViewController.loadingAccessoryView())
+    }
+
+    func actionButtonPressed() {
+        promotePostButtonTapped()
+    }
+}
+
+// MARK: - Constants
+
 extension BlazeCampaignsViewController {
 
     private enum Strings {
         static let navigationTitle = NSLocalizedString("blaze.campaigns.title", value: "Blaze Campaigns", comment: "Title for the screen that allows users to manage their Blaze campaigns.")
+        static let promoteButtonTitle = NSLocalizedString("blaze.campaigns.promote.button.title", value: "Promote", comment: "Button title for the button that shows the Blaze flow when tapped.")
+    }
+
+    private enum NoResults {
+        static let loadingTitle = NSLocalizedString("blaze.campaigns.loading.title", value: "Loading campaigns...", comment: "Displayed while Blaze campaigns are being loaded.")
+        static let emptyTitle = NSLocalizedString("blaze.campaigns.empty.title", value: "You have no campaigns", comment: "Title displayed when there are no Blaze campaigns to display.")
+        static let emptySubtitle = NSLocalizedString("blaze.campaigns.empty.subtitle", value: "You have not created any campaigns yet. Click promote to get started.", comment: "Text displayed when there are no Blaze campaigns to display.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -96,15 +96,15 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
         hideNoResults()
         noResultsViewController.hideImageView()
         configureAndDisplayNoResults(on: view,
-                                     title: NoResults.emptyTitle,
-                                     subtitle: NoResults.emptySubtitle,
+                                     title: Strings.NoResults.emptyTitle,
+                                     subtitle: Strings.NoResults.emptySubtitle,
                                      buttonTitle: Strings.promoteButtonTitle)
     }
 
     private func showLoadingView() {
         hideNoResults()
         configureAndDisplayNoResults(on: view,
-                                     title: NoResults.loadingTitle,
+                                     title: Strings.NoResults.loadingTitle,
                                      accessoryView: NoResultsViewController.loadingAccessoryView())
     }
 
@@ -115,16 +115,16 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
 
 // MARK: - Constants
 
-extension BlazeCampaignsViewController {
+private extension BlazeCampaignsViewController {
 
-    private enum Strings {
+    enum Strings {
         static let navigationTitle = NSLocalizedString("blaze.campaigns.title", value: "Blaze Campaigns", comment: "Title for the screen that allows users to manage their Blaze campaigns.")
         static let promoteButtonTitle = NSLocalizedString("blaze.campaigns.promote.button.title", value: "Promote", comment: "Button title for the button that shows the Blaze flow when tapped.")
-    }
 
-    private enum NoResults {
-        static let loadingTitle = NSLocalizedString("blaze.campaigns.loading.title", value: "Loading campaigns...", comment: "Displayed while Blaze campaigns are being loaded.")
-        static let emptyTitle = NSLocalizedString("blaze.campaigns.empty.title", value: "You have no campaigns", comment: "Title displayed when there are no Blaze campaigns to display.")
-        static let emptySubtitle = NSLocalizedString("blaze.campaigns.empty.subtitle", value: "You have not created any campaigns yet. Click promote to get started.", comment: "Text displayed when there are no Blaze campaigns to display.")
+        enum NoResults {
+            static let loadingTitle = NSLocalizedString("blaze.campaigns.loading.title", value: "Loading campaigns...", comment: "Displayed while Blaze campaigns are being loaded.")
+            static let emptyTitle = NSLocalizedString("blaze.campaigns.empty.title", value: "You have no campaigns", comment: "Title displayed when there are no Blaze campaigns to display.")
+            static let emptySubtitle = NSLocalizedString("blaze.campaigns.empty.subtitle", value: "You have not created any campaigns yet. Click promote to get started.", comment: "Text displayed when there are no Blaze campaigns to display.")
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -109,7 +109,7 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
     }
 
     func actionButtonPressed() {
-        promotePostButtonTapped()
+        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignsList, blog: blog)
     }
 }
 


### PR DESCRIPTION
Part of #20764 

## Description
- Adds a loading / empty view to the Blaze Campaigns screen (The logic to determine when to show an empty view will be handled in a future PR)

Design ref: 1Osrn9gb2xLaKG6lIft3WC-fi-1509_20493

## How to test
1. Replace `DashboardBlazeCardCell.swift` L18 with
```
BlazeFlowCoordinator.presentBlazeCampaigns(in: presentingViewController, blog: blog)
```
2. Right below the FIXME in `BlazeCampaignsViewController.swift` L72, add the following
```
DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
    self?.isLoading = false
}
```
4. Run the app
5. Tap on the Blaze dashboard card
6. ✅ A "loading campaigns" view is displayed while the screen loads
7. Wait for 2 seconds
8. ✅ A "You have no campaigns" view is displayed
9. Tap the "Promote" button
10. ✅ The Blaze flow is displayed


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/6016ca61-6f0b-4cb3-9d4f-ee78489d76be



## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)