### PR TITLE
Fix a race condition in story media loader

### DIFF
--- a/WordPress/Classes/Services/Stories/StoryMediaLoader.swift
+++ b/WordPress/Classes/Services/Stories/StoryMediaLoader.swift
@@ -1,13 +1,14 @@
+import Foundation
 import Kanvas
 
-class StoryMediaLoader {
+final class StoryMediaLoader {
 
     typealias Output = (CameraSegment, Data?)
 
-    var completion: (([Output]) -> Void)?
+    private var completion: (([Output]) -> Void)?
 
-    var downloadTasks: [ImageDownloaderTask] = []
-    var results: [Output?] = [] {
+    private var downloadTasks: [ImageDownloaderTask] = []
+    private var results: [Output?] = [] {
         didSet {
             if results.contains(where: { $0 == nil }) == false {
                 completion?(results.compactMap { $0 })
@@ -17,7 +18,6 @@ class StoryMediaLoader {
     }
 
     private let mediaUtility = EditorMediaUtility()
-    private let queue = DispatchQueue.global(qos: .userInitiated)
 
     func download(files: [MediaFile], for post: AbstractPost, completion: @escaping ([Output]) -> Void) {
 
@@ -60,7 +60,7 @@ class StoryMediaLoader {
                     let size = media.pixelSize()
                     if let url = URL(string: file.url) {
                         let task = self.mediaUtility.downloadImage(from: url, size: size, scale: 1, post: post, success: { [weak self] image in
-                            self?.queue.async {
+                            DispatchQueue.main.async {
                                 self?.results[idx] = (CameraSegment.image(image, nil, nil, Kanvas.MediaInfo(source: .kanvas_camera)), nil)
                             }
                         }, onFailure: { error in
@@ -72,7 +72,7 @@ class StoryMediaLoader {
                     EditorMediaUtility.fetchRemoteVideoURL(for: media, in: post, withToken: true) { [weak self] result in
                         switch result {
                         case .success((let videoURL)):
-                            self?.queue.async {
+                            DispatchQueue.main.async {
                                 self?.results[idx] = (CameraSegment.video(videoURL, nil), nil)
                             }
                         case .failure(let error):


### PR DESCRIPTION
Replaced a global queue, which is concurrency, with a serial (main) queue.

To test:

- Create a story with media
- Open the post with a story and edit the story
- Verify that media is loaded

## Regression Notes
1. Potential unintended areas of impact: Story Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
