### PR TITLE
Generate strings for Glotpress while creating a new beta

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -92,6 +92,7 @@ platform :ios do
   desc 'Trigger a new beta build on CI'
   lane :new_beta_release do |options|
     ios_betabuild_prechecks(options)
+    generate_strings_file_for_glotpress
     download_localized_strings_and_metadata(options)
     ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
     ios_bump_version_beta


### PR DESCRIPTION
Adds a call to `generate_strings_file_for_glotpress` from `new_beta_release` lane so that any string changes in the release branch can be sent for translation once the changes are merged into `trunk`. Without this change, we have to run this command manually as it was done in #21060 which makes it easy to miss.

This is targeting the `release/22.8` so that the change can be utilized for any new betas for `22.8` release.