### PR TITLE
Fix path calculation of Gutenberg `node_modules` folder

### DIFF
--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -91,7 +91,7 @@ def apply_rnreanimated_workaround!(dependencies:, gutenberg_path:)
   dependencies.delete('RNReanimated')
 
   # This is required to workaround an issue with RNReanimated after upgrading to version 2.17.0
-  rn_node_modules = File.join(gutenberg_path, '..', 'gutenberg', 'node_modules')
+  rn_node_modules = File.join(gutenberg_path, 'gutenberg', 'node_modules')
   raise "Could not find node modules at given path #{rn_node_modules}" unless File.exist? rn_node_modules
 
   ENV['REACT_NATIVE_NODE_MODULES_DIR'] = rn_node_modules


### PR DESCRIPTION
Fixes an issue when installing Pods using a local installation of Gutenberg.

**Error:**
```
[Gutenberg] Installing pods using local Gutenberg version from /<WORKSPACE_PATH>/WordPress-iOS/Gutenberg/../../gutenberg-mobile
Framework build type is dynamic framework
[Codegen] Generating ./build/generated/ios/React-Codegen.podspec.json

[!] Invalid `Podfile` file: Could not find node modules at given path /<WORKSPACE_PATH>/WordPress-iOS/Gutenberg/../../gutenberg-mobile/../gutenberg/node_modules.

 #  from /<WORKSPACE_PATH>/WordPress-iOS/Podfile:106
 #  -------------------------------------------
 #    ##
 >    gutenberg_pod
 #
 #  -------------------------------------------
```

**To test:**
1. Run the command `LOCAL_GUTENBERG=1 bundle exec pod install`.
2. Observe that the app can be built and run.
3. Open the app and navigate to a post.
4. Observe that the editor connects to the local Metro.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
