### PR TITLE
Add build phase to detect nested frameworks

### DIFF
--- a/Scripts/BuildPhases/LintNestedFrameworks.sh
+++ b/Scripts/BuildPhases/LintNestedFrameworks.sh
@@ -21,7 +21,7 @@ else
         #  * The `sed` command removes the leading `./` in the paths returned by `find`, then quote the results in backticks for nicer formatting in final message.
         #  * The `tr` command joins all the lines (= found frameworks) with a `,`. Note that this will result in an extra comma at the end of the list too, but we'll get rid of that in the final message using ${nested_fmks%,} bash substitution.
         nested_fmks=$(cd "${fmk_dir}" && find . -name '*.framework' -depth 1 | sed "s:^./\(.*\)$:\`\1\`:" | tr '\n' ',')
-        echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them. You might need to use Xcode 12.5 to fix this, due to an Xcode 12.4 bug – see paNNhX-ee-p2"
+        echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them."
     done
     exit 1
 fi

--- a/Scripts/BuildPhases/LintNestedFrameworks.sh
+++ b/Scripts/BuildPhases/LintNestedFrameworks.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -eu
+
+set pipefail
+
+# Nested frameworks (i.e. having a Frameworks/ folder inside *.app/Frameworks/.framework) is invalid and will make the build be rejected during TestFlight validation.
+#
+# See also https://github.com/woocommerce/woocommerce-ios/pull/4226
+
+# This script is intended to be used as a Build Phase on the main app target, as the very last build phase (and especially after the "Embed Frameworks" phase)
+
+NESTED_FMKS_DIRS=$(find "${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}" -name Frameworks -depth 2)
+if [ -z "$NESTED_FMKS_DIRS" ]; then
+    echo "✅ No nested framework found, you're good to go!"
+else
+    echo "❌ Found nested \`Frameworks\` folder inside frameworks of final bundle."
+    for fmk_dir in $NESTED_FMKS_DIRS; do
+        # Extract the name of the parent framework containing the nested ones
+        parent_fmk=$(basename $(dirname $fmk_dir) .framework)
+        # Extract the list of frameworks nested inside that parent framework. In the next command:
+        #  * `-depth 1` is to avoid logging cases of "C nested in B itself nested in A" (2+ levels of nesting), since C nested in B will already be logged when looping on fmk_dir=B, so no need to log it during fmk_dir=A too.
+        #  * The `sed` command removes the leading `./` in the paths returned by `find`, then quote the results in backticks for nicer formatting in final message.
+        #  * The `tr` command joins all the lines (= found frameworks) with a `,`. Note that this will result in an extra comma at the end of the list too, but we'll get rid of that in the final message using ${nested_fmks%,} bash substitution.
+        nested_fmks=$(cd "${fmk_dir}" && find . -name '*.framework' -depth 1 | sed "s:^./\(.*\)$:\`\1\`:" | tr '\n' ',')
+        echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them. You might need to use Xcode 12.5 to fix this, due to an Xcode 12.4 bug – see paNNhX-ee-p2"
+    done
+    exit 1
+fi

--- a/Scripts/BuildPhases/LintNestedFrameworks.sh
+++ b/Scripts/BuildPhases/LintNestedFrameworks.sh
@@ -21,7 +21,7 @@ else
         #  * The `sed` command removes the leading `./` in the paths returned by `find`, then quote the results in backticks for nicer formatting in final message.
         #  * The `tr` command joins all the lines (= found frameworks) with a `,`. Note that this will result in an extra comma at the end of the list too, but we'll get rid of that in the final message using ${nested_fmks%,} bash substitution.
         nested_fmks=$(cd "${fmk_dir}" && find . -name '*.framework' -depth 1 | sed "s:^./\(.*\)$:\`\1\`:" | tr '\n' ',')
-        echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them."
+        echo "error: Found nested frameworks in ${fmk_dir} -- Such a configuration is invalid and will be rejected by TestFlight. Please fix by choosing 'Do Not Embed' for the nested framework(s) ${nested_fmks%,} within the \`${parent_fmk}\` Xcode project which links to them. See paNNhX-ee-p2."
     done
     exit 1
 fi

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -18311,6 +18311,7 @@
 				37399571B0D91BBEAE911024 /* [CP] Embed Pods Frameworks */,
 				920B9A6DAD47189622A86A9C /* [CP] Copy Pods Resources */,
 				E1C5456F219F10E000896227 /* Copy Gutenberg JS */,
+				3FF795712A6671DB00F27B17 /* Lint against nested frameworks */,
 			);
 			buildRules = (
 			);
@@ -18607,6 +18608,7 @@
 				FABB264A2602FC2C00C8785C /* [CP] Embed Pods Frameworks */,
 				FABB264B2602FC2C00C8785C /* [CP] Copy Pods Resources */,
 				FABB264C2602FC2C00C8785C /* Copy Gutenberg JS */,
+				3FF795732A66730200F27B17 /* Lint against nested frameworks */,
 			);
 			buildRules = (
 			);
@@ -20119,6 +20121,43 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "$SRCROOT/../Scripts/BuildPhases/GenerateCredentials.sh\n";
+		};
+		3FF795712A6671DB00F27B17 /* Lint against nested frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Lint against nested frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/../Scripts/BuildPhases/LintNestedFrameworks.sh\"\n";
+		};
+		3FF795732A66730200F27B17 /* Lint against nested frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Lint against nested frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/../Scripts/BuildPhases/LintNestedFrameworks.sh\"\n";
 		};
 		49AE9271B82C7D67430387FA /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
The Hermes nested framework issue that gave us some grief could have been avoided if we had preemptively checked against that kind of setup.

The issue should be fixed now (either via https://github.com/wordpress-mobile/WordPress-iOS/pull/21021 or #21128) but we can benefit with this check to avoid paying the price again in the future.

## How to test

See https://github.com/wordpress-mobile/WordPress-iOS/pull/21129 picking up the issue in the "faulty" Gutenberg version.

---

**Regression Notes**

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.