### PR TITLE
Fix incorrectly terminated background task

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 * [*] [internal] Fix an issue with some media pickers not deallocating after selection in post editor [#21225]
 * [*] Fix occasional crashes when updating Notification, Posts, and Reader content [#21250]
 * [*] Fix an issue in Reader topics cleanup that could cause the app to crash. [#21243]
+* [*] [internal] Fix incorrectly terminated background task [#21254]
 
 22.9
 -----

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -167,15 +167,12 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             bgTask = .invalid
         }
 
-        bgTask = app.beginBackgroundTask(expirationHandler: {
-            // Synchronize the cleanup call on the main thread in case
-            // the task actually finishes at around the same time.
-            DispatchQueue.main.async { [weak self] in
-                if let task = self?.bgTask, task != .invalid {
-                    DDLogInfo("BackgroundTask: executing expirationHandler for bgTask = \(task.rawValue)")
-                    app.endBackgroundTask(task)
-                    self?.bgTask = .invalid
-                }
+        bgTask = app.beginBackgroundTask(expirationHandler: { [weak self] in
+            // WARNING: The task has to be terminated immediately on expiration
+            if let task = self?.bgTask, task != .invalid {
+                DDLogInfo("BackgroundTask: executing expirationHandler for bgTask = \(task.rawValue)")
+                app.endBackgroundTask(task)
+                self?.bgTask = .invalid
             }
         })
 


### PR DESCRIPTION
The app currently prints the following error message when the background task expiration handler is called:

```swift
2023-08-04 10:50:17.838280-0400 Jetpack[60050:4787549] [BackgroundTask] Background task still not 
ended after expiration handlers were called: <_UIBackgroundTaskInfo: 0x15523b7e0>: taskID = 30, 
taskName = Called by Jetpack, from $s9WordPress0aB11AppDelegateC29applicationDidEnterBackgroundyySo13UIApplicationCFTo, 
creationTime = 401007 (elapsed = 26). This app will likely be terminated by the system. 
Call UIApplication.endBackgroundTask(_:) to avoid this.
```

The reason is that the app doesn't end the task _immediately_ on termination. The expiration handler is already called on the main queue, so there is no need to dispatch it.

This may be one of the reasons of [WatchdogTermination](https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations) events.

To test:

- Put the app in the background
- Verify that the error messages is no longer called

## Regression Notes
1. Potential unintended areas of impact: background tasks
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual test
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
