### PR TITLE
Enable the weak_delegate SwiftLint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,10 @@ remote_timeout: 10.0
 
 opt_in_rules:
   - overridden_super_call
+  - weak_delegate
 
 overridden_super_call:
+  severity: error
+
+weak_delegate:
   severity: error

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -241,6 +241,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     let navigationBarManager: PostEditorNavigationBarManager
 
+    // swiftlint:disable:next weak_delegate
     lazy var attachmentDelegate = AztecAttachmentDelegate(post: post)
 
     lazy var mediaPickerHelper: GutenbergMediaPickerHelper = {

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -13,6 +13,7 @@ class MediaItemViewController: UITableViewController {
 
     }
 
+    // swiftlint:disable:next weak_delegate
     let delegate = DownloadDelegate()
 
     @objc let media: Media

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -45,6 +45,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// The table view that displays Comments
     @IBOutlet weak var commentsTableView: IntrinsicTableView!
+
+    // swiftlint:disable:next weak_delegate
     private let commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
 
     /// The table view that displays Related Posts

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -98,6 +98,7 @@ public protocol ThemePresenter: AnyObject {
 
     @IBOutlet weak var collectionView: UICollectionView!
 
+    // swiftlint:disable:next weak_delegate
     fileprivate lazy var customizerNavigationDelegate: ThemeWebNavigationDelegate = {
         return ThemeWebNavigationDelegate()
     }()

--- a/WordPress/WordPressTest/Dashboard/BlazeCampaignsStreamTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlazeCampaignsStreamTests.swift
@@ -6,6 +6,7 @@ import WordPressKit
 final class BlazeCampaignsStreamTests: CoreDataTestCase {
     private var sut: BlazeCampaignsStream!
     private var blog: Blog!
+    // swiftlint:disable:next weak_delegate
     private var delegate = MockCampaignsStreamDelegate()
     private let service = MockBlazePaginatedService()
 

--- a/WordPress/WordPressTest/Mention/SuggestionTableViewTests.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionTableViewTests.swift
@@ -6,6 +6,7 @@ import XCTest
 final class SuggestionTableViewTests: CoreDataTestCase {
 
     private var view: SuggestionsTableView!
+    // swiftlint:disable:next weak_delegate
     private var delegate: SuggestionsTableViewDelegateMock!
     private var viewModel: SuggestionsListViewModelType {
         return view.viewModel

--- a/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 class ReferrerDetailsViewModelTests: XCTestCase {
     private var sut: ReferrerDetailsViewModel!
+    // swiftlint:disable:next weak_delegate
     private var spyDelegate: ViewModelDelegateSpy!
 
     override func setUpWithError() throws {


### PR DESCRIPTION
Fixes #21050.

The `weak_delegate` SwiftLint rule reports issues on all strong references to types whose name has 'Delegate' in it. Enabling this SwiftLint rule will help us catching retain cycles.

Majority of "delegate" types follow observer pattern, which should be declared as weak references. For those cases where the "delegate" should be strongly referenced, we can use SwiftLint's `swiftlint:disable` special code comments to ignore the issue.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A