### PR TITLE
Add Test Coverage List

### DIFF
--- a/WordPress/UITests/README.md
+++ b/WordPress/UITests/README.md
@@ -8,18 +8,18 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
 
 1. Unified Login and Signup
     - [ ] Login:
-            - [ ] WPCom Account:
-                - [x] Login and Logout using WPCom Account
-                - [x] Login and Logout Self Hosted Site
-                - [x] Invalid Password WPCom Account
-                - [x] Add Self Hosted Site after WPCom Login
-            - [ ] Apple/Google:
-                - [ ] Login using Apple Account
-                - [ ] Login using Google Account
-            - [ ] iCloud Keychain:
-                - [ ] Login using credentials saved in Keychain
-            - [ ] Magic Link:
-                - [ ] Email Magic Link Login
+        - [ ] WPCom Account:
+            - [x] Login and Logout using WPCom Account
+            - [x] Login and Logout Self Hosted Site
+            - [x] Invalid Password WPCom Account
+            - [x] Add Self Hosted Site after WPCom Login
+        - [ ] Apple/Google:
+            - [ ] Login using Apple Account
+            - [ ] Login using Google Account
+        - [ ] iCloud Keychain:
+            - [ ] Login using credentials saved in Keychain
+        - [ ] Magic Link:
+            - [ ] Email Magic Link Login
     - [ ] Sign Up:
         - [ ] Email Sign Up - Create New Site
         - [ ] Email Sign Up - Link to Self-Hosted Site

--- a/WordPress/UITests/README.md
+++ b/WordPress/UITests/README.md
@@ -7,20 +7,20 @@ WordPress for iOS has UI acceptance tests for critical user flows through the ap
 The following flows are covered/planned to be covered by UI tests. Tests that are covered will be checked.
 
 1. Unified Login and Signup
-    - Login
-            - WPCom Account
+    - [ ] Login:
+            - [ ] WPCom Account:
                 - [x] Login and Logout using WPCom Account
                 - [x] Login and Logout Self Hosted Site
                 - [x] Invalid Password WPCom Account
                 - [x] Add Self Hosted Site after WPCom Login
-            - Apple/Google
+            - [ ] Apple/Google:
                 - [ ] Login using Apple Account
                 - [ ] Login using Google Account
-            - iCloud Keychain
+            - [ ] iCloud Keychain:
                 - [ ] Login using credentials saved in Keychain
-            - Magic Link
+            - [ ] Magic Link:
                 - [ ] Email Magic Link Login
-    - Sign Up
+    - [ ] Sign Up:
         - [ ] Email Sign Up - Create New Site
         - [ ] Email Sign Up - Link to Self-Hosted Site
 2. NUX
@@ -28,7 +28,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Create New Site - Follow Quick Start
     - [ ] Set Up Blogging Reminders on First Post
 3. Posting/Editing/Gutenberg
-    - Post
+    - [ ] Post:
         - [x] Publish Text Post
         - [x] Publish Basic Public Post with Category and Tag
         - [x] Add and Remove Featured Image
@@ -36,7 +36,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
         - [ ] Add Image Block
         - [ ] Add Video Block
         - [ ] Create Scheduled Post
-    - Pages
+    - [ ] Pages:
         - [ ] Create Page from Layout
         - [ ] Create Blank Page
 4. Notifications

--- a/WordPress/UITests/README.md
+++ b/WordPress/UITests/README.md
@@ -2,6 +2,79 @@
 
 WordPress for iOS has UI acceptance tests for critical user flows through the app, such as login, signup, and publishing a post. The tests use mocked network requests with [WireMock](http://wiremock.org/), defined in the `API-Mocks` folder in the project's root.
 
+## Test Coverage
+
+The following flows are covered/planned to be covered by UI tests. Tests that are covered will be checked.
+
+1. Unified Login and Signup
+    - Login
+            - WPCom Account
+                - [x] Login and Logout using WPCom Account
+                - [x] Login and Logout Self Hosted Site
+                - [x] Invalid Password WPCom Account
+                - [x] Add Self Hosted Site after WPCom Login
+            - Apple/Google
+                - [ ] Login using Apple Account
+                - [ ] Login using Google Account
+            - iCloud Keychain
+                - [ ] Login using credentials saved in Keychain
+            - Magic Link
+                - [ ] Email Magic Link Login
+    - Sign Up
+        - [ ] Email Sign Up - Create New Site
+        - [ ] Email Sign Up - Link to Self-Hosted Site
+2. NUX
+    - [ ] Create New Site - Skip Quick Start
+    - [ ] Create New Site - Follow Quick Start
+    - [ ] Set Up Blogging Reminders on First Post
+3. Posting/Editing/Gutenberg
+    - Post
+        - [x] Publish Text Post
+        - [x] Publish Basic Public Post with Category and Tag
+        - [x] Add and Remove Featured Image
+        - [x] Add Gallery Block
+        - [ ] Add Image Block
+        - [ ] Add Video Block
+        - [ ] Create Scheduled Post
+    - Pages
+        - [ ] Create Page from Layout
+        - [ ] Create Blank Page
+4. Notifications
+    - [ ] Browse/Scroll Through Notifications
+    - [ ] View Notification
+    - [ ] Reply from Notification
+    - [ ] Like Notification
+5. Blogging Reminders
+    - [ ] Set Up New Blogging Reminders from Post Publish Prompt
+    - [ ] Set Up Scheduled Story Post (iPhone Only)
+6. Stats
+    - [x] Insights Stats Load Properly
+    - [x] Years Stats Load Properly
+7. Reader
+    - [x] View Last Post
+    - [x] View Last Post in Safari
+    - [x] Add Comment to Post
+    - [ ] Follow New Topics on Discover Tab
+    - [ ] Save a Post
+    - [ ] Like a Post 
+8. Jetpack Settings
+    - [ ] Open and View Jetpack Settings Options
+    - [ ] Search and View a Plugin
+9. View Site
+    - [ ] View Site from My Site Screen
+    - [ ] Update Site and Validate Changes
+10. Dashboard (Jetpack Only)
+    - [x] Free to Paid Plans Card
+    - [x] Pages Card Header Navigation
+    - [x] Activity Log Card Header Navigation
+11. Navigation
+    - [x] Load People Screen
+    - [x] Tab Bar Navigation (Reader and Notification tabs)
+    - [x] Domains Navigation (Jetpack Only)
+12. Support Screen/Help
+    - [ ] Support Forums Loaded during Login
+    - [x] Contact Us Loaded during Login
+
 ## Running tests
 
 Note that due to the mock server setup, tests cannot be run on physical devices right now.

--- a/WordPress/UITests/README.md
+++ b/WordPress/UITests/README.md
@@ -6,28 +6,27 @@ WordPress for iOS has UI acceptance tests for critical user flows through the ap
 
 The following flows are covered/planned to be covered by UI tests. Tests that are covered will be checked.
 
-1. Unified Login and Signup
-    - [ ] Login:
-        - [ ] WPCom Account:
-            - [x] Login and Logout using WPCom Account
-            - [x] Login and Logout Self Hosted Site
-            - [x] Invalid Password WPCom Account
-            - [x] Add Self Hosted Site after WPCom Login
-        - [ ] Apple/Google:
-            - [ ] Login using Apple Account
-            - [ ] Login using Google Account
-        - [ ] iCloud Keychain:
-            - [ ] Login using credentials saved in Keychain
-        - [ ] Magic Link:
-            - [ ] Email Magic Link Login
-    - [ ] Sign Up:
-        - [ ] Email Sign Up - Create New Site
-        - [ ] Email Sign Up - Link to Self-Hosted Site
-2. NUX
+1. Unified Login
+    - [ ] WPCom Account:
+        - [x] Log in and log out using WPCom Account
+        - [x] Log in and log out Self Hosted Site
+        - [x] Invalid Password WPCom Account
+        - [x] Add Self Hosted Site after WPCom Login
+    - [ ] Apple/Google:
+        - [ ] Log in using Apple Account
+        - [ ] Log in using Google Account
+    - [ ] iCloud Keychain:
+        - [ ] Log in using credentials saved in Keychain
+    - [ ] Magic Link:
+        - [ ] Email Magic Link Login
+2. Sign Up:
+    - [ ] Email Sign Up - Create New Site
+    - [ ] Email Sign Up - Link to Self-Hosted Site
+3. NUX
     - [ ] Create New Site - Skip Quick Start
     - [ ] Create New Site - Follow Quick Start
     - [ ] Set Up Blogging Reminders on First Post
-3. Posting/Editing/Gutenberg
+4. Posting/Editing/Gutenberg
     - [ ] Post:
         - [x] Publish Text Post
         - [x] Publish Basic Public Post with Category and Tag
@@ -39,39 +38,39 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [ ] Pages:
         - [ ] Create Page from Layout
         - [ ] Create Blank Page
-4. Notifications
+5. Notifications
     - [ ] Browse/Scroll Through Notifications
     - [ ] View Notification
     - [ ] Reply from Notification
     - [ ] Like Notification
-5. Blogging Reminders
+6. Blogging Reminders
     - [ ] Set Up New Blogging Reminders from Post Publish Prompt
     - [ ] Set Up Scheduled Story Post (iPhone Only)
-6. Stats
+7. Stats
     - [x] Insights Stats Load Properly
     - [x] Years Stats Load Properly
-7. Reader
+8. Reader
     - [x] View Last Post
     - [x] View Last Post in Safari
     - [x] Add Comment to Post
     - [ ] Follow New Topics on Discover Tab
     - [ ] Save a Post
     - [ ] Like a Post 
-8. Jetpack Settings
+9. Jetpack Settings
     - [ ] Open and View Jetpack Settings Options
     - [ ] Search and View a Plugin
-9. View Site
+10. View Site
     - [ ] View Site from My Site Screen
     - [ ] Update Site and Validate Changes
-10. Dashboard (Jetpack Only)
+11. Dashboard (Jetpack Only)
     - [x] Free to Paid Plans Card
     - [x] Pages Card Header Navigation
     - [x] Activity Log Card Header Navigation
-11. Navigation
+12. Navigation
     - [x] Load People Screen
     - [x] Tab Bar Navigation (Reader and Notification tabs)
     - [x] Domains Navigation (Jetpack Only)
-12. Support Screen/Help
+13. Support Screen/Help
     - [ ] Support Forums Loaded during Login
     - [x] Contact Us Loaded during Login
 


### PR DESCRIPTION
### Description
I noticed that the list of automated UI tests is not listed in the project, so unless we go to the file one by one, we won't have an overview of the UI automation coverage. Also, while running the regression/smoke test, I noticed that a number of the tests (some tests, especially around login, would need more research on how to automate them, if at all possible) could be written as UI tests so it doesn't have to be part of the manual smoke test run.

The Test Coverage list is built using the Smoke Tests list (but I simplified the test names) and tests that are already automated in the project. The ones marked [x] are already automated and running on each build. 

With a list within the project, it would be easier for us to help write these tests and for the teams to pick them up during maintenance week.

### Testing
CI should be 🟢  (change is only on the README file)