### PR TITLE
Add warnings about incorrect `performQuery` usages

### DIFF
--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -369,7 +369,7 @@ extension CoreDataStack {
 /// the context object is, nor the context queue type (the main queue or a background queue). That means the caller
 /// does not have enough information to guarantee safe access to the returned `NSManagedObject` instances.
 ///
-/// The closure passed to the `performQuery` function should use the context to query objects and return none Core Data
+/// The closure passed to the `performQuery` function should use the context to query objects and return non- Core Data
 /// types. Here is an example of how it should be used.
 ///
 /// ```

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -196,6 +196,8 @@ extension ContextManager.ContextManagerError: LocalizedError, CustomDebugStringC
 
 extension CoreDataStack {
     /// Perform a query using the `mainContext` and return the result.
+    ///
+    /// - Warning: Do not return `NSManagedObject` instances from the closure.
     func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T) -> T {
         var value: T! = nil
         self.mainContext.performAndWait {
@@ -358,5 +360,71 @@ extension CoreDataStack {
             return
         }
         try ContextManager.migrateDataModelsIfNecessary(storeURL: databaseLocation, objectModel: objectModel)
+    }
+}
+
+/// This extension declares many `performQuery` usages that may introduce Core Data concurrency issues.
+///
+/// The context object used by the `performQuery` function is opaque to the caller. The caller should not assume what
+/// the context object is, nor the context queue type (the main queue or a background queue). That means the caller
+/// does not have enough information to guarantee safe access to the returned `NSManagedObject` instances.
+///
+/// The closure passed to the `performQuery` function should use the context to query objects and return none Core Data
+/// types. Here is an example of how it should be used.
+///
+/// ```
+/// // Wrong:
+/// let account = coreDataStack.performQuery { context in
+///     return Account.lookUp(in: context)
+/// }
+/// let name = account.username
+///
+/// // Right:
+/// let name = coreDataStack.performQuery { context in
+///     let account = Account.lookUp(in: context)
+///     return account.username
+/// }
+/// ```
+extension CoreDataStack {
+    @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
+    func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T) -> T where T: NSManagedObject {
+        mainContext.performAndWait { [mainContext] in
+            block(mainContext)
+        }
+    }
+
+    @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
+    func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T?) -> T? where T: NSManagedObject {
+        mainContext.performAndWait { [mainContext] in
+            block(mainContext)
+        }
+    }
+
+    @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
+    func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T) -> T where T: Sequence, T.Element: NSManagedObject {
+        mainContext.performAndWait { [mainContext] in
+            block(mainContext)
+        }
+    }
+
+    @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
+    func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T?) -> T? where T: Sequence, T.Element: NSManagedObject {
+        mainContext.performAndWait { [mainContext] in
+            block(mainContext)
+        }
+    }
+
+    @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
+    func performQuery<T, E>(_ block: @escaping (NSManagedObjectContext) -> Result<T, E>) -> Result<T, E> where T: NSManagedObject, E: Error {
+        mainContext.performAndWait { [mainContext] in
+            block(mainContext)
+        }
+    }
+
+    @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
+    func performQuery<T, E>(_ block: @escaping (NSManagedObjectContext) -> Result<T, E>?) -> Result<T, E>? where T: NSManagedObject, E: Error {
+        mainContext.performAndWait { [mainContext] in
+            block(mainContext)
+        }
     }
 }


### PR DESCRIPTION
See the code comments about what the warnings are about.

One alternative to using `performQuery` overrides is doing runtime type checks in the `performQuery` implementation. A huge disadvantage of that is it's runtime check, not compiling time check. And runtime check is very easy to miss. With compiling time check introduced by these overrides, we can easily find incorrect usages, which I'll address in separate PRs.

<img width="324" alt="Screenshot 2023-07-05 at 4 55 26 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1101828/8892b77f-c5b6-40d9-ba38-5228595e5be8">

I hoped that I could mark these functions as obsoleted or unavailable, so that compiler reports errors instead of warnings. But the Swift compiler doesn't pick up obsoleted or unavailable overrides when there is other override available, which means we don't see any error at all.

There is no way to catch all the violations where `NSManagedObject` is returned from the closure. For example, the return value may be a plain Swift class that holds a reference to `NSManagedObject` instances, which is impossible to detect. This PR only adds typical usages, like returning a `NSManagedObject` instance, an array of `NSManagedObject`, or a `NSManagedObject` wrapped in a `Result` type.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A