### PR TITLE
Use weak reference to avoid a retain cycle

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -1123,7 +1123,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
     cell.accessoryButtonAction = ^(UIView * _Nonnull sourceView) {
         if (comment) {
-            [self shareComment:comment sourceView:sourceView];
+            [weakSelf shareComment:comment sourceView:sourceView];
         }
     };
 


### PR DESCRIPTION
Fixes #21039.

See the issue details for how to verify the fix.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A