### PR TITLE
Jetpack Social: Handle remaining shares on post settings screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -504,6 +504,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         PostCoordinator.shared.cancelAnyPendingSaveOf(post: post)
         addObservers(toPost: post)
         registerMediaObserver()
+        disableSocialConnectionsIfNecessary()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -338,6 +338,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
         PostCoordinator.shared.cancelAnyPendingSaveOf(post: post)
         self.navigationBarManager.delegate = self
+        disableSocialConnectionsIfNecessary()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+JetpackSocial.swift
@@ -1,0 +1,18 @@
+
+extension PostEditor {
+
+    func disableSocialConnectionsIfNecessary() {
+        guard FeatureFlag.jetpackSocial.enabled,
+              let post = self.post as? Post,
+              let remainingShares = self.post.blog.sharingLimit?.remaining,
+              let connections = self.post.blog.sortedConnections as? [PublicizeConnection],
+              remainingShares < connections.count else {
+            return
+        }
+
+        for connection in connections {
+            post.disablePublicizeConnectionWithKeyringID(connection.keyringConnectionID)
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -66,6 +66,23 @@ extension PostSettingsViewController {
         return hostController.view
     }
 
+    // MARK: - Social share cells
+
+    @objc func userCanEditSharing() -> Bool {
+        guard let post = self.apost as? Post else {
+            return false
+        }
+        guard FeatureFlag.jetpackSocial.enabled else {
+            return post.canEditPublicizeSettings()
+        }
+
+        return post.canEditPublicizeSettings() && remainingSocialShares() > 0
+    }
+
+    @objc func remainingSocialShares() -> Int {
+        self.apost.blog.sharingLimit?.remaining ?? .max
+    }
+
 }
 
 // MARK: - Private methods

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2110,6 +2110,8 @@
 		83DC5C472A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */; };
 		83E1E5592A58B5C2000B576F /* JetpackSocialError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */; };
 		83E1E55A2A58B5C2000B576F /* JetpackSocialError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */; };
+		83E1E55F2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E55E2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift */; };
+		83E1E5602A5CB8BF000B576F /* PostEditor+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E55E2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift */; };
 		83EF3D7B2937D703000AF9BF /* SharedDataIssueSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */; };
 		83EF3D7F2937F08C000AF9BF /* SharedDataIssueSolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
@@ -7488,6 +7490,7 @@
 		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialSettingsRemainingSharesView.swift; sourceTree = "<group>"; };
 		83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialError.swift; sourceTree = "<group>"; };
+		83E1E55E2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditor+JetpackSocial.swift"; sourceTree = "<group>"; };
 		83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolverTests.swift; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
@@ -14796,6 +14799,7 @@
 				C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */,
 				E13ACCD31EE5672100CCE985 /* PostEditor.swift */,
 				E17FEAD7221490F7006E1D2D /* PostEditorAnalyticsSession.swift */,
+				83E1E55E2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift */,
 				91DCE84521A6A7F50062F134 /* PostEditor+MoreOptions.swift */,
 				91DCE84721A6C58C0062F134 /* PostEditor+Publish.swift */,
 				7E504D4921A5B8D400E341A8 /* PostEditorNavigationBarManager.swift */,
@@ -21587,6 +21591,7 @@
 				405BFB21223B37A000CD5BEA /* FollowersCountStatsRecordValue+CoreDataProperties.swift in Sources */,
 				D8212CC720AA85C1008E8AE8 /* ReaderHeaderAction.swift in Sources */,
 				405B53FB1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift in Sources */,
+				83E1E55F2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift in Sources */,
 				E6D2E1651B8AAD7E0000ED14 /* ReaderSiteStreamHeader.swift in Sources */,
 				F126FE0020A33BDB0010EB6E /* VideoUploadProcessor.swift in Sources */,
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
@@ -24629,6 +24634,7 @@
 				F4F9D5F2290993D400502576 /* MigrationWelcomeViewModel.swift in Sources */,
 				FABB22ED2602FC2C00C8785C /* EditorFactory.swift in Sources */,
 				FABB22EE2602FC2C00C8785C /* NotificationSiteSubscriptionViewController.swift in Sources */,
+				83E1E5602A5CB8BF000B576F /* PostEditor+JetpackSocial.swift in Sources */,
 				FABB22EF2602FC2C00C8785C /* PostingActivityDay.swift in Sources */,
 				C7A09A4B28401B7B003096ED /* QRLoginService.swift in Sources */,
 				FABB22F02602FC2C00C8785C /* ReaderTeamTopic.swift in Sources */,


### PR DESCRIPTION
See: #20784 

## Description

Adds:
- Disabling the social connections and user interaction when there are no remaining shares
- Handling when the user has more connections than social shares remaining:
  - Disables interaction for social connections not selected when the remaining share limit is hit
  - Disables all social connections initially so the user can pick which to share to

## Screenshots

| No remaining shares | Remaining Shares < Social Connections | Remaining Shares > Social Connections |
|----------------------|----------------------------------------|-----------------------------------------|
|  ![No shares](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/25a3fece-5d6e-43e9-9e51-36a72a396e8e) | ![Remaining less than social](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/34559b4f-b828-4278-812e-7ecf4a8579ac) | ![Remaining greater than social](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/27199a78-1bcb-498b-a363-3198e94a29e8) |

## Testing

> **Note**
> The publicize info is not currently fetched anywhere in the app. Due to that, I'm including some test debugger commands in the testing steps.

<details><summary><strong>Example breakpoint</strong></summary>

![breakpoint](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/381002f4-086f-4a5e-bad1-bea608241811)


**Debugger command:** 
```
p let remaining: Int64 = 30; let publicizeInfo = PublicizeInfo(context: ContextManager.shared.mainContext); publicizeInfo.shareLimit = 30; publicizeInfo.sharesRemaining = remaining; self.post.blog.publicizeInfo = publicizeInfo
```

</details>

**Prerequisites**
- Setup a self-hosted site with the Jetpack Social plugin
- Launch Jetpack and login
- Select the self-hosted site
- Setup **2+** social connections if necessary (Menu > Social) **OR** use test data in code or using Charles Proxy
- Setup the breakpoint from the above example ^ (Note: This is a different breakpoint from the previous PR) or use test code

**No remaining shares**
- Update the breakpoint `remaining` to 0 
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** the social connections are all turned off and user interaction is disabled

**Remaining shares < social connections**
- Navigate out of the editor (To hit the breakpoint again)
- Update the breakpoint `remaining` to a value less than the number of social connections you have
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** all social connections are turned off initially
- Enable up to the remaining shares available
- **Verify** the other social connections not selected have user interaction disabled

**Remaining shares > social connections**
- Navigate out of the editor (To hit the breakpoint again)
- Update the breakpoint `remaining` to a value greater than the number of social connections you have
- Create a blog post or edit one
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** all social connections are enabled initially

## Regression Notes
1. Potential unintended areas of impact
Current social list in post settings

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
