### PR TITLE
[UI Tests] - Remove checks that are no longer needed for tests using self hosted sites

### DIFF
--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -18,7 +18,7 @@ class LoginTests: XCTestCase {
             .selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithValidPassword()
-                    .verifyEpilogueDisplays(
+            .verifyEpilogueDisplays(
                 username: WPUITestCredentials.testWPcomUsername,
                 siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress
             )

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -56,16 +56,12 @@ public class LoginUsernamePasswordScreen: ScreenObject {
 
     public func proceedWithSelfHostedSiteAddedFromSitesList(username: String, password: String) throws -> MySitesScreen {
         fill(username: username, password: password)
-        try dismissQuickStartPromptIfNeeded()
-        try dismissOnboardingQuestionsPromptIfNeeded()
 
         return try MySitesScreen()
     }
 
     public func proceedWithSelfHosted(username: String, password: String) throws -> MySiteScreen {
         fill(username: username, password: password)
-        try dismissQuickStartPromptIfNeeded()
-        try dismissOnboardingQuestionsPromptIfNeeded()
 
         return try MySiteScreen()
     }


### PR DESCRIPTION
### Description
I noticed that tests using self-hosted sites would wait a long time during login before the test continued. Found that it was because of two lines that were no longer needed. This simple PR removes those lines as they are no longer needed, as having them in the code only makes the test run unnecessarily longer.

#### Before change:
`testSelfHostedLoginLogout`
```
Test Case '-[JetpackUITests.LoginTests testSelfHostedLoginLogout]' passed (68.677 seconds).
Test Suite 'LoginTests' passed at 2023-07-12 17:32:31.744.
	 Executed 1 test, with 0 failures (0 unexpected) in 68.677 (68.681) seconds
```

`testAddSelfHostedSiteAfterWPcomLogin`
```
Test Case '-[JetpackUITests.LoginTests testAddSelfHostedSiteAfterWPcomLogin]' passed (116.345 seconds).
Test Suite 'LoginTests' passed at 2023-07-12 17:40:23.288.
	 Executed 1 test, with 0 failures (0 unexpected) in 116.345 (116.347) seconds
```

#### After change:
`testSelfHostedLoginLogout` ⬇️ **40.221 Seconds**
```
Test Case '-[JetpackUITests.LoginTests testSelfHostedLoginLogout]' passed (28.460 seconds).
Test Suite 'LoginTests' passed at 2023-07-12 17:35:03.512.
	 Executed 1 test, with 0 failures (0 unexpected) in 28.460 (28.464) seconds
```

`testAddSelfHostedSiteAfterWPcomLogin` ⬇️ **40.684 Seconds**
```
Test Case '-[JetpackUITests.LoginTests testAddSelfHostedSiteAfterWPcomLogin]' passed (75.661 seconds).
Test Suite 'LoginTests' passed at 2023-07-12 17:43:31.512.
	 Executed 1 test, with 0 failures (0 unexpected) in 75.661 (75.663) seconds
```

### Testing
CI should be 🟢 and the affected tests `testSelfHostedLoginLogout` and `testAddSelfHostedSiteAfterWPcomLogin` should run faster than in current `trunk`