### PR TITLE
Jetpack Social: Refactor JetpackSocialService enum to PublicizeService

### DIFF
--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -24,3 +24,29 @@ open class PublicizeService: NSManagedObject {
         status == Self.defaultStatus
     }
 }
+
+// MARK: - Convenience Methods
+
+extension PublicizeService {
+
+    /// A convenient value-type representation for the destination sharing service.
+    enum ServiceName: String {
+        case facebook
+        case twitter
+        case tumblr
+        case linkedin
+        case instagram = "instagram-business"
+        case mastodon
+        case unknown
+
+        /// Returns an image of the social network's icon.
+        /// If the icon is not available locally,
+        var iconImage: UIImage {
+            WPStyleGuide.socialIcon(for: rawValue as NSString)
+        }
+    }
+
+    var name: ServiceName {
+        .init(rawValue: serviceID) ?? .unknown
+    }
+}

--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -39,9 +39,8 @@ extension PublicizeService {
         case mastodon
         case unknown
 
-        /// Returns an image of the social network's icon.
-        /// If the icon is not available locally,
-        var iconImage: UIImage {
+        /// Returns the local image for the icon representing the social network.
+        var localIconImage: UIImage {
             WPStyleGuide.socialIcon(for: rawValue as NSString)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
@@ -106,6 +106,7 @@ extension WPStyleGuide {
         }
     }
 
+    // TODO: Remove this in favor of `PublicizeService.ServiceName` once `jetpackSocial` flag is removed.
     enum SharingServiceNames: String {
         case Facebook = "facebook"
         case Twitter = "twitter"

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -79,25 +79,14 @@ class JetpackSocialNoConnectionViewModel: ObservableObject {
         updateIcons(services)
     }
 
-    enum JetpackSocialService: String {
-        case facebook
-        case twitter
-        case tumblr
-        case linkedin
-        case instagram = "instagram-business"
-        case mastodon
-        case unknown
-    }
-
     private func updateIcons(_ services: [PublicizeService]) {
         var icons: [UIImage] = []
         var downloadTasks: [(url: URL, index: Int)] = []
         for (index, service) in services.enumerated() {
-            let serviceType = JetpackSocialService(rawValue: service.serviceID) ?? .unknown
             let icon = WPStyleGuide.socialIcon(for: service.serviceID as NSString)
             icons.append(icon)
 
-            if serviceType == .unknown {
+            if service.name == .unknown {
                 guard let iconUrl = URL(string: service.icon) else {
                     continue
                 }


### PR DESCRIPTION
Refs #20783 

We have two `JetpackSocialService` (one for the remote service thing, and one is the private enum inside `JetpackSocialNoConnectionView`). Since I'll need the enum too, I'm moving it to `PublicizeService`.

Plus, I noticed that we have a legacy `SharingServiceNames` which serves a similar purpose. I'll look into updating this once we get rid of the feature flag later in the future.

## To test

- Launch the Jetpack app.
- Ensure that the `jetpackSocial` flag is turned on.
- Switch to a blog that supports Publicize, but does NOT have any social connections set up.
- Create a new post and go to Post Settings.
- Verify that the No Connection view is properly displayed.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The feature is unreleased, and usage is limited only to `JetpackSocialNoConnectionView`.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

4. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
