### PR TITLE
Remove the Core Data workaround in EditorMediaUtility

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * [*] Fix occasional crashes when updating Notification, Posts, and Reader content [#21250]
 * [*] Fix an issue in Reader topics cleanup that could cause the app to crash. [#21243]
 * [*] [internal] Fix incorrectly terminated background task [#21254]
+* [**] [internal] Refactor how image is downloaded in Gutenberg Editor and Aztec Edtiror. [#21227]
 
 22.9
 -----

--- a/WordPress/Classes/Networking/MediaHost+Blog.swift
+++ b/WordPress/Classes/Networking/MediaHost+Blog.swift
@@ -8,6 +8,13 @@ extension MediaHost {
         case baseInitializerError(error: Error, blog: Blog)
     }
 
+    init(with blog: Blog) {
+        self.init(with: blog) { error in
+            // We'll log the error, so we know it's there, but we won't halt execution.
+            WordPressAppDelegate.crashLogging?.logError(error)
+        }
+    }
+
     init(with blog: Blog, failure: (BlogError) -> ()) {
         let isAtomic = blog.isAtomic()
         self.init(with: blog, isAtomic: isAtomic, failure: failure)

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -191,7 +191,7 @@ class MediaThumbnailService: NSObject {
             return
         }
 
-        let download = AuthenticatedImageDownload(url: imageURL, blogObjectID: media.blog.objectID, callbackQueue: callbackQueue, onSuccess: onCompletion, onFailure: onError)
+        let download = AuthenticatedImageDownload(url: imageURL, mediaHost: MediaHost(with: media.blog), callbackQueue: callbackQueue, onSuccess: onCompletion, onFailure: onError)
 
         download.start()
     }


### PR DESCRIPTION
This is an attempt to fix #20630. The issue is the `NSManagedObjectContext.existingObject(with:)` call in `AuthenticatedImageDownload` throws an Objective-C exception.

The root cause is unknown. But this PR cleans up the code that accesses Core Data objects. Hopefully now that the Core Data objects (`Post` and `Blog` instances) are now used correctly, the issue would go away.

There are two main code changes:
1. `AuthenticatedImageDownload` no long access `NSManagedObject`. It used to have code to query `Blog`. The code is now moved to its caller.
2. The caller `EditorMediaUtilit.downloadImage` function is refactored to access the `Post` argument safely using `performAndQuery`.

> **Note**
> It might be easier to review this PR [with "Hide whitespace" option on](https://github.com/wordpress-mobile/WordPress-iOS/pull/21227/files?diff=unified&w=1).

## Test Instructions

Make sure Gutenberg editor and Aztec editor both can still load images.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the Test Instructions.

4. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A