### PR TITLE
Fix discarded notification observer in ContentMigrationCoordinator

### DIFF
--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -141,15 +141,16 @@ private extension ContentMigrationCoordinator {
             return
         }
 
-        notificationCenter.addObserver(forName: .WPAccountDefaultWordPressComAccountChanged, object: nil, queue: nil) { [weak self] notification in
-            // nil notification object means it's a logout event.
-            guard let self,
-                  notification.object == nil else {
-                return
-            }
+        notificationCenter.addObserver(self, selector: #selector(handleAccountChangedNotification(_:)), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+    }
 
-            self.cleanupExportedDataIfNeeded()
+    @objc private func handleAccountChangedNotification(_ notification: Foundation.Notification) {
+        // nil notification object means it's a logout event.
+        guard notification.object == nil else {
+            return
         }
+
+        self.cleanupExportedDataIfNeeded()
     }
 
     /// A "middleware" logic that attempts to record (or clear) any migration error to the App Group space

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -203,7 +203,7 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
     }
 
     func test_coordinatorShouldObserveLogoutNotifications() {
-        XCTAssertNotNil(mockNotificationCenter.observerBlock)
+        XCTAssertNotNil(mockNotificationCenter.observerSelector)
         XCTAssertNotNil(mockNotificationCenter.observedNotificationName)
         XCTAssertEqual(mockNotificationCenter.observedNotificationName, Foundation.Notification.Name.WPAccountDefaultWordPressComAccountChanged)
     }
@@ -213,7 +213,7 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
         let loginNotification = mockNotificationCenter.makeLoginNotification()
 
         // When
-        mockNotificationCenter.observerBlock?(loginNotification)
+        mockNotificationCenter.post(loginNotification)
 
         // Then
         XCTAssertFalse(mockDataMigrator.exportCalled)
@@ -226,7 +226,7 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
         let logoutNotification = mockNotificationCenter.makeLogoutNotification()
 
         // When
-        mockNotificationCenter.observerBlock?(logoutNotification)
+        mockNotificationCenter.post(logoutNotification)
 
         // Then
         XCTAssertFalse(mockDataMigrator.exportCalled)
@@ -300,15 +300,12 @@ private extension ContentMigrationCoordinatorTests {
 
 private final class MockNotificationCenter: NotificationCenter {
     var observedNotificationName: NSNotification.Name? = nil
-    var observerBlock: ((Foundation.Notification) -> Void)? = nil
+    var observerSelector: Selector? = nil
 
-    override func addObserver(forName name: NSNotification.Name?,
-                              object obj: Any?,
-                              queue: OperationQueue?,
-                              using block: @escaping @Sendable (Foundation.Notification) -> Void) -> NSObjectProtocol {
-        observedNotificationName = name
-        observerBlock = block
-        return NSNull()
+    override func addObserver(_ observer: Any, selector aSelector: Selector, name aName: NSNotification.Name?, object anObject: Any?) {
+        observedNotificationName = aName
+        observerSelector = aSelector
+        super.addObserver(observer, selector: aSelector, name: aName, object: anObject)
     }
 
     func makeLoginNotification() -> Foundation.Notification {


### PR DESCRIPTION
Relates to #20994.

Similar to PR #20919:
1. We now use `ContentMigrationCoordinator` as the observer, so that it can be automatically unregistered upon deallocation.
2. The `ContentMigrationCoordinator` is another singleton, changes in this PR have no effect to the app at all.
3. We should avoid discarding notification observer anyways.


## Regression Notes
1. Potential unintended areas of impact
None.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

5. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A