### PR TITLE
Show Plans card for free plans

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansDashboardCardHelper.swift
@@ -12,15 +12,7 @@ import Foundation
             return false
         }
 
-        /// If this propery is empty, it indicates that domain information is not yet loaded
-        let hasLoadedDomains = blog.domains?.isEmpty == false
-        let hasMappedDomain = blog.hasMappedDomain()
-        let hasFreePlan = !blog.hasPaidPlan
-
-        return blog.supports(.domains)
-            && hasFreePlan
-            && hasLoadedDomains
-            && !hasMappedDomain
+        return blog.supports(.domains) && !blog.hasPaidPlan
     }
 
     static func hideCard(for blog: Blog?) {

--- a/WordPress/WordPressTest/Dashboard/FreeToPaidPlansDashboardCardHelperTests.swift
+++ b/WordPress/WordPressTest/Dashboard/FreeToPaidPlansDashboardCardHelperTests.swift
@@ -28,7 +28,7 @@ final class FreeToPaidPlansDashboardCardHelperTests: CoreDataTestCase {
         XCTAssertFalse(result, "Card should not show for blogs without a free plan")
     }
 
-    func testShouldNotShowCardWithMappedDomain() {
+    func testShouldShowCardWithMappedDomain() {
         let blog = BlogBuilder(mainContext)
             .with(supportsDomains: true)
             .with(domainCount: 1, of: .wpCom)
@@ -39,20 +39,7 @@ final class FreeToPaidPlansDashboardCardHelperTests: CoreDataTestCase {
 
         let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
 
-        XCTAssertFalse(result, "Card should not show for blogs with a mapped domain")
-    }
-
-    func testShouldNotShowCardWhenDomainInformationIsNotLoaded() {
-        let blog = BlogBuilder(mainContext)
-            .with(supportsDomains: true)
-            .with(domainCount: 0, of: .wpCom)
-            .with(hasMappedDomain: false)
-            .with(hasPaidPlan: false)
-            .build()
-
-        let result = FreeToPaidPlansDashboardCardHelper.shouldShowCard(for: blog, isJetpack: true, featureFlagEnabled: true)
-
-        XCTAssertFalse(result, "Card should not show until domain information is loaded")
+        XCTAssertTrue(result, "Card should still be shown for blogs with a mapped domain and with a free plan")
     }
 
     func testShouldNotShowCardFeatureFlagDisabled() {


### PR DESCRIPTION
Related Android testing https://github.com/wordpress-mobile/WordPress-Android/pull/18742
Discussion: p1688563802683149-slack-C0560PCK2AD

## To test:


### Case 1 

1. Open Jetpack
2. Select a site with a free dotcom plan
3. Plans card should be shown

### Case 2

1. Open Jetpack
2. Select a site with a paid dotcom plan
3. Plans card should not be shown

## Regression Notes
1. Potential unintended areas of impact

Plans card will now be shown to users who already have domains without a dotcom plan

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual + automated testing

3. What automated tests I added (or what prevented me from doing so)

I updated test suite to confirm this case

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.