### PR TITLE
Passes UserDefaults.standard instead of creating new instances of UserDefaults

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 22.9
 -----
-* [**] Block editor: Move undo/redo buttons to the navigation bar [#20930]
+* [**] Block editor: Move undo/redo buttons to the navigation bar. [#20930]
+* [*] Fixed an issue that caused the UI to be briefly unresponsive in certian case when opening the app. [#21065]
 
 22.8
 -----

--- a/WordPress/Classes/Models/Blog+Editor.swift
+++ b/WordPress/Classes/Models/Blog+Editor.swift
@@ -39,7 +39,7 @@ extension Blog {
     /// The editor to use when creating a new post
     ///
     var editor: MobileEditor {
-        return mobileEditor ?? GutenbergSettings(database: UserDefaults.standard).getDefaultEditor(for: self)
+        return mobileEditor ?? GutenbergSettings().getDefaultEditor(for: self)
     }
 
     @objc var isGutenbergEnabled: Bool {

--- a/WordPress/Classes/Models/Blog+Editor.swift
+++ b/WordPress/Classes/Models/Blog+Editor.swift
@@ -39,7 +39,7 @@ extension Blog {
     /// The editor to use when creating a new post
     ///
     var editor: MobileEditor {
-        return mobileEditor ?? GutenbergSettings().getDefaultEditor(for: self)
+        return mobileEditor ?? GutenbergSettings(database: UserDefaults.standard).getDefaultEditor(for: self)
     }
 
     @objc var isGutenbergEnabled: Bool {

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -38,12 +38,8 @@ class GutenbergSettings {
     }
 
     // MARK: - Initialization
-    init(database: KeyValueDatabase) {
+    init(database: KeyValueDatabase = UserDefaults.standard) {
         self.database = database
-    }
-
-    convenience init() {
-        self.init(database: UserDefaults() as KeyValueDatabase)
     }
 
     // MARK: Public accessors


### PR DESCRIPTION
Fixes #20654

This PR attempts to resolve a severe hang that occurs when foregrounding the app in certain circumstances.  
User's with many blogs will be more affected than users with very few blogs.  What appears to happen is: 
1. The app is foregrounded.
2. The app delegate calls `GutenbergSettings().performGutenbergPhase2MigrationIfNeeded`
3. GutenbergRollout.atLeastOneSiteHasAztecEnabled is called which loops over every blog stored in the app.
4. The check for the editor current creates a new instance of GutenbergSettings for _each_ blog being checked, and each instance of GutenbergSettings creates a new instance of UserDefaults, which is automatically populated with the current values for the app and user.  (See [this comment](https://github.com/wordpress-mobile/WordPress-iOS/issues/20654#issuecomment-1631603338) in the related issue for more details.)

This PR attempts to resolve the hang by passing the singleton instance of UserDefaults.standard to GutenbergSettings, avoiding all the extra work being done to populate each new instance of UserDefaults.

NOTE: It's not clear to me if there is a reason GutenbergSettings needs a fresh instance of UserDefaults. There doesn't seem to be but I'm unfamiliar with the related code. Reviewers please take an extra look at this to make sure I haven't overlooked anything! 

To test:
Confirm the issue by follwing these steps: 

- Start fresh by force closing the app. Open and then background the app. Then open it again and confirm that the app is immediately responsive.
- Switch to the reader tab.
- Tap on a post with many comments and view the detail.
- Tap on the option to view the comments.
- Background and reopen the app. Confirm the app is not immediately responsive.
- Back out of the comments to the post stream. (The stream shouldn't matter.)
- Background and reopen the app. Confirm the app is still unresponsive.
- Switch tabs to either sites or notifications. Background and reopen the app. Confirm the app is still unresponsive.

Then switch to this branch and repeat the steps above and confirm that the app is NOT unresponsive. 


## Regression Notes
1. Potential unintended areas of impact
Potential unintended changes to UserDefaults.standard that were avoided by using an separate instance. I'm not seeing where this would be an issue but paranoia ftw! 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
No tests that I'm aware of. 

3. What automated tests I added (or what prevented me from doing so)
We could add a test to check that the same instance of UserDefaults is being used for each created copy of GutenbergSettings, but I'm not sure this is reasonable. It would seem to make more sense to to alter the default initializer so database: has a default value of UserDefaults.standard rather than add a test.  Or there may be other, better approaches.  Thoughts? 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
