### PR TITLE
Drop iOS 14 Support: Remove UIApplication/windows usage

### DIFF
--- a/WordPress/Classes/Extensions/UIApplication+mainWindow.swift
+++ b/WordPress/Classes/Extensions/UIApplication+mainWindow.swift
@@ -2,7 +2,13 @@ import UIKit
 
 extension UIApplication {
     @objc var mainWindow: UIWindow? {
-        return windows.filter {$0.isKeyWindow}.first
+        if #available(iOS 15, *) {
+            return connectedScenes
+                .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+                .first
+        } else {
+            return windows.filter { $0.isKeyWindow }.first
+        }
     }
 
     @objc var currentStatusBarFrame: CGRect {

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -251,7 +251,11 @@ public protocol ThemePresenter: AnyObject {
      *  @brief      Load theme screenshots at maximum displayed width
      */
     @objc open var screenshotWidth: Int = {
-        let windowSize = UIApplication.shared.mainWindow!.bounds.size
+        guard let window = UIApplication.shared.mainWindow else {
+            assertionFailure("The mainWindow is not set")
+            return Int(Styles.imageWidthForFrameWidth(852))
+        }
+        let windowSize = window.bounds.size
         let vWidth = Styles.imageWidthForFrameWidth(windowSize.width)
         let hWidth = Styles.imageWidthForFrameWidth(windowSize.height)
         let maxWidth = Int(max(hWidth, vWidth))


### PR DESCRIPTION
Related Issue #20860

The change was implemented the same way as in [Woo](https://github.com/woocommerce/woocommerce-ios/blob/372ffad1d4981381ee611920eb2e7d0839fca85f/WooCommerce/Classes/Extensions/UIApplication%2BWoo.swift).

## To test:

The code is used in multiple places. I tested it programmatically by making sure that the new code returns that same window as the old one. Here's on way to test it by running the app.

- Open Reader
- Perform 5+ searches
- On iPhone 8, it should display only 3 recent searches
- On iPhone 14 Pro (bigger screen), it displays 5 recent searches

## Regression Notes
1. Potential unintended areas of impact: multiple places in the app: reader, jetpack connection, theme browser just to name a few
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a (doesn't apply)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
