### PR TITLE
Drop iOS 14 Support: Update UTType usages (#2)

### DIFF
--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 extension URL {
 
@@ -92,25 +93,21 @@ extension URL {
         return mimeType
     }
 
-    var isVideo: Bool {
-        guard let uti = typeIdentifier else {
-            return false
-        }
+    private var contentType: UTType? {
+        typeIdentifier.flatMap(UTType.init)
+    }
 
-        return UTTypeConformsTo(uti as CFString, kUTTypeMovie)
+    var isVideo: Bool {
+        contentType?.conforms(to: .movie) ?? false
     }
 
     var isImage: Bool {
-        guard let uti = typeIdentifier else {
-            return false
-        }
-
-        return UTTypeConformsTo(uti as CFString, kUTTypeImage)
+        contentType?.conforms(to: .image) ?? false
     }
 
     var isGif: Bool {
-        if let uti = typeIdentifier {
-            return UTTypeConformsTo(uti as CFString, kUTTypeGIF)
+        if let type = contentType {
+            return type.conforms(to: .gif)
         } else {
             return pathExtension.lowercased() == "gif"
         }

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -437,7 +437,7 @@ extension ImageLoader {
             return
         }
 
-        if let typeIdentifier = asset.utTypeIdentifier(), UTTypeEqual(typeIdentifier as CFString, kUTTypeGIF) {
+        if asset.utTypeIdentifier() == UTType.gif.identifier {
             loadGif(from: asset)
         } else {
             loadImage(from: asset, preferredSize: size)

--- a/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
@@ -215,13 +215,13 @@ class MediaVideoExporter: MediaExporter {
     ///   exported videos to WordPress, and what WordPress itself supports.
     ///
     fileprivate var supportedExportFileTypes: [String] {
-        let types = [
-            kUTTypeMPEG4,
-            kUTTypeQuickTimeMovie,
-            kUTTypeMPEG,
-            kUTTypeAVIMovie
+        let types: [UTType] = [
+            .mpeg4Movie,
+            .quickTimeMovie,
+            .mpeg,
+            .avi
         ]
-        return types as [String]
+        return types.map(\.identifier)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -13,14 +13,14 @@ class GutenbergFilesAppMediaSource: NSObject {
 
     func presentPicker(origin: UIViewController, filters: [Gutenberg.MediaType], allowedTypesOnBlog: [String], multipleSelection: Bool, callback: @escaping MediaPickerDidPickMediaCallback) {
         mediaPickerCallback = callback
-        let documentTypes = getDocumentTypes(filters: filters, allowedTypesOnBlog: allowedTypesOnBlog)
+        let documentTypes = GutenbergFilesAppMediaSource.getDocumentTypes(filters: filters, allowedTypesOnBlog: allowedTypesOnBlog)
         let docPicker = UIDocumentPickerViewController(documentTypes: documentTypes, in: .import)
         docPicker.delegate = self
         docPicker.allowsMultipleSelection = multipleSelection
         origin.present(docPicker, animated: true)
     }
 
-    private func getDocumentTypes(filters: [Gutenberg.MediaType], allowedTypesOnBlog: [String]) -> [String] {
+    static func getDocumentTypes(filters: [Gutenberg.MediaType], allowedTypesOnBlog: [String]) -> [String] {
         if filters.contains(.any) {
             return allowedTypesOnBlog
         } else {
@@ -63,7 +63,7 @@ extension GutenbergFilesAppMediaSource: UIDocumentPickerDelegate {
     }
 }
 
-extension Gutenberg.MediaType {
+private extension Gutenberg.MediaType {
     func filterTypesConformingTo(allTypes: [String]) -> [String] {
         guard let uttype = typeIdentifier else {
             return []
@@ -71,7 +71,7 @@ extension Gutenberg.MediaType {
         return getTypesFrom(allTypes, conformingTo: uttype)
     }
 
-    private func getTypesFrom(_ allTypes: [String], conformingTo uttype: CFString) -> [String] {
+    func getTypesFrom(_ allTypes: [String], conformingTo uttype: CFString) -> [String] {
         guard let requiredType = UTType(uttype as String) else {
             return []
         }
@@ -90,7 +90,7 @@ extension Gutenberg.MediaType {
         }
     }
 
-    private var typeIdentifier: CFString? {
+    var typeIdentifier: CFString? {
         switch self {
         case .image:
             return kUTTypeImage

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -65,18 +65,14 @@ extension GutenbergFilesAppMediaSource: UIDocumentPickerDelegate {
 
 private extension Gutenberg.MediaType {
     func filterTypesConformingTo(allTypes: [String]) -> [String] {
-        guard let uttype = typeIdentifier else {
+        guard let type = typeIdentifier else {
             return []
         }
-        return getTypesFrom(allTypes, conformingTo: uttype)
+        return getTypesFrom(allTypes, conformingTo: type)
     }
 
-    func getTypesFrom(_ allTypes: [String], conformingTo uttype: CFString) -> [String] {
-        guard let requiredType = UTType(uttype as String) else {
-            return []
-        }
-
-        return allTypes.filter {
+    private func getTypesFrom(_ allTypes: [String], conformingTo requiredType: UTType) -> [String] {
+        allTypes.filter {
             guard let allowedType = UTType($0) else {
                 return false
             }
@@ -90,14 +86,14 @@ private extension Gutenberg.MediaType {
         }
     }
 
-    var typeIdentifier: CFString? {
+    private var typeIdentifier: UTType? {
         switch self {
         case .image:
-            return kUTTypeImage
+            return UTType.image
         case .video:
-            return kUTTypeMovie
+            return UTType.movie
         case .audio:
-            return kUTTypeAudio
+            return UTType.audio
         case .other, .any: // needs to be specified by the blog's allowed types.
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -4,6 +4,7 @@
 #import "Blog.h"
 #import "CoreDataStack.h"
 #import "WordPress-Swift.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 @interface  MediaLibraryPickerDataSource() <NSFetchedResultsControllerDelegate>
 
@@ -237,7 +238,7 @@
             NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @".jpg"];
             NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
             NSError *error;
-            if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:MediaImportService.preferredImageCompressionQuality metadata:metadata error:&error]){
+            if ([image writeToURL:fileURL type:UTTypeJPEG.identifier compressionQuality:MediaImportService.preferredImageCompressionQuality metadata:metadata error:&error]){
                 return [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:fileURL];
             }
             return nil;
@@ -246,7 +247,7 @@
         NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @".jpg"];        
         NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
         NSError *error;
-        if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:MediaImportService.preferredImageCompressionQuality metadata:metadata error:&error]){
+        if ([image writeToURL:fileURL type:UTTypeJPEG.identifier compressionQuality:MediaImportService.preferredImageCompressionQuality metadata:metadata error:&error]){
             [self addMediaFromURL:fileURL completionBlock:completionBlock];
         } else {
             if (completionBlock) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -13,6 +13,7 @@
 #import "WPAndDeviceMediaLibraryDataSource.h"
 #import <WPMediaPicker/WPMediaPicker.h>
 #import <Photos/Photos.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <Reachability/Reachability.h>
 #import "WPGUIConstants.h"
 #import <WordPressShared/NSString+XMLExtensions.h>
@@ -1248,7 +1249,7 @@ FeaturedImageViewControllerDelegate>
     options.allowMultipleSelection = NO;
     options.filter = WPMediaTypeImage;
     options.showSearchBar = YES;
-    options.badgedUTTypes = [NSSet setWithObject: (__bridge NSString *)kUTTypeGIF];
+    options.badgedUTTypes = [NSSet setWithObject:UTTypeGIF.identifier];
     options.preferredStatusBarStyle = [WPStyleGuide preferredStatusBarStyle];
     WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] initWithOptions:options];
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		0C391E612A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */; };
 		0C391E622A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */; };
 		0C391E642A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E632A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift */; };
+		0C63266F2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */; };
 		0C71959E2A3CDC8B002EA18C /* PostMetaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C71959D2A3CDC8B002EA18C /* PostMetaButton.swift */; };
 		0C71959F2A3CDC8B002EA18C /* PostMetaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C71959D2A3CDC8B002EA18C /* PostMetaButton.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
@@ -6044,6 +6045,7 @@
 		0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignView.swift; sourceTree = "<group>"; };
 		0C391E602A3002950040EA91 /* DashboardBlazeCampaignStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignStatusView.swift; sourceTree = "<group>"; };
 		0C391E632A312DB20040EA91 /* DashboardBlazeCampaignViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignViewModelTests.swift; sourceTree = "<group>"; };
+		0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergFilesAppMediaSourceTests.swift; sourceTree = "<group>"; };
 		0C71959D2A3CDC8B002EA18C /* PostMetaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMetaButton.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
@@ -16936,6 +16938,7 @@
 			isa = PBXGroup;
 			children = (
 				932645A31E7C206600134988 /* GutenbergSettingsTests.swift */,
+				0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */,
 			);
 			name = Editor;
 			sourceTree = "<group>";
@@ -23522,6 +23525,7 @@
 				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,
 				931215E1267DE1C0008C3B69 /* StatsTotalRowDataTests.swift in Sources */,
 				F41E4E8C28F18B7B001880C6 /* AppIconListViewModelTests.swift in Sources */,
+				0C63266F2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift in Sources */,
 				FE7FAABB299A36570032A6F2 /* WPComJetpackRemoteInstallViewModelTests.swift in Sources */,
 				08F8CD2D1EBD24600049D0C0 /* MediaExporterTests.swift in Sources */,
 				805CC0B7296680CF002941DC /* RemoteFeatureFlagStoreMock.swift in Sources */,

--- a/WordPress/WordPressTest/GutenbergFilesAppMediaSourceTests.swift
+++ b/WordPress/WordPressTest/GutenbergFilesAppMediaSourceTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Gutenberg
+@testable import WordPress
+
+final class GutenbergFilesAppMediaSourceTests: XCTestCase {
+    func testThatImageFiltersAreApplied() {
+        // Given
+        let filters: [Gutenberg.MediaType] = [.image]
+        let allowedTypes = [
+            "public.jpeg",
+            "public.mpeg-4",
+            "com.compuserve.gif",
+            "com.microsoft.excel.xls",
+            "com.adobe.pdf"
+        ]
+
+        // When
+        let documentTypes = GutenbergFilesAppMediaSource.getDocumentTypes(filters: filters, allowedTypesOnBlog: allowedTypes)
+
+        // Then only images are allowed
+        XCTAssertEqual(Set(documentTypes), Set([
+            "public.jpeg",
+            "com.compuserve.gif"
+        ]))
+    }
+
+    func testThatVideoAndImageFiltersAreApplied() {
+        // Given
+        let filters: [Gutenberg.MediaType] = [.image, .video]
+        let allowedTypes = [
+            "public.jpeg",
+            "public.mpeg-4",
+            "com.compuserve.gif",
+            "com.microsoft.excel.xls",
+            "com.adobe.pdf"
+        ]
+
+        // When
+        let documentTypes = GutenbergFilesAppMediaSource.getDocumentTypes(filters: filters, allowedTypesOnBlog: allowedTypes)
+
+        // Then both images and videos are allowed
+        XCTAssertEqual(Set(documentTypes), Set([
+            "public.jpeg",
+            "public.mpeg-4",
+            "com.compuserve.gif"
+        ]))
+    }
+
+    func testThatAllTypesAreAllowedWhenFiltersContainAny() {
+        // Given
+        let filters: [Gutenberg.MediaType] = [.any]
+        let allowedTypes = [
+            "public.jpeg",
+            "public.mpeg-4",
+            "com.compuserve.gif",
+            "com.microsoft.excel.xls",
+            "com.adobe.pdf"
+        ]
+
+        // When
+        let documentTypes = GutenbergFilesAppMediaSource.getDocumentTypes(filters: filters, allowedTypesOnBlog: allowedTypes)
+
+        // Then all types are allowed
+        XCTAssertEqual(Set(documentTypes), Set([
+            "public.jpeg",
+            "public.mpeg-4",
+            "com.compuserve.gif",
+            "com.microsoft.excel.xls",
+            "com.adobe.pdf"
+        ]))
+    }
+}

--- a/WordPress/WordPressTest/MediaAssetExporterTests.swift
+++ b/WordPress/WordPressTest/MediaAssetExporterTests.swift
@@ -241,7 +241,7 @@ class MediaAssetExporterTests: XCTestCase {
         exporter.imageOptions = options
         let expect = self.expectation(description: "image export by UIImage")
         exporter.export(onCompletion: { (imageExport) in
-            XCTAssert(UTTypeEqual(kUTTypePNG, imageExport.url.typeIdentifier! as CFString), "Unexpected image format when trying to target a PNG format from a JPEG.")
+            XCTAssertEqual(UTType.png.identifier, imageExport.url.typeIdentifier, "Unexpected image format when trying to target a PNG format from a JPEG.")
             MediaImageExporterTests.validateImageExport(imageExport, withExpectedSize: max(image.size.width, image.size.height))
             MediaExporterTests.cleanUpExportedMedia(atURL: imageExport.url)
             expect.fulfill()

--- a/WordPress/WordPressTest/MediaImageExporterTests.swift
+++ b/WordPress/WordPressTest/MediaImageExporterTests.swift
@@ -242,7 +242,7 @@ class MediaImageExporterTests: XCTestCase {
         exporter.mediaDirectoryType = .temporary
         exporter.options.exportImageType = UTType.png.identifier
         exporter.export(onCompletion: { (imageExport) in
-            XCTAssert(UTTypeEqual(kUTTypePNG, imageExport.url.typeIdentifier! as CFString), "Unexpected image format when trying to target a PNG format from a JPEG.")
+            XCTAssertEqual(UTType.png.identifier, imageExport.url.typeIdentifier, "Unexpected image format when trying to target a PNG format from a JPEG.")
             MediaImageExporterTests.validateImageExport(imageExport, withExpectedSize: max(image.size.width, image.size.height))
             MediaExporterTests.cleanUpExportedMedia(atURL: imageExport.url)
             expect.fulfill()

--- a/WordPress/WordPressTest/MediaURLExporterTests.swift
+++ b/WordPress/WordPressTest/MediaURLExporterTests.swift
@@ -103,4 +103,51 @@ class MediaURLExporterTests: XCTestCase {
             XCTAssert(hasLocationData == true, "The exported video's location data was unexpectedly removed.")
         }
     }
+
+    // MARK: - URL Extensions
+
+    func testURLTypeImage() throws {
+        // Given
+        let url = fileURL(forResourceNamed: testDeviceImageName)
+
+        // Then
+        XCTAssertFalse(url.isVideo)
+        XCTAssertTrue(url.isImage)
+        XCTAssertFalse(url.isGif)
+    }
+
+    func testURLTypeGIF() throws {
+        // Given
+        let url = fileURL(forResourceNamed: testGIFName)
+
+        // Then
+        XCTAssertFalse(url.isVideo)
+        XCTAssertTrue(url.isImage)
+        XCTAssertTrue(url.isGif)
+    }
+
+    func testURLTypeVideo() throws {
+        // Given
+        let url = fileURL(forResourceNamed: testDeviceVideoName)
+
+        // Then
+        XCTAssertTrue(url.isVideo)
+        XCTAssertFalse(url.isImage)
+        XCTAssertFalse(url.isGif)
+    }
+
+    func testURLTypeGifFallbackNoContentType() throws {
+        // Given URL with on content
+        let url = URL(fileURLWithPath: "/dev/null/hello.gif")
+
+        // Then the fallback checks the type based on the filename extension
+        XCTAssertFalse(url.isVideo)
+        XCTAssertFalse(url.isImage)
+        XCTAssertTrue(url.isGif)
+    }
+}
+
+private func fileURL(forResourceNamed name: String) -> URL {
+    let path = MediaImageExporterTests.filePathForTestImageNamed(name)
+    return URL(fileURLWithPath: path)
 }

--- a/WordPress/WordPressTest/MediaURLExporterTests.swift
+++ b/WordPress/WordPressTest/MediaURLExporterTests.swift
@@ -137,7 +137,7 @@ class MediaURLExporterTests: XCTestCase {
     }
 
     func testURLTypeGifFallbackNoContentType() throws {
-        // Given URL with on content
+        // Given URL with no content
         let url = URL(fileURLWithPath: "/dev/null/hello.gif")
 
         // Then the fallback checks the type based on the filename extension


### PR DESCRIPTION
Related Issue #20860

Removes deprecated UTType APIs. Previous related PRs that update UTType API usages: #20887, #20866, #20889.

## To test:

Most of the changes are covered by the new unit tests, but there were a couple of scenarios I tested manually, just to make sure:

### GIF Badges

- Open a Post / Post Settings / Set Featured Image
- Verify that GIFs have badges

### Filters Types

- Open a Post 
- Add an Image block
- Select “Other Apps”
- Verify that is allows you to select only images
- Repeat for other formats: video, audio

## Regression Notes
1. Potential unintended areas of impact: Media-related features
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests and unit tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
