### PR TITLE
Jetpack Social: Add tap actions to No Connection view in prepublishing

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController+JetpackSocial.swift
@@ -119,8 +119,4 @@ private extension PrepublishingViewController {
         // TODO: Tap actions
         return .init(services: services, preferredBackgroundColor: tableView.backgroundColor)
     }
-
-    enum Constants {
-        static let socialCellBackgroundColor = UIColor(light: .listForeground, dark: .listBackground)
-    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -25,7 +25,23 @@ enum PrepublishingIdentifier {
 
 class PrepublishingViewController: UITableViewController {
     let post: Post
+    let identifiers: [PrepublishingIdentifier]
     let coreDataStack: CoreDataStack
+    let persistentStore: UserPersistentRepository
+
+    lazy var postBlogID: Int? = {
+        coreDataStack.performQuery { [postObjectID = post.objectID] context in
+            guard let post = (try? context.existingObject(with: postObjectID)) as? Post else {
+                return nil
+            }
+            return post.blog.dotComID?.intValue
+        }
+    }()
+
+    /// The list of `PrepublishingIdentifier`s that have been filtered for display.
+    var filteredIdentifiers: [PrepublishingIdentifier] {
+        options.map { $0.id }
+    }
 
     private lazy var publishSettingsViewModel: PublishSettingsViewModel = {
         return PublishSettingsViewModel(post: post)
@@ -42,23 +58,8 @@ class PrepublishingViewController: UITableViewController {
 
     private let completion: (CompletionResult) -> ()
 
-    private let identifiers: [PrepublishingIdentifier]
-
-    private lazy var options: [PrepublishingOption] = {
-        return identifiers.compactMap { identifier in
-            switch identifier {
-            case .autoSharing:
-                // skip the social cell if the post's blog is not eligible for auto-sharing.
-                guard isEligibleForAutoSharing() else {
-                    return nil
-                }
-                break
-            default:
-                break
-            }
-            return .init(identifier: identifier)
-        }
-    }()
+    /// The data source for the table rows, based on the filtered `identifiers`.
+    private var options = [PrepublishingOption]()
 
     private var didTapPublish = false
 
@@ -77,11 +78,13 @@ class PrepublishingViewController: UITableViewController {
     init(post: Post,
          identifiers: [PrepublishingIdentifier],
          completion: @escaping (CompletionResult) -> (),
-         coreDataStack: CoreDataStack = ContextManager.shared) {
+         coreDataStack: CoreDataStack = ContextManager.shared,
+         persistentStore: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.post = post
         self.identifiers = identifiers
         self.completion = completion
         self.coreDataStack = coreDataStack
+        self.persistentStore = persistentStore
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -92,8 +95,26 @@ class PrepublishingViewController: UITableViewController {
     private var cancellables = Set<AnyCancellable>()
     @Published private var keyboardShown: Bool = false
 
+    func refreshOptions() {
+        options = identifiers.compactMap { identifier -> PrepublishingOption? in
+            switch identifier {
+            case .autoSharing:
+                // skip the social cell if the post's blog is not eligible for auto-sharing.
+                guard canDisplaySocialRow() else {
+                    return nil
+                }
+                break
+            default:
+                break
+            }
+            return .init(identifier: identifier)
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        refreshOptions()
 
         title = ""
 
@@ -139,6 +160,9 @@ class PrepublishingViewController: UITableViewController {
                 self?.hasSelectedText = true
             }
         })
+
+        // when displayed in a popover, update content size so the window is resized to fit the current content.
+        navigationController?.preferredContentSize = tableView.contentSize
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -541,7 +565,6 @@ private extension PrepublishingOption {
         case .tags:
             self.init(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"), type: .value)
         case .autoSharing:
-            // TODO: Which cell to show?
             self.init(id: .autoSharing, title: "Jetpack Social", type: .customContainer)
         }
     }


### PR DESCRIPTION
Refs #20783 

As titled, this PR adds tap actions to the No Connection view.

- Tapping "Connect your profiles" will show the current Sharing view controller in modal style.
- Tapping "Not now" will dismiss the No Connection view, and remembers the choice so next time it shouldn't appear.

I've mulled over whether I should present or push the `SharingViewController`, and have decided to go ahead with a modal presentation for now since it's simpler.

- On iPhone, the `SharingViewController` and its next view controllers are displayed "correctly" when it's shown modally. If we want to push this into the current navigation stack, I'll need to ensure that all the following controllers conform to `DrawerPresentable`.
- On iPad, there are two types of presentation for the pre-publishing sheet. With normal font size, it's shown in a popover style; and when we use an accessibility font size, the sheet is presented using the `.formSheet` style. In this context, the `SharingViewController` will be presented on top of the current modal, but I'm thinking it still makes sense since the `SharingViewController` sort of manages its own flow. Plus, using a modal presentation should be more convenient here (just dismiss when you're done), instead of going back 2-3 screens to return to the pre-publishing sheet.

## To test

### Case 1: Tapping Connect

- Launch the Jetpack app.
- Create a new blog post.
- Type in some text for the title and body, and tap Publish.
- Tap "Connect your profiles".
- 🔎 Verify that the Sharing view is shown.

Repeat the testing steps above on:
- iPad
- iPad, with accessibility font size

### Case 2: Dismissing the No Connection view

- Launch the Jetpack app.
- Create a new blog post.
- Type in some text for the title and body, and tap Publish.
- Tap "Not now".
- 🔎 Verify that the No Connection view is dismissed.
- Dismiss the sheet, and tap Publish again.
- 🔎 Verify that the No Connection view is not shown.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
