### PR TITLE
Dashboard Cards: Add "view" item to context menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -90,16 +90,17 @@ extension DashboardPostsListCardCell {
 
         switch cardType {
         case .draftPosts:
+            addDraftsContextMenu(card: cardType, blog: blog)
             configureDraftsList(blog: blog)
             status = .draft
         case .scheduledPosts:
+            addScheduledContextMenu(card: cardType, blog: blog)
             configureScheduledList(blog: blog)
             status = .scheduled
         default:
             assertionFailure("Cell used with wrong card type")
             return
         }
-        addContextMenu(card: cardType, blog: blog)
 
         viewModel = PostsCardViewModel(blog: blog, status: status, view: self)
         viewModel?.viewDidLoad()
@@ -107,12 +108,42 @@ extension DashboardPostsListCardCell {
         viewModel?.refresh()
     }
 
-    private func addContextMenu(card: DashboardCard, blog: Blog) {
+    private func addDraftsContextMenu(card: DashboardCard, blog: Blog) {
         guard FeatureFlag.personalizeHomeTab.enabled else { return }
 
         frameView.addMoreMenu(items: [
-            BlogDashboardHelpers.makeHideCardAction(for: card, blog: blog)
+            UIMenu(options: .displayInline, children: [
+                makeDraftsListMenuAction()
+            ]),
+            UIMenu(options: .displayInline, children: [
+                BlogDashboardHelpers.makeHideCardAction(for: card, blog: blog)
+            ])
         ], card: card)
+    }
+
+    private func addScheduledContextMenu(card: DashboardCard, blog: Blog) {
+        guard FeatureFlag.personalizeHomeTab.enabled else { return }
+
+        frameView.addMoreMenu(items: [
+            UIMenu(options: .displayInline, children: [
+                makeScheduledListMenuAction()
+            ]),
+            UIMenu(options: .displayInline, children: [
+                BlogDashboardHelpers.makeHideCardAction(for: card, blog: blog)
+            ])
+        ], card: card)
+    }
+
+    private func makeDraftsListMenuAction() -> UIAction {
+        UIAction(title: Strings.viewAllDrafts, image: UIImage(systemName: "square.and.pencil")) { [weak self] _ in
+            self?.presentPostList(with: .draft)
+        }
+    }
+
+    private func makeScheduledListMenuAction() -> UIAction {
+        UIAction(title: Strings.viewAllScheduledPosts, image: UIImage(systemName: "calendar")) { [weak self] _ in
+            self?.presentPostList(with: .scheduled)
+        }
     }
 
     private func configureDraftsList(blog: Blog) {
@@ -186,6 +217,8 @@ private extension DashboardPostsListCardCell {
     private enum Strings {
         static let draftsTitle = NSLocalizedString("my-sites.drafts.card.title", value: "Work on a draft post", comment: "Title for the card displaying draft posts.")
         static let scheduledTitle = NSLocalizedString("Upcoming scheduled posts", comment: "Title for the card displaying upcoming scheduled posts.")
+        static let viewAllDrafts = NSLocalizedString("my-sites.drafts.card.viewAllDrafts", value: "View all drafts", comment: "Title for the View all drafts button in the More menu")
+        static let viewAllScheduledPosts = NSLocalizedString("my-sites.scheduled.card.viewAllScheduledPosts", value: "View all scheduled posts", comment: "Title for the View all scheduled drafts button in the More menu")
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -116,7 +116,7 @@ extension DashboardPostsListCardCell {
     }
 
     private func configureDraftsList(blog: Blog) {
-        frameView.setTitle(Strings.draftsTitle, titleHint: Strings.draftsTitleHint)
+        frameView.setTitle(Strings.draftsTitle)
         frameView.onHeaderTap = { [weak self] in
             self?.presentPostList(with: .draft)
         }
@@ -185,7 +185,6 @@ private extension DashboardPostsListCardCell {
 
     private enum Strings {
         static let draftsTitle = NSLocalizedString("my-sites.drafts.card.title", value: "Work on a draft post", comment: "Title for the card displaying draft posts.")
-        static let draftsTitleHint = NSLocalizedString("my-sites.drafts.card.title.hint", value: "draft post", comment: "The part in the title that should be highlighted.")
         static let scheduledTitle = NSLocalizedString("Upcoming scheduled posts", comment: "Title for the card displaying upcoming scheduled posts.")
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -76,7 +76,12 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
 
         if FeatureFlag.personalizeHomeTab.enabled {
             frameView.addMoreMenu(items: [
-                BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, blog: blog)
+                UIMenu(options: .displayInline, children: [
+                    makeShowStatsMenuAction(for: blog, in: viewController)
+                ]),
+                UIMenu(options: .displayInline, children: [
+                    BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, blog: blog)
+                ])
             ], card: .todaysStats)
         }
 
@@ -93,6 +98,12 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         BlogDashboardAnalytics.shared.track(.dashboardCardShown,
                           properties: ["type": DashboardCard.todaysStats.rawValue],
                           blog: blog)
+    }
+
+    private func makeShowStatsMenuAction(for blog: Blog, in viewController: UIViewController) -> UIAction {
+        UIAction(title: Strings.viewStats, image: UIImage(systemName: "chart.bar.xaxis")) { [weak self] _ in
+            self?.showStats(for: blog, from: viewController)
+        }
     }
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
@@ -135,6 +146,7 @@ private extension DashboardStatsCardCell {
         static let statsTitle = NSLocalizedString("my-sites.stats.card.title", value: "Today's Stats", comment: "Title for the card displaying today's stats.")
         static let nudgeButtonTitle = NSLocalizedString("Interested in building your audience? Check out our top tips", comment: "Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped.")
         static let nudgeButtonHint = NSLocalizedString("top tips", comment: "The part of the nudge title that should be emphasized, this content needs to match a string in 'If you want to try get more...'")
+        static let viewStats = NSLocalizedString("dashboardCard.stats.viewStats", value: "View stats", comment: "Title for the View stats button in the More menu")
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -39,7 +39,7 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
     }
 
     private func addSubviews() {
-        frameView.setTitle(Strings.statsTitle, titleHint: Strings.statsTitleHint)
+        frameView.setTitle(Strings.statsTitle)
 
         let statsStackview = DashboardStatsStackView()
         frameView.add(subview: statsStackview)
@@ -133,7 +133,6 @@ private extension DashboardStatsCardCell {
 
     enum Strings {
         static let statsTitle = NSLocalizedString("my-sites.stats.card.title", value: "Today's Stats", comment: "Title for the card displaying today's stats.")
-        static let statsTitleHint = NSLocalizedString("my-sites.stats.card.title.hint", value: "Stats", comment: "The part of the title that needs to be emphasized")
         static let nudgeButtonTitle = NSLocalizedString("Interested in building your audience? Check out our top tips", comment: "Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped.")
         static let nudgeButtonHint = NSLocalizedString("top tips", comment: "The part of the nudge title that should be emphasized, this content needs to match a string in 'If you want to try get more...'")
     }


### PR DESCRIPTION
Slack ref: p1688452007679369-slack-C0290FLA0RM

## Description
- Removes highlighted text from stats and drafts cards
- Adds "View..." item to stats, drafts, and scheduled posts cards 

| / | Card title | Stats card | Drafts card | Scheduled card |
|--------|--------|--------|--------|--------|
| Before | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 10 45](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/e31b0b09-43c3-4cde-ba04-6663e4f44ce2) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 10 50](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ffb5dc80-afb8-4626-bc3d-1791c0e7ee1c) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 10 54](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/77d6ce60-6d21-435c-b6fa-705d2b8e0417) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 10 58](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ba1ecd32-5a97-4c25-8666-bdb5a942b98f) |
| After | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 04 06](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ecd848fd-5a0b-4cbd-aa75-4ae759ec9ef6) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 04 09](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f6333680-b2a3-461a-841b-6b1fb53401b3) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 04 14](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/a7833985-9975-452c-ad06-598d23cce2be) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-07-04 at 16 04 18](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f3733acf-7eae-42bb-a5fb-3eb1a77cc525) |

## How to test
1. Go to the dashboard
2. Turn on the stats, drafts, and scheduled cards via the "Personalize your home tab" screen (Create drafts or scheduled posts as needed)
3. ✅ Verify the stats card title contains no highlighted text
4. Stats card > ellipsis icon >"View stats"
5. ✅ Verify the stats screen is displayed
6. Go back to the dashboard
7. ✅ Verify the drafts card title contains no highlighted text
8. Drafts card > ellipsis icon > "View all drafts"
9. ✅ Verify the drafts screen is displayed
10. Go back to the dashboard
11. Scheduled card > ellipsis icon > "View all scheduled posts"
12. ✅ Verify the scheduled posts screen is displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

13. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

14. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)