### PR TITLE
UI Test: Fix featured image assertion

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -10,7 +10,7 @@ public class EditorPostSettings: ScreenObject {
     var categoriesSection: XCUIElement { settingsTable.cells["Categories"] }
     var tagsSection: XCUIElement { settingsTable.cells["Tags"] }
     var featuredImageButton: XCUIElement { settingsTable.cells["SetFeaturedImage"] }
-    var changeFeaturedImageButton: XCUIElement { settingsTable.cells["CurrentFeaturedImage"] }
+    var currentFeaturedImage: XCUIElement { settingsTable.cells["CurrentFeaturedImage"] }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -45,7 +45,7 @@ public class EditorPostSettings: ScreenObject {
     }
 
     public func removeFeatureImage() throws -> EditorPostSettings {
-        changeFeaturedImageButton.tap()
+        currentFeaturedImage.tap()
 
         try FeaturedImageScreen()
             .tapRemoveFeaturedImageButton()
@@ -69,13 +69,10 @@ public class EditorPostSettings: ScreenObject {
         if let postTag = tag {
             XCTAssertTrue(tagsSection.staticTexts[postTag].exists, "Tag \(postTag) not set")
         }
-        let imageCount = settingsTable.images.count
         if hasImage {
-            XCTAssertTrue(imageCount == 1, "Featured image not set")
-            expect(self.changeFeaturedImageButton.images.descendants(matching: .other).element.exists)
-                .toEventually(beFalse(), timeout: .seconds(30), description: "Featured image is not displayed")
+            XCTAssertTrue(currentFeaturedImage.exists, "Featured image not set")
         } else {
-            XCTAssertTrue(imageCount == 0, "Featured image is set but should not be")
+            XCTAssertFalse(currentFeaturedImage.exists, "Featured image is set but should not be")
         }
 
         return try EditorPostSettings()


### PR DESCRIPTION
## Description

Cherry-picks https://github.com/wordpress-mobile/WordPress-iOS/pull/20831 onto `release/22.6`

## How to test
`testAddRemoveFeaturedImage` should work as expected and CI should be green

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
