### PR TITLE
Blaze Manage Campaigns: Use abbreviated numbers for campaign stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignSingleStatView.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignSingleStatView.swift
@@ -28,7 +28,7 @@ final class BlazeCampaignSingleStatView: UIView {
     private lazy var numberLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         label.textColor = .text
         label.isAccessibilityElement = false
         return label

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -112,8 +112,8 @@ private extension DashboardBlazeCampaignView {
 struct BlazeCampaignViewModel {
     let title: String
     let imageURL: URL?
-    let impressions: Int
-    let clicks: Int
+    let impressions: String
+    let clicks: String
     let budget: String
     var status: BlazeCampaignStatusViewModel { .init(campaign: campaign) }
 
@@ -141,8 +141,8 @@ struct BlazeCampaignViewModel {
         self.campaign = campaign
         self.title = campaign.name ?? "–"
         self.imageURL = campaign.contentConfig?.imageURL.flatMap(URL.init)
-        self.impressions = campaign.stats?.impressionsTotal ?? 0
-        self.clicks = campaign.stats?.clicksTotal ?? 0
+        self.impressions = campaign.stats?.impressionsTotal?.abbreviatedString() ?? "0"
+        self.clicks = campaign.stats?.clicksTotal?.abbreviatedString() ?? "0"
         self.budget = currencyFormatter.string(from: ((campaign.budgetCents ?? 0) / 100) as NSNumber) ?? "-"
     }
 }

--- a/WordPress/WordPressTest/Dashboard/BlazeCampaignViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlazeCampaignViewModelTests.swift
@@ -12,8 +12,8 @@ final class BlazeCampaignViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.imageURL, URL(string: "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"))
 
         // Then stats are displayed
-        XCTAssertEqual(viewModel.impressions, 1000)
-        XCTAssertEqual(viewModel.clicks, 235)
+        XCTAssertEqual(viewModel.impressions, "1,000")
+        XCTAssertEqual(viewModel.clicks, "235")
         XCTAssertTrue(viewModel.isShowingStats)
     }
 }


### PR DESCRIPTION
Part of #20762 
Slack ref: p1689697477168499-slack-C04LJFS1G5P

## Description
- Updates campaign clicks / impressions to use abbreviated numbers
- Updates campaign stats to semibold font

Before | After
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/b9fcbbac-2f0d-4b9d-b736-e8a7f92fc5c0" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/86969dc5-6c05-439d-a9a4-6e9481a49bc7" width=200>

## How to test

1. Switch to a site that has blaze campaigns
2. Go to the campaigns list screen (site menu > blaze)
3. ✅ Campaign clicks / impressions are dispalyed as abbreviated numbers

## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.