### PR TITLE
Remove SDWebImage dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -124,7 +124,6 @@ abstract_target 'Apps' do
   pod 'FSInteractiveMap', git: 'https://github.com/wordpress-mobile/FSInteractiveMap.git', tag: '0.2.0'
   pod 'JTAppleCalendar', '~> 8.0.5'
   pod 'CropViewController', '2.5.3'
-  pod 'SDWebImage', '~> 5.11.1'
 
   ## Automattic libraries
   ## ====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -49,9 +49,6 @@ PODS:
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
   - Reachability (3.2)
-  - SDWebImage (5.11.1):
-    - SDWebImage/Core (= 5.11.1)
-  - SDWebImage/Core (5.11.1)
   - Sentry (8.15.2):
     - Sentry/Core (= 8.15.2)
     - SentryPrivate (= 8.15.2)
@@ -120,7 +117,6 @@ DEPENDENCIES:
   - OCMock (~> 3.4.3)
   - OHHTTPStubs/Swift (~> 9.1.0)
   - Reachability (= 3.2)
-  - SDWebImage (~> 5.11.1)
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
@@ -153,7 +149,6 @@ SPEC REPOS:
     - OCMock
     - OHHTTPStubs
     - Reachability
-    - SDWebImage
     - Sentry
     - SentryPrivate
     - Sodium
@@ -211,7 +206,6 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   Sentry: 6f5742b4c47c17c9adcf265f6f328cf4a0ed1923
   SentryPrivate: b2f7996f37781080f04a946eb4e377ff63c64195
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
@@ -236,6 +230,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 8f21b7aab84e57d7e16119c89573229552c8c418
+PODFILE CHECKSUM: beaa30560a95fe4f9e8153c20fa4b4ae54be1fd5
 
 COCOAPODS: 1.14.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 * [*] Integrate native photos picker (`PHPickerViewControlle`) in Story Editor [#22059]
 * [*] [internal] Fix an issue with scheduling of posts not working on iOS 17 with Xcode 15 [#22012]
+* [*] [internal] Remove SDWebImage dependency from the app and improve cache cost calculation for GIFs [#21285]
 
 23.7
 -----

--- a/WordPress/Classes/ViewRelated/Media/MemoryCache.swift
+++ b/WordPress/Classes/ViewRelated/Media/MemoryCache.swift
@@ -1,7 +1,6 @@
 import Foundation
 import AlamofireImage
 import WordPressUI
-import SDWebImage
 
 final class MemoryCache {
     /// A shared image cache used by the entire system.
@@ -22,7 +21,7 @@ final class MemoryCache {
     // MARK: - UIImage
 
     func setImage(_ image: UIImage, forKey key: String) {
-        cache.setObject(image, forKey: key as NSString, cost: Int(image.sd_memoryCost))
+        cache.setObject(image, forKey: key as NSString)
     }
 
     func getImage(forKey key: String) -> UIImage? {

--- a/WordPress/Classes/ViewRelated/Media/MemoryCache.swift
+++ b/WordPress/Classes/ViewRelated/Media/MemoryCache.swift
@@ -21,7 +21,7 @@ final class MemoryCache {
     // MARK: - UIImage
 
     func setImage(_ image: UIImage, forKey key: String) {
-        cache.setObject(image, forKey: key as NSString)
+        cache.setObject(image, forKey: key as NSString, cost: image.cost)
     }
 
     func getImage(forKey key: String) -> UIImage? {
@@ -44,6 +44,15 @@ final class MemoryCache {
 
     func removeData(forKey key: String) {
         cache.removeObject(forKey: key as NSString)
+    }
+}
+
+private extension UIImage {
+    /// Returns a rought estimation of how much space the image takes in memory.
+    var cost: Int {
+        let dataCost = (self as? AnimatedImageWrapper)?.gifData?.count ?? 0
+        let imageCost = cgImage.map { $0.bytesPerRow * $0.height } ?? 0
+        return dataCost + imageCost
     }
 }
 


### PR DESCRIPTION
This proposes replaces usage of `SDWebImage` in the new `MemoryCache` following the comment https://github.com/wordpress-mobile/WordPress-iOS/pull/20956#issuecomment-1653218906. It's only being used in one instance, to calculate the cost of objects added to the cache.

What's the difference between not passing in a cost and using `sd_memoryCost`? I'm not sure, so I'll share my current understanding and ask for feedback. For images, I don't see a difference because I think the cost is the image's size in bytes. For gifs (also `UIImage`s), the cost calculation seems more complex since I think it's only the number of frames loaded into memory (not the frames that are kept on disk).

This PR is meant to start a conversation about which option to take: a. Let `NSCache` calculate the cost and remove `SDWebImage` from the Podfile b. Re-implement a cost calculation and remove `SDWebImage` from the Podfile c. Leave things as-is and close this PR

The assumption here is that by removing `SDWebImage`, we're not importing the library twice (once here and once in Gutenberg as a transitive dependency of a RN library).

To test: TO-DO

## Regression Notes
1. Potential unintended areas of impact: TO-DO
2. What I did to test those areas of impact (or what existing automated tests I relied on): TO-DO
3. What automated tests I added (or what prevented me from doing so): TO-DO

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
