### PR TITLE
UI Test Fix - Properly update all renamed variables

### DIFF
--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -60,15 +60,15 @@ class EditorGutenbergTests: XCTestCase {
         try BlockEditorScreen()
             .verifyUndoIsDisabled()
             .verifyRedoIsDisabled()
-            .enterTextInTitle(text: title)
-            .addParagraphBlock(withText: content)
-            .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
+            .enterTextInTitle(text: postTitle)
+            .addParagraphBlock(withText: postContent)
+            .verifyContentStructure(blocks: 1, words: postContent.components(separatedBy: " ").count, characters: postContent.count)
             .undo()
             .undo()
             .verifyContentStructure(blocks: 0, words: 0, characters: 0)
             .redo()
             .redo()
-            .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
+            .verifyContentStructure(blocks: 1, words: postContent.components(separatedBy: " ").count, characters: postContent.count)
     }
 
     func testAddRemoveFeaturedImage() throws {


### PR DESCRIPTION
### Description
In https://github.com/wordpress-mobile/WordPress-iOS/pull/21042 a few variables were renamed, I missed updating them in one test case causing build failure ([Buildkite Build](https://buildkite.com/automattic/wordpress-ios/builds/15422#01894906-1742-4057-853c-73688a8896fc/595-8287))

Not sure how the original PR build passed with that error 🤔 

### Testing
CI should be 🟢 and updated all references of `title` and `content` in `WordPress/UITests/Tests/EditorGutenbergTests.swift` to the new names `postTitle` and `postContent`