### PR TITLE
Check for a feed ID before attempting a site topic lookup

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] [internal] Update calls to use UserDefaults singleton. [#21088]
 * [*] Fix memory leaks in setting up Jetpack connection. [#21052]
 * [*] Fix a memory leak caused by the theme customization web view. [#21051]
+* [*] Fixed a crash that could occur when following sites in Reader. [#21140]
 
 22.8
 -----

--- a/WordPress/Classes/Models/ReaderSiteTopic+Lookup.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic+Lookup.swift
@@ -34,8 +34,12 @@ extension ReaderSiteTopic {
     ///
     /// - Parameter feedID: The feed id of the topic
     @objc(lookupWithFeedID:inContext:)
-    static func objc_lookup(withFeedID feedID: NSNumber, in context: NSManagedObjectContext) -> ReaderSiteTopic? {
-        try? lookup(withFeedID: feedID, in: context)
+    static func objc_lookup(withFeedID feedID: NSNumber?, in context: NSManagedObjectContext) -> ReaderSiteTopic? {
+        guard let feedID else {
+            DDLogError("Obj-C lookupWithFeedID called with a nil feedID")
+            return nil
+        }
+        return try? lookup(withFeedID: feedID, in: context)
     }
 
     /// Find a site topic by its feed URL

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -310,10 +310,12 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         return;
     }
 
-    ReaderSiteTopic *feedSiteTopic = [ReaderSiteTopic lookupWithFeedID:readerPost.feedID inContext:context];
-    if (feedSiteTopic) {
-        [topicService toggleFollowingForSite:feedSiteTopic success:success failure:failure];
-        return;
+    if (readerPost.feedID) {
+        ReaderSiteTopic *feedSiteTopic = [ReaderSiteTopic lookupWithFeedID:readerPost.feedID inContext:context];
+        if (feedSiteTopic) {
+            [topicService toggleFollowingForSite:feedSiteTopic success:success failure:failure];
+            return;
+        }
     }
 
 


### PR DESCRIPTION
## Description

Fixes #20492

Fixes a crash where a `nil` feed ID doesn't result in a site topic lookup.

![nil feed ID](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/a17d2692-ad4b-424c-b359-0abcf2fa5659)


My understanding is the following:
1. When loading a Reader post externally (e.g. tapping the "OPEN" button from Safari), the post is loaded via the [slug API endpoint](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/slug:%24post_slug/), which does not provide a [feedID](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/ad6ed94ea4bbba9a82691ab9a979544f0c3af419/WordPressKit/RemoteReaderPost.m#L110).
2. When tapping the "Follow" button on the loaded post, [this line would be called](https://github.com/wordpress-mobile/WordPress-iOS/blob/d075157af9b1864b3cc364e90b87d791d9b4171b/WordPress/Classes/Services/Reader%20Post/ReaderPostService.m#L313) to fetch a `ReaderSiteTopic` with a feed ID of `nil`.
3. _Sometimes_ a `ReaderSiteTopic` would be returned because there was a match: A `feedID` _did_ equal `nil`. Upon inspection it seems that at some point an empty `ReaderSiteTopic` had been inserted into CoreData. I can't think of a reason why that would ever be valid, and that may be another bug to hunt down. 🤔 
5. This would cause the code to take [this branch](https://github.com/wordpress-mobile/WordPress-iOS/blob/d075157af9b1864b3cc364e90b87d791d9b4171b/WordPress/Classes/Services/Reader%20Post/ReaderPostService.m#L315).
6. Eventually `checkSubscribedToFeedByURL` [would be called](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/ad6ed94ea4bbba9a82691ab9a979544f0c3af419/WordPressKit/ReaderSiteServiceRemote.m#L249) with a `nil` siteURL.
7. [This line would throw the exception](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/ad6ed94ea4bbba9a82691ab9a979544f0c3af419/WordPressKit/ReaderSiteServiceRemote.m#L249) due to `rangeOfString` on a `nil`.

The proposed solution is to not fetch a feed site topic when the feed ID is `nil`.

## Testing

From [this comment](https://github.com/wordpress-mobile/WordPress-iOS/issues/20492#issuecomment-1640961522):

1. In a different app, tap on a link such as p7H4VZ-4tN-p2.
2. When the app opens, tap the follow button next to the post's title.
3. **Expect** that the app doesn't crash.

### Important notes:
1. On a physical device I could reproduce the crash every time. On Simulator it seemed to be intermittent.
2. When following the link referenced by p7H4VZ-4tN-p2, a toaster error will show "Unable to follow site". The site will actually be followed, and I've determined that this is from a `500` returned by the API. This can be confirmed by POSTing with the [developer console](https://developer.wordpress.com/docs/api/console/) to the site's ID with the follow API call, e.g. `/sites/[site ID]/follows/new`. At this time I don't think it's an issue with the app.

## Regression Notes
1. Potential unintended areas of impact
  - Following and unfollowing sites in Reader from a feed such as the "Discover" tab
  - Following and unfollowing sites in Reader that were loaded from another app, such as Safari

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - I manually tested following and unfollowing sites in Reader from various areas

3. What automated tests I added (or what prevented me from doing so)
  - I looked into this and struggled to find a way to make an effective test. I'm open to ideas here.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

N/A ~UI Changes testing checklist:~
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)