### PR TITLE
Test – Gutenberg + XCFramework + Tag version

### DIFF
--- a/Gutenberg/version.rb
+++ b/Gutenberg/version.rb
@@ -11,8 +11,12 @@
 #
 #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 GUTENBERG_CONFIG = {
-  # commit: ''
-  tag: 'v1.98.1'
+  # This is a version of Gutenberg built with RN 0.71
+  #
+  # See:
+  # - https://github.com/wordpress-mobile/gutenberg-mobile/pull/5924
+  commit: 'b275a9d4302aaddf1572cf1d22497a47c7076443'
+  # tag: 'v1.98.1'
 }
 
 GITHUB_ORG = 'wordpress-mobile'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (1.7.2)
-  - Gutenberg (1.98.1)
+  - Gutenberg (1.97.0)
   - JTAppleCalendar (8.0.3)
   - Kanvas (1.4.4)
   - MediaEditor (1.2.2):
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
   - Gridicons (~> 1.1.0)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.98.1.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b275a9d4302aaddf1572cf1d22497a47c7076443.podspec`)
   - JTAppleCalendar (~> 8.0.2)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -227,7 +227,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.98.1.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b275a9d4302aaddf1572cf1d22497a47c7076443.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -254,7 +254,7 @@ SPEC CHECKSUMS:
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: cf0107fac4110a45ec3c643dde69b29f647148bb
+  Gutenberg: 9a7c7e9dfc68855463464a05979605fb3dfd8a96
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae


### PR DESCRIPTION
<img width="1222" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/ba3601a0-59cb-4163-8f08-bcb5b7a60150">
