### PR TITLE
Capture weak references in some notification observers

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -759,19 +759,22 @@ extension CollapsableHeaderViewController: UIScrollViewDelegate {
 // MARK: - Keyboard Adjustments
 extension CollapsableHeaderViewController {
     private func startObservingKeyboardChanges() {
-        let willShowObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { (notification) in
+        let willShowObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { [weak self] (notification) in
+            guard let self else { return }
             UIView.animate(withKeyboard: notification) { (_, endFrame) in
                 self.scrollableContainerBottomConstraint.constant = endFrame.height - self.footerHeight
             }
         }
 
-        let willHideObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { (notification) in
+        let willHideObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { [weak self] (notification) in
+            guard let self else { return }
             UIView.animate(withKeyboard: notification) { (_, _) in
                 self.scrollableContainerBottomConstraint.constant = 0
             }
         }
 
-        let willChangeFrameObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: .main) { (notification) in
+        let willChangeFrameObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillChangeFrameNotification, object: nil, queue: .main) { [weak self] (notification) in
+            guard let self else { return }
             UIView.animate(withKeyboard: notification) { (_, endFrame) in
                 self.scrollableContainerBottomConstraint.constant = endFrame.height - self.footerHeight
             }


### PR DESCRIPTION
Relates to #20994.

From [NotificationCenter.addObserver(forName:object:queue:using:)](https://developer.apple.com/documentation/foundation/notificationcenter/1411723-addobserver):
> To avoid a retain cycle, use a weak reference to self inside the block when self contains the observer as a strong reference.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A