### PR TITLE
Fix retain cycles in Site Creation

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/TemplatePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/TemplatePreviewViewController.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-protocol TemplatePreviewViewDelegate {
+protocol TemplatePreviewViewDelegate: AnyObject {
     typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
     func deviceButtonTapped(_ previewDevice: PreviewDevice)
     func deviceModeChanged(_ previewDevice: PreviewDevice)
@@ -20,7 +20,7 @@ class TemplatePreviewViewController: UIViewController, NoResultsViewHost, UIPopo
     @IBOutlet weak var footerView: UIView!
     @IBOutlet weak var progressBar: UIProgressView!
 
-    internal var delegate: TemplatePreviewViewDelegate?
+    internal weak var delegate: TemplatePreviewViewDelegate?
     private let demoURL: String
     private var estimatedProgressObserver: NSKeyValueObservation?
     internal var selectedPreviewDevice: PreviewDevice {

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsStep.swift
@@ -8,7 +8,7 @@ final class SiteSegmentsStep: WizardStep {
         return SiteSegmentsWizardContent(service: self.service, selection: self.didSelect)
     }()
 
-    var delegate: WizardDelegate?
+    weak var delegate: WizardDelegate?
 
     init(creator: SiteCreator, service: SiteSegmentsService) {
         self.creator = creator


### PR DESCRIPTION
Relates to #21050.

I'll add PR comments regarding the two retain cycles.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A