### PR TITLE
Fix discarded notification observers in StatsWidgetsStore

### DIFF
--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -258,22 +258,21 @@ private extension StatsWidgetsStore {
     /// Observes WPAccountDefaultWordPressComAccountChanged notification and reloads widget data based on the state of account.
     /// The site data is not yet loaded after this notification and widget data cannot be cached for newly signed in account.
     func observeAccountChangesForWidgets() {
-        NotificationCenter.default.addObserver(forName: .WPAccountDefaultWordPressComAccountChanged,
-                                               object: nil,
-                                               queue: nil) { notification in
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAccountChangedNotification), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+    }
 
-            UserDefaults(suiteName: WPAppGroupName)?.setValue(AccountHelper.isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
+    @objc func handleAccountChangedNotification() {
+        UserDefaults(suiteName: WPAppGroupName)?.setValue(AccountHelper.isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
 
-            if !AccountHelper.isLoggedIn {
-                HomeWidgetTodayData.delete()
-                HomeWidgetThisWeekData.delete()
-                HomeWidgetAllTimeData.delete()
+        if !AccountHelper.isLoggedIn {
+            HomeWidgetTodayData.delete()
+            HomeWidgetThisWeekData.delete()
+            HomeWidgetAllTimeData.delete()
 
-                UserDefaults(suiteName: WPAppGroupName)?.setValue(nil, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
-                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
-                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
-                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
-            }
+            UserDefaults(suiteName: WPAppGroupName)?.setValue(nil, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
         }
     }
 
@@ -286,11 +285,11 @@ private extension StatsWidgetsStore {
 
     /// Observes applicationLaunchCompleted notification and runs migration.
     func observeApplicationLaunched() {
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.applicationLaunchCompleted,
-                                               object: nil,
-                                               queue: nil) { [weak self] _ in
-            self?.handleJetpackWidgetsMigration()
-        }
+        NotificationCenter.default.addObserver(self, selector: #selector(handleApplicationLaunchCompleted), name: NSNotification.Name.applicationLaunchCompleted, object: nil)
+    }
+
+    @objc private func handleApplicationLaunchCompleted() {
+        handleJetpackWidgetsMigration()
     }
 
     func observeJetpackFeaturesState() {

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -262,18 +262,20 @@ private extension StatsWidgetsStore {
     }
 
     @objc func handleAccountChangedNotification() {
-        UserDefaults(suiteName: WPAppGroupName)?.setValue(AccountHelper.isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
+        let isLoggedIn = AccountHelper.isLoggedIn
+        let userDefaults = UserDefaults(suiteName: WPAppGroupName)
+        userDefaults?.setValue(isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
 
-        if !AccountHelper.isLoggedIn {
-            HomeWidgetTodayData.delete()
-            HomeWidgetThisWeekData.delete()
-            HomeWidgetAllTimeData.delete()
+        guard !isLoggedIn else { return }
 
-            UserDefaults(suiteName: WPAppGroupName)?.setValue(nil, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
-        }
+        HomeWidgetTodayData.delete()
+        HomeWidgetThisWeekData.delete()
+        HomeWidgetAllTimeData.delete()
+
+        userDefaults?.setValue(nil, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
     }
 
     /// Observes WPSigninDidFinishNotification and wordpressLoginFinishedJetpackLogin notifications and initializes the widget.


### PR DESCRIPTION
Relates to #20994.

This PR changes to use `StatsWidgetsStore` as notification observers, so that `NSNotificationCenter` automatically unregister the observer when the store instance is released.

`StatsWidgetsStore` is currently a singleton, so technically there is no issue with current code and this PR has no effect at all to the app. However, `StatsWidgetsStore` may get to escape from [the `StoreContainer` singleton](https://github.com/wordpress-mobile/WordPress-iOS/blob/28dee282b052366e9d7d97971d8e986baa1f8c6a/WordPress/Classes/Stores/StoreContainer.swift) and the issue with notification observers will arise then. Also, we should not discard notification observers anyways.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Log in and log out.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
