### PR TITLE
Fix app hangs in StatsPeriodStore

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 23.0
 -----
 * [**] [internal] Upgrade React Native to 0.71.11 [#20956]
+* [*] [Jetpack-only] Fix app hangs on the Stats screen [#21067]
 
 22.9
 -----

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -97,6 +97,8 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     
     [WPAnalytics refreshMetadata];
     [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
+
+    [StatsCache clearCaches];
 }
 
 - (void)isEmailAvailable:(NSString *)email success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure

--- a/WordPress/Classes/Stores/StatsInsightsCache.swift
+++ b/WordPress/Classes/Stores/StatsInsightsCache.swift
@@ -3,7 +3,7 @@ import Foundation
 final class StatsInsightsCache {
     static let shared = StatsInsightsCache()
 
-    private var cache: [CacheKey: Any] = [:]
+    private var cache: [CacheKey: StatsInsightData] = [:]
 
     func getValue<T: StatsInsightData>(record: Record, siteID: NSNumber) -> T? {
         let key = CacheKey(record: record, siteID: siteID)

--- a/WordPress/Classes/Stores/StatsInsightsCache.swift
+++ b/WordPress/Classes/Stores/StatsInsightsCache.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+final class StatsInsightsCache {
+    static let shared = StatsInsightsCache()
+
+    private var cache: [CacheKey: Any] = [:]
+
+    func getValue<T: StatsInsightData>(record: Record, siteID: NSNumber) -> T? {
+        let key = CacheKey(record: record, siteID: siteID)
+        return cache[key] as? T
+    }
+
+    func setValue<T: StatsInsightData>(_ value: T, record: Record, siteID: NSNumber) {
+        let key = CacheKey(record: record, siteID: siteID)
+        cache[key] = value
+    }
+
+    func removeAll() {
+        cache.removeAll()
+    }
+
+    enum Record: Hashable {
+        case lastPostInsight
+        case allTimeStats
+        case annualAndMostPopularTime
+        case publicizeFollowers
+        case todaysStats
+        case postingActivity
+        case topTagsAndCategories
+        case topCommentsInsight
+        case dotComFollowers
+        case emailFollowers
+    }
+
+    private struct CacheKey: Hashable {
+        let record: Record
+        let siteID: NSNumber
+    }
+}

--- a/WordPress/Classes/Stores/StatsInsightsCache.swift
+++ b/WordPress/Classes/Stores/StatsInsightsCache.swift
@@ -1,9 +1,14 @@
 import Foundation
+import WordPressKit
+import CocoaLumberjack
 
 final class StatsInsightsCache {
     static let shared = StatsInsightsCache()
 
     private var cache: [CacheKey: StatsInsightData] = [:]
+    private var lastRefreshDates: [NSNumber: Date] = [:]
+
+    // MARK: - Accessing Cached Data
 
     func getValue<T: StatsInsightData>(record: Record, siteID: NSNumber) -> T? {
         let key = CacheKey(record: record, siteID: siteID)
@@ -18,6 +23,29 @@ final class StatsInsightsCache {
     func removeAll() {
         cache.removeAll()
     }
+
+    // MARK: - Expiration
+
+    var isExpired: Bool {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID,
+              let date = lastRefreshDates[siteID] else {
+                  return true
+              }
+
+        let interval = Date().timeIntervalSince(date)
+        let expired = interval > Constants.cacheTTL
+
+        let intervalLogMessage = "(\(String(format: "%.2f", interval))s since last refresh)"
+        DDLogInfo("Stats: Insights cache for site \(siteID) has \(expired ? "" : "not ")expired \(intervalLogMessage).")
+
+        return expired
+    }
+
+    func setLastRefreshDate(_ date: Date, forSiteID siteID: NSNumber) {
+        lastRefreshDates[siteID] = Date()
+    }
+
+    // MARK: - Helpers
 
     enum Record: Hashable {
         case lastPostInsight
@@ -35,5 +63,9 @@ final class StatsInsightsCache {
     private struct CacheKey: Hashable {
         let record: Record
         let siteID: NSNumber
+    }
+
+    private enum Constants {
+        static let cacheTTL: TimeInterval = 300 // 5 minutes
     }
 }

--- a/WordPress/Classes/Stores/StatsPeriodCache.swift
+++ b/WordPress/Classes/Stores/StatsPeriodCache.swift
@@ -3,7 +3,7 @@ import Foundation
 final class StatsPediodCache {
     static let shared = StatsPediodCache()
 
-    private var cache: [CacheKey: Any] = [:]
+    private var cache: [CacheKey: StatsTimeIntervalData] = [:]
 
     func getValue<T: StatsTimeIntervalData>(record: Record, date: Date, period: StatsPeriodUnit, siteID: NSNumber) -> T? {
         let key = makeKey(record: record, date: date, period: period, siteID: siteID)

--- a/WordPress/Classes/Stores/StatsPeriodCache.swift
+++ b/WordPress/Classes/Stores/StatsPeriodCache.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+final class StatsPediodCache {
+    static let shared = StatsPediodCache()
+
+    private var cache: [CacheKey: Any] = [:]
+
+    func getValue<T: StatsTimeIntervalData>(record: Record, date: Date, period: StatsPeriodUnit, siteID: NSNumber) -> T? {
+        let key = makeKey(record: record, date: date, period: period, siteID: siteID)
+        return cache[key] as? T
+    }
+
+    func setValue<T: StatsTimeIntervalData>(_ value: T, record: Record, siteID: NSNumber) {
+        let key = makeKey(record: record, date: value.periodEndDate, period: value.period, siteID: siteID)
+        cache[key] = value
+    }
+
+    func removeAll() {
+        cache.removeAll()
+    }
+
+    private func makeKey(record: Record, date: Date, period: StatsPeriodUnit, siteID: NSNumber) -> CacheKey {
+        let date = Calendar.current.startOfDay(for: date)
+        return CacheKey(record: record, date: date, period: period, siteID: siteID)
+    }
+
+    enum Record: Hashable {
+        case summary
+        case topPostsAndPages
+        case topReferrers
+        case topClicks
+        case topPublished
+        case topAuthors
+        case topSearchTerms
+        case topCountries
+        case topVideos
+        case topFileDownloads
+    }
+
+    private struct CacheKey: Hashable {
+        let record: Record
+        let date: Date
+        let period: StatsPeriodUnit
+        let siteID: NSNumber
+    }
+}
+
+final class StatsCache: NSObject {
+    @objc class func clearCaches() {
+        StatsPediodCache.shared.removeAll()
+        StatsInsightsCache.shared.removeAll()
+    }
+}

--- a/WordPress/Classes/Stores/StatsPeriodCache.swift
+++ b/WordPress/Classes/Stores/StatsPeriodCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressKit
 
 final class StatsPediodCache {
     static let shared = StatsPediodCache()

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -183,6 +183,7 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
     var statsServiceRemote: StatsServiceRemoteV2?
     private var operationQueue = OperationQueue()
     private let scheduler = Scheduler(seconds: 0.3)
+    private let cache: StatsPediodCache = .shared
 
     weak var delegate: StatsPeriodStoreDelegate?
 
@@ -249,26 +250,23 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
         processQueries()
     }
 
-    func persistToCoreData() {
-        guard
-            let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
-                return
+    private func storeDataInCache() {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID else {
+            return
         }
-
-        _ = state.summary.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topPostsAndPages.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topReferrers.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topClicks.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topPublished.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topAuthors.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topSearchTerms.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topCountries.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topVideos.flatMap { StatsRecord.record(from: $0, for: blog) }
-        _ = state.topFileDownloads.flatMap { StatsRecord.record(from: $0, for: blog) }
-
-        try? ContextManager.shared.mainContext.save()
-        DDLogInfo("Stats Period: finished persisting Period Stats to disk.")
+        func setValue<T: StatsTimeIntervalData>(_ value: T, _ record: StatsPediodCache.Record) {
+            cache.setValue(value, record: record, siteID: siteID)
+        }
+        state.summary.map { setValue($0, .summary) }
+        state.topPostsAndPages.map { setValue($0, .topPostsAndPages) }
+        state.topReferrers.map { setValue($0, .topReferrers) }
+        state.topClicks.map { setValue($0, .topClicks) }
+        state.topPublished.map { setValue($0, .topPublished) }
+        state.topAuthors.map { setValue($0, .topAuthors) }
+        state.topSearchTerms.map { setValue($0, .topSearchTerms) }
+        state.topCountries.map { setValue($0, .topCountries) }
+        state.topVideos.map { setValue($0, .topVideos) }
+        state.topFileDownloads.map { setValue($0, .topFileDownloads) }
     }
 }
 
@@ -578,45 +576,31 @@ private extension StatsPeriodStore {
         if FeatureFlag.statsNewAppearance.enabled {
             group.notify(queue: .main) { [weak self] in
                 DDLogInfo("Stats Period: Finished fetchAsyncData.")
-                self?.persistToCoreData()
+                self?.storeDataInCache()
             }
         }
     }
 
     func loadFromCache(date: Date, period: StatsPeriodUnit) {
-        guard
-            let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
-                return
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID else {
+            return
         }
-
-        let summary = StatsRecord.timeIntervalData(for: blog, type: .blogVisitsSummary, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let posts = StatsRecord.timeIntervalData(for: blog, type: .topViewedPost, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let referrers = StatsRecord.timeIntervalData(for: blog, type: .referrers, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let clicks = StatsRecord.timeIntervalData(for: blog, type: .clicks, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let published = StatsRecord.timeIntervalData(for: blog, type: .publishedPosts, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let authors = StatsRecord.timeIntervalData(for: blog, type: .topViewedAuthor, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let searchTerms = StatsRecord.timeIntervalData(for: blog, type: .searchTerms, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let countries = StatsRecord.timeIntervalData(for: blog, type: .countryViews, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let videos = StatsRecord.timeIntervalData(for: blog, type: .videos, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-        let fileDownloads = StatsRecord.timeIntervalData(for: blog, type: .fileDownloads, period: StatsRecordPeriodType(remoteStatus: period), date: date)
-
-        DDLogInfo("Stats Period: Finished loading Period data from Core Data.")
-
+        func getValue<T: StatsTimeIntervalData>(_ record: StatsPediodCache.Record) -> T? {
+            cache.getValue(record: record, date: date, period: period, siteID: siteID)
+        }
         transaction { state in
-            state.summary = summary.flatMap { StatsSummaryTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topPostsAndPages = posts.flatMap { StatsTopPostsTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topReferrers = referrers.flatMap { StatsTopReferrersTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topClicks = clicks.flatMap { StatsTopClicksTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topPublished = published.flatMap { StatsPublishedPostsTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topAuthors = authors.flatMap { StatsTopAuthorsTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topSearchTerms = searchTerms.flatMap { StatsSearchTermTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topCountries = countries.flatMap { StatsTopCountryTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topVideos = videos.flatMap { StatsTopVideosTimeIntervalData(statsRecordValues: $0.recordValues) }
-            state.topFileDownloads = fileDownloads.flatMap { StatsFileDownloadsTimeIntervalData(statsRecordValues: $0.recordValues) }
-
-            DDLogInfo("Stats Period: Finished setting data to Period store from Core Data.")
+            state.summary = getValue(.summary)
+            state.topPostsAndPages = getValue(.topPostsAndPages)
+            state.topReferrers = getValue(.topReferrers)
+            state.topClicks = getValue(.topClicks)
+            state.topPublished = getValue(.topPublished)
+            state.topAuthors = getValue(.topAuthors)
+            state.topSearchTerms = getValue(.topSearchTerms)
+            state.topCountries = getValue(.topCountries)
+            state.topVideos = getValue(.topVideos)
+            state.topFileDownloads = getValue(.topFileDownloads)
         }
+        DDLogInfo("Stats Period: Finished setting data to Period store from disk cache.")
     }
 
     func refreshPeriodOverviewData(date: Date, period: StatsPeriodUnit, forceRefresh: Bool) {
@@ -624,7 +608,7 @@ private extension StatsPeriodStore {
         // It's here because call to this method will usually happen after user selects a different
         // time period they're interested in. If we only relied on calls to `persistToCoreData()`
         // when user has left the screen/app, we would possibly lose on storing A LOT of data.
-        persistToCoreData()
+        storeDataInCache()
 
         if forceRefresh {
             cancelQueries()
@@ -652,7 +636,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedPostsAndPages(posts, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -684,7 +668,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedSearchTerms(searchTerms, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -716,7 +700,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedVideos(videos, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -748,7 +732,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedClicks(clicks, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -780,7 +764,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedAuthors(authors, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -812,7 +796,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedReferrers(referrers, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -844,7 +828,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedCountries(countries, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -876,7 +860,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedPublished(published, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 
@@ -908,7 +892,7 @@ private extension StatsPeriodStore {
             DispatchQueue.main.async {
                 self?.receivedFileDownloads(downloads, error)
             }
-            self?.persistToCoreData()
+            self?.storeDataInCache()
         })
     }
 

--- a/WordPress/Classes/Stores/StoreContainer.swift
+++ b/WordPress/Classes/Stores/StoreContainer.swift
@@ -9,8 +9,6 @@ class StoreContainer {
 
     @objc fileprivate func applicationWillResignActive() {
         try? plugin.persistState()
-        statsInsights.persistToCoreData()
-        statsPeriod.persistToCoreData()
     }
 
     let plugin = PluginStore()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -365,6 +365,10 @@
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C0D3B0E2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
+		0C2C83FA2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */; };
+		0C2C83FB2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */; };
+		0C2C83FD2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83FC2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift */; };
+		0C2C83FE2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83FC2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift */; };
 		0C35FFF129CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */; };
 		0C35FFF229CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */; };
 		0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */; };
@@ -6142,6 +6146,8 @@
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
+		0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodCache.swift; sourceTree = "<group>"; };
+		0C2C83FC2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsInsightsCache.swift; sourceTree = "<group>"; };
 		0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardHelpers.swift; sourceTree = "<group>"; };
 		0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModelTests.swift; sourceTree = "<group>"; };
 		0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardEmptyStateCell.swift; sourceTree = "<group>"; };
@@ -16875,7 +16881,9 @@
 				E1CA0A6B1FA73053004C4BBE /* PluginStore.swift */,
 				40ADB15420686870009A9161 /* PluginStore+Persistence.swift */,
 				98AE3DF4219A1788003C0E24 /* StatsInsightsStore.swift */,
+				0C2C83FC2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift */,
 				984B139321F66B2D0004B6A2 /* StatsPeriodStore.swift */,
+				0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */,
 				9A4A8F4A235758EF00088CE4 /* StatsStore+Cache.swift */,
 				E1CB6DA2200F376400945457 /* TimeZoneStore.swift */,
 				9A2D0B24225CB97F009E585F /* JetpackInstallStore.swift */,
@@ -21565,6 +21573,7 @@
 				4A82C43128D321A300486CFF /* Blog+Post.swift in Sources */,
 				731E88C921C9A10B0055C014 /* ErrorStateViewConfiguration.swift in Sources */,
 				17C3FA6F25E591D200EFFE12 /* UIFont+Weight.swift in Sources */,
+				0C2C83FD2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift in Sources */,
 				73E4E376227A033A0007D752 /* PostChart.swift in Sources */,
 				4631359124AD013F0017E65C /* PageCoordinator.swift in Sources */,
 				43290D04215C28D800F6B398 /* Blog+QuickStart.swift in Sources */,
@@ -22395,6 +22404,7 @@
 				400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */,
 				9A8ECE0E2254A3260043C8DA /* JetpackConnectionWebViewController.swift in Sources */,
 				B06378C1253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift in Sources */,
+				0C2C83FA2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */,
 				4353BFB221A376BF0009CED3 /* UntouchableWindow.swift in Sources */,
 				FE32F002275F602E0040BE67 /* CommentContentRenderer.swift in Sources */,
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
@@ -24361,6 +24371,7 @@
 				FABB220C2602FC2C00C8785C /* Blog.m in Sources */,
 				FABB220D2602FC2C00C8785C /* JetpackRemoteInstallStateView.swift in Sources */,
 				F4552086299D147B00D9F6A8 /* BlockedSite.swift in Sources */,
+				0C2C83FB2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */,
 				FABB220E2602FC2C00C8785C /* PublishSettingsViewController.swift in Sources */,
 				FABB220F2602FC2C00C8785C /* MediaHost+AbstractPost.swift in Sources */,
 				FABB22102602FC2C00C8785C /* PageTemplateCategory+CoreDataProperties.swift in Sources */,
@@ -25133,6 +25144,7 @@
 				FABB24462602FC2C00C8785C /* BaseRestoreStatusViewController.swift in Sources */,
 				FABB24472602FC2C00C8785C /* SignupEpilogueTableViewController.swift in Sources */,
 				FABB24482602FC2C00C8785C /* MyProfileViewController.swift in Sources */,
+				0C2C83FE2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift in Sources */,
 				FAD7626529F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift in Sources */,
 				3FE3D1FF26A6F56700F3CD10 /* Comment+Interface.swift in Sources */,
 				FABB24492602FC2C00C8785C /* CreateButtonActionSheet.swift in Sources */,


### PR DESCRIPTION
Related #20773

This PR fixes the top app hang: https://github.com/orgs/wordpress-mobile/projects/194/views/1?pane=issue&itemId=32912438.

**Update 24 Jul**: switched to storing stats in a memory cache (see https://github.com/wordpress-mobile/WordPress-iOS/pull/21067#issuecomment-1648361332 for more info)

<hr/>

TL;DR: 

- Stats now use a new file-based `DiskCache` to cache responses instead of Core Data
- I kept the reads and writes synchronous to minimize the changes to the store. It's not ideal, but I would not risk changing it now. The main goal was to get rid of `ContextManager.shared.mainContext.save()`

## Core Data vs Disk Cache

There are multiple reasons why using Core Data is problematic in this scenario. They mostly come down to the fact that repenting data like stats is hard in a relational database.

- It's slow because to represent a single response, it creates hundreds of records in the database (one for each stats record value). It also needs to delete all of the previous record values when the response is updated. I found reads and writes from a JSON-based cache to be **~20X** faster than using Core Data. It also frees the database resources to be used for other more valid purposes.
- It uses space inefficiently: stats often occupy 80%+ of the database. I used SQLite analyzer to investigate and found that the CREATE for the record value database columns looks [like this](https://gist.githubusercontent.com/kean/3fd7460407616348360e418301314578/raw/cdcfd86ae67087db9306df4f988787aca27fd722/create-table.txt). The reason this table is so massive is that there is a couple of dozen of managed object descriptions in the Core Data model that all inherit from the same entity `StatsRecordValue`. It looks pretty in the model, but Core Data represents these entities using a single table in SQLite. SQLite is usually very efficient with storage, and it uses binary storage, but despite that, the space used in the database was **~3X** times larger than what I saw by just storing the responses as text (JSON).
- It writes to the database on the main thread using `ContextManager.shared.mainContext.save()`, and it does every time **the app resigns** active, even if you never opened stats. I have a hunch that it contributes to other hard-to-debug Core Data crashes. It's impossible to know in what state the main context is at any of these points.

## To test:

- Verify that the stats data is still cached. This includes insights, and other stats.

## Regression Notes
1. Potential unintended areas of impact: Stats
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
