### PR TITLE
Fix fab overlapping the personalize dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -238,7 +238,7 @@ extension BlogDashboardViewController {
         let isQuickActionSection = viewModel.isQuickActionsSection(sectionIndex)
         let isMigrationSuccessCardSection = viewModel.isMigrationSuccessCardSection(sectionIndex)
         let horizontalInset = isQuickActionSection ? 0 : Constants.horizontalSectionInset
-        let bottomInset = isQuickActionSection || isMigrationSuccessCardSection ? 0 : Constants.verticalSectionInset
+        let bottomInset = isQuickActionSection || isMigrationSuccessCardSection ? 0 : Constants.bottomSectionInset
         section.contentInsets = NSDirectionalEdgeInsets(top: Constants.verticalSectionInset,
                                                         leading: horizontalInset,
                                                         bottom: bottomInset,
@@ -321,6 +321,10 @@ extension BlogDashboardViewController {
         static let estimatedHeight: CGFloat = 44
         static let horizontalSectionInset: CGFloat = 20
         static let verticalSectionInset: CGFloat = 20
+        static var bottomSectionInset: CGFloat {
+            // Make room for FAB on iPhone
+            WPDeviceIdentification.isiPad() ? verticalSectionInset : 86
+        }
         static let cellSpacing: CGFloat = 20
     }
 }


### PR DESCRIPTION
Fixes p1687520174373819-slack-C0290FLA0RM reported by @osullivanchris.

## To test:

- Verify that the FAB no longer cuts off the "Personalize" card on iPhone
- Verify that there is no extra spacing on the bottom of the dashboard on iPad

 
<img width="453" alt="Screenshot 2023-06-23 at 9 54 54 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b30f6319-a4ce-45c4-b90e-5765ed60aafa">

<img width="970" alt="Screenshot 2023-06-23 at 9 42 10 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/bb281800-7d7d-4dba-8076-5e9f5378ad1f">

## Regression Notes
1. Potential unintended areas of impact: Dashboard
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
