### PR TITLE
Blaze Manage Campaigns: Show Blaze overlay only once

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -455,6 +455,7 @@ import Foundation
     case blazeEntryPointTapped
     case blazeContextualMenuAccessed
     case blazeCardHidden
+    case blazeCardLearnMoreTapped
     case blazeOverlayDisplayed
     case blazeOverlayButtonTapped
     case blazeOverlayDismissed
@@ -1282,6 +1283,8 @@ import Foundation
             return "blaze_entry_point_menu_accessed"
         case .blazeCardHidden:
             return "blaze_entry_point_hide_tapped"
+        case .blazeCardLearnMoreTapped:
+            return "blaze_entry_point_learn_more_tapped"
         case .blazeOverlayDisplayed:
             return "blaze_overlay_displayed"
         case .blazeOverlayButtonTapped:

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
@@ -23,6 +23,10 @@ import Foundation
         WPAnalytics.track(.blazeCardHidden, properties: analyticsProperties(for: source))
     }
 
+    static func trackLearnMoreTapped(for source: BlazeSource) {
+        WPAnalytics.track(.blazeCardLearnMoreTapped, properties: analyticsProperties(for: source))
+    }
+
     // MARK: - Overlay
 
     static func trackOverlayDisplayed(for source: BlazeSource) {

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -23,9 +23,13 @@ import UIKit
         }
     }
 
-    /// Blaze overlays should be shown once only, regardless of entry point
+    /// Blaze overlays should be shown once only, regardless of entry point.
+    ///
+    /// We're using the dashboard card as the key to prevent showing the overlay to users who have
+    /// already seen it, based on the assumption that most users have either clicked the dashboard
+    /// card or haven't tried Blaze at all.
     var key: String {
-        return ""
+        return BlazeSource.dashboardCard.description
     }
 
     var frequencyType: OverlayFrequencyTracker.FrequencyType {

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -23,8 +23,9 @@ import UIKit
         }
     }
 
+    /// Blaze overlays should be shown once only, regardless of entry point
     var key: String {
-        return description
+        return ""
     }
 
     var frequencyType: OverlayFrequencyTracker.FrequencyType {
@@ -93,10 +94,10 @@ import UIKit
     ///   - post: `AbstractPost` object representing the specific post to blaze. If `nil` is passed,
     ///    a general blaze overlay is displayed. If a valid value is passed, a blaze overlay with a post preview
     ///    is displayed.
-    private static func presentBlazeOverlay(in viewController: UIViewController,
-                                            source: BlazeSource,
-                                            blog: Blog,
-                                            post: AbstractPost? = nil) {
+    static func presentBlazeOverlay(in viewController: UIViewController,
+                                    source: BlazeSource,
+                                    blog: Blog,
+                                    post: AbstractPost? = nil) {
         let overlayViewController = BlazeOverlayViewController(source: source, blog: blog, post: post)
         let navigationController = UINavigationController(rootViewController: overlayViewController)
         navigationController.modalPresentationStyle = .formSheet

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -77,7 +77,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
             self?.showCampaignList()
         }
 
-        campaignView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(campainViewTapped)))
+        campaignView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(campaignViewTapped)))
     }
 
     private func showCampaignList() {
@@ -103,7 +103,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
         }
     }
 
-    @objc private func campainViewTapped() {
+    @objc private func campaignViewTapped() {
         guard let presentingViewController, let blog, let campaign else { return }
         BlazeFlowCoordinator.presentBlazeCampaignDetails(in: presentingViewController, source: .dashboardCard, blog: blog, campaignID: campaign.campaignID)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -93,6 +93,7 @@ final class DashboardBlazeCampaignsCardView: UIView {
 
     private func showBlazeOverlay() {
         guard let presentingViewController, let blog else { return }
+        BlazeEventsTracker.trackLearnMoreTapped(for: .dashboardCard)
         BlazeFlowCoordinator.presentBlazeOverlay(in: presentingViewController, source: .dashboardCard, blog: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignsCardView.swift
@@ -91,6 +91,17 @@ final class DashboardBlazeCampaignsCardView: UIView {
         }
     }
 
+    private func showBlazeOverlay() {
+        guard let presentingViewController, let blog else { return }
+        BlazeFlowCoordinator.presentBlazeOverlay(in: presentingViewController, source: .dashboardCard, blog: blog)
+    }
+
+    private func makeLearnMoreMenuAction() -> UIAction {
+        UIAction(title: Strings.learnMore, image: UIImage(systemName: "info.circle")) { [weak self] _ in
+            self?.showBlazeOverlay()
+        }
+    }
+
     @objc private func campainViewTapped() {
         guard let presentingViewController, let blog, let campaign else { return }
         BlazeFlowCoordinator.presentBlazeCampaignDetails(in: presentingViewController, source: .dashboardCard, blog: blog, campaignID: campaign.campaignID)
@@ -112,6 +123,9 @@ final class DashboardBlazeCampaignsCardView: UIView {
                 makeShowCampaignsMenuAction()
             ]),
             UIMenu(options: .displayInline, children: [
+                makeLearnMoreMenuAction()
+            ]),
+            UIMenu(options: .displayInline, children: [
                 BlogDashboardHelpers.makeHideCardAction(for: .blaze, blog: blog)
             ])
         ], card: .blaze)
@@ -125,6 +139,7 @@ private extension DashboardBlazeCampaignsCardView {
     enum Strings {
         static let cardTitle = NSLocalizedString("dashboardCard.blazeCampaigns.title", value: "Blaze campaign", comment: "Title for the card displaying blaze campaigns.")
         static let viewAllCampaigns = NSLocalizedString("dashboardCard.blazeCampaigns.viewAllCampaigns", value: "View all campaigns", comment: "Title for the View All Campaigns button in the More menu")
+        static let learnMore = NSLocalizedString("dashboardCard.blazeCampaigns.learnMore", value: "Learn more", comment: "Title for the Learn more button in the More menu.")
         static let createCampaignButton = NSLocalizedString("dashboardCard.blazeCampaigns.createCampaignButton", value: "Create campaign", comment: "Title of a button that starts the campaign creation flow.")
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
@@ -167,6 +167,7 @@ struct DashboardBlazePromoViewModel {
             BlazeHelper.hideBlazeCard(for: blog)
         }, onLearnMoreTap: { [weak viewController] _ in
             guard let viewController = viewController else { return }
+            BlazeEventsTracker.trackLearnMoreTapped(for: .dashboardCard)
             BlazeFlowCoordinator.presentBlazeOverlay(in: viewController, source: .dashboardCard, blog: blog)
         })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
@@ -48,11 +48,21 @@ final class DashboardBlazePromoCardView: UIView {
     }()
 
     private lazy var contextMenu: UIMenu = {
+        let learnMoreAction = UIAction(title: Strings.learnMore,
+                                       image: Style.learnMoreImage,
+                                       handler: viewModel.onLearnMoreTap)
         let hideThisAction = UIAction(title: Strings.hideThis,
                                       image: Style.hideThisImage,
                                       attributes: [UIMenuElement.Attributes.destructive],
                                       handler: viewModel.onHideThisTap)
-        return UIMenu(title: String(), options: .displayInline, children: [hideThisAction])
+        return UIMenu(title: String(), options: .displayInline, children: [
+            UIMenu(options: .displayInline, children: [
+                learnMoreAction
+            ]),
+            UIMenu(options: .displayInline, children: [
+                hideThisAction
+            ])
+        ])
     }()
 
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
@@ -110,6 +120,7 @@ extension DashboardBlazePromoCardView {
         static let titleLabelFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
         static let descriptionLabelFont = WPStyleGuide.fontForTextStyle(.subheadline)
         static let hideThisImage = UIImage(systemName: "minus.circle")
+        static let learnMoreImage = UIImage(systemName: "info.circle")
     }
 
     private enum Metrics {
@@ -127,6 +138,9 @@ extension DashboardBlazePromoCardView {
         static let hideThis = NSLocalizedString("blaze.dashboard.card.menu.hide",
                                                  value: "Hide this",
                                                  comment: "Title for a menu action in the context menu on the Blaze card.")
+        static let learnMore = NSLocalizedString("blaze.dashboard.card.menu.learnMore",
+                                                 value: "Learn more",
+                                                 comment: "Title for a menu action in the context menu on the Blaze card.")
     }
 }
 
@@ -137,6 +151,7 @@ struct DashboardBlazePromoViewModel {
     let onViewTap: () -> Void
     let onEllipsisTap: () -> Void
     let onHideThisTap: UIActionHandler
+    let onLearnMoreTap: UIActionHandler
 
     static func make(with blog: Blog, viewController: BlogDashboardViewController?) -> DashboardBlazePromoViewModel {
         DashboardBlazePromoViewModel(onViewTap: { [weak viewController] in
@@ -150,6 +165,9 @@ struct DashboardBlazePromoViewModel {
             BlogDashboardAnalytics.trackHideTapped(for: .blaze)
             BlazeEventsTracker.trackHideThisTapped(for: .dashboardCard)
             BlazeHelper.hideBlazeCard(for: blog)
+        }, onLearnMoreTap: { [weak viewController] _ in
+            guard let viewController = viewController else { return }
+            BlazeFlowCoordinator.presentBlazeOverlay(in: viewController, source: .dashboardCard, blog: blog)
         })
     }
 }


### PR DESCRIPTION
Fixes #21127 
Ref: p1689601960878889-slack-C04LJFS1G5P

## Description
- Updates the overlay to display only once per user, not once per entry point
- Adds a "Learn more" action to the context menu

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/12317d46-0ce3-4ee9-ac0d-64f743d5a088" width=200>


## How to test 

### Show overlay once
1. Do a clean install of JPiOS
2. Enable the Blaze Manage Campaigns feature flag via the debug menu
3. Switch to a site with campaigns
4. Tap on the "Create campaign" CTA on the dashboard card
5. ✅ The Blaze overlay is displayed
6. Go to the campaigns list screen
7. Tap on the "Create" bar button
8. ✅ The Blaze overlay isn't displayed
9. Go to the Posts list screen
10. Tap on the ellipsis button
11.  ✅ The Blaze overlay isn't displayed
12. Go to the Pages list screen
13. Tap on the ellipsis button
14.  ✅ The Blaze overlay isn't displayed

### Learn more
> **Note**
> Please validate the new event on Tracks

1. Switch to a site with Blaze campaigns
2. Go to the dashboard and open the context menu for the Blaze campaign card
3. Tap on "Learn more"
4. ✅ `blaze_entry_point_learn_more_tapped <source: dashboard_card>` is tracked
5. Switch to a site without any campaigns
6. Go to the dashboard and open the context menu for the Blaze promo card
7. Tap on "Learn more"
8. ✅ `blaze_entry_point_learn_more_tapped <source: dashboard_card>` is tracked

## Regression Notes
1. Potential unintended areas of impact
n/a

9. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

10. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.