### PR TITLE
Remove some unused types from the unit tests target

### DIFF
--- a/WordPress/Classes/Services/SiteSegmentsService.swift
+++ b/WordPress/Classes/Services/SiteSegmentsService.swift
@@ -52,10 +52,6 @@ final class MockSiteSegmentsService: SiteSegmentsService {
                  shortSubtitle(identifier: 4) ]
     }()
 
-    var mockCount: Int {
-        return mockSiteTypes.count
-    }
-
     private func shortSubtitle(identifier: Int64) -> SiteSegment {
         return SiteSegment(identifier: identifier,
                            title: "Blogger",

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -21,28 +21,6 @@ protocol SiteVerticalsService {
     func retrieveVerticals(request: SiteVerticalsRequest, completion: @escaping SiteVerticalsServiceCompletion)
 }
 
-// MARK: - MockSiteVerticalsService
-
-/// Mock implementation of the SiteVerticalsService
-///
-final class MockSiteVerticalsService: SiteVerticalsService {
-    func retrieveVertical(named verticalName: String, completion: @escaping SiteVerticalRequestCompletion) {
-        let vertical = SiteVertical(identifier: "SV 1", title: "Vertical 1", isNew: false)
-        completion(.success(vertical))
-    }
-
-    func retrieveVerticals(request: SiteVerticalsRequest, completion: @escaping SiteVerticalsServiceCompletion) {
-        let result = SiteVerticalsResult.success(mockVerticals())
-        completion(result)
-    }
-
-    private func mockVerticals() -> [SiteVertical] {
-        return [ SiteVertical(identifier: "SV 1", title: "Vertical 1", isNew: false),
-                 SiteVertical(identifier: "SV 2", title: "Vertical 2", isNew: false),
-                 SiteVertical(identifier: "SV 3", title: "Landscap", isNew: true) ]
-    }
-}
-
 // MARK: - SiteCreationVerticalsService
 
 /// Retrieves candidate Site Verticals used to create a new site.

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3572,7 +3572,6 @@
 		F44293DD28E45DBA00D340AF /* AppIconListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44293D528E3BA1700D340AF /* AppIconListViewModel.swift */; };
 		F446B843296F2DED008B94B7 /* MigrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E79300296EEE320025E8E0 /* MigrationState.swift */; };
 		F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */; };
-		F44FB6CD287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */; };
 		F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = F44FB6D02878A1020001E3CE /* user-suggestions.json */; };
 		F45326D829F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */; };
 		F45326D929F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */; };
@@ -8957,7 +8956,6 @@
 		F44293D528E3BA1700D340AF /* AppIconListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconListViewModel.swift; sourceTree = "<group>"; };
 		F44F6ABD2937428B00DC94A2 /* MigrationEmailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
 		F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsListViewModelTests.swift; sourceTree = "<group>"; };
-		F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewMockDelegate.swift; sourceTree = "<group>"; };
 		F44FB6D02878A1020001E3CE /* user-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-suggestions.json"; sourceTree = "<group>"; };
 		F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedSiteCreationAnalyticsEvent.swift; sourceTree = "<group>"; };
 		F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76@2x.png"; sourceTree = "<group>"; };
@@ -17138,7 +17136,6 @@
 			isa = PBXGroup;
 			children = (
 				F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */,
-				F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */,
 				F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */,
 				F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */,
 				F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */,
@@ -23586,7 +23583,6 @@
 				8BE9AB8827B6B5A300708E45 /* BlogDashboardPersistenceTests.swift in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationSettingsServiceTests.swift in Sources */,
 				AC68C9CA28E5DF14009030A9 /* NotificationsViewControllerTests.swift in Sources */,
-				F44FB6CD287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift in Sources */,
 				179501CD27A01D4100882787 /* PublicizeAuthorizationURLComponentsTests.swift in Sources */,
 				4089C51422371EE30031CE78 /* TodayStatsTests.swift in Sources */,
 				7E53AB0A20FE83A9005796FE /* MockContentCoordinator.swift in Sources */,

--- a/WordPress/WordPressTest/Mention/SuggestionsTableViewMockDelegate.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionsTableViewMockDelegate.swift
@@ -1,5 +1,0 @@
-import Foundation
-import WordPress
-
-final class SuggestionsTableViewMockDelegate: NSObject, SuggestionsTableViewDelegate {
-}


### PR DESCRIPTION
I stumbled upon some unused code in the tests while working on https://github.com/wordpress-mobile/WordPress-iOS/pull/20900, which this PR removes.