### PR TITLE
Fix a retain cycle between RichTextView and its delegate

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
@@ -12,8 +12,8 @@ import UniformTypeIdentifiers
 
 
 @objc open class RichTextView: UIView, UITextViewDelegate {
-    @objc open var dataSource: RichTextViewDataSource?
-    @objc open var delegate: RichTextViewDelegate?
+    @objc open weak var dataSource: RichTextViewDataSource?
+    @objc open weak var delegate: RichTextViewDelegate?
 
 
     // MARK: - Initializers


### PR DESCRIPTION
Relates to #21050.

The `RichTextView` is only used in `NoteBlockTextTableViewCell`. The strong reference `dataSource` and `delegate` causes a retain cycle between the text view and the cell (its parent view).

https://github.com/wordpress-mobile/WordPress-iOS/blob/48b8a391394f2b4aee9b886abe21f62a521c0a81/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift#L114-L115


## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A