### PR TITLE
Fix an issue with unstable order on the media screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Fix incorrect WordPress Media images count in Media Picker. [#21181]
 * [*] [Jetpack-only] Fix app hangs on the Stats screen [#21067]
 * [*] Fix an issue with the size of the thumbnails in the media picker so it now loads faster and uses less memory [#21204]
+* [*] Fix an issue with unstable order of assets on the media screen [#21210]
 
 22.9
 -----

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -436,8 +436,10 @@
         fetchRequest.predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[fetchRequest.predicate, statusPredicate]];
     }
 
-    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.ascendingOrdering];
-    fetchRequest.sortDescriptors = @[sortDescriptor];
+    fetchRequest.sortDescriptors = @[
+        [NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.ascendingOrdering],
+        [NSSortDescriptor sortDescriptorWithKey:@"mediaID" ascending:self.ascendingOrdering]
+    ];
 
     _fetchController = [[NSFetchedResultsController alloc]
                             initWithFetchRequest:fetchRequest


### PR DESCRIPTION
Fixes #21208

To test:

- Follow the steps from the linked issue
- Verify that the order is now stable

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/4f9da718-6a19-446b-a163-edc8288ff318

## Notes

I considered using just the `mediaID` for ordering, but I'm not sure we should make any assumption about the contents of these IDs or their order.

<img width="593" alt="Screenshot 2023-07-31 at 10 38 52 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/efbc2f08-2fa3-4fcb-bad8-2bce650ffd0e">


## Regression Notes
1. Potential unintended areas of impact: Media Picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
