### PR TITLE
Use `AccountBuilder` over `WPAccount.init` in `AccountServiceTests`

### DIFF
--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -173,23 +173,28 @@ class AccountServiceTests: CoreDataTestCase {
 
     func testMergeDuplicateAccountsKeepingNonDups() throws {
         let context = contextManager.mainContext
-        let account1 = WPAccount(context: context)
-        account1.userID = 1
-        account1.username = "username"
-        account1.authToken = "authToken"
-        account1.uuid = UUID().uuidString
 
-        let account2 = WPAccount(context: context)
-        account2.userID = 1
-        account2.username = "username"
-        account2.authToken = "authToken"
-        account2.uuid = UUID().uuidString
+        let account1 = AccountBuilder(contextManager)
+            .with(id: 1)
+            .with(username: "username")
+            .with(authToken: "authToken")
+            .with(uuid: UUID().uuidString)
+            .build()
 
-        let account3 = WPAccount(context: context)
-        account3.userID = 3
-        account3.username = "username3"
-        account3.authToken = "authToken3"
-        account3.uuid = UUID().uuidString
+        // account2 is a duplicate of account1
+        let account2 = AccountBuilder(contextManager)
+            .with(id: 1)
+            .with(username: "username")
+            .with(authToken: "authToken")
+            .with(uuid: UUID().uuidString)
+            .build()
+
+        let account3 = AccountBuilder(contextManager)
+            .with(id: 3)
+            .with(username: "username3")
+            .with(authToken: "authToken3")
+            .with(uuid: UUID().uuidString)
+            .build()
 
         account1.addBlogs(createMockBlogs(withIDs: [1, 2, 3, 4, 5, 6], in: context))
         account2.addBlogs(createMockBlogs(withIDs: [1, 2, 3], in: context))


### PR DESCRIPTION
I'm dedicating part of my time at improving the unit tests. One low hanging fruit is the consistency and correctness of how we instantiate Core Data models.

I started looking at `AccountBuilder` and noticed that the `WPAccount.fixture` method I made at some point is redundant because of that type. I like fixtures, but I think for Core Data models the builder pattern might be more appropriate.

A first step I considered was to use the builder in the fixture under the hood, to ensure the tests behave in the same way. This is not possible because of `AccountBuilder` initializing with a `CoreDataStack` while the fixture takes a `NSManagedObjectContext`. The other builders all use a context, too, and some of the tests require a specific context, so I'll follow up by updating `AccountBuilder` accordingly.

In the meantime, there was one `fixture` that could be replaced with a builder usage.

While trying to remove other `fixture` usages, I noticed that `AccountBuilder` needs at least one default parameter, the user name:

<img width="2190" alt="Screenshot 2023-08-09 at 1 15 08 pm" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/92c8fea7-f811-4317-9eeb-5a308bc16f11">

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/aaba10e3-4b2b-4529-b98c-cb8837699198)

Again, I'll follow up accordingly.

---

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.