### PR TITLE
Blaze Manage Campaigns: Add contextual menu to Blaze Campaign card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -40,13 +40,19 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
 
         frameView.setTitle(Strings.cardTitle)
         frameView.onHeaderTap = { [weak self] in
-            self?.didTapHeader()
+            self?.showCampaignList()
         }
     }
 
-    private func didTapHeader() {
+    private func showCampaignList() {
         guard let presentingViewController, let blog else { return }
         BlazeFlowCoordinator.presentBlazeCampaigns(in: presentingViewController, blog: blog)
+    }
+
+    private func makeShowCampaignsMenuAction() -> UIAction {
+        UIAction(title: Strings.viewAllCampaigns, image: UIImage(systemName: "ellipsis.circle")) { [weak self] _ in
+            self?.showCampaignList()
+        }
     }
 
     // MARK: - BlogDashboardCardConfigurable
@@ -56,7 +62,12 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
         self.presentingViewController = viewController
 
         frameView.addMoreMenu(items: [
-            BlogDashboardHelpers.makeHideCardAction(for: .blaze, blog: blog)
+            UIMenu(options: .displayInline, children: [
+                makeShowCampaignsMenuAction()
+            ]),
+            UIMenu(options: .displayInline, children: [
+                BlogDashboardHelpers.makeHideCardAction(for: .blaze, blog: blog)
+            ])
         ], card: .blaze)
 
         let viewModel = DashboardBlazeCampaignViewModel(campaign: mockResponse.campaigns!.first!)
@@ -67,6 +78,7 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
 private extension DashboardBlazeCampaignCardCell {
     enum Strings {
         static let cardTitle = NSLocalizedString("dashboardCard.blazeCampaigns.title", value: "Blaze campaign", comment: "Title for the card displaying blaze campaigns.")
+        static let viewAllCampaigns = NSLocalizedString("dashboardCard.blazeCampaigns.viewAllCampaigns", value: "View all campaigns", comment: "Title for the View All Campaigns button in the More menu")
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -55,6 +55,10 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
         self.blog = blog
         self.presentingViewController = viewController
 
+        frameView.addMoreMenu(items: [
+            BlogDashboardHelpers.makeHideCardAction(for: .blaze, blog: blog)
+        ], card: .blaze)
+
         let viewModel = DashboardBlazeCampaignViewModel(campaign: mockResponse.campaigns!.first!)
         campaignView.configure(with: viewModel, blog: blog)
     }


### PR DESCRIPTION
Fixes [#20746](https://github.com/wordpress-mobile/WordPress-iOS/issues/20746)

To test:

- In `DashboardCard.swift`, replace `DashboardBlazeCardCell.self` with `DashboardBlazeCampaignCardCell.self`
- Open Dashboard with Blaze approved/enabled
- Tap the "More" menu and tap "View all campaigns" to verify that the new campaigns list opens
- Tap the "More" menu and tap "Hide" to test that the card gets hidden (you can unhide it from the Personalize Home Screen)

> Note: I will add analytics and update the id for hide (if needed) when we resolve p1686229992433489-slack-C04LJFS1G5P

<img width="302" alt="Screenshot 2023-06-08 at 3 04 41 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/95e82b44-9662-4377-a193-2264271b5673">

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on) manual test
3. What automated tests I added (or what prevented me from doing so) n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
