### PR TITLE
Jetpack Social: Update social icon opacity when it is disabled

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -894,8 +894,11 @@ FeaturedImageViewControllerDelegate>
                               interpolationQuality:kCGInterpolationDefault];
     }
     [cell.imageView setImage:image];
+    cell.imageView.alpha = 1.0;
     if (canEditSharing && !isJetpackSocialEnabled) {
         cell.imageView.tintColor = [WPStyleGuide tintColorForConnectedService: connection.service];
+    } else if (!canEditSharing && isJetpackSocialEnabled) {
+        cell.imageView.alpha = 0.36;
     }
     cell.textLabel.text = connection.externalDisplay;
     cell.textLabel.enabled = canEditSharing;


### PR DESCRIPTION
## Description

Reduces the image opacity for the social icons on the post settings screen when they are disabled.

## Screenshots

| Before | After |
|:------:|:-----:|
| ![Before](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/ec807f18-6fbb-416a-bd18-6b7da7f82aa1) | ![After](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/c096d55f-77dc-44a3-b5e5-c6b160b4fada) |

## Testing

To test:
- Launch Jetpack and login
- Select a blog with less remaining shares than social connections
- Create a new blog post
- Open the post settings (`...` > `Post Settings`)
- Tap on connection(s) if necessary to disable some of them
- **Verify** the disabled icon's opacity is reduced

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
