### PR TITLE
Jetpack Social: Prepublishing auto-sharing view model implementation

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -84,13 +84,15 @@ private extension PrepublishingAutoSharingView {
 /// The value-type data model that drives the `PrepublishingAutoSharingView`.
 struct PrepublishingAutoSharingViewModel {
 
+    // MARK: Helper Models
+
     /// A value-type representation of `PublicizeService` that's simplified for the needs of the auto-sharing view.
     struct Service: Hashable {
         let serviceName: PublicizeService.ServiceName
         let connections: [Connection]
 
         /// Whether the icon for this service should be opaque or transparent.
-        /// If at least one account is enabled, we'll show an opaque version.
+        /// If at least one account is enabled, an opaque version should be shown.
         var usesOpaqueIcon: Bool {
             connections.reduce(false) { partialResult, connection in
                 return partialResult || connection.enabled
@@ -107,18 +109,12 @@ struct PrepublishingAutoSharingViewModel {
         let enabled: Bool
     }
 
-    // TODO: Default values are for temporary testing purposes. Will be removed later.
-    let services: [Service] = [
-        Service(serviceName: .facebook, connections: [
-            Connection(account: "foo", enabled: true),
-            Connection(account: "foo-2", enabled: false)
-        ]),
-        Service(serviceName: .twitter, connections: [Connection(account: "bar", enabled: false)]),
-        Service(serviceName: .tumblr, connections: [Connection(account: "baz", enabled: true)])
-    ]
+    // MARK: Properties
 
-    // TODO: Default values are for temporary testing purposes. Will be removed later.
-    let sharingLimit: PublicizeInfo.SharingLimit? = .init(remaining: 1, limit: 30)
+    let services: [Service]
+    let sharingLimit: PublicizeInfo.SharingLimit?
+
+    // MARK: Computed Properties
 
     var enabledConnectionsCount: Int {
         services.reduce(0) { partialResult, service in

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -94,9 +94,7 @@ struct PrepublishingAutoSharingViewModel {
         /// Whether the icon for this service should be opaque or transparent.
         /// If at least one account is enabled, an opaque version should be shown.
         var usesOpaqueIcon: Bool {
-            connections.reduce(false) { partialResult, connection in
-                return partialResult || connection.enabled
-            }
+            connections.reduce(false) { $0 || $1.enabled }
         }
 
         var enabledConnections: [Connection] {
@@ -117,15 +115,11 @@ struct PrepublishingAutoSharingViewModel {
     // MARK: Computed Properties
 
     var enabledConnectionsCount: Int {
-        services.reduce(0) { partialResult, service in
-            return partialResult + service.enabledConnections.count
-        }
+        services.reduce(0) { $0 + $1.enabledConnections.count }
     }
 
     var totalConnectionsCount: Int {
-        services.reduce(0) { partialResult, service in
-            return partialResult + service.connections.count
-        }
+        services.reduce(0) { $0 + $1.connections.count }
     }
 
     var showsWarning: Bool {

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -8,7 +8,7 @@ struct PrepublishingAutoSharingView: View {
         HStack {
             textStack
             Spacer()
-            if model.connections.count > 0 {
+            if model.services.count > 0 {
                 socialIconsView
             }
         }
@@ -41,8 +41,8 @@ struct PrepublishingAutoSharingView: View {
 
     private var socialIconsView: some View {
         HStack(spacing: -2.0) {
-            ForEach(model.connections, id: \.self) { connection in
-                iconImage(connection.serviceName.localIconImage, opaque: connection.enabled)
+            ForEach(model.services, id: \.self) { service in
+                iconImage(service.serviceName.localIconImage, opaque: service.usesOpaqueIcon)
             }
         }
     }
@@ -84,22 +84,52 @@ private extension PrepublishingAutoSharingView {
 /// The value-type data model that drives the `PrepublishingAutoSharingView`.
 struct PrepublishingAutoSharingViewModel {
 
-    struct Connection: Hashable {
+    /// A value-type representation of `PublicizeService` that's simplified for the needs of the auto-sharing view.
+    struct Service: Hashable {
         let serviceName: PublicizeService.ServiceName
+        let connections: [Connection]
+
+        /// Whether the icon for this service should be opaque or transparent.
+        /// If at least one account is enabled, we'll show an opaque version.
+        var usesOpaqueIcon: Bool {
+            connections.reduce(false) { partialResult, connection in
+                return partialResult || connection.enabled
+            }
+        }
+
+        var enabledConnections: [Connection] {
+            connections.filter { $0.enabled }
+        }
+    }
+
+    struct Connection: Hashable {
         let account: String
         let enabled: Bool
     }
 
     // TODO: Default values are for temporary testing purposes. Will be removed later.
-    let connections: [Connection] = [.init(serviceName: .facebook, account: "foo", enabled: true),
-                                     .init(serviceName: .twitter, account: "bar", enabled: false),
-                                     .init(serviceName: .tumblr, account: "baz", enabled: true)]
+    let services: [Service] = [
+        Service(serviceName: .facebook, connections: [
+            Connection(account: "foo", enabled: true),
+            Connection(account: "foo-2", enabled: false)
+        ]),
+        Service(serviceName: .twitter, connections: [Connection(account: "bar", enabled: false)]),
+        Service(serviceName: .tumblr, connections: [Connection(account: "baz", enabled: true)])
+    ]
 
     // TODO: Default values are for temporary testing purposes. Will be removed later.
     let sharingLimit: PublicizeInfo.SharingLimit? = .init(remaining: 1, limit: 30)
 
     var enabledConnectionsCount: Int {
-        connections.filter({ $0.enabled }).count
+        services.reduce(0) { partialResult, service in
+            return partialResult + service.enabledConnections.count
+        }
+    }
+
+    var totalConnectionsCount: Int {
+        services.reduce(0) { partialResult, service in
+            return partialResult + service.connections.count
+        }
     }
 
     var showsWarning: Bool {
@@ -110,14 +140,14 @@ struct PrepublishingAutoSharingViewModel {
     }
 
     var labelText: String {
-        switch (enabledConnectionsCount, connections.count) {
+        switch (enabledConnectionsCount, totalConnectionsCount) {
         case (let enabled, _) where enabled == 0:
             // not sharing to any social media
             return Strings.notSharingText
 
         case (let enabled, let total) where enabled == total && total == 1:
             // sharing to the one and only connection
-            guard let account = connections.first?.account else {
+            guard let account = services.first?.connections.first?.account else {
                 return String()
             }
             return String(format: Strings.singleConnectionTextFormat, account)

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -1,21 +1,20 @@
 extension PrepublishingViewController {
 
     /// Determines whether the account and the post's blog is eligible to see auto-sharing options.
-    var isEligibleForAutoSharing: Bool {
-        let postObjectID = post.objectID
-        let blogSupportsPublicize = coreDataStack.performQuery { context in
+    func isEligibleForAutoSharing(isJetpack: Bool = AppConfiguration.isJetpack,
+                                  isFeatureEnabled: Bool = FeatureFlag.jetpackSocial.enabled) -> Bool {
+        let blogSupportsPublicize = coreDataStack.performQuery { [postObjectID = post.objectID] context in
             let post = (try? context.existingObject(with: postObjectID)) as? Post
             return post?.blog.supportsPublicize() ?? false
         }
 
-        return blogSupportsPublicize && FeatureFlag.jetpackSocial.enabled
+        return blogSupportsPublicize && isJetpack && isFeatureEnabled
     }
 
     func configureSocialCell(_ cell: UITableViewCell) {
         // TODO:
         // - Show the NoConnectionView if user has 0 connections.
-        // - Properly create and configure the view models.
-        let autoSharingView = UIView.embedSwiftUIView(PrepublishingAutoSharingView(model: .init()))
+        let autoSharingView = UIView.embedSwiftUIView(PrepublishingAutoSharingView(model: makeAutoSharingViewModel()))
         cell.contentView.addSubview(autoSharingView)
 
         // Pin constraints to the cell's layoutMarginsGuide so that the content is properly aligned.
@@ -25,6 +24,50 @@ extension PrepublishingViewController {
             autoSharingView.bottomAnchor.constraint(equalTo: cell.contentView.layoutMarginsGuide.bottomAnchor),
             autoSharingView.trailingAnchor.constraint(equalTo: cell.contentView.layoutMarginsGuide.trailingAnchor)
         ])
-        cell.accessoryType = .disclosureIndicator
+        cell.accessoryType = .disclosureIndicator // TODO: only for autoSharingView.
     }
+}
+
+// MARK: - Helper Methods
+
+private extension PrepublishingViewController {
+
+    func makeAutoSharingViewModel() -> PrepublishingAutoSharingViewModel {
+        return coreDataStack.performQuery { [postObjectID = post.objectID] context in
+            guard let post = (try? context.existingObject(with: postObjectID)) as? Post,
+                  let connections = post.blog.sortedConnections as? [PublicizeConnection],
+                  let supportedServices = try? PublicizeService.allSupportedServices(in: context) else {
+                return .init(services: [], sharingLimit: nil)
+            }
+
+            // first, build a dictionary to categorize the connections.
+            var connectionsMap = [PublicizeService.ServiceName: [PublicizeConnection]]()
+            connections.forEach { connection in
+                let serviceName = PublicizeService.ServiceName(rawValue: connection.service) ?? .unknown
+                var serviceConnections = connectionsMap[serviceName] ?? []
+                serviceConnections.append(connection)
+                connectionsMap[serviceName] = serviceConnections
+            }
+
+            // then, transform [PublicizeService] to [PrepublishingAutoSharingViewModel.Service].
+            let modelServices = supportedServices.compactMap { service -> PrepublishingAutoSharingViewModel.Service? in
+                // skip services without connections.
+                guard let serviceConnections = connectionsMap[service.name],
+                      !serviceConnections.isEmpty else {
+                    return nil
+                }
+
+                return PrepublishingAutoSharingViewModel.Service(
+                    serviceName: service.name,
+                    connections: serviceConnections.map {
+                        .init(account: $0.externalDisplay,
+                              enabled: !post.publicizeConnectionDisabledForKeyringID($0.keyringConnectionID))
+                    }
+                )
+            }
+
+            return .init(services: modelServices, sharingLimit: post.blog.sharingLimit)
+        }
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -49,7 +49,7 @@ class PrepublishingViewController: UITableViewController {
             switch identifier {
             case .autoSharing:
                 // skip the social cell if the post's blog is not eligible for auto-sharing.
-                guard isEligibleForAutoSharing else {
+                guard isEligibleForAutoSharing() else {
                     return nil
                 }
                 break


### PR DESCRIPTION
Refs #20783 

Changes in this PR:

- The view model now supports multiple accounts per service.
- `isEligibleForAutoSharing`now accepts `isJetpack` and `isFeatureEnabled` to decouple the dependencies.
- The view controller now properly populates the view model values from Core Data models.

Note that showing the No Connection view will be implemented in the next PR.

## To test

Since the sharing limit is not fetched yet, you can temporarily modify the sharing limit values in this file to something like `.init(remaining: 27, limit: 30)` to make testing easier.

https://github.com/wordpress-mobile/WordPress-iOS/blob/2aa090746c55303925b960cd2e1dd38f2b9e865a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController%2BJetpackSocial.swift#L69

- Launch the Jetpack app
- Create a new blog post, and add some text to the title and body
- Tap Publish
- 🔎 Verify that the auto-sharing view is shown.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
