### PR TITLE
Retain a notification observer in StatsForegroundObservable

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsForegroundObservable.swift
+++ b/WordPress/Classes/ViewRelated/Stats/StatsForegroundObservable.swift
@@ -4,9 +4,11 @@ protocol StatsForegroundObservable: AnyObject {
     func reloadStatsData()
 }
 
+private var observerKey = 0
+
 extension StatsForegroundObservable where Self: UIViewController {
     func addWillEnterForegroundObserver() {
-        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
+        enterForegroundObserver = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
                                                object: nil,
                                                queue: nil) { [weak self] _ in
             self?.reloadStatsData()
@@ -14,8 +16,18 @@ extension StatsForegroundObservable where Self: UIViewController {
     }
 
     func removeWillEnterForegroundObserver() {
-        NotificationCenter.default.removeObserver(self,
-                                                  name: UIApplication.willEnterForegroundNotification,
-                                                  object: nil)
+        if let enterForegroundObserver {
+            NotificationCenter.default.removeObserver(enterForegroundObserver)
+        }
+        enterForegroundObserver = nil
+    }
+
+    private var enterForegroundObserver: NSObjectProtocol? {
+        get {
+            objc_getAssociatedObject(self, &observerKey) as? NSObjectProtocol
+        }
+        set {
+            objc_setAssociatedObject(self, &observerKey, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
     }
 }


### PR DESCRIPTION
Relates to #20994.

The `removeWillEnterForegroundObserver` function removes the wrong observer. This PR fixes it by adding the correct notification observer as an associated object, so that it can be removed later.

I want to avoid using Objective-C runtime API, but I don't think there are other viable alternatives here. We can't use the selector API because we can't add a `@objc` function to an extension.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A