### PR TITLE
Jetpack Social: Create Jetpack Social no connection dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -122,7 +122,7 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
     struct Constants {
         static let hideNoConnectionViewKey = "dashboard-social-no-connection-view-hidden"
         static let connectTitle = NSLocalizedString("dashboard.card.social.noconnections.title",
-                                                    value: "Connect your social profiles",
+                                                    value: "Share across your social networks",
                                                     comment: "Title for the Jetpack Social dashboard card when the user has no social connections.")
         static let hideThis = NSLocalizedString("dashboard.card.social.menu.hide",
                                                 value: "Hide this",

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+import AutomatticTracks
+
+class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
+
+    // MARK: - Properties
+
+    private let repository: UserPersistentRepository
+
+    private var blog: Blog?
+    private weak var dashboardViewController: BlogDashboardViewController?
+
+    private(set) var displayState: DisplayState = .none {
+        didSet {
+            guard oldValue != displayState else {
+                return
+            }
+            updateUI()
+        }
+    }
+
+    private var isNoConnectionViewHidden: Bool {
+        get {
+            guard let dotComID = blog?.dotComID?.stringValue,
+                  let isNoConnectionHidden = noConnectionHiddenSites[dotComID] else {
+                return false
+            }
+            return isNoConnectionHidden
+        }
+        set {
+            guard let dotComID = blog?.dotComID?.stringValue else {
+                return
+            }
+            var currentHiddenSites = noConnectionHiddenSites
+            currentHiddenSites[dotComID] = true
+            repository.set(currentHiddenSites, forKey: Constants.hideNoConnectionViewKey)
+        }
+    }
+
+    private var noConnectionHiddenSites: [String: Bool] {
+        let dictionary = repository.dictionary(forKey: Constants.hideNoConnectionViewKey) as? [String: Bool]
+        return dictionary ?? [:]
+    }
+
+    // MARK: - UI Properties
+
+    private var cardTitle: String {
+        switch displayState {
+        // TODO: Out of shares title
+        case .noConnections:
+            return Constants.connectTitle
+        default:
+            return ""
+        }
+    }
+
+    private var cardFrameView: BlogDashboardCardFrameView {
+        let frameView = BlogDashboardCardFrameView()
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        frameView.setTitle(cardTitle)
+        frameView.onEllipsisButtonTap = { }
+        frameView.ellipsisButton.showsMenuAsPrimaryAction = true
+        frameView.ellipsisButton.menu = contextMenu
+
+        return frameView
+    }
+
+    private var contextMenu: UIMenu {
+        // TODO: Out of shares context menu handler
+        let hideNoConnectionView: UIActionHandler = { [weak self] _ in
+            guard let self else {
+                return
+            }
+
+            self.isNoConnectionViewHidden = true
+            self.dashboardViewController?.reloadCardsLocally()
+        }
+
+        let hideThisAction = UIAction(title: Constants.hideThis,
+                                      image: Constants.hideThisImage,
+                                      attributes: [UIMenuElement.Attributes.destructive],
+                                      handler: hideNoConnectionView)
+        return UIMenu(title: String(), options: .displayInline, children: [hideThisAction])
+    }
+
+    // MARK: - Initializers
+
+    override init(frame: CGRect) {
+        self.repository = UserPersistentStoreFactory.instance()
+        super.init(frame: frame)
+    }
+
+    init(repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+        self.repository = repository
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - DashboardCollectionViewCell
+
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        self.blog = blog
+        self.dashboardViewController = viewController
+        updateDisplayState(for: blog)
+    }
+
+    // MARK: - Functions
+
+    static func shouldShowCard(for blog: Blog) -> Bool {
+        guard FeatureFlag.jetpackSocial.enabled else {
+            return false
+        }
+        // TODO: Show when user is out of shares
+        return showNoConnectionView(for: blog)
+    }
+
+    // MARK: - Constants
+
+    struct Constants {
+        static let hideNoConnectionViewKey = "dashboard-social-no-connection-view-hidden"
+        static let connectTitle = NSLocalizedString("dashboard.card.social.noconnections.title",
+                                                    value: "Connect your social profiles",
+                                                    comment: "Title for the Jetpack Social dashboard card when the user has no social connections.")
+        static let hideThis = NSLocalizedString("dashboard.card.social.menu.hide",
+                                                value: "Hide this",
+                                                comment: "Title for a menu action in the context menu on the Jetpack Social dashboard card.")
+        static let hideThisImage = UIImage(systemName: "minus.circle")
+        static let cardInsets = EdgeInsets(top: 8.0, leading: 16.0, bottom: 8.0, trailing: 16.0)
+    }
+
+    enum DisplayState {
+        case none
+        case noConnections
+        // TODO: State for when a user is out of shares
+    }
+
+}
+
+// MARK: - Private Functions
+
+private extension DashboardJetpackSocialCardCell {
+
+    static func showNoConnectionView(for blog: Blog) -> Bool {
+        guard let context = blog.managedObjectContext,
+              let dotComID = blog.dotComID?.stringValue,
+              let services = try? PublicizeService.allPublicizeServices(in: context),
+              let connections = blog.connections else {
+            return false
+        }
+        let repository = UserPersistentStoreFactory.instance()
+        let hideNoConnectionViewKey = DashboardJetpackSocialCardCell.Constants.hideNoConnectionViewKey
+        let hiddenSites = (repository.dictionary(forKey: hideNoConnectionViewKey) as? [String: Bool]) ?? [:]
+        let isNoConnectionViewHidden = hiddenSites[dotComID] ?? false
+
+        return blog.supportsPublicize()
+        && services.count > 0
+        && connections.count == 0
+        && !isNoConnectionViewHidden
+    }
+
+    func updateDisplayState(for blog: Blog) {
+        // TODO: State for when a user is out of shares
+        let showNoConnectionView = DashboardJetpackSocialCardCell.showNoConnectionView(for: blog)
+        displayState = showNoConnectionView ? .noConnections : .none
+    }
+
+    func updateUI() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.updateUI()
+            }
+            return
+        }
+
+        // TODO: Out of shares view
+        if let noConnectionCard = createNoConnectionCard() {
+            for subview in contentView.subviews {
+                subview.removeFromSuperview()
+            }
+            contentView.addSubview(noConnectionCard)
+            contentView.pinSubviewToAllEdges(noConnectionCard)
+            contentView.layoutIfNeeded()
+        }
+    }
+
+    func createNoConnectionCard() -> UIView? {
+        guard let context = blog?.managedObjectContext,
+              let services = try? PublicizeService.allPublicizeServices(in: context) else {
+            // Note: The context and publicize services are checked prior to this call in
+            // `showNoConnectionView`. This scenario *shouldn't* be possible.
+            assertionFailure("No managed object context or publicize services")
+            let error = JetpackSocialError.noConnectionViewInvalidState
+            CrashLogging.main.logError(error, userInfo: ["source": "social_dashboard_card"])
+            return nil
+        }
+        let card = cardFrameView
+        let viewModel = JetpackSocialNoConnectionViewModel(services: services,
+                                                           padding: Constants.cardInsets,
+                                                           hideNotNow: true,
+                                                           bodyTextColor: .secondaryLabel,
+                                                           onConnectTap: onConnectTap())
+        let noConnectionViewController = JetpackSocialNoConnectionView.createHostController(with: viewModel)
+        card.add(subview: noConnectionViewController.view)
+        return card
+    }
+
+    func onConnectTap() -> () -> Void {
+        return { [weak self] in
+            guard let self,
+                  let blog = self.blog,
+                  let controller = SharingViewController(blog: blog, delegate: self) else {
+                return
+            }
+            self.dashboardViewController?.navigationController?.pushViewController(controller, animated: true)
+        }
+    }
+
+}
+
+// MARK: - SharingViewControllerDelegate
+
+extension DashboardJetpackSocialCardCell: SharingViewControllerDelegate {
+
+    func didChangePublicizeServices() {
+        dashboardViewController?.reloadCardsLocally()
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -15,6 +15,7 @@ enum DashboardCard: String, CaseIterable {
     case freeToPaidPlansDashboardCard
     case domainRegistration
     case todaysStats = "todays_stats"
+    case jetpackSocial
     case draftPosts
     case scheduledPosts
     case pages
@@ -64,6 +65,8 @@ enum DashboardCard: String, CaseIterable {
             return DashboardPagesListCardCell.self
         case .activityLog:
             return DashboardActivityLogCardCell.self
+        case .jetpackSocial:
+            return DashboardJetpackSocialCardCell.self
         }
     }
 
@@ -112,6 +115,8 @@ enum DashboardCard: String, CaseIterable {
             return DashboardPagesListCardCell.shouldShowCard(for: blog) && shouldShowRemoteCard(apiResponse: apiResponse)
         case .activityLog:
             return DashboardActivityLogCardCell.shouldShowCard(for: blog) && shouldShowRemoteCard(apiResponse: apiResponse)
+        case .jetpackSocial:
+            return DashboardJetpackSocialCardCell.shouldShowCard(for: blog)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -64,7 +64,7 @@ private func makeKey(for card: DashboardCard) -> String? {
         return "pages-card-enabled-site-settings"
     case .quickStart:
         return "quick-start-card-enabled-site-settings"
-    case .jetpackBadge, .jetpackInstall, .failure, .ghost, .personalize, .empty:
+    case .jetpackBadge, .jetpackInstall, .jetpackSocial, .failure, .ghost, .personalize, .empty:
         return nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -63,7 +63,7 @@ private extension DashboardCard {
             case .newSite:
                 return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Next steps", comment: "Card title for the pesonalization menu")
             }
-        case .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .domainsDashboardCard, .freeToPaidPlansDashboardCard, .domainRegistration:
+        case .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .domainsDashboardCard, .freeToPaidPlansDashboardCard, .domainRegistration, .jetpackSocial:
             assertionFailure("\(self) card should not appear in the personalization menus")
             return "" // These cards don't appear in the personalization menus
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -15,6 +15,7 @@ struct JetpackSocialNoConnectionView: View {
             .accessibilityLabel(Constants.iconGroupAccessibilityLabel)
             Text(Constants.bodyText)
                 .font(.callout)
+                .foregroundColor(Color(viewModel.bodyTextColor))
             HStack {
                 Text(Constants.connectText)
                     .font(.callout)
@@ -33,6 +34,7 @@ struct JetpackSocialNoConnectionView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(viewModel.padding)
         .background(Color(viewModel.preferredBackgroundColor))
     }
@@ -64,6 +66,7 @@ class JetpackSocialNoConnectionViewModel: ObservableObject {
     let padding: EdgeInsets
     let hideNotNow: Bool
     let preferredBackgroundColor: UIColor
+    let bodyTextColor: UIColor
     let onConnectTap: (() -> Void)?
     let onNotNowTap: (() -> Void)?
     @MainActor @Published var icons: [UIImage] = [UIImage()]
@@ -72,11 +75,13 @@ class JetpackSocialNoConnectionViewModel: ObservableObject {
          padding: EdgeInsets = Constants.defaultPadding,
          hideNotNow: Bool = false,
          preferredBackgroundColor: UIColor? = nil,
+         bodyTextColor: UIColor = .label,
          onConnectTap: (() -> Void)? = nil,
          onNotNowTap: (() -> Void)? = nil) {
         self.padding = padding
         self.hideNotNow = hideNotNow
         self.preferredBackgroundColor = preferredBackgroundColor ?? Constants.defaultBackgroundColor
+        self.bodyTextColor = bodyTextColor
         self.onConnectTap = onConnectTap
         self.onNotNowTap = onNotNowTap
         updateIcons(services)

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -131,7 +131,7 @@ private struct Constants {
                                             value: "Increase your traffic by auto-sharing your posts with your friends on social media.",
                                             comment: "Body text for the Jetpack Social no connection view")
     static let connectText = NSLocalizedString("social.noconnection.connect",
-                                               value: "Connect your profiles",
+                                               value: "Connect accounts",
                                                comment: "Title for the connect button to add social sharing for the Jetpack Social no connection view")
     static let notNowText = NSLocalizedString("social.noconnection.notnow",
                                               value: "Not now",

--- a/WordPress/Jetpack/Classes/Utility/JetpackSocialError.swift
+++ b/WordPress/Jetpack/Classes/Utility/JetpackSocialError.swift
@@ -1,4 +1,5 @@
 
 enum JetpackSocialError: Error {
     case missingSharingLimit
+    case noConnectionViewInvalidState
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2117,6 +2117,9 @@
 		83A1B1A328AFE89F00E737AC /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
 		83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
+		83BFAE482A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */; };
+		83BFAE492A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */; };
+		83BFAE502A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BFAE4F2A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift */; };
 		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83DC5C462A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */; };
@@ -7503,6 +7506,8 @@
 		839435922847F2200019A94F /* WordPress 143.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 143.xcdatamodel"; sourceTree = "<group>"; };
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
 		83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsAttribution.swift; sourceTree = "<group>"; };
+		83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardJetpackSocialCardCell.swift; sourceTree = "<group>"; };
+		83BFAE4F2A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardJetpackSocialCardCellTests.swift; sourceTree = "<group>"; };
 		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialSettingsRemainingSharesView.swift; sourceTree = "<group>"; };
 		83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialError.swift; sourceTree = "<group>"; };
@@ -13470,6 +13475,22 @@
 			path = Social;
 			sourceTree = "<group>";
 		};
+		83BFAE4D2A6EBF9900C7B683 /* Blog Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				83BFAE4E2A6EBF9900C7B683 /* Cards */,
+			);
+			path = "Blog Dashboard";
+			sourceTree = "<group>";
+		};
+		83BFAE4E2A6EBF9900C7B683 /* Cards */ = {
+			isa = PBXGroup;
+			children = (
+				83BFAE4F2A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift */,
+			);
+			path = Cards;
+			sourceTree = "<group>";
+		};
 		850BD4531922F95C0032F3AD /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -13793,11 +13814,12 @@
 				FA8E2FE327C6377D00DA0982 /* Quick Start */,
 				8BF9E03627B1AD2100915B27 /* Stats */,
 				8B4DDF24278F3AF60022494D /* Posts */,
-				83796698299C048E004A92B9 /* DashboardJetpackInstallCardCell.swift */,
 				0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */,
 				011896A129D5AF0700D34BA9 /* BlogDashboardCardConfigurable.swift */,
 				0C35FFF529CBB5DE00D224EB /* BlogDashboardEmptyStateCell.swift */,
 				F4026B1C2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift */,
+				83796698299C048E004A92B9 /* DashboardJetpackInstallCardCell.swift */,
+				83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */,
 			);
 			path = Cards;
 			sourceTree = "<group>";
@@ -15780,6 +15802,7 @@
 		BEC8A3FD1B4BAA08001CB8C3 /* Blog */ = {
 			isa = PBXGroup;
 			children = (
+				83BFAE4D2A6EBF9900C7B683 /* Blog Dashboard */,
 				027AC51F2278982D0033E56E /* DomainCredit */,
 				BE1071FD1BC75FCF00906AFF /* Style */,
 				02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */,
@@ -22665,6 +22688,7 @@
 				E174F6E6172A73960004F23A /* WPAccount.m in Sources */,
 				FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */,
 				98467A3F221CD48500DF51AE /* SiteStatsDetailTableViewController.swift in Sources */,
+				83BFAE482A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift in Sources */,
 				E11450DF1C4E47E600A6BD0F /* MessageAnimator.swift in Sources */,
 				C77FC90F2800CAC100726F00 /* OnboardingEnableNotificationsViewController.swift in Sources */,
 				FA4F65A72594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift in Sources */,
@@ -23747,6 +23771,7 @@
 				AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */,
 				08E77F471EE9D72F006F9515 /* MediaThumbnailExporterTests.swift in Sources */,
 				59FBD5621B5684F300734466 /* ThemeServiceTests.m in Sources */,
+				83BFAE502A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift in Sources */,
 				0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */,
 				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,
 				931215E1267DE1C0008C3B69 /* StatsTotalRowDataTests.swift in Sources */,
@@ -24802,6 +24827,7 @@
 				F4DDE2C329C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */,
 				FABB23402602FC2C00C8785C /* ReaderStreamViewController.swift in Sources */,
 				98ED5964265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */,
+				83BFAE492A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift in Sources */,
 				FABB23412602FC2C00C8785C /* SeparatorsView.swift in Sources */,
 				FABB23422602FC2C00C8785C /* JetpackScanCoordinator.swift in Sources */,
 				FABB23432602FC2C00C8785C /* WPStyleGuide+ReadableMargins.m in Sources */,

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
@@ -127,13 +127,13 @@ private extension DashboardJetpackSocialCardCellTests {
     func createTestBlog(isPublicizeSupported: Bool = true,
                         hasServices: Bool = true,
                         hasConnections: Bool = false) -> Blog {
-        let blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: mainContext) as! Blog
-        blog.account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: mainContext) as? WPAccount
-        blog.capabilities = [Blog.Capability.PublishPosts.rawValue: true]
-        blog.dotComID = 12345 as NSNumber
+        var builder = BlogBuilder(mainContext)
+            .withAnAccount()
+            .with(dotComID: 12345)
+            .with(capabilities: [.PublishPosts])
 
         if isPublicizeSupported {
-            blog.options = ["active_modules": ["value": ["publicize"]]]
+            builder = builder.with(modules: ["publicize"])
         }
 
         if hasServices {
@@ -142,9 +142,9 @@ private extension DashboardJetpackSocialCardCellTests {
 
         if hasConnections {
             let connection = PublicizeConnection(context: mainContext)
-            blog.connections = [connection]
+            builder = builder.with(connections: [connection])
         }
-        return blog
+        return builder.build()
     }
 
     func createPublicizeService() -> PublicizeService {

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import WordPress
+
+class DashboardJetpackSocialCardCellTests: CoreDataTestCase {
+
+    private let featureFlags = FeatureFlagOverrideStore()
+
+    override func setUp() {
+        super.setUp()
+
+        try? featureFlags.override(FeatureFlag.jetpackSocial, withValue: true)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        try? featureFlags.override(FeatureFlag.jetpackSocial, withValue: FeatureFlag.jetpackSocial.originalValue)
+    }
+
+    // MARK: - `shouldShowCard` tests
+
+    func testCardDisplays() {
+        // Given, when
+        let blog = createTestBlog()
+
+        // Then
+        XCTAssertTrue(shouldShowCard(for: blog))
+    }
+
+    func testCardDoesNotDisplayWhenFeatureDisabled() throws {
+        // Given, when
+        let blog = createTestBlog()
+
+        // When
+        try featureFlags.override(FeatureFlag.jetpackSocial, withValue: false)
+
+        // Then
+        XCTAssertFalse(shouldShowCard(for: blog))
+    }
+
+    func testCardNotDisplayWhenPublicizeNotSupported() {
+        // Given, when
+        let blog = createTestBlog(isPublicizeSupported: false)
+
+        // Then
+        XCTAssertFalse(shouldShowCard(for: blog))
+    }
+
+    func testCardNotDisplayWhenPublicizeServicesDoesNotExist() throws {
+        // Given, when
+        let blog = createTestBlog(hasServices: false)
+
+        // Then
+        XCTAssertFalse(shouldShowCard(for: blog))
+    }
+
+    func testCardDoesNotDisplayWithPublicizeConnections() throws {
+        // Given, when
+        let blog = createTestBlog(hasConnections: true)
+
+        // Then
+        XCTAssertFalse(shouldShowCard(for: blog))
+    }
+
+    func testCardDoesNotDisplayWhenViewHidden() throws {
+        // Given
+        let blog = createTestBlog()
+        let dotComID = try XCTUnwrap(blog.dotComID)
+        let repository = UserPersistentStoreFactory.instance()
+        let key = DashboardJetpackSocialCardCell.Constants.hideNoConnectionViewKey
+
+        // When
+        repository.set([dotComID.stringValue: true], forKey: key)
+        addTeardownBlock {
+            repository.removeObject(forKey: key)
+        }
+
+        // Then
+        XCTAssertFalse(shouldShowCard(for: blog))
+    }
+
+    // MARK: - Card state tests
+
+    func testInitialCardState() {
+        // Given, when
+        let subject = DashboardJetpackSocialCardCell()
+
+        // Then
+        XCTAssertEqual(subject.displayState, .none)
+    }
+
+    func testCardStateWithNoConnections() {
+        // Given
+        let subject = DashboardJetpackSocialCardCell()
+        let blog = createTestBlog()
+
+        // When
+        subject.configure(blog: blog, viewController: nil, apiResponse: nil)
+
+        // Then
+        XCTAssertEqual(subject.displayState, .noConnections)
+    }
+
+    func testCardStateWhenUpdatedWithUnsupportedBlog() {
+        // Given
+        let subject = DashboardJetpackSocialCardCell()
+        let initialBlog = createTestBlog()
+        let blog = createTestBlog(isPublicizeSupported: false, hasServices: false, hasConnections: true)
+        subject.configure(blog: initialBlog, viewController: nil, apiResponse: nil)
+
+        // When
+        subject.configure(blog: blog, viewController: nil, apiResponse: nil)
+
+        // Then
+        XCTAssertEqual(subject.displayState, .none)
+    }
+}
+
+// MARK: - Helpers
+
+private extension DashboardJetpackSocialCardCellTests {
+
+    func shouldShowCard(for blog: Blog) -> Bool {
+        return DashboardJetpackSocialCardCell.shouldShowCard(for: blog)
+    }
+
+    func createTestBlog(isPublicizeSupported: Bool = true,
+                        hasServices: Bool = true,
+                        hasConnections: Bool = false) -> Blog {
+        let blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: mainContext) as! Blog
+        blog.account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: mainContext) as? WPAccount
+        blog.capabilities = [Blog.Capability.PublishPosts.rawValue: true]
+        blog.dotComID = 12345 as NSNumber
+
+        if isPublicizeSupported {
+            blog.options = ["active_modules": ["value": ["publicize"]]]
+        }
+
+        if hasServices {
+            _ = createPublicizeService()
+        }
+
+        if hasConnections {
+            let connection = PublicizeConnection(context: mainContext)
+            blog.connections = [connection]
+        }
+        return blog
+    }
+
+    func createPublicizeService() -> PublicizeService {
+        return PublicizeService(context: mainContext)
+    }
+
+}

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -124,6 +124,11 @@ final class BlogBuilder {
         return self
     }
 
+    func with(dotComID: Int) -> Self {
+        blog.dotComID = dotComID as NSNumber
+        return self
+    }
+
     func with(url: String) -> Self {
         blog.url = url
 
@@ -166,6 +171,18 @@ final class BlogBuilder {
 
     func with(isWPForTeamsSite: Bool) -> Self {
         return set(blogOption: "is_wpforteams_site", value: isWPForTeamsSite)
+    }
+
+    func with(connections: Set<PublicizeConnection>) -> Self {
+        blog.connections = connections
+        return self
+    }
+
+    func with(capabilities: [Blog.Capability]) -> Self {
+        blog.capabilities = capabilities.reduce(into: [String: Bool]()) {
+            $0[$1.rawValue] = true
+        }
+        return self
     }
 
     @discardableResult


### PR DESCRIPTION
See: #20974 

## Description

Adds a new dashboard card, `DashboardJetpackSocialCardCell`. It currently only shows the no connections social view but will later be updated to include the view when the user is out of shares.

## Screenshots

| Light | Dark |
|------|------|
| ![Screenshot 2023-07-24 at 2 57 39 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/a0c3a252-b4ac-4ca0-8578-813ad8e83435) | ![Screenshot 2023-07-24 at 2 57 51 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/da39d878-f4ed-48a5-99f4-bb07ca5076f8) |

## Testing

### No connections dashboard card
- Launch Jetpack and login if needed
- Select a blog that supports social connections and also has none setup
- Navigate to the home dashboard
- Scroll down if necessary
- **Verify** the no connections dashboard card appears with UI matching Th1ahHKq53k5JT1PNDMavY-fi-833%3A13918
- **Verify** the dashboard card's position is below the stats card and above drafts
- Tap on `Connect your profiles`
- Setup a connection and then navigate back to the dashboard
- **Verify** the card no longer appears
- Remove the connection that was just setup (Menu > Social)
- Navigate back to the home dashboard
- Scroll down if necessary
- On the no connections dashboard card, tap on the context menu `...`
- Tap on `Hide this`
- **Verify** the card is now hidden
- Switch to a different blog with no social connections
- **Verify** the card appears for this blog
- Switch back to the original blog
- **Verify** the card is still hidden

### Post pre publishing & post settings quick check

- Select a blog that supports social connections and also has none setup
- Create a new blog post
- Navigate to the post settings screen (`...` > `Post Settings`)
- **Verify** the no connections view still appears the same as before
- Navigate back to the new blog post
- Type something to enable the `Publish` button
- Tap on `Publish`
- In the pre publishing sheet, **verify** the no connections view still appears the same as before

## Regression Notes
1. Potential unintended areas of impact
The no connections view on the pre publishing sheet & post settings screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
- Tests for the display logic of the card
- Test for the display state of the card

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)