### PR TITLE
[UI Tests] - Remove unused properties and unneeded throws

### DIFF
--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -2,8 +2,6 @@ import UITestsFoundation
 import XCTest
 
 class EditorGutenbergTests: XCTestCase {
-    private var editorScreen: BlockEditorScreen!
-
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -2,8 +2,6 @@ import UITestsFoundation
 import XCTest
 
 class MainNavigationTests: XCTestCase {
-    private var mySiteScreen: MySiteScreen!
-
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -2,8 +2,6 @@ import UITestsFoundation
 import XCTest
 
 class ReaderTests: XCTestCase {
-    private var readerScreen: ReaderScreen!
-
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -2,8 +2,6 @@ import UITestsFoundation
 import XCTest
 
 class StatsTests: XCTestCase {
-    private var statsScreen: StatsScreen!
-
     override func setUpWithError() throws {
         setUpTestSuite()
         try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -21,12 +21,12 @@ public class ReaderScreen: ScreenObject {
         )
     }
 
-    public func openLastPost() throws -> ReaderScreen {
+    public func openLastPost() -> ReaderScreen {
         getLastPost().tap()
         return self
     }
 
-    public func openLastPostInSafari() throws -> ReaderScreen {
+    public func openLastPostInSafari() -> ReaderScreen {
         getLastPost().buttons["More"].tap()
         app.buttons["Visit"].tap()
         return self


### PR DESCRIPTION
### Description
This PR is a follow-up to address the comments in https://github.com/wordpress-mobile/WordPress-iOS/pull/20825. The two changes made are:
1. Remove the unused property in the test class
2. Remove the unnecessary throws in a few methods

### Testing
CI should be 🟢 