### PR TITLE
Fix Core Data threading violation when scheduling reminders

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 23.1
 -----
-
+* [*] [internal] Fix Core Data multithreaded access exception in Blogging Reminders [#21232]
 
 23.0
 -----

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -17,7 +17,7 @@ extension InteractiveNotificationsManager: PushNotificationAuthorizer {
 
 /// Main interface for scheduling blogging reminders
 ///
-class BloggingRemindersScheduler {
+final class BloggingRemindersScheduler {
 
     // MARK: - Convenience Typealiases
 
@@ -276,16 +276,20 @@ class BloggingRemindersScheduler {
             return
         }
 
+        let blogObjectID = blog.objectID
         pushNotificationAuthorizer.requestAuthorization { [weak self] allowed in
             DispatchQueue.main.async {
-                guard let self = self else {
-                    return
-                }
+                guard let self else { return }
                 guard allowed else {
                     completion(.failure(Error.needsPermissionForPushNotifications))
                     return
                 }
-                self.pushAuthorizationReceived(blog: blog, schedule: schedule, time: time, completion: completion)
+                do {
+                    let blog = try self.coreDataStack.mainContext.existingObject(with: blogObjectID) as! Blog
+                    self.pushAuthorizationReceived(blog: blog, schedule: schedule, time: time, completion: completion)
+                } catch {
+                    completion(.failure(error))
+                }
             }
         }
     }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -277,16 +277,16 @@ class BloggingRemindersScheduler {
         }
 
         pushNotificationAuthorizer.requestAuthorization { [weak self] allowed in
-            guard let self = self else {
-                return
+            DispatchQueue.main.async {
+                guard let self = self else {
+                    return
+                }
+                guard allowed else {
+                    completion(.failure(Error.needsPermissionForPushNotifications))
+                    return
+                }
+                self.pushAuthorizationReceived(blog: blog, schedule: schedule, time: time, completion: completion)
             }
-
-            guard allowed else {
-                completion(.failure(Error.needsPermissionForPushNotifications))
-                return
-            }
-
-            self.pushAuthorizationReceived(blog: blog, schedule: schedule, time: time, completion: completion)
         }
     }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -17,7 +17,7 @@ extension InteractiveNotificationsManager: PushNotificationAuthorizer {
 
 /// Main interface for scheduling blogging reminders
 ///
-final class BloggingRemindersScheduler {
+class BloggingRemindersScheduler {
 
     // MARK: - Convenience Typealiases
 
@@ -92,9 +92,7 @@ final class BloggingRemindersScheduler {
     ///
     private let pushNotificationAuthorizer: PushNotificationAuthorizer
 
-    private var coreDataStack: CoreDataStackSwift {
-        ContextManager.shared
-    }
+    private let coreDataStack: CoreDataStackSwift
 
     /// The time of the day when blogging reminders will be received for the given blog
     /// - Parameter blog: the given blog
@@ -238,11 +236,13 @@ final class BloggingRemindersScheduler {
     init(
         store: BloggingRemindersStore,
         notificationCenter: NotificationScheduler = UNUserNotificationCenter.current(),
-        pushNotificationAuthorizer: PushNotificationAuthorizer = InteractiveNotificationsManager.shared) {
-
-        self.store = store
-        self.notificationScheduler = notificationCenter
-        self.pushNotificationAuthorizer = pushNotificationAuthorizer
+        pushNotificationAuthorizer: PushNotificationAuthorizer = InteractiveNotificationsManager.shared,
+        coreDataStack: CoreDataStackSwift = ContextManager.shared
+    ) {
+            self.store = store
+            self.notificationScheduler = notificationCenter
+            self.pushNotificationAuthorizer = pushNotificationAuthorizer
+            self.coreDataStack = coreDataStack
     }
 
     /// Default initializer.  Allows overriding the blogging reminders store and the notification center for testing purposes.
@@ -254,11 +254,13 @@ final class BloggingRemindersScheduler {
     ///
     init(
         notificationCenter: NotificationScheduler = UNUserNotificationCenter.current(),
-        pushNotificationAuthorizer: PushNotificationAuthorizer = InteractiveNotificationsManager.shared) throws {
-
+        pushNotificationAuthorizer: PushNotificationAuthorizer = InteractiveNotificationsManager.shared,
+        coreDataStack: CoreDataStackSwift = ContextManager.shared
+    ) throws {
         self.store = try Self.defaultStore()
         self.notificationScheduler = notificationCenter
         self.pushNotificationAuthorizer = pushNotificationAuthorizer
+        self.coreDataStack = coreDataStack
     }
 
     // MARK: - Scheduling

--- a/WordPress/WordPressTest/BloggingRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/BloggingRemindersSchedulerTests.swift
@@ -73,10 +73,15 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         let scheduler = BloggingRemindersScheduler(
             store: store,
             notificationCenter: notificationCenter,
-            pushNotificationAuthorizer: PushNotificationsAuthorizerMock())
+            pushNotificationAuthorizer: PushNotificationsAuthorizerMock(),
+            coreDataStack: contextManager
+        )
 
+        let expectation = self.expectation(description: "schedule-updated")
         scheduler.schedule(schedule, for: blog) { _ in
+            expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 1)
 
         XCTAssertEqual(scheduler.schedule(for: blog), schedule)
     }
@@ -114,7 +119,9 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         let scheduler = BloggingRemindersScheduler(
             store: store,
             notificationCenter: notificationCenter,
-            pushNotificationAuthorizer: PushNotificationsAuthorizerMock())
+            pushNotificationAuthorizer: PushNotificationsAuthorizerMock(),
+            coreDataStack: contextManager
+        )
 
         let storeHasRemindersExpectation = expectation(description: "The notifications are in the store")
         let storeIsEmptyExpectation = expectation(description: "The notifications have been cleared from the store")
@@ -123,15 +130,14 @@ class BloggingRemindersSchedulerTests: XCTestCase {
             if store.scheduledReminders(for: blog.objectID.uriRepresentation()) != .none {
                 storeHasRemindersExpectation.fulfill()
             }
-        }
-
-        scheduler.schedule(.none, for: blog) { _ in
-            if store.scheduledReminders(for: blog.objectID.uriRepresentation()) == .none {
-                storeIsEmptyExpectation.fulfill()
+            scheduler.schedule(.none, for: blog) { _ in
+                if store.scheduledReminders(for: blog.objectID.uriRepresentation()) == .none {
+                    storeIsEmptyExpectation.fulfill()
+                }
             }
         }
 
-        waitForExpectations(timeout: 0.1) { error in
+        waitForExpectations(timeout: 1) { error in
             if let error = error {
                 XCTFail(error.localizedDescription)
             }


### PR DESCRIPTION
Fixes #20979

To test:

- See the issue

## Notes

`BloggingRemindersScheduler` expects that it's used on the same thread on which the `Blog` entity was created. It doesn't modify the blog and only uses three of its properties: `objectID`, `dotComID`, and `title`.

The proliferation of the usages of the `Blog` entities makes it hard to reason about concurrency. I think maybe we could introduce some thread-safe (and immutable?) entities to be used in such scenarios:

```swift
struct SafeBlog {
  let id: Int
  let title: String
  let objectID: NSManagedObject
  // ...

  init(blog: Blog) {
    self.id = blog.id
    self.title = blog.title
    self.objectID = blog.objectID
    // ...
  }
}
```

It won't cover everything scenario, and I think entirely removing the uses of managed entities is a no-goal. But it will eliminate the risk of misuse in many scenarios.

There are also performance benefits. It will be much faster to create `SafeBlog(blog: blog)` from the already materialized object than pass an objectID to another thread and re-read the entity from the store in the background.

Confining every usage of `Blog` and other entities to the main thread is also not a great idea because it'll have performance implications. You need to have flexibility to use background threads.

## Regression Notes
1. Potential unintended areas of impact: blogging reminders
2. What I did to test those areas of impact (or what existing automated tests I relied on): tested manually
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
