### PR TITLE
Jetpack Social: Add initial view for the pre-publishing social cell

### DIFF
--- a/WordPress/Classes/Models/PublicizeService+Lookup.swift
+++ b/WordPress/Classes/Models/PublicizeService+Lookup.swift
@@ -27,4 +27,18 @@ extension PublicizeService {
         request.sortDescriptors = [sortDescriptor]
         return try context.fetch(request)
     }
+
+    /// Returns an array of all cached `PublicizeService` objects that are supported by Jetpack Social.
+    ///
+    /// Note that services without a `status` field from the remote will be marked as supported by default.
+    ///
+    /// - Parameter context: The managed object context.
+    /// - Returns: An array of `PublicizeService`. The array is empty if no objects are cached.
+    static func allSupportedServices(in context: NSManagedObjectContext) throws -> [PublicizeService] {
+        let request = NSFetchRequest<PublicizeService>(entityName: PublicizeService.classNameWithoutNamespaces())
+        let sortDescriptor = NSSortDescriptor(key: "order", ascending: true)
+        request.predicate = NSPredicate(format: "status == %@", Self.defaultStatus)
+        request.sortDescriptors = [sortDescriptor]
+        return try context.fetch(request)
+    }
 }

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -222,6 +222,10 @@ class StoryEditor: CameraController {
 
 extension StoryEditor: PublishingEditor {
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
+        if FeatureFlag.jetpackSocial.enabled {
+            return  [.title, .visibility, .schedule, .tags, .categories, .autoSharing]
+        }
+
         return  [.title, .visibility, .schedule, .tags, .categories]
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -145,6 +145,10 @@ extension PostEditor {
     }
 
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
+        if FeatureFlag.jetpackSocial.enabled {
+            return [.visibility, .schedule, .tags, .categories, .autoSharing]
+        }
+
         return [.visibility, .schedule, .tags, .categories]
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 struct PrepublishingAutoSharingView: View {
 
+    // TODO: view model.
+
     var body: some View {
         HStack {
             textStack
@@ -11,16 +13,17 @@ struct PrepublishingAutoSharingView: View {
     }
 
     var textStack: some View {
-        VStack {
-            Text("Sharing to @sporadicthoughts")
+        VStack(alignment: .leading) {
+            Text(String(format: Strings.primaryLabelActiveConnectionsFormat, 3))
                 .font(.body)
                 .foregroundColor(Color(.label))
-            Text("27/30 social shares remaining")
+            Text(String(format: Strings.remainingSharesTextFormat, 27, 30))
                 .font(.subheadline)
                 .foregroundColor(Color(.secondaryLabel))
         }
     }
 
+    // TODO: This will be implemented separately.
     var iconTrain: some View {
         HStack {
             if let uiImage = UIImage(named: "icon-tumblr") {
@@ -32,6 +35,38 @@ struct PrepublishingAutoSharingView: View {
                     .overlay(Circle().stroke(Color(UIColor.listForeground), lineWidth: 2.0))
             }
         }
+    }
+}
+
+// MARK: - Helpers
+
+private extension PrepublishingAutoSharingView {
+
+    enum Strings {
+        static let primaryLabelActiveConnectionsFormat = NSLocalizedString(
+            "prepublishing.social.text.activeConnections",
+            value: "Sharing to %1$d accounts",
+            comment: """
+                The primary label for the auto-sharing row on the pre-publishing sheet.
+                Indicates the number of social accounts that will be auto-sharing the blog post.
+                %1$d is a placeholder for the number of social network accounts that will be auto-shared.
+                Example: Sharing to 3 accounts
+                """
+        )
+
+        // TODO: More text variations.
+
+        static let remainingSharesTextFormat = NSLocalizedString(
+            "prepublishing.social.remainingShares",
+            value: "%1$d/%2$d social shares remaining",
+            comment: """
+                A subtext that's shown below the primary label in the auto-sharing row on the pre-publishing sheet.
+                Informs the remaining limit for post auto-sharing.
+                %1$d is a placeholder for the remaining shares.
+                %2$d is a placeholder for the maximum shares allowed for the user's blog.
+                Example: 27/30 social shares remaining
+                """
+        )
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct PrepublishingAutoSharingView: View {
+
+    var body: some View {
+        HStack {
+            textStack
+            Spacer()
+            iconTrain
+        }
+    }
+
+    var textStack: some View {
+        VStack {
+            Text("Sharing to @sporadicthoughts")
+                .font(.body)
+                .foregroundColor(Color(.label))
+            Text("27/30 social shares remaining")
+                .font(.subheadline)
+                .foregroundColor(Color(.secondaryLabel))
+        }
+    }
+
+    var iconTrain: some View {
+        HStack {
+            if let uiImage = UIImage(named: "icon-tumblr") {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .frame(width: 32.0, height: 32.0)
+                    .background(Color(UIColor.listForeground))
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color(UIColor.listForeground), lineWidth: 2.0))
+            }
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -13,11 +13,18 @@ extension PrepublishingViewController {
 
     func configureSocialCell(_ cell: UITableViewCell) {
         // TODO:
-        // - Show the PrepublishingAutoSharingView.
         // - Show the NoConnectionView if user has 0 connections.
-        // - Properly configure the view models.
+        // - Properly create and configure the view models.
         let autoSharingView = UIView.embedSwiftUIView(PrepublishingAutoSharingView())
         cell.contentView.addSubview(autoSharingView)
-        cell.pinSubviewToAllEdges(autoSharingView)
+
+        // Pin constraints to the cell's layoutMarginsGuide so that the content is properly aligned.
+        NSLayoutConstraint.activate([
+            autoSharingView.leadingAnchor.constraint(equalTo: cell.contentView.layoutMarginsGuide.leadingAnchor),
+            autoSharingView.topAnchor.constraint(equalTo: cell.contentView.layoutMarginsGuide.topAnchor),
+            autoSharingView.bottomAnchor.constraint(equalTo: cell.contentView.layoutMarginsGuide.bottomAnchor),
+            autoSharingView.trailingAnchor.constraint(equalTo: cell.contentView.layoutMarginsGuide.trailingAnchor)
+        ])
+        cell.accessoryType = .disclosureIndicator
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -16,7 +16,7 @@ extension PrepublishingViewController {
         // - Show the PrepublishingAutoSharingView.
         // - Show the NoConnectionView if user has 0 connections.
         // - Properly configure the view models.
-        let autoSharingView = UIView()
+        let autoSharingView = UIView.embedSwiftUIView(PrepublishingAutoSharingView())
         cell.contentView.addSubview(autoSharingView)
         cell.pinSubviewToAllEdges(autoSharingView)
     }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -1,0 +1,23 @@
+extension PrepublishingViewController {
+
+    /// Determines whether the account and the post's blog is eligible to see auto-sharing options.
+    var isEligibleForAutoSharing: Bool {
+        let postObjectID = post.objectID
+        let blogSupportsPublicize = coreDataStack.performQuery { context in
+            let post = (try? context.existingObject(with: postObjectID)) as? Post
+            return post?.blog.supportsPublicize() ?? false
+        }
+
+        return blogSupportsPublicize && FeatureFlag.jetpackSocial.enabled
+    }
+
+    func configureSocialCell(_ cell: UITableViewCell) {
+        // TODO:
+        // - Show the PrepublishingAutoSharingView.
+        // - Show the NoConnectionView if user has 0 connections.
+        // - Properly configure the view models.
+        let autoSharingView = UIView()
+        cell.contentView.addSubview(autoSharingView)
+        cell.pinSubviewToAllEdges(autoSharingView)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -11,15 +11,7 @@ private struct PrepublishingOption {
 private enum PrepublishingCellType {
     case value
     case textField
-
-    var cellType: UITableViewCell.Type {
-        switch self {
-        case .value:
-            return WPTableViewCell.self
-        case .textField:
-            return WPTextFieldTableViewCell.self
-        }
-    }
+    case customContainer
 }
 
 enum PrepublishingIdentifier {
@@ -28,10 +20,12 @@ enum PrepublishingIdentifier {
     case visibility
     case tags
     case categories
+    case autoSharing
 }
 
 class PrepublishingViewController: UITableViewController {
     let post: Post
+    let coreDataStack: CoreDataStack
 
     private lazy var publishSettingsViewModel: PublishSettingsViewModel = {
         return PublishSettingsViewModel(post: post)
@@ -48,7 +42,23 @@ class PrepublishingViewController: UITableViewController {
 
     private let completion: (CompletionResult) -> ()
 
-    private let options: [PrepublishingOption]
+    private let identifiers: [PrepublishingIdentifier]
+
+    private lazy var options: [PrepublishingOption] = {
+        return identifiers.compactMap { identifier in
+            switch identifier {
+            case .autoSharing:
+                // skip the social cell if the post's blog is not eligible for auto-sharing.
+                guard isEligibleForAutoSharing else {
+                    return nil
+                }
+                break
+            default:
+                break
+            }
+            return .init(identifier: identifier)
+        }
+    }()
 
     private var didTapPublish = false
 
@@ -64,12 +74,14 @@ class PrepublishingViewController: UITableViewController {
     /// Determines whether the text has been first responder already. If it has, don't force it back on the user unless it's been selected by them.
     private var hasSelectedText: Bool = false
 
-    init(post: Post, identifiers: [PrepublishingIdentifier], completion: @escaping (CompletionResult) -> ()) {
+    init(post: Post,
+         identifiers: [PrepublishingIdentifier],
+         completion: @escaping (CompletionResult) -> (),
+         coreDataStack: CoreDataStack = ContextManager.shared) {
         self.post = post
-        self.options = identifiers.map { identifier in
-            return PrepublishingOption(identifier: identifier)
-        }
+        self.identifiers = identifiers
         self.completion = completion
+        self.coreDataStack = coreDataStack
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -142,10 +154,9 @@ class PrepublishingViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        // Forced unwrap copied from this guide by Apple:
-        // https://developer.apple.com/documentation/uikit/views_and_controls/table_views/adding_headers_and_footers_to_table_sections
-        //
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: Constants.headerReuseIdentifier) as! PrepublishingHeaderView
+        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: Constants.headerReuseIdentifier) as? PrepublishingHeaderView else {
+            return nil
+        }
 
         header.delegate = self
         header.configure(post.blog)
@@ -179,6 +190,8 @@ class PrepublishingViewController: UITableViewController {
         case .value:
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = option.title
+        default:
+            break
         }
 
         switch option.id {
@@ -194,6 +207,8 @@ class PrepublishingViewController: UITableViewController {
             configureScheduleCell(cell)
         case .categories:
             configureCategoriesCell(cell)
+        case .autoSharing:
+            configureSocialCell(cell)
         }
 
         return cell
@@ -211,13 +226,13 @@ class PrepublishingViewController: UITableViewController {
                 return WPTableViewCell.init(style: .value1, reuseIdentifier: Constants.reuseIdentifier)
             }
             return cell
+        case .customContainer:
+            return WPTableViewCell()
         }
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch options[indexPath.row].id {
-        case .title:
-            break
         case .tags:
             didTapTagCell()
         case .visibility:
@@ -226,6 +241,8 @@ class PrepublishingViewController: UITableViewController {
             didTapSchedule(indexPath)
         case .categories:
             didTapCategoriesCell()
+        default:
+            break
         }
     }
 
@@ -523,6 +540,9 @@ private extension PrepublishingOption {
             self.init(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility"), type: .value)
         case .tags:
             self.init(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"), type: .value)
+        case .autoSharing:
+            // TODO: Which cell to show?
+            self.init(id: .autoSharing, title: "Jetpack Social", type: .customContainer)
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5611,6 +5611,8 @@
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDA8D9C2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */; };
 		FEDA8D9D2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */; };
+		FEDA8D9F2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */; };
+		FEDA8DA02A5B1B1B0081314F /* PrepublishingAutoSharingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
 		FEDDD47026A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
@@ -9411,6 +9413,7 @@
 		FED77257298BC5B300C2346E /* PluginJetpackProxyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginJetpackProxyService.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrepublishingViewController+JetpackSocial.swift"; sourceTree = "<group>"; };
+		FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingAutoSharingView.swift; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
@@ -14807,6 +14810,7 @@
 				E155EC711E9B7DCE009D7F63 /* PostTagPickerViewController.swift */,
 				8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */,
 				FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */,
+				FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */,
 				5DB3BA0318D0E7B600F3F3E9 /* WPPickerView.h */,
 				5DB3BA0418D0E7B600F3F3E9 /* WPPickerView.m */,
 				C9F1D4B92706EEEB00BDF917 /* HomepageEditorNavigationBarManager.swift */,
@@ -20989,6 +20993,7 @@
 				C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */,
 				9A73B7152362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift in Sources */,
 				74AF4D7C1FE417D200E3EBFE /* PostUploadOperation.swift in Sources */,
+				FEDA8D9F2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift in Sources */,
 				0857BB40299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift in Sources */,
 				37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */,
 				59DCA5211CC68AF3000F245F /* PageListViewController.swift in Sources */,
@@ -25101,6 +25106,7 @@
 				FABB24602602FC2C00C8785C /* BlogDetailsViewController+DomainCredit.swift in Sources */,
 				17C1D67D2670E3DC006C8970 /* SiteIconPickerView.swift in Sources */,
 				8BAC9D9F27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */,
+				FEDA8DA02A5B1B1B0081314F /* PrepublishingAutoSharingView.swift in Sources */,
 				80EF9287280D272E0064A971 /* DashboardPostsSyncManager.swift in Sources */,
 				FABB24612602FC2C00C8785C /* KeyringAccountHelper.swift in Sources */,
 				FABB24622602FC2C00C8785C /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5609,6 +5609,8 @@
 		FED77259298BC5B300C2346E /* PluginJetpackProxyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED77257298BC5B300C2346E /* PluginJetpackProxyService.swift */; };
 		FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
+		FEDA8D9C2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */; };
+		FEDA8D9D2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
 		FEDDD47026A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
@@ -9408,6 +9410,7 @@
 		FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolver.swift; sourceTree = "<group>"; };
 		FED77257298BC5B300C2346E /* PluginJetpackProxyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginJetpackProxyService.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
+		FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrepublishingViewController+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
@@ -14803,6 +14806,7 @@
 				593F26601CAB00CA00F14073 /* PostSharingController.swift */,
 				E155EC711E9B7DCE009D7F63 /* PostTagPickerViewController.swift */,
 				8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */,
+				FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */,
 				5DB3BA0318D0E7B600F3F3E9 /* WPPickerView.h */,
 				5DB3BA0418D0E7B600F3F3E9 /* WPPickerView.m */,
 				C9F1D4B92706EEEB00BDF917 /* HomepageEditorNavigationBarManager.swift */,
@@ -22076,6 +22080,7 @@
 				F5E032E82408D537003AF350 /* BottomSheetPresentationController.swift in Sources */,
 				FA98A24D2832A5E9003B9233 /* NewQuickStartChecklistView.swift in Sources */,
 				FA98B61929A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */,
+				FEDA8D9C2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */,
 				AB758D9E25EFDF9C00961C0B /* LikesListController.swift in Sources */,
 				E1FD45E01C030B3800750F4C /* AccountSettingsService.swift in Sources */,
 				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
@@ -25225,6 +25230,7 @@
 				F4D9188729D78C9100974A71 /* BlogDetailsViewController+Strings.swift in Sources */,
 				FABB24B82602FC2C00C8785C /* DynamicHeightCollectionView.swift in Sources */,
 				FABB24B92602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowList.swift in Sources */,
+				FEDA8D9D2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */,
 				FABB24BA2602FC2C00C8785C /* TenorGIF.swift in Sources */,
 				FABB24BB2602FC2C00C8785C /* ThemeBrowserViewController.swift in Sources */,
 				FA73D7ED27987E4500DF24B3 /* SitePickerViewController+QuickStart.swift in Sources */,


### PR DESCRIPTION
Refs #20783
Depends on #21036 

## Description

This PR adds minimal changes in `PrepublishingViewController` so it can display a custom cell that contains a SwiftUI view (or any `UIView`, really); along with a new `PrepublishingAutoSharingView` as the view for the social cell.

Here are some previews:

• | Light | Dark
-|-|-
iPhone, Portrait | ![iphone_portrait_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/fae162a6-ef71-46b6-8b12-db6fd23ada39) | ![iphone_portrait_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/6b2dfe8d-3dd3-4edd-8de7-03ec4936c932)
iPhone, Landscape | ![iphone_landscape_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/ccbfd133-5528-46ee-a8f1-af162b809252) | ![iphone_landscape_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/cf60bfc2-cf1d-4897-ad54-c1df1b09c516)
iPad | ![ipad_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5ed7ff6a-3596-4340-aa21-de5d7594afef) | ![ipad_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/bc04628a-b97a-414a-8b7e-2813fe033698)

⚠️ Note that this is just an initial, visual-only view with no actual implementation yet. Some changes that will be separated into separate PRs:

- Adding the view model & more variations to the `PrepublishingAutoSharingView` (including the social icon train).
- Showing the No Connection view when the user has no social connection yet.
- Hiding the social share limit for sites with unlimited Social sharing.
- Adding the actual tap functionalities.
- There might be some oddities with longer text / multiline behavior. I'll sort it out once all the UI components are built.
- ... and more.

## To test

### Case 1: Sites eligible for Publicize

- Launch the Jetpack app.
- Ensure that the `jetpackSocial` flag is on. (It should be on by default for debug builds.)
- Switch to any site that's eligible for Jetpack Social (WP.com, or self-hosted with an active Jetpack Social module).
- Create a new post.
- Fill in the title and body, and tap Publish. The pre-publishing sheet should be shown.
- 🔍  Verify that the auto-sharing cell appears.

### Case 2: Sites not eligible for Publicize

- Launch the Jetpack app.
- Ensure that the `jetpackSocial` flag is on. (It should be on by default for debug builds.)
- Switch to any site that's NOT eligible for Jetpack Social (pure self-hosted site).
- Create a new post.
- Fill in the title and body, and tap Publish. The pre-publishing sheet should be shown.
- 🔍  Verify that the auto-sharing cell does NOT appear.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
