### PR TITLE
Jetpack Social: Create no shares remaining Jetpack Social card

### DIFF
--- a/WordPress/Classes/Services/JetpackSocialService.swift
+++ b/WordPress/Classes/Services/JetpackSocialService.swift
@@ -89,6 +89,7 @@ import CoreData
             switch result {
             case .success:
                 success?()
+                NotificationCenter.default.post(name: .jetpackSocialUpdated, object: nil)
             case .failure(let error):
                 failure?(error as NSError)
             }

--- a/WordPress/Classes/Services/SharingSyncService.swift
+++ b/WordPress/Classes/Services/SharingSyncService.swift
@@ -33,11 +33,15 @@ import WordPressKit
             failure?(Error.siteWithNoRemote as NSError)
             return
         }
+        let onComplete = {
+            success?()
+            NotificationCenter.default.post(name: .jetpackSocialUpdated, object: nil)
+        }
 
         remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
 
             // Process the results
-            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
+            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: onComplete)
         },
         failure: failure)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -37,8 +37,31 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
         }
     }
 
+    private var isNoSharesViewHidden: Bool {
+        get {
+            guard let dotComID = blog?.dotComID?.stringValue,
+                  let isNoSharesHidden = noSharesHiddenSites[dotComID] else {
+                return false
+            }
+            return isNoSharesHidden
+        }
+        set {
+            guard let dotComID = blog?.dotComID?.stringValue else {
+                return
+            }
+            var currentHiddenSites = noSharesHiddenSites
+            currentHiddenSites[dotComID] = true
+            repository.set(currentHiddenSites, forKey: Constants.hideNoSharesViewKey)
+        }
+    }
+
     private var noConnectionHiddenSites: [String: Bool] {
         let dictionary = repository.dictionary(forKey: Constants.hideNoConnectionViewKey) as? [String: Bool]
+        return dictionary ?? [:]
+    }
+
+    private var noSharesHiddenSites: [String: Bool] {
+        let dictionary = repository.dictionary(forKey: Constants.hideNoSharesViewKey) as? [String: Bool]
         return dictionary ?? [:]
     }
 
@@ -46,9 +69,10 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
 
     private var cardTitle: String {
         switch displayState {
-        // TODO: Out of shares title
         case .noConnections:
             return Constants.connectTitle
+        case .noShares:
+            return Constants.noSharesTitle
         default:
             return ""
         }
@@ -66,21 +90,20 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
     }
 
     private var contextMenu: UIMenu {
-        // TODO: Out of shares context menu handler
-        let hideNoConnectionView: UIActionHandler = { [weak self] _ in
-            guard let self else {
-                return
-            }
-
-            self.isNoConnectionViewHidden = true
-            self.dashboardViewController?.reloadCardsLocally()
-        }
-
         let hideThisAction = UIAction(title: Constants.hideThis,
                                       image: Constants.hideThisImage,
                                       attributes: [UIMenuElement.Attributes.destructive],
-                                      handler: hideNoConnectionView)
+                                      handler: contextMenuHandler)
         return UIMenu(title: String(), options: .displayInline, children: [hideThisAction])
+    }
+
+    var contextMenuHandler: UIActionHandler {
+        return { [weak self] _ in
+            guard let self else {
+                return
+            }
+            self.hideCard(for: self.displayState)
+        }
     }
 
     // MARK: - Initializers
@@ -88,11 +111,13 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
     override init(frame: CGRect) {
         self.repository = UserPersistentStoreFactory.instance()
         super.init(frame: frame)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: .jetpackSocialUpdated, object: nil)
     }
 
     init(repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.repository = repository
         super.init(frame: .zero)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: .jetpackSocialUpdated, object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -113,17 +138,20 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
         guard FeatureFlag.jetpackSocial.enabled else {
             return false
         }
-        // TODO: Show when user is out of shares
-        return showNoConnectionView(for: blog)
+        return showNoConnectionView(for: blog) || showNoSharesView(for: blog)
     }
 
     // MARK: - Constants
 
     struct Constants {
         static let hideNoConnectionViewKey = "dashboard-social-no-connection-view-hidden"
+        static let hideNoSharesViewKey = "dashboard-social-no-shares-view-hidden"
         static let connectTitle = NSLocalizedString("dashboard.card.social.noconnections.title",
                                                     value: "Share across your social networks",
                                                     comment: "Title for the Jetpack Social dashboard card when the user has no social connections.")
+        static let noSharesTitle = NSLocalizedString("dashboard.card.social.noshares.title",
+                                                    value: "You’re out of shares!",
+                                                    comment: "Title for the Jetpack Social dashboard card when the user has no social shares left.")
         static let hideThis = NSLocalizedString("dashboard.card.social.menu.hide",
                                                 value: "Hide this",
                                                 comment: "Title for a menu action in the context menu on the Jetpack Social dashboard card.")
@@ -134,7 +162,7 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
     enum DisplayState {
         case none
         case noConnections
-        // TODO: State for when a user is out of shares
+        case noShares
     }
 
 }
@@ -162,9 +190,13 @@ private extension DashboardJetpackSocialCardCell {
     }
 
     func updateDisplayState(for blog: Blog) {
-        // TODO: State for when a user is out of shares
-        let showNoConnectionView = DashboardJetpackSocialCardCell.showNoConnectionView(for: blog)
-        displayState = showNoConnectionView ? .noConnections : .none
+        if DashboardJetpackSocialCardCell.showNoConnectionView(for: blog) {
+            displayState = .noConnections
+        } else if DashboardJetpackSocialCardCell.showNoSharesView(for: blog) {
+            displayState = .noShares
+        } else {
+            displayState = .none
+        }
     }
 
     func updateUI() {
@@ -175,14 +207,24 @@ private extension DashboardJetpackSocialCardCell {
             return
         }
 
-        // TODO: Out of shares view
-        if let noConnectionCard = createNoConnectionCard() {
+        var card: UIView?
+        switch displayState {
+        case .noConnections:
+            card = createNoConnectionCard()
+        case .noShares:
+            card = createNoSharesCard()
+        default:
+            card = nil
+        }
+        if let card {
             for subview in contentView.subviews {
                 subview.removeFromSuperview()
             }
-            contentView.addSubview(noConnectionCard)
-            contentView.pinSubviewToAllEdges(noConnectionCard)
+            contentView.addSubview(card)
+            contentView.pinSubviewToAllEdges(card)
             contentView.layoutIfNeeded()
+        } else {
+            dashboardViewController?.reloadCardsLocally()
         }
     }
 
@@ -218,6 +260,106 @@ private extension DashboardJetpackSocialCardCell {
         }
     }
 
+    static func showNoSharesView(for blog: Blog) -> Bool {
+        guard let sharingLimit = blog.sharingLimit,
+              let dotComID = blog.dotComID?.stringValue,
+              let connections = blog.connections as? Set<PublicizeConnection> else {
+            return false
+        }
+        let repository = UserPersistentStoreFactory.instance()
+        let hideNoSharesViewKey = DashboardJetpackSocialCardCell.Constants.hideNoSharesViewKey
+        let hiddenSites = (repository.dictionary(forKey: hideNoSharesViewKey) as? [String: Bool]) ?? [:]
+        let isNoSharesViewHidden = hiddenSites[dotComID] ?? false
+
+        return blog.supportsPublicize()
+        && connections.filter { !$0.requiresUserAction() }.count > 0
+        && !isNoSharesViewHidden
+        && sharingLimit.remaining == 0
+    }
+
+    func createNoSharesCard() -> UIView? {
+        guard let connections = blog?.connections as? Set<PublicizeConnection> else {
+            assertionFailure("No social connections")
+            let error = JetpackSocialError.noSharesViewInvalidState
+            CrashLogging.main.logError(error, userInfo: ["source": "social_dashboard_card"])
+            return nil
+        }
+        let card = cardFrameView
+        let filteredConnections = connections.filter { !$0.requiresUserAction() }
+        let services = filteredConnections.reduce(into: [PublicizeService.ServiceName]()) { partialResult, connection in
+            guard let service = PublicizeService.ServiceName(rawValue: connection.service) else {
+                return
+            }
+            if !partialResult.contains(service) {
+                partialResult.append(service)
+            }
+        }
+        let viewModel = JetpackSocialNoSharesViewModel(services: services,
+                                                       totalServiceCount: filteredConnections.count,
+                                                       onSubscribeTap: onSubscribeTap())
+        let noSharesView = UIView.embedSwiftUIView(JetpackSocialNoSharesView(viewModel: viewModel))
+        card.add(subview: noSharesView)
+        return card
+    }
+
+    func onSubscribeTap() -> () -> Void {
+        return { [weak self] in
+            guard let blog = self?.blog,
+                  let hostname = blog.hostname,
+                  let url = URL(string: "https://wordpress.com/checkout/\(hostname)/jetpack_social_basic_yearly") else {
+                return
+            }
+            let webViewController = WebViewControllerFactory.controller(url: url,
+                                                                        blog: blog,
+                                                                        source: "dashboard_card_no_shares_subscribe_now") {
+                self?.checkoutDismissed()
+            }
+            let navigationController = UINavigationController(rootViewController: webViewController)
+            self?.dashboardViewController?.present(navigationController, animated: true)
+        }
+    }
+
+    func checkoutDismissed() {
+        guard let blog else {
+            return
+        }
+        let coreDataStack = ContextManager.shared
+        let service = BlogService(coreDataStack: coreDataStack)
+        service.syncBlog(blog) { [weak self] in
+            let sharingLimit: PublicizeInfo.SharingLimit? = coreDataStack.performQuery { context in
+                guard let dotComID = blog.dotComID,
+                      let blog = Blog.lookup(withID: dotComID, in: context) else {
+                    return nil
+                }
+                return blog.sharingLimit
+            }
+            if sharingLimit == nil || sharingLimit?.remaining ?? 0 > 0 {
+                self?.dashboardViewController?.reloadCardsLocally()
+            }
+        } failure: { error in
+            DDLogError("Failed to sync blog after dismissing checkout webview due to error: \(error)")
+        }
+    }
+
+    @objc func handleNotification() {
+        guard let blog else {
+            return
+        }
+        updateDisplayState(for: blog)
+    }
+
+    func hideCard(for state: DisplayState) {
+        switch state {
+        case .noConnections:
+            isNoConnectionViewHidden = true
+        case .noShares:
+            isNoSharesViewHidden = true
+        default:
+            break
+        }
+        dashboardViewController?.reloadCardsLocally()
+    }
+
 }
 
 // MARK: - SharingViewControllerDelegate
@@ -227,5 +369,13 @@ extension DashboardJetpackSocialCardCell: SharingViewControllerDelegate {
     func didChangePublicizeServices() {
         dashboardViewController?.reloadCardsLocally()
     }
+
+}
+
+// MARK: - Notification
+
+extension NSNotification.Name {
+
+    static let jetpackSocialUpdated = NSNotification.Name(rawValue: "JetpackSocialUpdated")
 
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoSharesView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoSharesView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct JetpackSocialNoSharesView: View {
+
+    let viewModel: JetpackSocialNoSharesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4.0) {
+            HStack(spacing: -5.0) {
+                ForEach(viewModel.services, id: \.self) { service in
+                    iconImage(service.localIconImage)
+                }
+            }
+            .padding(.bottom, 8.0)
+            .accessibilityElement()
+            .accessibilityLabel(Constants.iconGroupAccessibilityLabel)
+            Text(bodyText)
+                .font(.callout)
+                .foregroundColor(Color(UIColor.secondaryLabel))
+                .padding(.bottom, 5.0)
+            Text(Constants.subscribeText)
+                .font(.callout)
+                .foregroundColor(Color(UIColor.primary))
+                .onTapGesture {
+                    viewModel.onSubscribeTap()
+                }
+                .accessibilityAddTraits(.isButton)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(EdgeInsets(top: 0.0, leading: 16.0, bottom: 8.0, trailing: 16.0))
+    }
+
+    var bodyText: String {
+        if viewModel.totalServiceCount > 1 {
+            return String(format: Constants.pluralShareTextFormat, viewModel.totalServiceCount)
+        }
+        return Constants.singularShareText
+    }
+
+    func iconImage(_ image: UIImage) -> some View {
+        Image(uiImage: image)
+            .resizable()
+            .frame(width: 32.0, height: 32.0)
+            .opacity(0.36)
+            .background(Color(UIColor.listForeground))
+            .clipShape(Circle())
+            .overlay(Circle().stroke(Color(UIColor.listForeground), lineWidth: 2.0))
+    }
+}
+
+// MARK: - View model
+
+struct JetpackSocialNoSharesViewModel {
+
+    let services: [PublicizeService.ServiceName]
+    let totalServiceCount: Int
+    let onSubscribeTap: () -> Void
+
+    init(services: [PublicizeService.ServiceName], totalServiceCount: Int, onSubscribeTap: @escaping () -> Void) {
+        self.services = services
+        self.totalServiceCount = totalServiceCount
+        self.onSubscribeTap = onSubscribeTap
+    }
+
+}
+
+// MARK: - Constants
+
+private struct Constants {
+
+    static let pluralShareTextFormat = NSLocalizedString("social.noshares.body.plural",
+                                                         value: "Your posts won’t be shared to your %1$d social accounts.",
+                                                         comment: "Plural body text for the Jetpack Social no shares dashboard card. %1$d is the number of social accounts the user has.")
+    static let singularShareText = NSLocalizedString("social.noshares.body.singular",
+                                                     value: "Your posts won’t be shared to your social account.",
+                                                     comment: "Singular body text for the Jetpack Social no shares dashboard card.")
+    static let subscribeText = NSLocalizedString("social.noshares.subscribe",
+                                                 value: "Subscribe to share more",
+                                                 comment: "Title for the button to subscribe to Jetpack Social on the no shares dashboard card")
+    static let iconGroupAccessibilityLabel = NSLocalizedString("social.noshares.icons.accessibility.label",
+                                                               value: "Social media icons",
+                                                               comment: "Accessibility label for the social media icons in the Jetpack Social no shares dashboard card")
+}

--- a/WordPress/Jetpack/Classes/Utility/JetpackSocialError.swift
+++ b/WordPress/Jetpack/Classes/Utility/JetpackSocialError.swift
@@ -2,4 +2,5 @@
 enum JetpackSocialError: Error {
     case missingSharingLimit
     case noConnectionViewInvalidState
+    case noSharesViewInvalidState
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2031,6 +2031,8 @@
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
+		835771352A7C2755006B2A3E /* JetpackSocialNoSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835771342A7C2755006B2A3E /* JetpackSocialNoSharesView.swift */; };
+		835771362A7C2755006B2A3E /* JetpackSocialNoSharesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835771342A7C2755006B2A3E /* JetpackSocialNoSharesView.swift */; };
 		836498C828172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */; };
 		836498C928172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */; };
 		836498CB2817301800A2C170 /* BloggingPromptsHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 836498CA2817301800A2C170 /* BloggingPromptsHeaderView.xib */; };
@@ -7349,6 +7351,7 @@
 		8350E49511D2C71E00A7B073 /* Media.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Media.m; sourceTree = "<group>"; };
 		8355D67D11D13EAD00A61362 /* MobileCoreServices.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		8355D7D811D260AA00A61362 /* CoreData.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		835771342A7C2755006B2A3E /* JetpackSocialNoSharesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialNoSharesView.swift; sourceTree = "<group>"; };
 		835E2402126E66E50085940B /* AssetsLibrary.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		836498CA2817301800A2C170 /* BloggingPromptsHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BloggingPromptsHeaderView.xib; sourceTree = "<group>"; };
@@ -13244,6 +13247,7 @@
 			isa = PBXGroup;
 			children = (
 				83914BD02A2E89F30017A588 /* JetpackSocialNoConnectionView.swift */,
+				835771342A7C2755006B2A3E /* JetpackSocialNoSharesView.swift */,
 				83DC5C452A4B769000DAA422 /* JetpackSocialSettingsRemainingSharesView.swift */,
 			);
 			path = Social;
@@ -22395,6 +22399,7 @@
 				C395FB232821FE4400AE7C11 /* SiteDesignSection.swift in Sources */,
 				FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */,
 				FEA6517B281C491C002EA086 /* BloggingPromptsService.swift in Sources */,
+				835771352A7C2755006B2A3E /* JetpackSocialNoSharesView.swift in Sources */,
 				436D55DF210F866900CEAA33 /* StoryboardLoadable.swift in Sources */,
 				D8212CC320AA7F57008E8AE8 /* ReaderBlockSiteAction.swift in Sources */,
 				FA8E1F7725EEFA7300063673 /* ReaderPostService+RelatedPosts.swift in Sources */,
@@ -23681,6 +23686,7 @@
 				80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */,
 				FABB21132602FC2C00C8785C /* AuthenticationService.swift in Sources */,
 				FABB21142602FC2C00C8785C /* JetpackSiteRef.swift in Sources */,
+				835771362A7C2755006B2A3E /* JetpackSocialNoSharesView.swift in Sources */,
 				FABB21152602FC2C00C8785C /* WPStyleGuide+Reply.swift in Sources */,
 				836498CF281735CC00A2C170 /* BloggingPromptsHeaderView.swift in Sources */,
 				FABB21162602FC2C00C8785C /* WPBlogTableViewCell.m in Sources */,


### PR DESCRIPTION
Closes: #20974 

## Description

Adds:
- Jetpack Social no shares dashboard card
- Subscription handling on tap
- Handling changes from network calls after the dashboard already displayed

## Screenshots

| Light | Dark |
|:-----:|:-----:|
| ![Light](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/f35622ee-ca37-4055-a36f-c715b947e661) | ![Dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/148b50d3-05ea-4229-a2e1-133d596cc6ad) |

## Testing

<details><summary><strong>Charles proxy rewrite rule</strong></summary>
You can save this to an xml file and then import it in the rewrite settings.

```xml
<?xml version='1.0' encoding='UTF-8' ?>
<?charles serialisation-version='2.0' ?>
<rewriteSet-array>
  <rewriteSet>
    <active>true</active>
    <name>Active Jetpack Social Blog</name>
    <hosts>
      <locationPatterns>
        <locationMatch>
          <location>
            <protocol>https</protocol>
            <host>public-api.wordpress.com</host>
            <path>/rest/v1.1/sites/*</path>
            <query>locale=en</query>
          </location>
          <enabled>true</enabled>
        </locationMatch>
      </locationPatterns>
    </hosts>
    <rules>
      <rewriteRule>
        <active>true</active>
        <ruleType>7</ruleType>
        <matchValue>&quot;advanced-seo&quot;,</matchValue>
        <matchHeaderRegex>false</matchHeaderRegex>
        <matchValueRegex>false</matchValueRegex>
        <matchRequest>false</matchRequest>
        <matchResponse>true</matchResponse>
        <newValue>&quot;advanced-seo&quot;, &quot;social-shares-1000&quot;,</newValue>
        <newHeaderRegex>false</newHeaderRegex>
        <newValueRegex>false</newValueRegex>
        <matchWholeValue>false</matchWholeValue>
        <caseSensitive>false</caseSensitive>
        <replaceType>2</replaceType>
      </rewriteRule>
    </rules>
  </rewriteSet>
</rewriteSet-array>
```
</details>

To test:
- Start with the rewrite rule disabled
- Launch Jetpack and login
- Select a blog which has a social connection and no remaining shares (Can be done by code or Charles)
- **Verify** the dashboard card UI matches Th1ahHKq53k5JT1PNDMavY-fi-1048%3A14596
- Tap on `Subscribe to share more`
- Enable the rewrite rule from above ^
- Dismiss the browser
- **Verify** the dashboard cards reload and the card is now hidden

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)