### PR TITLE
Jetpack Social: Convert Jetpack Social feature flag to remote flag

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -159,7 +159,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         dispatch_group_leave(syncGroup);
     }];
 
-    if ([Feature enabled:FeatureFlagJetpackSocial] && blog.dotComID != nil) {
+    if ([RemoteFeature enabled:RemoteFeatureFlagJetpackSocialImprovements] && blog.dotComID != nil) {
         JetpackSocialService *jetpackSocialService = [[JetpackSocialService alloc] initWithContextManager:ContextManager.sharedInstance];
         dispatch_group_enter(syncGroup);
         [jetpackSocialService syncSharingLimitWithDotComID:blog.dotComID success:^{

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -222,7 +222,7 @@ class StoryEditor: CameraController {
 
 extension StoryEditor: PublishingEditor {
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
-        if FeatureFlag.jetpackSocial.enabled {
+        if RemoteFeatureFlag.jetpackSocialImprovements.enabled() {
             return  [.title, .visibility, .schedule, .tags, .categories, .autoSharing]
         }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,7 +40,6 @@ enum FeatureFlag: Int, CaseIterable {
     case readerUserBlocking
     case personalizeHomeTab
     case commentModerationUpdate
-    case jetpackSocial
     case compliancePopover
 
     /// Returns a boolean indicating if the feature is enabled
@@ -130,8 +129,6 @@ enum FeatureFlag: Int, CaseIterable {
             return AppConfiguration.isJetpack
         case .commentModerationUpdate:
             return false
-        case .jetpackSocial:
-            return AppConfiguration.isJetpack && BuildConfiguration.current == .localDeveloper
         case .compliancePopover:
             return true
         }
@@ -232,8 +229,6 @@ extension FeatureFlag {
             return "Personalize Home Tab"
         case .commentModerationUpdate:
             return "Comments Moderation Update"
-        case .jetpackSocial:
-            return "Jetpack Social"
         case .compliancePopover:
             return "Compliance Popover"
         }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -21,6 +21,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case sdkLessGoogleSignIn
     case bloggingPromptsSocial
     case siteEditorMVP
+    case jetpackSocialImprovements
 
     var defaultValue: Bool {
         switch self {
@@ -62,6 +63,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return AppConfiguration.isJetpack
         case .siteEditorMVP:
             return true
+        case .jetpackSocialImprovements:
+            return AppConfiguration.isJetpack && BuildConfiguration.current == .localDeveloper
         }
     }
 
@@ -106,6 +109,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "blogging_prompts_social_enabled"
         case .siteEditorMVP:
             return "site_editor_mvp"
+        case .jetpackSocialImprovements:
+            return "jetpack_social_improvements_v1"
         }
     }
 
@@ -149,6 +154,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Blogging Prompts Social"
         case .siteEditorMVP:
             return "Site Editor MVP"
+        case .jetpackSocialImprovements:
+            return "Jetpack Social Improvements v1"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -110,7 +110,7 @@ class DashboardJetpackSocialCardCell: DashboardCollectionViewCell {
     // MARK: - Functions
 
     static func shouldShowCard(for blog: Blog) -> Bool {
-        guard FeatureFlag.jetpackSocial.enabled else {
+        guard RemoteFeatureFlag.jetpackSocialImprovements.enabled() else {
             return false
         }
         // TODO: Show when user is out of shares

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
@@ -70,7 +70,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func socialIcon(for service: NSString) -> UIImage {
-        guard FeatureFlag.jetpackSocial.enabled else {
+        guard RemoteFeatureFlag.jetpackSocialImprovements.enabled() else {
             return iconForService(service)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+JetpackSocial.swift
@@ -2,7 +2,7 @@
 extension PostEditor {
 
     func disableSocialConnectionsIfNecessary() {
-        guard FeatureFlag.jetpackSocial.enabled,
+        guard RemoteFeatureFlag.jetpackSocialImprovements.enabled(),
               let post = self.post as? Post,
               let remainingShares = self.post.blog.sharingLimit?.remaining,
               let connections = self.post.blog.sortedConnections as? [PublicizeConnection],

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -145,7 +145,7 @@ extension PostEditor {
     }
 
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
-        if FeatureFlag.jetpackSocial.enabled {
+        if RemoteFeatureFlag.jetpackSocialImprovements.enabled() {
             return [.visibility, .schedule, .tags, .categories, .autoSharing]
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -6,7 +6,7 @@ extension PostSettingsViewController {
     // MARK: - No connection view
 
     @objc func showNoConnection() -> Bool {
-        let isJetpackSocialEnabled = FeatureFlag.jetpackSocial.enabled
+        let isJetpackSocialEnabled = RemoteFeatureFlag.jetpackSocialImprovements.enabled()
         let isNoConnectionViewHidden = UserPersistentStoreFactory.instance().bool(forKey: hideNoConnectionViewKey())
         let blogSupportsPublicize = apost.blog.supportsPublicize()
         let blogHasNoConnections = publicizeConnections.count == 0
@@ -36,7 +36,7 @@ extension PostSettingsViewController {
     // MARK: - Remaining shares view
 
     @objc func showRemainingShares() -> Bool {
-        let isJetpackSocialEnabled = FeatureFlag.jetpackSocial.enabled
+        let isJetpackSocialEnabled = RemoteFeatureFlag.jetpackSocialImprovements.enabled()
         let blogSupportsPublicize = apost.blog.supportsPublicize()
         let blogHasConnections = publicizeConnections.count > 0
         let blogHasSharingLimit = apost.blog.sharingLimit != nil
@@ -75,7 +75,7 @@ extension PostSettingsViewController {
         guard let post = self.apost as? Post else {
             return false
         }
-        guard FeatureFlag.jetpackSocial.enabled else {
+        guard RemoteFeatureFlag.jetpackSocialImprovements.enabled() else {
             return post.canEditPublicizeSettings()
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -886,7 +886,7 @@ FeaturedImageViewControllerDelegate>
                                       canEditSharing:(BOOL)canEditSharing
                                              section:(NSInteger)section
 {
-    BOOL isJetpackSocialEnabled = [Feature enabled:FeatureFlagJetpackSocial];
+    BOOL isJetpackSocialEnabled = [RemoteFeature enabled:RemoteFeatureFlagJetpackSocialImprovements];
     UITableViewCell *cell = [self getWPTableViewImageAndAccessoryCell];
     UIImage *image = [WPStyleGuide socialIconFor:connection.service];
     if (isJetpackSocialEnabled) {
@@ -942,7 +942,7 @@ FeaturedImageViewControllerDelegate>
 
     if (indexPath.row < connections.count) {
         PublicizeConnection *connection = connections[indexPath.row];
-        if ([Feature enabled:FeatureFlagJetpackSocial]) {
+        if ([RemoteFeature enabled:RemoteFeatureFlagJetpackSocialImprovements]) {
             BOOL hasRemainingShares = self.enabledConnections.count < [self remainingSocialShares];
             BOOL isSwitchOn = ![self.post publicizeConnectionDisabledForKeyringID:connection.keyringConnectionID];
             canEditSharing = canEditSharing && (hasRemainingShares || isSwitchOn);
@@ -1174,7 +1174,7 @@ FeaturedImageViewControllerDelegate>
 - (void)toggleShareConnectionForIndexPath:(NSIndexPath *) indexPath
 {
     UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
-    BOOL isJetpackSocialEnabled = [Feature enabled:FeatureFlagJetpackSocial];
+    BOOL isJetpackSocialEnabled = [RemoteFeature enabled:RemoteFeatureFlagJetpackSocialImprovements];
     if (indexPath.row < self.publicizeConnections.count) {
         PublicizeConnection *connection = self.publicizeConnections[indexPath.row];
         if (connection.isBroken) {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -59,7 +59,7 @@ class PrepublishingNavigationController: LightNavigationController {
         }
 
         let preferredDrawerPosition: DrawerPosition = {
-            guard FeatureFlag.jetpackSocial.enabled else {
+            guard RemoteFeatureFlag.jetpackSocialImprovements.enabled() else {
                 return .collapsed
             }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -4,7 +4,7 @@ extension PrepublishingViewController {
 
     /// Determines whether the account and the post's blog is eligible to see the Jetpack Social row.
     func canDisplaySocialRow(isJetpack: Bool = AppConfiguration.isJetpack,
-                             isFeatureEnabled: Bool = FeatureFlag.jetpackSocial.enabled) -> Bool {
+                             isFeatureEnabled: Bool = RemoteFeatureFlag.jetpackSocialImprovements.enabled()) -> Bool {
         guard isJetpack && isFeatureEnabled else {
             return false
         }

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
@@ -8,13 +8,14 @@ class DashboardJetpackSocialCardCellTests: CoreDataTestCase {
     override func setUp() {
         super.setUp()
 
-        try? featureFlags.override(FeatureFlag.jetpackSocial, withValue: true)
+        try? featureFlags.override(RemoteFeatureFlag.jetpackSocialImprovements, withValue: true)
     }
 
     override func tearDown() {
         super.tearDown()
 
-        try? featureFlags.override(FeatureFlag.jetpackSocial, withValue: FeatureFlag.jetpackSocial.originalValue)
+        try? featureFlags.override(RemoteFeatureFlag.jetpackSocialImprovements,
+                                   withValue: RemoteFeatureFlag.jetpackSocialImprovements.defaultValue)
     }
 
     // MARK: - `shouldShowCard` tests
@@ -32,7 +33,7 @@ class DashboardJetpackSocialCardCellTests: CoreDataTestCase {
         let blog = createTestBlog()
 
         // When
-        try featureFlags.override(FeatureFlag.jetpackSocial, withValue: false)
+        try featureFlags.override(RemoteFeatureFlag.jetpackSocialImprovements, withValue: false)
 
         // Then
         XCTAssertFalse(shouldShowCard(for: blog))


### PR DESCRIPTION
## Description

Converts the local Jetpack Social feature flag to a remote feature flag.

> **Warning**
> This is being merged into #21255 to avoid merge conflicts. 

## Testing

To test:
- Do a quick smoke test through the Jetpack Social changes
- **Verify** WordPress tests pass

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
