### PR TITLE
Set the `selectedNotification` property within `showDetails`

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -786,8 +786,10 @@ extension NotificationsViewController {
         // The ideal solution would be not updating and saving `Notification.read` property in the main context.
         // Use `CoreDataStack.performAndSave` to do it in a background context instead. However, based on the comments on
         // `markAsRead` function call below, it appears we intentionally save the main context to maintain some undocumented
-        // but appears important "side effects". We may need more careful testing around moving the saving operation from
+        // but apperently important "side effects". We may need more careful testing around moving the saving operation from
         // the main context to a background context.
+        //
+        // See also https://github.com/wordpress-mobile/WordPress-iOS/issues/20850
         selectedNotification = note
 
         /// Note: markAsRead should be the *first* thing we do. This triggers a context save, and may have many side effects that


### PR DESCRIPTION
This is an attempt to workaround #20850. Please see the code comments for an explanation of this one line change.

Considering this is an unreproducible crash, I think it's reasonable to apply this workaround first, to verify the theory. If the workaround indeed fixes the crash, we can potentially invest more time into the proper solution—using `performAndSave` to save Notification related changes.

`showDetails` is a private function that's called in two call sites. One is the table view selection delegate method which you can see in this PR's diff and it already has `selectedNotification = note`, the other is in the `showDetailsForNotificationWithID` function which is in the crash stacktrace and doesn't have the `selectedNotification = note` assignment.

## Test Instructions

You can try to reproduce the crash on App Store build, by following my theory in https://github.com/wordpress-mobile/WordPress-iOS/issues/20850#issuecomment-1598061758, and verify the crash is gone in the PR build. If you don't have any luck with it, I can't think of anything better to do other than triggering and tapping push notifications.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Trigger new notification

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
