### PR TITLE
Blaze Manage Campaigns: show campaign details from dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -73,6 +73,8 @@ final class DashboardBlazeCampaignView: UIView {
         if viewModel.isShowingStats {
             makeStatsViews(for: viewModel).forEach(statsView.addArrangedSubview)
         }
+
+        enableVoiceOver(with: viewModel)
     }
 
     private func makeStatsViews(for viewModel: BlazeCampaignViewModel) -> [UIView] {
@@ -83,6 +85,16 @@ final class DashboardBlazeCampaignView: UIView {
         clicksView.countString = "\(viewModel.clicks)"
 
         return [impressionsView, clicksView]
+    }
+
+    private func enableVoiceOver(with viewModel: BlazeCampaignViewModel) {
+        var accessibilityLabel = "\(viewModel.title), \(viewModel.status.title)"
+        if viewModel.isShowingStats {
+            accessibilityLabel += ", \(Strings.impressions) \(viewModel.impressions), \(Strings.clicks) \(viewModel.clicks)"
+        }
+        self.isAccessibilityElement = true
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityTraits = .allowsDirectInteraction
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -78,8 +78,6 @@ final class DashboardBlazeCampaignsCardView: UIView {
         }
 
         campaignView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(campainViewTapped)))
-        campaignView.isAccessibilityElement = true
-        campaignView.accessibilityTraits = .allowsDirectInteraction
     }
 
     private func showCampaignList() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -14,13 +14,19 @@ final class DashboardBlazeCampaignsCardView: UIView {
     private lazy var createCampaignButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.configuration = {
+            var configuration = UIButton.Configuration.plain()
+            configuration.attributedTitle = {
+                var string = AttributedString(Strings.createCampaignButton)
+                string.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .bold)
+                string.foregroundColor = UIColor.primary
+                return string
+            }()
+            configuration.contentInsets = Constants.createCampaignInsets
+            return configuration
+        }()
         button.contentHorizontalAlignment = .leading
-        button.setTitle(Strings.createCampaignButton, for: .normal)
         button.addTarget(self, action: #selector(buttonCreateCampaignTapped), for: .touchUpInside)
-        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .bold)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.setTitleColor(UIColor.primary, for: .normal)
-        button.contentEdgeInsets = Constants.createCampaignInsets
         return button
     }()
 
@@ -126,6 +132,6 @@ private extension DashboardBlazeCampaignsCardView {
 
     enum Constants {
         static let campaignViewInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        static let createCampaignInsets = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16)
+        static let createCampaignInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 8, trailing: 16)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -26,6 +26,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
 
     private var blog: Blog?
     private weak var presentingViewController: BlogDashboardViewController?
+    private var campaign: BlazeCampaign?
 
     // MARK: - Initializers
 
@@ -69,6 +70,10 @@ final class DashboardBlazeCampaignsCardView: UIView {
         frameView.onHeaderTap = { [weak self] in
             self?.showCampaignList()
         }
+
+        campaignView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(campainViewTapped)))
+        campaignView.isAccessibilityElement = true
+        campaignView.accessibilityTraits = .allowsDirectInteraction
     }
 
     private func showCampaignList() {
@@ -82,15 +87,21 @@ final class DashboardBlazeCampaignsCardView: UIView {
         }
     }
 
+    @objc private func campainViewTapped() {
+        guard let presentingViewController, let blog, let campaign else { return }
+        BlazeFlowCoordinator.presentBlazeCampaignDetails(in: presentingViewController, source: .dashboardCard, blog: blog, campaignID: campaign.campaignID)
+    }
+
     @objc private func buttonCreateCampaignTapped() {
         guard let presentingViewController, let blog else { return }
         BlazeEventsTracker.trackEntryPointTapped(for: .dashboardCard)
         BlazeFlowCoordinator.presentBlaze(in: presentingViewController, source: .dashboardCard, blog: blog)
     }
 
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, campaign: BlazeCampaignViewModel) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, campaign: BlazeCampaign) {
         self.blog = blog
         self.presentingViewController = viewController
+        self.campaign = campaign
 
         frameView.addMoreMenu(items: [
             UIMenu(options: .displayInline, children: [
@@ -101,7 +112,8 @@ final class DashboardBlazeCampaignsCardView: UIView {
             ])
         ], card: .blaze)
 
-        campaignView.configure(with: campaign, blog: blog)
+        let viewModel = BlazeCampaignViewModel(campaign: campaign)
+        campaignView.configure(with: viewModel, blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCellViewModel.swift
@@ -14,7 +14,7 @@ final class DashboardBlazeCardCellViewModel {
         /// Showing "Promote you content with Blaze" promo card.
         case promo
         /// Showing the latest Blaze campaign.
-        case campaign(BlazeCampaignViewModel)
+        case campaign(BlazeCampaign)
     }
 
     var onRefresh: ((DashboardBlazeCardCellViewModel) -> Void)?
@@ -31,7 +31,7 @@ final class DashboardBlazeCardCellViewModel {
         if isBlazeCampaignsFlagEnabled(),
            let blogID = blog.dotComID?.intValue,
            let campaign = store.getBlazeCampaign(forBlogID: blogID) {
-            self.state = .campaign(BlazeCampaignViewModel(campaign: campaign))
+            self.state = .campaign(campaign)
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(refresh), name: .blazeCampaignCreated, object: nil)
@@ -57,7 +57,7 @@ final class DashboardBlazeCardCellViewModel {
                 store.setBlazeCampaign(campaign, forBlogID: blogID)
             }
             if let campaign {
-                state = .campaign(BlazeCampaignViewModel(campaign: campaign))
+                state = .campaign(campaign)
             } else {
                 state = .promo
             }

--- a/WordPress/WordPressTest/Dashboard/DashboardBlazeCardCellViewModelTest.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardBlazeCardCellViewModelTest.swift
@@ -51,8 +51,8 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
         switch sut.state {
         case .promo:
             XCTFail("The card should display the latest campaign")
-        case .campaign(let viewModel):
-            XCTAssertEqual(viewModel.title, "Test Post - don't approve")
+        case .campaign(let campaign):
+            XCTAssertEqual(campaign.name, "Test Post - don't approve")
         }
     }
 
@@ -70,8 +70,8 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
         switch sut.state {
         case .promo:
             XCTFail("The card should display the latest campaign")
-        case .campaign(let viewModel):
-            XCTAssertEqual(viewModel.title, "Test Post - don't approve")
+        case .campaign(let campaign):
+            XCTAssertEqual(campaign.name, "Test Post - don't approve")
         }
     }
 


### PR DESCRIPTION
Related #20765

- Show campaign details when you click the campaign from the dashboard card and make it accessible
- Fix a `UIButton` deprecation warning

## To test:

- Enable "Blaze Manage Campaigns" feature flag
- Log in with a user that has any Blaze campaigns
- Tap on a campaign view on dashboard 
- Verify that the details page is updated (the details page itself is out of the scope of this PR; some updates are pending)

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/9245bcbc-f577-47e8-8885-a5db9012dc46

## Regression Notes
1. Potential unintended areas of impact: new Blaze Campaign Dashboard card
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual test
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout) – [evidence](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/2195e485-5201-4c10-9ef2-18fbed71e5d1)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
