### PR TITLE
performQuery should not return NSManagedObject

### DIFF
--- a/WordPress/Classes/Services/ReaderSiteService.swift
+++ b/WordPress/Classes/Services/ReaderSiteService.swift
@@ -2,12 +2,6 @@ import Foundation
 
 @objc extension ReaderSiteService {
 
-    private var defaultAccount: WPAccount? {
-        self.coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
-        }
-    }
-
     /// Block/unblock the specified site from appearing in the user's reader
     /// - Parameters:
     ///   - id: The ID of the site.
@@ -15,7 +9,18 @@ import Foundation
     ///   - success: Closure called when the request succeeds.
     ///   - failure: Closure called when the request fails.
     func flagSite(withID id: NSNumber, asBlocked blocked: Bool, success: (() -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
-        guard let defaultAccount = defaultAccount, let api = defaultAccount.wordPressComRestApi, api.hasCredentials() else {
+        let queryResult: (NSNumber, WordPressComRestApi)? = self.coreDataStack.performQuery({
+            guard
+                let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: $0),
+                let api = defaultAccount.wordPressComRestApi,
+                api.hasCredentials()
+            else {
+                return nil
+            }
+            return (defaultAccount.userID, api)
+        })
+
+        guard let (userID, api) = queryResult else {
             failure?(self.errorForNotLoggedIn())
             return
         }
@@ -29,7 +34,7 @@ import Foundation
             let properties: [String: Any] = [WPAppAnalyticsKeyBlogID: id]
             WPAnalytics.track(.readerSiteBlocked, withProperties: properties)
             self.coreDataStack.performAndSave({ context in
-                self.flagSiteLocally(accountID: defaultAccount.userID, siteID: id, asBlocked: blocked, in: context)
+                self.flagSiteLocally(accountID: userID, siteID: id, asBlocked: blocked, in: context)
             }, completion: {
                 success?()
             }, on: .main)


### PR DESCRIPTION
Related to #21008, which explained why `performQuery` should not return `NSManagedObject`.

## Test Instructions

Go to Reader -> Discover. Tlick the kebab menu on a post. Tap the "Block this Site" button.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the Test Instructions.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A