### PR TITLE
[UI Tests] - Refactor tests that crashes test runner in CI

### DIFF
--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -7,8 +7,8 @@ class EditorGutenbergTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        editorScreen = try EditorFlow
+        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try EditorFlow
             .goToMySiteScreen()
             .tabBar.gotoBlockEditorScreen()
             .dismissNotificationAlertIfNeeded(.accept)
@@ -24,7 +24,7 @@ class EditorGutenbergTests: XCTestCase {
 
     func testTextPostPublish() throws {
 
-        try editorScreen
+        try BlockEditorScreen()
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
@@ -38,7 +38,7 @@ class EditorGutenbergTests: XCTestCase {
 
         let category = getCategory()
         let tag = getTag()
-        try editorScreen
+        try BlockEditorScreen()
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImage()
@@ -55,7 +55,7 @@ class EditorGutenbergTests: XCTestCase {
 
     func testAddRemoveFeaturedImage() throws {
 
-        try editorScreen
+        try BlockEditorScreen()
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
@@ -70,7 +70,7 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testAddGalleryBlock() throws {
-        try editorScreen
+        try BlockEditorScreen()
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImageGallery()

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -34,9 +34,7 @@ class MainNavigationTests: XCTestCase {
    func testTabBarNavigation() throws {
        XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
-       try MySiteScreen()
-           .tabBar.goToReaderScreen()
-
+       try TabNavComponent().goToReaderScreen()
        XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
 
        // We may get a notifications fancy alert when loading the reader for the first time
@@ -44,8 +42,8 @@ class MainNavigationTests: XCTestCase {
            alert.cancelAlert()
        }
 
-       try MySiteScreen()
-           .tabBar.goToNotificationsScreen()
+       try TabNavComponent()
+           .goToNotificationsScreen()
            .dismissNotificationAlertIfNeeded()
 
        XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -8,7 +8,7 @@ class MainNavigationTests: XCTestCase {
         setUpTestSuite()
 
         try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        mySiteScreen = try TabNavComponent()
+        try TabNavComponent()
             .goToMySiteScreen()
             .goToMenu()
     }
@@ -25,7 +25,7 @@ class MainNavigationTests: XCTestCase {
     func testLoadsPeopleScreen() throws {
         XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
-        try mySiteScreen
+        try MySiteScreen()
             .goToPeople()
 
         XCTAssertTrue(PeopleScreen.isLoaded(), "PeopleScreen screen isn't loaded.")
@@ -34,7 +34,7 @@ class MainNavigationTests: XCTestCase {
    func testTabBarNavigation() throws {
        XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
-       _ = try mySiteScreen
+       try MySiteScreen()
            .tabBar.goToReaderScreen()
 
        XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
@@ -44,7 +44,7 @@ class MainNavigationTests: XCTestCase {
            alert.cancelAlert()
        }
 
-       _ = try mySiteScreen
+       try MySiteScreen()
            .tabBar.goToNotificationsScreen()
            .dismissNotificationAlertIfNeeded()
 

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -7,8 +7,8 @@ class ReaderTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        readerScreen = try EditorFlow
+        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try EditorFlow
             .goToMySiteScreen()
             .tabBar.goToReaderScreen()
     }
@@ -22,18 +22,20 @@ class ReaderTests: XCTestCase {
 
     let commentContent = "Test comment."
 
-    func testViewPost() {
-        readerScreen.openLastPost()
-        XCTAssert(readerScreen.postContentEquals(expectedPostContent))
+    func testViewPost() throws {
+        try ReaderScreen()
+            .openLastPost()
+            .verifyPostContentEquals(expectedPostContent)
     }
 
-    func testViewPostInSafari() {
-        readerScreen.openLastPostInSafari()
-        XCTAssert(readerScreen.postContentEquals(expectedPostContent))
+    func testViewPostInSafari() throws {
+        try ReaderScreen()
+            .openLastPostInSafari()
+            .verifyPostContentEquals(expectedPostContent)
     }
 
     func testAddCommentToPost() throws {
-        try readerScreen
+        try ReaderScreen()
             .openLastPostComments()
             .verifyCommentsListEmpty()
             .replyToPost(commentContent)

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -6,8 +6,8 @@ class StatsTests: XCTestCase {
 
     override func setUpWithError() throws {
         setUpTestSuite()
-        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        statsScreen = try MySiteScreen()
+        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try MySiteScreen()
             .goToMenu()
             .goToStatsScreen()
             .switchTo(mode: .insights)
@@ -49,14 +49,14 @@ class StatsTests: XCTestCase {
         "Visitors,  2017: 465"
     ]
 
-    func testInsightsStatsLoadProperly() {
-        statsScreen
+    func testInsightsStatsLoadProperly() throws {
+        try StatsScreen()
             .switchTo(mode: .insights)
             .assertStatsAreLoaded(insightsStats)
     }
 
-    func testYearsStatsLoadProperly() {
-        statsScreen
+    func testYearsStatsLoadProperly() throws {
+        try StatsScreen()
             .switchTo(mode: .years)
             .assertStatsAreLoaded(yearsStats)
             .assertChartIsLoaded(yearsChartBars)

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -26,9 +26,7 @@ public class LoginEpilogueScreen: ScreenObject {
             firstSite.tap()
         }
 
-        try dismissQuickStartPromptIfNeeded()
         try dismissOnboardingQuestionsPromptIfNeeded()
-        try dismissFeatureIntroductionIfNeeded()
         return try MySiteScreen()
     }
 

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -9,7 +9,7 @@ public class ReaderScreen: ScreenObject {
 
     var discoverButton: XCUIElement { discoverButtonGetter(app) }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 // swiftlint:skip:next opening_brace
@@ -21,13 +21,15 @@ public class ReaderScreen: ScreenObject {
         )
     }
 
-    public func openLastPost() {
+    public func openLastPost() throws -> ReaderScreen {
         getLastPost().tap()
+        return self
     }
 
-    public func openLastPostInSafari() {
+    public func openLastPostInSafari() throws -> ReaderScreen {
         getLastPost().buttons["More"].tap()
         app.buttons["Visit"].tap()
+        return self
     }
 
     public func openLastPostComments() throws -> CommentsScreen {
@@ -53,11 +55,15 @@ public class ReaderScreen: ScreenObject {
         }
     }
 
-    public func postContentEquals(_ expected: String) -> Bool {
+    private func postContentEquals(_ expected: String) -> Bool {
         let equalsPostContent = NSPredicate(format: "label == %@", expected)
         let isPostContentEqual = app.staticTexts.element(matching: equalsPostContent).waitForIsHittable(timeout: 3)
 
         return isPostContentEqual
+    }
+
+    public func verifyPostContentEquals(_ expected: String) {
+        XCTAssertTrue(postContentEquals(expected))
     }
 
     public func dismissPost() {

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -64,6 +64,7 @@ public class TabNavComponent: ScreenObject {
         return try BlockEditorScreen()
     }
 
+    @discardableResult
     public func goToReaderScreen() throws -> ReaderScreen {
         readerTabButton.tap()
         return try ReaderScreen()

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -31,7 +31,7 @@ public class TabNavComponent: ScreenObject {
                 notificationsTabButtonGetter
             ],
             app: app,
-            waitTimeout: 3
+            waitTimeout: 7
         )
     }
 


### PR DESCRIPTION
### Description
Recently several tests have been causing the test runner to crash. The behavior is inconsistent (it doesn't crash all the time; more often, I notice that the test runner would crash on the rerun), and when this happens, the test failures report is not generated because when the test runner crashes, the XML report file is not generated.

I noticed a pattern for the failures. It's usually the same set of tests that fail. While it's not the same test every time, it's a group of the same tests:
1. StatsTests
2. MainNavigationTests
3. ReaderTests
4. EditorGutenbergTests

I have not seen the newly created test class `DashboardTests` part of the test runner crash, not even once. Looking at the differences between those tests, one difference is that the tests that crash the test runner are using instances of the screen that was created earlier and not during the test itself. I'm not really sure if that's the actual reason, as the crash log only mentions the test name and that it could be an issue with the test case, but trying this out to see if this would eliminate (or at least reduce) the number of test runner crashes that happens. 

### Testing
See that CI is green - 5 back-to-back runs are 🟢 without any test runner crashes (note that there are still flaky tests because of timeouts, those issues are not addressed in this PR and will be addressed separately)