### PR TITLE
Jetpack Social: Add sharing limit sync on launch or blog switch

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -159,6 +159,17 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         dispatch_group_leave(syncGroup);
     }];
 
+    if ([Feature enabled:FeatureFlagJetpackSocial] && blog.dotComID != nil) {
+        JetpackSocialService *jetpackSocialService = [[JetpackSocialService alloc] initWithContextManager:ContextManager.sharedInstance];
+        dispatch_group_enter(syncGroup);
+        [jetpackSocialService syncSharingLimitWithDotComID:blog.dotComID success:^{
+            dispatch_group_leave(syncGroup);
+        } failure:^(NSError * _Nullable error) {
+            DDLogError(@"Failed syncing publicize sharing limit for blog %@: %@", blog.url, error);
+            dispatch_group_leave(syncGroup);
+        }];
+    }
+
     dispatch_group_enter(syncGroup);
     [remote getAllAuthorsWithSuccess:^(NSArray<RemoteUser *> *users) {
         [self updateMultiAuthor:users forBlog:blogObjectID completionHandler:^{

--- a/WordPress/Classes/Services/JetpackSocialService.swift
+++ b/WordPress/Classes/Services/JetpackSocialService.swift
@@ -38,10 +38,11 @@ import CoreData
     ///   - blogID: The ID of the blog.
     ///   - completion: Closure that's called after the sync process completes.
     func syncSharingLimit(for blogID: Int, completion: @escaping (Result<PublicizeInfo.SharingLimit?, Error>) -> Void) {
-        remote.fetchPublicizeInfo(for: blogID) { [weak self] result in
+        // allow `self` to be retained inside this closure so the completion block will always be executed.
+        remote.fetchPublicizeInfo(for: blogID) { result in
             switch result {
             case .success(let remotePublicizeInfo):
-                self?.coreDataStack.performAndSave({ context -> PublicizeInfo.SharingLimit? in
+                self.coreDataStack.performAndSave({ context -> PublicizeInfo.SharingLimit? in
                     guard let blog = try Blog.lookup(withID: blogID, in: context) else {
                         // unexpected to fall into this case, since the API should return an error response.
                         throw ServiceError.blogNotFound(id: blogID)
@@ -84,7 +85,7 @@ import CoreData
             return
         }
 
-        syncSharingLimit(for: blogID, completion: { [success, failure] result in
+        syncSharingLimit(for: blogID, completion: { result in
             switch result {
             case .success:
                 success?()

--- a/WordPress/WordPressTest/JetpackSocialServiceTests.swift
+++ b/WordPress/WordPressTest/JetpackSocialServiceTests.swift
@@ -60,9 +60,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
     // non-existing PublicizeInfo + nil RemotePublicizeInfo -> nothing changes
     func testSyncSharingLimitWithNilPublicizeInfo() {
         stub(condition: isPath(jetpackSocialPath)) { _ in
-            HTTPStubsResponse(jsonObject: [String: Any](),
-                              statusCode: 200,
-                              headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
 
         let expectation = expectation(description: "syncSharingLimit should succeed")
@@ -110,9 +108,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
     func testSyncSharingLimitWithNilPublicizeInfoGivenPreExistingData() throws {
         try addPreExistingPublicizeInfo()
         stub(condition: isPath(jetpackSocialPath)) { _ in
-            HTTPStubsResponse(jsonObject: [String: Any](),
-                              statusCode: 200,
-                              headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
 
         let expectation = expectation(description: "syncSharingLimit should succeed")
@@ -133,9 +129,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
     func testSyncSharingLimitWithNewPublicizeInfoGivenInvalidBlogID() {
         let invalidBlogID = 1002
         stub(condition: isPath("/wpcom/v2/sites/\(invalidBlogID)/jetpack-social")) { _ in
-            HTTPStubsResponse(jsonObject: [String: Any](),
-                              statusCode: 200,
-                              headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
         }
 
         let expectation = expectation(description: "syncSharingLimit should fail")
@@ -154,9 +148,7 @@ class JetpackSocialServiceTests: CoreDataTestCase {
 
     func testSyncSharingLimitRemoteFetchFailure() {
         stub(condition: isPath(jetpackSocialPath)) { _ in
-            HTTPStubsResponse(jsonObject: [String: Any](),
-                              statusCode: 500,
-                              headers: nil)
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
         }
 
         let expectation = expectation(description: "syncSharingLimit should fail")
@@ -169,6 +161,56 @@ class JetpackSocialServiceTests: CoreDataTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: timeout)
+    }
+
+    // MARK: syncSharingLimit Objective-C
+
+    func testObjcSyncSharingLimitSuccess() async {
+        stub(condition: isPath(jetpackSocialPath)) { _ in
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 200, headers: nil)
+        }
+
+        let syncSucceeded = await withCheckedContinuation { continuation in
+            service.syncSharingLimit(dotComID: NSNumber(value: blogID)) {
+                continuation.resume(returning: true)
+            } failure: { error in
+                continuation.resume(returning: false)
+            }
+        }
+
+        XCTAssertTrue(syncSucceeded)
+    }
+
+    func testObjcSyncSharingLimitNilIDFailure() async {
+        stub(condition: isPath(jetpackSocialPath)) { _ in
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
+        }
+
+        let syncSucceeded = await withCheckedContinuation { continuation in
+            service.syncSharingLimit(dotComID: NSNumber(value: blogID)) {
+                continuation.resume(returning: true)
+            } failure: { error in
+                continuation.resume(returning: false)
+            }
+        }
+
+        XCTAssertFalse(syncSucceeded)
+    }
+
+    func testObjcSyncSharingLimitRequestFailure() async {
+        stub(condition: isPath(jetpackSocialPath)) { _ in
+            HTTPStubsResponse(jsonObject: [String: Any](), statusCode: 500, headers: nil)
+        }
+
+        let syncSucceeded = await withCheckedContinuation { continuation in
+            service.syncSharingLimit(dotComID: NSNumber(value: blogID)) {
+                continuation.resume(returning: true)
+            } failure: { error in
+                continuation.resume(returning: false)
+            }
+        }
+
+        XCTAssertFalse(syncSucceeded)
     }
 
 }


### PR DESCRIPTION
Refs #20974

This PR adds sharing limit sync to `syncBlogAndAllMetadata`.

## To test

- Launch the Jetpack app.
- Switch to a blog that has limited auto-sharing.
- Create a new blog post.
- Go to Post Settings.
- Verify that the sharing limit cell is shown.

## Regression Notes
1. Potential unintended areas of impact
Dispatch group not properly resolved during blog sync.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
Added some tests for the new method.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
