### PR TITLE
Fix a memory leak in Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -41,6 +41,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
 
     weak var collectionView: UICollectionView?
+
     var topics: [String] {
         didSet {
             reloadData()

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -53,7 +53,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
         super.init()
 
-        configureCollectionView()
+        configure(collectionView)
     }
 
     func invalidate() {
@@ -78,7 +78,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         layout.isExpanded = state == .expanded
     }
 
-    private func configureCollectionView() {
+    private func configure(_ collectionView: UICollectionView) {
         collectionView.isAccessibilityElement = false
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -105,7 +105,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         layout.allowsCentering = false
     }
 
-    private func sizeForCell(title: String) -> CGSize {
+    private func sizeForCell(title: String, of collectionView: UICollectionView)-> CGSize {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: ReaderInterestsStyleGuide.compactCellLabelTitleFont
         ]
@@ -206,7 +206,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return sizeForCell(title: topics[indexPath.row])
+        return sizeForCell(title: topics[indexPath.row], of: collectionView)
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -225,6 +225,6 @@ extension ReaderTopicCollectionViewCoordinator: ReaderInterestsCollectionViewFlo
     func collectionView(_ collectionView: UICollectionView, layout: ReaderInterestsCollectionViewFlowLayout, sizeForOverflowItem at: IndexPath, remainingItems: Int?) -> CGSize {
 
         let title = string(for: remainingItems)
-        return sizeForCell(title: title)
+        return sizeForCell(title: title, of: collectionView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -40,7 +40,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
 
-    unowned let collectionView: UICollectionView
+    weak var collectionView: UICollectionView?
     var topics: [String] {
         didSet {
             reloadData()
@@ -57,7 +57,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     }
 
     func invalidate() {
-        guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
+        guard let layout = collectionView?.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
             return
         }
 
@@ -66,12 +66,12 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     }
 
     func reloadData() {
-        collectionView.reloadData()
-        collectionView.invalidateIntrinsicContentSize()
+        collectionView?.reloadData()
+        collectionView?.invalidateIntrinsicContentSize()
     }
 
     func changeState(_ state: ReaderTopicCollectionViewState) {
-        guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
+        guard let layout = collectionView?.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
             return
         }
 
@@ -193,7 +193,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
     }
 
     @objc func toggleExpanded(_ sender: ReaderInterestsCollectionViewCell) {
-        guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
+        guard let layout = collectionView?.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -40,20 +40,11 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
 
-    let collectionView: UICollectionView
+    unowned let collectionView: UICollectionView
     var topics: [String] {
         didSet {
             reloadData()
         }
-    }
-
-    deinit {
-        guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
-            return
-        }
-
-        layout.isExpanded = false
-        layout.invalidateLayout()
     }
 
     init(collectionView: UICollectionView, topics: [String]) {
@@ -63,6 +54,15 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         super.init()
 
         configureCollectionView()
+    }
+
+    func invalidate() {
+        guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
+            return
+        }
+
+        layout.isExpanded = false
+        layout.invalidateLayout()
     }
 
     func reloadData() {

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -27,6 +27,10 @@ class TopicsCollectionView: DynamicHeightCollectionView {
         commonInit()
     }
 
+    deinit {
+        coordinator?.invalidate()
+    }
+
     func commonInit() {
         collectionViewLayout = ReaderInterestsCollectionViewFlowLayout()
 


### PR DESCRIPTION
Fixes #20972.

There is a retain cycle between [`TopicsCollectionView`](https://github.com/wordpress-mobile/WordPress-iOS/blob/32972a8dfadd96a10c1c423dbd1d3360228337e0/WordPress/Classes/ViewRelated/Reader/Tags%20View/TopicsCollectionView.swift#L33) and [`ReaderTopicCollectionViewCoordinator`](https://github.com/wordpress-mobile/WordPress-iOS/blob/32972a8dfadd96a10c1c423dbd1d3360228337e0/WordPress/Classes/ViewRelated/Reader/Tags%20View/ReaderTopicCollectionViewCoordinator.swift#L43). Given the collection view uses the coordinator to do the layout things, the collection view should hold a strong reference to the coordinator, and the coordinator holds a weak reference back to the collection view.

There is a logic in the `ReaderTopicCollectionViewCoordinator` where it invalidates collection view layout during `deinit`. Considering `TopicsCollectionView` is the only class that uses the coordinator, I have moved this logic into a plain function which is now called from the collection view's `deinit`.

Now that the `collectionView` in the coordinator becomes an optional `weak var`, I have changed some functions in the coordinator to use collection view references passed from `UICollectionView` related delegate and data source, instead of the `weak var` stored property. They are still referencing the same object at runtime, but it'd avoid some unnecessary optional unwrapping which is required if using the `weak var`.                                        

BTW, it might be easier to review this PR commit by commits.

## Test Instructions

`TopicsCollectionView` is the red square part in the screenshot below.

<img width="561" alt="Screenshot 2023-06-30 at 11 39 48 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1101828/068242cc-fd2f-4fd3-9b62-1a5729dbeb70">

When you scroll through the post lists in the Reader tab, some cell instances should be released which should release `TopicsCollectionView` instances along with them. That mean a breakpoint in `TopicsCollectionView.deinit` should be triggered when you scroll through the posts, switch tabs. You can verify there is indeed a memory leak by adding a breakpoint to `TopicsCollectionView.deinit` and seeing that it will never be triggered.

You can add the same breakpoint in this PR branch and verify that it will be triggered during browsing posts in the Reader tab.

## Regression Notes
1. Potential unintended areas of impact
None. `TopicsCollectionView` is the only place uses `ReaderTopicCollectionViewCoordinator`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Browsing Reader posts, tapping the expand and collapse buttons in the topics view.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
