### PR TITLE
Core Data: Alternate solution to fixing a Core Data Multithreading violation when unscheduling blogging reminders

### DIFF
--- a/WordPress/Classes/Services/BlogService+Reminders.swift
+++ b/WordPress/Classes/Services/BlogService+Reminders.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 extension BlogService {
-    @objc func unscheduleBloggingReminders(for blog: Blog) {
+    @objc func unscheduleBloggingReminders(for blog: Blog, context: NSManagedObjectContext) {
         do {
-            let scheduler = try ReminderScheduleCoordinator()
+            let scheduler = try ReminderScheduleCoordinator(customContext: context)
             scheduler.schedule(.none, for: blog, completion: { _ in })
             // We're currently not propagating success / failure here, as it's
             // it's only used when removing blogs or accounts, and there's

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -377,12 +377,11 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
 {
     DDLogInfo(@"<Blog:%@> remove", blog.hostURL);
     [blog.xmlrpcApi invalidateAndCancelTasks];
-    [self unscheduleBloggingRemindersFor:blog];
-
     WPAccount *account = blog.account;
 
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         Blog *blogInContext = [context existingObjectWithID:blog.objectID error:nil];
+        [self unscheduleBloggingRemindersFor:blogInContext context:context];
         [context deleteObject:blogInContext];
     }];
 
@@ -438,7 +437,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
     if ([toDelete count] > 0) {
         for (Blog *blog in account.blogs) {
             if ([toDelete containsObject:blog.dotComID]) {
-                [self unscheduleBloggingRemindersFor:blog];
+                [self unscheduleBloggingRemindersFor:blog context:context];
                 // Consider switching this to a call to removeBlog in the future
                 // to consolidate behaviour @frosty
                 [context deleteObject:blog];

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -36,7 +36,7 @@ class BloggingPromptsService {
     /// Convenience computed variable that returns prompt settings from the local store.
     ///
     var localSettings: BloggingPromptSettings? {
-        loadSettings(context: contextManager.mainContext)
+        loadSettings(context: contextManager.defaultContext)
     }
 
     /// Fetches a number of blogging prompts starting from the specified date.
@@ -125,7 +125,7 @@ class BloggingPromptsService {
         fetchRequest.predicate = NSPredicate(format: "\(#keyPath(BloggingPrompt.siteID)) = %@ AND \(#keyPath(BloggingPrompt.promptID)) = %@", siteID, NSNumber(value: promptID))
         fetchRequest.fetchLimit = 1
 
-        return (try? self.contextManager.mainContext.fetch(fetchRequest))?.first
+        return (try? self.contextManager.defaultContext.fetch(fetchRequest))?.first
     }
 
     // MARK: - Settings
@@ -141,7 +141,7 @@ class BloggingPromptsService {
             switch result {
             case .success(let remoteSettings):
                 self.saveSettings(remoteSettings) {
-                    let settings = self.loadSettings(context: self.contextManager.mainContext)
+                    let settings = self.loadSettings(context: self.contextManager.defaultContext)
                     success(settings)
                 }
             case .failure(let error):
@@ -168,7 +168,7 @@ class BloggingPromptsService {
                     return
                 }
                 self.saveSettings(updatedSettings) {
-                    let settings = self.loadSettings(context: self.contextManager.mainContext)
+                    let settings = self.loadSettings(context: self.contextManager.defaultContext)
                     success(settings)
                 }
             case .failure(let error):
@@ -182,7 +182,7 @@ class BloggingPromptsService {
     required init?(contextManager: CoreDataStackSwift = ContextManager.shared,
                    remote: BloggingPromptsServiceRemote? = nil,
                    blog: Blog? = nil) {
-        guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext),
+        guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.defaultContext),
               let siteID = blog?.dotComID ?? account.primaryBlogID else {
             return nil
         }
@@ -263,7 +263,7 @@ private extension BloggingPromptsService {
         fetchRequest.fetchLimit = number
         fetchRequest.sortDescriptors = [.init(key: #keyPath(BloggingPrompt.date), ascending: true)]
 
-        return (try? self.contextManager.mainContext.fetch(fetchRequest)) ?? []
+        return (try? self.contextManager.defaultContext.fetch(fetchRequest)) ?? []
     }
 
     /// Find and update existing prompts, or insert new ones if they don't exist.

--- a/WordPress/Classes/Utility/Blogging Prompts/ReminderScheduleCoordinator.swift
+++ b/WordPress/Classes/Utility/Blogging Prompts/ReminderScheduleCoordinator.swift
@@ -39,6 +39,12 @@ class ReminderScheduleCoordinator {
                   bloggingPromptsServiceFactory: bloggingPromptsServiceFactory)
     }
 
+    convenience init(customContext: NSManagedObjectContext) throws {
+        let contextManager = ContextManager(customContext: customContext)
+        let bloggingPromptsServiceFactory = BloggingPromptsServiceFactory(contextManager: contextManager)
+        try self.init(bloggingPromptsServiceFactory: bloggingPromptsServiceFactory)
+    }
+
     /// Returns the user's reminder schedule for the given `blog`, based on the current reminder type.
     ///
     /// - Parameter blog: The blog associated with the reminders.

--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -52,6 +52,7 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
     private let modelName: String
     private let storeURL: URL
     private let persistentContainer: NSPersistentContainer
+    private let customContext: NSManagedObjectContext?
 
     /// A serial queue used to ensure there is only one writing operation at a time.
     ///
@@ -62,11 +63,15 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
 
     @objc
     public var mainContext: NSManagedObjectContext {
-        persistentContainer.viewContext
+        customContext ?? persistentContainer.viewContext
     }
 
     convenience override init() {
         self.init(modelName: ContextManagerModelNameCurrent, store: Self.localDatabasePath)
+    }
+
+    convenience init(customContext: NSManagedObjectContext?) {
+        self.init(modelName: ContextManagerModelNameCurrent, store: Self.localDatabasePath, customContext: customContext)
     }
 
     /// Create a ContextManager instance with given model name and database location.
@@ -78,7 +83,7 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
     ///         Use ContextManagerModelNameCurrent for current version, or
     ///         "WordPress <version>" for specific version.
     ///   - store: Database location. Use `ContextManager.inMemoryStoreURL` to create an in-memory database.
-    init(modelName: String, store storeURL: URL) {
+    init(modelName: String, store storeURL: URL, customContext: NSManagedObjectContext? = nil) {
         assert(modelName == ContextManagerModelNameCurrent || modelName.hasPrefix("WordPress "))
         assert(storeURL.isFileURL)
 
@@ -88,6 +93,7 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
         self.writerQueue = OperationQueue()
         self.writerQueue.name = "org.wordpress.CoreDataStack.writer"
         self.writerQueue.maxConcurrentOperationCount = 1
+        self.customContext = customContext
 
         super.init()
 

--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -63,7 +63,13 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
 
     @objc
     public var mainContext: NSManagedObjectContext {
-        customContext ?? persistentContainer.viewContext
+        persistentContainer.viewContext
+    }
+
+    /// Returns the custom injected context if available, otherwise it returns the main context.
+    @objc
+    public var defaultContext: NSManagedObjectContext {
+        customContext ?? mainContext
     }
 
     convenience override init() {

--- a/WordPress/Classes/Utility/CoreDataStack.h
+++ b/WordPress/Classes/Utility/CoreDataStack.h
@@ -5,6 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol CoreDataStack
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
+@property (nonatomic, readonly, strong) NSManagedObjectContext *defaultContext;
 - (NSManagedObjectContext *const)newDerivedContext DEPRECATED_MSG_ATTRIBUTE("Use `performAndSave` instead");
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -214,6 +214,10 @@ class DataMigratorTests: XCTestCase {
 private final class CoreDataStackMock: CoreDataStack {
     var mainContext: NSManagedObjectContext
 
+    var defaultContext: NSManagedObjectContext {
+        mainContext
+    }
+
     init(mainContext: NSManagedObjectContext) {
         self.mainContext = mainContext
     }

--- a/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
+++ b/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
@@ -129,6 +129,10 @@ private extension SharedDataIssueSolverTests {
 private final class CoreDataStackMock: CoreDataStack {
     var mainContext: NSManagedObjectContext
 
+    var defaultContext: NSManagedObjectContext {
+        mainContext
+    }
+
     init(mainContext: NSManagedObjectContext) {
         self.mainContext = mainContext
     }


### PR DESCRIPTION
Fixes #20848

## Description

This is an alternate solution to #20852 for fixing a Core Data Multithreading violation. For more details, please check #20852's description.

## Testing Instructions

1. Pass `-com.apple.CoreData.ConcurrencyDebug 1` arguments on launch
2. Open the Jetpack app and log in to an account with multiple sites
3. Log in to the same account on the desktop
4. Delete a site
5. Go back to the app
6. Open the site picker
7. Make sure Xcode doesn't detect a Multithreading violation

## Regression Notes
1. Potential unintended areas of impact
N/A 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.