### PR TITLE
Comments: Remove VisualEffectView usage

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentTableHeaderView.swift
@@ -96,18 +96,6 @@ private struct CommentHeaderView: View {
     @State var showsDisclosureIndicator = true
 
     var body: some View {
-        if #available(iOS 15.0, *) {
-            // Material ShapeStyles are only available from iOS 15.0.
-            content.background(.ultraThinMaterial)
-        } else {
-            ZStack {
-                VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-                content
-            }
-        }
-    }
-
-    var content: some View {
         HStack {
             text
             Spacer()
@@ -115,6 +103,7 @@ private struct CommentHeaderView: View {
                 disclosureIndicator
             }
         }
+        .background(.ultraThinMaterial)
         .padding(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
     }
 
@@ -137,19 +126,5 @@ private struct CommentHeaderView: View {
             .foregroundColor(Color(.secondaryLabel))
             .font(.caption.weight(.semibold))
             .imageScale(.large)
-    }
-}
-
-// MARK: SwiftUI VisualEffect support for iOS 14
-
-private struct VisualEffectView: UIViewRepresentable {
-    var effect: UIVisualEffect
-
-    func makeUIView(context: Context) -> UIVisualEffectView {
-        return UIVisualEffectView()
-    }
-
-    func updateUIView(_ uiView: UIVisualEffectView, context: Context) {
-        uiView.effect = effect
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentTableHeaderView.swift
@@ -103,8 +103,8 @@ private struct CommentHeaderView: View {
                 disclosureIndicator
             }
         }
-        .background(.ultraThinMaterial)
         .padding(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
+        .background(.ultraThinMaterial)
     }
 
     var text: some View {


### PR DESCRIPTION
Fixes n/a

`VisualEffectView` was a SwiftUI fallback implementation for [materials](https://developer.apple.com/design/human-interface-guidelines/materials) on iOS 14. Now that we've bumped our minimum version to iOS 15 (via #20917), we can remove this custom implementation.

## To test

- Launch the Jetpack app.
- Turn on the `Comment moderation update` feature flag.
- Go to Reader > any comment thread.
- Verify that the comment header background is displayed in material.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The component is private and only used in one place where the feature is not released.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
