### PR TITLE
Change scanningDelegate to a weak reference

### DIFF
--- a/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraSession.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraSession.swift
@@ -23,7 +23,7 @@ class QRLoginCameraSession: NSObject, QRCodeScanningSession {
         return AVCaptureVideoPreviewLayer(session: session)
     }
 
-    var scanningDelegate: QRCodeScanningDelegate?
+    weak var scanningDelegate: QRCodeScanningDelegate?
 
     func configure() {
         configureCamera()

--- a/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginProtocols.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginProtocols.swift
@@ -51,7 +51,7 @@ protocol QRCameraPermissionsHandler: CameraPermissionsHandler {
 }
 
 /// A delegate that handles when a code was scanned and whether its valid or not
-protocol QRCodeScanningDelegate {
+protocol QRCodeScanningDelegate: AnyObject {
     func validLink(_ stringValue: String) -> Bool
     func didScanURLString(_ urlString: String)
 }

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
@@ -12,8 +12,8 @@ import UniformTypeIdentifiers
 
 
 @objc open class RichTextView: UIView, UITextViewDelegate {
-    @objc open var dataSource: RichTextViewDataSource?
-    @objc open var delegate: RichTextViewDelegate?
+    @objc open weak var dataSource: RichTextViewDataSource?
+    @objc open weak var delegate: RichTextViewDelegate?
 
 
     // MARK: - Initializers

--- a/WordPress/WordPressTest/QRLogin/QRLoginScanningCoordinatorTests.swift
+++ b/WordPress/WordPressTest/QRLogin/QRLoginScanningCoordinatorTests.swift
@@ -125,7 +125,7 @@ private class QRCodeScanningSessionMock: QRCodeScanningSession {
     var hasCamera: Bool = true
     var session: AVCaptureSession? = nil
     var previewLayer: CALayer? = nil
-    var scanningDelegate: QRCodeScanningDelegate? = nil
+    weak var scanningDelegate: QRCodeScanningDelegate? = nil
 
     var isConfigured: Bool = false
     func configure() {


### PR DESCRIPTION
Relates to #21050.

This PR fixes a retain cycle between `QRLoginScanningCoordinator` and `QRLoginCameraSession`:

https://github.com/wordpress-mobile/WordPress-iOS/blob/09143b4ffc4539ead1cbaab944c7af43d5e0c51f/WordPress/Classes/ViewRelated/QR%20Login/Coordinators/QRLoginScanningCoordinator.swift#L8-L15

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A