### PR TITLE
[UI Tests] - Add logout at launch capability

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -140,6 +140,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         setupBackgroundRefresh(application)
         setupComponentsAppearance()
         disableAnimationsForUITests(application)
+        logoutAtLaunchForUITests(application)
 
         // This was necessary to properly load fonts for the Stories editor. I believe external libraries may require this call to access fonts.
         let fonts = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: nil)
@@ -376,6 +377,12 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             UIView.setAnimationsEnabled(false)
             application.windows.first?.layer.speed = MAXFLOAT
             application.mainWindow?.layer.speed = MAXFLOAT
+        }
+    }
+
+    private func logoutAtLaunchForUITests(_ application: UIApplication) {
+        if CommandLine.arguments.contains("-logout-at-launch") {
+            AccountHelper.logOutDefaultWordPressComAccount()
         }
     }
 

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -15,7 +15,6 @@ class DashboardTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     func testFreeToPaidCardNavigation() throws {

--- a/WordPress/UITests/Tests/EditorAztecTests.swift
+++ b/WordPress/UITests/Tests/EditorAztecTests.swift
@@ -17,7 +17,6 @@ class EditorAztecTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     // TODO: Re-enable Aztec tests but for editing an existing Aztec post.

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -14,7 +14,6 @@ class EditorGutenbergTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     let title = "Rich post title"

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -10,12 +10,11 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     // Unified email login/out
     func testWPcomLoginLogout() throws {
-        let prologueScreen = try PrologueScreen().selectContinue()
+        try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithValidPassword()
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
@@ -23,15 +22,14 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
             .tabBar.goToMeScreen()
             .logoutToPrologue()
-
-        XCTAssert(prologueScreen.isLoaded)
+            .verifyPrologueScreenLoaded()
     }
 
     /**
      This test opens safari to trigger the mocked magic link redirect
      */
     func testEmailMagicLinkLogin() throws {
-        let welcomeScreen = try WelcomeScreen().selectLogin()
+        try WelcomeScreen().selectLogin()
             .selectEmailLogin()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithLink()
@@ -40,26 +38,23 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
             .tabBar.goToMeScreen()
             .logout()
-
-        XCTAssert(welcomeScreen.isLoaded)
+            .verifyWelcomeScreenLoaded()
     }
 
     // Unified self hosted login/out
     func testSelfHostedLoginLogout() throws {
-        let prologueScreen = try PrologueScreen()
-
-        try prologueScreen
+        try PrologueScreen()
             .selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .removeSelfHostedSite()
-
-        XCTAssert(prologueScreen.isLoaded)
+        try PrologueScreen()
+            .verifyPrologueScreenLoaded()
     }
 
     // Unified WordPress.com email login failure due to incorrect password
     func testWPcomInvalidPassword() throws {
-        _ = try PrologueScreen().selectContinue()
+        try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithInvalidPassword()
             .verifyLoginError()
@@ -84,7 +79,7 @@ class LoginTests: XCTestCase {
 
             // Login flow returns MySites modal, which needs to be closed.
             .closeModal()
-
-        XCTAssert(MySiteScreen.isLoaded())
+            .verifyMySiteScreenLoaded()
+            .removeSelfHostedSite()
     }
 }

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -13,7 +13,6 @@ class MainNavigationTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     // We run into an issue where the People screen would crash short after loading.

--- a/WordPress/UITests/Tests/MenuNavigationTests.swift
+++ b/WordPress/UITests/Tests/MenuNavigationTests.swift
@@ -15,7 +15,6 @@ final class MenuNavigationTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     // This test is JP only.

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -13,7 +13,6 @@ class ReaderTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."

--- a/WordPress/UITests/Tests/SignupTests.swift
+++ b/WordPress/UITests/Tests/SignupTests.swift
@@ -10,7 +10,6 @@ class SignupTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     func testEmailSignup() throws {

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -15,7 +15,6 @@ class StatsTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     let insightsStats: [String] = [

--- a/WordPress/UITests/Tests/SupportScreenTests.swift
+++ b/WordPress/UITests/Tests/SupportScreenTests.swift
@@ -8,7 +8,6 @@ class SupportScreenTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        removeApp()
     }
 
     func testSupportForumsCanBeLoadedDuringLogin() throws {

--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -8,12 +8,14 @@ extension XCTestCase {
         removeBeforeLaunching: Bool = false,
         crashOnCoreDataConcurrencyIssues: Bool = true
     ) {
+        // To ensure that the test starts with a new simulator launch each time
+        app.terminate()
         super.setUp()
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing"]
+        app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing", "-logout-at-launch"]
 
         if crashOnCoreDataConcurrencyIssues {
             app.launchArguments.append(contentsOf: ["-com.apple.CoreData.ConcurrencyDebug", "1"])

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -53,6 +53,7 @@ public class PasswordScreen: ScreenObject {
         app.dismissSavePasswordPrompt()
     }
 
+    @discardableResult
     public func verifyLoginError() -> PasswordScreen {
         let errorLabel = app.cells["Password Error"]
         _ = errorLabel.waitForExistence(timeout: 2)

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -36,6 +36,10 @@ public class PrologueScreen: ScreenObject {
         return try LoginSiteAddressScreen()
     }
 
+    public func verifyPrologueScreenLoaded() {
+        XCTAssertTrue(isLoaded)
+    }
+
     public static func isLoaded(app: XCUIApplication = XCUIApplication()) -> Bool {
         (try? PrologueScreen(app: app).isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -36,6 +36,10 @@ public class WelcomeScreen: ScreenObject {
         return try WelcomeScreenLoginComponent()
     }
 
+    public func verifyWelcomeScreenLoaded() {
+        XCTAssertTrue(isLoaded)
+    }
+
     static func isLoaded() -> Bool {
         (try? WelcomeScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -224,6 +224,11 @@ public class MySiteScreen: ScreenObject {
         return try PeopleScreen()
     }
 
+    public func verifyMySiteScreenLoaded() -> Self {
+        XCTAssertTrue(isLoaded)
+        return self
+    }
+
     public static func isLoaded() -> Bool {
         (try? MySiteScreen().isLoaded) ?? false
     }


### PR DESCRIPTION
## Description
Currently, there are a lot of "Failed to launch" errors being logged in Buildkite logs during UI test runs. This was a side effect of [deleting the app after each test run](https://github.com/wordpress-mobile/WordPress-iOS/pull/20728#issuecomment-1589558888). 

In this PR, I've removed `removeApp()` from `tearDown()` and replaced it with a new launch argument `-logout-at-launch` that will be called at the start of each test. This will reset the state to log out at the start of every test run. 

This change also comes with bonus speed improvements as the app is no longer removed after each test run (previously, the removal happened on the UI level). Below are screenshots to better visualize the before and after of the change:

### Before change 
(using the [current latest trunk build](https://buildkite.com/automattic/wordpress-ios/builds/14802#0188c117-df46-45d4-9fe7-22879573c6b3) for this comparison)

From `.xresults`:
<img width="390" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/20d01420-7ca4-45c7-bd1e-b9adde7809ec">

From Buildkite ([build](https://buildkite.com/automattic/wordpress-ios/builds/14802#0188c117-df41-47b1-85e4-a6622458a6bf/634-701)):
<img width="1090" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/45cfd50d-c607-45bb-bd49-6b8120352765">

iPhone total duration: **16m 24s**
iPad total duration: **21m 18s**

### After change
From `.xresults`:
<img width="368" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/34821434-a50c-47af-ada6-f716b0354748">

From Buildkite ([build](https://buildkite.com/automattic/wordpress-ios/builds/14806#0188c24f-43c2-4f6f-8878-956d21922aeb/634-700)):
<img width="321" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/3ec8b31b-d4a0-48b7-bac8-7cf5c008180d">

iPhone total duration: **13m 16s** (⬇️ 3m 8s)
iPad total duration: **18m 17s** (⬇️ 3m 1s)

### Testing
Errors like `[22:34:12]: ▸ 2023-06-15 22:34:12.514 xcodebuild[1865:17594]  iOSSimulator: 5C8F2C2C-3188-492D-B8B5-AF71DED82192: Failed to launch app with identifier: com.automattic.jetpack and options:` should no longer be logged in Buildkite logs and the test results file. CI should be 🟢 