### PR TITLE
Reader: Fix viewDidDisappear crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -206,8 +206,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
+        super.viewDidDisappear(animated)
         ReaderTracker.shared.stop(.readerPost)
     }
 


### PR DESCRIPTION
Fixes #20843

## Description
- Fixes a crash that happens when closing the Reader

## How to test

1. Switch to the Reader tab
2. Tap on a Reader post to open the details screen
3. Go back to the Reader feed
4. Repeat steps 2, 3 several times
5. ✅ Verify: the app doesn't crash

## Regression Notes
1. Potential unintended areas of impact
n/a

6. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

7. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
