### PR TITLE
Jetpack Social: Open social purchase link on subscribe now tap

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -44,9 +44,17 @@ extension PostSettingsViewController {
     }
 
     @objc func createRemainingSharesView() -> UIView {
-        let viewModel = JetpackSocialRemainingSharesViewModel {
-            // TODO
-            print("Subscribe tap")
+        let viewModel = JetpackSocialRemainingSharesViewModel { [weak self] in
+            guard let blog = self?.apost.blog,
+                  let hostname = blog.hostname,
+                  let url = URL(string: "https://wordpress.com/checkout/\(hostname)/jetpack_social_basic_yearly") else {
+                return
+            }
+            let webViewController = WebViewControllerFactory.controller(url: url,
+                                                                        blog: blog,
+                                                                        source: "post_settings_remaining_shares_subscribe_now")
+            let navigationController = UINavigationController(rootViewController: webViewController)
+            self?.present(navigationController, animated: true)
         }
         let hostController = UIHostingController(rootView: JetpackSocialSettingsRemainingSharesView(viewModel: viewModel))
         hostController.view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
See: #20784 

## Description

Opens the purchase link when `Subscribe now to share more` button is tapped on the social remaining shares view in the post settings.

## Testing

To test:
- Setup a self-hosted site with the Jetpack Social plugin
- Launch Jetpack and login
- Select the self-hosted site
- Setup a social connection if necessary (Menu > Social)
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- Scroll to the remaining shares view
- Tap on `Subscribe now to share more`
- **Verify** the checkout page appears with `Jetpack Social Basic` in the cart for the self-hosted site

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
