### PR TITLE
Jetpack Social: Update remaining shares string

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialSettingsRemainingSharesView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialSettingsRemainingSharesView.swift
@@ -27,7 +27,7 @@ struct JetpackSocialSettingsRemainingSharesView: View {
     }
 
     private var remainingText: some View {
-        let sharesRemainingString = String(format: Constants.remainingTextFormat, viewModel.remaining, viewModel.limit)
+        let sharesRemainingString = String(format: Constants.remainingTextFormat, viewModel.remaining)
         let sharesRemaining = Text(sharesRemainingString).font(.callout)
         if viewModel.displayWarning {
             return sharesRemaining
@@ -37,10 +37,10 @@ struct JetpackSocialSettingsRemainingSharesView: View {
     }
 
     private struct Constants {
-        static let remainingTextFormat = NSLocalizedString("postsettings.social.remainingshares.text.format",
-                                                           value: "%1$d/%2$d social shares remaining",
+        static let remainingTextFormat = NSLocalizedString("postsettings.social.shares.text.format",
+                                                           value: "%1$d social shares remaining",
                                                            comment: "Beginning text of the remaining social shares a user has left."
-                                                           + " %1$d is their current remaining shares. %2$d is their share limit."
+                                                           + " %1$d is their current remaining shares."
                                                            + " This text is combined with ' in the next 30 days' if there is no warning displayed.")
         static let remainingEndText = NSLocalizedString("postsettings.social.remainingshares.text.part",
                                                         value: " in the next 30 days",
@@ -55,16 +55,13 @@ struct JetpackSocialSettingsRemainingSharesView: View {
 
 struct JetpackSocialRemainingSharesViewModel {
     let remaining: Int
-    let limit: Int
     let displayWarning: Bool
     let onSubscribeTap: () -> Void
 
     init(remaining: Int,
-         limit: Int,
          displayWarning: Bool,
          onSubscribeTap: @escaping () -> Void) {
         self.remaining = remaining
-        self.limit = limit
         self.displayWarning = displayWarning
         self.onSubscribeTap = onSubscribeTap
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -57,7 +57,6 @@ extension PostSettingsViewController {
 
         let shouldDisplayWarning = publicizeConnections.count > sharingLimit.remaining
         let viewModel = JetpackSocialRemainingSharesViewModel(remaining: sharingLimit.remaining,
-                                                              limit: sharingLimit.limit,
                                                               displayWarning: shouldDisplayWarning,
                                                               onSubscribeTap: onSubscribeTap())
         let hostController = UIHostingController(rootView: JetpackSocialSettingsRemainingSharesView(viewModel: viewModel))


### PR DESCRIPTION
Closes #20784

Refs: 
- p1689071374943319-slack-C05362VSXFU
- pdcxQM-2no-p2#comment-2176

## Description

Removes the `/%2$d` from the remaining shares string. A new string key was used due to the existing one already being translated.

## Testing

To test:
- Setup a self-hosted site with the Jetpack Social plugin
- Launch Jetpack and login
- Select the self-hosted site
- Setup a social connection if necessary (Menu > Social)
- Create a new blog post
- On the editor, open the menu (`...`) in the top right
- Tap on `Post Settings`
- **Verify** the shares remaining view has the updated string

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)