### PR TITLE
Add improved feature flags menu

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
@@ -45,6 +45,10 @@ struct FeatureFlagOverrideStore {
         }
     }
 
+    func removeOverride(for featureFlag: OverridableFlag) {
+        store.removeObject(forKey: key(for: featureFlag))
+    }
+
     /// - returns: The overridden value for the specified feature flag, if one exists.
     /// If no override exists, returns `nil`.
     ///

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugFeatureFlagsView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugFeatureFlagsView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+struct DebugFeatureFlagsView: View {
+    @StateObject private var viewModel = DebugFeatureFlagsViewModel()
+
+    var body: some View {
+        List {
+            sections
+        }
+        .tint(Color(UIColor.jetpackGreen))
+        .listStyle(.grouped)
+        .searchable(text: $viewModel.filterTerm)
+        .navigationTitle(navigationTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .apply(addToolbarTitleMenu)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu(content: {
+                    Button("Enable All Flags", action: viewModel.enableAllFlags)
+                    Button("Reset All Flags", role: .destructive, action: viewModel.reset)
+                }, label: {
+                    Image(systemName: "ellipsis.circle")
+                })
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sections: some View {
+        let remoteFlags = viewModel.getRemoteFeatureFlags()
+        if !remoteFlags.isEmpty {
+            Section("Remote Feature Flags") {
+                ForEach(remoteFlags, id: \.self) { flag in
+                    makeToggle(flag.description, isOn: viewModel.binding(for: flag), isOverriden: viewModel.isOverriden(flag))
+                }
+            }
+        }
+
+        let localFlags = viewModel.getLocalFeatureFlags()
+        if !localFlags.isEmpty {
+            Section("Local Feature Flags") {
+                ForEach(localFlags, id: \.self) { flag in
+                    makeToggle(flag.description, isOn: viewModel.binding(for: flag), isOverriden: viewModel.isOverriden(flag))
+                }
+            }
+        }
+    }
+
+    private func makeToggle(_ title: String, isOn: Binding<Bool>, isOverriden: Bool) -> some View {
+        Toggle(isOn: isOn) {
+            VStack(alignment: .leading) {
+                Text(title)
+                if isOverriden {
+                    Text("Overriden")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    func addToolbarTitleMenu<T: View>(_ view: T) -> some View {
+        if #available(iOS 16, *) {
+            view.toolbarTitleMenu {
+                Picker("Filter", selection: $viewModel.filter) {
+                    Text("Feature Flags (All)").tag(DebugFeatureFlagFilter.all)
+                    Text("Remote Feature Flags").tag(DebugFeatureFlagFilter.remote)
+                    Text("Local Feature Flags").tag(DebugFeatureFlagFilter.local)
+                }.pickerStyle(.inline)
+            }
+        } else {
+            view
+        }
+    }
+
+    private var navigationTitle: String {
+        switch viewModel.filter {
+        case .all: return "Feature Flags"
+        case .remote: return "Remote Feature Flags"
+        case .local: return "Local Feature Flags"
+        }
+    }
+}
+
+private final class DebugFeatureFlagsViewModel: ObservableObject {
+    private let remoteStore = RemoteFeatureFlagStore()
+    private let overrideStore = FeatureFlagOverrideStore()
+
+    private let allRemoteFlags = RemoteFeatureFlag.allCases.filter(\.canOverride)
+    private let allLocalFlags = FeatureFlag.allCases.filter(\.canOverride)
+
+    @Published var filter: DebugFeatureFlagFilter = .all
+    @Published var filterTerm = ""
+
+    // MARK: Remote Feature Flags
+
+    func getRemoteFeatureFlags() -> [RemoteFeatureFlag] {
+        guard [.all, .remote].contains(filter) else { return [] }
+        guard !filterTerm.isEmpty else { return allRemoteFlags }
+        return allRemoteFlags.filter {
+            $0.description.localizedCaseInsensitiveContains(filterTerm) ||
+            $0.remoteKey.contains(filterTerm)
+        }
+    }
+
+    func binding(for flag: RemoteFeatureFlag) -> Binding<Bool> {
+        Binding(get: { [unowned self] in
+            flag.enabled(using: remoteStore, overrideStore: overrideStore)
+        }, set: { [unowned self] in
+            override(flag, withValue: $0)
+        })
+    }
+
+    func isOverriden(_ flag: OverridableFlag) -> Bool {
+        overrideStore.isOverridden(flag)
+    }
+
+    private func override(_ flag: OverridableFlag, withValue value: Bool) {
+        try? overrideStore.override(flag, withValue: value)
+        objectWillChange.send()
+    }
+
+    // MARK: Local Feature Flags
+
+    func getLocalFeatureFlags() -> [FeatureFlag] {
+        guard [.all, .local].contains(filter) else { return [] }
+        guard !filterTerm.isEmpty else { return allLocalFlags }
+        return allLocalFlags.filter {
+            $0.description.localizedCaseInsensitiveContains(filterTerm)
+        }
+    }
+
+    func binding(for flag: FeatureFlag) -> Binding<Bool> {
+        Binding(get: {
+            flag.enabled
+        }, set: { [unowned self] in
+            override(flag, withValue: $0)
+        })
+    }
+
+    // MARK: Actions
+
+    func enableAllFlags() {
+        for flag in RemoteFeatureFlag.allCases where !flag.enabled() {
+            try? overrideStore.override(flag, withValue: true)
+        }
+        for flag in FeatureFlag.allCases where !flag.enabled {
+            try? overrideStore.override(flag, withValue: true)
+        }
+        objectWillChange.send()
+    }
+
+    func reset() {
+        for flag in RemoteFeatureFlag.allCases {
+            overrideStore.removeOverride(for: flag)
+        }
+        for flag in FeatureFlag.allCases {
+            overrideStore.removeOverride(for: flag)
+        }
+        objectWillChange.send()
+    }
+}
+
+private enum DebugFeatureFlagFilter: Hashable {
+    case all
+    case remote
+    case local
+}
+
+private extension View {
+    func apply<T>(_ closure: (Self) -> T) -> T {
+        closure(self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -4,8 +4,6 @@ import SwiftUI
 
 class DebugMenuViewController: UITableViewController {
     private var handler: ImmuTableViewHandler!
-    private let remoteStore = RemoteFeatureFlagStore()
-    private let overrideStore = FeatureFlagOverrideStore()
 
     override init(style: UITableView.Style) {
         super.init(style: style)
@@ -39,40 +37,24 @@ class DebugMenuViewController: UITableViewController {
     }
 
     private func reloadViewModel() {
-        let remoteFeatureFlags = RemoteFeatureFlag.allCases.filter({ $0.canOverride })
-        let remoteFeatureFlagsRows: [ImmuTableRow] = remoteFeatureFlags.map({ makeRemoteFeatureFlagsRows(for: $0) })
-
-        let localFeatureFlags = FeatureFlag.allCases.filter({ $0.canOverride })
-        let localFeatureFlagsRows: [ImmuTableRow] = localFeatureFlags.map({ makeLocalFeatureFlagsRow(for: $0) })
-
         handler.viewModel = ImmuTable(sections: [
-            ImmuTableSection(headerText: Strings.remoteFeatureFlags, rows: remoteFeatureFlagsRows),
-            ImmuTableSection(headerText: Strings.localFeatureFlags, rows: localFeatureFlagsRows),
+            ImmuTableSection(headerText: "General", rows: generalRows),
             ImmuTableSection(headerText: Strings.tools, rows: toolsRows),
             ImmuTableSection(headerText: Strings.crashLogging, rows: crashLoggingRows),
             ImmuTableSection(headerText: Strings.reader, rows: readerRows),
         ])
     }
 
-    private func makeLocalFeatureFlagsRow(for flag: FeatureFlag) -> ImmuTableRow {
-        let overridden: String? = overrideStore.isOverridden(flag) ? Strings.overridden : nil
-
-        return SwitchWithSubtitleRow(title: String(describing: flag), value: flag.enabled, subtitle: overridden, onChange: { isOn in
-            try? self.overrideStore.override(flag, withValue: isOn)
-            self.reloadViewModel()
-        })
-    }
-
-    private func makeRemoteFeatureFlagsRows(for flag: RemoteFeatureFlag) -> ImmuTableRow {
-        let overridden: String? = overrideStore.isOverridden(flag) ? Strings.overridden : nil
-        let enabled = flag.enabled(using: remoteStore, overrideStore: overrideStore)
-        return SwitchWithSubtitleRow(title: String(describing: flag), value: enabled, subtitle: overridden, onChange: { isOn in
-            try? self.overrideStore.override(flag, withValue: isOn)
-            self.reloadViewModel()
-        })
-    }
-
     // MARK: Tools
+
+    private var generalRows: [ImmuTableRow] {
+        [
+            NavigationItemRow(title: "Feature Flags") { [weak self] _ in
+                let vc = UIHostingController(rootView: DebugFeatureFlagsView())
+                self?.navigationController?.pushViewController(vc, animated: true)
+            }
+        ]
+    }
 
     private var toolsRows: [ImmuTableRow] {
         var toolsRows = [
@@ -196,9 +178,6 @@ class DebugMenuViewController: UITableViewController {
     }
 
     enum Strings {
-        static let overridden = NSLocalizedString("Overridden", comment: "Used to indicate a setting is overridden in debug builds of the app")
-        static let localFeatureFlags = NSLocalizedString("debugMenu.section.localFeatureFlags", value: "Local Feature Flags", comment: "Title of the Local Feature Flags screen used in debug builds of the app")
-        static let remoteFeatureFlags = NSLocalizedString("debugMenu.section.remoteFeatureFlags", value: "Remote Feature Flags", comment: "Title of the Remote Feature Flags screen used in debug builds of the app")
         static let tools = NSLocalizedString("Tools", comment: "Title of the Tools section of the debug screen used in debug builds of the app")
         static let sandboxStoreCookieSecretRow = NSLocalizedString("Use Sandbox Store", comment: "Title of a row displayed on the debug screen used to configure the sandbox store use in the App.")
         static let quickStartForNewSiteRow = NSLocalizedString("Enable Quick Start for New Site", comment: "Title of a row displayed on the debug screen used in debug builds of the app")

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -38,7 +38,7 @@ class DebugMenuViewController: UITableViewController {
 
     private func reloadViewModel() {
         handler.viewModel = ImmuTable(sections: [
-            ImmuTableSection(headerText: "General", rows: generalRows),
+            ImmuTableSection(headerText: Strings.general, rows: generalRows),
             ImmuTableSection(headerText: Strings.tools, rows: toolsRows),
             ImmuTableSection(headerText: Strings.crashLogging, rows: crashLoggingRows),
             ImmuTableSection(headerText: Strings.reader, rows: readerRows),
@@ -49,7 +49,7 @@ class DebugMenuViewController: UITableViewController {
 
     private var generalRows: [ImmuTableRow] {
         [
-            NavigationItemRow(title: "Feature Flags") { [weak self] _ in
+            NavigationItemRow(title: Strings.featureFlags) { [weak self] _ in
                 let vc = UIHostingController(rootView: DebugFeatureFlagsView())
                 self?.navigationController?.pushViewController(vc, animated: true)
             }
@@ -191,8 +191,8 @@ class DebugMenuViewController: UITableViewController {
         static let readerCssTitle = NSLocalizedString("Reader CSS URL", comment: "Title of the screen that allows the user to change the Reader CSS URL for debug builds")
         static let readerURLPlaceholder = NSLocalizedString("Default URL", comment: "Placeholder for the reader CSS URL")
         static let readerURLHint = NSLocalizedString("Add a custom CSS URL here to be loaded in Reader. If you're running Calypso locally this can be something like: http://192.168.15.23:3000/calypso/reader-mobile.css", comment: "Hint for the reader CSS URL field")
-        static let remoteConfigTitle = NSLocalizedString("debugMenu.remoteConfig.title",
-                                                         value: "Remote Config",
-                                                         comment: "Remote Config debug menu title")
+        static let remoteConfigTitle = NSLocalizedString("debugMenu.remoteConfig.title", value: "Remote Config", comment: "Remote Config debug menu title")
+        static let general = NSLocalizedString("debugMenu.generalSectionTitle", value: "General", comment: "General section title")
+        static let featureFlags = NSLocalizedString("debugMenu.featureFlags", value: "Feature Flags", comment: "Feature flags menu item")
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -379,6 +379,8 @@
 		0CD382862A4B6FCF00612173 /* DashboardBlazeCardCellViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD382852A4B6FCE00612173 /* DashboardBlazeCardCellViewModelTest.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
+		0CED95602A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
+		0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
 		17039225282E6D2800F602E9 /* ViewsVisitorsLineChartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC772B0728201F5300664C02 /* ViewsVisitorsLineChartCell.swift */; };
@@ -6095,6 +6097,7 @@
 		0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModel.swift; sourceTree = "<group>"; };
 		0CD382852A4B6FCE00612173 /* DashboardBlazeCardCellViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModelTest.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
+		0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFeatureFlagsView.swift; sourceTree = "<group>"; };
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		150B6590614A28DF9AD25491 /* Pods-Apps-Jetpack.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		152F25D5C232985E30F56CAC /* Pods-Apps-Jetpack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.debug.xcconfig"; sourceTree = "<group>"; };
@@ -11098,6 +11101,7 @@
 				3F29EB6824041F6D005313DE /* About */,
 				FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */,
 				17E4CD0B238C33F300C56916 /* DebugMenuViewController.swift */,
+				0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */,
 				F9B862C82478170A008B093C /* EncryptedLogTableViewController.swift */,
 				CECEEB542823164800A28ADE /* MediaCacheSettingsViewController.swift */,
 				80A2154229D1177A002FE8EB /* RemoteConfigDebugViewController.swift */,
@@ -21658,6 +21662,7 @@
 				E15644E91CE0E47C00D96E64 /* RoundedButton.swift in Sources */,
 				08A250FC28D9F0E200F50420 /* CommentDetailInfoViewModel.swift in Sources */,
 				08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */,
+				0CED95602A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */,
 				FA73D7D6278D9E5D00DF24B3 /* BlogDashboardViewController.swift in Sources */,
 				4349B0AF218A477F0034118A /* RevisionsTableViewCell.swift in Sources */,
 				738B9A5921B85CF20005062B /* KeyboardInfo.swift in Sources */,
@@ -24651,6 +24656,7 @@
 				FABB23282602FC2C00C8785C /* LoggingURLRedactor.swift in Sources */,
 				FABB23292602FC2C00C8785C /* SiteStatsTableViewCells.swift in Sources */,
 				FABB232A2602FC2C00C8785C /* SharingButton.swift in Sources */,
+				0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */,
 				FABB232B2602FC2C00C8785C /* PostActionSheet.swift in Sources */,
 				FABB232C2602FC2C00C8785C /* PublicizeConnection.swift in Sources */,
 				FABB232D2602FC2C00C8785C /* TenorPageable.swift in Sources */,


### PR DESCRIPTION
> I started during the HACK week and wrapped up now that I had some time.

Add a dedicated screen for tweaking the feature flags. 
- Allows searching and filters flags
- You can easily enable all flags or reset all overrides
- The non-inset grouped style makes most flag titles fit in a single line
- You no longer have to scroll to the bottom of the Debug screen to reach tools and options previously below the feature flags sections. 

See the [recording](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/98435afa-4dc1-440d-b4c7-81cbe336f94a) for more info.

<img width="453" alt="Screenshot 2023-06-23 at 6 16 12 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/5541fe9d-8be1-40f6-bd71-567412114485"> 

## To test:

- Open the Debug Menu
- Verify that their is a dedicated Feature Flags screens
- Verify that search and filters work
- Verify that "Enable All" and "Reset All" features work

## Regression Notes
1. Potential unintended areas of impact: only the Debug menu
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.