### PR TITLE
[UI Tests] - Removing unnecessary flows to speed up tests

### DIFF
--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -10,8 +10,6 @@ class MainNavigationTests: XCTestCase {
             email: WPUITestCredentials.testWPcomUserEmail,
             password: WPUITestCredentials.testWPcomPassword
         )
-        try TabNavComponent()
-            .goToMySiteScreen()
             .goToMenu()
     }
 

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -10,9 +10,8 @@ class ReaderTests: XCTestCase {
             email: WPUITestCredentials.testWPcomUserEmail,
             password: WPUITestCredentials.testWPcomPassword
         )
-        try EditorFlow
-            .goToMySiteScreen()
-            .tabBar.goToReaderScreen()
+        try TabNavComponent()
+            .goToReaderScreen()
     }
 
     override func tearDownWithError() throws {

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -9,7 +9,6 @@ class StatsTests: XCTestCase {
             email: WPUITestCredentials.testWPcomUserEmail,
             password: WPUITestCredentials.testWPcomPassword
         )
-        try MySiteScreen()
             .goToMenu()
             .goToStatsScreen()
             .switchTo(mode: .insights)

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -65,29 +65,35 @@ public class LoginEpilogueScreen: ScreenObject {
     }
 
     private func dismissQuickStartPromptIfNeeded() throws {
-        try XCTContext.runActivity(named: "Dismiss quick start prompt if needed.") { _ in
-            guard QuickStartPromptScreen.isLoaded() else { return }
-
+        XCTContext.runActivity(named: "Dismiss quick start prompt if needed.") { _ in
             Logger.log(message: "Dismising quick start prompt...", event: .i)
-            _ = try QuickStartPromptScreen().selectNoThanks()
+            do {
+                _ = try QuickStartPromptScreen().selectNoThanks()
+            } catch {
+                return
+            }
         }
     }
 
     private func dismissOnboardingQuestionsPromptIfNeeded() throws {
-        try XCTContext.runActivity(named: "Dismiss onboarding questions prompt if needed.") { _ in
-            guard OnboardingQuestionsPromptScreen.isLoaded() else { return }
-
+        XCTContext.runActivity(named: "Dismiss onboarding questions prompt if needed.") { _ in
             Logger.log(message: "Dismissing onboarding questions prompt...", event: .i)
-            _ = try OnboardingQuestionsPromptScreen().selectSkip()
+            do {
+                _ = try OnboardingQuestionsPromptScreen().selectSkip()
+            } catch {
+                return
+            }
         }
     }
 
     private func dismissFeatureIntroductionIfNeeded() throws {
-        try XCTContext.runActivity(named: "Dismiss feature introduction screen if needed.") { _ in
-            guard FeatureIntroductionScreen.isLoaded() else { return }
-
+        XCTContext.runActivity(named: "Dismiss feature introduction screen if needed.") { _ in
             Logger.log(message: "Dismissing feature introduction screen...", event: .i)
-            _ = try FeatureIntroductionScreen().dismiss()
+            do {
+                _ = try FeatureIntroductionScreen().dismiss()
+            } catch {
+                return
+            }
         }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -29,8 +29,6 @@ public class PasswordScreen: ScreenObject {
     public func proceedWithValidPassword() throws -> LoginEpilogueScreen {
         try tryProceed(password: "pw")
 
-        app.dismissSavePasswordPrompt()
-
         return try LoginEpilogueScreen()
     }
 


### PR DESCRIPTION
### Description
I looked at the current `setup` implementation and found a few things that we could do to speed up the tests without changing the functionality. Since the `setup` step is part of every test case, the speed improvements from this would be for all test cases, existing and new. The changes are:
1. Remove the duplicated `app.dismissSavePasswordPrompt()` call on `proceedWithValidPassword()` (it's already called in `tryProceed()`)
2. Since `login()` returns `mySiteScreen()` the `.goToMySiteScreen()` step in some test cases was unnecessary and can be removed. Removed on 3 tests - `MainNavigationTests.swift`, `ReaderTests.swift` and `StatsTests.swift`
3. Update the `dismiss...` functions to not check for isLoaded first but to call the action immediately, this would save some unnecessary calls, see:

Before change - The check for elements on screen is repeated 3 times, first to check for the first element, then the whole screen, then the first element again before tapping the Skip button (Below logs for the first two checks, I somehow missed the last check...)
```
    t =    42.27s     Dismiss onboarding questions prompt if needed.
    t =    42.27s         Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.OnboardingQuestionsPromptScreen
    t =    43.31s             Checking `Expect predicate `isHittable == 1` for object "Skip" Button`
    t =    43.31s                 Find the "Skip" Button
    t =    43.39s         Confirm whole screen UITestsFoundation.OnboardingQuestionsPromptScreen is loaded
    t =    44.42s             Checking `Expect predicate `isHittable == 1` for object "Skip" Button`
    t =    44.42s                 Find the "Skip" Button
```

After change - Check if element is loaded and tap on it
```
    t =    25.96s     Dismiss onboarding questions prompt if needed.
2023-07-11 04:26:08921 [ℹ️][LoginEpilogueScreen.swift]:84 dismissOnboardingQuestionsPromptIfNeeded() -> Dismissing onboarding questions prompt...
    t =    25.96s         Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.OnboardingQuestionsPromptScreen
    t =    27.00s             Checking `Expect predicate `isHittable == 1` for object "Skip" Button`
    t =    27.00s                 Find the "Skip" Button
    t =    27.07s         Tap "Skip" Button
    t =    27.07s             Wait for com.automattic.jetpack to idle
    t =    27.10s             Find the "Skip" Button
```

### Testing
CI should be 🟢 and time taken to complete the test suite _should_ be faster than in `trunk`