### PR TITLE
Fix a crash during Reader topics cleanup

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Fix an issue with unstable order of assets on the media screen [#21210]
 * [*] Fix an issue with media screen flashing when opened [#21211]
 * [*] [internal] Fix an issue with some media pickers not deallocating after selection in post editor [#21225]
+* [*] Fix an issue in Reader topics cleanup that could cause the app to crash. [#21243]
 
 22.9
 -----

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -216,7 +216,14 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (void)preserveSavedPostsFromTopic:(ReaderAbstractTopic *)topic
 {
-    [topic.posts enumerateObjectsUsingBlock:^(ReaderPost * _Nonnull post, NSUInteger __unused idx, BOOL * _Nonnull __unused stop) {
+    // Copy posts so that `post.topic = nil` doesn't mutate `topic.posts` collection.
+    NSMutableArray *posts = [[NSMutableArray alloc] initWithCapacity:topic.posts.count];
+    for (id post in topic.posts) {
+        [posts addObject:post];
+    }
+
+    // Now it's safe to update `post.topic`.
+    [posts enumerateObjectsUsingBlock:^(ReaderPost * _Nonnull post, NSUInteger __unused idx, BOOL * _Nonnull __unused stop) {
         if (post.isSavedForLater) {
             DDLogInfo(@"Preserving saved post: %@", post.titleForDisplay);
             post.topic = nil;


### PR DESCRIPTION
Fixes #21203

## Test Instructions

This is one way I found to trigger `- (void)preserveSavedPostsFromTopic:(ReaderAbstractTopic *)topic`. I'm sure there are better ways.

1. Add the following code in `WordPressAppDelegate.applicationWillEnterForeground(_:)`
```swift
DispatchQueue.main.async {
    NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
}
```
2. Build and run the Jetpack app.
3. Head to Reader > Discover.
4. Tap a topic under the `You might like` banner at the top.
5. Follow then Unfollow the topic.
6. Save one of the posts linked to that topic.
7. Move the app to the background and then the foreground.
8. Set a breakpoint in `ReaderTopicService.m` at line 228.
9. Repeat 8. 
10. **Ensure** the breakpoint is hit.

## Regression Notes
1. Potential unintended areas of impact
None.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

11. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
