### PR TITLE
Blaze Manage Campaigns: Display campaigns card based on context

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -84,6 +84,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
 
     @objc private func buttonCreateCampaignTapped() {
         guard let presentingViewController, let blog else { return }
+        BlazeEventsTracker.trackEntryPointTapped(for: .dashboardCard)
         BlazeFlowCoordinator.presentBlaze(in: presentingViewController, source: .dashboardCard, blog: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressKit
 
-final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
+final class DashboardBlazeCampaignsCardView: UIView {
     private let frameView = BlogDashboardCardFrameView()
     private let campaignView = DashboardBlazeCampaignView()
 
@@ -41,9 +41,9 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
     // MARK: - View setup
 
     private func setupView() {
-        contentView.addSubview(frameView)
+        addSubview(frameView)
         frameView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(frameView, priority: UILayoutPriority(999))
+        pinSubviewToAllEdges(frameView, priority: UILayoutPriority(999))
 
         frameView.add(subview: contentStackView)
         contentStackView.addArrangedSubview({
@@ -107,7 +107,7 @@ final class DashboardBlazeCampaignCardCell: DashboardCollectionViewCell {
     }
 }
 
-private extension DashboardBlazeCampaignCardCell {
+private extension DashboardBlazeCampaignsCardView {
     enum Strings {
         static let cardTitle = NSLocalizedString("dashboardCard.blazeCampaigns.title", value: "Blaze campaign", comment: "Title for the card displaying blaze campaigns.")
         static let viewAllCampaigns = NSLocalizedString("dashboardCard.blazeCampaigns.viewAllCampaigns", value: "View all campaigns", comment: "Title for the View All Campaigns button in the More menu")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -87,9 +87,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
         BlazeFlowCoordinator.presentBlaze(in: presentingViewController, source: .dashboardCard, blog: blog)
     }
 
-    // MARK: - BlogDashboardCardConfigurable
-
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
         self.blog = blog
         self.presentingViewController = viewController
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -8,19 +8,29 @@ final class DashboardBlazeCardCell: DashboardCollectionViewCell {
             // Display campaigns
             let cardView = DashboardBlazeCampaignsCardView()
             cardView.configure(blog: blog, viewController: viewController)
-            setCardView(cardView)
+            setCardView(cardView, subtype: .campaigns)
         } else {
             // Display promo
             let cardView = DashboardBlazePromoCardView(.make(with: blog, viewController: viewController))
-            setCardView(cardView)
+            setCardView(cardView, subtype: .promo)
         }
     }
 
-    private func setCardView(_ cardView: UIView) {
+    private func setCardView(_ cardView: UIView, subtype: DashboardBlazeCardSubtype) {
         contentView.subviews.forEach { $0.removeFromSuperview() }
 
         cardView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(cardView)
         contentView.pinSubviewToAllEdges(cardView, priority: UILayoutPriority(999))
+
+        BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: [
+            "type": DashboardCard.blaze.rawValue,
+            "sub_type": subtype.rawValue
+        ])
     }
+}
+
+enum DashboardBlazeCardSubtype: String {
+    case promo = "no_campaigns"
+    case campaigns = "campaigns"
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -1,68 +1,19 @@
 import UIKit
 
-class DashboardBlazeCardCell: DashboardCollectionViewCell {
+final class DashboardBlazeCardCell: DashboardCollectionViewCell {
 
     private var blog: Blog?
     private weak var presentingViewController: BlogDashboardViewController?
-
-    // MARK: - Views
-
-    private lazy var cardViewModel: BlazeCardViewModel = {
-
-        let onViewTap: () -> Void = { [weak self] in
-            guard let presentingViewController = self?.presentingViewController,
-                  let blog = self?.blog else {
-                return
-            }
-            BlazeEventsTracker.trackEntryPointTapped(for: .dashboardCard)
-            BlazeFlowCoordinator.presentBlaze(in: presentingViewController, source: .dashboardCard, blog: blog)
-        }
-
-        let onEllipsisTap: () -> Void = { [weak self] in
-            BlogDashboardAnalytics.trackContextualMenuAccessed(for: .blaze)
-            BlazeEventsTracker.trackContextualMenuAccessed(for: .dashboardCard)
-        }
-
-        let onHideThisTap: UIActionHandler = { [weak self] _ in
-            BlogDashboardAnalytics.trackHideTapped(for: .blaze)
-            BlazeEventsTracker.trackHideThisTapped(for: .dashboardCard)
-            BlazeHelper.hideBlazeCard(for: self?.blog)
-        }
-
-        return BlazeCardViewModel(onViewTap: onViewTap,
-                                  onEllipsisTap: onEllipsisTap,
-                                  onHideThisTap: onHideThisTap)
-    }()
-
-    private lazy var cardView: BlazeCardView = {
-        let cardView = BlazeCardView(cardViewModel)
-        cardView.translatesAutoresizingMaskIntoConstraints = false
-        return cardView
-    }()
-
-    // MARK: - Initializers
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setupView()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - View setup
-
-    private func setupView() {
-        contentView.addSubview(cardView)
-        contentView.pinSubviewToAllEdges(cardView, priority: UILayoutPriority(999))
-    }
-
-    // MARK: - BlogDashboardCardConfigurable
 
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
         self.blog = blog
         self.presentingViewController = viewController
         BlazeEventsTracker.trackEntryPointDisplayed(for: .dashboardCard)
+
+        contentView.subviews.forEach { $0.removeFromSuperview() }
+        let cardView = DashboardBlazePromoCardView(.make(with: blog, viewController: viewController))
+        cardView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(cardView)
+        contentView.pinSubviewToAllEdges(cardView, priority: UILayoutPriority(999))
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -1,17 +1,24 @@
 import UIKit
 
 final class DashboardBlazeCardCell: DashboardCollectionViewCell {
-
-    private var blog: Blog?
-    private weak var presentingViewController: BlogDashboardViewController?
-
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
-        self.blog = blog
-        self.presentingViewController = viewController
         BlazeEventsTracker.trackEntryPointDisplayed(for: .dashboardCard)
 
+        if RemoteFeature.enabled(.blazeManageCampaigns) {
+            // Display campaigns
+            let cardView = DashboardBlazeCampaignsCardView()
+            cardView.configure(blog: blog, viewController: viewController)
+            setCardView(cardView)
+        } else {
+            // Display promo
+            let cardView = DashboardBlazePromoCardView(.make(with: blog, viewController: viewController))
+            setCardView(cardView)
+        }
+    }
+
+    private func setCardView(_ cardView: UIView) {
         contentView.subviews.forEach { $0.removeFromSuperview() }
-        let cardView = DashboardBlazePromoCardView(.make(with: blog, viewController: viewController))
+
         cardView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(cardView)
         contentView.pinSubviewToAllEdges(cardView, priority: UILayoutPriority(999))

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -4,7 +4,7 @@ final class DashboardBlazeCardCell: DashboardCollectionViewCell {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
         BlazeEventsTracker.trackEntryPointDisplayed(for: .dashboardCard)
 
-        if RemoteFeature.enabled(.blazeManageCampaigns) {
+        if RemoteFeatureFlag.blazeManageCampaigns.enabled() {
             // Display campaigns
             let cardView = DashboardBlazeCampaignsCardView()
             cardView.configure(blog: blog, viewController: viewController)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
@@ -1,10 +1,10 @@
 import UIKit
 
-final class BlazeCardView: UIView {
+final class DashboardBlazePromoCardView: UIView {
 
     // MARK: - Properties
 
-    private let viewModel: BlazeCardViewModel
+    private let viewModel: DashboardBlazePromoViewModel
 
     // MARK: - Views
 
@@ -70,7 +70,7 @@ final class BlazeCardView: UIView {
 
     // MARK: - Initializers
 
-    init(_ viewModel: BlazeCardViewModel = BlazeCardViewModel()) {
+    init(_ viewModel: DashboardBlazePromoViewModel) {
         self.viewModel = viewModel
         super.init(frame: .zero)
         setupView()
@@ -104,7 +104,7 @@ final class BlazeCardView: UIView {
     }
 }
 
-extension BlazeCardView {
+extension DashboardBlazePromoCardView {
 
     private enum Style {
         static let titleLabelFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
@@ -130,19 +130,26 @@ extension BlazeCardView {
     }
 }
 
-// MARK: - BlazeCardViewModel
+// MARK: - DashboardBlazePromoViewModel
 
-struct BlazeCardViewModel {
+struct DashboardBlazePromoViewModel {
 
     let onViewTap: () -> Void
     let onEllipsisTap: () -> Void
     let onHideThisTap: UIActionHandler
 
-    init(onViewTap: @escaping () -> Void = {},
-         onEllipsisTap: @escaping () -> Void = {},
-         onHideThisTap: @escaping UIActionHandler = { _ in }) {
-        self.onViewTap = onViewTap
-        self.onEllipsisTap = onEllipsisTap
-        self.onHideThisTap = onHideThisTap
+    static func make(with blog: Blog, viewController: BlogDashboardViewController?) -> DashboardBlazePromoViewModel {
+        DashboardBlazePromoViewModel(onViewTap: { [weak viewController] in
+            guard let viewController = viewController else { return }
+            BlazeEventsTracker.trackEntryPointTapped(for: .dashboardCard)
+            BlazeFlowCoordinator.presentBlaze(in: viewController, source: .dashboardCard, blog: blog)
+        }, onEllipsisTap: {
+            BlogDashboardAnalytics.trackContextualMenuAccessed(for: .blaze)
+            BlazeEventsTracker.trackContextualMenuAccessed(for: .dashboardCard)
+        }, onHideThisTap: { _ in
+            BlogDashboardAnalytics.trackHideTapped(for: .blaze)
+            BlazeEventsTracker.trackHideThisTapped(for: .dashboardCard)
+            BlazeHelper.hideBlazeCard(for: blog)
+        })
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -371,8 +371,8 @@
 		0CB4057A29C8DDEE008EED0A /* BlogDashboardPersonalizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */; };
 		0CB4057D29C8DF83008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
 		0CB4057E29C8DF84008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
-		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */; };
-		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */; };
+		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
+		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
 		17039225282E6D2800F602E9 /* ViewsVisitorsLineChartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC772B0728201F5300664C02 /* ViewsVisitorsLineChartCell.swift */; };
@@ -6062,7 +6062,7 @@
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
 		0CB4057229C8DD01008EED0A /* BlogDashboardPersonalizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationView.swift; sourceTree = "<group>"; };
 		0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizeCardCell.swift; sourceTree = "<group>"; };
-		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignCardCell.swift; sourceTree = "<group>"; };
+		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		150B6590614A28DF9AD25491 /* Pods-Apps-Jetpack.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		152F25D5C232985E30F56CAC /* Pods-Apps-Jetpack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.debug.xcconfig"; sourceTree = "<group>"; };
@@ -17810,7 +17810,7 @@
 			children = (
 				FA98B61529A3B76A0071AAE8 /* DashboardBlazeCardCell.swift */,
 				FA98B61829A3BF050071AAE8 /* DashboardBlazePromoCardView.swift */,
-				0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */,
+				0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */,
 				0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */,
 				0C391E602A3002950040EA91 /* BlazeCampaignStatusView.swift */,
 			);
@@ -22566,7 +22566,7 @@
 				329F8E5824DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift in Sources */,
 				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */,
-				0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */,
+				0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */,
 				FAD7626429F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift in Sources */,
 				24351254264DCA08009BB2B6 /* Secrets.swift in Sources */,
 				03216EC6279946CA00D444CA /* SchedulingDatePickerViewController.swift in Sources */,
@@ -24399,7 +24399,7 @@
 				FABB22C12602FC2C00C8785C /* DomainsService.swift in Sources */,
 				98BAA7C426F925F70073A2F9 /* InlineEditableSingleLineCell.swift in Sources */,
 				FABB22C22602FC2C00C8785C /* PasswordAlertController.swift in Sources */,
-				0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift in Sources */,
+				0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */,
 				4A1E77CD2989F2F7006281CC /* WPAccount+DeduplicateBlogs.swift in Sources */,
 				FA98B61D29A3DB840071AAE8 /* BlazeHelper.swift in Sources */,
 				FABB22C32602FC2C00C8785C /* ReaderTagsFooter.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3874,8 +3874,8 @@
 		FA98A2512833F1DC003B9233 /* QuickStartChecklistConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98A24F2833F1DC003B9233 /* QuickStartChecklistConfigurable.swift */; };
 		FA98B61629A3B76A0071AAE8 /* DashboardBlazeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61529A3B76A0071AAE8 /* DashboardBlazeCardCell.swift */; };
 		FA98B61729A3B76A0071AAE8 /* DashboardBlazeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61529A3B76A0071AAE8 /* DashboardBlazeCardCell.swift */; };
-		FA98B61929A3BF050071AAE8 /* BlazeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61829A3BF050071AAE8 /* BlazeCardView.swift */; };
-		FA98B61A29A3BF050071AAE8 /* BlazeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61829A3BF050071AAE8 /* BlazeCardView.swift */; };
+		FA98B61929A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61829A3BF050071AAE8 /* DashboardBlazePromoCardView.swift */; };
+		FA98B61A29A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61829A3BF050071AAE8 /* DashboardBlazePromoCardView.swift */; };
 		FA98B61C29A3DB840071AAE8 /* BlazeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61B29A3DB840071AAE8 /* BlazeHelper.swift */; };
 		FA98B61D29A3DB840071AAE8 /* BlazeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98B61B29A3DB840071AAE8 /* BlazeHelper.swift */; };
 		FAA4012D27B405DB009E1137 /* DashboardQuickActionsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4012C27B405DB009E1137 /* DashboardQuickActionsCardCell.swift */; };
@@ -9213,7 +9213,7 @@
 		FA98A24F2833F1DC003B9233 /* QuickStartChecklistConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistConfigurable.swift; sourceTree = "<group>"; };
 		FA98B61329A39DA80071AAE8 /* WordPress 148.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 148.xcdatamodel"; sourceTree = "<group>"; };
 		FA98B61529A3B76A0071AAE8 /* DashboardBlazeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCell.swift; sourceTree = "<group>"; };
-		FA98B61829A3BF050071AAE8 /* BlazeCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCardView.swift; sourceTree = "<group>"; };
+		FA98B61829A3BF050071AAE8 /* DashboardBlazePromoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazePromoCardView.swift; sourceTree = "<group>"; };
 		FA98B61B29A3DB840071AAE8 /* BlazeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeHelper.swift; sourceTree = "<group>"; };
 		FAA4012C27B405DB009E1137 /* DashboardQuickActionsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionsCardCell.swift; sourceTree = "<group>"; };
 		FAA4013327B52455009E1137 /* QuickActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionButton.swift; sourceTree = "<group>"; };
@@ -17809,7 +17809,7 @@
 			isa = PBXGroup;
 			children = (
 				FA98B61529A3B76A0071AAE8 /* DashboardBlazeCardCell.swift */,
-				FA98B61829A3BF050071AAE8 /* BlazeCardView.swift */,
+				FA98B61829A3BF050071AAE8 /* DashboardBlazePromoCardView.swift */,
 				0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignCardCell.swift */,
 				0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */,
 				0C391E602A3002950040EA91 /* BlazeCampaignStatusView.swift */,
@@ -21957,7 +21957,7 @@
 				E616E4B31C480896002C024E /* SharingService.swift in Sources */,
 				F5E032E82408D537003AF350 /* BottomSheetPresentationController.swift in Sources */,
 				FA98A24D2832A5E9003B9233 /* NewQuickStartChecklistView.swift in Sources */,
-				FA98B61929A3BF050071AAE8 /* BlazeCardView.swift in Sources */,
+				FA98B61929A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */,
 				AB758D9E25EFDF9C00961C0B /* LikesListController.swift in Sources */,
 				E1FD45E01C030B3800750F4C /* AccountSettingsService.swift in Sources */,
 				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
@@ -23990,7 +23990,7 @@
 				FABB21932602FC2C00C8785C /* GutenbergTenorMediaPicker.swift in Sources */,
 				3F8B45A029283D6C00730FA4 /* DashboardMigrationSuccessCell.swift in Sources */,
 				F45326D929F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */,
-				FA98B61A29A3BF050071AAE8 /* BlazeCardView.swift in Sources */,
+				FA98B61A29A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */,
 				FABB21942602FC2C00C8785C /* AztecPostViewController.swift in Sources */,
 				F1585442267D3BF900A2E966 /* CalendarDayToggleButton.swift in Sources */,
 				FE4C46FF27FAE61700285F35 /* DashboardPromptsCardCell.swift in Sources */,


### PR DESCRIPTION
Related Issue #20745

- `DashboardBlazeCardCell` now displays either `DashboardBlazePromoCardView` (renamed) or `DashboardBlazeCampaignsCardView` depending on the scenario. For now, it displays the campaigns when `.blazeManageCampaigns` flag is enabled.
- Add analytics

## To test:

- Enable `.blazeManageCampaigns` feature flag
- Restart (**note**: in the future, it'll reload automatically when the data that it binds to changes)
- Verify that the new card is displayed

## Regression Notes
1. Potential unintended areas of impact: the production version of the Blaze card aka Blaze Promo
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
