### PR TITLE
Blaze Manage Campaigns: Add event tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -463,6 +463,9 @@ import Foundation
     case blazeFlowCompleted
     case blazeFlowError
     case blazeCampaignListOpened
+    case blazeCampaignDetailsOpened
+    case blazeCampaignDetailsError
+    case blazeCampaignDetailsDismissed
 
     // Moved to Jetpack static screen
     case removeStaticPosterDisplayed
@@ -1295,6 +1298,12 @@ import Foundation
             return "blaze_flow_error"
         case .blazeCampaignListOpened:
             return "blaze_campaign_list_opened"
+        case .blazeCampaignDetailsOpened:
+            return "blaze_campaign_details_opened"
+        case .blazeCampaignDetailsError:
+            return "blaze_campaign_details_error"
+        case .blazeCampaignDetailsDismissed:
+            return "blaze_campaign_details_dismissed"
 
         // Moved to Jetpack static screen
         case .removeStaticPosterDisplayed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -462,6 +462,7 @@ import Foundation
     case blazeFlowCanceled
     case blazeFlowCompleted
     case blazeFlowError
+    case blazeCampaignListOpened
 
     // Moved to Jetpack static screen
     case removeStaticPosterDisplayed
@@ -1292,6 +1293,8 @@ import Foundation
             return "blaze_flow_completed"
         case .blazeFlowError:
             return "blaze_flow_error"
+        case .blazeCampaignListOpened:
+            return "blaze_campaign_list_opened"
 
         // Moved to Jetpack static screen
         case .removeStaticPosterDisplayed:

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -32,18 +32,20 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
 
     private var stream: BlazeCampaignsStream
     private var pendingStream: AnyObject?
+    private let source: BlazeSource
     private let blog: Blog
 
     // MARK: - Initializers
 
-    init(blog: Blog) {
+    init(source: BlazeSource, blog: Blog) {
+        self.source = source
         self.blog = blog
         self.stream = BlazeCampaignsStream(blog: blog)
         super.init(nibName: nil, bundle: nil)
     }
 
-    @objc class func make(blog: Blog) -> BlazeCampaignsViewController {
-        BlazeCampaignsViewController(blog: blog)
+    @objc class func makeWithSource(_ source: BlazeSource, blog: Blog) -> BlazeCampaignsViewController {
+        BlazeCampaignsViewController(source: source, blog: blog)
     }
 
     required init?(coder: NSCoder) {
@@ -65,6 +67,11 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
 
         // Refresh data automatically when new campaign is created
         NotificationCenter.default.addObserver(self, selector: #selector(setNeedsToRefreshCampaigns), name: .blazeCampaignCreated, object: nil)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        BlazeEventsTracker.trackCampaignListOpened(for: source)
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -155,8 +155,8 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
     }
 
     @objc private func buttonCreateCampaignTapped() {
-        BlazeEventsTracker.trackBlazeFlowStarted(for: .campaignsList)
-        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignsList, blog: blog)
+        BlazeEventsTracker.trackBlazeFlowStarted(for: .campaignList)
+        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignList, blog: blog)
     }
 
     // MARK: - Private
@@ -206,7 +206,7 @@ extension BlazeCampaignsViewController: UITableViewDataSource, UITableViewDelega
         guard let campaign = stream.campaigns[safe: indexPath.row] else {
             return
         }
-        BlazeFlowCoordinator.presentBlazeCampaignDetails(in: self, source: .campaignsList, blog: blog, campaignID: campaign.campaignID)
+        BlazeFlowCoordinator.presentBlazeCampaignDetails(in: self, source: .campaignList, blog: blog, campaignID: campaign.campaignID)
     }
 }
 
@@ -234,7 +234,7 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
     }
 
     func actionButtonPressed() {
-        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignsList, blog: blog)
+        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignList, blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
@@ -13,6 +13,8 @@ import Foundation
         WPAnalytics.track(.blazeEntryPointTapped, properties: analyticsProperties(for: source))
     }
 
+    // MARK: - Dashboard card
+
     static func trackContextualMenuAccessed(for source: BlazeSource) {
         WPAnalytics.track(.blazeContextualMenuAccessed, properties: analyticsProperties(for: source))
     }
@@ -20,6 +22,8 @@ import Foundation
     static func trackHideThisTapped(for source: BlazeSource) {
         WPAnalytics.track(.blazeCardHidden, properties: analyticsProperties(for: source))
     }
+
+    // MARK: - Overlay
 
     static func trackOverlayDisplayed(for source: BlazeSource) {
         WPAnalytics.track(.blazeOverlayDisplayed, properties: analyticsProperties(for: source))
@@ -32,6 +36,8 @@ import Foundation
     static func trackOverlayDismissed(for source: BlazeSource) {
         WPAnalytics.track(.blazeOverlayDismissed, properties: analyticsProperties(for: source))
     }
+
+    // MARK: - Blaze webview flow
 
     static func trackBlazeFlowStarted(for source: BlazeSource) {
         WPAnalytics.track(.blazeFlowStarted, properties: analyticsProperties(for: source))
@@ -51,6 +57,12 @@ import Foundation
             properties[Self.errorPropertyKey] = error.localizedDescription
         }
         WPAnalytics.track(.blazeFlowError, properties: properties)
+    }
+
+    // MARK: - Campaign list
+
+    static func trackCampaignListOpened(for source: BlazeSource) {
+        WPAnalytics.track(.blazeCampaignListOpened, properties: analyticsProperties(for: source))
     }
 
     private static func analyticsProperties(for source: BlazeSource) -> [String: String] {

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
@@ -65,6 +65,22 @@ import Foundation
         WPAnalytics.track(.blazeCampaignListOpened, properties: analyticsProperties(for: source))
     }
 
+    // MARK: - Campaign details
+
+    static func trackCampaignDetailsOpened(for source: BlazeSource) {
+        WPAnalytics.track(.blazeCampaignDetailsOpened, properties: analyticsProperties(for: source))
+    }
+
+    static func trackCampaignDetailsError(for source: BlazeSource) {
+        WPAnalytics.track(.blazeCampaignDetailsError, properties: analyticsProperties(for: source))
+    }
+
+    static func trackCampaignDetailsDismissed(for source: BlazeSource) {
+        WPAnalytics.track(.blazeCampaignDetailsDismissed, properties: analyticsProperties(for: source))
+    }
+
+    // MARK: - Helpers
+
     private static func analyticsProperties(for source: BlazeSource) -> [String: String] {
         return [WPAppAnalyticsKeySource: source.description]
     }

--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewModel.swift
@@ -18,7 +18,7 @@ struct BlazeOverlayViewModel {
         switch source {
         case .dashboardCard:
             fallthrough
-        case .campaignsList:
+        case .campaignList:
             fallthrough
         case .menuItem:
             return buttonTitleWithIcon(title: Strings.blazeButtonTitle)

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeCampaignDetailsWebViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeCampaignDetailsWebViewModel.swift
@@ -56,22 +56,22 @@ class BlazeCampaignDetailsWebViewModel: BlazeWebViewModel {
     func startBlazeFlow() {
         guard let initialURL,
               let cookieJar = view?.cookieJar else {
-            // TODO: Track Analytics Error Event
+            BlazeEventsTracker.trackCampaignDetailsError(for: source)
             view?.dismissView()
             return
         }
         authenticatedRequest(for: initialURL, with: cookieJar) { [weak self] (request) in
-            guard let weakSelf = self else {
+            guard let self else {
                 return
             }
-            weakSelf.view?.load(request: request)
-            // TODO: Track Analytics Event
+            self.view?.load(request: request)
+            BlazeEventsTracker.trackCampaignDetailsOpened(for: self.source)
         }
     }
 
     func dismissTapped() {
         view?.dismissView()
-        // TODO: Track Analytics Event
+        BlazeEventsTracker.trackCampaignDetailsDismissed(for: source)
     }
 
     func shouldNavigate(to request: URLRequest, with type: WKNavigationType) -> WKNavigationActionPolicy {

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -6,7 +6,7 @@ import UIKit
     case menuItem
     case postsList
     case pagesList
-    case campaignsList
+    case campaignList
 
     var description: String {
         switch self {
@@ -18,8 +18,8 @@ import UIKit
             return "posts_list"
         case .pagesList:
             return "pages_list"
-        case .campaignsList:
-            return "campaigns_list"
+        case .campaignList:
+            return "campaign_list"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -107,10 +107,11 @@ import UIKit
     /// - Parameters:
     ///   - viewController: The view controller where the screen should be presented in.
     ///   - blog: `Blog` object representing the site with Blaze campaigns.
-    @objc(presentBlazeCampaignsInViewController:blog:)
+    @objc(presentBlazeCampaignsInViewController:source:blog:)
     static func presentBlazeCampaigns(in viewController: UIViewController,
+                                      source: BlazeSource,
                                       blog: Blog) {
-        let campaignsViewController = BlazeCampaignsViewController(blog: blog)
+        let campaignsViewController = BlazeCampaignsViewController(source: source, blog: blog)
         viewController.navigationController?.pushViewController(campaignsViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -82,7 +82,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
 
     private func showCampaignList() {
         guard let presentingViewController, let blog else { return }
-        BlazeFlowCoordinator.presentBlazeCampaigns(in: presentingViewController, blog: blog)
+        BlazeFlowCoordinator.presentBlazeCampaigns(in: presentingViewController, source: .dashboardCard, blog: blog)
     }
 
     private func makeShowCampaignsMenuAction() -> UIAction {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1986,7 +1986,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [BlazeEventsTracker trackEntryPointTappedFor:BlazeSourceMenuItem];
 
     if ([RemoteFeature enabled:RemoteFeatureFlagBlazeManageCampaigns]) {
-        BlazeCampaignsViewController *controller = [BlazeCampaignsViewController makeWithBlog:self.blog];
+        BlazeCampaignsViewController *controller =  [BlazeCampaignsViewController makeWithSource:BlazeSourceMenuItem
+                                                                                            blog:self.blog];
         [self.presentationDelegate presentBlogDetailsViewController:controller];
     } else {
         [BlazeFlowCoordinator presentBlazeInViewController:self

--- a/WordPress/WordPressTest/Blaze/BlazeCampaignDetailsWebViewModelTests.swift
+++ b/WordPress/WordPressTest/Blaze/BlazeCampaignDetailsWebViewModelTests.swift
@@ -24,7 +24,7 @@ final class BlazeCampaignDetailsWebViewModelTests: CoreDataTestCase {
 
     func testInternalURLsAllowed() throws {
         // Given
-        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignsList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
+        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
         let validURL = try XCTUnwrap(URL(string: "https://wordpress.com/advertising/test.blog.com?source=menu_item"))
         var validRequest = URLRequest(url: validURL)
         validRequest.mainDocumentURL = validURL
@@ -39,7 +39,7 @@ final class BlazeCampaignDetailsWebViewModelTests: CoreDataTestCase {
 
     func testExternalURLsBlocked() throws {
         // Given
-        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignsList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
+        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
         let invalidURL = try XCTUnwrap(URL(string: "https://test.com/test?example=test"))
         var invalidRequest = URLRequest(url: invalidURL)
         invalidRequest.mainDocumentURL = invalidURL
@@ -55,7 +55,7 @@ final class BlazeCampaignDetailsWebViewModelTests: CoreDataTestCase {
 
     func testCallingDismissTappedDismissesTheView() {
         // Given
-        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignsList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
+        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
 
         // When
         viewModel.dismissTapped()
@@ -66,7 +66,7 @@ final class BlazeCampaignDetailsWebViewModelTests: CoreDataTestCase {
 
     func testCallingStartBlazeSiteFlowLoadsTheView() throws {
         // Given
-        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignsList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
+        let viewModel = BlazeCampaignDetailsWebViewModel(source: .campaignList, blog: blog, campaignID: 0, view: view, externalURLHandler: externalURLHandler)
 
         // When
         viewModel.startBlazeFlow()

--- a/WordPress/WordPressTest/Blaze/BlazeCampaignDetailsWebViewModelTests.swift
+++ b/WordPress/WordPressTest/Blaze/BlazeCampaignDetailsWebViewModelTests.swift
@@ -73,7 +73,7 @@ final class BlazeCampaignDetailsWebViewModelTests: CoreDataTestCase {
 
         // Then
         XCTAssertTrue(view.loadCalled)
-        XCTAssertEqual(view.requestLoaded?.url?.absoluteString, "https://wordpress.com/advertising/test.blog.com/campaigns/0?source=campaigns_list")
+        XCTAssertEqual(view.requestLoaded?.url?.absoluteString, "https://wordpress.com/advertising/test.blog.com/campaigns/0?source=campaign_list")
     }
 }
 


### PR DESCRIPTION
Part of #20762 
Part of #20765

## Description
Adds event tracking for the campaign list screen and the campaign details screen.

## How to test

> **Note**
> Please validate the new event on Tracks once you've verified the testing steps.

1. Make sure event tracking is enabled via Me > App Settings > Privacy Settings > Collect information
2. Go to the dashboard
3. Tap on the latest campaign
4. ✅ Verify: `blaze_campaign_details_opened <source: dashboard_card>` is tracked
5. Tap Done
6. ✅ Verify: `blaze_campaign_details_dismissed <source: dashboard_card>` is tracked
7. Tap on the card title
8. ✅ Verify: `blaze_campaign_list_opened <source: dashboard_card>` is tracked
9. Tap on a blaze campaign
10. ✅ Verify: `blaze_campaign_details_opened <source: campaign_list>` is tracked
11. Tap Done
12. ✅ Verify: `blaze_campaign_details_dismissed <source: campaign_list>` is tracked

## Regression Notes
1. Potential unintended areas of impact
n/a

14. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

15. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
