### PR TITLE
[UI Tests] - Use default timeout value on screen init

### DIFF
--- a/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
@@ -18,8 +18,7 @@ public class ActionSheetComponent: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [Self.getBlogPostButton, Self.getSitePageButton],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -20,8 +20,7 @@ public class ActivityLogScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ dateRangeButtonGetter, activityTypeButtonGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/CommentsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/CommentsScreen.swift
@@ -29,8 +29,7 @@ public class CommentsScreen: ScreenObject {
                 navigationBarTitleGetter,
                 replyFieldGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/DomainsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/DomainsScreen.swift
@@ -15,8 +15,7 @@ public class DomainsScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ siteDomainsNavbarHeaderGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/DomainsSuggestionsScreen.swift
@@ -12,8 +12,7 @@ public class DomainsSuggestionsScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ siteDomainsNavbarHeaderGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -49,8 +49,7 @@ public class AztecEditorScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ textViewGetter(textField) ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
 
         showOptionsStrip()

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -36,8 +36,7 @@ public class BlockEditorScreen: ScreenObject {
         // expect to encase the screen.
         try super.init(
             expectedElementGetters: [ editorCloseButtonGetter, addBlockButtonGetter ],
-            app: app,
-            waitTimeout: 10
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/ChooseLayoutScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/ChooseLayoutScreen.swift
@@ -10,8 +10,7 @@ public class ChooseLayoutScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [closeButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
@@ -19,8 +19,7 @@ public class EditorNoticeComponent: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ noticeTitleGetter, noticeActionGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -15,8 +15,7 @@ public class EditorPostSettings: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.tables["SettingsTable"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
@@ -22,8 +22,7 @@ public class EditorPublishEpilogueScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ getDoneButton, getViewButton, publishedPostStatusGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
@@ -6,8 +6,7 @@ public class CategoriesComponent: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.tables["CategoriesList"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
@@ -9,8 +9,7 @@ public class TagsComponent: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.textViews["add-tags"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
@@ -9,8 +9,7 @@ public class FeaturedImageScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.navigationBars.buttons["Remove Featured Image"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
@@ -6,8 +6,7 @@ public class JetpackBackupOptionsScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.otherElements.firstMatch } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
@@ -13,8 +13,7 @@ public class JetpackBackupScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ellipsisButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
@@ -6,8 +6,7 @@ public class JetpackScanScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.otherElements.firstMatch } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/FeatureIntroductionScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/FeatureIntroductionScreen.swift
@@ -11,8 +11,7 @@ public class FeatureIntroductionScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [closeButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -15,8 +15,7 @@ public class LinkOrPasswordScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [passwordOptionGetter, linkButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -14,8 +14,7 @@ public class LoginCheckMagicLinkScreen: ScreenObject {
                 // swiftlint:disable:next opening_brace
                 { $0.buttons["Open Mail Button"] }
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -19,8 +19,7 @@ public class LoginEmailScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [emailTextFieldGetter, nextButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -13,7 +13,7 @@ public class LoginEpilogueScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [loginEpilogueTableGetter],
             app: app,
-            waitTimeout: 60
+            waitTimeout: 65
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -13,7 +13,7 @@ public class LoginEpilogueScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [loginEpilogueTableGetter],
             app: app,
-            waitTimeout: 65
+            waitTimeout: 70
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -12,8 +12,7 @@ class LoginPasswordScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [passwordTextFieldGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -26,8 +26,7 @@ public class LoginSiteAddressScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [siteAddressTextFieldGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -44,8 +44,7 @@ public class LoginUsernamePasswordScreen: ScreenObject {
                 usernameTextFieldGetter,
                 passwordTextFieldGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/OnboardingQuestionsPromptScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/OnboardingQuestionsPromptScreen.swift
@@ -11,8 +11,7 @@ public class OnboardingQuestionsPromptScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [skipButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/QuickStartPromptScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/QuickStartPromptScreen.swift
@@ -12,8 +12,7 @@ public class QuickStartPromptScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [noThanksButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -38,8 +38,7 @@ public class GetStartedScreen: ScreenObject {
                 emailTextFieldGetter,
                 helpButtonGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -22,8 +22,7 @@ public class PasswordScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ passwordTextFieldGetter, continueButtonGetter ],
-            app: app,
-            waitTimeout: 10
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -17,8 +17,7 @@ public class PrologueScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [continueButtonGetter, siteAddressButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -19,8 +19,7 @@ public class WelcomeScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [logInButtonGetter, signupButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -15,8 +15,7 @@ public class WelcomeScreenLoginComponent: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [emailLoginButtonGetter, siteAddressButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
@@ -34,8 +34,7 @@ public class ContactUsScreen: ScreenObject {
                 closeButtonGetter,
                 attachButtonGetter,
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -39,8 +39,7 @@ public class SupportScreen: ScreenObject {
                 { $0.cells["activity-logs-button"] }
                 // swiftlint:enable opening_brace
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -20,8 +20,7 @@ public class MeTabScreen: ScreenObject {
 
         try super.init(
             expectedElementGetter: { $0.cells["appSettings"] },
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
@@ -10,8 +10,7 @@ public class MediaPickerAlbumListScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetter: albumListGetter,
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
@@ -9,8 +9,7 @@ public class MediaPickerAlbumScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [mediaCollectionGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MediaScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MediaScreen.swift
@@ -6,8 +6,7 @@ public class MediaScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.collectionViews["MediaCollection"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -128,8 +128,7 @@ public class MySiteScreen: ScreenObject {
                 mediaButtonGetter,
                 createButtonGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -24,8 +24,7 @@ public class MySitesScreen: ScreenObject {
                 cancelButtonGetter,
                 plusButtonGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -6,8 +6,7 @@ public class NotificationsScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.tables["Notifications Table"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/PagesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PagesScreen.swift
@@ -15,8 +15,7 @@ public class PagesScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ pagesTableGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
@@ -17,8 +17,7 @@ public class PeopleScreen: ScreenObject {
                 filterButtonGetter("followers"),
                 filterButtonGetter("email")
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/PlanSelectionScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PlanSelectionScreen.swift
@@ -9,8 +9,7 @@ public class PlanSelectionScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ webViewGetter ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -13,8 +13,7 @@ public class PostsScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.tables["PostsTable"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
         showOnly(.published)
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -16,8 +16,7 @@ public class ReaderScreen: ScreenObject {
                 { $0.tables["Reader"] },
                 discoverButtonGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
@@ -7,8 +7,7 @@ public class SignupCheckMagicLinkScreen: ScreenObject {
         try super.init(
             // swiftlint:disable:next opening_brace
             expectedElementGetters: [{ $0.buttons["Open Mail Button"] }],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
@@ -19,8 +19,7 @@ public class SignupEmailScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [emailTextFieldGetter, nextButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
@@ -6,8 +6,7 @@ public class SignupEpilogueScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.staticTexts["New Account Header"] } ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
@@ -14,8 +14,7 @@ public class WelcomeScreenSignupComponent: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [emailSignupButtonGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/SiteIntentScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/SiteIntentScreen.swift
@@ -14,8 +14,7 @@ public class SiteIntentScreen: ScreenObject {
                 { $0.tables["Site Intent Table"] },
                 cancelButtonGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
@@ -16,8 +16,7 @@ public class SiteSettingsScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [blockEditorToggleGetter],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -19,8 +19,7 @@ public class StatsScreen: ScreenObject {
         try super.init(
             // swiftlint:disable:next opening_brace
             expectedElementGetters: [{ $0.otherElements.firstMatch }],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -30,8 +30,7 @@ public class TabNavComponent: ScreenObject {
                 readerTabButtonGetter,
                 notificationsTabButtonGetter
             ],
-            app: app,
-            waitTimeout: 7
+            app: app
         )
     }
 

--- a/WordPress/UITestsFoundation/XCUIApplication+SavePassword.swift
+++ b/WordPress/UITestsFoundation/XCUIApplication+SavePassword.swift
@@ -6,7 +6,7 @@ extension XCUIApplication {
     // This method encapsulates the logic to dimiss the prompt.
     func dismissSavePasswordPrompt() {
         XCTContext.runActivity(named: "Dismiss save password prompt if needed.") { _ in
-            guard buttons["Save Password"].waitForExistence(timeout: 5) else { return  }
+            guard buttons["Save Password"].waitForExistence(timeout: 10) else { return  }
 
             // There should be no need to wait for this button to exist since it's part of the same
             // alert where "Save Password" is.


### PR DESCRIPTION
### Description
The iOS UI tests are seeing an increased number of flakiness because of timeouts. Not sure what the reason is but the worker seems to be slower now, causing the timeouts to happen more often. 

Example of tests timing out (randomly selected build from today):
<img width="1168" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/fcd405d0-8f87-46b5-8ecc-10a58a01c317">

While trying to increase the timeouts in some of the screens, I noticed that ScreenObject actually has a default timeout value of `20` but on the screens, we are adding individual timeout values, which doesn't seem to be necessary. If we want to increase the default timeout, we should be able to update it on 1 file and shouldn't need to go through individual files unless for specific cases where we would need to use a different value. The change I'm making is removing the timeout from the screen `init` (except on `LoginEpilogueScreen` which unfortunately needs a longer timeout value) and letting all the screens use the default timeout value set by ScreenObject, if we decide that timeout is no longer optimal we should make the change on the default value instead. 

### Testing
CI should be 🟢 in back to back runs