### PR TITLE
Fix memory leaks on viewing a post from a notification

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
@@ -15,7 +15,7 @@ class ReaderCommentsFollowPresenter: NSObject {
 
     private let post: ReaderPost
     private weak var delegate: ReaderCommentsFollowPresenterDelegate?
-    private let presentingViewController: UIViewController
+    private unowned let presentingViewController: UIViewController
     private let followCommentsService: FollowCommentsService?
 
     // MARK: - Initialization

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -7,7 +7,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
 
     private(set) var totalComments = 0
     private var post: ReaderPost?
-    private var presentingViewController: UIViewController?
+    private weak var presentingViewController: UIViewController?
     private weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
     private(set) var headerView: ReaderDetailCommentsHeader?
     var followButtonTappedClosure: (() ->Void)?

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import AutomatticTracks
 
-protocol ReaderDetailHeaderViewDelegate {
+protocol ReaderDetailHeaderViewDelegate: AnyObject {
     func didTapBlogName()
     func didTapMenuButton(_ sender: UIView)
     func didTapHeaderAvatar()
@@ -43,7 +43,7 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
 
     /// Any interaction with the header is sent to the delegate
     ///
-    var delegate: ReaderDetailHeaderViewDelegate?
+    weak var delegate: ReaderDetailHeaderViewDelegate?
 
     func configure(for post: ReaderPost) {
         self.post = post

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol ReaderDetailLikesViewDelegate {
+protocol ReaderDetailLikesViewDelegate: AnyObject {
     func didTapLikesView()
 }
 
@@ -13,7 +13,7 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     @IBOutlet private weak var selfAvatarImageView: CircularImageView!
 
     static let maxAvatarsDisplayed = 5
-    var delegate: ReaderDetailLikesViewDelegate?
+    weak var delegate: ReaderDetailLikesViewDelegate?
 
     /// Stores the number of total likes _without_ adding the like from self.
     private var totalLikes: Int = 0


### PR DESCRIPTION
Relates to #20989.

## Issue

When done viewing a post from the Notifications tab, the post detail view isn't released.

To reproduce this issue:
1. Put breakpoints at `viewDidLoad` and `deinit` functions in `ReaderDetailViewController`.
2. Launch the app from Xcode.
3. Go to the Notifications tab.
4. Tap a notification that says "<someone> posted on <some website>", or any other kinds of notification that takes you to `ReaderDetailViewController`.
5. Xcode should hit the breakpoint at `ReaderDetailViewController.viewDidLoad`. This step is just to confirm that the `ReaderDetailViewController` has been created
6. Exit the post details screen.
7. Xcode should hit the breakpoint at `ReaderDetailsViewController.deinit`.

Performing the above steps on the trunk branch doesn't hit the `deinit` breakpoint, which means the view controller is not released.

You can test this PR by repeating the same steps on this PR branch and verify that Xcode stops at `deinit` breakpoint.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Viewing notifications and posts.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A