### PR TITLE
Track EU/US Compliance Analytics Events

### DIFF
--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -4,6 +4,14 @@ import WordPressUI
 
 final class CompliancePopoverViewController: UIViewController {
 
+    // MARK: - Dependencies
+
+    private let viewModel: CompliancePopoverViewModel
+
+    private var analyticsTracker: PrivacySettingsAnalyticsTracking {
+        return viewModel.analyticsTracker
+    }
+
     // MARK: - Views
     private let hostingController: UIHostingController<CompliancePopover>
 
@@ -11,7 +19,6 @@ final class CompliancePopoverViewController: UIViewController {
         return hostingController.view
     }
 
-    private let viewModel: CompliancePopoverViewModel
     private var bannerIntrinsicHeight: CGFloat = 0
 
     init(viewModel: CompliancePopoverViewModel) {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -42,6 +42,7 @@ final class CompliancePopoverViewController: UIViewController {
         hostingController.rootView.saveAction = {
             self.viewModel.didTapSave()
         }
+        analyticsTracker.track(.privacyChoicesBannerPresented)
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -8,10 +8,6 @@ final class CompliancePopoverViewController: UIViewController {
 
     private let viewModel: CompliancePopoverViewModel
 
-    private var analyticsTracker: PrivacySettingsAnalyticsTracking {
-        return viewModel.analyticsTracker
-    }
-
     // MARK: - Views
     private let hostingController: UIHostingController<CompliancePopover>
 
@@ -42,7 +38,7 @@ final class CompliancePopoverViewController: UIViewController {
         hostingController.rootView.saveAction = {
             self.viewModel.didTapSave()
         }
-        analyticsTracker.track(.privacyChoicesBannerPresented)
+        viewModel.didDisplayPopover()
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -2,7 +2,8 @@ import Foundation
 import UIKit
 import WordPressUI
 
-final class CompliancePopoverViewModel: ObservableObject {
+class CompliancePopoverViewModel: ObservableObject {
+
     @Published
     var isAnalyticsEnabled: Bool = !WPAppAnalytics.userHasOptedOut()
 

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -8,10 +8,9 @@ final class CompliancePopoverViewModel: ObservableObject {
 
     // MARK: - Dependencies
 
-    let analyticsTracker: PrivacySettingsAnalyticsTracking
-
     var coordinator: CompliancePopoverCoordinatorProtocol?
 
+    private let analyticsTracker: PrivacySettingsAnalyticsTracking
     private let defaults: UserDefaults
     private let contextManager: ContextManager
 
@@ -23,6 +22,12 @@ final class CompliancePopoverViewModel: ObservableObject {
         self.defaults = defaults
         self.analyticsTracker = analyticsTracker
         self.contextManager = contextManager
+    }
+
+    // MARK: - API
+
+    func didDisplayPopover() {
+        analyticsTracker.track(.privacyChoicesBannerPresented)
     }
 
     func didTapSettings() {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -5,19 +5,30 @@ import WordPressUI
 final class CompliancePopoverViewModel: ObservableObject {
     @Published
     var isAnalyticsEnabled: Bool = !WPAppAnalytics.userHasOptedOut()
+
+    // MARK: - Dependencies
+
+    let analyticsTracker: PrivacySettingsAnalyticsTracking
+
     var coordinator: CompliancePopoverCoordinatorProtocol?
 
     private let defaults: UserDefaults
     private let contextManager: ContextManager
 
-    init(defaults: UserDefaults, contextManager: ContextManager) {
+    // MARK: - Init
+
+    init(defaults: UserDefaults,
+         contextManager: ContextManager,
+         analyticsTracker: PrivacySettingsAnalyticsTracking = PrivacySettingsAnalyticsTracker()) {
         self.defaults = defaults
+        self.analyticsTracker = analyticsTracker
         self.contextManager = contextManager
     }
 
     func didTapSettings() {
         coordinator?.navigateToSettings()
-        defaults.didShowCompliancePopup = true
+        defaults.didShowCompliancePopup = false
+        analyticsTracker.track(.privacyChoicesBannerSettingsButtonTapped)
     }
 
     func didTapSave() {
@@ -36,6 +47,7 @@ final class CompliancePopoverViewModel: ObservableObject {
         let change = AccountSettingsChange.tracksOptOut(!isAnalyticsEnabled)
         AccountSettingsService(userID: accountID.intValue, api: restAPI).saveChange(change)
         coordinator?.dismiss()
-        defaults.didShowCompliancePopup = true
+        defaults.didShowCompliancePopup = false
+        analyticsTracker.trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: isAnalyticsEnabled)
     }
 }

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -27,7 +27,7 @@ final class CompliancePopoverViewModel: ObservableObject {
 
     func didTapSettings() {
         coordinator?.navigateToSettings()
-        defaults.didShowCompliancePopup = false
+        defaults.didShowCompliancePopup = true
         analyticsTracker.track(.privacyChoicesBannerSettingsButtonTapped)
     }
 
@@ -47,7 +47,7 @@ final class CompliancePopoverViewModel: ObservableObject {
         let change = AccountSettingsChange.tracksOptOut(!isAnalyticsEnabled)
         AccountSettingsService(userID: accountID.intValue, api: restAPI).saveChange(change)
         coordinator?.dismiss()
-        defaults.didShowCompliancePopup = false
+        defaults.didShowCompliancePopup = true
         analyticsTracker.trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: isAnalyticsEnabled)
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalytics.swift
@@ -2,6 +2,7 @@ enum PrivacySettingsAnalytics: String {
     // Privacy Settings
     case privacySettingsOpened = "privacy_settings_opened"
     case privacySettingsReportCrashesToggled = "privacy_settings_report_crashes_toggled"
+    case privacySettingsAnalyticsTrackingToggled = "privacy_settings_analytics_tracking_toggled"
 
     // Privacy Choices Banner
     case privacyChoicesBannerPresented = "privacy_choices_banner_presented"

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalytics.swift
@@ -5,6 +5,6 @@ enum PrivacySettingsAnalytics: String {
 
     // Privacy Choices Banner
     case privacyChoicesBannerPresented = "privacy_choices_banner_presented"
-    case prviacyChoicesBannerSettingsButtonTapped = "privacy_choices_banner_settings_button_tapped"
+    case privacyChoicesBannerSettingsButtonTapped = "privacy_choices_banner_settings_button_tapped"
     case privacyChoicesBannerSaveButtonTapped = "privacy_choices_banner_save_button_tapped"
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalyticsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalyticsTracker.swift
@@ -5,6 +5,25 @@ protocol PrivacySettingsAnalyticsTracking {
     func trackPrivacySettingsReportCrashesToggled(enabled: Bool)
 
     func trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: Bool)
+
+    func track(_ event: PrivacySettingsAnalytics, properties: [String: String])
+}
+
+extension PrivacySettingsAnalyticsTracking {
+
+    func trackPrivacySettingsReportCrashesToggled(enabled: Bool) {
+        let props = ["enabled": enabled.stringLiteral]
+        self.track(.privacySettingsReportCrashesToggled, properties: props)
+    }
+
+    func trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: Bool) {
+        let props = ["analytics_enabled": analyticsEnabled.stringLiteral]
+        self.track(.privacyChoicesBannerSaveButtonTapped, properties: props)
+    }
+
+    func track(_ event: PrivacySettingsAnalytics) {
+        self.track(event, properties: [:])
+    }
 }
 
 final class PrivacySettingsAnalyticsTracker: PrivacySettingsAnalyticsTracking {
@@ -15,24 +34,8 @@ final class PrivacySettingsAnalyticsTracker: PrivacySettingsAnalyticsTracking {
         self.tracker = tracker
     }
 
-    // MARK: - API
-
-    func trackPrivacySettingsReportCrashesToggled(enabled: Bool) {
-        let props = ["enabled": enabled.stringLiteral]
-        self.track(.privacyChoicesBannerSaveButtonTapped, properties: props)
-    }
-
-    func trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: Bool) {
-        let props = ["analytics_enabled": analyticsEnabled.stringLiteral]
-        self.track(.privacyChoicesBannerSaveButtonTapped, properties: props)
-    }
-
-    func track(_ event: PrivacySettingsAnalytics, properties: Properties = [:]) {
+    func track(_ event: PrivacySettingsAnalytics, properties: [String: String]) {
         let event = AnalyticsEvent(name: event.rawValue, properties: properties)
         tracker.track(event)
     }
-
-    // MARK: - Types
-
-    typealias Properties = [String: String]
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalyticsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsAnalyticsTracker.swift
@@ -2,6 +2,8 @@ import WordPressShared
 
 protocol PrivacySettingsAnalyticsTracking {
 
+    func trackPrivacySettingsAnalyticsTrackingToggled(enabled: Bool)
+
     func trackPrivacySettingsReportCrashesToggled(enabled: Bool)
 
     func trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: Bool)
@@ -10,6 +12,11 @@ protocol PrivacySettingsAnalyticsTracking {
 }
 
 extension PrivacySettingsAnalyticsTracking {
+
+    func trackPrivacySettingsAnalyticsTrackingToggled(enabled: Bool) {
+        let props = ["enabled": enabled.stringLiteral]
+        self.track(.privacySettingsAnalyticsTrackingToggled, properties: props)
+    }
 
     func trackPrivacySettingsReportCrashesToggled(enabled: Bool) {
         let props = ["enabled": enabled.stringLiteral]

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3697,6 +3697,7 @@
 		F4CBE3DA29265BC8004FFBB6 /* LogOutActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */; };
 		F4D36AD5298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */; };
 		F4D36AD6298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */; };
+		F4D7FD6C2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */; };
 		F4D829622930E9F300038726 /* MigrationDeleteWordPressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829612930E9F300038726 /* MigrationDeleteWordPressViewController.swift */; };
 		F4D829642930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829632930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift */; };
 		F4D829662931046F00038726 /* UIButton+Dismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829652931046F00038726 /* UIButton+Dismiss.swift */; };
@@ -9082,6 +9083,7 @@
 		F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewControllerConfiguration.swift; sourceTree = "<group>"; };
 		F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutActionHandler.swift; sourceTree = "<group>"; };
 		F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostBlockingController.swift; sourceTree = "<group>"; };
+		F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompliancePopoverViewControllerTests.swift; sourceTree = "<group>"; };
 		F4D829612930E9F300038726 /* MigrationDeleteWordPressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationDeleteWordPressViewController.swift; sourceTree = "<group>"; };
 		F4D829632930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationDeleteWordPressViewModel.swift; sourceTree = "<group>"; };
 		F4D829652931046F00038726 /* UIButton+Dismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Dismiss.swift"; sourceTree = "<group>"; };
@@ -9893,6 +9895,7 @@
 			isa = PBXGroup;
 			children = (
 				088134FE2A56C5240027C086 /* CompliancePopoverViewModelTests.swift */,
+				F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */,
 			);
 			path = EUUSCompliance;
 			sourceTree = "<group>";
@@ -23476,6 +23479,7 @@
 				4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */,
 				24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,
+				F4D7FD6C2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift in Sources */,
 				DCFC6A29292523D20062D65B /* SiteStatsPinnedItemStoreTests.swift in Sources */,
 				D88A64AC208D9B09008AE9BC /* StockPhotosPageableTests.swift in Sources */,
 				40C403F82215D88100E8C894 /* TopViewedStatsTests.swift in Sources */,

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewControllerTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewControllerTests.swift
@@ -1,33 +1,40 @@
 import XCTest
-import Nimble
 
 @testable import WordPress
 
 final class CompliancePopoverViewControllerTests: CoreDataTestCase {
 
-    /// Tests that the event `privacyChoicesBannerPresented` is tracked.
-    func testTrackPrivacyChoicesBannerPresented() throws {
+    /// Tests that the method `viewModel.didDisplayPopover` is called on `viewDidLoad`.
+    func testViewModelDidDisplayPopoverCalled() throws {
         // Given
-        let tracker = PrivacySettingsAnalyticsTrackerSpy()
-        let viewModel = try makeCompliancePopoverViewModelMock(tracker: tracker)
+        let viewModel = try makeCompliancePopoverViewModelSpy()
         let controller = CompliancePopoverViewController(viewModel: viewModel)
 
         // When
         controller.loadViewIfNeeded()
 
         // Then
-        expect(tracker.trackedEvent).to(equal(.privacyChoicesBannerPresented))
-        expect(tracker.trackedEventProperties).to(beEmpty())
+        XCTAssertTrue(viewModel.didDisplayPopoverCalled)
     }
 
 }
 
-// MARK: - Mocks
+// MARK: - Test Doubles
 
-extension CompliancePopoverViewControllerTests {
+private final class CompliancePopoverViewModelSpy: CompliancePopoverViewModel {
 
-    func makeCompliancePopoverViewModelMock(tracker: PrivacySettingsAnalyticsTracking) throws -> CompliancePopoverViewModel {
+    private(set) var didDisplayPopoverCalled = false
+
+    override func didDisplayPopover() {
+        self.didDisplayPopoverCalled = true
+    }
+}
+
+fileprivate extension CompliancePopoverViewControllerTests {
+
+    func makeCompliancePopoverViewModelSpy() throws -> CompliancePopoverViewModelSpy {
+        let tracker = PrivacySettingsAnalyticsTrackerSpy()
         let defaults = try XCTUnwrap(UserDefaults(suiteName: "compliance-popover-mock"))
-        return .init(defaults: defaults, contextManager: contextManager, analyticsTracker: tracker)
+        return CompliancePopoverViewModelSpy(defaults: defaults, contextManager: contextManager, analyticsTracker: tracker)
     }
 }

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewControllerTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewControllerTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+final class CompliancePopoverViewControllerTests: CoreDataTestCase {
+
+    /// Tests that the event `privacyChoicesBannerPresented` is tracked.
+    func testTrackPrivacyChoicesBannerPresented() throws {
+        // Given
+        let tracker = PrivacySettingsAnalyticsTrackerSpy()
+        let viewModel = try makeCompliancePopoverViewModelMock(tracker: tracker)
+        let controller = CompliancePopoverViewController(viewModel: viewModel)
+
+        // When
+        controller.loadViewIfNeeded()
+
+        // Then
+        expect(tracker.trackedEvent).to(equal(.privacyChoicesBannerPresented))
+        expect(tracker.trackedEventProperties).to(beEmpty())
+    }
+
+}
+
+// MARK: - Mocks
+
+extension CompliancePopoverViewControllerTests {
+
+    func makeCompliancePopoverViewModelMock(tracker: PrivacySettingsAnalyticsTracking) throws -> CompliancePopoverViewModel {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "compliance-popover-mock"))
+        return .init(defaults: defaults, contextManager: contextManager, analyticsTracker: tracker)
+    }
+}

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
@@ -20,6 +20,22 @@ final class CompliancePopoverViewModelTests: CoreDataTestCase {
         testDefaults?.removeObject(forKey: UserDefaults.didShowCompliancePopupKey)
     }
 
+    /// Tests the tracking of the 'privacyChoicesBannerPresented' event when the privacy popover is displayed.
+    /// It also validates that no additional event properties are being tracked.
+    func testDidDisplayPopover() throws {
+        // Given
+        let defaults = try XCTUnwrap(testDefaults)
+        let tracker = PrivacySettingsAnalyticsTrackerSpy()
+        let sut = CompliancePopoverViewModel(defaults: defaults, contextManager: contextManager, analyticsTracker: tracker)
+
+        // When
+        sut.didDisplayPopover()
+
+        // Then
+        XCTAssertEqual(tracker.trackedEvent, .privacyChoicesBannerPresented)
+        XCTAssertEqual(tracker.trackedEventProperties, [:])
+    }
+
     func testDidTapSettingsUpdatesDefaults() throws {
         let defaults = try XCTUnwrap(testDefaults)
         let sut = CompliancePopoverViewModel(defaults: defaults, contextManager: contextManager)

--- a/WordPress/WordPressTest/Me/PrivacySettingsViewControllerTests.swift
+++ b/WordPress/WordPressTest/Me/PrivacySettingsViewControllerTests.swift
@@ -11,7 +11,7 @@ final class PrivacySettingsViewControllerTests: XCTestCase {
         viewController.crashReportingChanged(true)
 
         expect(spy.trackedEvent).to(equal(.privacySettingsReportCrashesToggled))
-        expect(spy.trackedEventProperties).to(equal(["enabled": "true"]))
+        expect(spy.trackedEventProperties).to(equal(["enabled": true.stringLiteral]))
     }
 }
 

--- a/WordPress/WordPressTest/Me/PrivacySettingsViewControllerTests.swift
+++ b/WordPress/WordPressTest/Me/PrivacySettingsViewControllerTests.swift
@@ -2,7 +2,7 @@ import Nimble
 @testable import WordPress
 import XCTest
 
-class PrivacySettingsViewControllerTests: XCTestCase {
+final class PrivacySettingsViewControllerTests: XCTestCase {
 
     func testCrashReportingChangedLogsEvent() {
         let spy = PrivacySettingsAnalyticsTrackerSpy()
@@ -10,20 +10,18 @@ class PrivacySettingsViewControllerTests: XCTestCase {
 
         viewController.crashReportingChanged(true)
 
-        expect(spy.trackedCrashReportingEnabled) == true
+        expect(spy.trackedEvent).to(equal(.privacySettingsReportCrashesToggled))
+        expect(spy.trackedEventProperties).to(equal(["enabled": "true"]))
     }
 }
 
-class PrivacySettingsAnalyticsTrackerSpy: PrivacySettingsAnalyticsTracking {
+final class PrivacySettingsAnalyticsTrackerSpy: PrivacySettingsAnalyticsTracking {
 
-    private(set) var trackedCrashReportingEnabled: Bool?
-    private(set) var trackedAnalyticsEnabled: Bool?
+    private(set) var trackedEvent: PrivacySettingsAnalytics?
+    private(set) var trackedEventProperties: [String: String]?
 
-    func trackPrivacySettingsReportCrashesToggled(enabled: Bool) {
-        trackedCrashReportingEnabled = enabled
-    }
-
-    func trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: Bool) {
-        trackedAnalyticsEnabled = analyticsEnabled
+    func track(_ event: PrivacySettingsAnalytics, properties: [String: String]) {
+        self.trackedEvent = event
+        self.trackedEventProperties = properties
     }
 }

--- a/WordPress/WordPressTest/PrivacySettingsAnalyticsTrackerTests.swift
+++ b/WordPress/WordPressTest/PrivacySettingsAnalyticsTrackerTests.swift
@@ -18,7 +18,7 @@ class PrivacySettingsAnalyticsTrackerTests: XCTestCase {
 
         expect(AnalyticsEventTrackingSpy.trackedEvents).to(haveCount(1))
         expect(AnalyticsEventTrackingSpy.trackedEvents).to(containElementSatisfying({ event in
-            event.name == PrivacySettingsAnalytics.privacyChoicesBannerSaveButtonTapped.rawValue &&
+            event.name == PrivacySettingsAnalytics.privacySettingsReportCrashesToggled.rawValue &&
             event.properties["enabled"] == true.stringLiteral
         }))
     }

--- a/WordPress/WordPressTest/PrivacySettingsAnalyticsTrackerTests.swift
+++ b/WordPress/WordPressTest/PrivacySettingsAnalyticsTrackerTests.swift
@@ -11,15 +11,51 @@ class PrivacySettingsAnalyticsTrackerTests: XCTestCase {
         AnalyticsEventTrackingSpy.reset()
     }
 
-    func test_trackPrivacySettingsReportCrashesToggled_enabled() {
+    /// Tests that the event `trackPrivacyChoicesBannerSaveButtonTapped` is tracked with the correct properties.
+    func test_trackPrivacyChoicesBannerSaveButtonTapped_analyticsEnabled() {
+        // Given
         let tracker = PrivacySettingsAnalyticsTracker(tracker: AnalyticsEventTrackingSpy.self)
 
+        // When
+        tracker.trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: true)
+
+        // Then
+        expect(AnalyticsEventTrackingSpy.trackedEvents).to(haveCount(1))
+        expect(AnalyticsEventTrackingSpy.trackedEvents).to(containElementSatisfying({ event in
+            event.name == PrivacySettingsAnalytics.privacyChoicesBannerSaveButtonTapped.rawValue &&
+            event.properties == ["analytics_enabled": true.stringLiteral]
+        }))
+    }
+
+    /// Tests that the event `privacyChoicesBannerSettingsButtonTapped` is tracked.
+    func test_privacyChoicesBannerSettingsButtonTapped() {
+        // Given
+        let tracker = PrivacySettingsAnalyticsTracker(tracker: AnalyticsEventTrackingSpy.self)
+
+        // When
+        tracker.track(.privacyChoicesBannerSettingsButtonTapped)
+
+        // Then
+        expect(AnalyticsEventTrackingSpy.trackedEvents).to(haveCount(1))
+        expect(AnalyticsEventTrackingSpy.trackedEvents).to(containElementSatisfying({ event in
+            event.name == PrivacySettingsAnalytics.privacyChoicesBannerSettingsButtonTapped.rawValue &&
+            event.properties.isEmpty
+        }))
+    }
+
+    /// Tests that the event `privacySettingsReportCrashesToggled` is tracked with the correct properties.
+    func test_trackPrivacySettingsReportCrashesToggled_enabled() {
+        // Given
+        let tracker = PrivacySettingsAnalyticsTracker(tracker: AnalyticsEventTrackingSpy.self)
+
+        // When
         tracker.trackPrivacySettingsReportCrashesToggled(enabled: true)
 
+        // Then
         expect(AnalyticsEventTrackingSpy.trackedEvents).to(haveCount(1))
         expect(AnalyticsEventTrackingSpy.trackedEvents).to(containElementSatisfying({ event in
             event.name == PrivacySettingsAnalytics.privacySettingsReportCrashesToggled.rawValue &&
-            event.properties["enabled"] == true.stringLiteral
+            event.properties == ["enabled": true.stringLiteral]
         }))
     }
 }

--- a/WordPress/WordPressTest/PrivacySettingsAnalyticsTrackerTests.swift
+++ b/WordPress/WordPressTest/PrivacySettingsAnalyticsTrackerTests.swift
@@ -12,6 +12,22 @@ class PrivacySettingsAnalyticsTrackerTests: XCTestCase {
     }
 
     /// Tests that the event `trackPrivacyChoicesBannerSaveButtonTapped` is tracked with the correct properties.
+    func test_privacySettingsAnalyticsTrackingToggled_enabled() {
+        // Given
+        let tracker = PrivacySettingsAnalyticsTracker(tracker: AnalyticsEventTrackingSpy.self)
+
+        // When
+        tracker.trackPrivacySettingsAnalyticsTrackingToggled(enabled: true)
+
+        // Then
+        expect(AnalyticsEventTrackingSpy.trackedEvents).to(haveCount(1))
+        expect(AnalyticsEventTrackingSpy.trackedEvents).to(containElementSatisfying({ event in
+            event.name == PrivacySettingsAnalytics.privacySettingsAnalyticsTrackingToggled.rawValue &&
+            event.properties == ["enabled": true.stringLiteral]
+        }))
+    }
+
+    /// Tests that the event `trackPrivacyChoicesBannerSaveButtonTapped` is tracked with the correct properties.
     func test_trackPrivacyChoicesBannerSaveButtonTapped_analyticsEnabled() {
         // Given
         let tracker = PrivacySettingsAnalyticsTracker(tracker: AnalyticsEventTrackingSpy.self)


### PR DESCRIPTION
Fixes #20798

## Description

This PR tracks EU/US Privacy Compliance Analytics. The tracking API was already implemented in another [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20937), so this PR merely calls the API and adds a few unit tests.

This PR also tracks an event when the Analytics Tracking switch is toggled in Private Settings screen. See [comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/21017#pullrequestreview-1516967883).

## Test Instructions

#### Privacy Compliance Popover

1. Change the following code to force display the compliance popup for testing purposes.
```swift
// Found in CompliancePopoverCoordinator.swift
func shouldShowPrivacyBanner(countryCode: String) -> Bool {
   let isCountryInEU = Self.gdprCountryCodes.contains(countryCode)
   return true // isCountryInEU && defaults.shouldShowCompliancePopup
}
```
2. Build and run Jetpack app and login.
3. Navigate to My Site > Dashboard.
4. Expect the compliance popup to appear.
5. Tap "Settings" button.
    - The popup will be dismissed, to bring it back, simply head to "Reader" tab then go back to "My Site" tab.
6. Tap "Save" button. 
7. Expect to see these logs in the console.
```
2023-07-06 14:26:39:881 Jetpack[82736:15540143] 🔵 Tracked: privacy_choices_banner_presented <>
2023-07-06 14:28:21:927 Jetpack[82736:15540143] 🔵 Tracked: privacy_choices_banner_settings_button_tapped <>
2023-07-06 14:28:23:382 Jetpack[82736:15540143] 🔵 Tracked: privacy_settings_opened <>
2023-07-06 14:28:30:178 Jetpack[82736:15540143] 🔵 Tracked: privacy_choices_banner_presented <>
2023-07-06 14:37:35:358 Jetpack[82736:15540143] 🔵 Tracked: privacy_choices_banner_save_button_tapped <analytics_enabled: true>
```

#### Private Settings
1. Head to My Site > Me > App Settings > Privacy Settings
2. Toggle the "Collect Information" switch on and off multiple times
3. Expect to see these logs in the console.
```
2023-07-10 18:32:33:411 Jetpack[16236:16778147] 🔵 Tracked: privacy_settings_analytics_tracking_toggled <enabled: true>
2023-07-10 18:32:39:303 Jetpack[16236:16778147] 🔵 Tracked: privacy_settings_analytics_tracking_toggled <enabled: false>
2023-07-10 18:32:42:605 Jetpack[16236:16778147] 🔵 Tracked: privacy_settings_analytics_tracking_toggled <enabled: true>
2023-07-10 18:32:45:664 Jetpack[16236:16778147] 🔵 Tracked: privacy_settings_analytics_tracking_toggled <enabled: false>
```

## Regression Notes
1. Potential unintended areas of impact
None.

9. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

10. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
