### PR TITLE
Fix an issue with media picker not deallocating after selection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 * [*] Fix an issue with the size of the thumbnails in the media picker so it now loads faster and uses less memory [#21204]
 * [*] Fix an issue with unstable order of assets on the media screen [#21210]
 * [*] Fix an issue with media screen flashing when opened [#21211]
-
+* [*] [internal] Fix an issue with some media pickers not deallocating after selection in post editor [#21225]
 
 22.9
 -----
@@ -22,6 +22,7 @@
 * [**] [internal] Fix a few potential Core Data issues in Blogging Prompts & Reminders. [#21016]
 * [*] [Jetpack-only] Made performance improvements for Posting Activity stats. [#21136]
 * [*] Fixed a crash that could occur when following sites in Reader. [#21140]
+* [*] Fix an issue with avatars not loading in mentions [#21169]
 * [*] [Jetpack-only] Fixed a crash that could occur when the user deletes the WordPress app upon a successful migration. [#21167]
 * [*] Fixed a crash that occurs in Weekly Roundup Background task due to a Core Data Concurrency violation. [#21076]
 * [***] Block editor: Editor UX improvements with new icons, colors and additional design enhancements. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5985]

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosPicker.swift
@@ -43,22 +43,22 @@ final class StockPhotosPicker: NSObject {
         return options
     }()
 
-    private lazy var picker: WPNavigationMediaPickerViewController = {
-        let picker = WPNavigationMediaPickerViewController(options: pickerOptions)
-        picker.delegate = self
-        picker.startOnGroupSelector = false
-        picker.showGroupSelector = false
-        picker.dataSource = dataSource
-        picker.cancelButtonTitle = .closePicker
-        return picker
-    }()
-
     func presentPicker(origin: UIViewController, blog: Blog) {
         NoResultsStockPhotosConfiguration.configureAsIntro(searchHint)
         self.blog = blog
 
+        let picker: WPNavigationMediaPickerViewController = {
+            let picker = WPNavigationMediaPickerViewController(options: pickerOptions)
+            picker.delegate = self
+            picker.startOnGroupSelector = false
+            picker.showGroupSelector = false
+            picker.dataSource = dataSource
+            picker.cancelButtonTitle = .closePicker
+            return picker
+        }()
+
         origin.present(picker, animated: true) {
-            self.picker.mediaPicker.searchBar?.becomeFirstResponder()
+            picker.mediaPicker.searchBar?.becomeFirstResponder()
         }
 
         observeDataSource()

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
@@ -48,23 +48,23 @@ final class TenorPicker: NSObject {
         return options
     }()
 
-    private lazy var picker: WPNavigationMediaPickerViewController = {
-        let picker = WPNavigationMediaPickerViewController(options: pickerOptions)
-        picker.delegate = self
-        picker.startOnGroupSelector = false
-        picker.showGroupSelector = false
-        picker.dataSource = dataSource
-        picker.cancelButtonTitle = .closePicker
-        picker.mediaPicker.registerClass(forReusableCellOverlayViews: CachedAnimatedImageView.self)
-        return picker
-    }()
-
     func presentPicker(origin: UIViewController, blog: Blog) {
         NoResultsTenorConfiguration.configureAsIntro(searchHint)
         self.blog = blog
 
+        let picker: WPNavigationMediaPickerViewController = {
+            let picker = WPNavigationMediaPickerViewController(options: pickerOptions)
+            picker.delegate = self
+            picker.startOnGroupSelector = false
+            picker.showGroupSelector = false
+            picker.dataSource = dataSource
+            picker.cancelButtonTitle = .closePicker
+            picker.mediaPicker.registerClass(forReusableCellOverlayViews: CachedAnimatedImageView.self)
+            return picker
+        }()
+
         origin.present(picker, animated: true) {
-            self.picker.mediaPicker.searchBar?.becomeFirstResponder()
+            picker.mediaPicker.searchBar?.becomeFirstResponder()
         }
 
         observeDataSource()


### PR DESCRIPTION
To test:

**Select Photo**

- Set breakpoint on init and dealloc of WPMediaPickerViewController
- Add image block
- Pick from “Free Photo Library”
- Select a photo
- Verify that the photo was added
- Verify that WPMediaPickerViewController is deallocated 

**Cancel**

- Add image block
- Pick “Free Photo Library”
- Tap “Cancel” 
- Verify that the screen was dismissed
- Verify that WPMediaPickerViewController is deallocated 

**Dismiss with Gesture**

- Add image block
- Pick “Free Photo Library”
- Swipe to dismiss screen
- Verify that the screen was dismissed
- Verify that WPMediaPickerViewController is deallocated 


Repeat for "Free GIF library".

## Regression Notes
1. Potential unintended areas of impact: Media Picker in Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual test
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
