### PR TITLE
Paste text instead of typing in Gutenberg UI tests

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
+    - automattic/a8c-ci-toolkit#2.18.1
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
+    - automattic/a8c-ci-toolkit#2.18.1
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
+    - automattic/a8c-ci-toolkit#2.18.1
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -57,9 +57,7 @@ public class BlockEditorScreen: ScreenObject {
     public func enterTextInTitle(text: String) -> BlockEditorScreen {
         let titleView = app.otherElements["Post title. Empty"].firstMatch // Uses a localized string
         XCTAssert(titleView.waitForExistence(timeout: 3), "Title View does not exist!")
-
-        titleView.tap()
-        titleView.typeText(text)
+        type(text: text, in: titleView)
 
         return self
     }
@@ -72,7 +70,7 @@ public class BlockEditorScreen: ScreenObject {
         addBlock("Paragraph block")
 
         let paragraphView = app.otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
-        paragraphView.typeText(text)
+        type(text: text, in: paragraphView)
 
         return self
     }
@@ -367,5 +365,45 @@ public class BlockEditorScreen: ScreenObject {
     public func closeBlockPicker() throws -> BlockEditorScreen {
         editorCloseButton.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0)).tap()
         return try BlockEditorScreen()
+    }
+
+    // This could be moved as an XCUIApplication method via an extension if needed elsewhere.
+    private func type(text: String, in element: XCUIElement) {
+        // A simple implementation here would be:
+        //
+        // element.tap()
+        // element.typeText(text)
+        //
+        // But as of a recent (but not pinpointed at the time of writing) Gutenberg update, that is not enough.
+        // The test would fail with: Neither element nor any descendant has keyboard focus.
+        // (E.g.: https://buildkite.com/automattic/wordpress-ios/builds/15598)
+        //
+        // The following is a convoluted but seemingly robust approach that bypasses the keyboard by using the pasteboard instead.
+        UIPasteboard.general.string = text
+
+        // Safety check
+        XCTAssertTrue(element.waitForExistence(timeout: 1))
+
+        element.doubleTap()
+
+        let pasteButton = app.menuItems["Paste"]
+
+        if pasteButton.waitForExistence(timeout: 1) == false {
+            // Drill in hierarchy looking for it
+            var found = false
+            element.descendants(matching: .any).enumerated().forEach { e in
+                guard found == false else { return }
+
+                e.element.firstMatch.doubleTap()
+
+                if pasteButton.waitForExistence(timeout: 1) {
+                    found = true
+                }
+            }
+        }
+
+        XCTAssertTrue(pasteButton.exists, "Could not find menu item paste button.")
+
+        pasteButton.tap()
     }
 }


### PR DESCRIPTION
We are seeing UI tests in the editor in the branches that updated the Gutenberg integration to use a new version of React Native, a new Javascript engine, and a new distribution mode. Those are a lot of core changes, so it's not that surprising some assumptions no longer hold, in particular when there is React Native involved.

Here's an example of a failure, which can be seen [here](https://buildkite.com/automattic/wordpress-ios/builds/15598) or [here](https://href.li/?https://buildkite.com/automattic/wordpress-ios/builds/15558#018967ec-8d3b-4062-91b2-dcb1b2416c05)

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/393b4ce6-2deb-46fa-986f-fc98b7ecb479)

I spent some time trying to make the standard approach work, including changing the element query to run on the `textViews[...].firstMatch` directly, but it didn't work. I'm not particularly happy with the approach I ended up with, but it's the only one I could make to work.

You can see the tests [in this build](https://buildkite.com/automattic/wordpress-ios/builds/15612), from which I cherry-picked, pass, while the ones in the previous runs failed.

I'm opening this PR against `trunk` to:

1. Decouple the test changes from the other Gutenberg upgrade work
2. See whether the implementation is sound by checking if it works in a context where `typeTexts` was shown to work, too

## Regression Notes

1. Potential unintended areas of impact – N.A.
3. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
4. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.