### PR TITLE
Drop iOS 14 Support: Address UIButton API deprecations (#2)

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -41,13 +41,7 @@ import WordPressShared
     }
 
     fileprivate func adjustInsetsForTextDirection() {
-        guard userInterfaceLayoutDirection() == .rightToLeft else {
-            return
-        }
-
-        followButton.contentEdgeInsets = followButton.contentEdgeInsets.flippedForRightToLeftLayoutDirection()
-        followButton.imageEdgeInsets = followButton.imageEdgeInsets.flippedForRightToLeftLayoutDirection()
-        followButton.titleEdgeInsets = followButton.titleEdgeInsets.flippedForRightToLeftLayoutDirection()
+        followButton.flipInsetsForRightToLeftLayoutDirection()
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -264,34 +264,6 @@ extension WPStyleGuide {
         button.setTitleColor(disabledColor, for: .disabled)
     }
 
-    @objc public class func applyReaderFollowConversationButtonStyle(_ button: UIButton) {
-        // General
-        button.naturalContentHorizontalAlignment = .leading
-        button.backgroundColor = .clear
-        button.titleLabel?.font = fontForTextStyle(.footnote)
-
-        // Color(s)
-        let normalColor = UIColor.primary
-        let highlightedColor =  UIColor.neutral
-        let selectedColor = UIColor.success
-
-        button.setTitleColor(normalColor, for: .normal)
-        button.setTitleColor(selectedColor, for: .selected)
-        button.setTitleColor(highlightedColor, for: .highlighted)
-
-        // Image(s)
-        let side = WPStyleGuide.fontSizeForTextStyle(.headline)
-        let size = CGSize(width: side, height: side)
-        let followIcon = UIImage.gridicon(.readerFollowConversation, size: size)
-        let followingIcon = UIImage.gridicon(.readerFollowingConversation, size: size)
-
-        button.setImage(followIcon.imageWithTintColor(normalColor), for: .normal)
-        button.setImage(followingIcon.imageWithTintColor(selectedColor), for: .selected)
-        button.setImage(followingIcon.imageWithTintColor(highlightedColor), for: .highlighted)
-        button.imageEdgeInsets = FollowConversationButton.Style.imageEdgeInsets
-        button.contentEdgeInsets = FollowConversationButton.Style.contentEdgeInsets
-    }
-
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
         let side = WPStyleGuide.fontSizeForTextStyle(.callout)
         let size = CGSize(width: side, height: side)


### PR DESCRIPTION
Related Issue #20860

Remove some unused code with `UIButton` deprecations.

## Regression Notes
1. Potential unintended areas of impact: Media-related features
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests and unit tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
