### PR TITLE
[EU/US Compliance] Show popover for EU users in WordPress

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -14,7 +14,6 @@ final class BlogDashboardViewController: UIViewController {
         BlogDashboardViewModel(viewController: self, blog: blog)
     }()
 
-    private var complianceCoordinator: CompliancePopoverCoordinator?
 
     lazy var collectionView: DynamicHeightCollectionView = {
         let collectionView = DynamicHeightCollectionView(frame: .zero, collectionViewLayout: createLayout())
@@ -81,9 +80,6 @@ final class BlogDashboardViewController: UIViewController {
         startAlertTimer()
 
         WPAnalytics.track(.mySiteDashboardShown)
-
-        complianceCoordinator = CompliancePopoverCoordinator(viewController: self)
-        complianceCoordinator?.presentIfNeeded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -91,6 +91,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     var willDisplayPostSignupFlow: Bool = false
 
     private var createButtonCoordinator: CreateButtonCoordinator?
+    private var complianceCoordinator: CompliancePopoverCoordinator?
 
     private let meScenePresenter: ScenePresenter
     private let blogService: BlogService
@@ -208,6 +209,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         createFABIfNeeded()
         fetchPrompt(for: blog)
+
+        complianceCoordinator = CompliancePopoverCoordinator(viewController: self)
+        complianceCoordinator?.presentIfNeeded()
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -17,7 +17,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
     }
 
     func presentIfNeeded() {
-        guard FeatureFlag.compliancePopover.enabled else {
+        guard FeatureFlag.compliancePopover.enabled, !defaults.didShowCompliancePopup else {
             return
         }
         complianceService.getIPCountryCode { [weak self] result in


### PR DESCRIPTION
Closes #21058

## Description
This PR builds on #20982. The PR enables the compliance popover on both WordPress and Jetpack. Previously, it was only displayed on Jetpack.

The PR also implements a small performance enhancement (f668fcee69d2e7665ecbcd47ad84a5dbdc042e79)

## Testing Instructions
Test the following scenarios on **BOTH** WordPress and Jetpack

### Popover Appears in EU

1. Fresh Install and run the app (Must be located in EU countries or VPN, alternatively, you can use [proxyman.io](https://proxyman.io/) to stub the `/geo` request).
2. Login
3. You should eventually land on "My Site"
4. ✅ Make sure the popup appears
5. Tap "Save" or "Go to Settings"
6. Come back to My Site
7. ✅ Make sure the popup doesn't appear

### Popover Shouldn't Appear outside of the EU

1. Fresh Install and run the app (Must be located outside of the EU countries or VPN, alternatively, you can use [proxyman.io](https://proxyman.io/) to stub the `/geo` request).
2. Login
3. You should eventually land on "My Site"
4. ✅ Make sure the popup doesn't appear

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
