### PR TITLE
Fix crashes when posing a comment and no associated post is found

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -685,6 +685,14 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     // post and content provided.
     BOOL isPrivateSite = post.isPrivate;
     [self createHierarchicalCommentWithContent:content withParent:nil postObjectID:post.objectID siteID:post.siteID completion:^(NSManagedObjectID *commentID) {
+        if (!commentID) {
+            NSError *error = [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{NSDebugDescriptionErrorKey: @"Failed to create a comment for a post"}];
+            if (failure) {
+                failure(error);
+            }
+            [WordPressAppDelegate logError:error];
+            return;
+        }
         void (^successBlock)(RemoteComment *remoteComment) = ^void(RemoteComment *remoteComment) {
             [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
                 Comment *comment = [context existingObjectWithID:commentID error:nil];
@@ -730,6 +738,14 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     // post and content provided.
     BOOL isPrivateSite = post.isPrivate;
     [self createHierarchicalCommentWithContent:content withParent:nil postObjectID:post.objectID siteID:post.siteID completion:^(NSManagedObjectID *commentObjectID) {
+        if (!commentObjectID) {
+            NSError *error = [NSError errorWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{NSDebugDescriptionErrorKey: @"Failed to create a comment for a post"}];
+            if (failure) {
+                failure(error);
+            }
+            [WordPressAppDelegate logError:error];
+            return;
+        }
         void (^successBlock)(RemoteComment *remoteComment) = ^void(RemoteComment *remoteComment) {
             // Update and save the comment
             [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -776,6 +776,11 @@ extension WordPressAppDelegate {
         SetCocoaLumberjackObjCLogLevel(level.rawValue)
         CocoaLumberjack.dynamicLogLevel = level
     }
+
+    /// Logs the error in Sentry.
+    @objc class func logError(_ error: Error) {
+        crashLogging?.logError(error)
+    }
 }
 
 // MARK: - Local Notification Helpers


### PR DESCRIPTION
Fixes the following crash when posting comments:

```
__54-[CommentService replyToPost:content:success:failure:]_block_invoke_3 (CommentService.m:690)
```

To test:

- Replace the line 1064 in CommentService.m 

```swift
completion(nil);
// completion(objectID);
```
- Post a comment to any post in Reader
- Verify that it shows an error messages, but the app doesn't crash

<img width="453" alt="Screenshot 2023-07-14 at 2 26 45 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0a7569ee-e839-4e82-a87d-e4da3dcbf8ef">

> I've tried to identify the root cause, but haven't found it in a reasonable amount of time. @crazytonyli , maybe you have any ideas? The issues is in the `CommentService` where it fails to find an associated post in Core Data.
>
> I added this error to Sentry, but not as a crash, so it's still on our radar.

## Regression Notes
1. Potential unintended areas of impact: Reader Comments
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
