### PR TITLE
Jetpack Social: Pre-publishing sheet UI tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -38,7 +38,7 @@ struct PrepublishingSocialAccountsFooterView: View {
             remainingSharesLabel
             subscribeButton
         }
-        .padding(EdgeInsets(top: 24.0, leading: 0, bottom: 0, trailing: 0))
+        .padding(EdgeInsets(top: 16.0, leading: 0, bottom: 0, trailing: 0))
     }
 
     var remainingSharesLabel: some View {
@@ -82,7 +82,7 @@ struct PrepublishingSocialAccountsFooterView: View {
     }
 
     private enum Constants {
-        static let buttonLabelFont = Font.title3.weight(.semibold)
+        static let buttonLabelFont = Font.title3.weight(.medium)
         static let buttonColor = UIColor.primary
         static let buttonHighlightedColor = UIColor.muriel(color: .jetpackGreen, .shade70)
         static let warningColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade50))

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsTableFooterView.swift
@@ -47,9 +47,11 @@ struct PrepublishingSocialAccountsFooterView: View {
                 .font(.callout)
                 .foregroundColor(Color(showsWarning ? Constants.warningColor : .label))
         } icon: {
-            Image("icon-warning")
-                .resizable()
-                .frame(width: warningIconLength, height: warningIconLength)
+            if showsWarning {
+                Image("icon-warning")
+                    .resizable()
+                    .frame(width: warningIconLength, height: warningIconLength)
+            }
         }
         .accessibilityLabel(showsWarning ? "\(Constants.warningIconAccessibilityText), \(sharesText)" : sharesText)
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -111,6 +111,9 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
         title = Constants.navigationTitle
 
         tableView.register(SwitchTableViewCell.self, forCellReuseIdentifier: Constants.accountCellIdentifier)
+
+        // setting a custom spacer view will override the default 34pt padding from the grouped table view style.
+        tableView.tableHeaderView = UIView(frame: .init(x: 0, y: 0, width: 0, height: Constants.tableTopPadding))
     }
 
     override func viewDidLayoutSubviews() {
@@ -350,6 +353,7 @@ private extension PrepublishingSocialAccountsViewController {
         static let disabledCellImageOpacity = 0.36
         static let cellImageSize = CGSize(width: 28.0, height: 28.0)
 
+        static let tableTopPadding: CGFloat = 16.0
         static let minContentHeight: CGFloat = 300.0
         static let defaultBottomInset: CGFloat = 34.0
         static let additionalBottomInset: CGFloat = 16.0


### PR DESCRIPTION
Refs #20783

This PR addresses the design reviews from @osullivanchris, as listed in https://github.com/wordpress-mobile/WordPress-iOS/pull/21199#issuecomment-1660127703 and https://github.com/wordpress-mobile/WordPress-iOS/pull/21199#issuecomment-1660129108. What's changed:

- Modified the spacing between the remaining shares text to 16.0.
- Modified the table view's top padding to 16.0 (from the previous system default of 34.0).
- Fixed a bug where the warning icon is displayed in the social account toggles despite the number of remaining shares.
- Updated the font weight of the "Subscribe to share more" label to `medium`, from previously `semibold`.

Here are some previews:

• | Before | After
-|-|-
iPhone, Light | ![iphone_light_before](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/3fa6f122-5511-4948-9661-fa0eb461ae47) | ![iphone_light_after](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f6f2b4c6-afac-45bb-9229-5585f13c2800)
iPhone, Dark | ![iphone_dark_before](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b458c38b-6dc3-4efa-8480-b1632af4c398) | ![iphone_dark_after](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/4e44e510-af23-4c92-8c09-cee5715aaf47)

## To test

- Launch the Jetpack app.
- Switch to a site with existing social connections.
- Create a new blog post.
- Enter some text, and hit Publish.
- Tap the auto-sharing cell.
- 🔎 Verify that the UI changes are as described.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
