### PR TITLE
Fix an issue with Related Posts settings not being saved

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/Related Posts/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/Related Posts/RelatedPostsSettingsViewController.m
@@ -251,7 +251,7 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     self.settings.relatedPostsShowHeadline = self.relatedPostsShowHeaderCell.on;
     self.settings.relatedPostsShowThumbnails = self.relatedPostsShowThumbnailsCell.on;
     
-    BlogService *blogService = nil;
+    BlogService *blogService = [[BlogService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     [blogService updateSettingsForBlog:self.blog success:^{
         [self.tableView reloadData];
     } failure:^(NSError * __unused error) {


### PR DESCRIPTION
Fixes an issue where Related Posts settings were not getting saved.

**RCA**: The `blogService` variable was always `nil`.

```swift
BlogService *blogService = nil;
[blogService updateSettingsForBlog:self.blog success:^{
```

> I'm not sure the way save works is ideal. It starts a new network request every time you change a setting. If you change them quickly, you may end up with multiple requests running in parallel, which will lead to a race condition. But that's not in the scope of this ticket, and it's the same with other Site Settings screens.

## To test:

- Go to Site Settings / Related Posts
- Change one of the properties (**warning**: don't change any other settings on the Site Settings screen itself)
- Check on another device that the Related Posts settings were updated

## Regression Notes
1. Potential unintended areas of impact: Related Posts settings
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.