### PR TITLE
Drop iOS 14 Support: Address UIButton API deprecations (#3) 

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -33,7 +33,7 @@ class ActionSheetViewController: UIViewController {
 
         enum Button {
             static let height: CGFloat = 54
-            static let contentInsets  = NSDirectionalEdgeInsets(top: 0, leading: 18, bottom: 0, trailing: 35)
+            static let contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 18, bottom: 0, trailing: 35)
             static let imagePadding: CGFloat = 16
             static let imageTintColor: UIColor = .neutral(.shade30)
             static let font: UIFont = .preferredFont(forTextStyle: .callout)

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -33,8 +33,8 @@ class ActionSheetViewController: UIViewController {
 
         enum Button {
             static let height: CGFloat = 54
-            static let contentInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 35)
-            static let titleInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+            static let contentInsets  = NSDirectionalEdgeInsets(top: 0, leading: 18, bottom: 0, trailing: 35)
+            static let imagePadding: CGFloat = 16
             static let imageTintColor: UIColor = .neutral(.shade30)
             static let font: UIFont = .preferredFont(forTextStyle: .callout)
             static let textColor: UIColor = .text
@@ -147,27 +147,32 @@ class ActionSheetViewController: UIViewController {
         updateScrollViewHeight()
     }
 
-    private func createButton(_ handler: @escaping () -> Void) -> UIButton {
-        let button = UIButton(type: .custom, primaryAction: UIAction(handler: { _ in handler() }))
-        button.titleLabel?.font = Constants.Button.font
-        button.setTitleColor(Constants.Button.textColor, for: .normal)
-        button.imageView?.tintColor = Constants.Button.imageTintColor
-        button.setBackgroundImage(UIImage(color: .divider), for: .highlighted)
-        button.titleEdgeInsets = Constants.Button.titleInsets
-        button.naturalContentHorizontalAlignment = .leading
-        button.contentEdgeInsets = Constants.Button.contentInsets
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.flipInsetsForRightToLeftLayoutDirection()
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        return button
-    }
-
     private func button(_ info: ActionSheetButton) -> UIButton {
-        let button = createButton(info.action)
+        let button = UIButton(type: .system, primaryAction: UIAction(handler: { _ in info.action() }))
 
-        button.setTitle(info.title, for: .normal)
-        button.setImage(info.image, for: .normal)
+        button.configuration = {
+            var configuration = UIButton.Configuration.plain()
+            configuration.attributedTitle = {
+                var string = AttributedString(info.title)
+                string.font = Constants.Button.font
+                string.foregroundColor = Constants.Button.textColor
+                return string
+            }()
+            configuration.image = info.image
+            configuration.imageColorTransformer = UIConfigurationColorTransformer { _ in
+                Constants.Button.imageTintColor
+            }
+            configuration.imagePadding = Constants.Button.imagePadding
+            configuration.contentInsets = Constants.Button.contentInsets
+            configuration.background.cornerRadius = 0
+            return configuration
+        }()
+        button.configurationUpdateHandler = { button in
+            button.configuration?.background.backgroundColor = button.isHighlighted ? .divider : .clear
+        }
+        button.contentHorizontalAlignment = .leading
         button.accessibilityIdentifier = info.identifier
+        button.translatesAutoresizingMaskIntoConstraints = false
 
         if let badge = info.badge {
             button.addSubview(badge)


### PR DESCRIPTION
Related Issue #20860

Remove some unused code with `UIButton` deprecations.

## Test Test

- Tap the "Create New" FAB on dashboard
- Verify that buttons are displayed correctly

I verified it with an image diff tool. The new API works the same with the only exception how the dynamic type works: it leaves slightly less space between buttons, which I think is an improvement.

**before** → **after**

<img width="302" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/c12cb0b6-ad60-42b1-9806-ec54d2715dc4">
<img width="302" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/bd4d1367-e235-4f9d-b924-0030588ebe89">


<img width="302" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/adb7dce8-9932-423e-99e7-165b0089a1df">
<img width="302" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0be8ca7a-136d-4777-b565-0aa960a4f6cb">

<img width="302" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/90033a91-0f41-4d5b-9165-54df34b40112">
<img width="302" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b1884008-4b5a-4c48-81b8-29d373b826a6">


## Regression Notes
1. Potential unintended areas of impact: Media-related features
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests and unit tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
