### PR TITLE
Jetpack Social: Add tracks for the pre-publishing sheet

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -491,6 +491,13 @@ import Foundation
     // Jetpack Social - Twitter Deprecation Notice
     case jetpackSocialTwitterNoticeLinkTapped
 
+    // Jetpack Social Improvements v1
+    case jetpackSocialConnectionToggled
+    case jetpackSocialShareLimitDisplayed
+    case jetpackSocialUpgradeLinkTapped
+    case jetpackSocialNoConnectionCardDisplayed
+    case jetpackSocialNoConnectionCTATapped
+
     // Free to Paid Plans Dashboard Card
     case freeToPaidPlansDashboardCardShown
     case freeToPaidPlansDashboardCardTapped
@@ -1343,6 +1350,17 @@ import Foundation
         // Jetpack Social - Twitter Deprecation Notice
         case .jetpackSocialTwitterNoticeLinkTapped:
             return "twitter_notice_link_tapped"
+
+        case .jetpackSocialConnectionToggled:
+            return "jetpack_social_auto_sharing_connection_toggled"
+        case .jetpackSocialShareLimitDisplayed:
+            return "jetpack_social_share_limit_displayed"
+        case .jetpackSocialUpgradeLinkTapped:
+            return "jetpack_social_upgrade_link_tapped"
+        case .jetpackSocialNoConnectionCardDisplayed:
+            return "jetpack_social_add_connection_cta_displayed"
+        case .jetpackSocialNoConnectionCTATapped:
+            return "jetpack_social_add_connection_tapped"
 
         // Free to Paid Plans Dashboard Card
         case .freeToPaidPlansDashboardCardShown:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -497,6 +497,7 @@ import Foundation
     case jetpackSocialUpgradeLinkTapped
     case jetpackSocialNoConnectionCardDisplayed
     case jetpackSocialNoConnectionCTATapped
+    case jetpackSocialNoConnectionCardDismissed
 
     // Free to Paid Plans Dashboard Card
     case freeToPaidPlansDashboardCardShown
@@ -1361,6 +1362,8 @@ import Foundation
             return "jetpack_social_add_connection_cta_displayed"
         case .jetpackSocialNoConnectionCTATapped:
             return "jetpack_social_add_connection_tapped"
+        case .jetpackSocialNoConnectionCardDismissed:
+            return "jetpack_social_add_connection_dismissed"
 
         // Free to Paid Plans Dashboard Card
         case .freeToPaidPlansDashboardCardShown:

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -260,6 +260,8 @@ private extension PrepublishingSocialAccountsViewController {
 
         lastToggledRow = index
         toggleInteractivityIfNeeded()
+
+        WPAnalytics.track(.jetpackSocialConnectionToggled, properties: ["source": Constants.trackingSource, "value": value])
     }
 
     func toggleInteractivityIfNeeded() {
@@ -284,6 +286,8 @@ private extension PrepublishingSocialAccountsViewController {
         guard let checkoutViewController = makeCheckoutViewController() else {
             return
         }
+
+        WPAnalytics.track(.jetpackSocialUpgradeLinkTapped, properties: ["source": Constants.trackingSource])
 
         let navigationController = UINavigationController(rootViewController: checkoutViewController)
         show(navigationController, sender: nil)
@@ -362,6 +366,7 @@ private extension PrepublishingSocialAccountsViewController {
         static let messageCellIdentifier = "MessageCell"
 
         static let webViewSource = "prepublishing_social_accounts_subscribe"
+        static let trackingSource = "pre_publishing"
 
         static let navigationTitle = NSLocalizedString(
             "prepublishing.socialAccounts.navigationTitle",

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -102,6 +102,10 @@ private extension PrepublishingViewController {
         ])
 
         cell.accessoryType = .disclosureIndicator
+
+        if let _ = viewModel.sharingLimit {
+            WPAnalytics.track(.jetpackSocialShareLimitDisplayed, properties: ["source": Constants.trackingSource])
+        }
     }
 
     // MARK: - No Connection View
@@ -114,6 +118,8 @@ private extension PrepublishingViewController {
 
         cell.contentView.addSubview(viewToEmbed)
         cell.contentView.pinSubviewToSafeArea(viewToEmbed)
+
+        WPAnalytics.track(.jetpackSocialNoConnectionCardDisplayed, properties: ["source": Constants.trackingSource])
     }
 
     func makeNoConnectionView() -> UIView {
@@ -143,7 +149,7 @@ private extension PrepublishingViewController {
                 return
             }
 
-            // TODO: Set up delegate to react to changes when a new connection is set up.
+            WPAnalytics.track(.jetpackSocialNoConnectionCTATapped, properties: ["source": Constants.trackingSource])
 
             let navigationController = UINavigationController(rootViewController: controller)
             self.show(navigationController, sender: nil)
@@ -224,6 +230,7 @@ private extension PrepublishingViewController {
     // MARK: - Constants
 
     enum Constants {
+        static let trackingSource = "pre_publishing"
         static let noConnectionKey = "prepublishing-social-no-connection-view-hidden"
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -164,6 +164,8 @@ private extension PrepublishingViewController {
                 return
             }
 
+            WPAnalytics.track(.jetpackSocialNoConnectionCardDismissed, properties: ["source": Constants.trackingSource])
+
             self.isNoConnectionDismissed = true
             self.refreshOptions()
 


### PR DESCRIPTION
Refs #21221 

As titled, I've added tracks when:

- Sharing limit is displayed. Note: The event is not tracked for sites with unlimited sharing.
- No Connection card is displayed.
- No Connection card's `Connect accounts` button is tapped.
- Subscribe button is tapped.
- Accounts are toggled.

There's a bit of a caveat for the view display tracking; since most of the Social-related work is done in `PrepublishingViewController+JetpackSocial`, the display event is tracked whenever the auto-sharing cell or the No Connection card is configured. However, the view controller might reload data on social account changes—which will reload all the cells, thus re-triggering the tracking event again.

The fix for this is to either:

1. Define a boolean variable (e.g. `autoSharingCellTracked`), but this needs to be defined in the `PrepublishingViewController` and must have internal access.
2. Isolate the tracking code into a method and put it in `PrepublishingViewController`. That way, the properties can be defined as `private`.

Anyways, I felt like I'd committed a little too much on this small thing, so I've decided to just allow the event tracking to re-trigger. I think there shouldn't be a lot of retriggers since it depends on user action, and we'll likely build our funnel based on unique counts anyway, so it shouldn't matter much.

Of course, let me know if you have a better solution! The ideal scenario is to track sharing limit info and/or the No Connection card display event **once** per pre-publishing flow.

## To test:

### Limited sharing

- Launch the Jetpack app.
- Switch to a site with limited Social sharing.
- Go to the pre-publishing sheet.
- 🔎 Verify that this is tracked: `🔵 Tracked: jetpack_social_share_limit_displayed <source: pre_publishing>`
- Tap the auto-sharing cell.
- Tap the Subscribe button.
- 🔎 Verify that this is tracked: `🔵 Tracked: jetpack_social_upgrade_link_tapped <source: pre_publishing>`

### Unlimited sharing

- Launch the Jetpack app.
- Switch to a WP.com site with existing connections.
- Go to the pre-publishing sheet.
- 🔎 Verify that the `jetpack_social_share_limit_displayed` event is NOT tracked.

### No Connection

- Launch the Jetpack app.
- Switch to a WP.com site with no connections.
- Go to the pre-publishing sheet.
- 🔎 Verify that this is tracked: `🔵 Tracked: jetpack_social_add_connection_cta_displayed <source: pre_publishing>`
- Tap `Connect accounts`.
- 🔎 Verify that this is tracked: `🔵 Tracked: jetpack_social_add_connection_tapped <source: pre_publishing>`
- Dismiss the Social screen.
- Tap `Not now`.
- 🔎 Verify that this is tracked: `🔵 Tracked: jetpack_social_add_connection_dismissed <source: pre_publishing>`

## Regression Notes
1. Potential unintended areas of impact
Should be none.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

5. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
