### PR TITLE
[UI Tests] - Move XCTAsserts away from tests

### DIFF
--- a/WordPress/UITests/Flows/EditorFlow.swift
+++ b/WordPress/UITests/Flows/EditorFlow.swift
@@ -14,7 +14,7 @@ class EditorFlow {
 
     static func toggleBlockEditor(to state: SiteSettingsScreen.Toggle) throws -> SiteSettingsScreen {
         if !SiteSettingsScreen.isLoaded() {
-            _ = try TabNavComponent()
+            try TabNavComponent()
                 .goToMySiteScreen()
                 .goToSettingsScreen()
         }

--- a/WordPress/UITests/Flows/LoginFlow.swift
+++ b/WordPress/UITests/Flows/LoginFlow.swift
@@ -5,7 +5,8 @@ class LoginFlow {
 
     @discardableResult
     static func login(email: String, password: String, selectedSiteTitle: String? = nil) throws -> MySiteScreen {
-        return try PrologueScreen().selectContinue()
+        return try PrologueScreen()
+            .selectContinue()
             .proceedWith(email: email)
             .proceedWithValidPassword()
             .continueWithSelectedSite(title: selectedSiteTitle)
@@ -15,7 +16,8 @@ class LoginFlow {
     // Login with self-hosted site via Site Address.
     @discardableResult
     static func login(siteUrl: String, username: String, password: String) throws -> MySiteScreen {
-        return try PrologueScreen().selectSiteAddress()
+        return try PrologueScreen()
+            .selectSiteAddress()
             .proceedWith(siteUrl: siteUrl)
             .proceedWith(username: username, password: password)
             .continueWithSelectedSite()
@@ -25,12 +27,13 @@ class LoginFlow {
     // Login with WP site via Site Address.
     @discardableResult
     static func login(siteUrl: String, email: String, password: String) throws -> MySiteScreen {
-        return try PrologueScreen().selectSiteAddress()
+        return try PrologueScreen()
+            .selectSiteAddress()
             .proceedWithWP(siteUrl: siteUrl)
             .proceedWith(email: email)
             .proceedWithValidPassword()
-        .continueWithSelectedSite()
-        .dismissNotificationAlertIfNeeded()
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
     }
 
     // Login with self-hosted site via Site Address.

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -22,10 +22,10 @@ class DashboardTests: XCTestCase {
             .scrollToFreeToPaidPlansCard()
             .verifyFreeToPaidPlansCard()
             .tapFreeToPaidPlansCard()
-            .verifyDomainsSuggestionsScreenLoaded()
+            .assertScreenIsLoaded()
             .selectDomain()
             .goToPlanSelection()
-            .verifyPlanSelectionScreenLoaded()
+            .assertScreenIsLoaded()
     }
 
     func testPagesCardHeaderNavigation() throws {
@@ -36,7 +36,7 @@ class DashboardTests: XCTestCase {
             .verifyPagesCard(hasPage: "Shop")
             .verifyPagesCard(hasPage: "Cart")
             .tapPagesCardHeader()
-            .verifyPagesScreenLoaded()
+            .assertScreenIsLoaded()
             .verifyPagesScreen(hasPage: "Blog")
             .verifyPagesScreen(hasPage: "Shop")
             .verifyPagesScreen(hasPage: "Cart")
@@ -50,7 +50,7 @@ class DashboardTests: XCTestCase {
             .verifyActivityLogCard(hasActivityPartial: "The Jetpack connection")
             .verifyActivityLogCard(hasActivityPartial: "This site is connected to")
             .tapActivityLogCardHeader()
-            .verifyActivityLogScreenLoaded()
+            .assertScreenIsLoaded()
             .verifyActivityLogScreen(hasActivityPartial: "Enabled Jetpack Social")
             .verifyActivityLogScreen(hasActivityPartial: "The Jetpack connection")
             .verifyActivityLogScreen(hasActivityPartial: "This site is connected to")

--- a/WordPress/UITests/Tests/EditorAztecTests.swift
+++ b/WordPress/UITests/Tests/EditorAztecTests.swift
@@ -7,8 +7,12 @@ class EditorAztecTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        editorScreen = try EditorFlow
+        try LoginFlow.login(
+            siteUrl: WPUITestCredentials.testWPcomSiteAddress,
+            email: WPUITestCredentials.testWPcomUserEmail,
+            password: WPUITestCredentials.testWPcomPassword
+        )
+        try EditorFlow
             .toggleBlockEditor(to: .off)
             .goBackToMySite()
             .tabBar.goToAztecEditorScreen()

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -5,7 +5,11 @@ class EditorGutenbergTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(
+            siteUrl: WPUITestCredentials.testWPcomSiteAddress,
+            email: WPUITestCredentials.testWPcomUserEmail,
+            password: WPUITestCredentials.testWPcomPassword
+        )
         try EditorFlow
             .goToMySiteScreen()
             .tabBar.gotoBlockEditorScreen()

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -23,7 +23,7 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
             .tabBar.goToMeScreen()
             .logoutToPrologue()
-            .verifyPrologueScreenLoaded()
+            .assertScreenIsLoaded()
     }
 
     /**
@@ -40,7 +40,7 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
             .tabBar.goToMeScreen()
             .logout()
-            .verifyWelcomeScreenLoaded()
+            .assertScreenIsLoaded()
     }
 
     // Unified self hosted login/out
@@ -51,7 +51,7 @@ class LoginTests: XCTestCase {
             .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .removeSelfHostedSite()
         try PrologueScreen()
-            .verifyPrologueScreenLoaded()
+            .assertScreenIsLoaded()
     }
 
     // Unified WordPress.com email login failure due to incorrect password
@@ -83,7 +83,7 @@ class LoginTests: XCTestCase {
 
             // Login flow returns MySites modal, which needs to be closed.
             .closeModal()
-            .verifyMySiteScreenLoaded()
+            .assertScreenIsLoaded()
             .removeSelfHostedSite()
     }
 }

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -18,7 +18,10 @@ class LoginTests: XCTestCase {
             .selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithValidPassword()
-            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+                    .verifyEpilogueDisplays(
+                username: WPUITestCredentials.testWPcomUsername,
+                siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress
+            )
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
             .tabBar.goToMeScreen()
@@ -48,7 +51,10 @@ class LoginTests: XCTestCase {
         try PrologueScreen()
             .selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+            .proceedWithSelfHosted(
+                username: WPUITestCredentials.selfHostedUsername,
+                password: WPUITestCredentials.selfHostedPassword
+            )
             .removeSelfHostedSite()
         try PrologueScreen()
             .assertScreenIsLoaded()
@@ -70,7 +76,10 @@ class LoginTests: XCTestCase {
             .selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithValidPassword()
-            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .verifyEpilogueDisplays(
+                username: WPUITestCredentials.testWPcomUsername,
+                siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress
+            )
             .continueWithSelectedSite() //returns MySite screen
 
             // From here, bring up the sites list and choose to add a new self-hosted site.
@@ -79,7 +88,10 @@ class LoginTests: XCTestCase {
 
             // Then, go through the self-hosted login flow:
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWithSelfHostedSiteAddedFromSitesList(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+            .proceedWithSelfHostedSiteAddedFromSitesList(
+                username: WPUITestCredentials.selfHostedUsername,
+                password: WPUITestCredentials.selfHostedPassword
+            )
 
             // Login flow returns MySites modal, which needs to be closed.
             .closeModal()

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -14,7 +14,8 @@ class LoginTests: XCTestCase {
 
     // Unified email login/out
     func testWPcomLoginLogout() throws {
-        try PrologueScreen().selectContinue()
+        try PrologueScreen()
+            .selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithValidPassword()
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
@@ -29,7 +30,8 @@ class LoginTests: XCTestCase {
      This test opens safari to trigger the mocked magic link redirect
      */
     func testEmailMagicLinkLogin() throws {
-        try WelcomeScreen().selectLogin()
+        try WelcomeScreen()
+            .selectLogin()
             .selectEmailLogin()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithLink()
@@ -54,7 +56,8 @@ class LoginTests: XCTestCase {
 
     // Unified WordPress.com email login failure due to incorrect password
     func testWPcomInvalidPassword() throws {
-        try PrologueScreen().selectContinue()
+        try PrologueScreen()
+            .selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithInvalidPassword()
             .verifyLoginError()
@@ -63,7 +66,8 @@ class LoginTests: XCTestCase {
     // Self-Hosted after WordPress.com login.
     // Login to a WordPress.com account, open site switcher, then add a self-hosted site.
     func testAddSelfHostedSiteAfterWPcomLogin() throws {
-        try PrologueScreen().selectContinue()
+        try PrologueScreen()
+            .selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithValidPassword()
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -5,7 +5,11 @@ class MainNavigationTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(
+            siteUrl: WPUITestCredentials.testWPcomSiteAddress,
+            email: WPUITestCredentials.testWPcomUserEmail,
+            password: WPUITestCredentials.testWPcomPassword
+        )
         try TabNavComponent()
             .goToMySiteScreen()
             .goToMenu()
@@ -20,19 +24,17 @@ class MainNavigationTests: XCTestCase {
     //
     // It would be wise to add similar tests for each item in the menu (then remove this comment).
     func testLoadsPeopleScreen() throws {
-        XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
-
         try MySiteScreen()
+            .verifyMySiteScreenLoaded()
             .goToPeople()
-
-        XCTAssertTrue(PeopleScreen.isLoaded(), "PeopleScreen screen isn't loaded.")
+            .verifyPeopleScreenLoaded()
     }
 
    func testTabBarNavigation() throws {
-       XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
-
-       try TabNavComponent().goToReaderScreen()
-       XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
+       try MySiteScreen()
+           .verifyMySiteScreenLoaded()
+           .tabBar.goToReaderScreen()
+           .verifyReaderScreenLoaded()
 
        // We may get a notifications fancy alert when loading the reader for the first time
        if let alert = try? FancyAlertComponent() {

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -25,16 +25,15 @@ class MainNavigationTests: XCTestCase {
     // It would be wise to add similar tests for each item in the menu (then remove this comment).
     func testLoadsPeopleScreen() throws {
         try MySiteScreen()
-            .verifyMySiteScreenLoaded()
+            .assertScreenIsLoaded()
             .goToPeople()
-            .verifyPeopleScreenLoaded()
+            .assertScreenIsLoaded()
     }
 
    func testTabBarNavigation() throws {
        try MySiteScreen()
-           .verifyMySiteScreenLoaded()
            .tabBar.goToReaderScreen()
-           .verifyReaderScreenLoaded()
+           .assertScreenIsLoaded()
 
        // We may get a notifications fancy alert when loading the reader for the first time
        if let alert = try? FancyAlertComponent() {

--- a/WordPress/UITests/Tests/MenuNavigationTests.swift
+++ b/WordPress/UITests/Tests/MenuNavigationTests.swift
@@ -22,6 +22,6 @@ final class MenuNavigationTests: XCTestCase {
         try MySiteScreen()
             .goToMenu()
             .goToDomainsScreen()
-            .verifyDomainsScreenLoaded()
+            .assertScreenIsLoaded()
     }
 }

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -5,7 +5,11 @@ class ReaderTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(
+            siteUrl: WPUITestCredentials.testWPcomSiteAddress,
+            email: WPUITestCredentials.testWPcomUserEmail,
+            password: WPUITestCredentials.testWPcomPassword
+        )
         try EditorFlow
             .goToMySiteScreen()
             .tabBar.goToReaderScreen()

--- a/WordPress/UITests/Tests/SignupTests.swift
+++ b/WordPress/UITests/Tests/SignupTests.swift
@@ -18,7 +18,10 @@ class SignupTests: XCTestCase {
             .selectEmailSignup()
             .proceedWith(email: WPUITestCredentials.signupEmail)
             .openMagicSignupLink()
-            .verifyEpilogueContains(username: WPUITestCredentials.signupUsername, displayName: WPUITestCredentials.signupDisplayName)
+            .verifyEpilogueContains(
+                username: WPUITestCredentials.signupUsername,
+                displayName: WPUITestCredentials.signupDisplayName
+            )
             .setPassword(WPUITestCredentials.signupPassword)
             .continueWithSignup()
             .dismissNotificationAlertIfNeeded()

--- a/WordPress/UITests/Tests/SignupTests.swift
+++ b/WordPress/UITests/Tests/SignupTests.swift
@@ -22,6 +22,6 @@ class SignupTests: XCTestCase {
             .setPassword(WPUITestCredentials.signupPassword)
             .continueWithSignup()
             .dismissNotificationAlertIfNeeded()
-            .verifyMySiteScreenLoaded()
+            .assertScreenIsLoaded()
     }
 }

--- a/WordPress/UITests/Tests/SignupTests.swift
+++ b/WordPress/UITests/Tests/SignupTests.swift
@@ -13,7 +13,8 @@ class SignupTests: XCTestCase {
     }
 
     func testEmailSignup() throws {
-        let mySiteScreen = try WelcomeScreen().selectSignup()
+        try WelcomeScreen()
+            .selectSignup()
             .selectEmailSignup()
             .proceedWith(email: WPUITestCredentials.signupEmail)
             .openMagicSignupLink()
@@ -21,7 +22,6 @@ class SignupTests: XCTestCase {
             .setPassword(WPUITestCredentials.signupPassword)
             .continueWithSignup()
             .dismissNotificationAlertIfNeeded()
-
-        XCTAssert(mySiteScreen.isLoaded)
+            .verifyMySiteScreenLoaded()
     }
 }

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -4,7 +4,11 @@ import XCTest
 class StatsTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
-        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(
+            siteUrl: WPUITestCredentials.testWPcomSiteAddress,
+            email: WPUITestCredentials.testWPcomUserEmail,
+            password: WPUITestCredentials.testWPcomPassword
+        )
         try MySiteScreen()
             .goToMenu()
             .goToStatsScreen()

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -101,6 +101,12 @@ extension ScreenObject {
 
         return self
     }
+
+    @discardableResult
+    public func assertScreenIsLoaded(file: StaticString = #file, line: UInt = #line) -> Self {
+        XCTAssertTrue(isLoaded, file: file, line: line)
+        return self
+    }
 }
 
 public enum Apps {

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -30,12 +30,6 @@ public class ActivityLogScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifyActivityLogScreenLoaded() -> Self {
-        XCTAssertTrue(ActivityLogScreen.isLoaded(), "\"Activity\" screen isn't loaded.")
-        return self
-    }
-
-    @discardableResult
     public func verifyActivityLogScreen(hasActivityPartial activityTitle: String) -> Self {
         XCTAssertTrue(
             app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", activityTitle)).firstMatch.waitForIsHittable(),

--- a/WordPress/UITestsFoundation/Screens/DomainsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/DomainsScreen.swift
@@ -23,10 +23,4 @@ public class DomainsScreen: ScreenObject {
     public static func isLoaded() -> Bool {
         (try? DomainsScreen().isLoaded) ?? false
     }
-
-    @discardableResult
-    public func verifyDomainsScreenLoaded() -> Self {
-        XCTAssertTrue(DomainsScreen.isLoaded(), "\"Domains\" screen isn't loaded.")
-        return self
-    }
 }

--- a/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
@@ -22,12 +22,6 @@ public class DomainsSuggestionsScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifyDomainsSuggestionsScreenLoaded() -> Self {
-        XCTAssertTrue(DomainsSuggestionsScreen.isLoaded(), "\"Domains suggestions\" screen isn't loaded.")
-        return self
-    }
-
-    @discardableResult
     public func selectDomain() throws -> Self {
         app.tables["DomainSuggestionsTable"].cells.lastMatch?.tap()
         return self

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -24,7 +24,7 @@ public class GetStartedScreen: ScreenObject {
     }
 
     var navBar: XCUIElement { navBarGetter(app) }
-    public var emailTextField: XCUIElement { emailTextFieldGetter(app) }
+    var emailTextField: XCUIElement { emailTextFieldGetter(app) }
     var continueButton: XCUIElement { continueButtonGetter(app) }
     var helpButton: XCUIElement { helpButtonGetter(app) }
     var backButton: XCUIElement { backButtonGetter(app) }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -3,10 +3,25 @@ import XCTest
 
 public class PasswordScreen: ScreenObject {
 
+    private let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields["Password"]
+    }
+
+    private let passwordErrorLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Password Error"]
+    }
+
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Continue Button"]
+    }
+
+    var passwordTextField: XCUIElement { passwordTextFieldGetter(app) }
+    var passwordErrorLabel: XCUIElement { passwordErrorLabelGetter(app) }
+    var continueButton: XCUIElement { continueButtonGetter(app) }
+
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            // swiftlint:disable:next opening_brace
-            expectedElementGetters: [ { $0.secureTextFields["Password"] } ],
+            expectedElementGetters: [ passwordTextFieldGetter, continueButtonGetter ],
             app: app,
             waitTimeout: 10
         )
@@ -20,15 +35,13 @@ public class PasswordScreen: ScreenObject {
         return try LoginEpilogueScreen()
     }
 
-    public func proceedWithInvalidPassword() throws -> PasswordScreen {
+    public func proceedWithInvalidPassword() throws -> Self {
         try tryProceed(password: "invalidPswd")
 
-        return try PasswordScreen()
+        return self
     }
 
     public func tryProceed(password: String) throws {
-        let passwordTextField = expectedElement
-
         // A hack to make tests pass for RtL languages.
         //
         // An unintended side effect of calling passwordTextField.tap() while testing a RtL language is that the
@@ -47,18 +60,13 @@ public class PasswordScreen: ScreenObject {
         }
 
         passwordTextField.typeText(password)
-        let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
-
         app.dismissSavePasswordPrompt()
     }
 
     @discardableResult
-    public func verifyLoginError() -> PasswordScreen {
-        let errorLabel = app.cells["Password Error"]
-        _ = errorLabel.waitForExistence(timeout: 2)
-
-        XCTAssertTrue(errorLabel.exists)
+    public func verifyLoginError() -> Self {
+        XCTAssertTrue(passwordErrorLabel.waitForExistence(timeout: 3))
         return self
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -36,10 +36,6 @@ public class PrologueScreen: ScreenObject {
         return try LoginSiteAddressScreen()
     }
 
-    public func verifyPrologueScreenLoaded() {
-        XCTAssertTrue(isLoaded)
-    }
-
     public static func isLoaded(app: XCUIApplication = XCUIApplication()) -> Bool {
         (try? PrologueScreen(app: app).isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -36,10 +36,6 @@ public class WelcomeScreen: ScreenObject {
         return try WelcomeScreenLoginComponent()
     }
 
-    public func verifyWelcomeScreenLoaded() {
-        XCTAssertTrue(isLoaded)
-    }
-
     static func isLoaded() -> Bool {
         (try? WelcomeScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -187,6 +187,7 @@ public class MySiteScreen: ScreenObject {
         return try StatsScreen()
     }
 
+    @discardableResult
     public func goToSettingsScreen() throws -> SiteSettingsScreen {
         app.cells[ElementStringIDs.settingsButton].tap()
         return try SiteSettingsScreen()
@@ -224,6 +225,7 @@ public class MySiteScreen: ScreenObject {
         return try PeopleScreen()
     }
 
+    @discardableResult
     public func verifyMySiteScreenLoaded() -> Self {
         XCTAssertTrue(isLoaded)
         return self

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -225,12 +225,6 @@ public class MySiteScreen: ScreenObject {
         return try PeopleScreen()
     }
 
-    @discardableResult
-    public func verifyMySiteScreenLoaded() -> Self {
-        XCTAssertTrue(isLoaded)
-        return self
-    }
-
     public static func isLoaded() -> Bool {
         (try? MySiteScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/PagesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PagesScreen.swift
@@ -25,12 +25,6 @@ public class PagesScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifyPagesScreenLoaded() -> Self {
-        XCTAssertTrue(PagesScreen.isLoaded(), "\"Pages\" screen isn't loaded.")
-        return self
-    }
-
-    @discardableResult
     public func verifyPagesScreen(hasPage pageTitle: String) -> Self {
         XCTAssertTrue(pagesTable.staticTexts[pageTitle].waitForIsHittable(), "Pages Screen: \"\(pageTitle)\" page not displayed.")
         return self

--- a/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
@@ -22,6 +22,10 @@ public class PeopleScreen: ScreenObject {
         )
     }
 
+    public func verifyPeopleScreenLoaded() {
+        XCTAssertTrue(isLoaded)
+    }
+
     public static func isLoaded() -> Bool {
         (try? PeopleScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
@@ -22,10 +22,6 @@ public class PeopleScreen: ScreenObject {
         )
     }
 
-    public func verifyPeopleScreenLoaded() {
-        XCTAssertTrue(isLoaded)
-    }
-
     public static func isLoaded() -> Bool {
         (try? PeopleScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/PlanSelectionScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PlanSelectionScreen.swift
@@ -17,10 +17,4 @@ public class PlanSelectionScreen: ScreenObject {
     public static func isLoaded() -> Bool {
         (try? PlanSelectionScreen().isLoaded) ?? false
     }
-
-    @discardableResult
-    public func verifyPlanSelectionScreenLoaded() -> Self {
-        XCTAssertTrue(PlanSelectionScreen.isLoaded(), "\"Plan Selection\" screen isn't loaded.")
-        return self
-    }
 }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -74,6 +74,10 @@ public class ReaderScreen: ScreenObject {
         if backButton.isHittable { backButton.tap() }
     }
 
+    public func verifyReaderScreenLoaded() {
+        XCTAssertTrue(isLoaded)
+    }
+
     public static func isLoaded() -> Bool {
         (try? ReaderScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -74,11 +74,7 @@ public class ReaderScreen: ScreenObject {
         if backButton.isHittable { backButton.tap() }
     }
 
-    public func verifyReaderScreenLoaded() {
-        XCTAssertTrue(isLoaded)
-    }
-
-    public static func isLoaded() -> Bool {
+    public func isLoaded() -> Bool {
         (try? ReaderScreen().isLoaded) ?? false
     }
 


### PR DESCRIPTION
### Description 
While working on the tests the last week I noticed that there are still XCTAsserts being called on the test level, so this is the clean-up PR to remove those from tests, along with small changes that shouldn't affect the functionality of the tests (update indentations for better readability, and removal of unnecessary code)

This PR does not include any functional changes.

### Testing
CI should be 🟢 