### PR TITLE
Blaze Manage Campaigns: Update campaign details url

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeCampaignDetailsWebViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeCampaignDetailsWebViewModel.swift
@@ -32,7 +32,7 @@ class BlazeCampaignDetailsWebViewModel: BlazeWebViewModel {
         guard let siteURL = blog.displayURL else {
             return nil
         }
-        let urlString = String(format: Constants.campaignDetailsURLFormat, siteURL, campaignID, source.description)
+        let urlString = String(format: Constants.campaignDetailsURLFormat, campaignID, siteURL, source.description)
         return URL(string: urlString)
     }
 
@@ -111,6 +111,6 @@ private extension BlazeCampaignDetailsWebViewModel {
     enum Constants {
         // TODO: Replace these constants with remote config params
         static let baseURLFormat = "https://wordpress.com/advertising/%@"
-        static let campaignDetailsURLFormat = "https://wordpress.com/advertising/%@/campaigns/%d?source=%@"
+        static let campaignDetailsURLFormat = "https://wordpress.com/advertising/campaigns/%d/%@?source=%@"
     }
 }

--- a/WordPress/WordPressTest/Blaze/BlazeCampaignDetailsWebViewModelTests.swift
+++ b/WordPress/WordPressTest/Blaze/BlazeCampaignDetailsWebViewModelTests.swift
@@ -73,7 +73,7 @@ final class BlazeCampaignDetailsWebViewModelTests: CoreDataTestCase {
 
         // Then
         XCTAssertTrue(view.loadCalled)
-        XCTAssertEqual(view.requestLoaded?.url?.absoluteString, "https://wordpress.com/advertising/test.blog.com/campaigns/0?source=campaign_list")
+        XCTAssertEqual(view.requestLoaded?.url?.absoluteString, "https://wordpress.com/advertising/campaigns/0/test.blog.com?source=campaign_list")
     }
 }
 


### PR DESCRIPTION
Fixes p1690901408555089-slack-C04LJFS1G5P

## Description
Updates url from `/advertising/{$site_url}/campaigns/{campaign_id}` to `/advertising/campaigns/{campaign_id}/{$site_url}`

## How to test
1. Switch to an account with blaze campaigns
2. Tap on the latest campaign on the campaigns dashboard card
3. ✅ Verify: the campaign details webview loads


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/636818c4-34b1-4881-a6f4-7c6ba698299a



## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
