### PR TITLE
Blogging Reminders: Don't show prompt if not allowed for blog

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 22.8
 -----
-
+* [*] Blogging Reminders: Disabled prompt for self-hosted sites not connected to Jetpack. [#20970]
 
 22.7
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -11,7 +11,7 @@ class BloggingRemindersFlow {
                         delegate: BloggingRemindersFlowDelegate? = nil,
                         onDismiss: DismissClosure? = nil) {
 
-        guard Feature.enabled(.bloggingReminders) && JetpackNotificationMigrationService.shared.shouldPresentNotifications() else {
+        guard blog.areBloggingRemindersAllowed() else {
             return
         }
 


### PR DESCRIPTION
Fixes #20963

## Description

The Blogging Reminders feature has two main UI components:
1. A one-time prompt shown per-blog to promote the feature.
2. A setting in Site Settings for the user to adjust when the local reminder notification is shown.

This PR adds the `blog.areBloggingRemindersAllowed()` check to the Blogging Reminders prompt so that it matches Site Settings.

Currently, the Blogging Reminders feature is only available in the Jetpack app. After the changes in this PR, it's also not available for self-hosted sites not connected to Jetpack. This PR mainly keeps these users from being able to set a Blogging Reminder once with no way to reconfigure it. See #20971.

## Testing

### No prompt shown after publishing first post
1. Add a self-hosted site that's not connected to Jetpack to the Jetpack app
4. Add a title and body to a new Post and publish it
5. Confirm that the Blogging Reminders prompt is not shown

| Before | After |
| - | - |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/9c834150-e90a-413d-acfb-dd2cd197975f" /> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/ea0efe6c-e131-48ef-a6b1-57b6f7c3105f" /> |

### Settings
1. In the Site Picker, choose self-hosted site that's not connected to Jetpack
2. From My Site with the Menu tab selected, go to Site Settings
3. Confirm that there's no "BLOGGING" section and no "Reminders" option

| Before | After (no change) |
| - | - |
| ![IMG_0406](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/8c86f996-a03d-4637-adfd-fad265898469) | ![IMG_0406](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/8c86f996-a03d-4637-adfd-fad265898469) |

## Regression Notes
1. Potential unintended areas of impact
- In the Jetpack app:
  - The initial promotional prompt should be shown for WordPress.com sites and self-hosted sites with a Jetpack connection.
  - Settings for Blogging Reminders should be accessible for WordPress.com sites and self-hosted sites with a Jetpack connection.
  - A reminder notification is shown at the scheduled time.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I tested that the blogging prompt appeared when posting (for the first time from a clean install) for a .com and Jetpack connected site.
- I accessed the Blogging Reminders settings from My Site -> Site Settings.
- I scheduled a Blogging Reminder for a .com and Jetpack connected site and confirmed that the notification was shown.
- **Note:** When testing, debug builds may stop on 

3. What automated tests I added (or what prevented me from doing so)
- I didn't add any automated tests for this change since it's based on boolean logic of `Feature.enabled(.bloggingReminders)`, `isUserCapableOf(.EditPosts)`, and `JetpackNotificationMigrationService.shared.shouldPresentNotifications()`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A
