### PR TITLE
Drop iOS 14 Support: Address UIButton API deprecations (#4)

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -63,16 +63,4 @@ struct StoryAction: ActionSheetItem {
                                                 handler()
                                             })
     }
-
-    static func newBadge(title: String) -> UIButton {
-        let badge = UIButton(type: .custom)
-        badge.translatesAutoresizingMaskIntoConstraints = false
-        badge.setTitle(title, for: .normal)
-        badge.titleLabel?.font = Constants.Badge.font
-        badge.contentEdgeInsets = Constants.Badge.insets
-        badge.layer.cornerRadius = Constants.Badge.cornerRadius
-        badge.isUserInteractionEnabled = false
-        badge.backgroundColor = Constants.Badge.backgroundColor
-        return badge
-    }
 }

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -61,9 +61,14 @@ class WhatIsNewView: UIView {
     private lazy var backButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentEdgeInsets = UIEdgeInsets(top: self.appearance.backButtonInset, left: self.appearance.backButtonInset, bottom: 0, right: 0)
-        button.setImage(UIImage.gridicon(.arrowLeft), for: .normal)
+        button.configuration = {
+            var configuration = UIButton.Configuration.plain()
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: self.appearance.backButtonInset, leading: self.appearance.backButtonInset, bottom: 0, trailing: 0)
+            configuration.image = UIImage.gridicon(.arrowLeft)
+            return configuration
+        }()
         button.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+        button.semanticContentAttribute = .forceLeftToRight
         button.accessibilityLabel = NSLocalizedString("Back", comment: "Dismiss view")
         button.tintColor = self.appearance.backButtonTintColor
         return button

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -803,7 +803,6 @@
 		3F421DF524A3EC2B00CA9B9E /* Spotlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F421DF424A3EC2B00CA9B9E /* Spotlightable.swift */; };
 		3F435220289B2B2B00CE19ED /* JetpackBrandingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43704328932F0100475B6E /* JetpackBrandingCoordinator.swift */; };
 		3F435221289B2B5100CE19ED /* JetpackOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43703E2893201400475B6E /* JetpackOverlayViewController.swift */; };
-		3F435222289B2B5A00CE19ED /* JetpackOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4370402893207C00475B6E /* JetpackOverlayView.swift */; };
 		3F43602F23F31D48001DEE70 /* ScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43602E23F31D48001DEE70 /* ScenePresenter.swift */; };
 		3F43603123F31E09001DEE70 /* MeScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43603023F31E09001DEE70 /* MeScenePresenter.swift */; };
 		3F43603323F36515001DEE70 /* BlogListViewController+BlogDetailsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43603223F36515001DEE70 /* BlogListViewController+BlogDetailsFactory.swift */; };
@@ -25279,7 +25278,6 @@
 				8313B9EF298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */,
 				982DA9A8263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
 				FABB24E12602FC2C00C8785C /* MediaLibraryPicker.swift in Sources */,
-				3F435222289B2B5A00CE19ED /* JetpackOverlayView.swift in Sources */,
 				46F583D52624D0BC0010A723 /* Blog+BlockEditorSettings.swift in Sources */,
 				FABB24E22602FC2C00C8785C /* SharingAccountViewController.swift in Sources */,
 				FABB24E32602FC2C00C8785C /* TodayExtensionService.m in Sources */,


### PR DESCRIPTION
Related Issue #20860

Removes some unused code and fixed a couple of other deprecation warnings.

## To Test

- Fresh install (or make sure you haven't created any stories before)
- Tap FAB and select Create Story
- Verify that the back button layout appears normal

**before** → **after**

<img width="254" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/340a940c-5791-49e4-b2dd-613ef67602d9">
<img width="254" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/dbfa835a-62d8-497c-abfb-c8a84d429e35">
<br/>

<img width="254" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/f92789c1-eb23-4623-87f0-bb129831b45e">
<img width="254" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/58b2da1c-c058-4228-9ac2-9e6c197371de">

## Regression Notes
1. Potential unintended areas of impact: Stories What's New
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
