### PR TITLE
Remove custom operators from posts list

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -4,31 +4,6 @@ import WordPressShared
 import Gridicons
 import UIKit
 
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l < r
-  case (nil, _?):
-    return true
-  default:
-    return false
-  }
-}
-
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l > r
-  default:
-    return rhs < lhs
-  }
-}
-
-
 class PostListViewController: AbstractPostListViewController, UIViewControllerRestoration, InteractivePostViewDelegate {
 
     private let postCompactCellIdentifier = "PostCompactCellIdentifier"
@@ -779,7 +754,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     override func updateForLocalPostsMatchingSearchText() {
         // If the user taps and starts to type right away, avoid doing the search
         // while the tableViewHandler is not ready yet
-        if !_tableViewHandler.isSearching && currentSearchTerm()?.count > 0 {
+        if !_tableViewHandler.isSearching, let search = currentSearchTerm(), !search.isEmpty {
             return
         }
 


### PR DESCRIPTION
I was inspecting the `PostListViewController` for crashes and found the TODO for custom operators that were easy to remove.

## To test

- Verify that the search in posts works

## Regression Notes
1. Potential unintended areas of impact: search in Posts List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
