### PR TITLE
Avoid WPMediaPickerViewController performBatchUpdates crash by wrapping the call in try-catch block

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -142,7 +142,7 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-  pod 'WPMediaPicker', '~> 1.8.8'
+  pod 'WPMediaPicker', '~> 1.8.9-beta.1'
   ## while PR is in review:
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -520,7 +520,7 @@ PODS:
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.2.0)
   - WordPressUI (1.12.5)
-  - WPMediaPicker (1.8.8)
+  - WPMediaPicker (1.8.9-beta.1)
   - wpxmlrpc (0.10.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.2)
@@ -615,7 +615,7 @@ DEPENDENCIES:
   - WordPressKit (~> 8.5)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.12.5)
-  - WPMediaPicker (~> 1.8.8)
+  - WPMediaPicker (~> 1.8.9-beta.1)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.100.1/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -883,7 +883,7 @@ SPEC CHECKSUMS:
   WordPressKit: f6943a6e927e9f57bc8793938af1e3a4c3adb614
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
-  WPMediaPicker: 0d40b8d66b6dfdaa2d6a41e3be51249ff5898775
+  WPMediaPicker: 0ef7f4abcbff7ad20e271e7d09586e32924f5785
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   Yoga: 5e12f4deb20582f86f6323e1cdff25f07afc87f6
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
@@ -895,6 +895,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: bc29b8c7c29da0feaa4a5ed3dff2a805e1a06a93
+PODFILE CHECKSUM: a7d5e5fc2a4ed59865ef070abe76626512854e58
 
 COCOAPODS: 1.12.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 * [*] [Jetpack-only] Fixed a crash that could occur when the user deletes the WordPress app upon a successful migration. [#21167]
 * [*] Fixed a crash that occurs in Weekly Roundup Background task due to a Core Data Concurrency violation. [#21076]
 * [***] Block editor: Editor UX improvements with new icons, colors and additional design enhancements. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5985]
+* [**] Fixed an occassional crash when opening Media picker. [#21231]
 
 22.8
 -----


### PR DESCRIPTION
Fixes #21102

This is a number one crash for 22.8, more context about the fix in MediaPicker repository: https://github.com/wordpress-mobile/MediaPicker-iOS/pull/412

## To test:

1. Fresh install app
2. Login
3. My Site
4. Media
5. Confirm that the media appears and there's no crash

## Regression Notes
1. Potential unintended areas of impact

Instead of crashing, the media picker may appear in an unexpected state or layout

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing of media picker

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

