### PR TITLE
Run the "null blog property sanitization" logic as the very first Core Data operation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 22.7
 -----
-
+* [**] [internal] Make sure a database tidy-up task (null blog property sanitizer) is completed before any other Core Data queries. [#20867]
 
 22.6
 -----

--- a/WordPress/Classes/Services/NullBlogPropertySanitizer.swift
+++ b/WordPress/Classes/Services/NullBlogPropertySanitizer.swift
@@ -39,7 +39,7 @@ import Foundation
             PostCategory.entityName()
         ]
 
-        context.perform {
+        let block = {
             entityNamesWithRequiredBlogProperties.forEach { entityName in
                 let request = NSFetchRequest<NSManagedObject>(entityName: entityName)
                 let predicate = NSPredicate(format: "blog == NULL")
@@ -57,6 +57,13 @@ import Foundation
             }
 
             try? self.context.save()
+        }
+
+        // Make sure the "sanitization" work is done before any other Core Data reads or writes.
+        if Thread.isMainThread, context.concurrencyType == .mainQueueConcurrencyType {
+            block()
+        } else {
+            context.perform(block)
         }
     }
 


### PR DESCRIPTION
The stacktrace captured in https://github.com/wordpress-mobile/WordPress-iOS/issues/20847 shows the "sanitization" work was done asynchronously from [its only call site the ContextManager initialiser](https://github.com/wordpress-mobile/WordPress-iOS/blob/e4db21b30a9fa50809d26493b670e7b39b9fabbe/WordPress/Classes/Utility/ContextManager.swift#L96).

Just by looking at the ContextManager's initialiser and [the documentation around the sanitization code's intention](https://github.com/wordpress-mobile/WordPress-iOS/blob/e4db21b30a9fa50809d26493b670e7b39b9fabbe/WordPress/Classes/Services/NullBlogPropertySanitizer.swift#L3), I think it's best to make sure the sanitization work is done before any other Core Data query, otherwise other parts of the app may (probably not likely) see an unexpected null blog property.

As I explained in https://github.com/wordpress-mobile/WordPress-iOS/issues/20847#issuecomment-1590225799, I don't think that crash was one of Matt's. So I opened this PR targeting the trunk branch, rather than the release branch.

@leandroalonso This null blog property sanitizer code was introduced in your PR https://github.com/wordpress-mobile/WordPress-iOS/pull/13021. I know it's been a while and it's okay if you forgot about the issue this code was trying to address. But I'd appreciate your review on this change. Thanks!

@mokagio @jkmassel This null blog property sanitizer code was added before my time. I don't know much about the context. Feel free to add more reviewers if needed.

## Test Instructions

Put a breakpoint inside the `entityNamesWithRequiredBlogProperties.forEach` line. Update `NullBlogPropertySanitizer.appWasUpdated` to return `true`. Run the app. The breakpoint should be triggered on the main thread with `ContextManager.init` appearing in the stacktrace as the caller.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the test instructions.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
