### PR TITLE
Fix an issue with media screen flashing when opened

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,8 @@
 * [*] [Jetpack-only] Fix app hangs on the Stats screen [#21067]
 * [*] Fix an issue with the size of the thumbnails in the media picker so it now loads faster and uses less memory [#21204]
 * [*] Fix an issue with unstable order of assets on the media screen [#21210]
+* [*] Fix an issue with media screen flashing when opened [#21211]
+
 
 22.9
 -----

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -51,7 +51,7 @@ extension Media {
 
     func setMediaType(forFilenameExtension filenameExtension: String) {
         let type = UTType(filenameExtension: filenameExtension)
-        self.mediaType = getMediaType(for: type)
+        setMediaType(getMediaType(for: type))
     }
 
     func setMediaType(forMimeType mimeType: String) {
@@ -59,7 +59,12 @@ extension Media {
         if mimeType == "video/videopress" {
             mimeType = "video/mp4"
         }
-        self.mediaType = getMediaType(for: UTType(mimeType: mimeType))
+        setMediaType(getMediaType(for: UTType(mimeType: mimeType)))
+    }
+
+    private func setMediaType(_ newType: MediaType) {
+        guard self.mediaType != newType else { return }
+        self.mediaType = newType
     }
 
     private func getMediaType(for type: UTType?) -> MediaType {


### PR DESCRIPTION
Recordings: [before](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/a01ce311-1b1e-4570-beca-47b2fc834478), [after](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/aaaa869f-324c-492c-a2b1-57859ecba4af).

## To test:

- Open media (especially good if you have unstable order of assets like I do - more info [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/21208))
- Verify that it is no longer flashes (and reloads all images) when you open it

## RCA

When the app syncs the media, it uses the following method to update the existing objects:

```swift
func update(media: Media, with remoteMedia: RemoteMedia) {
    if media.mediaID != remoteMedia.mediaID {
        media.mediaID =  remoteMedia.mediaID
    }
    if media.remoteURL != remoteMedia.url?.absoluteString {
        media.remoteURL = remoteMedia.url?.absoluteString
    }
    if media.remoteLargeURL != remoteMedia.largeURL?.absoluteString {
        media.remoteLargeURL = remoteMedia.largeURL?.absoluteString
    }
```

It nearly achieves its job except for this part, which ruins the updates, and all the media assets are updated in the DB every time you open the screen.

```swift
        if let mimeType = remoteMedia.mimeType, !mimeType.isEmpty {
            media.setMediaType(forMimeType: mimeType)
        } else if let fileExtension = remoteMedia.extension, !fileExtension.isEmpty {
            media.setMediaType(forFilenameExtension: fileExtension)
        }
```

If you now put a breakpoint in the following method that tracks incremental updates, it never gets called (unless the library does in fact get updated):

```objc
- (void)updateDataWithRemoved:(NSIndexSet *)removed inserted:(NSIndexSet *)inserted changed:(NSIndexSet *)changed moved:(NSArray<id<WPMediaMove>> *)moves {
```

## Regression Notes
1. Potential unintended areas of impact: Media Picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
