### PR TITLE
Add release note for WP.com plans

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * [**] [internal] Check required WordPress version to set "galleryWithImageBlocks" flag [#20736]
 * [**] [Jetpack-only] Add a "Personalize Home Tab" button to the bottom of the My Site Dashboard that opens a new screen where you can customize which dashboard cards are visible. You can now also hide any of the dashboard cards directly from My Site Dashboard using the "more" menu. [#20296]
 * [*] [Jetpack-only] Domains selection: Show error message when selecting unsupported domains. [#20786]
-* [**] [Jetpack-only] Added a dashboard card for purchasing domains. [#20822]
+* [***] [Jetpack-only] Plans: Bringing WPCOM plans to Jetpack app. [#20822]
 
 22.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [**] [internal] Check required WordPress version to set "galleryWithImageBlocks" flag [#20736]
 * [**] [Jetpack-only] Add a "Personalize Home Tab" button to the bottom of the My Site Dashboard that opens a new screen where you can customize which dashboard cards are visible. You can now also hide any of the dashboard cards directly from My Site Dashboard using the "more" menu. [#20296]
 * [*] [Jetpack-only] Domains selection: Show error message when selecting unsupported domains. [#20786]
+* [***] [internal] Allow users to purchase a WP.com plan (Personal or Premium) and in doing so get a domain free for the first year. Entry point is new dashboard card. []
 
 22.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * [**] [internal] Check required WordPress version to set "galleryWithImageBlocks" flag [#20736]
 * [**] [Jetpack-only] Add a "Personalize Home Tab" button to the bottom of the My Site Dashboard that opens a new screen where you can customize which dashboard cards are visible. You can now also hide any of the dashboard cards directly from My Site Dashboard using the "more" menu. [#20296]
 * [*] [Jetpack-only] Domains selection: Show error message when selecting unsupported domains. [#20786]
-* [***] [internal] Allow users to purchase a WP.com plan (Personal or Premium) and in doing so get a domain free for the first year. Entry point is new dashboard card. [#20822]
+* [**] [Jetpack-only] Added a dashboard card for purchasing domains. [#20822]
 
 22.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * [**] [internal] Check required WordPress version to set "galleryWithImageBlocks" flag [#20736]
 * [**] [Jetpack-only] Add a "Personalize Home Tab" button to the bottom of the My Site Dashboard that opens a new screen where you can customize which dashboard cards are visible. You can now also hide any of the dashboard cards directly from My Site Dashboard using the "more" menu. [#20296]
 * [*] [Jetpack-only] Domains selection: Show error message when selecting unsupported domains. [#20786]
-* [***] [internal] Allow users to purchase a WP.com plan (Personal or Premium) and in doing so get a domain free for the first year. Entry point is new dashboard card. []
+* [***] [internal] Allow users to purchase a WP.com plan (Personal or Premium) and in doing so get a domain free for the first year. Entry point is new dashboard card. [#20822]
 
 22.5
 -----


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/20817

Internal PT: pcdRpT-2Bo-p2

To test: Verify CI is green

## Regression Notes
1. Potential unintended areas of impact: **Not applicable**
2. What I did to test those areas of impact (or what existing automated tests I relied on): **Not applicable**
3. What automated tests I added (or what prevented me from doing so): **Not applicable**

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: **Not applicable**