### PR TITLE
Use UserDefaults singleton

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] [internal] Fix multiple memory leaks after logging in and logging out. [#21047, #21092]
 * [**] Block editor: Move undo/redo buttons to the navigation bar. [#20930]
 * [*] Fixed an issue that caused the UI to be briefly unresponsive in certain case when opening the app. [#21065]
+* [*] [internal] Update calls to use UserDefaults singleton. [#21088]
 
 22.8
 -----

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -37,7 +37,7 @@ class RecentSitesService: NSObject {
     /// Initialize the service using the standard UserDefaults as the database.
     ///
     convenience override init() {
-        self.init(database: UserDefaults() as KeyValueDatabase)
+        self.init(database: UserDefaults.standard as KeyValueDatabase)
     }
 
     // MARK: - Public accessors

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -470,7 +470,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     ///
     private var mediaPreviewHelper: MediaPreviewHelper? = nil
 
-    private let database: KeyValueDatabase = UserDefaults()
+    private let database: KeyValueDatabase = UserDefaults.standard
     private enum Key {
         static let classicDeprecationNoticeHasBeenShown = "kClassicDeprecationNoticeHasBeenShown"
     }


### PR DESCRIPTION
Fixes a couple spots where we should just access `UserDefaults.standard`.

Related to #21065.

## Testing

### Recently accessed sites are shown in the Site Picker

**Prerequisites:** An account with access to multiple sites.

1. Go to My Site and open the Site Picker
2. Select a site (e.g. Site A)
3. Open the Site Picker and select another site (e.g. Site B)
4. Open the Site Picker
5. **Expect:** Site B is shown above Site A in the site picker
6. Restart the app and open the Site Picker
7. **Expect:** The list in step 5

### Message to try the new Block Editor is shown once

**Prerequisites:** A self-hosted site connected to Jetpack.

1. Select the site from the Site Picker
2. Go to Site Settings -> Editor -> Use block editor and disable it
3. Start a new post
4. **Expect:** Message to try the new Block Editor
5. Close the post
6. Start a new post
7. **Expect:** No message to try the new Block Editor (it was committed properly)

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/259027df-54b2-43c6-b82c-18c0dc8e1419" width="330px" />

## Regression Notes
1. Potential unintended areas of impact
  - Recent Sites ordering isn't saved.
  - Aztec message is shown more than once.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manually tested the above flows.

3. What automated tests I added (or what prevented me from doing so)
  - None. This PR doesn't change our logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

N/A ~UI Changes testing checklist:~
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
