### PR TITLE
Fix discarded notification observers in a few places

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -57,11 +57,12 @@ final class SitePickerViewController: UIViewController {
     }
 
     private func startObservingTitleChanges() {
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.WPBlogUpdated,
-                                               object: nil,
-                                               queue: .main) { [weak self] _ in
+        NotificationCenter.default.addObserver(self, selector: #selector(handleBlogUpdated), name: .WPBlogUpdated, object: nil)
+    }
 
-            self?.updateTitles()
+    @objc private func handleBlogUpdated() {
+        DispatchQueue.main.async {
+            self.updateTitles()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/EncryptedLogTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/EncryptedLogTableViewController.swift
@@ -31,10 +31,7 @@ class EncryptedLogTableViewController: UITableViewController {
         let item = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addEncryptedLog))
         self.navigationItem.rightBarButtonItem = item
 
-        let name = WPLoggingStack.QueuedLogsDidChangeNotification
-        NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main) { _ in
-            self.updateData()
-        }
+        NotificationCenter.default.addObserver(self, selector: #selector(handleQueuedLogsDidChangeNotification), name: WPLoggingStack.QueuedLogsDidChangeNotification, object: nil)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -80,6 +77,13 @@ class EncryptedLogTableViewController: UITableViewController {
     }
 
     // MARK: Internal Helpers
+
+    @objc private func handleQueuedLogsDidChangeNotification() {
+        DispatchQueue.main.async {
+            self.updateData()
+        }
+    }
+
     private func updateData() {
         self.logs = eventLogging.queuedLogFiles
         self.tableView.reloadData()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -211,22 +211,21 @@ extension ReaderTabViewModel: NetworkStatusReceiver, NetworkStatusDelegate {
 extension ReaderTabViewModel {
 
     private func addNotificationsObservers() {
-        NotificationCenter.default.addObserver(forName: UIApplication.willTerminateNotification,
-                                               object: nil,
-                                               queue: nil) { notification in
-                                                self.clearTopics(removeAllTopics: false)
-                                                self.clearFlags()
-        }
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAppTerminationNotification), name: UIApplication.willTerminateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAccountChangedNotification), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+    }
 
-        NotificationCenter.default.addObserver(forName: .WPAccountDefaultWordPressComAccountChanged,
-                                               object: nil,
-                                               queue: nil) { notification in
-                                                self.clearFlags()
-                                                self.clearSavedPosts()
-                                                self.clearTopics(removeAllTopics: true)
-                                                self.clearSearchSuggestions()
-                                                self.selectedIndex = 0
-        }
+    @objc private func handleAppTerminationNotification() {
+         clearTopics(removeAllTopics: false)
+         clearFlags()
+    }
+
+    @objc private func handleAccountChangedNotification() {
+         clearFlags()
+         clearSavedPosts()
+         clearTopics(removeAllTopics: true)
+         clearSearchSuggestions()
+         selectedIndex = 0
     }
 
     private func clearFlags() {


### PR DESCRIPTION
Relates to #20994.

All the changed notification observers are registered once (on viewDidLoad or init), but discarded. This PR now uses the "self" instance as the observers, and NotificationCenter should automatically unregister them upon their deallocation.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A