### PR TITLE
Update Editor Publish button tint color from editorPrimary to UIColor.black

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -30,7 +30,7 @@ class PostEditorNavigationBarManager {
         cancelButton.rightSpacing = Constants.cancelButtonPadding.right
         cancelButton.setContentHuggingPriority(.required, for: .horizontal)
         cancelButton.accessibilityIdentifier = "editor-close-button"
-        cancelButton.tintColor = .editorPrimary
+        cancelButton.tintColor = UIColor.black
         return cancelButton
     }()
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -43,6 +43,7 @@ class PostEditorNavigationBarManager {
         button.accessibilityIdentifier = "more_post_options"
         button.addTarget(self, action: #selector(moreWasPressed), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)
+        button.tintColor = UIColor.black
         return button
     }()
 
@@ -164,7 +165,7 @@ class PostEditorNavigationBarManager {
     }
 
     var rightBarButtonItems: [UIBarButtonItem] {
-        return [moreBarButtonItem, publishBarButtonItem, separatorButtonItem]
+        return [publishBarButtonItem, separatorButtonItem, moreBarButtonItem]
     }
 
     func reloadPublishButton() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -72,7 +72,7 @@ class PostEditorNavigationBarManager {
         button.sizeToFit()
         button.isEnabled = delegate?.isPublishButtonEnabled ?? false
         button.setContentHuggingPriority(.required, for: .horizontal)
-        button.tintColor = .editorPrimary
+        button.tintColor = UIColor.black
         return button
     }()
 


### PR DESCRIPTION
To test:

1. Open a page or post
2. Type text into post header and post content
3. Note that Publish button has changed from blue (`.editorPrimary`) to `UIColor.black`

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
TBD

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
