### PR TITLE
Jetpack Social: Add view model for the pre-publishing social cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -2,47 +2,69 @@ import SwiftUI
 
 struct PrepublishingAutoSharingView: View {
 
-    // TODO: view model.
+    let model: PrepublishingAutoSharingViewModel
 
     var body: some View {
         HStack {
             textStack
             Spacer()
-            iconTrain
-        }
-    }
-
-    var textStack: some View {
-        VStack(alignment: .leading) {
-            Text(String(format: Strings.primaryLabelActiveConnectionsFormat, 3))
-                .font(.body)
-                .foregroundColor(Color(.label))
-            Text(String(format: Strings.remainingSharesTextFormat, 27, 30))
-                .font(.subheadline)
-                .foregroundColor(Color(.secondaryLabel))
-        }
-    }
-
-    // TODO: This will be implemented separately.
-    var iconTrain: some View {
-        HStack {
-            if let uiImage = UIImage(named: "icon-tumblr") {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .frame(width: 32.0, height: 32.0)
-                    .background(Color(UIColor.listForeground))
-                    .clipShape(Circle())
-                    .overlay(Circle().stroke(Color(UIColor.listForeground), lineWidth: 2.0))
+            if model.connections.count > 0 {
+                socialIconsView
             }
         }
     }
+
+    private var textStack: some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            Text(String(format: Constants.primaryLabelActiveConnectionsFormat, 3))
+                .font(.body)
+                .foregroundColor(Color(.label))
+            if let sharingLimit = model.sharingLimit {
+                remainingSharesView(sharingLimit: sharingLimit, showsWarning: model.showsWarning)
+            }
+        }
+    }
+
+    private func remainingSharesView(sharingLimit: PublicizeInfo.SharingLimit, showsWarning: Bool) -> some View {
+        HStack(spacing: 4.0) {
+            if showsWarning {
+                Image("icon-warning")
+                    .resizable()
+                    .frame(width: 16.0, height: 16.0)
+                    .padding(4.0)
+            }
+            Text(String(format: Constants.remainingSharesTextFormat, sharingLimit.remaining, sharingLimit.limit))
+                .font(.subheadline)
+                .foregroundColor(Color(showsWarning ? Constants.warningColor : .secondaryLabel))
+        }
+    }
+
+    private var socialIconsView: some View {
+        HStack(spacing: -2.0) {
+            ForEach(model.connections, id: \.self) { connection in
+                iconImage(connection.serviceName.localIconImage, opaque: connection.enabled)
+            }
+        }
+    }
+
+    private func iconImage(_ uiImage: UIImage, opaque: Bool) -> some View {
+        Image(uiImage: uiImage)
+            .resizable()
+            .frame(width: 28.0, height: 28.0)
+            .opacity(opaque ? 1.0 : Constants.disabledSocialIconOpacity)
+            .background(Color(.listForeground))
+            .clipShape(Circle())
+    }
 }
 
-// MARK: - Helpers
+// MARK: - View Helpers
 
 private extension PrepublishingAutoSharingView {
 
-    enum Strings {
+    enum Constants {
+        static let disabledSocialIconOpacity: CGFloat = 0.36
+        static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))
+
         static let primaryLabelActiveConnectionsFormat = NSLocalizedString(
             "prepublishing.social.text.activeConnections",
             value: "Sharing to %1$d accounts",
@@ -68,5 +90,35 @@ private extension PrepublishingAutoSharingView {
                 """
         )
     }
+}
 
+// MARK: - View Model
+
+/// The value-type data model that drives the `PrepublishingAutoSharingView`.
+struct PrepublishingAutoSharingViewModel {
+
+    struct Connection: Hashable {
+        let serviceName: PublicizeService.ServiceName
+        let account: String
+        let enabled: Bool
+    }
+
+    // TODO: Default values are for temporary testing purposes. Will be removed later.
+    let connections: [Connection] = [.init(serviceName: .facebook, account: "foo", enabled: true),
+                                     .init(serviceName: .twitter, account: "bar", enabled: false),
+                                     .init(serviceName: .tumblr, account: "baz", enabled: true)]
+
+    // TODO: Default values are for temporary testing purposes. Will be removed later.
+    let sharingLimit: PublicizeInfo.SharingLimit? = .init(remaining: 1, limit: 30)
+
+    var enabledConnectionsCount: Int {
+        connections.filter({ $0.enabled }).count
+    }
+
+    var showsWarning: Bool {
+        guard let remaining = sharingLimit?.remaining else {
+            return false
+        }
+        return enabledConnectionsCount > remaining
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -16,7 +16,7 @@ struct PrepublishingAutoSharingView: View {
 
     private var textStack: some View {
         VStack(alignment: .leading, spacing: .zero) {
-            Text(String(format: Constants.primaryLabelActiveConnectionsFormat, 3))
+            Text(model.labelText)
                 .font(.body)
                 .foregroundColor(Color(.label))
             if let sharingLimit = model.sharingLimit {
@@ -65,19 +65,6 @@ private extension PrepublishingAutoSharingView {
         static let disabledSocialIconOpacity: CGFloat = 0.36
         static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))
 
-        static let primaryLabelActiveConnectionsFormat = NSLocalizedString(
-            "prepublishing.social.text.activeConnections",
-            value: "Sharing to %1$d accounts",
-            comment: """
-                The primary label for the auto-sharing row on the pre-publishing sheet.
-                Indicates the number of social accounts that will be auto-sharing the blog post.
-                %1$d is a placeholder for the number of social network accounts that will be auto-shared.
-                Example: Sharing to 3 accounts
-                """
-        )
-
-        // TODO: More text variations.
-
         static let remainingSharesTextFormat = NSLocalizedString(
             "prepublishing.social.remainingShares",
             value: "%1$d/%2$d social shares remaining",
@@ -121,4 +108,80 @@ struct PrepublishingAutoSharingViewModel {
         }
         return enabledConnectionsCount > remaining
     }
+
+    var labelText: String {
+        switch (enabledConnectionsCount, connections.count) {
+        case (let enabled, _) where enabled == 0:
+            // not sharing to any social media
+            return Strings.notSharingText
+
+        case (let enabled, let total) where enabled == total && total == 1:
+            // sharing to the one and only connection
+            guard let account = connections.first?.account else {
+                return String()
+            }
+            return String(format: Strings.singleConnectionTextFormat, account)
+
+        case (let enabled, let total) where enabled == total && total > 1:
+            // sharing to all connections
+            return String(format: Strings.multipleConnectionsTextFormat, enabled)
+
+        case (let enabled, let total) where enabled < total && total > 1:
+            // sharing to some connections
+            return String(format: Strings.partialConnectionsTextFormat, enabled, total)
+
+        default:
+            return String()
+        }
+    }
+}
+
+private extension PrepublishingAutoSharingViewModel {
+
+    enum Strings {
+        static let notSharingText = NSLocalizedString(
+            "prepublishing.social.label.notSharing",
+            value: "Not sharing to social",
+            comment: """
+                The primary label for the auto-sharing row on the pre-publishing sheet.
+                Indicates the blog post will not be shared to any social accounts.
+                """
+        )
+
+        static let singleConnectionTextFormat = NSLocalizedString(
+            "prepublishing.social.label.singleConnection",
+            value: "Sharing to %1$@",
+            comment: """
+                The primary label for the auto-sharing row on the pre-publishing sheet.
+                Indicates the blog post will be shared to a social media account.
+                %1$@ is a placeholder for the account name.
+                Example: Sharing to @wordpress
+                """
+        )
+
+        static let multipleConnectionsTextFormat = NSLocalizedString(
+            "prepublishing.social.label.multipleConnections",
+            value: "Sharing to %1$d accounts",
+            comment: """
+                The primary label for the auto-sharing row on the pre-publishing sheet.
+                Indicates the number of social accounts that will be sharing the blog post.
+                %1$d is a placeholder for the number of social network accounts that will be auto-shared.
+                Example: Sharing to 3 accounts
+                """
+        )
+
+        static let partialConnectionsTextFormat = NSLocalizedString(
+            "prepublishing.social.label.partialConnections",
+            value: "Sharing to %1$d of %2$d accounts",
+            comment: """
+                The primary label for the auto-sharing row on the pre-publishing sheet.
+                Indicates the number of social accounts that will be sharing the blog post.
+                This string is displayed when some of the social accounts are turned off for auto-sharing.
+                %1$d is a placeholder for the number of social media accounts that will be sharing the blog post.
+                %2$d is a placeholder for the total number of social media accounts connected to the user's blog.
+                Example: Sharing to 2 of 3 accounts
+                """
+        )
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -15,7 +15,7 @@ extension PrepublishingViewController {
         // TODO:
         // - Show the NoConnectionView if user has 0 connections.
         // - Properly create and configure the view models.
-        let autoSharingView = UIView.embedSwiftUIView(PrepublishingAutoSharingView())
+        let autoSharingView = UIView.embedSwiftUIView(PrepublishingAutoSharingView(model: .init()))
         cell.contentView.addSubview(autoSharingView)
 
         // Pin constraints to the cell's layoutMarginsGuide so that the content is properly aligned.


### PR DESCRIPTION
Refs #20783 

This adds an immutable view model structure for the `PrepublishingAutoSharingView`, along with various UI improvements:

- Warning label is now shown based on the view model property.
- Text variations are adjusted depending on the state of enabled accounts (as per designed). 
- The remaining shares line will be hidden when the site has unlimited sharing (i.e., doesn't have any `SharingLimit`).
- The social icon train is now shown opaque or muted according to the state of the connection.

### Previews
Sharing to:
All accounts | Partial | Single | Not sharing
-|-|-|-
![iphone_multiple](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/e92705a7-534b-45a9-807c-c469942176a9) | ![iphone_partial](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/2fb6b801-df02-4874-8cbb-30a9d9a08ef2) | ![iphone_singular](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8333f37b-3b20-4106-9ae7-bd3050f737f0) | ![iphone_notSharing](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/72d0481a-561a-4a88-b9a8-e622ef4d1855)


### Notes
- These are strictly UI changes. The view model is still initialized with temp data that'll be wiped & replaced with actual implementation in the next PR.
- It's possible for one service to have multiple connections, and currently the `Connection` struct only supports one account per service. This will be addressed in the next PR.
- I've also found that the VoiceOver somehow won't step into the `UITableView` in the pre-publishing sheet. I'll investigate (and fix) this through a later PR, along with any accessibility adjustments for the social cell.

## To test

Since these are only visual changes, you can test the changes by modifying the temp data in `PrepublishingAutoSharingViewModel`.

To see the pre-publishing sheet:

- Launch the Jetpack app,
- Create a new blog post,
- Enter some text for the title and body,
- Tap publish.

### Case 1: Sharing to all accounts

In `PrepublishingAutoSharingViewModel`, modify the default value for `connections` so all its `enabled` properties are `true`:

```swift
let connections: [Connection] = [.init(serviceName: .facebook, account: "foo", enabled: true),
                                 .init(serviceName: .twitter, account: "bar", enabled: false),
                                 .init(serviceName: .tumblr, account: "baz", enabled: true)]
```

🔎 When the pre-publishing sheet is shown, verify that the text is `Sharing to 3 accounts`.

### Case 2: Sharing to partially selected accounts

The default values in the PR should have partially selected accounts by default.

🔎 When the pre-publishing sheet is shown, verify that: 
- The text is `Sharing to 2 of 3 accounts`.
- The Twitter logo is muted, while the others are displayed normally.

### Case 3: Sharing to the one and only account

In `PrepublishingAutoSharingViewModel`, modify the default value for `connections` it only has one account:

```swift
let connections: [Connection] = [.init(serviceName: .facebook, account: "@sporadicthoughts", enabled: true)]
```

🔎 When the pre-publishing sheet is shown, verify that the text is `Sharing to @sporadicthoughts`.

### Case 4: Not sharing

In `PrepublishingAutoSharingViewModel`, modify the default value for `connections` so that all the of the items are disabled:

```swift
let connections: [Connection] = [.init(serviceName: .facebook, account: "foo", enabled: false),
                                 .init(serviceName: .twitter, account: "bar", enabled: false),
                                 .init(serviceName: .tumblr, account: "baz", enabled: false)]
```

🔎 When the pre-publishing sheet is shown, verify that the text is `Not sharing to social`.

### Case 5: Warning label

The default values in the PR should display the warning by default.

🔎 When the pre-publishing sheet is shown, verify that the remaining shares label is shown with a warning icon.

### Case 6: Unlimited sharing

In the code, set the view model's `sharingLimit` value to `nil`:

```swift
let sharingLimit: PublicizeInfo.SharingLimit? = nil
```

🔎 When the pre-publishing sheet is shown, verify that **the remaining shares label is hidden.**

## Regression Notes
1. Potential unintended areas of impact
Should be none. The feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the feature.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
