### PR TITLE
Enable Sentry stitchAsyncCode option to capture async code stacktraces

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -134,9 +134,9 @@ abstract_target 'Apps' do
 
   # Production
 
-  pod 'Automattic-Tracks-iOS', '~> 2.2'
+  # pod 'Automattic-Tracks-iOS', '~> 2.2'
   # While in PR
-  # pod 'Automattic-Tracks-iOS', git: 'https://github.com/Automattic/Automattic-Tracks-iOS.git', branch: ''
+  pod 'Automattic-Tracks-iOS', git: 'https://github.com/Automattic/Automattic-Tracks-iOS.git', branch: 'task/sentry-stitch-async-code'
   # Local Development
   # pod 'Automattic-Tracks-iOS', path: '~/Projects/Automattic-Tracks-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -138,7 +138,7 @@ abstract_target 'Apps' do
   # While in PR
   pod 'Automattic-Tracks-iOS', git: 'https://github.com/Automattic/Automattic-Tracks-iOS.git', branch: 'task/sentry-stitch-async-code'
   # Local Development
-  # pod 'Automattic-Tracks-iOS', path: '~/Projects/Automattic-Tracks-iOS'
+  # pod 'Automattic-Tracks-iOS', path: '../Automattic-Tracks-iOS'
 
   pod 'NSURL+IDN', '~> 0.4'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
   - AppCenter/Distribute (4.4.1):
     - AppCenter/Core
   - Automattic-Tracks-iOS (2.2.0):
-    - Sentry (= 8.5.0)
+    - Sentry (= 8.6.0)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
   - boost (1.76.0)
@@ -490,12 +490,12 @@ PODS:
   - SDWebImageWebPCoder (0.8.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
-  - Sentry (8.5.0):
-    - Sentry/Core (= 8.5.0)
-    - SentryPrivate (= 8.5.0)
-  - Sentry/Core (8.5.0):
-    - SentryPrivate (= 8.5.0)
-  - SentryPrivate (8.5.0)
+  - Sentry (8.6.0):
+    - Sentry/Core (= 8.6.0)
+    - SentryPrivate (= 8.6.0)
+  - Sentry/Core (8.6.0):
+    - SentryPrivate (= 8.6.0)
+  - SentryPrivate (8.6.0)
   - Sodium (0.9.1)
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
@@ -786,7 +786,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
-    :commit: 5db6060bcba4445cc1639e5f60af29e90999cca4
+    :commit: fb9c07316f566db2d274de6839947e07ee9ea4e5
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
@@ -809,7 +809,7 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   AppCenter: b0b6f1190215b5f983c42934db718f3b46fff3c0
-  Automattic-Tracks-iOS: cbf13a8021f04f1095273cdcafce2687600e4f5e
+  Automattic-Tracks-iOS: 3535dbafdaeb4a5dc73f66ded18e3ebc694d8782
   boost: 32a63928ef0a5bf8b60f6b930c8864113fa28779
   BVLinearGradient: 9168d5f3bdb636b9bd861bf9fbe747f77e835065
   CocoaLumberjack: 78abfb691154e2a9df8ded4350d504ee19d90732
@@ -880,8 +880,8 @@ SPEC CHECKSUMS:
   RNTAztecView: 81c4a49d5482514d90e568cdf37142ad78f7c297
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
-  Sentry: 3be3f42e40e5a552935552e115744d5810a216d9
-  SentryPrivate: 8c9463280e282527f938d1a5d1d60f8e10ff279b
+  Sentry: d80553ff85ea72def75b792aaa5a71c158e51595
+  SentryPrivate: ef1c5b3dfe44ec0c70e2eb343a5be2689164c021
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -905,6 +905,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: be9b6383ab5f7a483fe937f3a101bffa28a4ebbe
+PODFILE CHECKSUM: 1021bddc8e12afedc67edd3077ab3b2431f62b36
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -490,12 +490,12 @@ PODS:
   - SDWebImageWebPCoder (0.8.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
-  - Sentry (8.6.0):
-    - Sentry/Core (= 8.6.0)
-    - SentryPrivate (= 8.6.0)
-  - Sentry/Core (8.6.0):
-    - SentryPrivate (= 8.6.0)
-  - SentryPrivate (8.6.0)
+  - Sentry (8.8.0):
+    - Sentry/Core (= 8.8.0)
+    - SentryPrivate (= 8.8.0)
+  - Sentry/Core (8.8.0):
+    - SentryPrivate (= 8.8.0)
+  - SentryPrivate (8.8.0)
   - Sodium (0.9.1)
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
@@ -544,7 +544,7 @@ DEPENDENCIES:
   - AlamofireNetworkActivityIndicator (~> 2.4)
   - AppCenter (~> 4.1)
   - AppCenter/Distribute (~> 4.1)
-  - Automattic-Tracks-iOS (~> 2.2)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, branch `task/sentry-stitch-async-code`)
   - boost (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.97.1/third-party-podspecs/boost.podspec.json`)
   - BVLinearGradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.97.1/third-party-podspecs/BVLinearGradient.podspec.json`)
   - CocoaLumberjack/Swift (~> 3.0)
@@ -630,7 +630,6 @@ SPEC REPOS:
     - AlamofireNetworkActivityIndicator
     - AppAuth
     - AppCenter
-    - Automattic-Tracks-iOS
     - CocoaLumberjack
     - CropViewController
     - DoubleConversion
@@ -675,6 +674,9 @@ SPEC REPOS:
     - ZIPFoundation
 
 EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :branch: task/sentry-stitch-async-code
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   boost:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.97.1/third-party-podspecs/boost.podspec.json
   BVLinearGradient:
@@ -783,6 +785,9 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.97.1/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :commit: f5bd4f4cffa5a6687c85b972a8b6ba5f20c959cb
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
@@ -875,8 +880,8 @@ SPEC CHECKSUMS:
   RNTAztecView: 81c4a49d5482514d90e568cdf37142ad78f7c297
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
-  Sentry: d80553ff85ea72def75b792aaa5a71c158e51595
-  SentryPrivate: ef1c5b3dfe44ec0c70e2eb343a5be2689164c021
+  Sentry: 927dfb29d18a14d924229a59cc2ad149f43349f2
+  SentryPrivate: 4350d865f898224ab9fa02b37d6ee7fbb623f47e
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -900,6 +905,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 8d45f149d70efe7560994bad2b7d40816dfc12b0
+PODFILE CHECKSUM: be9b6383ab5f7a483fe937f3a101bffa28a4ebbe
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
   - AppCenter/Distribute (4.4.1):
     - AppCenter/Core
   - Automattic-Tracks-iOS (2.2.0):
-    - Sentry (~> 8.0)
+    - Sentry (= 8.5.0)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
   - boost (1.76.0)
@@ -490,12 +490,12 @@ PODS:
   - SDWebImageWebPCoder (0.8.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.10)
-  - Sentry (8.8.0):
-    - Sentry/Core (= 8.8.0)
-    - SentryPrivate (= 8.8.0)
-  - Sentry/Core (8.8.0):
-    - SentryPrivate (= 8.8.0)
-  - SentryPrivate (8.8.0)
+  - Sentry (8.5.0):
+    - Sentry/Core (= 8.5.0)
+    - SentryPrivate (= 8.5.0)
+  - Sentry/Core (8.5.0):
+    - SentryPrivate (= 8.5.0)
+  - SentryPrivate (8.5.0)
   - Sodium (0.9.1)
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
@@ -786,7 +786,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
-    :commit: f5bd4f4cffa5a6687c85b972a8b6ba5f20c959cb
+    :commit: 5db6060bcba4445cc1639e5f60af29e90999cca4
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
@@ -809,7 +809,7 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   AppCenter: b0b6f1190215b5f983c42934db718f3b46fff3c0
-  Automattic-Tracks-iOS: a1b020ab02f0e5a39c5d4e6870a498273f286158
+  Automattic-Tracks-iOS: cbf13a8021f04f1095273cdcafce2687600e4f5e
   boost: 32a63928ef0a5bf8b60f6b930c8864113fa28779
   BVLinearGradient: 9168d5f3bdb636b9bd861bf9fbe747f77e835065
   CocoaLumberjack: 78abfb691154e2a9df8ded4350d504ee19d90732
@@ -880,8 +880,8 @@ SPEC CHECKSUMS:
   RNTAztecView: 81c4a49d5482514d90e568cdf37142ad78f7c297
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
-  Sentry: 927dfb29d18a14d924229a59cc2ad149f43349f2
-  SentryPrivate: 4350d865f898224ab9fa02b37d6ee7fbb623f47e
+  Sentry: 3be3f42e40e5a552935552e115744d5810a216d9
+  SentryPrivate: 8c9463280e282527f938d1a5d1d60f8e10ff279b
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] Block editor: Display lock icon in disabled state of `Cell` component [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5798]
 * [*] Block editor: Show "No title"/"No description" placeholder for not belonged videos in VideoPress block [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5840]
 * [*] Resolve an issue that was causing the app crash when `CrashLogging.logError` is called from a background thread. [#20846]
+* [*] [internal] Enable Sentry's swiftAsyncStacktraces option to capture async code stacktraces. [#20912]
 
 22.5
 -----

--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -43,7 +43,7 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
 
     let sentryDSN: String = ApiCredentials.sentryDSN
 
-    var swiftAsyncStacktraces: Bool {
+    var enhancedAsyncStacktraces: Bool {
         return true
     }
 

--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -43,6 +43,10 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
 
     let sentryDSN: String = ApiCredentials.sentryDSN
 
+    var swiftAsyncStacktraces: Bool {
+        return true
+    }
+
     var userHasOptedOut: Bool {
         return UserSettings.userHasOptedOutOfCrashLogging
     }


### PR DESCRIPTION
Ref p1687271187638419-slack-C05CANZ2B6F

## Related PR

This PR from `Automattic-Tracks-iOS` repo should be merged prior to this one:

- https://github.com/Automattic/Automattic-Tracks-iOS/pull/260

## Description

This PR enhances our ability to track errors by enabling a specific option in Sentry. This option improves the capture of stacktraces from asynchronous code. Previously, without this option, Sentry faced challenges in capturing async stacktraces effectively. With this option enabled, we expect to see an improvement in the way we trace async code errors. 

To demonstrate the impact of this option, I created a test scenario where an error was deliberately thrown in an asynchronous block of code. Here's a sample of the test code:

```swift
func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
  // ...
  self.performOnMainContextThenCrash()
  return true 
}

func performOnMainContextThenCrash() {
  // Override these flags to enable Sentry during development.
  //
  // These values are persisted in `NSUserDefaults`, so make sure to toggle them back when done to disable Sentry during development.
  UserSettings.userHasOptedOutOfCrashLogging = false
  UserSettings.userHasForcedCrashLoggingEnabled = true

  // Simulate error in async block.
  ContextManager.shared.mainContext.perform {
    CrashLogging.main.logMessage("Test Crash With Async Stacktraces Enabled", level: .error)
  }
}
```

Observations from the test results are noteworthy. When the option was disabled, the stacktrace failed to identify the `performOnMainContextThenCrash` method. In contrast, with the option enabled, the method was successfully included in the stacktrace. 

| Option Disabled | Option Enabled |
| --------------- | ---------------- |
| <img width="921" alt="test-crash-async-stacktraces-disabled" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/f0a725f4-d63f-41f5-bce1-7c52ef4cca50"> | <img width="922" alt="test-crash-async-stacktraces-enabled" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/02d8ec3c-d890-4ef8-885d-c96a7cd48ae5"> |

## To test:

#### Sentry Async Stacktraces Option Disabled
1. Add the `performOnMainContextThenCrash` method and call it in AppDelegate's `didFinishLaunchingWithOptions` method. Make sure to change the message `Test Crash With Async Stacktraces Enabled` to `Test Crash With Async Stacktraces Disabled`.
2. Set `enhancedAsyncStacktraces` in `WPCrashLoggingProvider` to `false`.
3. Build and run the app.
4. Navigate to Sentry and filter the issues by selecting the `localDeveloper` environment.
5. **Expect** to see a `Test Crash With Async Stacktraces Enabled` event. 
6. Tap the event and **verify** the stacktrace looks similar to the **Option Enabled** screenshot.

⚠️ Make sure to resolve the event before moving to the next test case or repeating this one.

#### Sentry Async Stacktraces Option Enabled
1. Add the `performOnMainContextThenCrash` method and call it in AppDelegate's `didFinishLaunchingWithOptions` method.
2. Set `enhancedAsyncStacktraces` in `WPCrashLoggingProvider` to `true`.
3. Build and run the app.
4. Navigate to Sentry and filter the issues by selecting the `localDeveloper` environment.
5. **Expect** to see a `Test Crash With Async Stacktraces Enabled` event. 
6. Tap the event and **verify** the stacktrace looks similar to the **Option Enabled** screenshot.

## Regression Notes
1. Potential unintended areas of impact
This is an internal change, and there shouldn't be an impact on the app features. But according to `SentryOptions.stitchAsyncCode` documentation, there might be an impact on how events are grouped on Sentry.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

8. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.