### PR TITLE
Core Data: Fixes a Core Data Multithreading violation when unscheduling blogging reminders

### DIFF
--- a/WordPress/Classes/Services/BlogService+Reminders.swift
+++ b/WordPress/Classes/Services/BlogService+Reminders.swift
@@ -1,15 +1,21 @@
 import Foundation
 
 extension BlogService {
-    @objc func unscheduleBloggingReminders(for blog: Blog) {
-        do {
-            let scheduler = try ReminderScheduleCoordinator()
-            scheduler.schedule(.none, for: blog, completion: { _ in })
-            // We're currently not propagating success / failure here, as it's
-            // it's only used when removing blogs or accounts, and there's
-            // no extra action we can take if it fails anyway.
-        } catch {
-            DDLogError("Could not instantiate the reminders scheduler: \(error.localizedDescription)")
+    @objc func unscheduleBloggingReminders(for blogID: NSManagedObjectID) {
+        let context = ContextManager.shared.mainContext
+        context.performAndWait {
+            do {
+                guard let blogInContext = try context.existingObject(with: blogID) as? Blog else {
+                    return
+                }
+                let scheduler = try ReminderScheduleCoordinator()
+                scheduler.schedule(.none, for: blogInContext, completion: { _ in })
+                // We're currently not propagating success / failure here, as it's
+                // it's only used when removing blogs or accounts, and there's
+                // no extra action we can take if it fails anyway.
+            } catch {
+                DDLogError("Could not instantiate the reminders scheduler: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -377,7 +377,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
 {
     DDLogInfo(@"<Blog:%@> remove", blog.hostURL);
     [blog.xmlrpcApi invalidateAndCancelTasks];
-    [self unscheduleBloggingRemindersFor:blog];
+    [self unscheduleBloggingRemindersFor:blog.objectID];
 
     WPAccount *account = blog.account;
 
@@ -438,7 +438,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
     if ([toDelete count] > 0) {
         for (Blog *blog in account.blogs) {
             if ([toDelete containsObject:blog.dotComID]) {
-                [self unscheduleBloggingRemindersFor:blog];
+                [self unscheduleBloggingRemindersFor:blog.objectID];
                 // Consider switching this to a call to removeBlog in the future
                 // to consolidate behaviour @frosty
                 [context deleteObject:blog];


### PR DESCRIPTION
Fixes #20848 

## Description
Fixes a Core Data Multithreading violation when unscheduling blogging reminders.

## Root Cause
* `BlogService.unscheduleBloggingReminders()` was being called in `BlogService.mergeBlogs` from a derived background context thread.
* `BlogService.unscheduleBloggingReminders()` eventually calls some code that uses the main context.

## Solution
Always run `BlogService.unscheduleBloggingReminders()` on the main context. `BlogService.mergeBlogs` now passes the blog's objectID, and `unscheduleBloggingReminders()` fetches a new Blog object from the main context.

## Alternate Solution
Another solution would be to pass down the background context from `BlogService.mergeBlogs` all the way down to `BloggingPromptsService`. `BloggingPromptsService` uses a ContextManager, and uses `ContextManager.mainContext` to perform tasks, as well as `ContextManager.perfromAndSave`. So in order to inject our original background context, we'll need to introduce a way to change the definition of `ContextManager.mainContext` using a custom context.

This solution has the advantage of avoiding jumping between contexts through one flow. And it adds a pattern that can be used to fix other problematic Blogging Reminders flows. On the other side, it requires a significant tweak to `ContextManager`, which might cause future misuse.

Check #20853 for this solution's implementation.

## Testing Instructions

1. Pass `-com.apple.CoreData.ConcurrencyDebug 1` arguments on launch
2. Open the Jetpack app and log in to an account with multiple sites
3. Log in to the same account on the desktop
4. Delete a site
5. Go back to the app
6. Open the site picker
7. Make sure Xcode doesn't detect a Multithreading violation

## Regression Notes
1. Potential unintended areas of impact
N/A 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
