### PR TITLE
Move liked users query to a static function

### DIFF
--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -42,7 +42,6 @@ extension PostService {
                                                         purgeExisting: purgeExisting) {
                                         let users = self.likeUsersFor(postID: postID, siteID: siteID)
                                         success(users, totalLikes.intValue, count)
-                                        LikeUserHelper.purgeStaleLikes()
                                     }
                                  }, failure: { error in
                                     DDLogError(String(describing: error))
@@ -104,6 +103,8 @@ private extension PostService {
             if purgeExisting {
                 self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext, likesToKeep: likers)
             }
+
+            LikeUserHelper.purgeStaleLikes(fromContext: derivedContext)
         }, completion: onComplete, on: .main)
     }
 

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -231,7 +231,7 @@ class LikesListController: NSObject {
         case .post(let postID):
             likingUsers = postService.likeUsersFor(postID: postID, siteID: siteID)
         case .comment(let commentID):
-            likingUsers = commentService.likeUsersFor(commentID: commentID, siteID: siteID)
+            likingUsers = LikeUserHelper.likeUsersFor(commentID: commentID, siteID: siteID, in: ContextManager.shared.mainContext)
         }
     }
 
@@ -283,7 +283,7 @@ class LikesListController: NSObject {
         case .post(let postID):
             fetchedUsers = postService.likeUsersFor(postID: postID, siteID: siteID, after: modifiedDate)
         case .comment(let commentID):
-            fetchedUsers = commentService.likeUsersFor(commentID: commentID, siteID: siteID, after: modifiedDate)
+            fetchedUsers = LikeUserHelper.likeUsersFor(commentID: commentID, siteID: siteID, after: modifiedDate, in: ContextManager.shared.mainContext)
         }
 
         excludeUserIDs = fetchedUsers.map { NSNumber(value: $0.userID) }

--- a/WordPress/WordPressTest/LikeUserHelperTests.swift
+++ b/WordPress/WordPressTest/LikeUserHelperTests.swift
@@ -95,7 +95,7 @@ class LikeUserHelperTests: CoreDataTestCase {
             let user = RemoteLikeUser(dictionary: dict, commentID: commentID, siteID: siteID)
             _ = LikeUserHelper.createOrUpdateFrom(remoteUser: user, context: mainContext)
         }
-        // Insert likes with an older data
+        // Insert likes with an older date
         for _ in 1...5 {
             let dict = createTestRemoteUserDictionary(withPreferredBlog: false, year: 1990)
             let user = RemoteLikeUser(dictionary: dict, commentID: commentID, siteID: siteID)

--- a/WordPress/WordPressTest/LikeUserHelperTests.swift
+++ b/WordPress/WordPressTest/LikeUserHelperTests.swift
@@ -114,7 +114,8 @@ class LikeUserHelperTests: CoreDataTestCase {
         // There are 15 likes on the comment with `commentID`
         XCTAssertEqual(LikeUserHelper.likeUsersFor(commentID: commentID, siteID: siteID, in: mainContext).count, 15)
 
-        // There are 10 likes since 2001
-        XCTAssertEqual(LikeUserHelper.likeUsersFor(commentID: commentID, siteID: siteID, after: Date(timeIntervalSinceReferenceDate: 0), in: mainContext).count, 10)
+        // There are 10 likes since 2001 and 5 likes before.
+        // How the `after` argument should behave might be confusing. See https://github.com/wordpress-mobile/WordPress-iOS/pull/21028#issuecomment-1624661943
+        XCTAssertEqual(LikeUserHelper.likeUsersFor(commentID: commentID, siteID: siteID, after: Date(timeIntervalSinceReferenceDate: 0), in: mainContext).count, 5)
     }
 }


### PR DESCRIPTION
Relates to #21008. The `CommentService.likeUsersFor(...)` function calls `performQuery` and returns `NSManagedObject` instances which can potentially introduce Core Data concurrency issues.

There are some code movements (which I'll add some comments to highlight) in this PR, but no major logic change.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A