### PR TITLE
Fix Core Data threading issue in ThemeService

### DIFF
--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -216,7 +216,7 @@ const NSInteger ThemeOrderTrailing = 9999;
                                               NSMutableSet *unsyncedThemes = [NSMutableSet setWithSet:blogInContext.themes];
                                               [unsyncedThemes minusSet:[NSSet setWithArray:themes]];
                                               for (Theme *deleteTheme in unsyncedThemes) {
-                                                  if (![blog.currentThemeId isEqualToString:deleteTheme.themeId]) {
+                                                  if (![blogInContext.currentThemeId isEqualToString:deleteTheme.themeId]) {
                                                       [context deleteObject:deleteTheme];
                                                   }
                                               }


### PR DESCRIPTION
Fixes an issue where `ThemeService` was accessing a blog object from the main thread in the background context.

Steps to reproduce:
- Run the app with Xcode debugger attached
- Open a site that doesn't support custom themes that has unsynced themes
- Open Menu / Themes

Actual result:
- Xcode reports invalid Core Data usage

## Regression Notes
1. Potential unintended areas of impact: Menu / Themes
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual test
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
