### PR TITLE
Blaze Manage Campaigns: Add Create Campaign button to Blaze Campaign card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -8,10 +8,20 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
     private lazy var contentStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.layoutMargins = Constants.contentInsets
-        stackView.spacing = 4
-        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
+    }()
+
+    private lazy var createCampaignButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.contentHorizontalAlignment = .leading
+        button.setTitle(Strings.createCampaignButton, for: .normal)
+        button.addTarget(self, action: #selector(buttonCreateCampaignTapped), for: .touchUpInside)
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.setTitleColor(UIColor.primary, for: .normal)
+        button.contentEdgeInsets = Constants.createCampaignInsets
+        return button
     }()
 
     private var blog: Blog?
@@ -36,7 +46,24 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
         contentView.pinSubviewToAllEdges(frameView, priority: UILayoutPriority(999))
 
         frameView.add(subview: contentStackView)
-        contentStackView.addArrangedSubview(campaignView)
+        contentStackView.addArrangedSubview({
+            let container = UIStackView(arrangedSubviews: [campaignView])
+            container.layoutMargins = Constants.campaignViewInsets
+            container.isLayoutMarginsRelativeArrangement = true
+            return container
+        }())
+        contentStackView.addArrangedSubview({
+            let separator = UIView()
+            separator.translatesAutoresizingMaskIntoConstraints = false
+            separator.heightAnchor.constraint(equalToConstant: 0.5).isActive = true
+            separator.backgroundColor = UIColor.separator
+
+            let container = UIView()
+            container.addSubview(separator)
+            container.pinSubviewToAllEdges(separator, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0))
+            return container
+        }())
+        contentStackView.addArrangedSubview(createCampaignButton)
 
         frameView.setTitle(Strings.cardTitle)
         frameView.onHeaderTap = { [weak self] in
@@ -53,6 +80,11 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
         UIAction(title: Strings.viewAllCampaigns, image: UIImage(systemName: "ellipsis.circle")) { [weak self] _ in
             self?.showCampaignList()
         }
+    }
+
+    @objc private func buttonCreateCampaignTapped() {
+        guard let presentingViewController, let blog else { return }
+        BlazeFlowCoordinator.presentBlaze(in: presentingViewController, source: .dashboardCard, blog: blog)
     }
 
     // MARK: - BlogDashboardCardConfigurable
@@ -79,10 +111,12 @@ private extension DashboardBlazeCampaignCardCell {
     enum Strings {
         static let cardTitle = NSLocalizedString("dashboardCard.blazeCampaigns.title", value: "Blaze campaign", comment: "Title for the card displaying blaze campaigns.")
         static let viewAllCampaigns = NSLocalizedString("dashboardCard.blazeCampaigns.viewAllCampaigns", value: "View all campaigns", comment: "Title for the View All Campaigns button in the More menu")
+        static let createCampaignButton = NSLocalizedString("dashboardCard.blazeCampaigns.createCampaignButton", value: "Create campaign", comment: "Title of a button that starts the campaign creation flow.")
     }
 
     enum Constants {
-        static let contentInsets = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 16)
+        static let campaignViewInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        static let createCampaignInsets = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignCardCell.swift
@@ -17,7 +17,7 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
         button.contentHorizontalAlignment = .leading
         button.setTitle(Strings.createCampaignButton, for: .normal)
         button.addTarget(self, action: #selector(buttonCreateCampaignTapped), for: .touchUpInside)
-        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold)
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .bold)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.setTitleColor(UIColor.primary, for: .normal)
         button.contentEdgeInsets = Constants.createCampaignInsets


### PR DESCRIPTION
Fixes #20759

To test: 
- In `DashboardCard.swift`, replace `DashboardBlazeCardCell.self` with `DashboardBlazeCampaignCardCell.self`
- Open Dashboard with Blaze approved/enabled
- Tap "Create Campaign" and verify that the flow for starting a Blaze campaign opens

<img width="453" alt="Screenshot 2023-06-08 at 4 02 59 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0fbd1c4e-718c-4051-9feb-157cbaac3d49">

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a
 
PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
