### PR TITLE
Blaze Manage Campaigns: "Create" bar button item

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -5,8 +5,8 @@ import WordPressFlux
 final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, BlazeCampaignsStreamDelegate {
     // MARK: - Views
 
-    private lazy var plusButton = UIBarButtonItem(
-        image: UIImage(systemName: "plus"),
+    private lazy var createButton = UIBarButtonItem(
+        title: Strings.createButtonTitle,
         style: .plain,
         target: self,
         action: #selector(buttonCreateCampaignTapped)
@@ -169,7 +169,7 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
 
     private func setupNavBar() {
         title = Strings.navigationTitle
-        navigationItem.rightBarButtonItem = plusButton
+        navigationItem.rightBarButtonItem = createButton
     }
 
     private func setupNoResults() {
@@ -245,6 +245,7 @@ private extension BlazeCampaignsViewController {
     enum Strings {
         static let navigationTitle = NSLocalizedString("blaze.campaigns.title", value: "Blaze Campaigns", comment: "Title for the screen that allows users to manage their Blaze campaigns.")
         static let promoteButtonTitle = NSLocalizedString("blaze.campaigns.promote.button.title", value: "Promote", comment: "Button title for the button that shows the Blaze flow when tapped.")
+        static let createButtonTitle = NSLocalizedString("blaze.campaigns.create.button.title", value: "Create", comment: "Button title for the button that shows the Blaze flow when tapped.")
 
         enum NoResults {
             static let loadingTitle = NSLocalizedString("blaze.campaigns.loading.title", value: "Loading campaigns...", comment: "Displayed while Blaze campaigns are being loaded.")


### PR DESCRIPTION
Fixes #20763 

## Description
- Displays "Create" instead of "+" for the nav bar button item

## How to test
1. Switch to a site that has Blaze campaigns
2. Go to the campaigns list screen
3. ✅ Verify: the nav bar button displays "Create"

iPhone | iPad
-- | -- 
![Simulator Screen Shot - iPhone 14 Pro - 2023-07-10 at 17 05 10](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/406f51ae-5400-4ce3-a923-79a3d0f4f75d) | ![Simulator Screen Shot - iPad Air (5th generation) - 2023-07-10 at 17 47 46](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/1e8476de-3945-4066-94a5-b0f611cacc27) 


## Regression Notes
1. Potential unintended areas of impact
n/a

5. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
