### PR TITLE
Support forum: remove feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -10,7 +10,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case jetpackFeaturesRemovalPhaseSelfHosted
     case jetpackFeaturesRemovalStaticPosters
     case jetpackMigrationPreventDuplicateNotifications
-    case wordPressSupportForum
     case blaze
     case blazeManageCampaigns
     case wordPressIndividualPluginSupport
@@ -40,8 +39,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .jetpackFeaturesRemovalStaticPosters:
             return false
-        case .wordPressSupportForum:
-            return true
         case .blaze:
             return false
         case .blazeManageCampaigns:
@@ -84,8 +81,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "jp_removal_static_posters"
         case .jetpackMigrationPreventDuplicateNotifications:
             return "prevent_duplicate_notifs_remote_field"
-        case .wordPressSupportForum:
-            return "wordpress_support_forum_remote_field"
         case .blaze:
             return "blaze"
         case .blazeManageCampaigns:
@@ -127,8 +122,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Jetpack Features Removal Phase For Self-Hosted Sites"
         case .jetpackFeaturesRemovalStaticPosters:
             return "Jetpack Features Removal Static Screens Phase"
-        case .wordPressSupportForum:
-            return "Provide support through a forum"
         case .blaze:
             return "Blaze"
         case .blazeManageCampaigns:

--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -12,7 +12,7 @@ enum SupportConfiguration {
             return .forum
         }
 
-        if isWordPress && RemoteFeatureFlag.wordPressSupportForum.enabled(using: featureFlagStore) {
+        if isWordPress {
             return .forum
         } else {
             return .zendesk

--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -5,7 +5,6 @@ enum SupportConfiguration {
     case forum
 
     static func current(
-        featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
         isWordPress: Bool = AppConfiguration.isWordPress,
         zendeskEnabled: Bool = ZendeskUtils.zendeskEnabled) -> SupportConfiguration {
         guard zendeskEnabled else {

--- a/WordPress/WordPressTest/Support/SupportConfigurationTests.swift
+++ b/WordPress/WordPressTest/Support/SupportConfigurationTests.swift
@@ -10,7 +10,6 @@ final class SupportConfigurationTests: XCTestCase {
 
     func testSupportConfigurationWhenWordPressWithFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: true,
             zendeskEnabled: true
         )
@@ -18,52 +17,12 @@ final class SupportConfigurationTests: XCTestCase {
         XCTAssertTrue(configuration == .forum)
     }
 
-    func testSupportConfigurationWhenWordPressWithFeatureFlagDisabled() {
-        let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: false),
-            isWordPress: true,
-            zendeskEnabled: true
-        )
-
-        XCTAssertTrue(configuration == .zendesk)
-    }
-
     func testSupportConfigurationWhenJetpackWithFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: false,
             zendeskEnabled: true
         )
 
         XCTAssertTrue(configuration == .zendesk)
-    }
-
-    func testSupportConfigurationWhenJetpackWithFeatureFlagDisabled() {
-        let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: false),
-            isWordPress: false,
-            zendeskEnabled: true
-        )
-
-        XCTAssertTrue(configuration == .zendesk)
-    }
-}
-
-private extension SupportConfigurationTests {
-    class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
-        var isSupportForumEnabled = false
-
-        init(isSupportForumEnabled: Bool) {
-            self.isSupportForumEnabled = isSupportForumEnabled
-            super.init()
-        }
-
-        override func value(for flagKey: String) -> Bool? {
-            if flagKey == RemoteFeatureFlag.wordPressSupportForum.remoteKey {
-                return isSupportForumEnabled
-            }
-
-            return false
-        }
     }
 }


### PR DESCRIPTION
The feature is no longer expected to be disabled remotely

Equivalent Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/18818

### To test:

#### On Jetpack app

1. Me
2. Help & Support
3. Contact Support option should be available

#### On WordPress app

1. Me
2. Help & Support
3. Community Support forums option should be available

## Regression Notes
1. Potential unintended areas of impact

None

5. What I did to test those areas of impact (or what existing automated tests I relied on)

None


6. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x]  I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
