### PR TITLE
[UI Tests] Disable testFreeToPaidCardNavigation() for investigation/maintenance.

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -22,6 +22,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "DashboardTests\/testFreeToPaidCardNavigation()",
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -17,6 +17,7 @@ class DashboardTests: XCTestCase {
         takeScreenshotOfFailedTest()
     }
 
+    // Disabled for investigation/maintenance: https://github.com/wordpress-mobile/WordPress-iOS/pull/21132
     func testFreeToPaidCardNavigation() throws {
         try MySiteScreen()
             .scrollToFreeToPaidPlansCard()


### PR DESCRIPTION
### Description
`testFreeToPaidCardNavigation()` started failing recently. It's still not clear if it's a real bug or misconfiguration due to API mocks. This PR disables the test to avoid noise and PRs being blocked while we investigate the issue.

#### Related:
- #21124 
- #21131 
- p1689685562354659-slack-C5ALGJYEP