### PR TITLE
[UI Tests] - Update ScreenObject package and revert previous login tests change

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "add-retry-to-waitforscreen",
-          "revision": "4d67a857542819cee4c75d21418f92206f3ae3b4",
+          "revision": "9521833fd7ab5429e0600eebcb8611921403bbe0",
           "version": null
         }
       },

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,9 +59,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": null,
-          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
-          "version": "0.2.2"
+          "branch": "add-retry-to-waitforscreen",
+          "revision": "1e2daaf18adcde8115f40b647af7938258eb14fe",
+          "version": null
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "add-retry-to-waitforscreen",
-          "revision": "1e2daaf18adcde8115f40b647af7938258eb14fe",
+          "revision": "4d67a857542819cee4c75d21418f92206f3ae3b4",
           "version": null
         }
       },

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,9 +59,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "add-retry-to-waitforscreen",
-          "revision": "9521833fd7ab5429e0600eebcb8611921403bbe0",
-          "version": null
+          "branch": null,
+          "revision": "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+          "version": "0.2.3"
         }
       },
       {

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -26,7 +26,6 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
         try TabNavComponent()
             .goToMeScreen()
-        try MeTabScreen()
             .logoutToPrologue()
             .assertScreenIsLoaded()
     }
@@ -45,7 +44,6 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
         try TabNavComponent()
             .goToMeScreen()
-        try MeTabScreen()
             .logout()
             .assertScreenIsLoaded()
     }

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -44,7 +44,7 @@ public class MeTabScreen: ScreenObject {
     var myProfileButton: XCUIElement { myProfileButtonGetter(app) }
     var notificationSettingsButton: XCUIElement { notificationSettingsButtonGetter(app) }
 
-    public init(app: XCUIApplication = XCUIApplication()) throws {
+    init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ appSettingsButtonGetter ],
             app: app

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -39,11 +39,10 @@ public class TabNavComponent: ScreenObject {
         )
     }
 
-    // Removed the MeTabScreen return value because MeTabScreen is a modal on top of MySiteScreen on iPad
-    // Returning it causes flakiness in CI as MySiteScreen is loaded first, making the test look for elements on MySiteScreen instead of MeTabScreen
-    public func goToMeScreen() throws {
+    public func goToMeScreen() throws -> MeTabScreen {
         try goToMySiteScreen()
         meTabButton.tap()
+        return try MeTabScreen()
     }
 
     @discardableResult

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10624,7 +10624,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -19016,14 +19016,14 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				17A8858B2757B97F0071FCA3 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */,
 				3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
+				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
@@ -20732,11 +20732,11 @@
 			files = (
 			);
 			inputPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 				"",
@@ -20909,13 +20909,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 			);
@@ -30823,7 +30823,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
+		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -30843,8 +30843,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.2;
+				branch = "add-retry-to-waitforscreen";
+				kind = branch;
 			};
 		};
 		EA14532629AD874C001F3143 /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {
@@ -30904,12 +30904,12 @@
 		};
 		3F411B6E28987E3F002513AE /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3F44DD57289C379C006334CD /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */ = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -30843,8 +30843,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = "add-retry-to-waitforscreen";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.3;
 			};
 		};
 		EA14532629AD874C001F3143 /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {


### PR DESCRIPTION
### Description
This PR was used to test the `ScreenObject` package changes, I decided to leave the empty commits as proof of the test runs being 🟢 This updates the repo to use the latest version of `ScreenObject` and reverted the changes done in https://github.com/wordpress-mobile/WordPress-iOS/pull/21200 as that is no longer needed with the changes made in `ScreenObject`

### Testing
CI should be 🟢 