### PR TITLE
Drop iOS 14 Support: Update Share Extensions

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MobileCoreServices
+import UniformTypeIdentifiers
 import UIKit
 import ZIPFoundation
 import Down
@@ -334,7 +335,7 @@ private extension TypeBasedExtensionContentExtractor {
 
 private struct URLExtractor: TypeBasedExtensionContentExtractor {
     typealias Payload = URL
-    let acceptedType = kUTTypeURL as String
+    let acceptedType = UTType.url.identifier
 
     func convert(payload: URL) -> ExtractedItem? {
         guard !payload.isFileURL else {
@@ -499,7 +500,8 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
 
 private struct ImageExtractor: TypeBasedExtensionContentExtractor {
     typealias Payload = AnyObject
-    let acceptedType = kUTTypeImage as String
+    let acceptedType = UTType.image.identifier
+
     func convert(payload: AnyObject) -> ExtractedItem? {
         var returnedItem = ExtractedItem()
 
@@ -527,7 +529,8 @@ private struct ImageExtractor: TypeBasedExtensionContentExtractor {
 
 private struct PropertyListExtractor: TypeBasedExtensionContentExtractor {
     typealias Payload = [String: Any]
-    let acceptedType = kUTTypePropertyList as String
+    let acceptedType = UTType.propertyList.identifier
+
     func convert(payload: [String: Any]) -> ExtractedItem? {
         guard let results = payload[NSExtensionJavaScriptPreprocessingResultsKey] as? [String: Any] else {
             return nil
@@ -556,7 +559,7 @@ private struct PropertyListExtractor: TypeBasedExtensionContentExtractor {
 
 private struct PlainTextExtractor: TypeBasedExtensionContentExtractor {
     typealias Payload = String
-    let acceptedType = kUTTypePlainText as String
+    let acceptedType = UTType.plainText.identifier
 
     func convert(payload: String) -> ExtractedItem? {
         guard !payload.isEmpty else {

--- a/WordPress/WordPressShareExtension/TextBundleWrapper.m
+++ b/WordPress/WordPressShareExtension/TextBundleWrapper.m
@@ -7,6 +7,7 @@
 
 #import "TextBundleWrapper.h"
 #import <CoreServices/CoreServices.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 // Filenames constants
 NSString * const kTextBundleInfoFileName = @"info.json";
@@ -29,7 +30,7 @@ NSString * const TextBundleErrorDomain = @"TextBundleErrorDomain";
 
 + (BOOL)isTextBundleType:(NSString *)typeName
 {
-    return UTTypeConformsTo((__bridge CFStringRef)typeName, (__bridge CFStringRef)kUTTypeTextBundle);
+    return [[UTType typeWithIdentifier:typeName] conformsToType:[UTType typeWithIdentifier:kUTTypeTextBundle]];
 }
 
 - (instancetype)init
@@ -193,7 +194,7 @@ NSString * const TextBundleErrorDomain = @"TextBundleErrorDomain";
 
 - (NSString *)textFilenameForType:(NSString *)type
 {
-    NSString *ext = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassFilenameExtension);
+    NSString *ext = [UTType typeWithIdentifier:type].preferredFilenameExtension;
     return [@"text" stringByAppendingPathExtension:ext];
 }
 

--- a/WordPress/WordPressShareExtension/UIImage+Extensions.swift
+++ b/WordPress/WordPressShareExtension/UIImage+Extensions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import ImageIO
 
 extension UIImage {


### PR DESCRIPTION
Related: #20860

Update* share extensions to support iOS 15 as minimum deployment target.

> \* There is one more change needed, but it'll affect multiple screens – I'll update it separately.

## To test:

Test the following supported types (all or at least some of them):

- **Plain Text**: Share plain text from any app in the system and verify that the extension [displays it](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/dfc10033-89ac-4cd3-b668-e4083eb83a67).
- **URL**: Share a URL and verify that the extension [displays it](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/f7023e61-1366-47de-973f-f8ee3ac77362).
- **Property List**: Share a link from Safari, e.g. apple.com, and verify that the extension [displays it](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/c8a9615d-50f6-4bc9-b53d-9655868120cf).
- **Image**: Share an image from Photos.
- [**TextBundle**](http://textbundle.org): It's a relatively obscure format that's powered by the [following library](https://github.com/shinyfrog/TextBundle). To test it, you can download one of the [sample bundles](https://github.com/shinyfrog/TextBundle/tree/master/TextBundleTests) from the repo, save it to Files, and share it from there. Verify that bundles with media work:

<img width="302" alt="Screenshot 2023-06-13 at 7 20 30 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/ebabfd1a-244f-49c2-a115-f4405d7bd2e6">

> If you need to debug the extension select Debug / Attach to Process by PID or Process Name: “JetpackShareExtension”

The changes I made to TextBundle.m **do not** affect any of the functionality because this code is unused, but I tested it manually just to make sure it still works:

```swift
// Before
(__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)@"net.daringfireball.markdown", kUTTagClassFilenameExtension);
// prints "md"

// After
[[UTType typeWithIdentifier:@"net.daringfireball.markdown"] preferredFilenameExtension];
// prints "md"
```

> (Unrelated to PR) The `preferredFilenameExtension` is not going to work for `@"org.textbundle.package"` unless the app exports it as a custom file type, but that's not a problem unless we add writing of these files :)

## Regression Notes
1. Potential unintended areas of impact: Share Extension
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
