### PR TITLE
Jetpack Social: Add tracks to Jetpack Social dashboard cards

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -494,6 +494,7 @@ import Foundation
     // Jetpack Social Improvements v1
     case jetpackSocialConnectionToggled
     case jetpackSocialShareLimitDisplayed
+    case jetpackSocialShareLimitDismissed
     case jetpackSocialUpgradeLinkTapped
     case jetpackSocialNoConnectionCardDisplayed
     case jetpackSocialNoConnectionCTATapped
@@ -1356,6 +1357,8 @@ import Foundation
             return "jetpack_social_auto_sharing_connection_toggled"
         case .jetpackSocialShareLimitDisplayed:
             return "jetpack_social_share_limit_displayed"
+        case .jetpackSocialShareLimitDismissed:
+            return "jetpack_social_share_limit_dismissed"
         case .jetpackSocialUpgradeLinkTapped:
             return "jetpack_social_upgrade_link_tapped"
         case .jetpackSocialNoConnectionCardDisplayed:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -157,6 +157,7 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
                                                 comment: "Title for a menu action in the context menu on the Jetpack Social dashboard card.")
         static let hideThisImage = UIImage(systemName: "minus.circle")
         static let cardInsets = EdgeInsets(top: 8.0, leading: 16.0, bottom: 8.0, trailing: 16.0)
+        static let trackingSource = "home_dashboard"
     }
 
     enum DisplayState {
@@ -235,9 +236,11 @@ private extension DashboardJetpackSocialCardCell {
             // `showNoConnectionView`. This scenario *shouldn't* be possible.
             assertionFailure("No managed object context or publicize services")
             let error = JetpackSocialError.noConnectionViewInvalidState
-            CrashLogging.main.logError(error, userInfo: ["source": "social_dashboard_card"])
+            CrashLogging.main.logError(error, userInfo: ["source": Constants.trackingSource])
             return nil
         }
+        WPAnalytics.track(.jetpackSocialNoConnectionCardDisplayed,
+                          properties: ["source": Constants.trackingSource])
         let card = cardFrameView
         let viewModel = JetpackSocialNoConnectionViewModel(services: services,
                                                            padding: Constants.cardInsets,
@@ -251,6 +254,8 @@ private extension DashboardJetpackSocialCardCell {
 
     func onConnectTap() -> () -> Void {
         return { [weak self] in
+            WPAnalytics.track(.jetpackSocialNoConnectionCTATapped,
+                              properties: ["source": Constants.trackingSource])
             guard let self,
                   let blog = self.blog,
                   let controller = SharingViewController(blog: blog, delegate: self) else {
@@ -284,6 +289,8 @@ private extension DashboardJetpackSocialCardCell {
             CrashLogging.main.logError(error, userInfo: ["source": "social_dashboard_card"])
             return nil
         }
+        WPAnalytics.track(.jetpackSocialShareLimitDisplayed,
+                          properties: ["source": Constants.trackingSource])
         let card = cardFrameView
         let filteredConnections = connections.filter { !$0.requiresUserAction() }
         let services = filteredConnections.reduce(into: [PublicizeService.ServiceName]()) { partialResult, connection in
@@ -304,6 +311,8 @@ private extension DashboardJetpackSocialCardCell {
 
     func onSubscribeTap() -> () -> Void {
         return { [weak self] in
+        WPAnalytics.track(.jetpackSocialUpgradeLinkTapped,
+                          properties: ["source": Constants.trackingSource])
             guard let blog = self?.blog,
                   let hostname = blog.hostname,
                   let url = URL(string: "https://wordpress.com/checkout/\(hostname)/jetpack_social_basic_yearly") else {
@@ -352,8 +361,12 @@ private extension DashboardJetpackSocialCardCell {
         switch state {
         case .noConnections:
             isNoConnectionViewHidden = true
+            WPAnalytics.track(.jetpackSocialNoConnectionCardDismissed,
+                              properties: ["source": Constants.trackingSource])
         case .noShares:
             isNoSharesViewHidden = true
+            WPAnalytics.track(.jetpackSocialShareLimitDismissed,
+                              properties: ["source": Constants.trackingSource])
         default:
             break
         }


### PR DESCRIPTION
Closes: #21221 

## Description

Adds tracks to the Jetpack Social dashboard cards.

## Testing

To test:
- Launch Jetpack and login
- Select a blog with no social connections initially
- Navigate to the home dashboard if necessary
- Perform the following actions and **verify** tracks match:

| Action | Event |
|:------:|:-----:|
| **No connections:** scroll to card | `🔵 Tracked: jetpack_social_add_connection_cta_displayed <source: home_dashboard>` |
| **No connections:** Tap on `Connect accounts` | `🔵 Tracked: jetpack_social_add_connection_tapped <source: home_dashboard>` |
| **No connections:** Tap on the context menu > `Hide this` | `🔵 Tracked: jetpack_social_add_connection_dismissed <source: home_dashboard>` |
| **With connections:** no shares remaining, scroll to card | `🔵 Tracked: jetpack_social_share_limit_displayed <source: home_dashboard>` |
| **With connections:** no shares remaining, tap on `Subscribe now to share more` | `🔵 Tracked: jetpack_social_upgrade_link_tapped <source: home_dashboard>` |
| **With connections:** no shares remaining, Tap on the context menu > `Hide this` | `🔵 Tracked: jetpack_social_share_limit_dismissed <source: home_dashboard>` |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
