### PR TITLE
Remove flaky free to paid card navigation UI test

### DIFF
--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -17,17 +17,6 @@ class DashboardTests: XCTestCase {
         takeScreenshotOfFailedTest()
     }
 
-    func testFreeToPaidCardNavigation() throws {
-        try MySiteScreen()
-            .scrollToFreeToPaidPlansCard()
-            .verifyFreeToPaidPlansCard()
-            .tapFreeToPaidPlansCard()
-            .assertScreenIsLoaded()
-            .selectDomain()
-            .goToPlanSelection()
-            .assertScreenIsLoaded()
-    }
-
     func testPagesCardHeaderNavigation() throws {
         try MySiteScreen()
             .scrollToPagesCard()


### PR DESCRIPTION
**Ref:**  p1689687185217419/1689685562.354659-slack-C5ALGJYEP

We're observing consistently repeating failures of freeToPaidCardNavigation UI test. It could've been indirectly caused by changes made with [dashboard cards](https://github.com/wordpress-mobile/WordPress-iOS/pull/21110). However, we have observed flakiness with [this test previously as well](https://github.com/wordpress-mobile/WordPress-iOS/pull/20805#pullrequestreview-1466401092).

Since it's causing failures and slows don't other PRs, and due to the time constraints, I suggest removing this test before we can invest time in looking for solutions. 

## To test:

Wait for CI to complete

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.