### PR TITLE
Remove WPAvatarSource usage from SuggestionsTableView.swift

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 23.1
 -----
 * [*] [internal] Fix Core Data multithreaded access exception in Blogging Reminders [#21232]
+* [*] [internal] Remove one of the image loading subsystems for avatars and consolidate the cache [#21259]
 
 23.0
 -----

--- a/WordPress/Classes/ViewRelated/SuggestionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/SuggestionViewModel.swift
@@ -23,7 +23,7 @@ import Foundation
         self.imageURL = suggestion.blavatarURL
     }
 
-    private static func preprocessAvatarURL(_ url: URL) -> URL {
+    static func preprocessAvatarURL(_ url: URL) -> URL {
         guard url.host?.contains("gravatar.com") ?? false else {
             return url
         }

--- a/WordPress/Classes/ViewRelated/SuggestionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/SuggestionViewModel.swift
@@ -12,7 +12,7 @@ import Foundation
             self.title = "\(SuggestionType.mention.trigger)\(username)"
         }
         self.subtitle = suggestion.displayName
-        self.imageURL = suggestion.imageURL
+        self.imageURL = suggestion.imageURL.map(SuggestionViewModel.preprocessAvatarURL)
     }
 
     init(suggestion: SiteSuggestion) {
@@ -21,5 +21,22 @@ import Foundation
         }
         self.subtitle = suggestion.title
         self.imageURL = suggestion.blavatarURL
+    }
+
+    private static func preprocessAvatarURL(_ url: URL) -> URL {
+        guard url.host?.contains("gravatar.com") ?? false else {
+            return url
+        }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+        if let index = components.queryItems?.firstIndex(where: { $0.name == "s" }) {
+            components.queryItems![index].value = String(Constants.avatarSize)
+        }
+        return components.url ?? url
+    }
+
+    private struct Constants {
+        static let avatarSize = 96
     }
 }

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
@@ -41,7 +41,7 @@ extension SuggestionType {
         let suggestion = viewModel.sections[indexPath.section].rows[indexPath.row]
         cell.titleLabel.text = suggestion.title
         cell.subtitleLabel.text = suggestion.subtitle
-        self.loadImage(for: suggestion, in: cell, at: indexPath, with: viewModel)
+        cell.iconImageView.downloadImage(from: suggestion.imageURL, placeholderImage: UIImage(named: "gravatar"))
 
         return cell
     }
@@ -148,60 +148,5 @@ extension SuggestionType {
     /// Returns the a list of prominent suggestions excluding the current user.
     static func prominentSuggestions(fromPostAuthorId postAuthorId: NSNumber?, commentAuthorId: NSNumber?, defaultAccountId: NSNumber?) -> [NSNumber] {
         return [postAuthorId, commentAuthorId].compactMap { $0 != defaultAccountId ? $0 : nil }
-    }
-
-    // MARK: - Private
-
-    private func loadImage(for suggestion: SuggestionViewModel, in cell: SuggestionsTableViewCell, at indexPath: IndexPath, with viewModel: SuggestionsListViewModelType) {
-        cell.iconImageView.image = UIImage(named: "gravatar")
-        guard let imageURL = suggestion.imageURL else { return }
-        cell.imageDownloadHash = imageURL.hashValue
-
-        retrieveIcon(for: imageURL) { image in
-            guard indexPath.section < viewModel.sections.count && indexPath.row < viewModel.sections[indexPath.section].rows.count else { return }
-            if let reloadedImageURL = viewModel.sections[indexPath.section].rows[indexPath.row].imageURL, reloadedImageURL.hashValue == cell.imageDownloadHash {
-                cell.iconImageView.image = image
-            }
-        }
-    }
-
-    private func retrieveIcon(for imageURL: URL?, success: @escaping (UIImage?) -> Void) {
-        let imageSize = CGSize(width: SuggestionsTableViewCellIconSize, height: SuggestionsTableViewCellIconSize)
-
-        if let image = cachedIcon(for: imageURL, with: imageSize) {
-            success(image)
-        } else {
-            fetchIcon(for: imageURL, with: imageSize, success: success)
-        }
-    }
-
-    private func cachedIcon(for imageURL: URL?, with size: CGSize) -> UIImage? {
-        var hash: NSString?
-        let type = avatarSourceType(for: imageURL, with: &hash)
-
-        if let hash = hash, let type = type {
-            return WPAvatarSource.shared()?.cachedImage(forAvatarHash: hash as String, of: type, with: size)
-        }
-        return nil
-    }
-
-    private func fetchIcon(for imageURL: URL?, with size: CGSize, success: @escaping ((UIImage?) -> Void)) {
-        var hash: NSString?
-        let type = avatarSourceType(for: imageURL, with: &hash)
-
-        if let hash = hash, let type = type {
-            WPAvatarSource.shared()?.fetchImage(forAvatarHash: hash as String, of: type, with: size, success: success)
-        } else {
-            success(nil)
-        }
-    }
-}
-
-extension SuggestionsTableView {
-    func avatarSourceType(for imageURL: URL?, with hash: inout NSString?) -> WPAvatarSourceType? {
-        if let imageURL = imageURL {
-            return WPAvatarSource.shared()?.parseURL(imageURL, forAvatarHash: &hash)
-        }
-        return .unknown
     }
 }

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableViewCell.m
@@ -58,14 +58,18 @@ NSInteger const SuggestionsTableViewCellIconSize = 24;
                             @"title": _titleLabel,
                             @"subtitle": _subtitleLabel,
                             @"icon": _iconImageView };
-        
-    NSDictionary *metrics = @{@"iconsize": @(SuggestionsTableViewCellIconSize) };
-        
+
     // Horizontal spacing
-    NSArray *horizConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[icon(iconsize)]-16-[title]-[subtitle]-|"
+    NSArray *horizConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[icon]-16-[title]-[subtitle]-|"
                                                                         options:0
-                                                                        metrics:metrics
+                                                                        metrics:nil
                                                                           views:views];
+
+    [NSLayoutConstraint activateConstraints:@[
+            [_iconImageView.heightAnchor constraintEqualToConstant:SuggestionsTableViewCellIconSize],
+            [_iconImageView.widthAnchor constraintEqualToConstant:SuggestionsTableViewCellIconSize],
+    ]];
+
     [self.contentView addConstraints:horizConstraints];
                 
     // Vertically constrain centers of each element

--- a/WordPress/WordPressTest/Mention/SuggestionViewModelTests.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionViewModelTests.swift
@@ -47,4 +47,15 @@ final class SuggestionViewModelTests: CoreDataTestCase {
         XCTAssertEqual(viewModel.subtitle, "Pied Piper")
         XCTAssertEqual(viewModel.imageURL, URL(string: "https://fakeimg.pl/250x100"))
     }
+
+    func testAvatarURLPreprocessing() {
+        // Given
+        let url = URL(string: "https://0.gravatar.com/avatar/6e010add837aef0e1bc8fd0a762c053e6184883ab9fbc7e92b72fae53c475f6c?s=32&d=identicon&r=G")!
+
+        // When
+        let processedURL = SuggestionViewModel.preprocessAvatarURL(url)
+
+        // Then it changes the size, but keeps all the other query items
+        XCTAssertEqual(processedURL.absoluteString, "https://0.gravatar.com/avatar/6e010add837aef0e1bc8fd0a762c053e6184883ab9fbc7e92b72fae53c475f6c?s=96&d=identicon&r=G")
+    }
 }


### PR DESCRIPTION
This is a long-term fix for https://github.com/wordpress-mobile/WordPress-iOS/issues/21155. It replaces `WPAvatarSource` with `UIImageView+Networking` and simply uses the provided user URL to download and display the avatars.

The code is identical to what's used in other places of the app that download avatars, for example, `ReaderPostCardCell` that uses `BasePost/authorAvatarURL`. Example: https://1.gravatar.com/avatar/da00fd286db5b0fe12085f9143c40f845962feb2507ad7aed0f67055a5f25910?s=96&d=identicon&r=G.

The advantages are clear: it re-uses the same avatars fetched in other parts of the app, reducing the network traffic and the memory footprint. It also uses the avatar URLs with smaller sizes now. But there are also a couple of disadvantages:

**Disadvantage 1**. The size does not exactly match the view size, but it's acceptably close. With images this small, I doubt there is going to be any measurable difference in rendering performance, but it will allow us to reuse caches from other parts of the app. 

**Disadvantage 2**: Some URLs have smaller sizes. I'm not sure why, but some suggestions contain URLs with `s=32`.

- https://2.gravatar.com/avatar/5f21ec6bee829d80daeaa1e789fce31e8f9b129b945a104b2f237c8aec0d5c4b?s=96&d=identicon&r=G
- https://0.gravatar.com/avatar/c6f085a4416002154a4aba6700d519d19f44e9f5bcbe4e4d3f06adb4bc184117?s=32&d=identicon&r=G

I see two ways to approach it:

- Ignore it. The size is acceptable for this use case.
- Decode the URL using `URLComponents` and replace the `s` parameter with URLs with `gravatar.com` host

I'm not sure why the size is backed-in in the avatars. Ideally, we need a system that would process these URLs and adjust the sizes according to the app's needs. Kind of like `WPAvatarSource`, but with fewer assumptions about the URL contents.

## Notes

Some URLs that I encountered are not using gravatar, so in production, they currently still don't get loaded even after the previous fix. Example:

```js
"image_URL": "https:\/\/zenithp2.files.wordpress.com\/2021\/08\/cropped-zenith-logo.png?w=96".
```

Ultimately, I think we need a dedicated component – `AvatarView` – that would handle all the intricacies of the avatar download.

## To Test

- Open one of the P2 posts in the Reader
- Tap to start writing a comment
- Start typing a user mention
- Verify that the avatar are loaded and look the same as in the production version

## Regression Notes
1. Potential unintended areas of impact: Mention Suggestions in P2s
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
