### PR TITLE
Jetpack Social: Show no connection view in pre-publishing sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -34,16 +34,16 @@ struct JetpackSocialNoConnectionView: View {
             }
         }
         .padding(viewModel.padding)
-        .background(Color(UIColor.listForeground))
+        .background(Color(viewModel.preferredBackgroundColor))
     }
 
     func iconImage(_ image: UIImage) -> some View {
         Image(uiImage: image)
             .resizable()
             .frame(width: 32.0, height: 32.0)
-            .background(Color(UIColor.listForeground))
+            .background(Color(viewModel.preferredBackgroundColor))
             .clipShape(Circle())
-            .overlay(Circle().stroke(Color(UIColor.listForeground), lineWidth: 2.0))
+            .overlay(Circle().stroke(Color(viewModel.preferredBackgroundColor), lineWidth: 2.0))
     }
 }
 
@@ -53,7 +53,7 @@ extension JetpackSocialNoConnectionView {
     static func createHostController(with viewModel: JetpackSocialNoConnectionViewModel = JetpackSocialNoConnectionViewModel()) -> UIHostingController<JetpackSocialNoConnectionView> {
         let hostController = UIHostingController(rootView: JetpackSocialNoConnectionView(viewModel: viewModel))
         hostController.view.translatesAutoresizingMaskIntoConstraints = false
-        hostController.view.backgroundColor = .listForeground
+        hostController.view.backgroundColor = viewModel.preferredBackgroundColor
         return hostController
     }
 }
@@ -63,6 +63,7 @@ extension JetpackSocialNoConnectionView {
 class JetpackSocialNoConnectionViewModel: ObservableObject {
     let padding: EdgeInsets
     let hideNotNow: Bool
+    let preferredBackgroundColor: UIColor
     let onConnectTap: (() -> Void)?
     let onNotNowTap: (() -> Void)?
     @MainActor @Published var icons: [UIImage] = [UIImage()]
@@ -70,10 +71,12 @@ class JetpackSocialNoConnectionViewModel: ObservableObject {
     init(services: [PublicizeService] = [],
          padding: EdgeInsets = Constants.defaultPadding,
          hideNotNow: Bool = false,
+         preferredBackgroundColor: UIColor? = nil,
          onConnectTap: (() -> Void)? = nil,
          onNotNowTap: (() -> Void)? = nil) {
         self.padding = padding
         self.hideNotNow = hideNotNow
+        self.preferredBackgroundColor = preferredBackgroundColor ?? Constants.defaultBackgroundColor
         self.onConnectTap = onConnectTap
         self.onNotNowTap = onNotNowTap
         updateIcons(services)
@@ -118,6 +121,7 @@ class JetpackSocialNoConnectionViewModel: ObservableObject {
 
 private struct Constants {
     static let defaultPadding = EdgeInsets(top: 16.0, leading: 16.0, bottom: 24.0, trailing: 16.0)
+    static let defaultBackgroundColor = UIColor.listForeground
     static let bodyText = NSLocalizedString("social.noconnection.body",
                                             value: "Increase your traffic by auto-sharing your posts with your friends on social media.",
                                             comment: "Body text for the Jetpack Social no connection view")

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingAutoSharingView.swift
@@ -84,31 +84,6 @@ private extension PrepublishingAutoSharingView {
 /// The value-type data model that drives the `PrepublishingAutoSharingView`.
 struct PrepublishingAutoSharingViewModel {
 
-    // MARK: Helper Models
-
-    /// A value-type representation of `PublicizeService` that's simplified for the needs of the auto-sharing view.
-    struct Service: Hashable {
-        let serviceName: PublicizeService.ServiceName
-        let connections: [Connection]
-
-        /// Whether the icon for this service should be opaque or transparent.
-        /// If at least one account is enabled, an opaque version should be shown.
-        var usesOpaqueIcon: Bool {
-            connections.reduce(false) { partialResult, connection in
-                return partialResult || connection.enabled
-            }
-        }
-
-        var enabledConnections: [Connection] {
-            connections.filter { $0.enabled }
-        }
-    }
-
-    struct Connection: Hashable {
-        let account: String
-        let enabled: Bool
-    }
-
     // MARK: Properties
 
     let services: [Service]
@@ -159,6 +134,31 @@ struct PrepublishingAutoSharingViewModel {
         default:
             return String()
         }
+    }
+
+    // MARK: Helper Models
+
+    /// A value-type representation of `PublicizeService` that's simplified for the needs of the auto-sharing view.
+    struct Service: Hashable {
+        let serviceName: PublicizeService.ServiceName
+        let connections: [Connection]
+
+        /// Whether the icon for this service should be opaque or transparent.
+        /// If at least one account is enabled, an opaque version should be shown.
+        var usesOpaqueIcon: Bool {
+            connections.reduce(false) { partialResult, connection in
+                return partialResult || connection.enabled
+            }
+        }
+
+        var enabledConnections: [Connection] {
+            connections.filter { $0.enabled }
+        }
+    }
+
+    struct Connection: Hashable {
+        let account: String
+        let enabled: Bool
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -111,14 +111,13 @@ private extension PrepublishingViewController {
     }
 
     func makeNoConnectionViewModel() -> JetpackSocialNoConnectionViewModel {
-        return coreDataStack.performQuery { [weak self] context in
-            guard let services = try? PublicizeService.allSupportedServices(in: context) else {
-                return .init()
-            }
-
-            // TODO: Tap actions
-            return .init(services: services, preferredBackgroundColor: self?.tableView.backgroundColor)
+        let context = post.managedObjectContext ?? coreDataStack.mainContext
+        guard let services = try? PublicizeService.allSupportedServices(in: context) else {
+            return .init()
         }
+
+        // TODO: Tap actions
+        return .init(services: services, preferredBackgroundColor: tableView.backgroundColor)
     }
 
     enum Constants {


### PR DESCRIPTION
Refs #20783
Depends on #21073

This PR shows the No Connection view in the pre-publishing sheet if the blog doesn't have any connections. I've also made a minor change in `JetpackSocialNoConnectionView` to accept a custom background color.

Here are some previews:

• | Light 🌞  | Dark 🌚 
-|-|-
iPhone, portrait | ![iphone_portrait_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/523415a0-e123-41f6-b5e0-c5d7b9f68b3b) | ![iphone_portrait_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/01c9ba46-d2f5-4124-8202-2c8e3ef8a19a)
iPhone, landscape | ![iphone_landscape_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/bb02059e-205c-43b9-b98d-de78f413901b) | ![iphone_landscape_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b11c63f2-9e41-45b3-b894-a8d6a8ec72ce)
iPad | ![ipad_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f1586404-3cf7-43cc-8958-20071318a640) | ![ipad_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/984e8a31-6e74-47a4-bdf9-b09d68de212e)

## To test

### Case 1: Sites with existing Social connections

- Launch the Jetpack app.
- Switch to a site that has existing Social connections.
- Create a new blog post.
- Fill in some text for the title and body.
- Tap Publish.
- 🔎 Verify that the auto-sharing view is shown.

### Case 2: Sites with no social connections

- Launch the Jetpack app.
- Switch to a site that does not have any Social connections.
- Create a new blog post.
- Fill in some text for the title and body.
- Tap Publish.
- 🔎 Verify that the no connection view is shown.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
