### PR TITLE
Jetpack Social: Add tracks for Jetpack Social in post settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -20,6 +20,8 @@ extension PostSettingsViewController {
     }
 
     @objc func createNoConnectionView() -> UIView {
+        WPAnalytics.track(.jetpackSocialNoConnectionCardDisplayed,
+                          properties: ["source": Constants.trackingSource])
         let services = availableServices()
         let viewModel = JetpackSocialNoConnectionViewModel(services: services,
                                                            onConnectTap: onConnectTap(),
@@ -54,6 +56,8 @@ extension PostSettingsViewController {
             CrashLogging.main.logError(error, userInfo: ["source": "post_settings"])
             return UIView()
         }
+        WPAnalytics.track(.jetpackSocialShareLimitDisplayed,
+                          properties: ["source": Constants.trackingSource])
 
         let shouldDisplayWarning = publicizeConnections.count > sharingLimit.remaining
         let viewModel = JetpackSocialRemainingSharesViewModel(remaining: sharingLimit.remaining,
@@ -98,6 +102,8 @@ private extension PostSettingsViewController {
 
     func onConnectTap() -> () -> Void {
         return { [weak self] in
+            WPAnalytics.track(.jetpackSocialNoConnectionCTATapped,
+                              properties: ["source": Constants.trackingSource])
             guard let blog = self?.apost.blog,
                   let controller = SharingViewController(blog: blog, delegate: nil) else {
                 return
@@ -108,6 +114,8 @@ private extension PostSettingsViewController {
 
     func onNotNowTap() -> () -> Void {
         return { [weak self] in
+            WPAnalytics.track(.jetpackSocialNoConnectionCardDismissed,
+                              properties: ["source": Constants.trackingSource])
             guard let key = self?.hideNoConnectionViewKey() else {
                 return
             }
@@ -118,6 +126,8 @@ private extension PostSettingsViewController {
 
     func onSubscribeTap() -> () -> Void {
         return { [weak self] in
+            WPAnalytics.track(.jetpackSocialUpgradeLinkTapped,
+                              properties: ["source": Constants.trackingSource])
             guard let blog = self?.apost.blog,
                   let hostname = blog.hostname,
                   let url = URL(string: "https://wordpress.com/checkout/\(hostname)/jetpack_social_basic_yearly") else {
@@ -162,6 +172,7 @@ private extension PostSettingsViewController {
 
     struct Constants {
         static let hideNoConnectionViewKey = "post-settings-social-no-connection-view-hidden"
+        static let trackingSource = "post_settings"
     }
 
 }


### PR DESCRIPTION
See: #21221 

## Description

Adds tracks for the post settings screen of Jetpack Social.

## Testing

To test:
- Launch Jetpack and login
- Select a blog with no social connections initially
- Create a new blog post
- Perform the following actions and **verify** tracks match:

| Action | Event |
|:------:|:-----:|
| **No connections:** open post settings | `🔵 Tracked: jetpack_social_add_connection_cta_displayed <source: post_settings>` |
| **No connections:** Tap on `Connect accounts` | `🔵 Tracked: jetpack_social_add_connection_tapped <source: post_settings>` |
| **No connections:** Tap on `Not now` | `🔵 Tracked: jetpack_social_add_connection_dismissed <source: post_settings>` |
| **With connections:** low shares remaining, open post settings | `🔵 Tracked: jetpack_social_share_limit_displayed <source: post_settings>` |
| **With connections:** low shares remaining, tap on `Subscribe now to share more` | `🔵 Tracked: jetpack_social_upgrade_link_tapped <source: post_settings>` |
| **With connections:** toggle social connection on/off | `🔵 Tracked: jetpack_social_auto_sharing_connection_toggled <source: post_settings, value: true>` <br> `🔵 Tracked: jetpack_social_auto_sharing_connection_toggled <source: post_settings, value: false>` |
 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
