### PR TITLE
TEST PR - PLEASE IGNORE

### DIFF
--- a/WordPress/UITests/Flows/LoginFlow.swift
+++ b/WordPress/UITests/Flows/LoginFlow.swift
@@ -27,7 +27,7 @@ class LoginFlow {
     static func login(siteUrl: String, email: String, password: String, selectedSiteTitle: String? = nil) throws -> MySiteScreen {
         return try PrologueScreen()
             .selectSiteAddress()
-            .proceedWithWP(siteUrl: siteUrl)
+            .proceedWithWordPress(siteUrl: siteUrl)
             .proceedWith(email: email)
             .proceedWithValidPassword()
             .continueWithSelectedSite(title: selectedSiteTitle)

--- a/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
@@ -15,7 +15,7 @@ public class ActionSheetComponent: ScreenObject {
     var blogPostButton: XCUIElement { Self.getBlogPostButton(app) }
     var sitePageButton: XCUIElement { Self.getSitePageButton(app) }
 
-    public init(app: XCUIApplication = XCUIApplication()) throws {
+    init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [Self.getBlogPostButton, Self.getSitePageButton],
             app: app

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -4,11 +4,11 @@ import XCTest
 public class ActivityLogScreen: ScreenObject {
     public let tabBar: TabNavComponent
 
-    let dateRangeButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let dateRangeButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Date Range"].firstMatch
     }
 
-    let activityTypeButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let activityTypeButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Activity Type"].firstMatch
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -252,7 +252,7 @@ public class AztecEditorScreen: ScreenObject {
 
         try confirmPublish()
 
-        return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")
+        return try EditorNoticeComponent(withNotice: "Post published")
     }
 
     private func confirmPublish() throws {

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -4,48 +4,108 @@ import XCUITestHelpers
 
 public class BlockEditorScreen: ScreenObject {
 
-    let editorCloseButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let editorCloseButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"]
     }
 
-    let undoButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let undoButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.navigationBars["Gutenberg Editor Navigation Bar"].buttons["Undo"]
     }
 
-    let redoButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let redoButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.navigationBars["Gutenberg Editor Navigation Bar"].buttons["Redo"]
     }
 
-    let addBlockButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let addBlockButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["add-block-button"]
     }
 
-    let moreButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let moreButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["more_post_options"]
     }
 
-    let insertFromUrlButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let insertFromUrlButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Insert from URL"]
     }
 
-    let applyButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let applyButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Apply"]
     }
 
-    var editorCloseButton: XCUIElement { editorCloseButtonGetter(app) }
-    var undoButton: XCUIElement { undoButtonGetter(app) }
-    var redoButton: XCUIElement { redoButtonGetter(app) }
+    private let discardButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Discard"]
+    }
+
+    private let firstParagraphBlockGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements["Paragraph Block. Row 1. Empty"]
+    }
+
+    private let postTitleViewGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements["Post title. Empty"]
+    }
+
+    private let editorNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Gutenberg Editor Navigation Bar"]
+    }
+
+    private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Close"]
+    }
+
+    private let dismissPopoverRegionGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements["PopoverDismissRegion"]
+    }
+
+    private let keepEditingButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Keep Editing"]
+    }
+
+    private let postSettingsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Post Settings"]
+    }
+
+    private let chooseFromDeviceButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Choose from device"]
+    }
+
+    private let setRemindersButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Set reminders"]
+    }
+
+    private let fullScreenImageGetter: (XCUIApplication) -> XCUIElement = {
+        $0.images["Fullscreen view of image. Double tap to dismiss"]
+    }
+
+    private let unsavedChangesLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["You have unsaved changes."]
+    }
+
     var addBlockButton: XCUIElement { addBlockButtonGetter(app) }
-    var moreButton: XCUIElement { moreButtonGetter(app) }
-    var insertFromUrlButton: XCUIElement { insertFromUrlButtonGetter(app) }
     var applyButton: XCUIElement { applyButtonGetter(app) }
+    var chooseFromDeviceButton: XCUIElement { chooseFromDeviceButtonGetter(app) }
+    var closeButton: XCUIElement { closeButtonGetter(app) }
+    var discardButton: XCUIElement { discardButtonGetter(app) }
+    var dismissPopoverRegion: XCUIElement { dismissPopoverRegionGetter(app) }
+    var editorCloseButton: XCUIElement { editorCloseButtonGetter(app) }
+    var editorNavigationBar: XCUIElement { editorNavigationBarGetter(app) }
+    var firstParagraphBlock: XCUIElement { firstParagraphBlockGetter(app) }
+    var fullScreenImage: XCUIElement { fullScreenImageGetter(app) }
+    var insertFromUrlButton: XCUIElement { insertFromUrlButtonGetter(app) }
+    var keepEditingButton: XCUIElement { keepEditingButtonGetter(app) }
+    var moreButton: XCUIElement { moreButtonGetter(app) }
+    var postSettingsButton: XCUIElement { postSettingsButtonGetter(app) }
+    var postTitleView: XCUIElement { postTitleViewGetter(app) }
+    var redoButton: XCUIElement { redoButtonGetter(app) }
+    var setRemindersButton: XCUIElement { setRemindersButtonGetter(app) }
+    var undoButton: XCUIElement { undoButtonGetter(app) }
+    var unsavedChangesLabel: XCUIElement { unsavedChangesLabelGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         // The block editor has _many_ elements but most are loaded on-demand. To verify the screen
         // is loaded, we rely only on the button to add a new block and on the navigation bar we
         // expect to encase the screen.
         try super.init(
-            expectedElementGetters: [ editorCloseButtonGetter, undoButtonGetter, redoButtonGetter, addBlockButtonGetter ],
+            expectedElementGetters: [ addBlockButtonGetter, editorCloseButtonGetter, redoButtonGetter, undoButtonGetter ],
             app: app
         )
     }
@@ -55,7 +115,7 @@ public class BlockEditorScreen: ScreenObject {
      - Parameter text: the test to enter into the title
      */
     public func enterTextInTitle(text: String) -> BlockEditorScreen {
-        let titleView = app.otherElements["Post title. Empty"].firstMatch // Uses a localized string
+        let titleView = postTitleView.firstMatch // Uses a localized string
         XCTAssert(titleView.waitForExistence(timeout: 3), "Title View does not exist!")
 
         titleView.tap()
@@ -71,7 +131,7 @@ public class BlockEditorScreen: ScreenObject {
     public func addParagraphBlock(withText text: String) -> BlockEditorScreen {
         addBlock("Paragraph block")
 
-        let paragraphView = app.otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
+        let paragraphView = firstParagraphBlock.textViews.element(boundBy: 0)
         paragraphView.typeText(text)
 
         return self
@@ -160,27 +220,15 @@ public class BlockEditorScreen: ScreenObject {
             editorCloseButton.tap()
 
             XCTContext.runActivity(named: "Discard any local changes") { (activity) in
-                guard app.staticTexts["You have unsaved changes."].waitForIsHittable(timeout: 3) else { return }
+                guard unsavedChangesLabel.waitForIsHittable(timeout: 3) else { return }
 
                 Logger.log(message: "Discarding unsaved changes", event: .v)
-                let discardButton = app.buttons["Discard"] // Uses a localized string
                 discardButton.tap()
             }
 
-            let editorNavBar = app.navigationBars["Gutenberg Editor Navigation Bar"]
-            let waitForEditorToClose = editorNavBar.waitFor(predicateString: "isEnabled == false")
+            let waitForEditorToClose = editorNavigationBar.waitFor(predicateString: "isEnabled == false")
             XCTAssertEqual(waitForEditorToClose, .completed, "Block editor should be closed but is still loaded.")
         }
-    }
-
-    // Sometimes ScreenObject times out due to long loading time making the Editor Screen evaluate to `nil`.
-    // This function adds the ability to still close the Editor Screen when that happens.
-    public static func closeEditorDiscardingChanges(app: XCUIApplication = XCUIApplication()) {
-        let closeButton = app.buttons["Close"]
-        if closeButton.waitForIsHittable() { closeButton.tap() }
-
-        let discardChangesButton = app.buttons["Discard"]
-        if discardChangesButton.waitForIsHittable() { discardChangesButton.tap() }
     }
 
     public func publish() throws -> EditorNoticeComponent {
@@ -213,13 +261,12 @@ public class BlockEditorScreen: ScreenObject {
             throw NSError(domain: "InvalidAction", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid action: \(action)"])
         }
 
-        return try EditorNoticeComponent(withNotice: "Post \(actionInNotice)", andAction: "View")
+        return try EditorNoticeComponent(withNotice: "Post \(actionInNotice)")
     }
 
     @discardableResult
     public func openPostSettings() throws -> EditorPostSettings {
         moreButton.tap()
-        let postSettingsButton = app.buttons["Post Settings"] // Uses a localized string
         postSettingsButton.tap()
 
         return try EditorPostSettings()
@@ -235,15 +282,14 @@ public class BlockEditorScreen: ScreenObject {
 
     private func dismissBlockEditorPopovers() {
         if XCUIDevice.isPad {
-            app.otherElements["PopoverDismissRegion"].tap()
+            dismissPopoverRegion.tap()
             dismissImageViewIfNeeded()
         } else {
-            app.buttons["Keep Editing"].tap()
+            keepEditingButton.tap()
         }
     }
 
     private func dismissImageViewIfNeeded() {
-        let fullScreenImage = app.images["Fullscreen view of image. Double tap to dismiss"]
         if fullScreenImage.exists { fullScreenImage.tap() }
     }
 
@@ -322,9 +368,7 @@ public class BlockEditorScreen: ScreenObject {
     }
 
     private func chooseFromDevice() throws -> MediaPickerAlbumScreen {
-        let imageDeviceButton = app.buttons["Choose from device"] // Uses a localized string
-
-        imageDeviceButton.tap()
+        chooseFromDeviceButton.tap()
 
         // Allow access to device media
         app.tap() // trigger the media permissions alert handler
@@ -343,7 +387,7 @@ public class BlockEditorScreen: ScreenObject {
     }
 
     public func dismissBloggingRemindersAlertIfNeeded() {
-        guard app.buttons["Set reminders"].waitForExistence(timeout: 3) else { return }
+        guard setRemindersButton.waitForExistence(timeout: 3) else { return }
 
         if XCUIDevice.isPad {
             app.swipeDown(velocity: .fast)

--- a/WordPress/UITestsFoundation/Screens/Editor/ChooseLayoutScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/ChooseLayoutScreen.swift
@@ -3,9 +3,11 @@ import XCTest
 
 public class ChooseLayoutScreen: ScreenObject {
 
-    let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Close"]
     }
+
+    var closeButton: XCUIElement { closeButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -16,7 +18,7 @@ public class ChooseLayoutScreen: ScreenObject {
 
     @discardableResult
     public func closeModal() throws -> MySiteScreen {
-        closeButtonGetter(app).tap()
+        closeButton.tap()
         return try MySiteScreen()
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
@@ -3,22 +3,25 @@ import XCTest
 
 public class EditorNoticeComponent: ScreenObject {
 
-    private let noticeTitleGetter: (XCUIApplication) -> XCUIElement
-    private let noticeActionGetter: (XCUIApplication) -> XCUIElement
+    private let noticeViewTitleGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements["notice_title_and_message"]
+    }
 
-    private let expectedNoticeTitle: String
+    private let noticeViewButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["View"]
+    }
+
+    var expectedNoticeTitle: String
+    var noticeViewButton: XCUIElement { noticeViewButtonGetter(app) }
+    var noticeViewTitle: XCUIElement { noticeViewTitleGetter(app) }
 
     init(
         withNotice noticeTitle: String,
-        andAction buttonText: String,
         app: XCUIApplication = XCUIApplication()
     ) throws {
-        noticeTitleGetter = { app in app.otherElements["notice_title_and_message"] }
-        noticeActionGetter = { app in app.buttons[buttonText] }
         expectedNoticeTitle = noticeTitle
-
         try super.init(
-            expectedElementGetters: [ noticeTitleGetter, noticeActionGetter ],
+            expectedElementGetters: [ noticeViewTitleGetter ],
             app: app
         )
     }
@@ -28,13 +31,12 @@ public class EditorNoticeComponent: ScreenObject {
         // (the postTitle). It does not seem possible to target the specific postTitle label
         // only because of this.
         XCTAssertEqual(
-            noticeTitleGetter(app).label,
+            noticeViewTitle.label,
             String(format: "%@. %@", expectedNoticeTitle, postTitle),
             "Post title not visible on published post notice"
         )
 
-        noticeActionGetter(app).tap()
-
+        noticeViewButton.tap()
         return try EditorPublishEpilogueScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -3,58 +3,58 @@ import XCTest
 
 public class EditorPostSettings: ScreenObject {
 
-    let settingsTableGetter: (XCUIApplication) -> XCUIElement = {
+    private let settingsTableGetter: (XCUIApplication) -> XCUIElement = {
         $0.tables["SettingsTable"]
     }
 
-    let categoriesSectionGetter: (XCUIApplication) -> XCUIElement = {
+    private let categoriesSectionGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["Categories"]
     }
 
-    let tagsSectionGetter: (XCUIApplication) -> XCUIElement = {
+    private let tagsSectionGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["Tags"]
     }
 
-    let featuredImageButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let featuredImageButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["SetFeaturedImage"]
     }
 
-    let currentFeaturedImageGetter: (XCUIApplication) -> XCUIElement = {
+    private let currentFeaturedImageGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["CurrentFeaturedImage"]
     }
 
-    let publishDateButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let publishDateButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Publish Date"]
     }
 
-    let dateSelectorGetter: (XCUIApplication) -> XCUIElement = {
+    private let dateSelectorGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["Immediately"]
     }
 
-    let nextMonthButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let nextMonthButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Next Month"]
     }
 
-    let firstCalendarDayLabelGetter: (XCUIApplication) -> XCUIElement = {
+    private let firstCalendarDayLabelGetter: (XCUIApplication) -> XCUIElement = {
         $0.staticTexts["1"]
     }
 
-    let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Done"]
     }
 
-    var settingsTable: XCUIElement { settingsTableGetter(app) }
     var categoriesSection: XCUIElement { categoriesSectionGetter(app) }
-    var tagsSection: XCUIElement { tagsSectionGetter(app) }
-    var featuredImageButton: XCUIElement { featuredImageButtonGetter(app) }
     var currentFeaturedImage: XCUIElement { currentFeaturedImageGetter(app) }
-    var publishDateButton: XCUIElement { publishDateButtonGetter(app) }
     var dateSelector: XCUIElement { dateSelectorGetter(app) }
-    var nextMonthButton: XCUIElement { nextMonthButtonGetter(app) }
-    var firstCalendarDayLabel: XCUIElement { firstCalendarDayLabelGetter(app) }
     var doneButton: XCUIElement { doneButtonGetter(app) }
+    var featuredImageButton: XCUIElement { featuredImageButtonGetter(app) }
+    var firstCalendarDayLabel: XCUIElement { firstCalendarDayLabelGetter(app) }
+    var nextMonthButton: XCUIElement { nextMonthButtonGetter(app) }
+    var publishDateButton: XCUIElement { publishDateButtonGetter(app) }
+    var settingsTable: XCUIElement { settingsTableGetter(app) }
+    var tagsSection: XCUIElement { tagsSectionGetter(app) }
 
-    public init(app: XCUIApplication = XCUIApplication()) throws {
+    init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ settingsTableGetter ],
             app: app

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
@@ -3,25 +3,35 @@ import XCTest
 
 public class EditorPublishEpilogueScreen: ScreenObject {
 
-    private let getDoneButton: (XCUIApplication) -> XCUIElement = {
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.navigationBars.buttons["doneButton"]
     }
 
-    private let getViewButton: (XCUIApplication) -> XCUIElement = {
+    private let viewButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["viewPostButton"]
     }
 
-    var doneButton: XCUIElement { getDoneButton(app) }
-    var viewButton: XCUIElement { getViewButton(app) }
+    private let publishedPostStatusLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["publishedPostStatusLabel"]
+    }
 
-    public init(app: XCUIApplication = XCUIApplication()) throws {
-        // Defining this via a `let` rather than inline only to avoid a SwiftLint style violation
-        let publishedPostStatusGetter: (XCUIApplication) -> XCUIElement = {
-            $0.staticTexts["publishedPostStatusLabel"]
-        }
+    private let postTitleGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["postTitle"]
+    }
 
+    private let siteUrlGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["siteUrl"]
+    }
+
+    var doneButton: XCUIElement { doneButtonGetter(app) }
+    var postTitle: XCUIElement { postTitleGetter(app) }
+    var publishedPostStatusLabel: XCUIElement { publishedPostStatusLabelGetter(app) }
+    var siteUrl: XCUIElement { siteUrlGetter(app) }
+    var viewButton: XCUIElement { viewButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ getDoneButton, getViewButton, publishedPostStatusGetter ],
+            expectedElementGetters: [ doneButtonGetter, viewButtonGetter, publishedPostStatusLabelGetter ],
             app: app
         )
     }
@@ -32,11 +42,11 @@ public class EditorPublishEpilogueScreen: ScreenObject {
     }
 
     public func verifyEpilogueDisplays(postTitle expectedPostTitle: String, siteAddress expectedSiteAddress: String) -> EditorPublishEpilogueScreen {
-        let actualPostTitle = app.staticTexts["postTitle"].label
-        let actualSiteAddress = app.staticTexts["siteUrl"].label
+        let actualPostTitle = postTitle.label
+        let actualSiteUrl = siteUrl.label
 
         XCTAssertEqual(expectedPostTitle, actualPostTitle, "Post title doesn't match expected title")
-        XCTAssertEqual(expectedSiteAddress, actualSiteAddress, "Site address doesn't match expected address")
+        XCTAssertEqual(expectedSiteAddress, actualSiteUrl, "Site address doesn't match expected address")
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
@@ -3,14 +3,20 @@ import XCTest
 
 public class CategoriesComponent: ScreenObject {
 
+    private let categoriesListGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["CategoriesList"]
+    }
+
+    var categoriesList: XCUIElement { categoriesListGetter(app) }
+
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.tables["CategoriesList"] } ],
+            expectedElementGetters: [ categoriesListGetter ],
             app: app
         )
     }
 
-    public func selectCategory(name: String) -> CategoriesComponent {
+    public func selectCategory(name: String) -> Self {
         let category = app.cells.staticTexts[name]
         category.tap()
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
@@ -3,12 +3,15 @@ import XCTest
 
 public class TagsComponent: ScreenObject {
 
-    // expectedElement comes from the superclass and gets the first expectedElementGetters result
-    var tagsField: XCUIElement { expectedElement }
+    private let tagsFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textViews["add-tags"]
+    }
+
+    var tagsField: XCUIElement { tagsFieldGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.textViews["add-tags"] } ],
+            expectedElementGetters: [ tagsFieldGetter ],
             app: app
         )
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
@@ -3,19 +3,27 @@ import XCTest
 
 public class FeaturedImageScreen: ScreenObject {
 
-    // expectedElement comes from the superclass and gets the first expectedElementGetters result
-    var removeButton: XCUIElement { expectedElement }
+    private let removeFeaturedImageButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars.buttons["Remove Featured Image"]
+    }
 
-    public init(app: XCUIApplication = XCUIApplication()) throws {
+    private let removeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Remove"]
+    }
+
+    var removeButton: XCUIElement { removeButtonGetter(app) }
+    var removeFeaturedImageButton: XCUIElement { removeFeaturedImageButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.navigationBars.buttons["Remove Featured Image"] } ],
+            expectedElementGetters: [ removeFeaturedImageButtonGetter ],
             app: app
         )
     }
 
     public func tapRemoveFeaturedImageButton() {
+        removeFeaturedImageButton.tap()
         removeButton.tap()
-        app.buttons["Remove"].tap()
     }
 
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,16 +1,18 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 public class LinkOrPasswordScreen: ScreenObject {
 
-    let passwordOptionGetter: (XCUIApplication) -> XCUIElement = {
+    private let passwordOptionGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Use Password"]
     }
-    let linkButtonGetter: (XCUIApplication) -> XCUIElement = {
+
+    private let linkButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Send Link Button"]
     }
+
+    var linkButton: XCUIElement { linkButtonGetter(app) }
+    var passwordOption: XCUIElement { passwordOptionGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -20,13 +22,13 @@ public class LinkOrPasswordScreen: ScreenObject {
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {
-        passwordOptionGetter(app).tap()
+        passwordOption.tap()
 
         return try LoginPasswordScreen()
     }
 
     public func proceedWithLink() throws -> LoginCheckMagicLinkScreen {
-        linkButtonGetter(app).tap()
+        linkButton.tap()
 
         return try LoginCheckMagicLinkScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -3,23 +3,29 @@ import XCTest
 
 public class LoginCheckMagicLinkScreen: ScreenObject {
 
-    let passwordOptionGetter: (XCUIApplication) -> XCUIElement = {
+    private let passwordOptionGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Use Password"]
     }
+
+    private let openMailButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Open Mail Button"]
+    }
+
+    var openMailButton: XCUIElement { openMailButtonGetter(app) }
+    var passwordOption: XCUIElement { passwordOptionGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 passwordOptionGetter,
-                // swiftlint:disable:next opening_brace
-                { $0.buttons["Open Mail Button"] }
+                openMailButtonGetter
             ],
             app: app
         )
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {
-        passwordOptionGetter(app).tap()
+        passwordOption.tap()
 
         return try LoginPasswordScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -1,8 +1,6 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 public class LoginEmailScreen: ScreenObject {
 
     let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
@@ -13,8 +11,13 @@ public class LoginEmailScreen: ScreenObject {
         $0.buttons["Login Email Next Button"]
     }
 
+    let selfHostedLoginButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Self Hosted Login Button"]
+    }
+
     var emailTextField: XCUIElement { emailTextFieldGetter(app) }
     var nextButton: XCUIElement { nextButtonGetter(app) }
+    var selfHostedLoginButton: XCUIElement { selfHostedLoginButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -32,7 +35,7 @@ public class LoginEmailScreen: ScreenObject {
     }
 
     func goToSiteAddressLogin() throws -> LoginSiteAddressScreen {
-        app.buttons["Self Hosted Login Button"].tap()
+        selfHostedLoginButton.tap()
 
         return try LoginSiteAddressScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -41,7 +41,7 @@ public class LoginEpilogueScreen: ScreenObject {
         return try MySitesScreen()
     }
 
-    public func verifyEpilogueDisplays(username: String? = nil, siteUrl: String) -> LoginEpilogueScreen {
+    public func verifyEpilogueDisplays(username: String? = nil, siteUrl: String) -> Self {
         if var expectedUsername = username {
             expectedUsername = "@\(expectedUsername)"
             let actualUsername = app.staticTexts["login-epilogue-username-label"].label

--- a/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -1,13 +1,23 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 class LoginPasswordScreen: ScreenObject {
 
-    let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+    private let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.secureTextFields["Password"]
     }
+
+    private let passwordErrorLabelGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["pswdErrorLabel"]
+    }
+
+    private let loginButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Password next Button"]
+    }
+
+    var loginButton: XCUIElement { loginButtonGetter(app) }
+    var passwordErrorLabel: XCUIElement { passwordErrorLabelGetter(app) }
+    var passwordTextField: XCUIElement { passwordTextFieldGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -17,16 +27,15 @@ class LoginPasswordScreen: ScreenObject {
     }
 
     func proceedWith(password: String) throws -> LoginEpilogueScreen {
-        _ = tryProceed(password: password)
+        tryProceed(password: password)
 
         return try LoginEpilogueScreen()
     }
 
-    func tryProceed(password: String) -> LoginPasswordScreen {
-        let passwordTextField = passwordTextFieldGetter(app)
+    @discardableResult
+    func tryProceed(password: String) -> Self {
         passwordTextField.tap()
         passwordTextField.typeText(password)
-        let loginButton = app.buttons["Password next Button"]
         loginButton.tap()
         if loginButton.exists && !loginButton.isHittable {
             XCTAssertEqual(loginButton.waitFor(predicateString: "isEnabled == true"), .completed)
@@ -34,11 +43,8 @@ class LoginPasswordScreen: ScreenObject {
         return self
     }
 
-    func verifyLoginError() -> LoginPasswordScreen {
-        let errorLabel = app.staticTexts["pswdErrorLabel"]
-        _ = errorLabel.waitForExistence(timeout: 2)
-
-        XCTAssertTrue(errorLabel.exists)
+    func verifyLoginError() -> Self {
+        XCTAssertTrue(passwordErrorLabel.waitForExistence(timeout: 2))
         return self
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,27 +1,18 @@
 import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let nextButton = "Site Address Next Button"
-
-    // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
-
-    // For original Site Address. This matches accessibilityIdentifier in Login.storyboard.
-    // Leaving here for now in case unifiedSiteAddress is disabled.
-    // static let siteAddressTextField = "usernameField"
-
-    // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
-    static let siteAddressTextField = "Site address"
-}
-
 public class LoginSiteAddressScreen: ScreenObject {
 
-    let siteAddressTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+    private let siteAddressTextFieldGetter: (XCUIApplication) -> XCUIElement = {
         $0.textFields["Site address"]
     }
 
+    private let siteAddressNextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Site Address Next Button"]
+    }
+
     var siteAddressTextField: XCUIElement { siteAddressTextFieldGetter(app) }
-    var nextButton: XCUIElement { app.buttons[ElementStringIDs.nextButton] }
+    var siteAddressNextButton: XCUIElement { siteAddressNextButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -33,15 +24,15 @@ public class LoginSiteAddressScreen: ScreenObject {
     public func proceedWith(siteUrl: String) throws -> LoginUsernamePasswordScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
-        nextButton.tap()
+        siteAddressNextButton.tap()
 
         return try LoginUsernamePasswordScreen()
     }
 
-    public func proceedWithWP(siteUrl: String) throws -> GetStartedScreen {
+    public func proceedWithWordPress(siteUrl: String) throws -> GetStartedScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
-        nextButton.tap()
+        siteAddressNextButton.tap()
 
         return try GetStartedScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,41 +1,25 @@
 import ScreenObject
 import XCTest
-import XCUITestHelpers
-
-private struct ElementStringIDs {
-    // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
-
-    // For original Site Address. These match accessibilityIdentifier in Login.storyboard.
-    // Leaving here for now in case unifiedSiteAddress is disabled.
-    // static let usernameTextField = "usernameField"
-    // static let passwordTextField = "passwordField"
-    // static let nextButton = "submitButton"
-
-    // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
-    static let usernameTextField = "Username"
-    static let passwordTextField = "Password"
-    static let nextButton = "Continue Button"
-}
 
 public class LoginUsernamePasswordScreen: ScreenObject {
 
-    let usernameTextFieldGetter: (XCUIApplication) -> XCUIElement = {
-        $0.textFields[ElementStringIDs.usernameTextField]
+    private let usernameTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Username"]
     }
 
-    let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
-        $0.secureTextFields[ElementStringIDs.passwordTextField]
+    private let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields["Password"]
     }
 
-    let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons[ElementStringIDs.nextButton]
+    private let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Continue Button"]
     }
 
-    var usernameTextField: XCUIElement { usernameTextFieldGetter(app) }
-    var passwordTextField: XCUIElement { passwordTextFieldGetter(app) }
     var nextButton: XCUIElement { nextButtonGetter(app) }
+    var passwordTextField: XCUIElement { passwordTextFieldGetter(app) }
+    var usernameTextField: XCUIElement { usernameTextFieldGetter(app) }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         // Notice that we don't use the "next button" getter because, at the time the screen loads,
         // that element is disabled. `ScreenObject` uses `isEnabled == true` on the elements we
         // pass at `init`.

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -1,8 +1,6 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 public class WelcomeScreen: ScreenObject {
 
     private let logInButtonGetter: (XCUIApplication) -> XCUIElement = {

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -1,14 +1,13 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 public class WelcomeScreenLoginComponent: ScreenObject {
 
-    let emailLoginButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let emailLoginButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Log in with Email Button"]
     }
-    let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
+
+    private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Self Hosted Login Button"]
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
@@ -3,10 +3,15 @@ import XCTest
 
 public class SignupCheckMagicLinkScreen: ScreenObject {
 
+    private let openMailButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Open Mail Button"]
+    }
+
+    var openMailButton: XCUIElement { openMailButtonGetter(app) }
+
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            // swiftlint:disable:next opening_brace
-            expectedElementGetters: [{ $0.buttons["Open Mail Button"] }],
+            expectedElementGetters: [openMailButtonGetter],
             app: app
         )
     }

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
@@ -1,8 +1,6 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 public class SignupEmailScreen: ScreenObject {
 
     private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
@@ -3,16 +3,42 @@ import XCTest
 
 public class SignupEpilogueScreen: ScreenObject {
 
+    private let newAccountHeaderGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["New Account Header"]
+    }
+
+    private let usernameFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Username Field"]
+    }
+
+    private let displayNameFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Display Name Field"]
+    }
+
+    private let passwordFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields["Password Field"]
+    }
+
+    private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Done"]
+    }
+
+    var displayNameField: XCUIElement { displayNameFieldGetter(app) }
+    var doneButton: XCUIElement { doneButtonGetter(app) }
+    var newAccountHeader: XCUIElement { newAccountHeaderGetter(app) }
+    var passwordField: XCUIElement { passwordFieldGetter(app) }
+    var usernameField: XCUIElement { usernameFieldGetter(app) }
+
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ { $0.staticTexts["New Account Header"] } ],
+            expectedElementGetters: [newAccountHeaderGetter],
             app: app
         )
     }
 
-    public func verifyEpilogueContains(username: String, displayName: String) -> SignupEpilogueScreen {
-        let actualUsername = app.textFields["Username Field"].value as! String
-        let actualDisplayName = app.textFields["Display Name Field"].value as! String
+    public func verifyEpilogueContains(username: String, displayName: String) -> Self {
+        let actualUsername = usernameField.value as! String
+        let actualDisplayName = displayNameField.value as! String
 
         XCTAssertEqual(username, actualUsername, "Username is set to \(actualUsername) but should be \(username)")
         XCTAssertEqual(displayName, actualDisplayName, "Display name is set to \(actualDisplayName) but should be \(displayName)")
@@ -20,17 +46,16 @@ public class SignupEpilogueScreen: ScreenObject {
         return self
     }
 
-    public func setPassword(_ password: String) -> SignupEpilogueScreen {
-        let passwordField = app.secureTextFields["Password Field"]
+    public func setPassword(_ password: String) -> Self {
         passwordField.tap()
         passwordField.typeText(password)
-        app.buttons["Done"].tap()
+        doneButton.tap()
 
         return self
     }
 
     public func continueWithSignup() throws -> MySiteScreen {
-        app.buttons["Done Button"].tap()
+        doneButton.tap()
 
         return try MySiteScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
@@ -1,8 +1,6 @@
 import ScreenObject
 import XCTest
 
-// TODO: remove when unifiedAuth is permanent.
-
 public class WelcomeScreenSignupComponent: ScreenObject {
 
     private let emailSignupButtonGetter: (XCUIApplication) -> XCUIElement = {


### PR DESCRIPTION
### Description
While working more on the UI tests recently, I noticed that multiple screens are structured differently. And when going through some flows (especially login and editor) it took a while for me to understand them individually, even though they aim to do the same thing. While all of the screens work (nothing wrong with the different implementations), I wondered if it was necessary, the main reason it happened was that different people were working on them at different times. There wasn't a standard for how the screens were defined. 

To make it easier for contributors (especially first-time contributors to UI tests), I'm updating the screens to follow the same structure (especially for `getters`, `elements`, and screen initialization `init`). While at it, I also did some clean up to remove unused code and some comments that are no longer relevant on the screens I updated.

This first cleanup is for Login and Editor-related screens. As these two are used in most of the tests `Setup()` I figured it would be good to combine them. 

### Testing
CI should be 🟢 