### PR TITLE
Do not discard notification observers in NoticePresenter

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -102,8 +102,8 @@ class NoticePresenter {
     private func listenToKeyboardEvents() {
         NotificationCenter.default
             .publisher(for: UIResponder.keyboardWillShowNotification)
-            .sink { [weak self] (notification) in
-                guard let self = self,
+            .sink { [weak self] notification in
+                guard let self,
                     let userInfo = notification.userInfo,
                     let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
                     let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else {
@@ -122,12 +122,13 @@ class NoticePresenter {
                 })
             }
             .store(in: &notificationObservers)
+
         NotificationCenter.default
             .publisher(for: UIResponder.keyboardWillHideNotification)
-            .sink { [weak self] (notification) in
+            .sink { [weak self] notification in
                 self?.currentKeyboardPresentation = .notPresent
 
-                guard let self = self,
+                guard let self,
                     let currentContainer = self.currentNoticePresentation?.containerView,
                     let userInfo = notification.userInfo,
                     let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else {


### PR DESCRIPTION
Relates to #20994.

Even though the discarded observers are not likely to cause any issues because they use `weak self`, but it's still better to unregister them properly.

This PR uses Combine to observe and automatically unregister the observer. We have a couple of other options here:
1. Moving the notification handling code to their own functions, and use `self` as the observer.
2. Store the registered observers in an array and unregister them in `deinit`.

I chose to use Combine because the first option would introduce a large diff and the second option has an extra step of manually unregistering observers.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A