### PR TITLE
Drop iOS 14 Support: Replace deprecated UTType APIs in Media

### DIFF
--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -84,10 +84,6 @@ typedef NS_ENUM(NSUInteger, MediaType) {
 
 - (nullable NSString *)fileExtension;
 
-- (void)setMediaTypeForExtension:(NSString *)extension;
-
-- (void)setMediaTypeForMimeType:(NSString *)mimeType;
-
 // CoreData helpers
 
 - (void)remove;

--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -83,7 +83,6 @@ typedef NS_ENUM(NSUInteger, MediaType) {
 + (NSString *)stringFromMediaType:(MediaType)mediaType;
 
 - (nullable NSString *)fileExtension;
-- (nullable NSString *)mimeType;
 
 - (void)setMediaTypeForExtension:(NSString *)extension;
 

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -96,47 +96,6 @@
     self.mediaTypeString = [[self class] stringFromMediaType:mediaType];    
 }
 
-- (void)setMediaTypeForExtension:(NSString *)extension
-{
-    CFStringRef fileExt = (__bridge CFStringRef)extension;
-    CFStringRef fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExt, nil);
-    [self setMediaTypeForUTI:CFBridgingRelease(fileUTI)];
-}
-
-- (void)setMediaTypeForMimeType:(NSString *)mimeType
-{
-    NSString *filteredMimeType = mimeType;
-    if ( [filteredMimeType isEqual:@"video/videopress"]) {
-        filteredMimeType = @"video/mp4";
-    }
-    CFStringRef fileType = (__bridge CFStringRef)filteredMimeType;
-    CFStringRef fileUTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, fileType, nil);
-    [self setMediaTypeForUTI:CFBridgingRelease(fileUTI)];
-}
-
-
-- (void)setMediaTypeForUTI:(NSString *)uti
-{
-    CFStringRef fileUTI = (__bridge CFStringRef _Nonnull)(uti);
-    MediaType type;
-    if (UTTypeConformsTo(fileUTI, kUTTypeImage)) {
-        type = MediaTypeImage;
-    } else if (UTTypeConformsTo(fileUTI, kUTTypeVideo)) {
-        type = MediaTypeVideo;
-    } else if (UTTypeConformsTo(fileUTI, kUTTypeMovie)) {
-        type = MediaTypeVideo;
-    } else if (UTTypeConformsTo(fileUTI, kUTTypeMPEG4)) {
-        type = MediaTypeVideo;
-    } else if (UTTypeConformsTo(fileUTI, kUTTypePresentation)) {
-        type = MediaTypePowerpoint;
-    } else if (UTTypeConformsTo(fileUTI, kUTTypeAudio)) {
-        type = MediaTypeAudio;
-    } else {
-        type = MediaTypeDocument;
-    }    
-    self.mediaType = type;
-}
-
 #pragma mark - Remote Status
 
 - (MediaRemoteStatus)remoteStatus

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -72,22 +72,6 @@
     return extension;
 }
 
-- (NSString *)mimeType
-{
-    NSString *unknown = @"application/octet-stream";
-    NSString *extension = [self fileExtension];
-    if (!extension.length) {
-        return unknown;
-    }
-    NSString *fileUTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
-    NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)fileUTI, kUTTagClassMIMEType);
-    if (!mimeType) {
-        return unknown;
-    } else {
-        return mimeType;
-    }
-}
-
 #pragma mark - Media Types
 
 - (MediaType)mediaType

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 
 extension Media {
 
@@ -48,6 +49,23 @@ extension Media {
         return mimeType
     }
 
+    func setMediaType(forFilenameExtension filenameExtension: String) {
+        let type = UTType(filenameExtension: filenameExtension)
+        self.mediaType = getMediaType(for: type)
+    }
+
+    func setMediaType(forMimeType mimeType: String) {
+        var mimeType = mimeType
+        if mimeType == "video/videopress" {
+            mimeType = "video/mp4"
+        }
+        self.mediaType = getMediaType(for: UTType(mimeType: mimeType))
+    }
+
+    private func getMediaType(for type: UTType?) -> MediaType {
+        type.map(MediaType.init) ?? .document
+    }
+
     // MARK: - Media Link
 
     var link: String {
@@ -57,6 +75,26 @@ extension Media {
                 return ""
             }
             return "\(siteURL)/?p=\(mediaID)"
+        }
+    }
+}
+
+private extension MediaType {
+    init(type: UTType) {
+        if type.conforms(to: .image) {
+            self = .image
+        } else if type.conforms(to: .video) {
+            self = .video
+        } else if type.conforms(to: .movie) {
+            self = .video
+        } else if type.conforms(to: .mpeg4Movie) {
+            self = .video
+        } else if type.conforms(to: .presentation) {
+            self = .powerpoint
+        } else if type.conforms(to: .audio) {
+            self = .audio
+        } else {
+            self = .document
         }
     }
 }

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -36,6 +36,18 @@ extension Media {
         return !posts.isEmpty
     }
 
+    // MARK: - Media Type
+
+    /// Returns the MIME type, e.g. "image/png".
+    @objc var mimeType: String? {
+        guard let fileExtension = self.fileExtension(),
+              let type = UTType(filenameExtension: fileExtension),
+              let mimeType = type.preferredMIMEType else {
+            return "application/octet-stream"
+        }
+        return mimeType
+    }
+
     // MARK: - Media Link
 
     var link: String {

--- a/WordPress/Classes/Services/MediaService+Swift.swift
+++ b/WordPress/Classes/Services/MediaService+Swift.swift
@@ -22,9 +22,9 @@ extension MediaService {
             media.filename = remoteMedia.file
         }
         if let mimeType = remoteMedia.mimeType, !mimeType.isEmpty {
-            media.setMediaTypeForMimeType(mimeType)
+            media.setMediaType(forMimeType: mimeType)
         } else if let fileExtension = remoteMedia.extension, !fileExtension.isEmpty {
-            media.setMediaTypeForExtension(fileExtension)
+            media.setMediaType(forFilenameExtension: fileExtension)
         }
         if media.title != remoteMedia.title {
             media.title = remoteMedia.title

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -641,7 +641,7 @@ deleteUnreferencedMedia:(BOOL)deleteUnreferencedMedia
     remoteMedia.height = media.height;
     remoteMedia.width = media.width;
     remoteMedia.localURL = media.absoluteLocalURL;
-    remoteMedia.mimeType = [media mimeType];
+    remoteMedia.mimeType = media.mimeType;
 	remoteMedia.videopressGUID = media.videopressGUID;
     remoteMedia.remoteThumbnailURL = media.remoteThumbnailURL;
     remoteMedia.postID = media.postID;
@@ -660,7 +660,7 @@ deleteUnreferencedMedia:(BOOL)deleteUnreferencedMedia
             if ([field isEqualToString: @"fileExtension"]) {
                 updateDict[field] = [media fileExtension] ?: @"unknown";
             } else if ([field isEqualToString: @"mimeType"]) {
-                updateDict[field] = [media mimeType];
+                updateDict[field] = media.mimeType;
             } else {
                 updateDict[field] = value;
             }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -21,7 +21,7 @@ public extension WPAppAnalytics {
      */
     @objc class func properties(for media: Media) -> Dictionary<String, Any> {
         var properties = [String: Any]()
-        properties[MediaProperties.mime] = media.mimeType()
+        properties[MediaProperties.mime] = media.mimeType
         if let fileExtension = media.fileExtension(), !fileExtension.isEmpty {
             properties[MediaProperties.fileExtension] = fileExtension
         }

--- a/WordPress/WordPressTest/MediaServiceUpdateTests.m
+++ b/WordPress/WordPressTest/MediaServiceUpdateTests.m
@@ -96,7 +96,7 @@
             return NO;
         } else if (![remoteMedia.localURL isEqual:media.absoluteLocalURL]) {
             return NO;
-        } else if (![remoteMedia.mimeType isEqualToString:[media mimeType]]) {
+        } else if (![remoteMedia.mimeType isEqualToString:media.mimeType]) {
             return NO;
         } else if (![remoteMedia.videopressGUID isEqualToString:media.videopressGUID]) {
             return NO;
@@ -152,7 +152,7 @@
             return NO;
         } else if (![remoteMedia.localURL isEqual:media.absoluteLocalURL]) {
             return NO;
-        } else if (![remoteMedia.mimeType isEqualToString:[media mimeType]]) {
+        } else if (![remoteMedia.mimeType isEqualToString:media.mimeType]) {
             return NO;
         } else if (![remoteMedia.videopressGUID isEqualToString:media.videopressGUID]) {
             return NO;

--- a/WordPress/WordPressTest/MediaTests.swift
+++ b/WordPress/WordPressTest/MediaTests.swift
@@ -126,12 +126,93 @@ class MediaTests: CoreDataTestCase {
         XCTAssertEqual(media.mimeType, "image/png")
     }
 
-    func testUknownMimeType() {
+    func testMimeTypeUnknown() {
         // Given
         let media = newTestMedia()
         media.filename = "file.there-goes-nothing"
 
         // Then
         XCTAssertEqual(media.mimeType, "application/octet-stream")
+    }
+
+    // MARK: - Set Media Type (MIME Type)
+
+    func testSetMediaTypeForMimeTypeImage() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forMimeType: "image/png")
+
+        // Then
+        XCTAssertEqual(media.mediaType, .image)
+    }
+
+    func testSetMediaTypeForMimeTypeVideo() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forMimeType: "video/mp4")
+
+        // Then
+        XCTAssertEqual(media.mediaType, .video)
+    }
+
+    func testSetMediaTypeForMimeTypeVideopress() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forMimeType: "video/videopress")
+
+        // Then Media has special handling for this custom MIME type
+        XCTAssertEqual(media.mediaType, .video)
+    }
+
+    func testSetMediaTypeForMimeTypeUnknown() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forMimeType: "unknown/unknown")
+
+        // Then falls bac
+        XCTAssertEqual(media.mediaType, .document)
+    }
+
+    // MARK: - Set Media Type (File Extension)
+
+    func testSetMediaTypeForPathExtensionPNG() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forFilenameExtension: "png")
+
+        // Then
+        XCTAssertEqual(media.mediaType, .image)
+    }
+
+    func testSetMediaTypeForPathExtensionMP4() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forFilenameExtension: "mp4")
+
+        // Then
+        XCTAssertEqual(media.mediaType, .video)
+    }
+
+    func testSetMediaTypeForPathExtensionUnknown() {
+        // Given
+        let media = newTestMedia()
+
+        // When
+        media.setMediaType(forFilenameExtension: "hello")
+
+        // Then
+        XCTAssertEqual(media.mediaType, .document)
     }
 }

--- a/WordPress/WordPressTest/MediaTests.swift
+++ b/WordPress/WordPressTest/MediaTests.swift
@@ -114,4 +114,24 @@ class MediaTests: CoreDataTestCase {
         XCTAssertEqual(blog.mediaLibraryCount(types: [MediaType.image.rawValue, MediaType.video.rawValue]), 3)
         XCTAssertEqual(blog.mediaLibraryCount(types: [MediaType.audio.rawValue, MediaType.powerpoint.rawValue]), 9)
     }
+
+    // MARK: - Media Type
+
+    func testMimeType() {
+        // Given
+        let media = newTestMedia()
+        media.filename = "file.png"
+
+        // Then MIME type is derived from the file extension
+        XCTAssertEqual(media.mimeType, "image/png")
+    }
+
+    func testUknownMimeType() {
+        // Given
+        let media = newTestMedia()
+        media.filename = "file.there-goes-nothing"
+
+        // Then
+        XCTAssertEqual(media.mimeType, "application/octet-stream")
+    }
 }


### PR DESCRIPTION
Related Issue #20860

This is a straightforward change that replaces APIs deprecated in iOS 15 with their direct replacements.

## To test:

My main way to test it was by writing unit tests (prior to making a change), but I also tested it by checking media uploads from the app.

- Create a post
- Upload image/video/document
- Verify that upload worked
- Set breakpoint in `MediaService.swift` line 648 and verify that `remoteMedia.mimeType` is set according to the uploaded file

## Regression Notes
1. Potential unintended areas of impact: media uploads
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing, automated testing
3. What automated tests I added (or what prevented me from doing so): every changes was covered by tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
