### PR TITLE
Fix incorrect size of thumbnails in media picker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [**] [Jetpack-only] Made significant performance improvements for Total Likes stats card. [#21168]
 * [**] [internal] Upgrade React Native to 0.71.11 [#20956]
 * [*] [Jetpack-only] Fix app hangs on the Stats screen [#21067]
+* [*] Fix an issue with the size of the thumbnails in the media picker so it now loads faster and uses less memory [#21204]
 
 22.9
 -----

--- a/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
+++ b/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
@@ -21,8 +21,8 @@ class MediaThumbnailCoordinator: NSObject {
     /// Tries to generate a thumbnail for the specified media object with the size requested
     ///
     /// - Parameters:
-    ///   - media: the media object to generate the thumbnail representation
-    ///   - size: the size of the thumbnail
+    ///   - media: The media object to generate the thumbnail representation.
+    ///   - size: The size of the thumbnail in pixels.
     ///   - onCompletion: a block that is invoked when the thumbnail generation is completed with success or failure.
     @objc func thumbnail(for media: Media, with size: CGSize, onCompletion: @escaping ThumbnailBlock) {
         if media.remoteStatus == .stub {
@@ -57,7 +57,7 @@ class MediaThumbnailCoordinator: NSObject {
     ///
     /// - Parameters:
     ///   - media: the media object to generate the thumbnail representation
-    ///   - size: the size of the thumbnail
+    ///   - size: The size of the thumbnail in pixels.
     ///   - onCompletion: a block that is invoked when the thumbnail generation is completed with success or failure.
     func fetchThumbnailForMediaStub(for media: Media, with size: CGSize, onCompletion: @escaping ThumbnailBlock) {
         fetchStubMedia(for: media) { [weak self] (fetchedMedia, error) in

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -177,6 +177,8 @@ class MediaThumbnailService: NSObject {
                 if media.blog.isPrivateAtWPCom() || (!media.blog.isHostedAtWPcom && media.blog.isBasicAuthCredentialStored()) {
                     remoteURL = WPImageURLHelper.imageURLWithSize(preferredSize, forImageURL: remoteAssetURL)
                 } else {
+                    let scale = 1.0 / UIScreen.main.scale
+                    let preferredSize = preferredSize.applying(CGAffineTransform(scaleX: scale, y: scale))
                     remoteURL = PhotonImageURLHelper.photonURL(with: preferredSize, forImageURL: remoteAssetURL)
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21197 (see for more info on the root cause)

## To test:

- Verify that the images in the Media Picker are loading and have adequate retina resolution

> [!IMPORTANT]  
> `MediaThumbnailService` stores thumbnails on disk. You'll need to re-install the app or clear the caches in other ways to verify the size reduction.

We can make one more improvement: the app downloads full GIFs but displays only the first frame. We can change the app to download _only_ the first frame. It will dramatically reduce the download size even further. But I'm not sure how yet.

## Measurements

| | Memory (Rest) | Memory (Peak) | Time to Download | Demo |
|--------|---------------|---------------|------------------|-----|
| Before | 365 MB        | 569 MB        | 15 sec           | [recording-01.mp4](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/309c94d7-5508-441b-8f49-68a609387917) |
| After  | 99 MB         | 148 MB        | 4 sec            | [recording-02.mp4](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/039c2b38-e281-4ab9-89d9-c4994fc949b1) |

> The measurements indicate how much memory just the picker uses (not including the rest of the app footprint). It was tested in the simulator. The results on the device may be different.

This test scenario is a bit exaggerated because I have multiple GIFs in this library, but the size reduction apply equally to all images.

## Notes

The method to fetch the thumbnails that I modified is used with non-zero size only from here:

```objc
@implementation Media(WPMediaAsset)

- (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
{
    [MediaThumbnailCoordinator.shared thumbnailFor:self with:size onCompletion:^(UIImage *image, NSError *error) {
```

This `imageWithSize` is in turn is called only from WPMediaCollectionViewCell and it passes the size in pixels:

```objc
CGFloat scale = [[UIScreen mainScreen] scale];
CGSize requestSize = CGSizeApplyAffineTransform(self.frame.size, CGAffineTransformMakeScale(scale, scale));
```

## Regression Notes

1. Potential unintended areas of impact: Media Picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
