### PR TITLE
Blaze Manage Campaigns: Fix an issue with dashboard card not reloading when switching sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -112,10 +112,7 @@ final class BlogDashboardViewController: UIViewController {
         }
 
         self.blog = blog
-        viewModel.blog = blog
-        BlogDashboardAnalytics.shared.reset()
-        viewModel.loadCardsFromCache()
-        viewModel.loadCards()
+        self.viewModel.update(blog: blog)
     }
 
     @objc func refreshControlPulled() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCellViewModel.swift
@@ -4,7 +4,7 @@ import WordPressKit
 final class DashboardBlazeCardCellViewModel {
     private(set) var state: State = .promo
 
-    private let blog: Blog
+    private var blog: Blog
     private let service: BlazeServiceProtocol
     private let store: DashboardBlazeStoreProtocol
     private var isRefreshing = false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -19,12 +19,12 @@ enum DashboardItem: Hashable {
 typealias DashboardSnapshot = NSDiffableDataSourceSnapshot<DashboardSection, DashboardItem>
 typealias DashboardDataSource = UICollectionViewDiffableDataSource<DashboardSection, DashboardItem>
 
-class BlogDashboardViewModel {
+final class BlogDashboardViewModel {
     private weak var viewController: BlogDashboardViewController?
 
     private let managedObjectContext: NSManagedObjectContext
 
-    var blog: Blog
+    private var blog: Blog
 
     private var currentCards: [DashboardCardModel] = []
 
@@ -78,7 +78,7 @@ class BlogDashboardViewModel {
         }
     }()
 
-    private let blazeViewModel: DashboardBlazeCardCellViewModel
+    private var blazeViewModel: DashboardBlazeCardCellViewModel
 
     init(viewController: BlogDashboardViewController, managedObjectContext: NSManagedObjectContext = ContextManager.shared.mainContext, blog: Blog) {
         self.viewController = viewController
@@ -91,6 +91,15 @@ class BlogDashboardViewModel {
     /// Apply the initial configuration when the view loaded
     func viewDidLoad() {
         loadCardsFromCache()
+    }
+
+    /// Update to display the selected blog.
+    func update(blog: Blog) {
+        BlogDashboardAnalytics.shared.reset()
+        self.blog = blog
+        self.blazeViewModel = DashboardBlazeCardCellViewModel(blog: blog)
+        self.loadCardsFromCache()
+        self.loadCards()
     }
 
     /// Call the API to return cards for the current blog

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -145,7 +145,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             blogDetailsViewController?.presentationDelegate = self
         }
     }
-    private(set) var blogDashboardViewController: BlogDashboardViewController?
+    private var blogDashboardViewController: BlogDashboardViewController?
 
     /// When we display a no results view, we'll do so in a scrollview so that
     /// we can allow pull to refresh to sync the user's list of sites.


### PR DESCRIPTION
Fixes #21043

## To test:

- Follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/issues/21043

## RCA

- `BlogDashboardViewController` doesn't get re-created after switching a blog (which I assumed it did during development)

## Regression Notes
1. Potential unintended areas of impact: Blaze Campaigns dashboard card
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
