### PR TITLE
Jetpack Social: Add footer and subscribe flow for prepublishing social accounts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+class PrepublishingSocialAccountsTableFooterView: UITableViewHeaderFooterView, Reusable {
+
+    init(remaining: Int,
+         showsWarning: Bool,
+         onButtonTap: (() -> Void)?,
+         reuseIdentifier: String? = PrepublishingSocialAccountsTableFooterView.defaultReuseID) {
+        super.init(reuseIdentifier: reuseIdentifier)
+
+        let footerView = PrepublishingSocialAccountsFooterView(remaining: remaining,
+                                                               showsWarning: showsWarning,
+                                                               onButtonTap: onButtonTap)
+        let viewToEmbed = UIView.embedSwiftUIView(footerView)
+        contentView.addSubview(viewToEmbed)
+        contentView.pinSubviewToAllEdges(viewToEmbed)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - SwiftUI View
+
+struct PrepublishingSocialAccountsFooterView: View {
+
+    @State var remaining: Int
+    @State var showsWarning: Bool
+    var onButtonTap: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 16.0) {
+            remainingSharesText
+            subscribeButton
+        }
+        .padding(EdgeInsets(top: 24.0, leading: 0, bottom: 0, trailing: 0))
+    }
+
+    var remainingSharesText: some View {
+        HStack(alignment: .top, spacing: 6.0) {
+            if showsWarning {
+                Image("icon-warning")
+                    .resizable()
+                    .frame(width: 16.0, height: 16.0)
+                    .padding(2.0)
+                    .accessibilityElement()
+                    .accessibilityLabel(Constants.warningIconAccessibilityText)
+            }
+            Text(String(format: Constants.remainingSharesLabelTextFormat, remaining))
+                .font(.callout)
+                .foregroundColor(Color(showsWarning ? Constants.warningColor : .label))
+        }
+    }
+
+    var subscribeButton: some View {
+        Button {
+            onButtonTap?()
+        } label: {
+            Text(Constants.subscribeButtonText)
+                .padding(12.0)
+                .frame(maxWidth: .infinity) // needs to be set here to make the button stretch full-width.
+        }
+        .buttonStyle(SubscribeButtonStyle())
+    }
+
+    private struct SubscribeButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .font(Constants.buttonLabelFont)
+                .foregroundColor(.white)
+                .background(Color(configuration.isPressed ? Constants.buttonHighlightedColor : Constants.buttonColor))
+                .clipShape(RoundedRectangle(cornerRadius: 8.0))
+        }
+    }
+
+    private enum Constants {
+        static let buttonLabelFont = Font(WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold))
+        static let buttonColor = UIColor.primary
+        static let buttonHighlightedColor = UIColor.muriel(color: .jetpackGreen, .shade70)
+        static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))
+
+        static let remainingSharesLabelTextFormat = NSLocalizedString(
+            "prepublishing.socialAccounts.footer.remainingShares.text",
+            value: "%1$d social shares remaining in the next 30 days",
+            comment: """
+                Text shown below the list of social accounts to indicate how many social shares available for the site.
+                Note that the '30 days' part is intended to be a static value.
+                %1$d is a placeholder for the amount of remaining shares.
+                Example: 27 social shares remaining in the next 30 days
+                """
+        )
+
+        static let subscribeButtonText = NSLocalizedString(
+            "prepublishing.socialAccounts.footer.button.text",
+            value: "Subscribe to share more",
+            comment: "The label for a call-to-action button in the social accounts' footer section."
+        )
+
+        static let warningIconAccessibilityText = NSLocalizedString(
+            "prepublishing.socialAccounts.footer.warningIcon.a11y",
+            value: "Warning",
+            comment: "a VoiceOver description for the warning icon to hint that the remaining shares are low."
+        )
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -77,7 +77,7 @@ struct PrepublishingSocialAccountsFooterView: View {
     }
 
     private enum Constants {
-        static let buttonLabelFont = Font(WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold))
+        static let buttonLabelFont = Font.title3.weight(.semibold)
         static let buttonColor = UIColor.primary
         static let buttonHighlightedColor = UIColor.muriel(color: .jetpackGreen, .shade70)
         static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -51,6 +51,8 @@ struct PrepublishingSocialAccountsFooterView: View {
                 .font(.callout)
                 .foregroundColor(Color(showsWarning ? Constants.warningColor : .label))
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isStaticText)
     }
 
     var subscribeButton: some View {
@@ -98,7 +100,7 @@ struct PrepublishingSocialAccountsFooterView: View {
         )
 
         static let warningIconAccessibilityText = NSLocalizedString(
-            "prepublishing.socialAccounts.footer.warningIcon.a11y",
+            "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint",
             value: "Warning",
             comment: "a VoiceOver description for the warning icon to hint that the remaining shares are low."
         )

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -78,11 +78,11 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
         self.blogID = blogID
         self.connections = model.services.flatMap { service in
             service.connections.map {
-                .init(service: service.name, account: $0.account, keyringID: $0.keyringID, isOn: false)
+                .init(service: service.name, account: $0.account, keyringID: $0.keyringID, isOn: $0.enabled)
             }
         }
         self.shareMessage = model.message
-        self.sharingLimit = .init(remaining: 1, limit: 30)
+        self.sharingLimit = model.sharingLimit
         self.coreDataStack = coreDataStack
         self.service = blogService ?? BlogService(coreDataStack: coreDataStack)
         self.canInteractWithDisabledConnections = model.enabledConnectionsCount < (sharingLimit?.remaining ?? .max)

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -6,7 +6,7 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
 
     private let coreDataStack: CoreDataStack
 
-    private let postObjectID: NSManagedObjectID
+    private let blogID: Int
 
     private var connections: [Connection]
 
@@ -56,10 +56,8 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(postObjectID: NSManagedObjectID,
-         model: PrepublishingAutoSharingModel,
-         coreDataStack: CoreDataStack = ContextManager.shared) {
-        self.postObjectID = postObjectID
+    init(blogID: Int, model: PrepublishingAutoSharingModel, coreDataStack: CoreDataStack = ContextManager.shared) {
+        self.blogID = blogID
         self.connections = model.services.flatMap { service in
             service.connections.map {
                 .init(service: service.name, account: $0.account, keyringID: $0.keyringID, isOn: $0.enabled)
@@ -240,13 +238,13 @@ private extension PrepublishingSocialAccountsViewController {
     func makeCheckoutViewController() -> UIViewController? {
         coreDataStack.performQuery { [weak self] context in
             guard let self,
-                  let post = (try? context.existingObject(with: self.postObjectID)) as? Post,
-                  let host = post.blog.hostname,
+                  let blog = try? Blog.lookup(withID: self.blogID, in: context),
+                  let host = blog.hostname,
                   let url = URL(string: "https://wordpress.com/checkout/\(host)/jetpack_social_basic_yearly") else {
                 return nil
             }
 
-            return WebViewControllerFactory.controller(url: url, blog: post.blog, source: Constants.webViewSource)
+            return WebViewControllerFactory.controller(url: url, blog: blog, source: Constants.webViewSource)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -88,11 +88,10 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
         super.viewDidLayoutSubviews()
 
         // manually configure preferredContentSize for precise drawer sizing.
-        if let safeAreaInsets = UIApplication.shared.mainWindow?.safeAreaInsets {
-            preferredContentSize = CGSize(width: tableView.contentSize.width,
-                                          height: tableView.contentSize.height + safeAreaInsets.bottom + 16.0)
-            onContentHeightUpdated?()
-        }
+        let safeBottomInset = UIApplication.shared.mainWindow?.safeAreaInsets.bottom ?? Constants.defaultBottomInset
+        preferredContentSize = CGSize(width: tableView.contentSize.width,
+                                      height: tableView.contentSize.height + safeBottomInset + 16.0)
+        onContentHeightUpdated?()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -235,8 +234,7 @@ private extension PrepublishingSocialAccountsViewController {
         }
 
         let navigationController = UINavigationController(rootViewController: checkoutViewController)
-        navigationController.modalPresentationStyle = .overFullScreen // .fullScreen messes up the drawer position.
-        present(navigationController, animated: true)
+        show(navigationController, sender: nil)
     }
 
     func makeCheckoutViewController() -> UIViewController? {
@@ -295,6 +293,8 @@ private extension PrepublishingSocialAccountsViewController {
     enum Constants {
         static let disabledCellImageOpacity = 0.36
         static let cellImageSize = CGSize(width: 28.0, height: 28.0)
+
+        static let defaultBottomInset: CGFloat = 34.0
 
         static let accountCellIdentifier = "AccountCell"
         static let messageCellIdentifier = "MessageCell"

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 class PrepublishingSocialAccountsViewController: UITableViewController {
 
     // MARK: Properties
@@ -97,6 +99,16 @@ extension PrepublishingSocialAccountsViewController {
         }
 
         showEditMessageScreen()
+    }
+
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard let sharingLimit else {
+            return nil
+        }
+
+        return PrepublishingSocialAccountsTableFooterView(remaining: sharingLimit.remaining,
+                                                          showsWarning: true,
+                                                          onButtonTap: nil)
     }
 }
 
@@ -226,4 +238,15 @@ private extension PrepublishingSocialAccountsViewController {
         )
     }
 
+}
+
+extension PrepublishingSocialAccountsViewController: DrawerPresentable {
+
+    var collapsedHeight: DrawerHeight {
+        .intrinsicHeight
+    }
+
+    var scrollableView: UIScrollView? {
+        tableView
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -37,6 +37,11 @@ extension PrepublishingViewController {
 
         let model = makeAutoSharingModel()
         let socialAccountsViewController = PrepublishingSocialAccountsViewController(model: model)
+
+        socialAccountsViewController.onContentHeightUpdated = { [weak self] in
+            self?.presentedVC?.containerViewWillLayoutSubviews()
+        }
+
         self.navigationController?.pushViewController(socialAccountsViewController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -36,7 +36,9 @@ extension PrepublishingViewController {
         }
 
         let model = makeAutoSharingModel()
-        let socialAccountsViewController = PrepublishingSocialAccountsViewController(model: model)
+        let socialAccountsViewController = PrepublishingSocialAccountsViewController(postObjectID: post.objectID,
+                                                                                     model: model,
+                                                                                     coreDataStack: coreDataStack)
 
         socialAccountsViewController.onContentHeightUpdated = { [weak self] in
             self?.presentedVC?.containerViewWillLayoutSubviews()

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -31,12 +31,13 @@ extension PrepublishingViewController {
     }
 
     func didTapAutoSharingCell() {
-        guard hasExistingConnections else {
+        guard let postBlogID,
+              hasExistingConnections else {
             return
         }
 
         let model = makeAutoSharingModel()
-        let socialAccountsViewController = PrepublishingSocialAccountsViewController(postObjectID: post.objectID,
+        let socialAccountsViewController = PrepublishingSocialAccountsViewController(blogID: postBlogID,
                                                                                      model: model,
                                                                                      coreDataStack: coreDataStack)
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -26,7 +26,7 @@ enum PrepublishingIdentifier {
 class PrepublishingViewController: UITableViewController {
     let post: Post
     let identifiers: [PrepublishingIdentifier]
-    let coreDataStack: CoreDataStack
+    let coreDataStack: CoreDataStackSwift
     let persistentStore: UserPersistentRepository
 
     lazy var postBlogID: Int? = {
@@ -78,7 +78,7 @@ class PrepublishingViewController: UITableViewController {
     init(post: Post,
          identifiers: [PrepublishingIdentifier],
          completion: @escaping (CompletionResult) -> (),
-         coreDataStack: CoreDataStack = ContextManager.shared,
+         coreDataStack: CoreDataStackSwift = ContextManager.shared,
          persistentStore: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.post = post
         self.identifiers = identifiers

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5587,6 +5587,8 @@
 		FE76C5E0293A63A800573C92 /* UIApplication+AppAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */; };
 		FE7B9A872A6A613000488791 /* PrepublishingSocialAccountsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */; };
 		FE7B9A882A6A613000488791 /* PrepublishingSocialAccountsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */; };
+		FE7B9A8A2A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */; };
+		FE7B9A8B2A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */; };
 		FE7FAABB299A36570032A6F2 /* WPComJetpackRemoteInstallViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7FAABA299A36570032A6F2 /* WPComJetpackRemoteInstallViewModelTests.swift */; };
 		FE7FAABE299A998E0032A6F2 /* EventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7FAABC299A98B90032A6F2 /* EventTracker.swift */; };
 		FE7FAABF299A998F0032A6F2 /* EventTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7FAABC299A98B90032A6F2 /* EventTracker.swift */; };
@@ -9410,6 +9412,7 @@
 		FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinator.swift; sourceTree = "<group>"; };
 		FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingSocialAccountsViewController.swift; sourceTree = "<group>"; };
+		FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingSocialAccountsTableFooterView.swift; sourceTree = "<group>"; };
 		FE7FAABA299A36570032A6F2 /* WPComJetpackRemoteInstallViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComJetpackRemoteInstallViewModelTests.swift; sourceTree = "<group>"; };
 		FE7FAABC299A98B90032A6F2 /* EventTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTracker.swift; sourceTree = "<group>"; };
 		FE9438B12A050251006C40EC /* BlockEditorSettings_GutenbergEditorSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettings_GutenbergEditorSettingsTests.swift; sourceTree = "<group>"; };
@@ -18225,6 +18228,7 @@
 				FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */,
 				FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */,
 				FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */,
+				FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */,
 			);
 			path = Prepublishing;
 			sourceTree = "<group>";
@@ -22726,6 +22730,7 @@
 				80EF929028105CFA0064A971 /* QuickStartFactory.swift in Sources */,
 				082635BB1CEA69280088030C /* MenuItemsViewController.m in Sources */,
 				822876F11E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift in Sources */,
+				FE7B9A8A2A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift in Sources */,
 				E15632CC1EB9ECF40035A099 /* TableViewKeyboardObserver.swift in Sources */,
 				E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */,
 				B522C4F81B3DA79B00E47B59 /* NotificationSettingsViewController.swift in Sources */,
@@ -23957,6 +23962,7 @@
 				FABB20E22602FC2C00C8785C /* NotificationSyncMediator.swift in Sources */,
 				FABB20E42602FC2C00C8785C /* ThemeBrowserHeaderView.swift in Sources */,
 				FABB20E52602FC2C00C8785C /* SiteStatsInformation.swift in Sources */,
+				FE7B9A8B2A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift in Sources */,
 				FABB20E62602FC2C00C8785C /* TitleSubtitleHeader.swift in Sources */,
 				FABB20E82602FC2C00C8785C /* AppAppearance.swift in Sources */,
 				FABB20E92602FC2C00C8785C /* ReaderTabViewController.swift in Sources */,


### PR DESCRIPTION
Refs #20783 

In this PR:

- Added a table footer view, containing the remaining shares label and the subscribe button. This footer is only shown when the site has sharing limits.
- Tapping the subscribe button shows the checkout page in an authenticated web view.
- When dismissed, the view controller will try to sync the sharing limit in case the user did make a purchase. When the user obtains unlimited sharing, the social accounts sheet should be refreshed.

Some previews:

Normal state | Warning state
-|-
![footer_normal](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/ccc00c7e-93dd-430a-952c-185339733c5b) | ![footer_warning](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1dc1b3a4-7e45-44e8-998a-7fd1f07b3793)

> **Warning**
> Changes in this view are still isolated. In the next PR, the changes will be propagated back to the pre-publishing sheet, and persisted into Core Data.
> 
> Additionally, I've also noticed some oddities with the table view displayed in a popover. Somehow the default top padding of the table is now gone, and I'm not sure what caused it. I'm beginning to think it's a framework thing, but I'll leave it be for now since it's a minor visual issue.

## To test

### Case 1: Testing limited sharing state

- Launch the Jetpack app.
- Switch to a site with limited social sharing.
- Open a draft, or create a new blog post along with some title and text.
- Tap Publish.
- Tap the auto-sharing cell.
- 🔎  Verify that the footer is displayed.

### Case 2: Testing unlimited sharing state

- Repeat the steps in Case 1 with a WP.com site.
- 🔎 Verify that the footer view is NOT displayed.

### Case 3: Testing the warning state

To make things easy, let's make 2 small changes in the `PrepublishingSocialAccountsViewController`:

<details>
<summary>Test setup</summary>

---

In line 68, set all accounts to be disabled:

```swift
.init(service: service.name, account: $0.account, keyringID: $0.keyringID, isOn: $0.enabled)
```

And in line 72, replace the assigned `SharingLimit` with a test instance:

```swift
self.sharingLimit = .init(remaining: 1, limit: 30)
```

---

</details>

- Launch the Jetpack app again, and follow the testing steps in Case 1.
- 🔎  Verify that the remaining shares text is shown with a warning style.

### Case 4: Testing the subscribe flow

In addition to the test setup above, let's now going to make additional changes to simplify testing:

<details>

<summary>Additional test setup</summary>

---

Replace the entire body of `onCheckoutDismissed()` in line 261-276 with:

```swift
        DispatchQueue.main.async { [weak self] in
            self?.sharingLimit = nil // assume the upgrade is successful.
            self?.toggleInteractivityIfNeeded()
            self?.tableView.reloadData()
        }
```

This simply assumes that the upgrade is successful (sharing limit is removed), and the table view should be reloaded properly.

---

</details>

- With the test setups set, launch the Jetpack app and follow the testing steps from Case 1.
- Enable one of the accounts. The other account should now be in a disabled/non-interactive state.
- Tap the Subscribe button.
- Dismiss the web view.
- 🔎 Verify that the footer view is now gone.
- 🔎 Verify that the account switches can be interacted with.

### Additional

- Test with accessibility font size.
- Test with landscape orientation.
- Test with iPad.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
