### PR TITLE
Break retain cycle between MySiteViewController and CompliancePopoverCoordinator

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -210,8 +210,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         createFABIfNeeded()
         fetchPrompt(for: blog)
 
-        complianceCoordinator = CompliancePopoverCoordinator(viewController: self)
-        complianceCoordinator?.presentIfNeeded()
+        complianceCoordinator = CompliancePopoverCoordinator()
+        complianceCoordinator?.presentIfNeeded(on: self)
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -16,7 +16,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
     }
 
     func presentIfNeeded(on viewController: UIViewController) {
-        guard FeatureFlag.compliancePopover.enabled else {
+        guard FeatureFlag.compliancePopover.enabled, !defaults.didShowCompliancePopup else {
             return
         }
         complianceService.getIPCountryCode { [weak self] result in

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -1,23 +1,22 @@
 import UIKit
 
-protocol CompliancePopoverCoordinatorProtocol {
-    func presentIfNeeded()
+protocol CompliancePopoverCoordinatorProtocol: AnyObject {
+    func presentIfNeeded(on viewController: UIViewController)
     func navigateToSettings()
     func dismiss()
 }
 
 final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
-    private let viewController: UIViewController
+    private weak var presentingViewController: UIViewController?
     private let complianceService = ComplianceLocationService()
     private let defaults: UserDefaults
 
-    init(viewController: UIViewController, defaults: UserDefaults = UserDefaults.standard) {
-        self.viewController = viewController
+    init(defaults: UserDefaults = UserDefaults.standard) {
         self.defaults = defaults
     }
 
-    func presentIfNeeded() {
-        guard FeatureFlag.compliancePopover.enabled, !defaults.didShowCompliancePopup else {
+    func presentIfNeeded(on viewController: UIViewController) {
+        guard FeatureFlag.compliancePopover.enabled else {
             return
         }
         complianceService.getIPCountryCode { [weak self] result in
@@ -26,20 +25,20 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
                     return
                 }
                 DispatchQueue.main.async {
-                    self.presentPopover()
+                    self.presentPopover(on: viewController)
                 }
             }
         }
     }
 
     func navigateToSettings() {
-        viewController.dismiss(animated: true) {
+        presentingViewController?.dismiss(animated: true) {
             RootViewCoordinator.sharedPresenter.navigateToPrivacySettings()
         }
     }
 
     func dismiss() {
-        viewController.dismiss(animated: true)
+        presentingViewController?.dismiss(animated: true)
     }
 
     private func shouldShowPrivacyBanner(countryCode: String) -> Bool {
@@ -47,7 +46,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
         return isCountryInEU && !defaults.didShowCompliancePopup
     }
 
-    private func presentPopover() {
+    private func presentPopover(on viewController: UIViewController) {
         let complianceViewModel = CompliancePopoverViewModel(
             defaults: defaults,
             contextManager: ContextManager.shared
@@ -56,7 +55,9 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
         let complianceViewController = CompliancePopoverViewController(viewModel: complianceViewModel)
         let bottomSheetViewController = BottomSheetViewController(childViewController: complianceViewController, customHeaderSpacing: 0)
 
-        bottomSheetViewController.show(from: self.viewController)
+        bottomSheetViewController.show(from: viewController)
+
+        self.presentingViewController = viewController
     }
 }
 

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
@@ -81,7 +81,7 @@ private class MockCompliancePopoverCoordinator: CompliancePopoverCoordinatorProt
     private(set) var presentIfNeededCallCount = 0
     private(set) var dismissCallCount = 0
 
-    func presentIfNeeded() {
+    func presentIfNeeded(on viewController: UIViewController) {
         presentIfNeededCallCount += 1
     }
 


### PR DESCRIPTION
Partially addresses #21100
Related to https://github.com/wordpress-mobile/WordPress-iOS/pull/21047

## Description

There's a cycle between MySiteViewController and CompliancePopoverViewController holding each other strongly. It prevents dashboard from being deallocated after logout Fixing the issue.

There's still an issue of `CompliancePopoverViewController` not being deallocated but it looks to be related to some SwiftUI and HostingController lifecycles so I'm not addressing it here. (https://tiagolopes.blog/2022/11/01/when-does-a-swiftui-environment-get-retained/)

## To test:

1. Fresh Install and run the app (Must be located in EU countries or VPN, alternatively, you can use [proxyman.io](https://proxyman.io/) to stub the /geo request).
2. Login
3. You should eventually land on "My Site"
4. Make sure the popup appears
5. Tap "Save"
6. Logout
7. Open Memory Graph Debugger
8. Confirm MySiteViewController, BlogDashboardViewController are deallocated

## Regression Notes
1. Potential unintended areas of impact

Compliance popover not working anymore

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Existing automated tests and manual tests

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
