### PR TITLE
Blaze Manage Campaigns: Update CTA for empty campaigns screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -225,7 +225,7 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
         configureAndDisplayNoResults(on: view,
                                      title: Strings.NoResults.emptyTitle,
                                      subtitle: Strings.NoResults.emptySubtitle,
-                                     buttonTitle: Strings.promoteButtonTitle)
+                                     buttonTitle: Strings.createButtonTitle)
     }
 
     private func showErrorView() {
@@ -251,13 +251,12 @@ private extension BlazeCampaignsViewController {
 
     enum Strings {
         static let navigationTitle = NSLocalizedString("blaze.campaigns.title", value: "Blaze Campaigns", comment: "Title for the screen that allows users to manage their Blaze campaigns.")
-        static let promoteButtonTitle = NSLocalizedString("blaze.campaigns.promote.button.title", value: "Promote", comment: "Button title for the button that shows the Blaze flow when tapped.")
         static let createButtonTitle = NSLocalizedString("blaze.campaigns.create.button.title", value: "Create", comment: "Button title for the button that shows the Blaze flow when tapped.")
 
         enum NoResults {
             static let loadingTitle = NSLocalizedString("blaze.campaigns.loading.title", value: "Loading campaigns...", comment: "Displayed while Blaze campaigns are being loaded.")
             static let emptyTitle = NSLocalizedString("blaze.campaigns.empty.title", value: "You have no campaigns", comment: "Title displayed when there are no Blaze campaigns to display.")
-            static let emptySubtitle = NSLocalizedString("blaze.campaigns.empty.subtitle", value: "You have not created any campaigns yet. Click promote to get started.", comment: "Text displayed when there are no Blaze campaigns to display.")
+            static let emptySubtitle = NSLocalizedString("blaze.campaigns.empty.subtitle", value: "You have not created any campaigns yet. Click create to get started.", comment: "Text displayed when there are no Blaze campaigns to display.")
             static let errorTitle = NSLocalizedString("blaze.campaigns.errorTitle", value: "Oops", comment: "Title for the view when there's an error loading Blaze campiagns.")
             static let errorSubtitle = NSLocalizedString("blaze.campaigns.errorMessage", value: "There was an error loading campaigns.", comment: "Text displayed when there is a failure loading Blaze campaigns.")
         }


### PR DESCRIPTION
Part of #20764
Slack ref: p1689843728942379/1688729817.258079-slack-C04LJFS1G5P

## Description
Updates "Promote" CTA to "Create"

Before | After
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/666200cf-0075-45d4-9d74-e139b20cd2b2" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/9f613145-f617-4305-9277-bc14bf0f8a56" width=200>



## How to test
> **Warning**
> The updated subtitle copy won't be displayed unless you manually change the NSLocalizedString key

1. Switch to a site without any Blaze campaigns
2. Navigate to the Blaze campaigns list screen
3. ✅ The subtitle and CTA have been updated to "Create" 

## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
