### PR TITLE
Add editorialized release notes for version 22.9

### DIFF
--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -81,11 +81,13 @@ msgctxt "app_store_keywords"
 msgid "social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal"
 msgstr ""
 
-msgctxt "v22.8-whats-new"
+msgctxt "v22.9-whats-new"
 msgid ""
-"We disabled blogging reminders for self-hosted sites that aren’t connected to Jetpack, since this feature is only available in the Jetpack app.\n"
+"We made some big changes to the block editor, including styles, colors, and icons. You’ll also find more buttons and block options in the header toolbar, including the undo and redo buttons. That’s right, you now have more tools than Batman’s utility belt.\n"
 "\n"
-"Reusable blocks are now known as synced patterns, the same as in the desktop editor.\n"
+"While we were at it, we plugged a few memory leaks, improved posting activity stats, and solved an issue where the app wouldn’t work for some users after opening.\n"
+"\n"
+"We also fixed several crashes caused by tapping blogging prompts, following sites in the Reader, and deleting the WordPress app after a successful migration.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of the first screenshot in the App Store.

--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -1,15 +1,5 @@
-* [*] [internal] Fix multiple memory leaks after logging in and logging out. [#21047, #21092]
-* [**] Block editor: Move undo/redo buttons to the navigation bar. [#20930]
-* [*] Fixed an issue that caused the UI to be briefly unresponsive in certain case when opening the app. [#21065]
-* [**] Blogging Prompts: Fixed a crash in Reader after tapping on a blogging prompt multiple times. [#21112]
-* [*] [internal] Update calls to use UserDefaults singleton. [#21088]
-* [*] Fix memory leaks in setting up Jetpack connection. [#21052]
-* [*] Fix a memory leak caused by the theme customization web view. [#21051]
-* [**] [internal] Updated the code that enables Gutenberg editor in all blogs when the user is in the Gutenberg rollout group. [#21146]
-* [**] [internal] Fix a few potential Core Data issues in Blogging Prompts & Reminders. [#21016]
-* [*] Made performance improvements for Posting Activity stats. [#21136]
-* [*] Fixed a crash that could occur when following sites in Reader. [#21140]
-* [*] Fixed a crash that could occur when the user deletes the WordPress app upon a successful migration. [#21167]
-* [*] Fixed a crash that occurs in Weekly Roundup Background task due to a Core Data Concurrency violation. [#21076]
-* [***] Block editor: Editor UX improvements with new icons, colors and additional design enhancements. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5985]
+We made some big changes to the block editor, including styles, colors, and icons. You’ll also find more buttons and block options in the header toolbar, including the undo and redo buttons. That’s right, you now have more tools than Batman’s utility belt.
 
+While we were at it, we plugged a few memory leaks, improved posting activity stats, and solved an issue where the app wouldn’t work for some users after opening.
+
+We also fixed several crashes caused by tapping blogging prompts, following sites in the Reader, and deleting the WordPress app after a successful migration.

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -45,9 +45,11 @@ msgctxt "app_store_keywords"
 msgid "blogger,writing,blogging,web,maker,online,store,business,make,create,write,blogs"
 msgstr ""
 
-msgctxt "v22.8-whats-new"
+msgctxt "v22.9-whats-new"
 msgid ""
-"We disabled blogging reminders for self-hosted sites that aren’t connected to Jetpack, since this feature is only available in the Jetpack app. Short and sweet.\n"
+"We made some big changes to the block editor, including styles, colors, and icons. You’ll also find more buttons and block options in the header toolbar, including the undo and redo buttons. That’s right, you now have more tools than Batman’s utility belt.\n"
+"\n"
+"While we were at it, we plugged a few memory leaks and solved an issue where the app wouldn’t work for some users after opening.\n"
 msgstr ""
 
 #. translators: This is a standard chunk of text used to tell a user what's new with a release when nothing major has changed.

--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -1,10 +1,3 @@
-* [*] [internal] Fix multiple memory leaks after logging in and logging out. [#21047, #21092]
-* [**] Block editor: Move undo/redo buttons to the navigation bar. [#20930]
-* [*] Fixed an issue that caused the UI to be briefly unresponsive in certain case when opening the app. [#21065]
-* [*] [internal] Update calls to use UserDefaults singleton. [#21088]
-* [*] Fix memory leaks in setting up Jetpack connection. [#21052]
-* [*] Fix a memory leak caused by the theme customization web view. [#21051]
-* [**] [internal] Updated the code that enables Gutenberg editor in all blogs when the user is in the Gutenberg rollout group. [#21146]
-* [**] [internal] Fix a few potential Core Data issues in Blogging Prompts & Reminders. [#21016]
-* [***] Block editor: Editor UX improvements with new icons, colors and additional design enhancements. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5985]
+We made some big changes to the block editor, including styles, colors, and icons. You’ll also find more buttons and block options in the header toolbar, including the undo and redo buttons. That’s right, you now have more tools than Batman’s utility belt.
 
+While we were at it, we plugged a few memory leaks and solved an issue where the app wouldn’t work for some users after opening.


### PR DESCRIPTION
- [x] `AppStoreStrings.po(t)` changed with editorialized release notes 

Standalone PR with no beta to ensure the new release notes land on `trunk` and go off for transaltion ASAP