### PR TITLE
Blaze Manage Campaigns: Show campaigns list from site menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -42,6 +42,10 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
         super.init(nibName: nil, bundle: nil)
     }
 
+    @objc class func make(blog: Blog) -> BlazeCampaignsViewController {
+        BlazeCampaignsViewController(blog: blog)
+    }
+
     required init?(coder: NSCoder) {
         // This VC is designed to be initialized programmatically.
         fatalError("init(coder:) has not been implemented")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -805,7 +805,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                             callback:^{
         [weakSelf showBlaze];
     }];
-    blazeRow.showsSelectionState = NO;
+    blazeRow.showsSelectionState = [RemoteFeature enabled:RemoteFeatureFlagBlazeManageCampaigns];
     return blazeRow;
 }
 
@@ -1984,11 +1984,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showBlaze
 {
     [BlazeEventsTracker trackEntryPointTappedFor:BlazeSourceMenuItem];
-    
-    [BlazeFlowCoordinator presentBlazeInViewController:self
-                                                source:BlazeSourceMenuItem
-                                                  blog:self.blog
-                                                  post:nil];
+
+    if ([RemoteFeature enabled:RemoteFeatureFlagBlazeManageCampaigns]) {
+        BlazeCampaignsViewController *controller = [BlazeCampaignsViewController makeWithBlog:self.blog];
+        [self.presentationDelegate presentBlogDetailsViewController:controller];
+    } else {
+        [BlazeFlowCoordinator presentBlazeInViewController:self
+                                                    source:BlazeSourceMenuItem
+                                                      blog:self.blog
+                                                      post:nil];
+    }
 }
 
 - (void)showScan


### PR DESCRIPTION
Fixes #21020

## To test:

- Enable "Blaze Manage Campaign" remote feature flag
- Go Dashboard / Site Menu and select Blaze
- Verify that it opens the new campaign list
- (iPad-only) Verify that the menu selection works as expected

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/1867fed3-ce92-4db3-9ff5-df0abaa37b2e

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/c284a80a-cea0-4723-868f-3a60b9e10b82

## Regression Notes
1. Potential unintended areas of impact: Blaze menu item
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
