### PR TITLE
Enable `overridden_super_call` SwiftLint rule and address violations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,8 @@
 parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
 remote_timeout: 10.0
+
+opt_in_rules:
+  - overridden_super_call
+
+overridden_super_call:
+  severity: error

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -499,7 +499,7 @@ PODS:
   - Sodium (0.9.1)
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
-  - SwiftLint (0.50.3)
+  - SwiftLint (0.52.2)
   - UIDeviceIdentifier (2.3.0)
   - WordPress-Aztec-iOS (1.19.8)
   - WordPress-Editor-iOS (1.19.8):
@@ -880,7 +880,7 @@ SPEC CHECKSUMS:
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  SwiftLint: 77f7cb2b9bb81ab4a12fcc86448ba3f11afa50c6
+  SwiftLint: 1ac76dac888ca05cb0cf24d0c85887ec1209961d
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -60,6 +60,8 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
     var router: ActivityContentRouter?
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         setupLabelStyles()
         setupViews()
         setupText()

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -155,6 +155,8 @@ class BaseActivityListViewController: UIViewController, TableViewContainer, Immu
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
         SVProgressHUD.dismiss()
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -57,6 +57,8 @@ class CalendarViewController: UIViewController {
     }
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         title = NSLocalizedString("Choose date range", comment: "Title to choose date range in a calendar")
 
         // Configure Calendar

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -82,6 +82,8 @@ final class BlogDashboardViewController: UIViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
         stopAlertTimer()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -156,6 +156,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     // MARK: - View Lifecycle
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         setupView()
         setupConstraints()
         setupNavigationItem()

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SettingsTitleSubtitleController.swift
@@ -115,6 +115,8 @@ final class SettingsTitleSubtitleController: UITableViewController {
     }
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         setupNavigationBar()
         setupTitle()
         setupTable()

--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -46,6 +46,8 @@ class ExpandableCell: WPReusableTableViewCell {
     }
 
     override func awakeFromNib() {
+        super.awakeFromNib()
+
         setupSubviews()
     }
 

--- a/WordPress/Classes/ViewRelated/Cells/TitleBadgeDisclosureCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TitleBadgeDisclosureCell.swift
@@ -50,6 +50,8 @@ final class TitleBadgeDisclosureCell: WPTableViewCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
+
         cellTitle.text = ""
         cellBadge.text = ""
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
@@ -55,6 +55,8 @@ public class GutenbergSuggestionsViewController: UIViewController {
     }
 
     override public func viewDidLoad() {
+        super.viewDidLoad()
+
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .clear
 
@@ -98,6 +100,8 @@ public class GutenbergSuggestionsViewController: UIViewController {
     }
 
     override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
         suggestionsView.showSuggestions(forWord: suggestionType.trigger)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -156,6 +156,8 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     // MARK: Cell Lifecycle
 
     override func prepareForReuse() {
+        super.prepareForReuse()
+
         containerStackView.removeAllSubviews()
     }
 

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -34,6 +34,8 @@ class ChangeUsernameViewController: SignupUsernameTableViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
         viewModel.start()
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -71,6 +71,8 @@ class UnifiedProloguePageViewController: UIViewController {
     }
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         activateConstraints()
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -10,6 +10,8 @@ class PeopleCell: WPTableViewCell {
     @IBOutlet private weak var badgeStackView: UIStackView!
 
     override func awakeFromNib() {
+        super.awakeFromNib()
+
         WPStyleGuide.configureLabel(displayNameLabel, textStyle: .callout)
         WPStyleGuide.configureLabel(usernameLabel, textStyle: .caption2)
     }

--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -219,6 +219,8 @@ class CollectionViewContainerCell: UITableViewCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
+
         noResultsView?.removeFromView()
         noResultsView = nil
     }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -115,6 +115,8 @@ class EditPostViewController: UIViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
         if !openWithPostPost && !hasShownEditor {
             showEditor()
             hasShownEditor = true

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionsNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionsNavigationController.swift
@@ -6,6 +6,8 @@ class RevisionsNavigationController: UINavigationController {
     }
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         navigationBar.setBackgroundImage(UIImage(color: .neutral(.shade70)), for: .default)
         navigationBar.shadowImage = UIImage(color: .neutral(.shade60))
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -20,6 +20,8 @@ class ReaderDetailLikesListController: UITableViewController, NoResultsViewHost 
 
     // MARK: - View
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         configureViewTitle()
         configureTable()
         WPAnalytics.track(.likeListOpened, properties: ["list_type": "post", "source": "like_reader_list"])

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -15,6 +15,8 @@ class ReaderWebView: WKWebView {
     /// Make the webview transparent
     ///
     override func awakeFromNib() {
+        super.awakeFromNib()
+
         isOpaque = false
         backgroundColor = .clear
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -172,6 +172,8 @@ extension ReaderTabViewController: UIViewControllerRestoration {
     }
 
     override func encodeRestorableState(with coder: NSCoder) {
+        super.encodeRestorableState(with: coder)
+
         coder.encode(viewModel.selectedIndex, forKey: ReaderTabViewController.encodedIndexKey)
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Intent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Intent/IntentCell.swift
@@ -42,6 +42,8 @@ final class IntentCell: UITableViewCell, ModelSettableCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
+
         title.text = nil
         emoji.text = nil
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsCell.swift
@@ -53,6 +53,8 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
+
         title.text = ""
         subtitle.text = ""
         icon.image = nil

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -269,6 +269,8 @@ extension AddressTableViewCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
+
         update(with: nil as DomainSuggestion?)
         borders.forEach({ $0.removeFromSuperview() })
         borders = []

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -22,6 +22,8 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
     // MARK: - Configure
 
     override func awakeFromNib() {
+        super.awakeFromNib()
+
         defaultStackViewTopConstraint = stackViewTopConstraint.constant
         defaultStackViewHeightConstraint = stackViewHeightConstraint.constant
     }

--- a/WordPress/Classes/ViewRelated/System/BlurredEmptyViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/BlurredEmptyViewController.swift
@@ -21,6 +21,8 @@ class BlurredEmptyViewController: UIViewController {
     // MARK: View Lifecycle
 
     override func viewDidLoad() {
+        super.viewDidLoad()
+
         view.addSubview(visualEffectView)
         view.pinSubviewToAllEdges(visualEffectView)
     }


### PR DESCRIPTION
Recently, we discovered some issues possibly due to our code calling the wrong `super` life cycle method, e.g.

- https://github.com/wordpress-mobile/MediaEditor-iOS/pull/40
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20844

This PR enable as SwiftLint rule that ensures various overrides of `UIKit` methods call their respective superclass method. As an added bonus, the rule will pick up any inconsistent `super` call:

<img width="811" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/f81abc6e-fcdf-434b-a5e8-37dfc07c79a7">

It's worth mentioning that calling `super` in those subclasses could be [superfluous](https://stackoverflow.com/a/51995637/809944). At the same time, there's no guarantee UIKit will start doing _something_ in those internal methods. Plus, enforcing calling `super` ensures that, were we to add a custom subclass in between the UIKit one, our custom code will be called. Finally, this ensures consistency across the codebase, which is almost always desirable.