### PR TITLE
Blaze Manage Campaigns: Add dark mode support to Blaze Campaign card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignStatusView.swift
@@ -49,17 +49,41 @@ struct DashboardBlazeCampaignViewStatusViewModel {
 
         switch status {
         case .created, .processing, .scheduled, .canceled:
-            self.textColor = UIColor(fromHex: 0x4F3500)
-            self.backgroundColor = UIColor(fromHex: 0xF5E6B3)
+            self.textColor = UIColor(
+                light: UIColor(fromHex: 0x4F3500),
+                dark: UIColor(fromHex: 0xDEB100)
+            )
+            self.backgroundColor = UIColor(
+                light: UIColor(fromHex: 0xF5E6B3),
+                dark: UIColor(fromHex: 0x332200)
+            )
         case .rejected:
-            self.textColor = UIColor(fromHex: 0x8A2424)
-            self.backgroundColor = UIColor(fromHex: 0xFACFD2)
+            self.textColor = UIColor(
+                light: UIColor(fromHex: 0x8A2424),
+                dark: UIColor(fromHex: 0xF86368)
+            )
+            self.backgroundColor = UIColor(
+                light: UIColor(fromHex: 0xFACFD2),
+                dark: UIColor(fromHex: 0x451313)
+            )
         case .active, .approved:
-            self.textColor = UIColor(fromHex: 0x00450C)
-            self.backgroundColor = UIColor(fromHex: 0xB8E6BF)
+            self.textColor = UIColor(
+                light: UIColor(fromHex: 0x00450C),
+                dark: UIColor(fromHex: 0x00BA37)
+            )
+            self.backgroundColor = UIColor(
+                light: UIColor(fromHex: 0xB8E6BF),
+                dark: UIColor(fromHex: 0x003008)
+            )
         case .finished:
-            self.textColor = UIColor(fromHex: 0x02395C)
-            self.backgroundColor = UIColor(fromHex: 0xBBE0FA)
+            self.textColor = UIColor(
+                light: UIColor(fromHex: 0x02395C),
+                dark: UIColor(fromHex: 0x399CE3)
+            )
+            self.backgroundColor = UIColor(
+                light: UIColor(fromHex: 0xBBE0FA),
+                dark: UIColor(fromHex: 0x01283D)
+            )
         case .unknown:
             self.textColor = .label
             self.backgroundColor = .secondarySystemBackground


### PR DESCRIPTION
Related Issue: #20745

To test:
- In `DashboardCard.swift`, replace `DashboardBlazeCardCell.self` with `DashboardBlazeCampaignCardCell.self`
- Open Dashboard with Blaze approved/enabled
- Update status in `DashboardBlazeCampaignStatusView.swift` (it will be easier to test when the backend is integrated and can be mocked dynamically)

## Regression Notes
1. Potential unintended areas of impact: n/a (only affects the new card)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
