### PR TITLE
Catch NSInternalInconsistencyException in WPTableViewHandler to avoid crashes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] Block editor: Remove Gallery caption button on mobile [https://github.com/WordPress/gutenberg/pull/53010]
 * [*] Block editor: Fix Gallery block selection when adding media [https://github.com/WordPress/gutenberg/pull/53127]
 * [*] [internal] Fix an issue with some media pickers not deallocating after selection in post editor [#21225]
+* [*] Fix occasional crashes when updating Notification, Posts, and Reader content [#21250]
 
 22.9
 -----

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -626,7 +626,18 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
 {
-    [self.tableView endUpdates];
+    
+    // Catch unexpected expections when ending tableView updates to prevent crashes
+    NSError *error;
+    [WPException objcTryBlock:^{
+        [self.tableView endUpdates];
+    } error:&error];
+    
+    if (error) {
+        DDLogError(@"TableViewHandler: Error ending updates %@", error);
+        [self refreshTableView];
+        return;
+    }
 
     // Prevent crashes in iOS 14 if the row is negative
     // See http://git.io/JIKIB


### PR DESCRIPTION
Fixes #20991

## Description

`WPTableViewHandler` crashes occasionally on `self.tableView endUpdates` call. This is not a top crash but happens dozen times a day (8th most popular crash).

```
0   CoreFoundation                  0x357c0148c         __exceptionPreprocess
1   libobjc.A.dylib                 0x34a2a504c         objc_exception_throw
2   Foundation                      0x34c8648fc         -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:]
3   UIKitCore                       0x35c8dbfa8         -[UITableView _Bug_Detected_In_Client_Of_UITableView_Invalid_Number_Of_Rows_In_Section:]
4   UIKitCore                       0x35bdc1d94         -[UITableView _endCellAnimationsWithContext:]
5   UIKitCore                       0x35bd82d50         -[UITableView endUpdatesWithContext:]
6   Jetpack                         0x200dfe648         -[WPTableViewHandler controllerDidChangeContent:] (WPTableViewHandler.m:629)
```

## Solution

Wrap `endUpdates` in try-catch block. This is not an ideal solution but it allows us to avoid refactoring of WPTableViewHandler for the moment being and avoiding crashes. [There's no performance penalty](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Exceptions/Articles/Exceptions64Bit.html) for wrapping the call in a try-catch block and we refresh the table view instead of crashing when exception happens. Similar solutions chosen for:

- [Media picker](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Exceptions/Articles/Exceptions64Bit.html)
- [Reader comments](https://github.com/wordpress-mobile/WordPress-iOS/pull/21222)

## To test:

1. Open Posts
2. Confirm the content appears (you can add a breakpoint on `endUpdates` and confirm that is gets triggered and continues execution)
3. Write additional an post on the web
4. Pull to refresh Posts view
5. Confirm that the new post appears (you can add a breakpoint on `endUpdates` and confirm that is gets triggered and continues execution)

I haven't been able to reproduce crash cases from bug reports. I triggered crashes manually by making incorrect table view updates in-between `beginUpdates`, and `endUpdates` which successfully hit the catch block and refreshed the table view manually

## Regression Notes
1. Potential unintended areas of impact

`WPTableViewHandler` is used for `CommentsViewController`, `NotificationsViewController`, `PageListViewController`, `PostListViewController`, various `Reader` sub-controllers

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing to ensure that try-catch block doesn't change the behavior

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
