### PR TITLE
Jetpack Social: Update display rules and values for the remaining shares view

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialSettingsRemainingSharesView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialSettingsRemainingSharesView.swift
@@ -59,9 +59,9 @@ struct JetpackSocialRemainingSharesViewModel {
     let displayWarning: Bool
     let onSubscribeTap: () -> Void
 
-    init(remaining: Int = 27,
-         limit: Int = 30,
-         displayWarning: Bool = false,
+    init(remaining: Int,
+         limit: Int,
+         displayWarning: Bool,
          onSubscribeTap: @escaping () -> Void) {
         self.remaining = remaining
         self.limit = limit

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AutomatticTracks
 
 extension PostSettingsViewController {
 
@@ -49,6 +50,8 @@ extension PostSettingsViewController {
             // This scenario *shouldn't* happen since we check that the publicize info is not nil before
             // showing this view
             assertionFailure("No sharing limit on the blog")
+            let error = JetpackSocialError.missingSharingLimit
+            CrashLogging.main.logError(error, userInfo: ["source": "post_settings"])
             return UIView()
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -36,17 +36,13 @@ extension PostSettingsViewController {
         let isJetpackSocialEnabled = FeatureFlag.jetpackSocial.enabled
         let blogSupportsPublicize = apost.blog.supportsPublicize()
         let blogHasConnections = publicizeConnections.count > 0
-        let isSocialSharingLimited = apost.blog.isSocialSharingLimited
-        let blogHasPublicizeInfo = apost.blog.publicizeInfo != nil
+        let blogHasSharingLimit = apost.blog.sharingLimit != nil
 
         return isJetpackSocialEnabled
         && blogSupportsPublicize
         && blogHasConnections
-        && isSocialSharingLimited
-        && blogHasPublicizeInfo
+        && blogHasSharingLimit
     }
-
-
 
     @objc func createRemainingSharesView() -> UIView {
         guard let sharingLimit = apost.blog.sharingLimit else {

--- a/WordPress/Jetpack/Classes/Utility/JetpackSocialError.swift
+++ b/WordPress/Jetpack/Classes/Utility/JetpackSocialError.swift
@@ -1,0 +1,4 @@
+
+enum JetpackSocialError: Error {
+    case missingSharingLimit
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2104,6 +2104,8 @@
 		83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83DC5C462A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */; };
 		83DC5C472A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */; };
+		83E1E5592A58B5C2000B576F /* JetpackSocialError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */; };
+		83E1E55A2A58B5C2000B576F /* JetpackSocialError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */; };
 		83EF3D7B2937D703000AF9BF /* SharedDataIssueSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */; };
 		83EF3D7F2937F08C000AF9BF /* SharedDataIssueSolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
@@ -7473,6 +7475,7 @@
 		83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsAttribution.swift; sourceTree = "<group>"; };
 		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialSettingsRemainingSharesView.swift; sourceTree = "<group>"; };
+		83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialError.swift; sourceTree = "<group>"; };
 		83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolverTests.swift; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
@@ -13378,9 +13381,10 @@
 		8332DD2229259ABA00802F7D /* Utility */ = {
 			isa = PBXGroup;
 			children = (
-				8332DD2329259AE300802F7D /* DataMigrator.swift */,
-				FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */,
 				F4DD58312A095210009A772D /* DataMigrationError.swift */,
+				8332DD2329259AE300802F7D /* DataMigrator.swift */,
+				83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */,
+				FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -22472,6 +22476,7 @@
 				D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */,
 				9A09F915230C3E9700F42AB7 /* StoreFetchingStatus.swift in Sources */,
 				F582060223A85495005159A9 /* SiteDateFormatters.swift in Sources */,
+				83E1E5592A58B5C2000B576F /* JetpackSocialError.swift in Sources */,
 				F504D44825D717F600A2764C /* PostEditor.swift in Sources */,
 				837B49D7283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift in Sources */,
 				98BC522A27F6259700D6E8C2 /* BloggingPromptsFeatureDescriptionView.swift in Sources */,
@@ -23946,6 +23951,7 @@
 				011F52BE2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
 				FABB211B2602FC2C00C8785C /* CredentialsService.swift in Sources */,
 				3F5AAC242877791900AEF5DD /* JetpackButton.swift in Sources */,
+				83E1E55A2A58B5C2000B576F /* JetpackSocialError.swift in Sources */,
 				FABB211C2602FC2C00C8785C /* EncryptedLogTableViewController.swift in Sources */,
 				FABB211D2602FC2C00C8785C /* ActivityDateFormatting.swift in Sources */,
 				FABB211E2602FC2C00C8785C /* UIView+Subviews.m in Sources */,


### PR DESCRIPTION
See: #20784

## Description

- Updates the display rules for the remaining shares view. It now only shows when:
  - Jetpack Social feature flag is enabled
  - The blog supports publicize
  - The blog has social connections
  - The sharing is limited
  - The blog has the publicize info
- Wires up the remaining shares UI to the publicize info

## Testing

> **Note**
> The publicize info is not currently fetched anywhere in the app. Due to that, I'm including some test debugger commands in the testing steps.

<details><summary><strong>Example breakpoint</strong></summary>

![breakpoint](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/aea79549-3104-4a7e-b557-6ada4d65834f)

**Debugger command:** 
```
p let publicizeInfo = PublicizeInfo(context: ContextManager.shared.mainContext); publicizeInfo.shareLimit = 30; publicizeInfo.sharesRemaining = 27; apost.blog.publicizeInfo = publicizeInfo
```

</details>

**Shares remaining - No warning**
- Setup a self-hosted site with the Jetpack Social plugin
- Launch Jetpack and login
- Select the self-hosted site
- Setup a social connection if necessary (Menu > Social)
- Setup the breakpoint like the example from above ^ with the `sharesRemaining` set to a higher value than the number of social connections you have
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** the shares remaining view numbers match the numbers you used in the breakpoint

**Shares remaining - warning**
- Setup the breakpoint like the example from above ^ with the `sharesRemaining` set to a lower value than the number of social connections you have
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** the shares remaining view displays a warning icon now

**WP.com site**
- Switch to a WP.com hosted site
- Keep the breakpoint that sets the publicize info there
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** the shares remaining view does not appear

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
