### PR TITLE
Core Data: Fixes a Core Data Multithreading violation when unscheduling blogging reminders

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -36,7 +36,9 @@ class BloggingPromptsService {
     /// Convenience computed variable that returns prompt settings from the local store.
     ///
     var localSettings: BloggingPromptSettings? {
-        loadSettings(context: contextManager.mainContext)
+        return contextManager.performQuery { mainContext in
+            self.loadSettings(context: mainContext)
+        }
     }
 
     /// Fetches a number of blogging prompts starting from the specified date.
@@ -349,7 +351,7 @@ private extension BloggingPromptsService {
         }, completion: completion, on: .main)
     }
 
-    func loadSettings(context: NSManagedObjectContext) -> BloggingPromptSettings? {
+    private func loadSettings(context: NSManagedObjectContext) -> BloggingPromptSettings? {
         let fetchRequest = BloggingPromptSettings.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "\(#keyPath(BloggingPromptSettings.siteID)) = %@", siteID)
         fetchRequest.fetchLimit = 1

--- a/WordPress/Classes/Utility/Blogging Prompts/ReminderScheduleCoordinator.swift
+++ b/WordPress/Classes/Utility/Blogging Prompts/ReminderScheduleCoordinator.swift
@@ -147,12 +147,16 @@ private extension ReminderScheduleCoordinator {
     }
 
     func reminderType(for blog: Blog) -> ReminderType {
-        if Feature.enabled(.bloggingPrompts),
-           let settings = promptReminderSettings(for: blog),
-           settings.promptRemindersEnabled {
-            return .bloggingPrompts
+        guard Feature.enabled(.bloggingPrompts),
+              let settings = promptReminderSettings(for: blog),
+              let context = settings.managedObjectContext else {
+            return .bloggingReminders
         }
 
-        return .bloggingReminders
+        var reminderType: ReminderType = .bloggingReminders
+        context.performAndWait {
+            reminderType = settings.promptRemindersEnabled ? .bloggingPrompts : .bloggingReminders
+        }
+        return reminderType
     }
 }


### PR DESCRIPTION
Fixes #20848 

## Description
Fixes a Core Data Multithreading violation when unscheduling blogging reminders.

## Root Cause
* `BlogService.unscheduleBloggingReminders()` was being called in `BlogService.mergeBlogs` from a derived background context thread.
* `BlogService.unscheduleBloggingReminders()` eventually calls `ReminderScheduleCoordinator.reminderType()` that uses the main context.

## Solution
This PR fixes the issue by ensuring the use of the main context is performed on the main context queue.

## Testing Instructions

1. Pass `-com.apple.CoreData.ConcurrencyDebug 1` arguments on launch
2. Open the Jetpack app and log in to an account with multiple sites
3. Log in to the same account on the desktop
4. Delete a site
5. Go back to the app
6. Open the site picker
7. Make sure Xcode doesn't detect a Multithreading violation

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.