### PR TITLE
Return NSManagedObjectID instead of PublicizeConnection

### DIFF
--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -97,9 +97,7 @@ import WordPressKit
                 WPAppAnalytics.track(.sharingPublicizeConnected, withProperties: properties, withBlogID: dotComID)
 
                 self.coreDataStack.performAndSave({ context -> NSManagedObjectID in
-                    let pubConn = try self.createOrReplacePublicizeConnectionForBlogWithObjectID(blogObjectID, remoteConnection: remoteConnection, in: context)
-                    try context.obtainPermanentIDs(for: [pubConn])
-                    return pubConn.objectID
+                    try self.createOrReplacePublicizeConnectionForBlogWithObjectID(blogObjectID, remoteConnection: remoteConnection, in: context)
                 }, completion: { result in
                     let transformed = result.flatMap { objectID in
                         Result {
@@ -367,12 +365,14 @@ import WordPressKit
         _ blogObjectID: NSManagedObjectID,
         remoteConnection: RemotePublicizeConnection,
         in context: NSManagedObjectContext
-    ) throws -> PublicizeConnection {
+    ) throws -> NSManagedObjectID {
         let blog = try context.existingObject(with: blogObjectID) as! Blog
         let pubConn = PublicizeConnection.createOrReplace(from: remoteConnection, in: context)
         pubConn.blog = blog
 
-        return pubConn
+        try context.obtainPermanentIDs(for: [pubConn])
+
+        return pubConn.objectID
     }
 
 


### PR DESCRIPTION
Similar to `performQuery`, `performAndSave`'s closure [should not return a `NSManagedObject` instance](https://github.com/wordpress-mobile/WordPress-iOS/blob/030ba54425981e23225cacfe495f7a2d1021978f/WordPress/Classes/Utility/CoreDataHelper.swift#L364-L385).

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A