### PR TITLE
Update WPMediaPicker to 1.8.9-beta.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -142,9 +142,9 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-  pod 'WPMediaPicker', '~> 1.8.8'
+  # pod 'WPMediaPicker', '~> 1.8.8'
   ## while PR is in review:
-  # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
+  pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: 'task/address-crash-in-navigation'
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
   pod 'Gridicons', '~> 1.1.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -520,7 +520,7 @@ PODS:
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.2.0)
   - WordPressUI (1.12.5)
-  - WPMediaPicker (1.8.8)
+  - WPMediaPicker (1.8.9-beta.1)
   - wpxmlrpc (0.10.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.2)
@@ -615,7 +615,7 @@ DEPENDENCIES:
   - WordPressKit (~> 8.5)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.12.5)
-  - WPMediaPicker (~> 1.8.8)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, branch `task/address-crash-in-navigation`)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.100.0-alpha1/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -664,7 +664,6 @@ SPEC REPOS:
     - WordPressKit
     - WordPressShared
     - WordPressUI
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
     - ZendeskCoreSDK
@@ -777,6 +776,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.0-alpha1
+  WPMediaPicker:
+    :branch: task/address-crash-in-navigation
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.100.0-alpha1/third-party-podspecs/Yoga.podspec.json
 
@@ -792,6 +794,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.0-alpha1
+  WPMediaPicker:
+    :commit: 16b43df1dd0c40aae9faf67405a202b7b1421022
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -883,7 +888,7 @@ SPEC CHECKSUMS:
   WordPressKit: f6943a6e927e9f57bc8793938af1e3a4c3adb614
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
-  WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
+  WPMediaPicker: 0ef7f4abcbff7ad20e271e7d09586e32924f5785
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   Yoga: 5e12f4deb20582f86f6323e1cdff25f07afc87f6
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
@@ -895,6 +900,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: d1a2566033c325f4188d736422f6997b7551d2cb
+PODFILE CHECKSUM: 8b727221fd21bd66d4ddb200ca70552433a9cc56
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/20890

To test:

- Go to Post / Post Settings / Set Featured Image
- Select an album
- Verify that the album opens
- Go back, select another album
- Verify that the album opens

> There are no reliable ways to reproduce the crash

## Regression Notes
1. Potential unintended areas of impact: Media Picker 
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual  testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
