### PR TITLE
Fix navigation bar colors in prepublishing sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -44,6 +44,8 @@ class PrepublishingNavigationController: LightNavigationController {
     init(rootViewController: UIViewController, shouldDisplayPortrait: Bool) {
         self.shouldDisplayPortrait = shouldDisplayPortrait
         super.init(rootViewController: rootViewController)
+
+        configureNavigationBar()
     }
 
     required init?(coder: NSCoder) {
@@ -54,6 +56,20 @@ class PrepublishingNavigationController: LightNavigationController {
         if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
             presentedVC.transition(to: .collapsed)
         }
+    }
+
+    /// Updates the navigation bar color so it matches the view's background.
+    ///
+    /// Originally, in dark mode the navigation bar color is grayish, but there's a few points gap on top of the
+    /// navigation bar to accommodate the `GripButton` from `BottomSheetViewController`. The bottom sheet itself
+    /// assigns the background color according to its child controller's view background color.
+    private func configureNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .basicBackground
+
+        navigationBar.scrollEdgeAppearance = appearance
+        navigationBar.compactAppearance = appearance
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -160,9 +160,6 @@ class PrepublishingViewController: UITableViewController {
                 self?.hasSelectedText = true
             }
         })
-
-        // when displayed in a popover, update content size so the window is resized to fit the current content.
-        navigationController?.preferredContentSize = tableView.contentSize
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Refs #20783 

This is a quick fix for a visual issue where the navigation bar's color appears "bugged" due to the extra gap on the top from `BottomSheetViewController` (to accommodate for the `GripButton`). To fix this, all the navigation bars displayed within `PrepublishingNavigationController` are set with the default background color. This makes the navigation bar look consistent.

Note that this issue is only affecting dark mode. This shouldn't introduce any differences in light mode, except for a thin 1pt border below the navigation bar.

Additionally, in https://github.com/wordpress-mobile/WordPress-iOS/commit/0b9a1cdae2fef97b82b7f35fc2668e02958f7391 I've removed the `preferredContentSize` assignment for now, since it's already been done in `viewDidLayoutSubviews`. I'll review later if this needs to be added back because this line messed up the sizing under certain scenarios.

Here are some previews:

### Dark 🌚 

• | Before | After
-|-|-
iPhone, portrait | <img width="396" alt="iphone_portrait_dark_before" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5eee9f69-54f3-42c3-af85-c8fcd5099f66"> | <img width="393" alt="iphone_portrait_dark_after" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/75999340-ecd3-4518-b891-45fd971da980">
iPhone, landscape | <img width="503" alt="iphone_landscape_dark_before" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c000a10b-8eb3-4bc1-b646-947499e1aeba"> | <img width="505" alt="iphone_landscape_dark_after" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/545c67d0-5a88-4168-b3f2-12fbb936f613">
iPad | <img width="350" alt="ipad_dark_before" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/88075498-634e-450e-bede-b68609a2cc01"> | <img width="339" alt="ipad_dark_after" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/702d171f-27c9-4771-81a4-1c4e5c82fec6">

### Light 🌝 

• | Before | After
-|-|-
iPhone, portrait | <img width="396" alt="iphone_portrait_light_before" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8f42c873-cf9c-427b-8faa-8b2d1302b94d"> | <img width="394" alt="iphone_portrait_light_after" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/ae9dd233-99e6-4f51-9033-eb63382ea990">
iPhone, landscape | <img width="506" alt="iphone_landscape_light_before" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5ac84b20-2c8a-4441-8a8e-15522fcfc34e"> | <img width="501" alt="iphone_landscape_light_after" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c3b7b1ad-8b79-45cf-ba81-656c492bf075">
iPad | <img width="339" alt="ipad_light_before" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/952f2a7f-73d8-4727-b195-00347f50f706"> | <img width="324" alt="ipad_light_after" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1986f402-6a2d-4d58-ac71-965588c8dcdc">

Another annoyance is that on iPad, the grouped table view somehow lost its default top inset. I haven't found out what caused this, but this issue only appears when the table is displayed in a popover context. I've spent a bit looking into this with no leads whatsoever. Will leave this aside for later since it's a non-blocking issue.

## To test

- Launch the Jetpack app.
- Create a new blog post.
- Type in some text for the title and body.
- Tap Publish.
- 🔎 Verify that the navigation bar is displayed correctly.

Repeat the tests on iPhone and iPad, and in both light and dark modes.

## Regression Notes
1. Potential unintended areas of impact
Should be none. This simply modifies the navigation bar color through `PrepublishingNavigationController`, which only affects the pre-publishing flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
