### PR TITLE
Fix memory leaks in ReaderStreamViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
@@ -7,7 +7,7 @@ import WordPressShared.WPStyleGuide
     @IBOutlet fileprivate weak var detailLabel: UILabel!
 
     // Required by ReaderStreamHeader protocol.
-    open var delegate: ReaderStreamHeaderDelegate?
+    open weak var delegate: ReaderStreamHeaderDelegate?
 
 
     // MARK: - Lifecycle Methods

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
@@ -9,7 +9,7 @@ class ReaderRecommendedSiteCardCell: UITableViewCell {
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var infoTrailingConstraint: NSLayoutConstraint!
 
-    var delegate: ReaderRecommendedSitesCardCellDelegate?
+    weak var delegate: ReaderRecommendedSitesCardCellDelegate?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -110,6 +110,6 @@ class ReaderRecommendedSiteCardCell: UITableViewCell {
     }
 }
 
-protocol ReaderRecommendedSitesCardCellDelegate {
+protocol ReaderRecommendedSitesCardCellDelegate: AnyObject {
     func handleFollowActionForCell(_ cell: ReaderRecommendedSiteCardCell)
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -5,7 +5,7 @@ import WordPressShared
 /// Defines methods that a delegate should implement for clearing suggestions
 /// and for responding to a selected suggestion.
 ///
-protocol ReaderSearchSuggestionsDelegate {
+protocol ReaderSearchSuggestionsDelegate: AnyObject {
     func searchSuggestionsController(_ controller: ReaderSearchSuggestionsViewController, selectedItem: String)
 }
 
@@ -28,7 +28,7 @@ class ReaderSearchSuggestionsViewController: UIViewController {
     }
 
     @objc var tableViewHandler: WPTableViewHandler!
-    var delegate: ReaderSearchSuggestionsDelegate?
+    weak var delegate: ReaderSearchSuggestionsDelegate?
     @objc let cellIdentifier = "CellIdentifier"
     @objc let rowAndButtonHeight = CGFloat(44.0)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -36,7 +36,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     @IBOutlet fileprivate weak var descriptionLabel: UILabel!
     @IBOutlet fileprivate weak var descriptionLabelTopConstraint: NSLayoutConstraint!
 
-    open var delegate: ReaderStreamHeaderDelegate?
+    open weak var delegate: ReaderStreamHeaderDelegate?
     fileprivate var defaultBlavatar = "blavatar-default"
 
     // MARK: - Lifecycle Methods

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamHeader.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public protocol ReaderStreamHeaderDelegate: NSObjectProtocol {
+@objc public protocol ReaderStreamHeaderDelegate {
     func handleFollowActionForHeader(_ header: ReaderStreamHeader, completion: @escaping () -> Void)
 }
 
-public protocol ReaderStreamHeader: NSObjectProtocol {
-    var delegate: ReaderStreamHeaderDelegate? {get set}
+@objc public protocol ReaderStreamHeader {
+    weak var delegate: ReaderStreamHeaderDelegate? {get set}
     func enableLoggedInFeatures(_ enable: Bool)
     func configureHeader(_ topic: ReaderAbstractTopic)
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -5,7 +5,7 @@ import WordPressShared
     @IBOutlet fileprivate weak var titleLabel: UILabel!
     @IBOutlet fileprivate weak var followButton: UIButton!
 
-    open var delegate: ReaderStreamHeaderDelegate?
+    open weak var delegate: ReaderStreamHeaderDelegate?
 
     // MARK: - Lifecycle Methods
     open override func awakeFromNib() {


### PR DESCRIPTION
## Issue

There are many delegate type references in Reader that are not declared as weak references.

Here are steps to reproduce the memory leak issue caused by them:
1. Launch the app from Xcode
2. Go to the Reader tab -> Discover
3. Tap a topic in the "You might like" section: DIY, Baking, etc.
4. You should see a "Topic" screen at this point, which is implemented as `ReaderStreamViewController`.
5. Set a breakpoint at `ReaderStreamViewController.deinit`.
6. Exit the "Topic" screen
7. Xcode should stop at the `ReaderStreamViewController.deinit` breakpoint.

Performing the above steps on the trunk branch doesn't hit the `deinit` breakpoint, which means the view controller is not released.

You can test this PR by repeating the same steps on this PR branch and verify that Xcode stops at the `deinit` breakpoint.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A