### PR TITLE
Fix failing UI tests after React Native upgrade in Gutenberg

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
+    - automattic/a8c-ci-toolkit#2.18.1
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
+    - automattic/a8c-ci-toolkit#2.18.1
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#2.17.0
+    - automattic/a8c-ci-toolkit#2.18.1
     - automattic/git-s3-cache#1.1.4:
         bucket: "a8c-repo-mirrors"
         repo: "automattic/wordpress-ios/"

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -57,9 +57,7 @@ public class BlockEditorScreen: ScreenObject {
     public func enterTextInTitle(text: String) -> BlockEditorScreen {
         let titleView = app.otherElements["Post title. Empty"].firstMatch // Uses a localized string
         XCTAssert(titleView.waitForExistence(timeout: 3), "Title View does not exist!")
-
-        titleView.tap()
-        titleView.typeText(text)
+        type(text: text, in: titleView)
 
         return self
     }
@@ -72,7 +70,7 @@ public class BlockEditorScreen: ScreenObject {
         addBlock("Paragraph block")
 
         let paragraphView = app.otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
-        paragraphView.typeText(text)
+        type(text: text, in: paragraphView)
 
         return self
     }
@@ -367,5 +365,45 @@ public class BlockEditorScreen: ScreenObject {
     public func closeBlockPicker() throws -> BlockEditorScreen {
         editorCloseButton.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0)).tap()
         return try BlockEditorScreen()
+    }
+
+    // This could be moved as an XCUIApplication method via an extension if needed elsewhere.
+    private func type(text: String, in element: XCUIElement) {
+        // A simple implementation here would be:
+        //
+        // element.tap()
+        // element.typeText(text)
+        //
+        // But as of a recent (but not pinpointed at the time of writing) Gutenberg update, that is not enough.
+        // The test would fail with: Neither element nor any descendant has keyboard focus.
+        // (E.g.: https://buildkite.com/automattic/wordpress-ios/builds/15598)
+        //
+        // The following is a convoluted but seemingly robust approach that bypasses the keyboard by using the pasteboard instead.
+        UIPasteboard.general.string = text
+
+        // Safety check
+        XCTAssertTrue(element.waitForExistence(timeout: 1))
+
+        element.doubleTap()
+
+        let pasteButton = app.menuItems["Paste"]
+
+        if pasteButton.waitForExistence(timeout: 1) == false {
+            // Drill in hierarchy looking for it
+            var found = false
+            element.descendants(matching: .any).enumerated().forEach { e in
+                guard found == false else { return }
+
+                e.element.firstMatch.doubleTap()
+
+                if pasteButton.waitForExistence(timeout: 1) {
+                    found = true
+                }
+            }
+        }
+
+        XCTAssertTrue(pasteButton.exists, "Could not find menu item paste button.")
+
+        pasteButton.tap()
     }
 }


### PR DESCRIPTION
Implements a working albeit not elegant workaround to the issue of UI tests not being able to get a handle on the keyboard when attempting to insert text in the title and paragraph blocks in the Gutenberg editor built and integrated via XCFramework.

As you can see, CI is green here, while it's red in the base branch.

Based on https://github.com/wordpress-mobile/WordPress-iOS/pull/21134. In that PR, @jostnes made a few suggestions of approaches to try. I haven't had a chance to do so yet. If you trust I'll followup on the approaches, I'd rather merge with the tests green as is sooner rather than later. 😅

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.