### PR TITLE
Fix text change notification observer in ChangeUsernameViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -156,21 +156,28 @@ private extension ChangeUsernameViewController {
             textField.placeholder = Constants.Alert.confirm
             NotificationCenter.default.addObserver(forName: UITextField.textDidChangeNotification,
                                                    object: textField,
-                                                   queue: .main) {_ in
-                                                    if let text = textField.text,
-                                                        !text.isEmpty,
-                                                        let username = self?.viewModel.selectedUsername,
-                                                        text == username {
-                                                        self?.changeUsernameAction?.isEnabled = true
-                                                        textField.textColor = .success
-                                                        return
-                                                    }
-                                                    self?.changeUsernameAction?.isEnabled = false
-                                                    textField.textColor = .text
+                                                   queue: .main) { [weak self] notification in
+                                                    self?.handleTextDidChangeNotification(notification)
             }
         }
         DDLogInfo("Prompting user for confirmation of change username")
         return alertController
+    }
+
+    @objc func handleTextDidChangeNotification(_ notification: Foundation.Notification) {
+        guard let textField = notification.object as? UITextField else {
+            return
+        }
+
+         if let text = textField.text,
+            !text.isEmpty,
+            text == self.viewModel.selectedUsername {
+             self.changeUsernameAction?.isEnabled = true
+             textField.textColor = .success
+             return
+         }
+         self.changeUsernameAction?.isEnabled = false
+         textField.textColor = .text
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -17,7 +17,6 @@ class ChangeUsernameViewController: SignupUsernameTableViewController {
     }()
 
     private weak var confirmationController: UIAlertController?
-    private var changeUsernameAction: UIAlertAction?
 
     init(service: AccountSettingsService, settings: AccountSettings?, completionBlock: @escaping CompletionBlock) {
         self.viewModel = ChangeUsernameViewModel(service: service, settings: settings)
@@ -149,7 +148,7 @@ private extension ChangeUsernameViewController {
         alertController.addCancelActionWithTitle(Constants.Alert.cancel, handler: { _ in
             DDLogInfo("User cancelled alert")
         })
-        changeUsernameAction = alertController.addDefaultActionWithTitle(Constants.Alert.change, handler: { [weak alertController, weak self] _ in
+        let action = alertController.addDefaultActionWithTitle(Constants.Alert.change, handler: { [weak alertController, weak self] _ in
             guard let self, let alertController else { return }
             guard let textField = alertController.textFields?.first,
                 textField.text == self.viewModel.selectedUsername else {
@@ -159,7 +158,7 @@ private extension ChangeUsernameViewController {
             DDLogInfo("User changes username")
             self.changeUsername()
         })
-        changeUsernameAction?.isEnabled = false
+        action.isEnabled = false
         alertController.addTextField { textField in
             textField.placeholder = Constants.Alert.confirm
         }
@@ -180,6 +179,10 @@ private extension ChangeUsernameViewController {
         // We need to add another condition to check if the text field is the username confirmation text field, if there
         // are more than one text field in the prompt.
         precondition(confirmationController.textFields?.count == 1, "There should be only one text field in the prompt")
+
+        let actions = confirmationController.actions.filter({ $0.title == Constants.Alert.change })
+        precondition(actions.count == 1, "More than one 'Change username' action found")
+        let changeUsernameAction = actions.first
 
         let enabled = textField.text?.isEmpty == false && textField.text == self.viewModel.selectedUsername
         changeUsernameAction?.isEnabled = enabled

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -149,8 +149,9 @@ private extension ChangeUsernameViewController {
         alertController.addCancelActionWithTitle(Constants.Alert.cancel, handler: { _ in
             DDLogInfo("User cancelled alert")
         })
-        changeUsernameAction = alertController.addDefaultActionWithTitle(Constants.Alert.change, handler: { [weak alertController] _ in
-            guard let textField = alertController?.textFields?.first,
+        changeUsernameAction = alertController.addDefaultActionWithTitle(Constants.Alert.change, handler: { [weak alertController, weak self] _ in
+            guard let self, let alertController else { return }
+            guard let textField = alertController.textFields?.first,
                 textField.text == self.viewModel.selectedUsername else {
                     DDLogInfo("Username confirmation failed")
                     return

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -169,15 +169,9 @@ private extension ChangeUsernameViewController {
             return
         }
 
-         if let text = textField.text,
-            !text.isEmpty,
-            text == self.viewModel.selectedUsername {
-             self.changeUsernameAction?.isEnabled = true
-             textField.textColor = .success
-             return
-         }
-         self.changeUsernameAction?.isEnabled = false
-         textField.textColor = .text
+        let enabled = textField.text?.isEmpty == false && textField.text == self.viewModel.selectedUsername
+        changeUsernameAction?.isEnabled = enabled
+        textField.textColor = enabled ? .success : .text
     }
 
     enum Constants {


### PR DESCRIPTION
Relates to #20994.

When the user wants to change their username from `ChangeUsernameViewController`, the app shows a confirmation alert which has a text field to ask the user to type the new username. The confirmation button in the alert will be disabled first and turn into enabled only when the user types the new username correctly.

Current implementation adds notification observer at the time of creating the alert and unregisters the observer when alert is dismissed. There are a few issues with current implementation, I'll post an inline comments to highlight them. This PR refactors the observing notification approach to register an observer once the view controller is loaded and let iOS SDK to unregister it when the view controller is released.

## Test Instructions

1. Modify [this code in "Account Settings"](https://github.com/wordpress-mobile/WordPress-iOS/blob/0768bdabfb3433e967c2c5aeca911f3d2c6afb61/WordPress/Classes/ViewRelated/Me/Account%20Settings/AccountSettingsViewController.swift#L147) to always be `editableUsername`, so that we can enter the "change username" screen.
2. Launch the app from Xcode.
3. Navigate to "Avatar" -> "Account Settings" -> "Username".
4. Select or type a new username.
5. Tap "Save". This is where you'll see the confirmation alert.

The "Change username" alert button should be disabled. The button should become enabled when the text in the text field matches the new username, and should become disable if it doesn't.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the test instruction section.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A