### PR TITLE
Jetpack Social: Add delegate methods for the social accounts sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -123,15 +123,6 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
         onContentHeightUpdated?()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        // only call the delegate method if the user has made some changes.
-        if !connectionChanges.isEmpty || shareMessage != originalMessage {
-            delegate?.didFinish(with: connectionChanges, message: shareMessage)
-        }
-    }
-
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -142,6 +133,14 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
             presentedVC?.transition(to: traitCollection.verticalSizeClass == .compact ? .expanded : .collapsed)
         }
     }
+
+    deinit {
+        // only call the delegate method if the user has made some changes.
+        if hasChanges {
+            delegate?.didFinish(with: connectionChanges, message: shareMessage)
+        }
+    }
+
 }
 
 // MARK: - UITableView
@@ -206,6 +205,10 @@ private extension PrepublishingSocialAccountsViewController {
 
     var shouldDisplayWarning: Bool {
         connections.count >= (sharingLimit?.remaining ?? .max)
+    }
+
+    var hasChanges: Bool {
+        !connectionChanges.isEmpty || shareMessage != originalMessage
     }
 
     func accountCell(for indexPath: IndexPath) -> UITableViewCell {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -192,8 +192,7 @@ private extension PrepublishingSocialAccountsViewController {
 
     var enabledCount: Int {
         connections
-            .map { connectionChanges[$0.keyringID] ?? $0.isOn }
-            .filter { $0 }
+            .filter { connectionChanges[$0.keyringID] ?? $0.isOn }
             .count
     }
 
@@ -239,7 +238,7 @@ private extension PrepublishingSocialAccountsViewController {
         guard let connection = connections[safe: index] else {
             return false
         }
-        return connectionChanges[index] ?? connection.isOn
+        return connectionChanges[connection.keyringID] ?? connection.isOn
     }
 
     func updateConnection(at index: Int, value: Bool) {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -138,7 +138,7 @@ private extension PrepublishingViewController {
     func noConnectionConnectTapped() -> () -> Void {
         return { [weak self] in
             guard let self,
-                  let controller = SharingViewController(blog: self.post.blog, delegate: nil),
+                  let controller = SharingViewController(blog: self.post.blog, delegate: self),
                   self.presentedViewController == nil else {
                 return
             }
@@ -248,12 +248,22 @@ struct PrepublishingAutoSharingModel {
     }
 }
 
+// MARK: - Sharing View Controller Delegate
+
+extension PrepublishingViewController: SharingViewControllerDelegate {
+
+    func didChangePublicizeServices() {
+        reloadData()
+    }
+
+}
+
+// MARK: - Prepublishing Social Accounts Delegate
+
 extension PrepublishingViewController: PrepublishingSocialAccountsDelegate {
 
     func didUpdateSharingLimit(with newValue: PublicizeInfo.SharingLimit?) {
-        if newValue == nil {
-            reloadData()
-        }
+        reloadData()
     }
 
     func didFinish(with connectionChanges: [Int: Bool], message: String?) {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -269,7 +269,8 @@ class PrepublishingViewController: UITableViewController {
         }
     }
 
-    private func reloadData() {
+    func reloadData() {
+        refreshOptions()
         tableView.reloadData()
     }
 


### PR DESCRIPTION
Refs #20783 

This PR adds the delegate method implementation for the `PrepublishingViewController` for the social accounts sheet and the No Connection view. There are some slight changes made to the social accounts: 
- Changes to the connections' state are now stored in `connectionChanges` instead of being applied directly to the object. Similarly, there's also a new `originalMessage` property.
- The `didFinish` delegate method is only called during `deinit`, AND when there are changes to either the connections' state, OR the share message.

## To test

### Case 1: Testing new connections from the No Connection view

- Launch the Jetpack app.
- Switch to a blog that doesn't have any social connections yet.
- Create a new blog post, fill in some text, and tap Publish.
- Tap the "Connect your profiles" button on the No Connection view.
- Go through the connection process and return to the pre-publishing sheet.
- 🔎  Verify that the No Connection view is now replaced with the auto-sharing view.

### Case 2: Testing changes from the Social Accounts sheet

- Launch the Jetpack app.
- Switch to a blog with existing social connections, preferably for testing, with more than one connections.
- Create a new blog post, fill in some text, and tap Publish.
- Tap the auto-sharing cell.
- Disable one or all accounts, and navigate back.
- 🔎 Verify that the changes are reflected on the pre-publishing sheet.
- Tap the auto-sharing cell again.
- Make some changes to the switches. Make sure to leave one or more connections **disabled**.
- Edit the sharing message.
- Go back to the pre-publishing sheet.
- 🔎 Verify that the changes are reflected on the pre-publishing sheet.

> **Warning**
> There's currently an issue with auto-sharing options not being honored by the backend. Refer to #21186.

To verify that the metadata keys are being properly set, place a breakpoint in `PostService.m`:

https://github.com/wordpress-mobile/WordPress-iOS/blob/c83f0e4914a946fe5de3ea0292fdf30541ad0642/WordPress/Classes/Services/PostService.m#L911

- Once the breakpoint is set up, tap Publish on the pre-publishing sheet.
- Type in `po disabledConnectionsDictionary`.
- 🔎 Verify that the metadata entries are properly set.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

These are mostly data flow changes that don't have much impact on the UI.

- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
