### PR TITLE
[UI Tests] - Fix featured image assertion

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -10,7 +10,7 @@ public class EditorPostSettings: ScreenObject {
     var categoriesSection: XCUIElement { settingsTable.cells["Categories"] }
     var tagsSection: XCUIElement { settingsTable.cells["Tags"] }
     var featuredImageButton: XCUIElement { settingsTable.cells["SetFeaturedImage"] }
-    var changeFeaturedImageButton: XCUIElement { settingsTable.cells["CurrentFeaturedImage"] }
+    var currentFeaturedImage: XCUIElement { settingsTable.cells["CurrentFeaturedImage"] }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -45,7 +45,7 @@ public class EditorPostSettings: ScreenObject {
     }
 
     public func removeFeatureImage() throws -> EditorPostSettings {
-        changeFeaturedImageButton.tap()
+        currentFeaturedImage.tap()
 
         try FeaturedImageScreen()
             .tapRemoveFeaturedImageButton()
@@ -69,13 +69,10 @@ public class EditorPostSettings: ScreenObject {
         if let postTag = tag {
             XCTAssertTrue(tagsSection.staticTexts[postTag].exists, "Tag \(postTag) not set")
         }
-        let imageCount = settingsTable.images.count
         if hasImage {
-            XCTAssertTrue(imageCount == 1, "Featured image not set")
-            expect(self.changeFeaturedImageButton.images.descendants(matching: .other).element.exists)
-                .toEventually(beFalse(), timeout: .seconds(30), description: "Featured image is not displayed")
+            XCTAssertTrue(currentFeaturedImage.exists, "Featured image not set")
         } else {
-            XCTAssertTrue(imageCount == 0, "Featured image is set but should not be")
+            XCTAssertFalse(currentFeaturedImage.exists, "Featured image is set but should not be")
         }
 
         return try EditorPostSettings()


### PR DESCRIPTION
### Description
In [release 22.6 branch](https://buildkite.com/automattic/wordpress-ios/builds?branch=release%2F22.6), the `testAddRemoveFeaturedImage` test is consistently failing. I found that the assertion no longer works. I'm not sure how it worked before but I suspect that the element tree may have been updated in this release. 

The previous assertion depended on an `imageCount` value and it should return 1 here: `let imageCount = settingsTable.images.count` After debugging found that it now returns 5 which is correct as I've verified the number of times the element appear on the element tree. Updated/simplified the assertion to only look for the featured image so it should work now without depending on the total number of Images displayed on the Post Settings screen.

I also removed 
```
expect(self.changeFeaturedImageButton.images.descendants(matching: .other).element.exists)
                .toEventually(beFalse(), timeout: .seconds(30), description: "Featured image is not displayed")
```
because now that we're checking the featured image directly that seems to be redundant (it is also using `expect` syntax which is not really part of XCTest framework)

### Testing
`testAddRemoveFeaturedImage` should work as expected and CI should be green.