### PR TITLE
Make sure context is saved before calling the completion callback

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 22.8
 -----
+* [**] [internal] Make sure synced posts are saved before calling completion block. [#20960]
 
 
 22.7

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -701,10 +701,15 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
         }
     }
 
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    if (completion) {
-        completion(posts);
-    }
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+        // Call the completion block after context is saved. The callback is called on the context queue because `posts`
+        // contains models that are bound to the `self.managedObjectContext` object.
+        [self.managedObjectContext performBlock:^{
+            if (completion) {
+                completion(posts);
+            }
+        }];
+    } onQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
 }
 
 - (NSDictionary *)remoteSyncParametersDictionaryForRemote:(nonnull id <PostServiceRemote>)remote

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -704,11 +704,11 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
         // Call the completion block after context is saved. The callback is called on the context queue because `posts`
         // contains models that are bound to the `self.managedObjectContext` object.
-        [self.managedObjectContext performBlock:^{
-            if (completion) {
+        if (completion) {
+            [self.managedObjectContext performBlock:^{
                 completion(posts);
-            }
-        }];
+            }];
+        }
     } onQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
 }
 


### PR DESCRIPTION
Related to #20927 and #20809.

`saveContext:` performs `context.save` asynchronously. I think we'd want to call the `completion` block _after_ the context is saved, not while the context is being saved.

## Regression Notes
1. Potential unintended areas of impact
Features that relate to post.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
View post list (published, draft, etc).

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:N/A