### PR TITLE
Fix crash in ReaderDetailCommentsTableViewDelegate

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -83,7 +83,9 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             }
 
             cell.configureForPostDetails(with: comment) { _ in
-                tableView.performBatchUpdates({})
+                try? WPException.objcTry {
+                    tableView.performBatchUpdates({})
+                }
             }
 
             return cell

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -83,8 +83,12 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             }
 
             cell.configureForPostDetails(with: comment) { _ in
-                try? WPException.objcTry {
-                    tableView.performBatchUpdates({})
+                do {
+                    try WPException.objcTry {
+                        tableView.performBatchUpdates({})
+                    }
+                } catch {
+                    WordPressAppDelegate.crashLogging?.logError(error)
                 }
             }
 


### PR DESCRIPTION
Fixes #21202

To test:

- Verify that when you open the post details from the Reader, the comments are displayed

I've spent some time investigating it, but I thought it was no longer warranted the time because of how few occurrences of this crash there are. The workaround is not great, but I think it's better than a crash.

## Regression Notes
1. Potential unintended areas of impact: Reader
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
