### PR TITLE
Jetpack Social: Add tap actions to the no connections social view on the post settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -3,7 +3,7 @@ extension PostSettingsViewController {
 
     @objc func showNoConnection() -> Bool {
         let isJetpackSocialEnabled = FeatureFlag.jetpackSocial.enabled
-        let isNoConnectionViewHidden = UserPersistentStoreFactory.instance().bool(forKey: Constants.hideNoConnectionViewKey)
+        let isNoConnectionViewHidden = UserPersistentStoreFactory.instance().bool(forKey: hideNoConnectionViewKey())
         let blogSupportsPublicize = apost.blog.supportsPublicize()
         let blogHasNoConnections = publicizeConnections.count == 0
         let blogHasServices = availableServices().count > 0
@@ -27,6 +27,14 @@ extension PostSettingsViewController {
         return viewController.view
     }
 
+    private func hideNoConnectionViewKey() -> String {
+        guard let dotComID = apost.blog.dotComID?.stringValue else {
+            return Constants.hideNoConnectionViewKey
+        }
+
+        return "\(dotComID)-\(Constants.hideNoConnectionViewKey)"
+    }
+
     private func onConnectTap() -> () -> Void {
         return { [weak self] in
             guard let blog = self?.apost.blog,
@@ -39,7 +47,10 @@ extension PostSettingsViewController {
 
     private func onNotNowTap() -> () -> Void {
         return { [weak self] in
-            UserPersistentStoreFactory.instance().set(true, forKey: Constants.hideNoConnectionViewKey)
+            guard let key = self?.hideNoConnectionViewKey() else {
+                return
+            }
+            UserPersistentStoreFactory.instance().set(true, forKey: key)
             self?.tableView.reloadData()
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -3,11 +3,13 @@ extension PostSettingsViewController {
 
     @objc func showNoConnection() -> Bool {
         let isJetpackSocialEnabled = FeatureFlag.jetpackSocial.enabled
+        let isNoConnectionViewHidden = UserPersistentStoreFactory.instance().bool(forKey: Constants.hideNoConnectionViewKey)
         let blogSupportsPublicize = apost.blog.supportsPublicize()
         let blogHasNoConnections = publicizeConnections.count == 0
         let blogHasServices = availableServices().count > 0
 
         return isJetpackSocialEnabled
+        && !isNoConnectionViewHidden
         && blogSupportsPublicize
         && blogHasNoConnections
         && blogHasServices
@@ -15,16 +17,9 @@ extension PostSettingsViewController {
 
     @objc func createNoConnectionView() -> UIView {
         let services = availableServices()
-        let viewModel = JetpackSocialNoConnectionViewModel(
-            services: services,
-            onConnectTap: {
-                // TODO: Open the social screen
-                print("Connect tap")
-            }, onNotNowTap: {
-                // TODO: Add condition to hide the connection view after not now is tapped
-                print("Not now tap")
-            }
-        )
+        let viewModel = JetpackSocialNoConnectionViewModel(services: services,
+                                                           onConnectTap: onConnectTap(),
+                                                           onNotNowTap: onNotNowTap())
         let viewController = JetpackSocialNoConnectionView.createHostController(with: viewModel)
 
         // Returning just the view means the view controller will deallocate but we don't need a
@@ -32,10 +27,43 @@ extension PostSettingsViewController {
         return viewController.view
     }
 
+    private func onConnectTap() -> () -> Void {
+        return { [weak self] in
+            guard let blog = self?.apost.blog,
+                  let controller = SharingViewController(blog: blog, delegate: self) else {
+                return
+            }
+            self?.navigationController?.pushViewController(controller, animated: true)
+        }
+    }
+
+    private func onNotNowTap() -> () -> Void {
+        return { [weak self] in
+            UserPersistentStoreFactory.instance().set(true, forKey: Constants.hideNoConnectionViewKey)
+            self?.tableView.reloadData()
+        }
+    }
+
     private func availableServices() -> [PublicizeService] {
         let context = apost.managedObjectContext ?? ContextManager.shared.mainContext
         let services = try? PublicizeService.allPublicizeServices(in: context)
         return services ?? []
+    }
+
+    // MARK: - Constants
+
+    private struct Constants {
+        static let hideNoConnectionViewKey = "post-settings-social-no-connection-view-hidden"
+    }
+
+}
+
+// MARK: - SharingViewControllerDelegate
+
+extension PostSettingsViewController: SharingViewControllerDelegate {
+
+    public func didChangePublicizeServices() {
+        tableView.reloadData()
     }
 
 }


### PR DESCRIPTION
See: #20784

## Description

Adds the tap actions on the no connections view in the post settings screen.

## Testing

To test:
- Launch Jetpack and login
- Select a site which has no social connections but has services available
- Ensure the `PublicizeService` objects are cached (this can be done by going to the social screen)
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- Scroll to the no connections view
- Tap on `Connect your profiles`
- **Verify** the social screen is pushed into view
- Setup one of the social connections
- Navigate back to the post settings screen
- **Verify** the no connections view no longer appears and the social connection you setup is there
- Disconnect the social connection that was just added (Dashboard > Menu > Social)
- Navigate back to the post settings screen
- Tap on `Not now`
- **Verify** the no connections view disappears
- Navigate out of the post settings and then back
- **Verify** the no connections view still does not appear

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
