### PR TITLE
Fix an issue with avatars not loading in suggestions

### DIFF
--- a/WordPress/Classes/Utility/WPAvatarSource.m
+++ b/WordPress/Classes/Utility/WPAvatarSource.m
@@ -129,7 +129,7 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
     if ([components count] > 2) {
         NSString *type = components[1];
         NSString *hash = components[2];
-        if ([hash length] == 32) {
+        if ([hash length] == 32 || [hash length] == 64) {
             // Looks like a valid hash
             if ([type isEqualToString:@"avatar"]) {
                 if (avatarHash) *avatarHash = hash;


### PR DESCRIPTION
Fixes #21155

The reason it's not working is the following change to the avatar hashes: pb6Nl-gyD-p2.

The proper fix will require a little more work. The app shouldn't make any assumptions about the contents of these identifiers. It should also not use `WPAvatarSource` because it's yet another non-centralized image loading system in the app with its own cache, which contributes to high memory usage issues, and it fails to reuse the caches and there work for fetching the same avatars in other places of the app.

To test:

- Open Reader
- Open one of the A8C posts
- Tap to reply and start typing a user name (staring with @ sign)
- Verify that the avatars are loaded

## Regression Notes
1. Potential unintended areas of impact: user suggestions list in reader replies
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
