### PR TITLE
Jetpack Social: Prepublishing sheet accessibility improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -6,9 +6,9 @@ struct PrepublishingAutoSharingView: View {
 
     @SwiftUI.Environment(\.sizeCategory) private var sizeCategory
 
-    @ScaledMetric(relativeTo: .subheadline) private var warningIconSize = 16.0
+    @ScaledMetric(relativeTo: .subheadline) private var warningIconLength = 16.0
 
-    @ScaledMetric(relativeTo: .body) private var imageSize = 28.0
+    @ScaledMetric(relativeTo: .body) private var imageLength = 28.0
 
     var body: some View {
         Group {
@@ -28,7 +28,7 @@ struct PrepublishingAutoSharingView: View {
             textStack
             if model.services.count > 0 {
                 if !shouldStackContentVertically {
-                    Spacer() // to push the icons to the trailing side in horizontal layout.
+                    Spacer(minLength: .zero) // to push the icons to the trailing side in horizontal layout.
                 }
                 socialIconsView
             }
@@ -57,7 +57,7 @@ struct PrepublishingAutoSharingView: View {
                 Image("icon-warning")
                     .resizable()
                     .padding(4.0)
-                    .frame(width: warningIconSize, height: warningIconSize)
+                    .frame(width: warningIconLength, height: warningIconLength)
                     .accessibilityElement()
                     .accessibilityLabel(Constants.warningIconAccessibilityText)
             }
@@ -76,7 +76,7 @@ struct PrepublishingAutoSharingView: View {
     private func iconImage(_ uiImage: UIImage, opaque: Bool) -> some View {
         Image(uiImage: uiImage)
             .resizable()
-            .frame(width: imageSize, height: imageSize)
+            .frame(width: imageLength, height: imageLength)
             .opacity(opaque ? 1.0 : Constants.disabledSocialIconOpacity)
             .background(Color(.listForeground))
             .clipShape(Circle())

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -4,11 +4,32 @@ struct PrepublishingAutoSharingView: View {
 
     let model: PrepublishingAutoSharingModel
 
+    @SwiftUI.Environment(\.sizeCategory) private var sizeCategory
+
+    @ScaledMetric(relativeTo: .subheadline) private var warningIconSize = 16.0
+
+    @ScaledMetric(relativeTo: .body) private var imageSize = 28.0
+
     var body: some View {
-        HStack {
+        Group {
+            if shouldStackContentVertically {
+                VStack(alignment: .leading, spacing: 8.0) { content }
+            } else {
+                HStack { content }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var content: some View {
+        Group {
             textStack
-            Spacer()
             if model.services.count > 0 {
+                if !shouldStackContentVertically {
+                    Spacer() // to push the icons to the trailing side in horizontal layout.
+                }
                 socialIconsView
             }
         }
@@ -19,24 +40,29 @@ struct PrepublishingAutoSharingView: View {
             Text(model.labelText)
                 .font(.body)
                 .foregroundColor(Color(.label))
-            if let sharingLimit = model.sharingLimit {
-                remainingSharesView(sharingLimit: sharingLimit, showsWarning: model.showsWarning)
+            if let text = model.remainingSharesText {
+                remainingSharesLabel(text: text, showsWarning: model.showsWarning)
             }
         }
     }
 
-    private func remainingSharesView(sharingLimit: PublicizeInfo.SharingLimit, showsWarning: Bool) -> some View {
-        HStack(spacing: 4.0) {
+    @ViewBuilder
+    private func remainingSharesLabel(text: String, showsWarning: Bool) -> some View {
+        Label {
+            Text(text)
+                .font(.subheadline)
+                .foregroundColor(Color(showsWarning ? Constants.warningColor : .secondaryLabel))
+        } icon: {
             if showsWarning {
                 Image("icon-warning")
                     .resizable()
-                    .frame(width: 16.0, height: 16.0)
                     .padding(4.0)
+                    .frame(width: warningIconSize, height: warningIconSize)
+                    .accessibilityElement()
+                    .accessibilityLabel(Constants.warningIconAccessibilityText)
             }
-            Text(String(format: Constants.remainingSharesTextFormat, sharingLimit.remaining))
-                .font(.subheadline)
-                .foregroundColor(Color(showsWarning ? Constants.warningColor : .secondaryLabel))
         }
+        .accessibilityLabel(showsWarning ? "\(Constants.warningIconAccessibilityText), \(text)" : text)
     }
 
     private var socialIconsView: some View {
@@ -50,7 +76,7 @@ struct PrepublishingAutoSharingView: View {
     private func iconImage(_ uiImage: UIImage, opaque: Bool) -> some View {
         Image(uiImage: uiImage)
             .resizable()
-            .frame(width: 28.0, height: 28.0)
+            .frame(width: imageSize, height: imageSize)
             .opacity(opaque ? 1.0 : Constants.disabledSocialIconOpacity)
             .background(Color(.listForeground))
             .clipShape(Circle())
@@ -61,19 +87,19 @@ struct PrepublishingAutoSharingView: View {
 
 private extension PrepublishingAutoSharingView {
 
+    var shouldStackContentVertically: Bool {
+        (model.services.count > Constants.maxServicesForHorizontalLayout) || sizeCategory.isAccessibilityCategory
+    }
+
     enum Constants {
+        static let maxServicesForHorizontalLayout = 3
         static let disabledSocialIconOpacity: CGFloat = 0.36
         static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))
 
-        static let remainingSharesTextFormat = NSLocalizedString(
-            "prepublishing.social.remainingShares.text",
-            value: "%1$d social shares remaining",
-            comment: """
-                A subtext that's shown below the primary label in the auto-sharing row on the pre-publishing sheet.
-                Informs the remaining limit for post auto-sharing.
-                %1$d is a placeholder for the remaining shares.
-                Example: 27 social shares remaining
-                """
+        static let warningIconAccessibilityText = NSLocalizedString(
+            "prepublishing.social.warningIcon.accessibilityHint",
+            value: "Warning",
+            comment: "a VoiceOver description for the warning icon to hint that the remaining shares are low."
         )
     }
 }
@@ -136,6 +162,14 @@ private extension PrepublishingAutoSharingModel {
         }
     }
 
+    var remainingSharesText: String? {
+        guard let remaining = sharingLimit?.remaining else {
+            return nil
+        }
+
+        return String(format: Strings.remainingSharesTextFormat, remaining)
+    }
+
     enum Strings {
         static let notSharingText = NSLocalizedString(
             "prepublishing.social.label.notSharing",
@@ -178,6 +212,17 @@ private extension PrepublishingAutoSharingModel {
                 %1$d is a placeholder for the number of social media accounts that will be sharing the blog post.
                 %2$d is a placeholder for the total number of social media accounts connected to the user's blog.
                 Example: Sharing to 2 of 3 accounts
+                """
+        )
+
+        static let remainingSharesTextFormat = NSLocalizedString(
+            "prepublishing.social.remainingShares.format",
+            value: "%1$d social shares remaining",
+            comment: """
+                A subtext that's shown below the primary label in the auto-sharing row on the pre-publishing sheet.
+                Informs the remaining limit for post auto-sharing.
+                %1$d is a placeholder for the remaining shares.
+                Example: 27 social shares remaining
                 """
         )
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -56,8 +56,8 @@ struct PrepublishingAutoSharingView: View {
             if showsWarning {
                 Image("icon-warning")
                     .resizable()
-                    .padding(4.0)
                     .frame(width: warningIconLength, height: warningIconLength)
+                    .padding(4.0)
                     .accessibilityElement()
                     .accessibilityLabel(Constants.warningIconAccessibilityText)
             }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -133,7 +133,7 @@ private extension PrepublishingAutoSharingModel {
         guard let remaining = sharingLimit?.remaining else {
             return false
         }
-        return enabledConnectionsCount > remaining
+        return totalConnectionsCount > remaining
     }
 
     var labelText: String {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -33,7 +33,7 @@ struct PrepublishingAutoSharingView: View {
                     .frame(width: 16.0, height: 16.0)
                     .padding(4.0)
             }
-            Text(String(format: Constants.remainingSharesTextFormat, sharingLimit.remaining, sharingLimit.limit))
+            Text(String(format: Constants.remainingSharesTextFormat, sharingLimit.remaining))
                 .font(.subheadline)
                 .foregroundColor(Color(showsWarning ? Constants.warningColor : .secondaryLabel))
         }
@@ -66,14 +66,13 @@ private extension PrepublishingAutoSharingView {
         static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))
 
         static let remainingSharesTextFormat = NSLocalizedString(
-            "prepublishing.social.remainingShares",
-            value: "%1$d/%2$d social shares remaining",
+            "prepublishing.social.remainingShares.text",
+            value: "%1$d social shares remaining",
             comment: """
                 A subtext that's shown below the primary label in the auto-sharing row on the pre-publishing sheet.
                 Informs the remaining limit for post auto-sharing.
                 %1$d is a placeholder for the remaining shares.
-                %2$d is a placeholder for the maximum shares allowed for the user's blog.
-                Example: 27/30 social shares remaining
+                Example: 27 social shares remaining
                 """
         )
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -36,7 +36,7 @@ struct PrepublishingAutoSharingView: View {
     }
 
     private var textStack: some View {
-        VStack(alignment: .leading, spacing: .zero) {
+        VStack(alignment: .leading, spacing: 2.0) {
             Text(model.labelText)
                 .font(.body)
                 .foregroundColor(Color(.label))
@@ -57,7 +57,6 @@ struct PrepublishingAutoSharingView: View {
                 Image("icon-warning")
                     .resizable()
                     .frame(width: warningIconLength, height: warningIconLength)
-                    .padding(4.0)
                     .accessibilityElement()
                     .accessibilityLabel(Constants.warningIconAccessibilityText)
             }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -50,7 +50,6 @@ struct PrepublishingSocialAccountsFooterView: View {
             Image("icon-warning")
                 .resizable()
                 .frame(width: warningIconLength, height: warningIconLength)
-                .padding(4.0)
         }
         .accessibilityLabel(showsWarning ? "\(Constants.warningIconAccessibilityText), \(sharesText)" : sharesText)
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -29,7 +29,7 @@ struct PrepublishingSocialAccountsFooterView: View {
 
     @State var showsWarning: Bool
 
-    @ScaledMetric(relativeTo: .callout) private var warningIconSize = 16.0
+    @ScaledMetric(relativeTo: .callout) private var warningIconLength = 16.0
 
     var onButtonTap: (() -> Void)?
 
@@ -49,7 +49,7 @@ struct PrepublishingSocialAccountsFooterView: View {
         } icon: {
             Image("icon-warning")
                 .resizable()
-                .frame(width: warningIconSize, height: warningIconSize)
+                .frame(width: warningIconLength, height: warningIconLength)
                 .padding(4.0)
         }
         .accessibilityLabel(showsWarning ? "\(Constants.warningIconAccessibilityText), \(sharesText)" : sharesText)

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -26,33 +26,33 @@ class PrepublishingSocialAccountsTableFooterView: UITableViewHeaderFooterView, R
 struct PrepublishingSocialAccountsFooterView: View {
 
     @State var remaining: Int
+
     @State var showsWarning: Bool
+
+    @ScaledMetric(relativeTo: .callout) private var warningIconSize = 16.0
+
     var onButtonTap: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 16.0) {
-            remainingSharesText
+            remainingSharesLabel
             subscribeButton
         }
         .padding(EdgeInsets(top: 24.0, leading: 0, bottom: 0, trailing: 0))
     }
 
-    var remainingSharesText: some View {
-        HStack(alignment: .top, spacing: 6.0) {
-            if showsWarning {
-                Image("icon-warning")
-                    .resizable()
-                    .frame(width: 16.0, height: 16.0)
-                    .padding(2.0)
-                    .accessibilityElement()
-                    .accessibilityLabel(Constants.warningIconAccessibilityText)
-            }
-            Text(String(format: Constants.remainingSharesLabelTextFormat, remaining))
+    var remainingSharesLabel: some View {
+        Label {
+            Text(sharesText)
                 .font(.callout)
                 .foregroundColor(Color(showsWarning ? Constants.warningColor : .label))
+        } icon: {
+            Image("icon-warning")
+                .resizable()
+                .frame(width: warningIconSize, height: warningIconSize)
+                .padding(4.0)
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isStaticText)
+        .accessibilityLabel(showsWarning ? "\(Constants.warningIconAccessibilityText), \(sharesText)" : sharesText)
     }
 
     var subscribeButton: some View {
@@ -64,6 +64,10 @@ struct PrepublishingSocialAccountsFooterView: View {
                 .frame(maxWidth: .infinity) // needs to be set here to make the button stretch full-width.
         }
         .buttonStyle(SubscribeButtonStyle())
+    }
+
+    private var sharesText: String {
+        String(format: Constants.remainingSharesLabelTextFormat, remaining)
     }
 
     private struct SubscribeButtonStyle: ButtonStyle {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -117,9 +117,10 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
         super.viewDidLayoutSubviews()
 
         // manually configure preferredContentSize for precise drawer sizing.
-        let safeBottomInset = UIApplication.shared.mainWindow?.safeAreaInsets.bottom ?? Constants.defaultBottomInset
+        let bottomInset = max(UIApplication.shared.mainWindow?.safeAreaInsets.bottom ?? 0, Constants.defaultBottomInset)
+        let contentHeight = tableView.contentSize.height + bottomInset + Constants.additionalBottomInset
         preferredContentSize = CGSize(width: tableView.contentSize.width,
-                                      height: tableView.contentSize.height + safeBottomInset + 16.0)
+                                      height: max(contentHeight, Constants.minContentHeight))
         onContentHeightUpdated?()
     }
 
@@ -349,7 +350,9 @@ private extension PrepublishingSocialAccountsViewController {
         static let disabledCellImageOpacity = 0.36
         static let cellImageSize = CGSize(width: 28.0, height: 28.0)
 
+        static let minContentHeight: CGFloat = 300.0
         static let defaultBottomInset: CGFloat = 34.0
+        static let additionalBottomInset: CGFloat = 16.0
 
         static let accountCellIdentifier = "AccountCell"
         static let messageCellIdentifier = "MessageCell"


### PR DESCRIPTION
Closes #20783

This PR adds some accessibility and UI improvements for the Jetpack Social flow in the pre-publishing sheet. Here's a list of them:

- Fixed the [drawer height issue](https://github.com/wordpress-mobile/WordPress-iOS/pull/21188#pullrequestreview-1547771096) in the social accounts sheet when displayed on iPhones without the home bar. Additionally, I've put in a minimum height of 300 so that the drawer is not too small for cases where content is minimal, which would make it easier to accidentally dismiss the sheet. Here's an example from iPhone SE:

  <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/2d44a337-3636-4a35-b70e-da644eaf2624" width=350 />

- Updated the remaining shares text in the auto-sharing cell to omit the sharing limit part. Note that the localization key is also updated.
- The auto-sharing cell now switches between VStack and HStack depending on the number of social icons and/or the preferred content size category. 
- Now that our minimum deployment target is iOS 14, I'm updating all the remaining shares texts (within the pre-publishing sheet) with `Label` so I don't have to think about vertically aligning the icon with the first text line.
- Switched to using `@ScaledMetric` wrapper (instead of using a static constant) for the icons so that they can scale along with the content size. Here are some screenshots in accessibility size: 

  Auto-sharing cell | Auto-sharing cell, warning | Social accounts, warning
  -|-|-
  ![autosharing_cell](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8072fe03-aa82-448f-b406-de83d2636918) | ![autosharing_cell_warning](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5baccb5b-d9bb-473d-b4fd-3cd950329ab2) | ![social_accounts_footer](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/ca0eaa18-2c64-4ab3-a20f-a3fe48f85ab2)

- Updated the accessibility labels for the auto-sharing cell so that it's properly recognized as a button. Furthermore, it should also recognize the warning icon when it is displayed. For example: 🗣️ "Warning, 1 social shares remaining."
  - I've thought about singular/plural versions, but there are some intricacies since we can't simply check `if count == 1 { .singular }`, as stated in #6327. The best way to go about this is with the stringsdict format, but it isn't supported yet by GlotPress. I'll try to look for alternatives/workarounds next week.
  - Also, note that I've left the social icons "invisible" to the VoiceOver. I haven't figured out how to (or if we should) dictate the icons to the user since we have the disabled state and there could be more than one connection per network. And since it's a button, I personally prefer to keep the label at a "manageable" length (since the VoiceOver reads "button" at the very end, prompting the user to take action).

cc @osullivanchris — with this, the whole pre-publishing sheet flow is now complete and testable.

## To test

### Testing the auto-sharing cell's adaptive layout

> **Note**
> The auto-sharing cell switches to a vertical layout when either one of these conditions is true:
> - The number of displayed social icons exceeds 3. (see comment on Th1ahHKq53k5JT1PNDMavY-fi-1041_16822)
> - The device is using an accessibility content size category.

Since it might not be trivial to create connections in 4 or more different social networks, I'd recommend temporarily modifying the method `shouldStackContentVertically` in `PrepublishingAutoSharingView` to true:

```swift
    var shouldStackContentVertically: Bool {
        return true
//        (model.services.count > Constants.maxServicesForHorizontalLayout) || sizeCategory.isAccessibilityCategory
    }
```

(Or, another alternative would be to temporarily mock the supplied `PrepublishingAutoSharingModel` so it has 4 or more services.)

- With the above code change, launch the Jetpack app. 
- Create a new blog post, and enter some text on the title and body.
- Tap Publish.
- 🔎 Verify that the auto-sharing cell is displayed in a vertical layout.

Now, stop the app and undo the code change. Let's verify if it responds properly to content size changes.

- In your device or simulator, go to Settings > Accessibility > Display & Text Size > Larger Text.
- Turn on the Larger Accessibility Sizes setting.
- Set the content size slider to one of the accessibility sizes (i.e., one of the last five options).
- Launch the Jetpack app.
- Go to the pre-publishing sheet by following the previous step.
- 🔎 Verify that the auto-sharing cell is displayed in a vertical layout.

### Testing VoiceOver improvements

- Launch the Jetpack app.
- Go to the pre-publishing sheet by following the previous step.
- Open Xcode > Open Developer Tool > Accessibility Inspector.
- Target the Simulator process.
- Tap on the target/inspector button, and tap on the auto-sharing cell.
- 🔎 Verify that the VoiceOver reads the strings within the cell and identifies it as a button.

In both the `PrepublishingAutoSharingView` and `PrepublishingSocialAccountsFooterView`, modify the `showsWarning` variable to always return true for testing purposes:

```swift
    var showsWarning: Bool {
        return true
    }
```

- With the above code change, launch the Jetpack app.
- Go to the pre-publishing sheet by following the previous step.
- Ready the Accessibility Inspector tool, and target the auto-sharing cell.
- 🔎 Verify that the VoiceOver now spells out the warning icon. For example: 🗣️ "Sharing to one of two accounts, warning, 1 social shares remaining".

## Regression Notes
1. Potential unintended areas of impact
Should be none. Features are unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes on various devices and content sizes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)