### PR TITLE
Draft post card: Prevent crash when re-opening post mid-upload

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 22.7
 -----
-
+* [**] Fixed crash issue when accessing drafts that are mid-upload from the Home 'Work on a Draft Post' card. [#20872]
 
 22.6
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -152,23 +152,8 @@ extension DashboardPostsListCardCell: UITableViewDelegate {
                           properties: ["type": "post", "sub_type": status.rawValue])
         viewController.presentedPostStatus = viewModel?.currentPostStatus()
 
-        guard !PostCoordinator.shared.isUploading(post: post) else {
-            presentAlertForPostBeingUploaded()
-            return
-        }
-
         PostListEditorPresenter.handle(post: post, in: viewController, entryPoint: .dashboard)
     }
-}
-
-func presentAlertForPostBeingUploaded() {
-    let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
-
-    let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
-
-    let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-    alertController.addCancelActionWithTitle(alertCancel, handler: nil)
-    alertController.presentFromRootViewController()
 }
 
 // MARK: PostsCardView

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -151,8 +151,24 @@ extension DashboardPostsListCardCell: UITableViewDelegate {
         WPAnalytics.track(.dashboardCardItemTapped,
                           properties: ["type": "post", "sub_type": status.rawValue])
         viewController.presentedPostStatus = viewModel?.currentPostStatus()
+
+        guard !PostCoordinator.shared.isUploading(post: post) else {
+            presentAlertForPostBeingUploaded()
+            return
+        }
+
         PostListEditorPresenter.handle(post: post, in: viewController, entryPoint: .dashboard)
     }
+}
+
+func presentAlertForPostBeingUploaded() {
+    let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
+
+    let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+
+    let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+    alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+    alertController.presentFromRootViewController()
 }
 
 // MARK: PostsCardView

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -151,7 +151,6 @@ extension DashboardPostsListCardCell: UITableViewDelegate {
         WPAnalytics.track(.dashboardCardItemTapped,
                           properties: ["type": "post", "sub_type": status.rawValue])
         viewController.presentedPostStatus = viewModel?.currentPostStatus()
-
         PostListEditorPresenter.handle(post: post, in: viewController, entryPoint: .dashboard)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -16,6 +16,20 @@ struct PostListEditorPresenter {
 
     static func handle(post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
 
+        // Return early if a post is still uploading when the editor's requested.
+        guard !PostCoordinator.shared.isUploading(post: post) else {
+            let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
+
+            let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+
+            let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+
+            alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+            alertController.presentFromRootViewController()
+
+            return
+        }
+
         // Autosaves are ignored for posts with local changes.
         if !post.hasLocalChanges(), post.hasAutosaveRevision, let saveDate = post.dateModified, let autosaveDate = post.autosaveModifiedDate {
             let autosaveViewController = autosaveOptionsViewController(forSaveDate: saveDate, autosaveDate: autosaveDate, didTapOption: { loadAutosaveRevision in

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -18,15 +18,7 @@ struct PostListEditorPresenter {
 
         // Return early if a post is still uploading when the editor's requested.
         guard !PostCoordinator.shared.isUploading(post: post) else {
-            let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
-
-            let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
-
-            let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-
-            alertController.addCancelActionWithTitle(alertCancel, handler: nil)
-            alertController.presentFromRootViewController()
-
+            presentAlertForPostBeingUploaded()
             return
         }
 
@@ -151,5 +143,15 @@ struct PostListEditorPresenter {
         alertController.view.accessibilityIdentifier = "copy-version-conflict-alert"
 
         return alertController
+    }
+
+    private static func presentAlertForPostBeingUploaded() {
+        let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
+
+        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        alertController.presentFromRootViewController()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -610,10 +610,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         guard let post = apost as? Post else {
             return
         }
-        guard !PostCoordinator.shared.isUploading(post: post) else {
-            presentAlertForPostBeingUploaded()
-            return
-        }
 
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
         PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
@@ -625,16 +621,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
 
         PostListEditorPresenter.handleCopy(post: post, in: self)
-    }
-
-    func presentAlertForPostBeingUploaded() {
-        let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
-
-        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
-
-        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
-        alertController.presentFromRootViewController()
     }
 
     override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/20870

## Description

Prevents a crash when accessing drafts that are mid-upload from the Home screen's 'Work on a Draft Post' card. 

The proposed fix takes the existing code preventing posts being edited mid-upload from the main posts lists [from the `PostListViewController.swift` file](https://github.com/wordpress-mobile/WordPress-iOS/blob/0520842897ec3f11868fef24e3f76d916f4b21c3/WordPress/Classes/ViewRelated/Post/PostListViewController.swift#L613-L616). The code is then added at the top of [the `PostListEditorPresenter.swift` file](https://github.com/wordpress-mobile/WordPress-iOS/blob/0520842897ec3f11868fef24e3f76d916f4b21c3/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift), so that it fires no matter the screen the user is attempting to access the post from. 

## Testing

> **Note**
> It may be necessary to simulate a poor connection in order to be able to re-open a post while it's still uploading.

**Verify crash is resolved**

* Navigate to the Home screen and scroll to the "Work on a draft post" card.
* Tap on a draft post.
* Modify the content.
* Tap the X icon to the editor's upper left and choose the option to update the post.
* While the post is being uploaded, open the post again from the "Work on a draft post" card.
* Verify that a prompt prevents you from editing the post while it's uploading, as per the following screenshot.

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2998162/0ab58833-307d-4903-877e-bd67dec758fd" width="50%">

**Verify there are no regressions via Post List screen**

* Navigate to the Post List screen.
* Tap on a draft post.
* Modify the content.
* Tap the X icon to the editor's upper left and choose the option to update the post.
* While the post is being uploaded, open the post again from the Post List screen.
* Verify that a prompt prevents you from editing the post while it's uploading.

## Regression Notes
1. Potential unintended areas of impact

Any other changes to the 'Work on a Draft Post' card's functionality would be unintended, such as any blockers to the ability to open uploaded drafts via that card.  

In addition, as we're moving code that impacts the Post List screen, it would be unintentional to introduce any issues related to editing posts via that screen. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually tested opening and editing posts via the card and the Post List screen.

3. What automated tests I added (or what prevented me from doing so)

As I lack native expertise, I'd like to await feedback on this proposal before investigating automated tests.

<hr />

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.