### PR TITLE
Fix flaky iPad UI Test - testWPcomLoginLogout

### DIFF
--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -26,6 +26,7 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
         try TabNavComponent()
             .goToMeScreen()
+        try MeTabScreen()
             .logoutToPrologue()
             .assertScreenIsLoaded()
     }
@@ -44,6 +45,7 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
         try TabNavComponent()
             .goToMeScreen()
+        try MeTabScreen()
             .logout()
             .assertScreenIsLoaded()
     }

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -44,7 +44,7 @@ public class MeTabScreen: ScreenObject {
     var myProfileButton: XCUIElement { myProfileButtonGetter(app) }
     var notificationSettingsButton: XCUIElement { notificationSettingsButtonGetter(app) }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ appSettingsButtonGetter ],
             app: app

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -39,7 +39,7 @@ public class TabNavComponent: ScreenObject {
         )
     }
 
-    // This method no longer return MeTabScreen because MeTabScreen is a pop up on top of MySiteScreen on iPad
+    // Removed the MeTabScreen return value because MeTabScreen is a modal on top of MySiteScreen on iPad
     // Returning it causes flakiness in CI as MySiteScreen is loaded first, making the test look for elements on MySiteScreen instead of MeTabScreen
     public func goToMeScreen() throws {
         try goToMySiteScreen()

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -39,10 +39,11 @@ public class TabNavComponent: ScreenObject {
         )
     }
 
-    public func goToMeScreen() throws -> MeTabScreen {
+    // This method no longer return MeTabScreen because MeTabScreen is a pop up on top of MySiteScreen on iPad
+    // Returning it causes flakiness in CI as MySiteScreen is loaded first, making the test look for elements on MySiteScreen instead of MeTabScreen
+    public func goToMeScreen() throws {
         try goToMySiteScreen()
         meTabButton.tap()
-        return try MeTabScreen()
     }
 
     @discardableResult


### PR DESCRIPTION
### Description
The `testWPcomLoginLogout` test is flaky on [iPad test runs](https://buildkite.com/organizations/automattic/analytics/suites/jetpack-ios-ui-tests-ipad/tests/0186e8a8-f65e-7a50-9892-e6897c161402?branch=trunk#failed). On [iPhone test runs](https://buildkite.com/organizations/automattic/analytics/suites/jetpack-ios-ui-tests-iphone/tests/0186e8a7-57eb-7462-a37c-ec4b7526ee3a?branch=trunk), it has a 100% passing rate.

When looking at the difference between iPad and iPhone, I found that on iPad, the `MeTabScreen` is a modal on top of the `MySiteScreen`. Because there is often a bit of a timing issue in CI, when the test is verifying that `MeTabScreen` is loaded, it's still testing against `MySiteScreen` element tree causing the test to hang and fail. 

I'm not 100% sure this will be the right solution because, in theory, the test without any changes should work, but that isn't the reality. I'd like to try this out and monitor for a bit if it works. There are also other iPad-only flakiness that could be because of the same issue. If this works, we can apply the same to those tests too.

### Testing
`testWPcomLoginLogout` is not flaky on iPad (with error: `Failed to determine hittability of "appSettings" Cell: Activation point invalid and no suggested hit points based on element frame`) and CI is 🟢 