### PR TITLE
Fix WPTableViewHandler warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1373,7 +1373,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
         return ContextManager.sharedInstance().mainContext
     }
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: entityName())
         request.sortDescriptors = [NSSortDescriptor(key: Filter.sortKey, ascending: false)]
         request.predicate = predicateForFetchRequest()
@@ -1817,7 +1817,9 @@ extension NotificationsViewController: WPSplitViewControllerDetailProvider {
 
     private func fetchFirstNotification() -> Notification? {
         let context = managedObjectContext()
-        let fetchRequest = self.fetchRequest()
+        guard let fetchRequest = self.fetchRequest() else {
+            return nil
+        }
         fetchRequest.fetchLimit = 1
 
         if let results = try? context.fetch(fetchRequest) as? [Notification] {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -434,7 +434,7 @@ class AbstractPostListViewController: UIViewController,
         return ContextManager.sharedInstance().mainContext
     }
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName())
         fetchRequest.predicate = predicateForFetchRequest()
         fetchRequest.sortDescriptors = sortDescriptorsForFetchRequest()

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -173,7 +173,7 @@ extension RevisionsTableViewController: WPTableViewHandlerDelegate {
         return ContextManager.sharedInstance().mainContext
     }
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         guard let postId = post?.postID, let siteId = post?.blog.dotComID else {
             preconditionFailure("Expected a postId or a siteId")
         }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -27,7 +27,7 @@ extension ReaderTagsTableViewModel: WPTableViewHandlerDelegate {
         return context
     }
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         return ReaderTagTopic.tagsFetchRequest
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -175,7 +175,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 
     // MARK: - TableViewHandler
 
-    override func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    override func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderCard.classNameWithoutNamespaces())
         fetchRequest.sortDescriptors = sortDescriptorsForFetchRequest(ascending: true)
         return fetchRequest

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -393,7 +393,7 @@ extension ReaderFollowedSitesViewController: WPTableViewHandlerDelegate {
     }
 
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSiteTopic")
         fetchRequest.predicate = NSPredicate(format: "following = YES")
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -176,7 +176,7 @@ extension ReaderSearchSuggestionsViewController: WPTableViewHandlerDelegate {
     }
 
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
         request.predicate = predicateForFetchRequest()
         request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1494,7 +1494,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
     }
 
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderPost.classNameWithoutNamespaces())
         fetchRequest.predicate = predicateForFetchRequest()
         fetchRequest.sortDescriptors = sortDescriptorsForFetchRequest()

--- a/WordPress/WordPressTest/PostListTableViewHandlerTests.swift
+++ b/WordPress/WordPressTest/PostListTableViewHandlerTests.swift
@@ -22,7 +22,7 @@ class PostListHandlerMock: NSObject, WPTableViewHandlerDelegate {
         return setUpInMemoryManagedObjectContext()
     }
 
-    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult> {
+    func fetchRequest() -> NSFetchRequest<NSFetchRequestResult>? {
         let a = NSFetchRequest<NSFetchRequestResult>(entityName: String(describing: Post.self))
         a.sortDescriptors = [NSSortDescriptor(key: BasePost.statusKeyPath, ascending: true)]
         return a


### PR DESCRIPTION
After the delegate changes introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/20863/files#diff-1496219d33cddc00c719d055bc396208aeb55a69ea23e32baf150afff5c55d57, there were a few new warnings that this PR addressed.

<img width="824" alt="Screenshot 2023-07-06 at 4 39 44 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/672b5922-e3b3-43fb-bfb5-0435f836a479">


## To Test

- Verify that Reader, Post List, Pages List, Notifications are loading

## Regression Notes
1. Potential unintended areas of impact: Reader, Post List, Pages List, Notifications
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
