### PR TITLE
[UI Tests] Disable Auto Fill Passwords for UI Tests

### DIFF
--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -8,6 +8,9 @@ extension XCTestCase {
         removeBeforeLaunching: Bool = false,
         crashOnCoreDataConcurrencyIssues: Bool = true
     ) {
+        // To avoid handling 'Save Password' prompts after login.
+        disableAutoFillPasswords()
+
         // To ensure that the test starts with a new simulator launch each time
         app.terminate()
         super.setUp()
@@ -30,6 +33,24 @@ extension XCTestCase {
         // Media permissions alert handler
         let alertButtonTitle = "Allow Access to All Photos"
         systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: alertButtonTitle)
+    }
+
+    public func disableAutoFillPasswords() {
+        let settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+        settings.activate()
+        settings.staticTexts["Passwords"].tap()
+
+        let enterPasscodeScreen = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        enterPasscodeScreen.secureTextFields["Passcode field"].typeText(" ")
+        enterPasscodeScreen.buttons["done"].tap()
+
+        settings.staticTexts["Password Options"].tap()
+
+        let autoFillPasswordsSwitch = settings.switches["AutoFill Passwords"]
+        if autoFillPasswordsSwitch.value as? String == "1" {
+            autoFillPasswordsSwitch.tap()
+        }
+        settings.terminate()
     }
 
     public func takeScreenshotOfFailedTest() {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -86,8 +86,6 @@ public class LoginUsernamePasswordScreen: ScreenObject {
             passwordTextField.typeText(password)
         }
         nextButton.tap()
-
-        app.dismissSavePasswordPrompt()
     }
 
     private func dismissQuickStartPromptIfNeeded() throws {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -29,8 +29,6 @@ public class PasswordScreen: ScreenObject {
     public func proceedWithValidPassword() throws -> LoginEpilogueScreen {
         try tryProceed(password: "pw")
 
-        app.dismissSavePasswordPrompt()
-
         return try LoginEpilogueScreen()
     }
 
@@ -60,7 +58,6 @@ public class PasswordScreen: ScreenObject {
 
         passwordTextField.typeText(password)
         continueButton.tap()
-        app.dismissSavePasswordPrompt()
     }
 
     @discardableResult

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -24,8 +24,6 @@ public class PrologueScreen: ScreenObject {
     public func selectContinue() throws -> GetStartedScreen {
         continueButton.tap()
 
-        app.dismissSavePasswordPrompt()
-
         return try GetStartedScreen()
     }
 


### PR DESCRIPTION
### Description

The objective of this PR is to disable Auto Fill Passwords under Settings for UI Tests to avoid the burden of dealing with the `Save Password` prompt, which is handled now in regular runs but it's heavily impacted by the long delays during Login perceived in CI (analysis available below). 

<details><summary><b>iPad FAIL/PASS analysis</b></summary>
<img width="2068" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/b88d58f5-8bad-4fe3-8d54-33c5a456a9a5">
</details> 

<details><summary><b>iPhone FAIL/PASS analysis</b></summary>
<img width="1996" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/82303e2c-7c54-4886-b38b-4c7a053c4aee">
</details> 

### Testing

* UI Test steps in CI should be 🟢.