### PR TITLE
Related Posts: Add period to the end of footer

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsRelatedPostsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsRelatedPostsView.swift
@@ -131,7 +131,7 @@ private extension RelatedPostsSettingsView {
         static let showRelatedPosts = NSLocalizedString("relatedPostsSettings.showRelatedPosts", value: "Show Related Posts", comment: "Label for configuration switch to enable/disable related posts")
         static let showHeader = NSLocalizedString("relatedPostsSettings.showHeader", value: "Show Header", comment: "Label for configuration switch to show/hide the header for the related posts section")
         static let showThumbnail = NSLocalizedString("relatedPostsSettings.showThumbnail", value: "Show Images", comment: "Label for configuration switch to show/hide images thumbnail for the related posts")
-        static let optionsFooter = NSLocalizedString("relatedPostsSettings.optionsFooter", value: "Related Posts displays relevant content from your site below your posts", comment: "Information of what related post are and how they are presented")
+        static let optionsFooter = NSLocalizedString("relatedPostsSettings.optionsFooter", value: "Related Posts displays relevant content from your site below your posts.", comment: "Information of what related post are and how they are presented")
         static let previewsHeader = NSLocalizedString("relatedPostsSettings.previewsHeaders", value: "Preview", comment: "Section title for related posts section preview")
         static let relatedPostsHeader = NSLocalizedString("relatedPostsSettings.relatedPostsHeader", value: "Related Posts", comment: "Label for Related Post header preview")
         static let saveFailed = NSLocalizedString("relatedPostsSettings.settingsUpdateFailed", value: "Settings update failed", comment: "Message to show when setting save failed")


### PR DESCRIPTION
Adds a period to the end of the footer in the Related Posts view:

| Before | After |
| - | - |
| ![Simulator Screenshot - iPhone 14 - 2023-07-12 at 23 04 25](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/9ef2b705-aed5-4977-bf34-519ca6b7a2b0) | ![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/3386b2d4-4618-4ecb-8d57-291f823c742b) |

This will keep consistency with other views, such as Discussion:

<img width="300" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/12ccf764-8ad6-4db7-892e-bdec8abb37a2" />

To test:
1. Load the Related Posts view
2. Observe the period added

**Note:** The translated string will be loaded so the period may not be visible. Switching to a language for which there's no translation should default to the original string.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
