### PR TITLE
Jetpack Social: Add methods and fields to Blog for auto-sharing limit

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,6 +5,10 @@ data model as well as any custom migrations.
 
 ## WordPress 151
 
+@dvdchr 2023-06-28
+
+- `Blog`: added `planActiveFeatures` (optional, no default, `Transformable` with type `[String]`)
+
 @dvdchr 2023-06-23
 
 - Created a new entity `PublicizeInfo` with:

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 8.4-beta'
+  pod 'WordPressKit', '~> 8.5-beta'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -512,7 +512,7 @@ PODS:
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.4.0):
+  - WordPressKit (8.5.0-beta.2):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -612,7 +612,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 6.1-beta)
-  - WordPressKit (~> 8.4-beta)
+  - WordPressKit (~> 8.5-beta)
   - WordPressShared (~> 2.2-beta)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8-beta)
@@ -623,7 +623,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -662,6 +661,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -880,7 +880,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: b0b900696de5129a215adcd1e9ae6eb89da36ac8
-  WordPressKit: f445e6fc3c63ddf611513a435408f86fdf3808b3
+  WordPressKit: 31f5a9809b9c732e0da517967d8a94de725c15e6
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
@@ -895,6 +895,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 623e3fe64f67d2c0352e26d1ac2bcd58c06b3494
+PODFILE CHECKSUM: dd2923ba0655d06a0e85bdf9aa0d38304e8f087e
 
 COCOAPODS: 1.12.1

--- a/WordPress/Classes/Models/Blog+JetpackSocial.swift
+++ b/WordPress/Classes/Models/Blog+JetpackSocial.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Blog extension for methods related to Jetpack Social.
+extension Blog {
+    // MARK: - Publicize
+
+    /// Whether the blog has Social auto-sharing limited.
+    /// Note that sites hosted at WP.com has no Social sharing limitations.
+    var isSocialSharingLimited: Bool {
+        let features = planActiveFeatures ?? []
+        return !isHostedAtWPcom && !features.contains(Constants.socialSharingFeature)
+    }
+
+    /// The auto-sharing limit information for the blog.
+    var sharingLimit: PublicizeInfo.SharingLimit? {
+        // For blogs with unlimited shares, return nil early.
+        // This is because the endpoint will still return sharing limits as if the blog doesn't have unlimited sharing.
+        guard isSocialSharingLimited else {
+            return nil
+        }
+        return publicizeInfo?.sharingLimit
+    }
+
+    // MARK: - Private constants
+
+    private enum Constants {
+        /// The feature key listed in the blog's plan's features. At the moment, `social-shares-1000` means unlimited
+        /// sharing, but in the future we might introduce a proper differentiation between 1000 and unlimited.
+        static let socialSharingFeature = "social-shares-1000"
+    }
+}

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -164,6 +164,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, assign, readwrite) SiteVisibility siteVisibility;
 @property (nonatomic, strong, readwrite, nullable) NSNumber *planID;
 @property (nonatomic, strong, readwrite, nullable) NSString *planTitle;
+@property (nonatomic, strong, readwrite, nullable) NSArray<NSString *> *planActiveFeatures;
 @property (nonatomic, assign, readwrite) BOOL hasPaidPlan;
 @property (nonatomic, strong, readwrite, nullable) NSSet *sharingButtons;
 @property (nonatomic, strong, readwrite, nullable) NSDictionary *capabilities;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -81,6 +81,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 @dynamic settings;
 @dynamic planID;
 @dynamic planTitle;
+@dynamic planActiveFeatures;
 @dynamic hasPaidPlan;
 @dynamic sharingButtons;
 @dynamic capabilities;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -499,6 +499,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
     blog.options = remoteBlog.options;
     blog.planID = remoteBlog.planID;
     blog.planTitle = remoteBlog.planTitle;
+    blog.planActiveFeatures = remoteBlog.planActiveFeatures;
     blog.hasPaidPlan = remoteBlog.hasPaidPlan;
     blog.quotaSpaceAllowed = remoteBlog.quotaSpaceAllowed;
     blog.quotaSpaceUsed = remoteBlog.quotaSpaceUsed;

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 151.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 151.xcdatamodel/contents
@@ -171,6 +171,7 @@
         <attribute name="mobileEditor" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="organizationID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="planActiveFeatures" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]" syncable="YES"/>
         <attribute name="planID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="planTitle" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="postFormats" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5586,6 +5586,8 @@
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
 		FEDDD47026A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
+		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
+		FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEF4DC5528439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEF4DC5628439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEFA263E26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */; };
@@ -9362,6 +9364,7 @@
 		FED77257298BC5B300C2346E /* PluginJetpackProxyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginJetpackProxyService.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
+		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
 		FEFC0F872730510F001F7F1D /* WordPress 136.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 136.xcdatamodel"; sourceTree = "<group>"; };
@@ -14906,6 +14909,7 @@
 				F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */,
 				8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */,
 				4AD5656E28E413160054C676 /* Blog+History.swift */,
+				FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -21777,6 +21781,7 @@
 				D816C1E920E0880400C4D82F /* NotificationAction.swift in Sources */,
 				E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */,
 				FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */,
+				FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */,
 				E15644EF1CE0E53B00D96E64 /* PlanListViewModel.swift in Sources */,
 				983002A822FA05D600F03DBB /* InsightsManagementViewController.swift in Sources */,
 				98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */,
@@ -24448,6 +24453,7 @@
 				FABB22D42602FC2C00C8785C /* ManagedPerson+CoreDataProperties.swift in Sources */,
 				FE32F003275F602E0040BE67 /* CommentContentRenderer.swift in Sources */,
 				3FAE0653287C8FC500F46508 /* JPScrollViewDelegate.swift in Sources */,
+				FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */,
 				FABB22D52602FC2C00C8785C /* TenorStrings.swift in Sources */,
 				FAFC064F27D2360B002F0483 /* QuickStartCell.swift in Sources */,
 				086F2482284F52DD00032F39 /* TooltipAnchor.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5588,6 +5588,7 @@
 		FEDDD47026A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
+		FEE48EFF2A4C9855008A48E0 /* Blog+PublicizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */; };
 		FEF4DC5528439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEF4DC5628439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEFA263E26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */; };
@@ -9365,6 +9366,7 @@
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
+		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
 		FEFC0F872730510F001F7F1D /* WordPress 136.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 136.xcdatamodel"; sourceTree = "<group>"; };
@@ -12335,6 +12337,7 @@
 				2481B1E7260D4EAC00AE59DB /* WPAccount+LookupTests.swift */,
 				2481B20B260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m */,
 				C38C5D8027F61D2C002F517E /* MenuItemTests.swift */,
+				FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -23303,6 +23306,7 @@
 				570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */,
 				FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */,
 				3F1B66A323A2F54B0075F09E /* ReaderReblogActionTests.swift in Sources */,
+				FEE48EFF2A4C9855008A48E0 /* Blog+PublicizeTests.swift in Sources */,
 				5749984722FA0F2E00CE86ED /* PostNoticeViewModelTests.swift in Sources */,
 				08B6E51C1F037ADD00268F57 /* MediaFileManagerTests.swift in Sources */,
 				5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */,

--- a/WordPress/WordPressTest/Blog+PublicizeTests.swift
+++ b/WordPress/WordPressTest/Blog+PublicizeTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import XCTest
+
+@testable import WordPress
+
+final class Blog_PublicizeTests: CoreDataTestCase {
+
+    func testAutoSharingInfoForDotComBlog() {
+        let blog = makeBlog(hostedAtWPCom: true, activeSocialFeature: false)
+
+        // all dotcom sites should have no sharing limitations.
+        XCTAssertFalse(blog.isSocialSharingLimited)
+    }
+
+    func testAutoSharingInfoForDotComBlogWithStoredSharingLimit() {
+        // unlikely case, but let's test anyway.
+        let blog = makeBlog(hostedAtWPCom: true, activeSocialFeature: false, hasPreExistingData: true)
+
+        XCTAssertFalse(blog.isSocialSharingLimited)
+        XCTAssertNil(blog.sharingLimit)
+    }
+
+    func testAutoSharingInfoForSelfHostedBlog() {
+        let blog = makeBlog(hostedAtWPCom: false, activeSocialFeature: false)
+
+        XCTAssertTrue(blog.isSocialSharingLimited)
+    }
+
+    func testAutoSharingInfoForSelfHostedBlogWithStoredSharingLimit() {
+        let blog = makeBlog(hostedAtWPCom: false, activeSocialFeature: false, hasPreExistingData: true)
+
+        XCTAssertNotNil(blog.sharingLimit)
+    }
+
+    func testAutoSharingInfoForSelfHostedBlogWithSocialFeature() {
+        let blog = makeBlog(hostedAtWPCom: false, activeSocialFeature: true)
+
+        XCTAssertFalse(blog.isSocialSharingLimited)
+    }
+
+    func testAutoSharingInfoForSelfHostedBlogWithSocialFeatureAndStoredSharingLimit() {
+        // Example: a free site purchased an individual Social Basic plan. In this case, there should still be a
+        // `PublicizeInfo` data stored in Core Data, but the blog might still have the social feature active.
+        let blog = makeBlog(hostedAtWPCom: false, activeSocialFeature: true, hasPreExistingData: true)
+
+        // the sharing limit should be nil regardless of the existence of stored data.
+        XCTAssertNil(blog.sharingLimit)
+    }
+
+    // MARK: - Helpers
+
+    private func makeBlog(hostedAtWPCom: Bool, activeSocialFeature: Bool, hasPreExistingData: Bool = false) -> Blog {
+        let blog = BlogBuilder(mainContext)
+            .with(isHostedAtWPCom: hostedAtWPCom)
+            .with(planActiveFeatures: activeSocialFeature ? ["social-shares-1000"] : [])
+            .build()
+
+        if hasPreExistingData {
+            let publicizeInfo = PublicizeInfo(context: mainContext)
+            publicizeInfo.shareLimit = 30
+            publicizeInfo.sharesRemaining = 25
+            blog.publicizeInfo = publicizeInfo
+        }
+
+        return blog
+    }
+
+}

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -40,6 +40,11 @@ final class BlogBuilder {
         return self
     }
 
+    func with(planActiveFeatures: [String]) -> Self {
+        blog.planActiveFeatures = planActiveFeatures
+        return self
+    }
+
     func withJetpack(version: String? = nil, username: String? = nil, email: String? = nil) -> Self {
         set(blogOption: "jetpack_client_id", value: 1)
         set(blogOption: "jetpack_version", value: version as Any)

--- a/WordPress/WordPressTest/Dashboard/BlazeCampaignViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlazeCampaignViewModelTests.swift
@@ -29,6 +29,7 @@ private let campaign: BlazeCampaign = {
         "start_date": "2023-06-13T00:00:00Z",
         "end_date": "2023-06-01T19:15:45Z",
         "status": "finished",
+        "ui_status": "finished",
         "avatar_url": "https://0.gravatar.com/avatar/614d27bcc21db12e7c49b516b4750387?s=96&amp;d=identicon&amp;r=G",
         "budget_cents": 500,
         "target_url": "https://alextest9123.wordpress.com/2023/06/01/test-post/",


### PR DESCRIPTION
Closes #20806 

Two things are added through this PR:

- Added `planActiveFeatures` field to `Blog`, which contains an array of strings.
- Added convenience methods to `Blog`: `isSocialSharingLimited` (returns a boolean), and `sharingLimit` (returns a `PublicizeInfo.SharingLimit?`.

With this change, you can now simply check `isSocialSharingLimited` to determine whether to show auto-sharing limit information.

## To test

### Core Data additions

- In the model file, ensure that the `planActiveFeatures` field has a specified Transformer class `NSSecureUnarchiveFromData` with `[String]` as the custom class.
- Ensure that the MIGRATIONS.md addition matches the actual change.

Note that since this PR is targeting 22.8, I'm not bumping the model version.

### Blog+JetpackSocial

- Ensure that the unit tests are passing.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is unreleased and hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests for the new methods.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A. The PR doesn't contain user-facing changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
