### PR TITLE
Use MediaEditor 1.2.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -154,7 +154,7 @@ abstract_target 'Apps' do
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
-  pod 'MediaEditor', '~> 1.2.1'
+  pod 'MediaEditor', '~> 1.2', '>= 1.2.2'
   # pod 'MediaEditor', git: 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', commit: ''
   # pod 'MediaEditor', path: '../MediaEditor-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
   - libwebp/mux (1.2.4):
     - libwebp/demux
   - libwebp/webp (1.2.4)
-  - MediaEditor (1.2.1):
+  - MediaEditor (1.2.2):
     - CropViewController (~> 2.5.3)
   - MRProgress (0.8.3):
     - MRProgress/ActivityIndicator (= 0.8.3)
@@ -559,7 +559,7 @@ DEPENDENCIES:
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.97.1`)
   - JTAppleCalendar (~> 8.0.2)
   - Kanvas (~> 1.4.4)
-  - MediaEditor (~> 1.2.1)
+  - MediaEditor (>= 1.2.2, ~> 1.2)
   - MRProgress (= 0.8.3)
   - NSObject-SafeExpectations (~> 0.0.4)
   - "NSURL+IDN (~> 0.4)"
@@ -825,7 +825,7 @@ SPEC CHECKSUMS:
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
-  MediaEditor: 20cdeb46bdecd040b8bc94467ac85a52b53b193a
+  MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
@@ -900,6 +900,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 8d45f149d70efe7560994bad2b7d40816dfc12b0
+PODFILE CHECKSUM: 3aafe3a791569455de8949833d0cf31de28aee99
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
This version has a fix for a possible life-cycle issue, see https://github.com/wordpress-mobile/MediaEditor-iOS/pull/40

Unfortunately, I've never run into a crash due to the offending code. I only noticed the inconsistency and addressed it.