### PR TITLE
[UI Tests] Run disableAutoFillPasswords once before all the UI Tests.

### DIFF
--- a/WordPress/UITests/JetpackUITests-Info.plist
+++ b/WordPress/UITests/JetpackUITests-Info.plist
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>${PRODUCT_NAME}.TestObserver</string>
 </dict>
 </plist>

--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -8,9 +8,6 @@ extension XCTestCase {
         removeBeforeLaunching: Bool = false,
         crashOnCoreDataConcurrencyIssues: Bool = true
     ) {
-        // To avoid handling 'Save Password' prompts after login.
-        disableAutoFillPasswords()
-
         // To ensure that the test starts with a new simulator launch each time
         app.terminate()
         super.setUp()
@@ -33,24 +30,6 @@ extension XCTestCase {
         // Media permissions alert handler
         let alertButtonTitle = "Allow Access to All Photos"
         systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: alertButtonTitle)
-    }
-
-    public func disableAutoFillPasswords() {
-        let settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
-        settings.activate()
-        settings.staticTexts["Passwords"].tap()
-
-        let enterPasscodeScreen = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        enterPasscodeScreen.secureTextFields["Passcode field"].typeText(" ")
-        enterPasscodeScreen.buttons["done"].tap()
-
-        settings.staticTexts["Password Options"].tap()
-
-        let autoFillPasswordsSwitch = settings.switches["AutoFill Passwords"]
-        if autoFillPasswordsSwitch.value as? String == "1" {
-            autoFillPasswordsSwitch.tap()
-        }
-        settings.terminate()
     }
 
     public func takeScreenshotOfFailedTest() {

--- a/WordPress/UITests/WordPressUITests-Info.plist
+++ b/WordPress/UITests/WordPressUITests-Info.plist
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>${PRODUCT_NAME}.TestObserver</string>
 </dict>
 </plist>

--- a/WordPress/UITestsFoundation/TestObserver.swift
+++ b/WordPress/UITestsFoundation/TestObserver.swift
@@ -30,20 +30,20 @@ class TestObserver: NSObject, XCTestObservation {
         settings.activate()
 
         let passwordsMenuItem = settings.staticTexts["Passwords"]
-        passwordsMenuItem.waitForIsHittable()
+        guard passwordsMenuItem.waitForIsHittable() else { return false }
         passwordsMenuItem.tap()
 
         let enterPasscodeScreen = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         let passwordField = enterPasscodeScreen.secureTextFields["Passcode field"]
-        passwordField.waitForIsHittable()
+        guard passwordField.waitForIsHittable() else { return false }
         passwordField.typeText(" \r")
 
-        let passwordOptions = settings.staticTexts["Password Options"]
-        passwordOptions.waitForIsHittable()
+        let passwordOptions = settings.staticTexts["Passwordd Options"]
+        guard passwordOptions.waitForIsHittable() else { return false }
         passwordOptions.tap()
 
         let autoFillPasswordsSwitch = settings.switches["AutoFill Passwords"]
-        autoFillPasswordsSwitch.waitForIsHittable()
+        guard autoFillPasswordsSwitch.waitForIsHittable() else { return false }
 
         if autoFillPasswordsSwitch.value as? String == "1" {
             autoFillPasswordsSwitch.tap()

--- a/WordPress/UITestsFoundation/TestObserver.swift
+++ b/WordPress/UITestsFoundation/TestObserver.swift
@@ -38,7 +38,7 @@ class TestObserver: NSObject, XCTestObservation {
         guard passwordField.waitForIsHittable() else { return false }
         passwordField.typeText(" \r")
 
-        let passwordOptions = settings.staticTexts["Passwordd Options"]
+        let passwordOptions = settings.staticTexts["Password Options"]
         guard passwordOptions.waitForIsHittable() else { return false }
         passwordOptions.tap()
 

--- a/WordPress/UITestsFoundation/TestObserver.swift
+++ b/WordPress/UITestsFoundation/TestObserver.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+class TestObserver: NSObject, XCTestObservation {
+    override init() {
+            super.init()
+            XCTestObservationCenter.shared.addTestObserver(self)
+        }
+
+    func testBundleWillStart(_ testBundle: Bundle) {
+        // Code added here will run only once before all the tests
+        executeWithRetries(disableAutoFillPasswords)
+    }
+
+    func executeWithRetries(_ operation: () -> Bool) {
+        var retryCount = 3
+
+        while !operation() && retryCount > 0 {
+            retryCount -= 1
+        }
+    }
+
+    func disableAutoFillPasswords() -> Bool {
+        let settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+        settings.terminate()
+
+        settings.activate()
+        let passwordsMenuItem = settings.staticTexts["Passwords"]
+        passwordsMenuItem.waitForIsHittable()
+        guard passwordsMenuItem.waitForIsHittable() else {
+            XCTFail("SetUp Failed: Passwords menu item was not hittable in Settings.")
+            return false
+        }
+        settings.staticTexts["Passwords"].tap()
+
+        let enterPasscodeScreen = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let passwordField = enterPasscodeScreen.secureTextFields["Passcode field"]
+        guard passwordField.waitForIsHittable() else {
+            XCTFail("SetUp Failed: Password field was not hittable in 'Enter passcode screen.")
+            return false
+        }
+        passwordField.typeText(" \r")
+
+        let passwordOptions = settings.staticTexts["Password Options"]
+        guard passwordOptions.waitForIsHittable() else {
+            XCTFail("SetUp Failed: Password Options was not hittable in Passwords.")
+            return false
+        }
+        passwordOptions.tap()
+
+        let autoFillPasswordsSwitch = settings.switches["AutoFill Passwords"]
+        guard autoFillPasswordsSwitch.waitForIsHittable() else {
+            XCTFail("SetUp Failed: AutoFill Passwords switch was not hittable in Passwords Options.")
+            return false
+        }
+
+        if autoFillPasswordsSwitch.value as? String == "1" {
+            autoFillPasswordsSwitch.tap()
+        }
+
+        settings.terminate()
+        return true
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3461,6 +3461,9 @@
 		EA14533829AD874C001F3143 /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA640572670CCD40064401E /* UITestsFoundation.framework */; };
 		EA14533929AD874C001F3143 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = EA14532529AD874C001F3143 /* BuildkiteTestCollector */; };
 		EA78189427596B2F00554DFA /* ContactUsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA78189327596B2F00554DFA /* ContactUsScreen.swift */; };
+		EA85B7AB2A686C7A0096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
+		EA85B7AF2A688AB00096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
+		EA85B7B02A688B1C0096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
 		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
 		EAD08D0E29D45E23001A72F9 /* CommentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD08D0D29D45E23001A72F9 /* CommentsScreen.swift */; };
 		EAD2BF4227594DAB00A847BB /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD2BF4127594DAB00A847BB /* StatsTests.swift */; };
@@ -8901,6 +8904,7 @@
 		EA14534229AD874C001F3143 /* JetpackUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JetpackUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA14534629AEF479001F3143 /* JetpackUITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = JetpackUITests.xctestplan; sourceTree = "<group>"; };
 		EA78189327596B2F00554DFA /* ContactUsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
+		EA85B7A92A6860370096E097 /* TestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObserver.swift; sourceTree = "<group>"; };
 		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		EAD08D0D29D45E23001A72F9 /* CommentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsScreen.swift; sourceTree = "<group>"; };
 		EAD2BF4127594DAB00A847BB /* StatsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
@@ -11635,6 +11639,7 @@
 				3F762E9226784A950088CD45 /* Logger.swift */,
 				3FE39A4326F8391D006E2B3A /* Screens */,
 				3FA640592670CCD40064401E /* UITestsFoundation.h */,
+				EA85B7A92A6860370096E097 /* TestObserver.swift */,
 				3F762E9426784B540088CD45 /* WireMock.swift */,
 				3F107B1829B6F7E0009B3658 /* XCTestCase+Utils.swift */,
 				3F6A8CDF2A246357009DBC2B /* XCUIApplication+SavePassword.swift */,
@@ -22996,6 +23001,7 @@
 				3F2F855026FAF227000FCDA5 /* SignupEmailScreen.swift in Sources */,
 				3F2F855826FAF227000FCDA5 /* SignupEpilogueScreen.swift in Sources */,
 				3F2F855726FAF227000FCDA5 /* WelcomeScreenSignupComponent.swift in Sources */,
+				EA85B7AB2A686C7A0096E097 /* TestObserver.swift in Sources */,
 				3F107B1929B6F7E0009B3658 /* XCTestCase+Utils.swift in Sources */,
 				3F2F855326FAF227000FCDA5 /* EditorPostSettings.swift in Sources */,
 				3F2F856026FAF235000FCDA5 /* NotificationsScreen.swift in Sources */,
@@ -23874,6 +23880,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA85B7AF2A688AB00096E097 /* TestObserver.swift in Sources */,
 				EA14532929AD874C001F3143 /* MainNavigationTests.swift in Sources */,
 				80379C6F2A5C0D8F00D924AC /* PostTests.swift in Sources */,
 				EA14532A29AD874C001F3143 /* ReaderTests.swift in Sources */,
@@ -25839,6 +25846,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA85B7B02A688B1C0096E097 /* TestObserver.swift in Sources */,
 				FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */,
 				80379C6E2A5C0D8F00D924AC /* PostTests.swift in Sources */,
 				EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3461,7 +3461,6 @@
 		EA14533829AD874C001F3143 /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA640572670CCD40064401E /* UITestsFoundation.framework */; };
 		EA14533929AD874C001F3143 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = EA14532529AD874C001F3143 /* BuildkiteTestCollector */; };
 		EA78189427596B2F00554DFA /* ContactUsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA78189327596B2F00554DFA /* ContactUsScreen.swift */; };
-		EA85B7AB2A686C7A0096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
 		EA85B7AF2A688AB00096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
 		EA85B7B02A688B1C0096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
 		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
@@ -23001,7 +23000,6 @@
 				3F2F855026FAF227000FCDA5 /* SignupEmailScreen.swift in Sources */,
 				3F2F855826FAF227000FCDA5 /* SignupEpilogueScreen.swift in Sources */,
 				3F2F855726FAF227000FCDA5 /* WelcomeScreenSignupComponent.swift in Sources */,
-				EA85B7AB2A686C7A0096E097 /* TestObserver.swift in Sources */,
 				3F107B1929B6F7E0009B3658 /* XCTestCase+Utils.swift in Sources */,
 				3F2F855326FAF227000FCDA5 /* EditorPostSettings.swift in Sources */,
 				3F2F856026FAF235000FCDA5 /* NotificationsScreen.swift in Sources */,


### PR DESCRIPTION
### Description
The objective of this PR is to make `disableAutoFillPasswords()` run only once before all the whole suite as the change is persisted in the simulators and doesn't need to run before each test. It was done by adding a [TestObserver](https://developer.apple.com/documentation/xctest/xctestobservationcenter) and running `disableAutoFillPasswords()` 
 within `testBundleWillStart(_:)`. h/t to @mokagio for the tip!
I also added some waiting for the elements because, even though it will run only once per simulator, it's still navigating through UI and still can be impacted by eventual CI slowness.

### Testing
Ci should be 🟢 