### PR TITLE
Reduce GIF buffer limits

### DIFF
--- a/WordPress/Classes/Utility/Media/GIFPlaybackStrategy.swift
+++ b/WordPress/Classes/Utility/Media/GIFPlaybackStrategy.swift
@@ -69,12 +69,12 @@ class SmallGIFPlaybackStrategy: GIFPlaybackStrategy {
 
 class MediumGIFPlaybackStrategy: GIFPlaybackStrategy {
     var maxSize = 20_000_000  // in MB
-    var frameBufferCount = 150
+    var frameBufferCount = 50
     var gifStrategy: GIFStrategy = .mediumGIFs
 }
 
 class LargeGIFPlaybackStrategy: GIFPlaybackStrategy {
     var maxSize = 50_000_000  // in MB
-    var frameBufferCount = 300
+    var frameBufferCount = 50
     var gifStrategy: GIFStrategy = .largeGIFs
 }


### PR DESCRIPTION
By default, Gifu preloads and stores 50 frames in memory, which is more than enough to support smooth playback.

The limits set by the application, especially for large images, are excessive, to say the least. If you take a 1000x1000 pixels GIF with a typical 32 bits per pixel, it'll be 4 MB per single frame/bitmap. Multiple that by 300, and that's 1.2 GB for a single GIF without taking into account how this memory is allocated – it'll most likely take even more memory.

You can't fit many large GIFs fully in memory, so the buffer is typically there to preload just some of the frames to avoid choppy playback. I'm not sure it's even necessary on modern CPUs. GIF playback has been notoriously hard to do efficiently for as long as it existed.

### To test:

I'm not sure if there is a good way to test it because even without the buffer, the system will still keep the bitmaps in memory but will clear them on memory warnings. But Gifu won't clear its frame store on memory warnings. If you set it to 300, it'll force these bitmaps to stay in memory.

I'll try to set up a good post with GIFs of different sizes to facilitate further testing and improvements in this area. But this change is a quick hotfix before Monday just to address the most egregious issues. If we switch to FLAnimatedImage, it won't really be necessary because they've already done a lot of performance testing and have an excellent sample for simulating memory pressure scenarios.

> **Note**
> Update: I uploaded a few open images from Wikimedia to my [test site](https://alextest41234.wordpress.com) for testing purposes. I'll upload more different variants tomorrow; done for today.

## Regression Notes
1. Potential unintended areas of impact: GIF playback
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
