### PR TITLE
Blaze Manage Campaigns: Update blaze campaign status colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -241,7 +241,7 @@ extension BlazeCampaignsViewController: NoResultsViewControllerDelegate {
     }
 
     func actionButtonPressed() {
-        BlazeFlowCoordinator.presentBlaze(in: self, source: .campaignList, blog: blog)
+        buttonCreateCampaignTapped()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift
@@ -55,7 +55,7 @@ struct BlazeCampaignStatusViewModel {
         case .created, .processing, .scheduled, .canceled:
             self.textColor = UIColor(
                 light: .muriel(name: .yellow, .shade80),
-                dark: .muriel(name: .yellow, .shade30)
+                dark: .muriel(name: .yellow, .shade10)
             )
             self.backgroundColor = UIColor(
                 light: .muriel(name: .yellow, .shade5),
@@ -64,7 +64,7 @@ struct BlazeCampaignStatusViewModel {
         case .rejected:
             self.textColor = UIColor(
                 light: .muriel(name: .red, .shade70),
-                dark: .muriel(name: .red, .shade30)
+                dark: .muriel(name: .red, .shade10)
             )
             self.backgroundColor = UIColor(
                 light: .muriel(name: .red, .shade5),
@@ -73,7 +73,7 @@ struct BlazeCampaignStatusViewModel {
         case .active, .approved:
             self.textColor = UIColor(
                 light: .muriel(name: .green, .shade80),
-                dark: .muriel(name: .green, .shade30)
+                dark: .muriel(name: .green, .shade10)
             )
             self.backgroundColor = UIColor(
                 light: .muriel(name: .green, .shade5),
@@ -82,7 +82,7 @@ struct BlazeCampaignStatusViewModel {
         case .finished:
             self.textColor = UIColor(
                 light: .muriel(name: .blue, .shade80),
-                dark: .muriel(name: .blue, .shade30).lightVariant() /// Explicitly using the light variant of blue
+                dark: .muriel(name: .blue, .shade10).lightVariant() /// Explicitly using the light variant of blue
             )
             self.backgroundColor = UIColor(
                 light: .muriel(name: .blue, .shade5),

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift
@@ -54,39 +54,39 @@ struct BlazeCampaignStatusViewModel {
         switch status {
         case .created, .processing, .scheduled, .canceled:
             self.textColor = UIColor(
-                light: UIColor(fromHex: 0x4F3500),
-                dark: UIColor(fromHex: 0xDEB100)
+                light: .muriel(name: .yellow, .shade80),
+                dark: .muriel(name: .yellow, .shade30)
             )
             self.backgroundColor = UIColor(
-                light: UIColor(fromHex: 0xF5E6B3),
-                dark: UIColor(fromHex: 0x332200)
+                light: .muriel(name: .yellow, .shade5),
+                dark: .muriel(name: .yellow, .shade90)
             )
         case .rejected:
             self.textColor = UIColor(
-                light: UIColor(fromHex: 0x8A2424),
-                dark: UIColor(fromHex: 0xF86368)
+                light: .muriel(name: .red, .shade70),
+                dark: .muriel(name: .red, .shade30)
             )
             self.backgroundColor = UIColor(
-                light: UIColor(fromHex: 0xFACFD2),
-                dark: UIColor(fromHex: 0x451313)
+                light: .muriel(name: .red, .shade5),
+                dark: .muriel(name: .red, .shade90)
             )
         case .active, .approved:
             self.textColor = UIColor(
-                light: UIColor(fromHex: 0x00450C),
-                dark: UIColor(fromHex: 0x00BA37)
+                light: .muriel(name: .green, .shade80),
+                dark: .muriel(name: .green, .shade30)
             )
             self.backgroundColor = UIColor(
-                light: UIColor(fromHex: 0xB8E6BF),
-                dark: UIColor(fromHex: 0x003008)
+                light: .muriel(name: .green, .shade5),
+                dark: .muriel(name: .green, .shade90)
             )
         case .finished:
             self.textColor = UIColor(
-                light: UIColor(fromHex: 0x02395C),
-                dark: UIColor(fromHex: 0x399CE3)
+                light: .muriel(name: .blue, .shade80),
+                dark: .muriel(name: .blue, .shade30).lightVariant() /// Explicitly using the light variant of blue
             )
             self.backgroundColor = UIColor(
-                light: UIColor(fromHex: 0xBBE0FA),
-                dark: UIColor(fromHex: 0x01283D)
+                light: .muriel(name: .blue, .shade5),
+                dark: .muriel(name: .blue, .shade90).lightVariant() /// Explicitly using the light variant of blue
             )
         case .unknown:
             self.textColor = .label


### PR DESCRIPTION
Slack ref: p1689763282257429-slack-C04LJFS1G5P

## Description
- Adds tracking for the empty campaigns CTA
- Maps colors from hex to muriel colors
- Updates dark text color from shade30 to shade10

Variant | Before | Hex -> Muriel [a950a49](https://github.com/wordpress-mobile/WordPress-iOS/pull/21166/commits/a950a499397f24b1cefb576bffdb2d36aa07da94) </br> (should be the same as Before) | After
-- | -- | -- | --
Light | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/4a0a7cee-fe67-4fdf-b3e2-7b0f9e68c14f" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f4624f7a-5f82-43a7-b74d-5bb3d3b0eac8" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/2347f542-1d98-4ab9-95eb-8c64575c1112" width=200>
Dark | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f7c4cca6-c09d-4de9-bf4a-a0bb58d090d9" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/873285c3-8842-47b6-956e-9dbc5baa836e" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/1c835547-e0d4-4dfd-9370-60b472608fc0" width=200>

## How to test

1. Switch to an account with blaze campaigns
2. Go to the campaigns list screen
3. ✅ The status colors remain the same for light mode
4. ✅ The status text colors have been toned down to shade10 for dark mode


## Regression Notes
1. Potential unintended areas of impact
n/a

5. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.