### PR TITLE
Add `testError()` syntax sugar for the self-documenting general purpose errors unit tests

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -880,6 +880,7 @@
 		3F568A0025420DE80048A9E4 /* MultiStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689FF25420DE80048A9E4 /* MultiStatsView.swift */; };
 		3F568A1F254213B60048A9E4 /* VerticalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A1E254213B60048A9E4 /* VerticalCard.swift */; };
 		3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A2E254216550048A9E4 /* FlexibleCard.swift */; };
+		3F593FDD2A81DC6D00B29E86 /* NSError+TestInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F593FDC2A81DC6D00B29E86 /* NSError+TestInstance.swift */; };
 		3F5AAC242877791900AEF5DD /* JetpackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFA5ED12876152E00830E28 /* JetpackButton.swift */; };
 		3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */; };
 		3F5B3EB123A851480060FF1F /* ReaderReblogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */; };
@@ -6530,6 +6531,7 @@
 		3F5689FF25420DE80048A9E4 /* MultiStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiStatsView.swift; sourceTree = "<group>"; };
 		3F568A1E254213B60048A9E4 /* VerticalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCard.swift; sourceTree = "<group>"; };
 		3F568A2E254216550048A9E4 /* FlexibleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleCard.swift; sourceTree = "<group>"; };
+		3F593FDC2A81DC6D00B29E86 /* NSError+TestInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+TestInstance.swift"; sourceTree = "<group>"; };
 		3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogPresenter.swift; sourceTree = "<group>"; };
 		3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogFormatter.swift; sourceTree = "<group>"; };
 		3F5B9B42288AFE4B001D17E9 /* DashboardBadgeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBadgeCell.swift; sourceTree = "<group>"; };
@@ -12123,6 +12125,7 @@
 				E157D5DF1C690A6C00F04FB9 /* ImmuTableTestUtils.swift */,
 				59B48B611B99E132008EBB84 /* JSONObject.swift */,
 				F11023A223186BCA00C4E84A /* MediaBuilder.swift */,
+				3F593FDC2A81DC6D00B29E86 /* NSError+TestInstance.swift */,
 				57889AB723589DF100DAE56D /* PageBuilder.swift */,
 				570BFD8F2282418A007859A8 /* PostBuilder.swift */,
 				3F759FBB2A2DB2CF0039A845 /* TestError.swift */,
@@ -23577,6 +23580,7 @@
 				FAE8EE9C273AD0A800A65307 /* QuickStartSettingsTests.swift in Sources */,
 				8BD8201D24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift in Sources */,
 				DCF892D2282FA45500BB71E1 /* StatsMockDataLoader.swift in Sources */,
+				3F593FDD2A81DC6D00B29E86 /* NSError+TestInstance.swift in Sources */,
 				02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */,
 				8B749E9025AF8D2E00023F03 /* JetpackCapabilitiesServiceTests.swift in Sources */,
 				F1450CF72437E8F800A28BFE /* MediaHostTests.swift in Sources */,

--- a/WordPress/WordPressTest/AccountSettingsRemoteInterfaceStub.swift
+++ b/WordPress/WordPressTest/AccountSettingsRemoteInterfaceStub.swift
@@ -13,7 +13,7 @@ class AccountSettingsRemoteInterfaceStub: AccountSettingsRemoteInterface {
     init(
         updateSettingResult: Result<Void, Error> = .success(()),
         // Defaulting to failure to avoid having to create AccountSettings here, because it required an NSManagedContext
-        getSettingsResult: Result<AccountSettings, Error> = .failure(NSError.testError()),
+        getSettingsResult: Result<AccountSettings, Error> = .failure(NSError.testInstance()),
         changeUsernameShouldSucceed: Bool = true,
         suggestUsernamesResult: [String] = [],
         updatePasswordResult: Result<Void, Error> = .success(()),

--- a/WordPress/WordPressTest/AccountSettingsRemoteInterfaceStub.swift
+++ b/WordPress/WordPressTest/AccountSettingsRemoteInterfaceStub.swift
@@ -13,7 +13,7 @@ class AccountSettingsRemoteInterfaceStub: AccountSettingsRemoteInterface {
     init(
         updateSettingResult: Result<Void, Error> = .success(()),
         // Defaulting to failure to avoid having to create AccountSettings here, because it required an NSManagedContext
-        getSettingsResult: Result<AccountSettings, Error> = .failure(NSError.testInstance()),
+        getSettingsResult: Result<AccountSettings, Error> = .failure(testError()),
         changeUsernameShouldSucceed: Bool = true,
         suggestUsernamesResult: [String] = [],
         updatePasswordResult: Result<Void, Error> = .success(()),

--- a/WordPress/WordPressTest/AccountSettingsRemoteInterfaceStub.swift
+++ b/WordPress/WordPressTest/AccountSettingsRemoteInterfaceStub.swift
@@ -13,7 +13,7 @@ class AccountSettingsRemoteInterfaceStub: AccountSettingsRemoteInterface {
     init(
         updateSettingResult: Result<Void, Error> = .success(()),
         // Defaulting to failure to avoid having to create AccountSettings here, because it required an NSManagedContext
-        getSettingsResult: Result<AccountSettings, Error> = .failure(TestError()),
+        getSettingsResult: Result<AccountSettings, Error> = .failure(NSError.testError()),
         changeUsernameShouldSucceed: Bool = true,
         suggestUsernamesResult: [String] = [],
         updatePasswordResult: Result<Void, Error> = .success(()),

--- a/WordPress/WordPressTest/AccountSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/AccountSettingsServiceTests.swift
@@ -46,7 +46,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
         // Since this approach bypasses the entire network stack, the hope is that it'll result in a more robust test.
         let service = AccountSettingsService(
             userID: 1,
-            remote: AccountSettingsRemoteInterfaceStub(updateSettingResult: .failure(NSError.testError())),
+            remote: AccountSettingsRemoteInterfaceStub(updateSettingResult: .failure(NSError.testInstance())),
             coreDataStack: contextManager
         )
 

--- a/WordPress/WordPressTest/AccountSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/AccountSettingsServiceTests.swift
@@ -46,7 +46,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
         // Since this approach bypasses the entire network stack, the hope is that it'll result in a more robust test.
         let service = AccountSettingsService(
             userID: 1,
-            remote: AccountSettingsRemoteInterfaceStub(updateSettingResult: .failure(NSError.testInstance())),
+            remote: AccountSettingsRemoteInterfaceStub(updateSettingResult: .failure(testError())),
             coreDataStack: contextManager
         )
 

--- a/WordPress/WordPressTest/AccountSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/AccountSettingsServiceTests.swift
@@ -1,8 +1,7 @@
-import XCTest
 import Nimble
 import OHHTTPStubs
-
 @testable import WordPress
+import XCTest
 
 class AccountSettingsServiceTests: CoreDataTestCase {
     private var service: AccountSettingsService!
@@ -47,7 +46,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
         // Since this approach bypasses the entire network stack, the hope is that it'll result in a more robust test.
         let service = AccountSettingsService(
             userID: 1,
-            remote: AccountSettingsRemoteInterfaceStub(updateSettingResult: .failure(TestError())),
+            remote: AccountSettingsRemoteInterfaceStub(updateSettingResult: .failure(NSError.testError())),
             coreDataStack: contextManager
         )
 

--- a/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
@@ -17,8 +17,7 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
         expect(attachment.overlayImage).to(beNil())
 
         // Act
-        let error = NSError(domain: "domain", code: 0, userInfo: nil)
-        vc.mediaObserver(media: media, state: .failed(error: error))
+        vc.mediaObserver(media: media, state: .failed(error: NSError.testError()))
 
         // Assert
         expect(attachment.message).notTo(beNil())
@@ -35,8 +34,7 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
         let attachment = vc.findAttachment(withUploadID: media.uploadID)!
 
         // Trigger an error
-        let error = NSError(domain: "domain", code: 0, userInfo: nil)
-        vc.mediaObserver(media: media, state: .failed(error: error))
+        vc.mediaObserver(media: media, state: .failed(error: NSError.testError()))
 
         // Act
         // Simulate the restarting of uploads

--- a/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
@@ -17,7 +17,7 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
         expect(attachment.overlayImage).to(beNil())
 
         // Act
-        vc.mediaObserver(media: media, state: .failed(error: NSError.testError()))
+        vc.mediaObserver(media: media, state: .failed(error: NSError.testInstance()))
 
         // Assert
         expect(attachment.message).notTo(beNil())
@@ -34,7 +34,7 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
         let attachment = vc.findAttachment(withUploadID: media.uploadID)!
 
         // Trigger an error
-        vc.mediaObserver(media: media, state: .failed(error: NSError.testError()))
+        vc.mediaObserver(media: media, state: .failed(error: NSError.testInstance()))
 
         // Act
         // Simulate the restarting of uploads

--- a/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
@@ -17,7 +17,7 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
         expect(attachment.overlayImage).to(beNil())
 
         // Act
-        vc.mediaObserver(media: media, state: .failed(error: NSError.testInstance()))
+        vc.mediaObserver(media: media, state: .failed(error: .testInstance()))
 
         // Assert
         expect(attachment.message).notTo(beNil())
@@ -34,7 +34,7 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
         let attachment = vc.findAttachment(withUploadID: media.uploadID)!
 
         // Trigger an error
-        vc.mediaObserver(media: media, state: .failed(error: NSError.testInstance()))
+        vc.mediaObserver(media: media, state: .failed(error: .testInstance()))
 
         // Act
         // Simulate the restarting of uploads

--- a/WordPress/WordPressTest/BlogServiceMock.swift
+++ b/WordPress/WordPressTest/BlogServiceMock.swift
@@ -12,7 +12,7 @@ class BlogServiceMock: BlogService {
             success()
         }
         else {
-            failure(NSError.testInstance())
+            failure(testError())
         }
 
     }

--- a/WordPress/WordPressTest/BlogServiceMock.swift
+++ b/WordPress/WordPressTest/BlogServiceMock.swift
@@ -12,8 +12,7 @@ class BlogServiceMock: BlogService {
             success()
         }
         else {
-            let error = NSError(domain: "", code: 0)
-            failure(error)
+            failure(NSError.testError())
         }
 
     }

--- a/WordPress/WordPressTest/BlogServiceMock.swift
+++ b/WordPress/WordPressTest/BlogServiceMock.swift
@@ -12,7 +12,7 @@ class BlogServiceMock: BlogService {
             success()
         }
         else {
-            failure(TestError())
+            failure(NSError.testInstance())
         }
 
     }

--- a/WordPress/WordPressTest/BlogServiceMock.swift
+++ b/WordPress/WordPressTest/BlogServiceMock.swift
@@ -12,7 +12,7 @@ class BlogServiceMock: BlogService {
             success()
         }
         else {
-            failure(NSError.testError())
+            failure(TestError())
         }
 
     }

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -193,7 +193,7 @@ class ContextManagerTests: XCTestCase {
         }
         XCTAssertEqual(numberOfAccounts(), 1)
 
-        let expectedError = NSError.testError()
+        let expectedError = NSError.testInstance()
         do {
             try await contextManager.performAndSave { context in
                 _ = WPAccount.fixture(context: context, userID: 100)

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -193,14 +193,15 @@ class ContextManagerTests: XCTestCase {
         }
         XCTAssertEqual(numberOfAccounts(), 1)
 
+        let expectedError = NSError.testError()
         do {
             try await contextManager.performAndSave { context in
                 _ = WPAccount.fixture(context: context, userID: 100)
-                throw NSError(domain: "save", code: 1)
+                throw expectedError
             }
             XCTFail("The above call should throw")
         } catch {
-            XCTAssertEqual((error as NSError).domain, "save")
+            XCTAssertEqual(error as NSError, expectedError)
         }
         XCTAssertEqual(numberOfAccounts(), 1)
 

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -1,6 +1,23 @@
 import Foundation
 import XCTest
 
+extension Error {
+
+    static func testError(
+        description: String = "A test error",
+        domain: String = "org.wordpress.unit-tests",
+        code: Int = 1
+    ) -> NSError {
+        NSError(
+            domain: domain,
+            code: code,
+            userInfo: [
+                NSLocalizedDescriptionKey: description
+            ]
+        )
+    }
+}
+
 @testable import WordPress
 
 class MediaProgressCoordinatorTests: CoreDataTestCase {
@@ -9,10 +26,6 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
 
     fileprivate func makeTestMedia() -> Media {
         return NSEntityDescription.insertNewObject(forEntityName: Media.classNameWithoutNamespaces(), into: mainContext) as! Media
-    }
-
-    fileprivate func makeTestError() -> NSError {
-        return NSError(domain: "org.wordpress.media-tests", code: 1, userInfo: nil)
     }
 
     override func setUp() {
@@ -146,7 +159,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // simulate a failed request
         progress.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: makeTestError(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: .testError(), toMediaID: "1")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
 
@@ -169,7 +182,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // Fail all the requests
         mediaProgressCoordinator.mediaInProgress.values.enumerated().forEach({ index, progress in
             progress.completedUnitCount = 0
-            mediaProgressCoordinator.attach(error: makeTestError(), toMediaID: "\(index+1)")
+            mediaProgressCoordinator.attach(error: .testError(), toMediaID: "\(index+1)")
         })
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
@@ -194,8 +207,8 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         mediaProgressCoordinator.mediaInProgress["1"]!.completedUnitCount = 0
         mediaProgressCoordinator.mediaInProgress["2"]!.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: makeTestError(), toMediaID: "1")
-        mediaProgressCoordinator.attach(error: makeTestError(), toMediaID: "2")
+        mediaProgressCoordinator.attach(error: .testError(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: .testError(), toMediaID: "2")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning)
 

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -142,7 +142,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // simulate a failed request
         progress.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: TestError(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "1")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
 
@@ -165,7 +165,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // Fail all the requests
         mediaProgressCoordinator.mediaInProgress.values.enumerated().forEach({ index, progress in
             progress.completedUnitCount = 0
-            mediaProgressCoordinator.attach(error: TestError(), toMediaID: "\(index+1)")
+            mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "\(index+1)")
         })
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
@@ -190,8 +190,8 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         mediaProgressCoordinator.mediaInProgress["1"]!.completedUnitCount = 0
         mediaProgressCoordinator.mediaInProgress["2"]!.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: TestError(), toMediaID: "1")
-        mediaProgressCoordinator.attach(error: TestError(), toMediaID: "2")
+        mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "2")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning)
 

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -142,7 +142,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // simulate a failed request
         progress.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: .testError(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: TestError(), toMediaID: "1")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
 
@@ -165,7 +165,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // Fail all the requests
         mediaProgressCoordinator.mediaInProgress.values.enumerated().forEach({ index, progress in
             progress.completedUnitCount = 0
-            mediaProgressCoordinator.attach(error: .testError(), toMediaID: "\(index+1)")
+            mediaProgressCoordinator.attach(error: TestError(), toMediaID: "\(index+1)")
         })
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
@@ -190,8 +190,8 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         mediaProgressCoordinator.mediaInProgress["1"]!.completedUnitCount = 0
         mediaProgressCoordinator.mediaInProgress["2"]!.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: .testError(), toMediaID: "1")
-        mediaProgressCoordinator.attach(error: .testError(), toMediaID: "2")
+        mediaProgressCoordinator.attach(error: TestError(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: TestError(), toMediaID: "2")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning)
 

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -1,23 +1,6 @@
 import Foundation
 import XCTest
 
-extension Error {
-
-    static func testError(
-        description: String = "A test error",
-        domain: String = "org.wordpress.unit-tests",
-        code: Int = 1
-    ) -> NSError {
-        NSError(
-            domain: domain,
-            code: code,
-            userInfo: [
-                NSLocalizedDescriptionKey: description
-            ]
-        )
-    }
-}
-
 @testable import WordPress
 
 class MediaProgressCoordinatorTests: CoreDataTestCase {

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -142,7 +142,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // simulate a failed request
         progress.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: .testInstance(), toMediaID: "1")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
 
@@ -165,7 +165,7 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         // Fail all the requests
         mediaProgressCoordinator.mediaInProgress.values.enumerated().forEach({ index, progress in
             progress.completedUnitCount = 0
-            mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "\(index+1)")
+            mediaProgressCoordinator.attach(error: .testInstance(), toMediaID: "\(index+1)")
         })
 
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.completedUnitCount == 0)
@@ -190,8 +190,8 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
         mediaProgressCoordinator.mediaInProgress["1"]!.completedUnitCount = 0
         mediaProgressCoordinator.mediaInProgress["2"]!.completedUnitCount = 0
 
-        mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "1")
-        mediaProgressCoordinator.attach(error: NSError.testInstance(), toMediaID: "2")
+        mediaProgressCoordinator.attach(error: .testInstance(), toMediaID: "1")
+        mediaProgressCoordinator.attach(error: .testInstance(), toMediaID: "2")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning)
 

--- a/WordPress/WordPressTest/NSError+TestInstance.swift
+++ b/WordPress/WordPressTest/NSError+TestInstance.swift
@@ -1,0 +1,17 @@
+extension NSError {
+
+    static func testInstance(
+        description: String = "A test error",
+        domain: String = "org.wordpress.unit-tests",
+        code: Int = 1
+    ) -> NSError {
+        .init(code: code, domain: domain, description: description)
+    }
+}
+
+extension NSError {
+
+    convenience init(code: Int, domain: String, description: String) {
+        self.init(domain: domain, code: code, userInfo: [NSLocalizedDescriptionKey: description])
+    }
+}

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -24,7 +24,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(image: "test.jpeg", status: .failed)
             .with(remoteStatus: .local)
             .build()
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testInstance()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: .testInstance()))
         let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
 
         postCoordinator.save(post)
@@ -121,7 +121,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(image: "test.jpeg", status: .failed)
             .with(remoteStatus: .local)
             .build()
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testInstance()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: .testInstance()))
         let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
         var returnedError: Error?
 
@@ -366,7 +366,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
 
-            let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testInstance()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: .testInstance()))
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
@@ -403,7 +403,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .build()
 
         let onUpdateParameters = post.media.reduce(into: [Media: MediaCoordinator.MediaState]()) { dict, media in
-            dict[media] = MediaCoordinator.MediaState.failed(error: NSError.testInstance())
+            dict[media] = MediaCoordinator.MediaState.failed(error: .testInstance())
         }
         let mediaCoordinatorMock = MediaCoordinatorMock(onUpdateParameters: onUpdateParameters)
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -24,7 +24,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(image: "test.jpeg", status: .failed)
             .with(remoteStatus: .local)
             .build()
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testError()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testInstance()))
         let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
 
         postCoordinator.save(post)
@@ -121,7 +121,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(image: "test.jpeg", status: .failed)
             .with(remoteStatus: .local)
             .build()
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testError()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testInstance()))
         let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
         var returnedError: Error?
 
@@ -366,7 +366,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
 
-            let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testError()))
+            let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testInstance()))
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
@@ -403,7 +403,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .build()
 
         let onUpdateParameters = post.media.reduce(into: [Media: MediaCoordinator.MediaState]()) { dict, media in
-            dict[media] = MediaCoordinator.MediaState.failed(error: NSError.testError())
+            dict[media] = MediaCoordinator.MediaState.failed(error: NSError.testInstance())
         }
         let mediaCoordinatorMock = MediaCoordinatorMock(onUpdateParameters: onUpdateParameters)
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -24,7 +24,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(image: "test.jpeg", status: .failed)
             .with(remoteStatus: .local)
             .build()
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testError()))
         let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
 
         postCoordinator.save(post)
@@ -121,7 +121,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(image: "test.jpeg", status: .failed)
             .with(remoteStatus: .local)
             .build()
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError()))
+        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testError()))
         let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
         var returnedError: Error?
 
@@ -366,7 +366,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
 
-        let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError()))
+            let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError.testError()))
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
@@ -403,7 +403,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .build()
 
         let onUpdateParameters = post.media.reduce(into: [Media: MediaCoordinator.MediaState]()) { dict, media in
-            dict[media] = MediaCoordinator.MediaState.failed(error: NSError())
+            dict[media] = MediaCoordinator.MediaState.failed(error: NSError.testError())
         }
         let mediaCoordinatorMock = MediaCoordinatorMock(onUpdateParameters: onUpdateParameters)
 

--- a/WordPress/WordPressTest/SiteManagementServiceTests.swift
+++ b/WordPress/WordPressTest/SiteManagementServiceTests.swift
@@ -118,7 +118,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let context = contextManager.mainContext
         let blog = insertBlog(context)
 
-        let testError = NSError(domain: "UnitTest", code: 0, userInfo: nil)
+        let testError = NSError.testError()
         let expect = expectation(description: "Delete Site failure expectation")
         mockRemoteService.reset()
         siteManagementService.deleteSiteForBlog(blog,
@@ -138,7 +138,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
 
         XCTAssertFalse(blogObjectID.isTemporaryID, "Should be a permanent object")
 
-        let testError = NSError(domain: "UnitTest", code: 0, userInfo: nil)
+        let testError = NSError.testError()
         let expect = expectation(description: "Remove Blog success expectation")
         mockRemoteService.reset()
         siteManagementService.deleteSiteForBlog(blog,
@@ -181,7 +181,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let context = contextManager.mainContext
         let blog = insertBlog(context)
 
-        let testError = NSError(domain: "UnitTest", code: 0, userInfo: nil)
+        let testError = NSError.testError()
         let expect = expectation(description: "ExportContent failure expectation")
         mockRemoteService.reset()
         siteManagementService.exportContentForBlog(blog,
@@ -221,7 +221,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let context = contextManager.mainContext
         let blog = insertBlog(context)
 
-        let testError = NSError(domain: "UnitTest", code: 0, userInfo: nil)
+        let testError = NSError.testError()
         let expect = expectation(description: "GetActivePurchases failure expectation")
         mockRemoteService.reset()
         siteManagementService.getActivePurchasesForBlog(blog,

--- a/WordPress/WordPressTest/SiteManagementServiceTests.swift
+++ b/WordPress/WordPressTest/SiteManagementServiceTests.swift
@@ -118,7 +118,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let context = contextManager.mainContext
         let blog = insertBlog(context)
 
-        let testError = NSError.testError()
+        let testError = NSError.testInstance()
         let expect = expectation(description: "Delete Site failure expectation")
         mockRemoteService.reset()
         siteManagementService.deleteSiteForBlog(blog,
@@ -138,7 +138,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
 
         XCTAssertFalse(blogObjectID.isTemporaryID, "Should be a permanent object")
 
-        let testError = NSError.testError()
+        let testError = NSError.testInstance()
         let expect = expectation(description: "Remove Blog success expectation")
         mockRemoteService.reset()
         siteManagementService.deleteSiteForBlog(blog,
@@ -181,7 +181,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let context = contextManager.mainContext
         let blog = insertBlog(context)
 
-        let testError = NSError.testError()
+        let testError = NSError.testInstance()
         let expect = expectation(description: "ExportContent failure expectation")
         mockRemoteService.reset()
         siteManagementService.exportContentForBlog(blog,
@@ -221,7 +221,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         let context = contextManager.mainContext
         let blog = insertBlog(context)
 
-        let testError = NSError.testError()
+        let testError = NSError.testInstance()
         let expect = expectation(description: "GetActivePurchases failure expectation")
         mockRemoteService.reset()
         siteManagementService.getActivePurchasesForBlog(blog,

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -1,3 +1,10 @@
+/// Global free function only available for the unit test target to make creating general purpose errors in the test DRY and self-documenting.
+///
+/// The Swift API guidelines reccomend against free functions, but the improved ergonomics and limited scope make the approach worth the trade off in this case.
+func testError(id: Int = 1, description: String = "A test error") -> Error {
+    NSError.testInstance(description: description, code: id)
+}
+
 // There must be a way to make this as an Error extension.
 // However, when I try to do so I get the following errors.
 //
@@ -18,39 +25,4 @@ extension Error {
         // This would be discouraged if it wasn't for the facts that we know that NSError converts to Error.
         NSError.testInstance(description: description, domain: domain, code: code) as! Self
     }
-}
-
-extension NSError {
-
-    static func testInstance(
-        description: String = "A test error",
-        domain: String = "org.wordpress.unit-tests",
-        code: Int = 1
-    ) -> NSError {
-        .init(code: code, domain: domain, description: description)
-    }
-}
-
-extension NSError {
-
-    convenience init(
-        code: Int,
-        domain: String,
-        description: String
-    ) {
-        self.init(
-            domain: domain,
-            code: code,
-            userInfo: [
-                NSLocalizedDescriptionKey: description
-            ]
-        )
-    }
-}
-
-/// Global free function only available for the unit test target to make creating general purpose errors in the test DRY and self-documenting.
-///
-/// The Swift API guidelines reccomend against free functions, but the improved ergonomics and limited scope make the approach worth the trade off in this case.
-func testError(id: Int = 0, description: String = "A test error") -> Error {
-    NSError.testInstance(description: description, code: id)
 }

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -47,3 +47,10 @@ extension NSError {
         )
     }
 }
+
+/// Global free function only available for the unit test target to make creating general purpose errors in the test DRY and self-documenting.
+///
+/// The Swift API guidelines reccomend against free functions, but the improved ergonomics and limited scope make the approach worth the trade off in this case.
+func testError(id: Int = 0, description: String = "A test error") -> Error {
+    NSError.testInstance(description: description, code: id)
+}

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -23,3 +23,15 @@ extension NSError {
         )
     }
 }
+
+extension Error {
+
+    static func testError(
+        description: String = "A test error",
+        domain: String = "org.wordpress.unit-tests",
+        code: Int = 1
+    ) -> Self {
+        // This would be discouraged if it wasn't for the facts that we know that NSError converts to Error.
+        NSError.testError(description: description, domain: domain, code: code) as! Self
+    }
+}

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -1,3 +1,33 @@
+typealias TestError = NSError
+
+extension TestError {
+
+    convenience init(
+        id: Int = 1,
+        description: String = "A test error",
+        domain: String = "org.wordpress.unit-tests"
+    ) {
+        self.init(code: id, domain: domain, description: description)
+    }
+}
+
+extension NSError {
+
+    convenience init(
+        code: Int,
+        domain: String,
+        description: String
+    ) {
+        self.init(
+            domain: domain,
+            code: code,
+            userInfo: [
+                NSLocalizedDescriptionKey: description
+            ]
+        )
+    }
+}
+
 // There must be a way to make this as an Error extension.
 // However, when I try to do so I get the following errors.
 //
@@ -15,13 +45,7 @@ extension NSError {
         domain: String = "org.wordpress.unit-tests",
         code: Int = 1
     ) -> NSError {
-        NSError(
-            domain: domain,
-            code: code,
-            userInfo: [
-                NSLocalizedDescriptionKey: description
-            ]
-        )
+        .init(code: code, domain: domain, description: description)
     }
 }
 

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -14,7 +14,7 @@ func testError(id: Int = 1, description: String = "A test error") -> Error {
 // Usage: Error.testError()
 // Error: Static member 'testError' cannot be used on protocol metatype '(any Error).Type'
 //
-// In the meantime, we can call this via NSError.testInstance() in the tests.
+// In the meantime, we can call this via testError() in the tests.
 extension Error {
 
     static func testError(

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -4,25 +4,3 @@
 func testError(id: Int = 1, description: String = "A test error") -> Error {
     NSError.testInstance(description: description, code: id)
 }
-
-// There must be a way to make this as an Error extension.
-// However, when I try to do so I get the following errors.
-//
-// Usage: .testError()
-// Error: Contextual member reference to static method 'testError(description:domain:code:)' requires 'Self' constraint in the protocol extension
-//
-// Usage: Error.testError()
-// Error: Static member 'testError' cannot be used on protocol metatype '(any Error).Type'
-//
-// In the meantime, we can call this via testError() in the tests.
-extension Error {
-
-    static func testError(
-        description: String = "A test error",
-        domain: String = "org.wordpress.unit-tests",
-        code: Int = 1
-    ) -> Self {
-        // This would be discouraged if it wasn't for the facts that we know that NSError converts to Error.
-        NSError.testInstance(description: description, domain: domain, code: code) as! Self
-    }
-}

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -7,6 +7,16 @@ struct TestError: Error {
     }
 }
 
+// There must be a way to make this as an Error extension.
+// However, when I try to do so I get the following errors.
+//
+// Usage: .testError()
+// Error: Contextual member reference to static method 'testError(description:domain:code:)' requires 'Self' constraint in the protocol extension
+//
+// Usage: Error.testError()
+// Error: Static member 'testError' cannot be used on protocol metatype '(any Error).Type'
+//
+// In the meantime, we can call this via NSError.testError()
 extension NSError {
 
     static func testError(

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -1,12 +1,3 @@
-struct TestError: Error {
-
-    let id: Int
-
-    init(id: Int = 1) {
-        self.id = id
-    }
-}
-
 // There must be a way to make this as an Error extension.
 // However, when I try to do so I get the following errors.
 //

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -6,3 +6,20 @@ struct TestError: Error {
         self.id = id
     }
 }
+
+extension NSError {
+
+    static func testError(
+        description: String = "A test error",
+        domain: String = "org.wordpress.unit-tests",
+        code: Int = 1
+    ) -> NSError {
+        NSError(
+            domain: domain,
+            code: code,
+            userInfo: [
+                NSLocalizedDescriptionKey: description
+            ]
+        )
+    }
+}

--- a/WordPress/WordPressTest/TestError.swift
+++ b/WordPress/WordPressTest/TestError.swift
@@ -1,13 +1,33 @@
-typealias TestError = NSError
+// There must be a way to make this as an Error extension.
+// However, when I try to do so I get the following errors.
+//
+// Usage: .testError()
+// Error: Contextual member reference to static method 'testError(description:domain:code:)' requires 'Self' constraint in the protocol extension
+//
+// Usage: Error.testError()
+// Error: Static member 'testError' cannot be used on protocol metatype '(any Error).Type'
+//
+// In the meantime, we can call this via NSError.testInstance() in the tests.
+extension Error {
 
-extension TestError {
-
-    convenience init(
-        id: Int = 1,
+    static func testError(
         description: String = "A test error",
-        domain: String = "org.wordpress.unit-tests"
-    ) {
-        self.init(code: id, domain: domain, description: description)
+        domain: String = "org.wordpress.unit-tests",
+        code: Int = 1
+    ) -> Self {
+        // This would be discouraged if it wasn't for the facts that we know that NSError converts to Error.
+        NSError.testInstance(description: description, domain: domain, code: code) as! Self
+    }
+}
+
+extension NSError {
+
+    static func testInstance(
+        description: String = "A test error",
+        domain: String = "org.wordpress.unit-tests",
+        code: Int = 1
+    ) -> NSError {
+        .init(code: code, domain: domain, description: description)
     }
 }
 
@@ -25,38 +45,5 @@ extension NSError {
                 NSLocalizedDescriptionKey: description
             ]
         )
-    }
-}
-
-// There must be a way to make this as an Error extension.
-// However, when I try to do so I get the following errors.
-//
-// Usage: .testError()
-// Error: Contextual member reference to static method 'testError(description:domain:code:)' requires 'Self' constraint in the protocol extension
-//
-// Usage: Error.testError()
-// Error: Static member 'testError' cannot be used on protocol metatype '(any Error).Type'
-//
-// In the meantime, we can call this via NSError.testError()
-extension NSError {
-
-    static func testError(
-        description: String = "A test error",
-        domain: String = "org.wordpress.unit-tests",
-        code: Int = 1
-    ) -> NSError {
-        .init(code: code, domain: domain, description: description)
-    }
-}
-
-extension Error {
-
-    static func testError(
-        description: String = "A test error",
-        domain: String = "org.wordpress.unit-tests",
-        code: Int = 1
-    ) -> Self {
-        // This would be discouraged if it wasn't for the facts that we know that NSError converts to Error.
-        NSError.testError(description: description, domain: domain, code: code) as! Self
     }
 }

--- a/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
@@ -148,7 +148,7 @@ class TimeZoneSelectorViewModelTests: CoreDataTestCase {
         // Given ViewModel
         // When ViewModel state is error
         viewModel = TimeZoneSelectorViewModel(
-                state: TimeZoneSelectorViewModel.State.with(storeState: TimeZoneStoreState.error(NSError.testError())),
+                state: TimeZoneSelectorViewModel.State.with(storeState: TimeZoneStoreState.error(NSError.testInstance())),
                 selectedValue: "",
                 filter: nil)
 

--- a/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
@@ -148,7 +148,7 @@ class TimeZoneSelectorViewModelTests: CoreDataTestCase {
         // Given ViewModel
         // When ViewModel state is error
         viewModel = TimeZoneSelectorViewModel(
-                state: TimeZoneSelectorViewModel.State.with(storeState: TimeZoneStoreState.error(TestError.testError)),
+                state: TimeZoneSelectorViewModel.State.with(storeState: TimeZoneStoreState.error(NSError.testError())),
                 selectedValue: "",
                 filter: nil)
 
@@ -173,10 +173,6 @@ class TimeZoneSelectorViewModelTests: CoreDataTestCase {
 }
 
 private extension TimeZoneSelectorViewModelTests {
-    enum TestError: Error {
-        case testError
-    }
-
     enum DecodingError: Error {
         case decodingFailed
     }

--- a/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
@@ -148,7 +148,7 @@ class TimeZoneSelectorViewModelTests: CoreDataTestCase {
         // Given ViewModel
         // When ViewModel state is error
         viewModel = TimeZoneSelectorViewModel(
-                state: TimeZoneSelectorViewModel.State.with(storeState: TimeZoneStoreState.error(NSError.testInstance())),
+                state: TimeZoneSelectorViewModel.State.with(storeState: TimeZoneStoreState.error(testError())),
                 selectedValue: "",
                 filter: nil)
 

--- a/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
+++ b/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
@@ -99,7 +99,7 @@ final class WPComJetpackRemoteInstallViewModelTests: CoreDataTestCase {
 
         // act
         viewModel.installJetpack(for: blog, isRetry: false)
-        api.failureBlockPassedIn?(NSError.testInstance(), nil) // call the failure block to trigger Result.failure
+        api.failureBlockPassedIn?(.testInstance(), nil) // call the failure block to trigger Result.failure
 
         // assert
         guard case .failure(let error) = viewModel.state else {

--- a/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
+++ b/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
@@ -96,11 +96,10 @@ final class WPComJetpackRemoteInstallViewModelTests: CoreDataTestCase {
     func test_installJetpack_givenValidSite_AndRequestFails_shouldUpdateStateToFailure() {
         // arrange
         let blog = makeBlog(with: .selfHostedWithIndividualPluginViaWPCom)
-        let mockError = NSError(domain: "error.domain", code: 500)
 
         // act
         viewModel.installJetpack(for: blog, isRetry: false)
-        api.failureBlockPassedIn?(mockError, nil) // call the failure block to trigger Result.failure
+        api.failureBlockPassedIn?(NSError.testError(), nil) // call the failure block to trigger Result.failure
 
         // assert
         guard case .failure(let error) = viewModel.state else {

--- a/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
+++ b/WordPress/WordPressTest/WPComJetpackRemoteInstallViewModelTests.swift
@@ -99,7 +99,7 @@ final class WPComJetpackRemoteInstallViewModelTests: CoreDataTestCase {
 
         // act
         viewModel.installJetpack(for: blog, isRetry: false)
-        api.failureBlockPassedIn?(NSError.testError(), nil) // call the failure block to trigger Result.failure
+        api.failureBlockPassedIn?(NSError.testInstance(), nil) // call the failure block to trigger Result.failure
 
         // assert
         guard case .failure(let error) = viewModel.state else {


### PR DESCRIPTION
**~~Good idea or bad idea?~~** Update: Thank you all for the feedback. Promoted to good idea 😄 

I find having to think about what error to create in a test adds unnecessary friction. In some project, I used to create a dedicated `struct TestError: Error` type, but @crazytonyli pointed out that using an `NSError` might be best. It's definitely one less type.

Enter, `NSError.testInstance()` a method to use in the tests to generate a hassle-free, consistent, yet customizable placeholder error.

~~What do you think? Does this remove noise from the tests? Or is it the need to know about this convention a point of friction?~~

On top of that, to make the usage smoother, the unit tests target has a `testError()` that can be used in any place where `Error` is required.

---

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.