### PR TITLE
Blaze Manage Campaigns: Add promote button to campaigns list screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
@@ -35,7 +35,7 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
         stackView.axis = .horizontal
         stackView.alignment = .center
         stackView.spacing = Metrics.detailsOuterStackViewSpacing
-        stackView.addArrangedSubviews([detailsInnerStackView, featuredImageView, chevronView])
+        stackView.addArrangedSubviews([detailsInnerStackView, UIView(), featuredImageView, chevronView])
         return stackView
     }()
 
@@ -80,7 +80,6 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
         let imageView = UIImageView(image: image)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.tintColor = .separator
-        imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return imageView
     }()
 

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -12,6 +12,13 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
         action: #selector(buttonCreateCampaignTapped)
     )
 
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [tableView, promoteButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .plain)
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -179,8 +186,12 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
 
     private func setupView() {
         view.backgroundColor = .DS.Background.primary
-        view.addSubview(tableView)
-        view.pinSubviewToAllEdges(tableView)
+        view.addSubview(stackView)
+        view.pinSubviewToAllEdges(stackView)
+
+        NSLayoutConstraint.activate([
+            promoteButton.heightAnchor.constraint(equalToConstant: Metrics.promoteButtonHeight)
+        ])
     }
 
     private func setupNavBar() {

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -26,6 +26,26 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
         return tableView
     }()
 
+    private lazy var promoteButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(buttonCreateCampaignTapped), for: .touchUpInside)
+
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = Strings.promoteButtonTitle
+        configuration.image = UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(scale: .large))
+        configuration.imagePlacement = .leading
+        configuration.imagePadding = 8
+        configuration.baseBackgroundColor = UIColor(
+            light: UIColor(fromHex: 0xFDFDFD),
+            dark: UIColor(fromHex: 0x202020)
+        )
+        configuration.baseForegroundColor = .jetpackGreen
+        button.configuration = configuration
+
+        return button
+    }()
+
     private let refreshControl = UIRefreshControl()
 
     // MARK: - Properties
@@ -237,6 +257,10 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
 // MARK: - Constants
 
 private extension BlazeCampaignsViewController {
+
+    enum Metrics {
+        static let promoteButtonHeight: CGFloat = 55
+    }
 
     enum Strings {
         static let navigationTitle = NSLocalizedString("blaze.campaigns.title", value: "Blaze Campaigns", comment: "Title for the screen that allows users to manage their Blaze campaigns.")

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -41,6 +41,11 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
 
         var configuration = UIButton.Configuration.filled()
         configuration.title = Strings.promoteButtonTitle
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer({ incoming in
+            var outgoing = incoming
+            outgoing.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+            return outgoing
+        })
         configuration.image = UIImage(systemName: "plus", withConfiguration: UIImage.SymbolConfiguration(scale: .large))
         configuration.imagePlacement = .leading
         configuration.imagePadding = 8


### PR DESCRIPTION
Closes #20763 

## Description
- Adds a "+ Promote" button that hides on scroll
- Fixes a layout issue with the campaigns cell where the chevron was being collapsed

## How to test

0. Switch to a site that has multiple Blaze campaigns (See: p1687419588093579/1687363386.825549-slack-C04LJFS1G5P)
1. Dashboard > Blaze campaign dashboard card > Tap on the card header
2. ✅ Verify: the campaigns list screen is shown with the "+ Promote" button at the bottom of the screen
3. Pull to refresh
4. ✅  Verify: the "+ Promote" button stays visible
5. Scroll down
6.  ✅  Verify: the "+ Promote" button disappears
7. Scroll to the very top
8.  ✅  Verify: the "+ Promote" button reappears
9. Tap on the "+ Promote" button
10.  ✅  Verify: the Blaze flow is presented in a webview


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/1d597b27-de47-49ab-8dc5-f055e1d569b1



## Regression Notes
1. Potential unintended areas of impact
n/a

11. What I did to test those areas of impact (or what existing automated tests I relied on)
visual changes

12. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)