### PR TITLE
Drop iOS 14 Support: Update UTType usages (#1)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 22.7
 -----
 * [**] [internal] Make sure a database tidy-up task (null blog property sanitizer) is completed before any other Core Data queries. [#20867]
+* [**] [internal] Make sure media-related features function correctly. [#20889], [20887]
 
 22.6
 -----

--- a/WordPress/Classes/Extensions/NSAttributedString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+Helpers.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 @objc
 public extension NSAttributedString {
@@ -24,7 +25,7 @@ public extension NSAttributedString {
 
         for (value, image) in unwrappedEmbeds {
             let imageAttachment = NSTextAttachment()
-            let gifType = kUTTypeGIF as String
+            let gifType = UTType.gif.identifier
             var displayAnimatedGifs = false
 
             // Check to see if the animated gif view provider is registered

--- a/WordPress/Classes/Models/Blog+Files.swift
+++ b/WordPress/Classes/Models/Blog+Files.swift
@@ -1,5 +1,5 @@
 import MobileCoreServices
-
+import UniformTypeIdentifiers
 
 // MARK: - Support for Files-based functionality
 
@@ -20,7 +20,7 @@ extension Blog {
                 NB: For self-hosted plans, this collection has been observed to be empty. In that
                 case, we fall back to base [System-Declared Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html).
              */
-            return [String(kUTTypeContent), String(kUTTypeZipArchive)]
+            return [UTType.content.identifier, UTType.zip.identifier]
         }
 
         var typeIdentifiers = [String]()

--- a/WordPress/Classes/Models/SharePost+UIActivityItemSource.swift
+++ b/WordPress/Classes/Models/SharePost+UIActivityItemSource.swift
@@ -1,4 +1,5 @@
 import MobileCoreServices
+import UniformTypeIdentifiers
 import UIKit
 
 extension SharePost: UIActivityItemSource {
@@ -21,13 +22,13 @@ extension SharePost: UIActivityItemSource {
 
     func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivity.ActivityType?) -> String {
         guard let activityType = activityType else {
-            return kUTTypeURL as String
+            return UTType.url.identifier
         }
         switch activityType {
         case SharePost.activityType:
             return SharePost.typeIdentifier
         default:
-            return kUTTypeURL as String
+            return UTType.url.identifier
         }
     }
 }

--- a/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MobileCoreServices
+import UniformTypeIdentifiers
 import AVFoundation
 
 /// Media export handling of PHAssets
@@ -145,7 +146,7 @@ class MediaAssetExporter: MediaExporter {
         if allowableFileExtensions.contains(extensionType) {
             return uti
         } else {
-            return kUTTypeJPEG as String
+            return UTType.jpeg.identifier
         }
     }
 

--- a/WordPress/Classes/Utility/Media/MediaImageExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaImageExporter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Media export handling of UIImages.
 ///
@@ -111,12 +112,12 @@ class MediaImageExporter: MediaExporter {
         // If the exportImageType is targeting a PNG, try to init PNG data.
         if let exportType = options.exportImageType, UTTypeEqual(exportType as CFString, kUTTypePNG) {
             data = image.pngData()
-            hint = kUTTypePNG as String
+            hint = UTType.png.identifier
         }
         // If the data failed to init as PNG, or is another type, try and init as JPEG data.
         if data == nil {
             data = image.jpegData(compressionQuality: 1.0)
-            hint = kUTTypeJPEG as String
+            hint = UTType.jpeg.identifier
         }
         // Ensure that we do indeed have image data.
         guard let imageData = data else {
@@ -142,7 +143,7 @@ class MediaImageExporter: MediaExporter {
     ///
     func exportImage(withData data: Data, fileName: String?, typeHint: String?, onCompletion: @escaping OnMediaExport, onError: @escaping OnExportError) -> Progress {
         do {
-            let hint = typeHint ?? kUTTypeJPEG as String
+            let hint = typeHint ?? UTType.jpeg.identifier
             let sourceOptions: [String: Any] = [kCGImageSourceTypeIdentifierHint as String: hint as CFString]
             guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions as CFDictionary) else {
                 throw ImageExportError.imageSourceCreationWithDataFailed
@@ -175,7 +176,7 @@ class MediaImageExporter: MediaExporter {
     ///
     func exportImage(atFile url: URL, onCompletion: @escaping OnMediaExport, onError: @escaping OnExportError) -> Progress {
         do {
-            let identifierHint = url.typeIdentifierFileExtension ?? kUTTypeJPEG as String
+            let identifierHint = url.typeIdentifierFileExtension ?? UTType.jpeg.identifier
             let sourceOptions: [String: Any] = [kCGImageSourceTypeIdentifierHint as String: identifierHint as CFString]
             guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions as CFDictionary)  else {
                 throw ImageExportError.imageSourceCreationWithURLFailed

--- a/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Media export handling of thumbnail images from videos or images.
 ///
@@ -41,7 +42,7 @@ class MediaThumbnailExporter: MediaExporter {
         ///
         /// - Note: Passed on to the MediaImageExporter.Options.exportImageType.
         ///
-        var thumbnailImageType = kUTTypeJPEG as String
+        var thumbnailImageType = UTType.jpeg.identifier
 
         /// Computed preferred size, at scale.
         ///

--- a/WordPress/Classes/Utility/Spotlight/SearchableActivityConvertable.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchableActivityConvertable.swift
@@ -1,6 +1,7 @@
 import CoreSpotlight
 import Intents
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Custom NSUSerActivity types for the WPiOS. Primarily used for navigation points.
 ///
@@ -95,7 +96,7 @@ extension SearchableActivityConvertable where Self: UIViewController {
         }
 
         if let activityDescription = activityDescription {
-            let contentAttributeSet = CSSearchableItemAttributeSet(itemContentType: kUTTypeText as String)
+            let contentAttributeSet = CSSearchableItemAttributeSet(itemContentType: UTType.text.identifier)
             contentAttributeSet.contentDescription = activityDescription
             contentAttributeSet.contentCreationDate = nil // Set this to nil so it doesn't display in spotlight
             activity.contentAttributeSet = contentAttributeSet

--- a/WordPress/Classes/Utility/Spotlight/SearchableItemConvertable.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchableItemConvertable.swift
@@ -1,5 +1,6 @@
 import CoreSpotlight
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 @objc enum SearchItemType: Int {
     case abstractPost
@@ -89,7 +90,7 @@ extension SearchableItemConvertable {
             return nil
         }
 
-        let searchableItemAttributeSet = CSSearchableItemAttributeSet(itemContentType: kUTTypeText as String)
+        let searchableItemAttributeSet = CSSearchableItemAttributeSet(itemContentType: UTType.text.identifier)
         searchableItemAttributeSet.title = searchTitle
         searchableItemAttributeSet.contentDescription = searchDescription
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -12,6 +12,7 @@ import AVKit
 import MobileCoreServices
 import AutomatticTracks
 import MediaEditor
+import UniformTypeIdentifiers
 
 // MARK: - Aztec's Native Editor!
 //
@@ -1211,7 +1212,7 @@ private extension AztecPostViewController {
         let documentType = documentURL.pathExtension
         guard
             let uti = String.typeIdentifier(for: documentType),
-            uti == String(kUTTypePDF) || uti == String(kUTTypePlainText)
+            uti == UTType.pdf.identifier || uti == UTType.plainText.identifier
         else {
             insertExternalMediaWithURL(documentURL)
             return
@@ -1234,7 +1235,7 @@ private extension AztecPostViewController {
         let addContentsToPostTitle = NSLocalizedString("Add Contents to Post", comment: "Alert option to add document contents into a blog post.")
 
         let addContentsActionHandler: (() -> Void)
-        if uti == String(kUTTypePDF) {
+        if uti == UTType.pdf.identifier {
             addContentsActionHandler = { [weak self] in
                 guard let strongSelf = self else {
                     return
@@ -1915,7 +1916,7 @@ extension AztecPostViewController {
         options.filter = [.all]
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
 
         let picker = WPNavigationMediaPickerViewController()
@@ -1962,7 +1963,7 @@ extension AztecPostViewController {
         options.allowMultipleSelection = true
         options.allowCaptureOfMedia = false
         options.scrollVertically = true
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
 
         let picker = WPInputMediaPickerViewController(options: options)

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
@@ -3,6 +3,7 @@ import SVProgressHUD
 import WPMediaPicker
 import WordPressShared
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Encapsulates the interactions required to capture a new site icon image, crop it and resize it.
 ///
@@ -35,7 +36,7 @@ class SiteIconPickerPresenter: NSObject {
         options.filter = [.image]
         options.allowMultipleSelection = false
         options.showSearchBar = true
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
 
         let pickerViewController = WPNavigationMediaPickerViewController(options: options)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -5,6 +5,7 @@ import Photos
 import WordPressShared
 import WPMediaPicker
 import Gutenberg
+import UniformTypeIdentifiers
 
 public typealias GutenbergMediaPickerHelperCallback = ([WPMediaAsset]?) -> Void
 
@@ -249,7 +250,7 @@ fileprivate extension WPMediaPickerOptions {
         filter: WPMediaType = [.image],
         allowCaptureOfMedia: Bool = false,
         showSearchBar: Bool = true,
-        badgedUTTypes: Set<String> = [String(kUTTypeGIF)],
+        badgedUTTypes: Set<String> = [UTType.gif.identifier],
         allowMultipleSelection: Bool = false,
         preferredStatusBarStyle: UIStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
     ) -> WPMediaPickerOptions {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarPickerViewController.swift
@@ -3,6 +3,7 @@ import WPMediaPicker
 import WordPressShared
 import Photos
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 // Encapsulates all of the interactions required to capture a new Gravatar image, and resize it.
 //
@@ -96,7 +97,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
         options.filter = [.image]
         options.preferFrontCamera = true
         options.allowMultipleSelection = false
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
 
         let pickerViewController = WPNavigationMediaPickerViewController(options: options)

--- a/WordPress/Classes/ViewRelated/Media/CameraCaptureCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/CameraCaptureCoordinator.swift
@@ -1,4 +1,5 @@
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Encapsulates capturing media from a device camera
 final class CameraCaptureCoordinator {
@@ -40,12 +41,12 @@ final class CameraCaptureCoordinator {
         guard let mediaType = mediaInfo[UIImagePickerController.InfoKey.mediaType.rawValue] as? String else { return }
 
         switch mediaType {
-        case String(kUTTypeImage):
+        case UTType.image.identifier:
             if let image = mediaInfo[UIImagePickerController.InfoKey.originalImage.rawValue] as? UIImage,
                 let metadata = mediaInfo[UIImagePickerController.InfoKey.mediaMetadata.rawValue] as? [AnyHashable: Any] {
                 WPPHAssetDataSource().add(image, metadata: metadata, completionBlock: completionBlock)
             }
-        case String(kUTTypeMovie):
+        case UTType.movie.identifier:
             if let mediaURL = mediaInfo[UIImagePickerController.InfoKey.mediaURL.rawValue] as? URL {
                 WPPHAssetDataSource().addVideo(from: mediaURL, completionBlock: completionBlock)
             }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
@@ -2,6 +2,7 @@ import WPMediaPicker
 import MobileCoreServices
 import CoreGraphics
 import Photos
+import UniformTypeIdentifiers
 
 /// Encapsulates launching and customization of a media picker to import media from the Photos Library
 final class MediaLibraryPicker: NSObject {
@@ -16,7 +17,7 @@ final class MediaLibraryPicker: NSObject {
         options.showMostRecentFirst = true
         options.filter = [.all]
         options.allowCaptureOfMedia = false
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
 
         let picker = WPNavigationMediaPickerViewController(options: options)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -4,6 +4,7 @@ import SVProgressHUD
 import WordPressShared
 import WPMediaPicker
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// Displays the user's media library in a grid
 ///
@@ -82,7 +83,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
         options.showActionBar = false
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
 
         return options

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorMedia.swift
@@ -1,5 +1,6 @@
 import MobileCoreServices
 import WPMediaPicker
+import UniformTypeIdentifiers
 
 struct TenorImageCollection {
     let largeURL: URL
@@ -89,7 +90,7 @@ extension TenorMedia: WPMediaAsset {
     }
 
     func utTypeIdentifier() -> String? {
-        return String(kUTTypeGIF)
+        return UTType.gif.identifier
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
@@ -1,5 +1,6 @@
 import MobileCoreServices
 import WPMediaPicker
+import UniformTypeIdentifiers
 
 protocol TenorPickerDelegate: AnyObject {
     func tenorPicker(_ picker: TenorPicker, didFinishPicking assets: [TenorMedia])
@@ -41,7 +42,7 @@ final class TenorPicker: NSObject {
         options.filter = [.all]
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
-        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.badgedUTTypes = [UTType.gif.identifier]
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
         options.allowMultipleSelection = allowMultipleSelection
         return options

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Sharing.swift
@@ -1,6 +1,6 @@
 
 import MobileCoreServices
-
+import UniformTypeIdentifiers
 import Gridicons
 
 // MARK: - Functionality related to sharing a blog via the reader.
@@ -115,6 +115,6 @@ extension ReaderSiteTopic: UIActivityItemSource {
             return ShareBlog.typeIdentifier
         }
 
-        return kUTTypeURL as String
+        return UTType.url.identifier
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 @objc public protocol RichTextViewDataSource {
     @objc optional func textView(_ textView: UITextView, viewForTextAttachment attachment: NSTextAttachment) -> UIView?
@@ -163,7 +164,7 @@ import MobileCoreServices
 
         // Allow animatable gifs to be displayed
         if #available(iOS 15.0, *) {
-            NSTextAttachment.registerViewProviderClass(AnimatedGifAttachmentViewProvider.self, forFileType: kUTTypeGIF as String)
+            NSTextAttachment.registerViewProviderClass(AnimatedGifAttachmentViewProvider.self, forFileType: UTType.gif.identifier)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import WordPressUI
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 /// An NSTextAttachment for representing remote HTML content such as images, iframes and video.
 ///
@@ -40,7 +41,7 @@ open class WPTextAttachment: NSTextAttachment {
         self.src = src
 
         // Initialize with default image data to prevent placeholder graphics appearing on iOS 13.
-        super.init(data: UIImage(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
+        super.init(data: UIImage(color: .basicBackground).pngData(), ofType: UTType.png.identifier)
     }
 
 

--- a/WordPress/WordPressTest/MediaAssetExporterTests.swift
+++ b/WordPress/WordPressTest/MediaAssetExporterTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import WordPress
 import MobileCoreServices
+import UniformTypeIdentifiers
 import Photos
 
 class MediaAssetExporterTests: XCTestCase {
@@ -236,7 +237,7 @@ class MediaAssetExporterTests: XCTestCase {
         let exporter = MediaAssetExporter(asset: asset)
         exporter.mediaDirectoryType = .temporary
         var options = MediaImageExporter.Options()
-        options.exportImageType = kUTTypePNG as String
+        options.exportImageType = UTType.png.identifier
         exporter.imageOptions = options
         let expect = self.expectation(description: "image export by UIImage")
         exporter.export(onCompletion: { (imageExport) in

--- a/WordPress/WordPressTest/MediaExporterTests.swift
+++ b/WordPress/WordPressTest/MediaExporterTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import MobileCoreServices
+import UniformTypeIdentifiers
 import OHHTTPStubs
 @testable import WordPress
 
@@ -41,7 +42,7 @@ class MediaExporterTests: XCTestCase {
         // Testing JPEG as a simple test of the implementation.
         // Maybe expanding the test to all of our supported types would be helpful.
         let expected = "jpeg"
-        XCTAssert(URL.fileExtensionForUTType(kUTTypeJPEG as String) == expected, "Error: unexpected extension found when converting from UTType")
+        XCTAssert(URL.fileExtensionForUTType(UTType.jpeg.identifier) == expected, "Error: unexpected extension found when converting from UTType")
     }
 
     func testThatURLFileSizeWorks() {

--- a/WordPress/WordPressTest/MediaImageExporterTests.swift
+++ b/WordPress/WordPressTest/MediaImageExporterTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import MobileCoreServices
+import UniformTypeIdentifiers
 import OHHTTPStubs
 @testable import WordPress
 
@@ -239,7 +240,7 @@ class MediaImageExporterTests: XCTestCase {
         let expect = self.expectation(description: "image export by UIImage")
         let exporter = MediaImageExporter(image: image, filename: nil)
         exporter.mediaDirectoryType = .temporary
-        exporter.options.exportImageType = kUTTypePNG as String
+        exporter.options.exportImageType = UTType.png.identifier
         exporter.export(onCompletion: { (imageExport) in
             XCTAssert(UTTypeEqual(kUTTypePNG, imageExport.url.typeIdentifier! as CFString), "Unexpected image format when trying to target a PNG format from a JPEG.")
             MediaImageExporterTests.validateImageExport(imageExport, withExpectedSize: max(image.size.width, image.size.height))


### PR DESCRIPTION
Related Issue #20860

I've been working with the updated `UTType` in previous PRs, for example #20887 and #20866. While some changes requires manual work, there are many where `kUTType*` can be automatically replaced with the new `UTType` APIs.

These calls are equivalent (they all return a [UTI](https://developer.apple.com/documentation/uniformtypeidentifiers)):

```swift
print(kUTTypePNG)
print(kUTTypePNG as String)
print(String(kUTTypePNG))
print(UTType.png.identifier)
```

Prints:

```
public.png
public.png
public.png
public.png
```

## To test:

This change can potentially affect any media-related feature in the app. I tested it extensively while working on #20866, which was the first test PR that replaced deprecated `kUTType*` usage. I don't think it requires any additional testing at this point – just a thorough code review.

## Regression Notes
1. Potential unintended areas of impact: nearly all media-related features
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.