### PR TITLE
Change SharingAccountViewController.delegate to be a weak reference

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -10,7 +10,7 @@ import WordPressShared
     @objc var keyringConnections: [KeyringConnection]
     @objc var existingPublicizeConnections: [PublicizeConnection]?
     @objc var immutableHandler: ImmuTableViewHandler!
-    @objc var delegate: SharingAccountSelectionDelegate?
+    @objc weak var delegate: SharingAccountSelectionDelegate?
     private let keyringAccountHelper = KeyringAccountHelper()
 
     fileprivate lazy var noResultsViewController: NoResultsViewController = {


### PR DESCRIPTION
Relates to #21050.

The delegate property causes a retain cycle between `SharingAuthorizationHelper` and `SharingAccountViewController`:

https://github.com/wordpress-mobile/WordPress-iOS/blob/48b8a391394f2b4aee9b886abe21f62a521c0a81/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m#L236-L243

```mermaid
flowchart TD
  SharingAuthorizationHelper -->|navController| UINavigationController --> SharingAccountViewController -->|delegate| SharingAuthorizationHelper
```

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A