### PR TITLE
Blaze Manage Campaigns: Match colors on web

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCampaignStatusView.swift
@@ -52,7 +52,7 @@ struct BlazeCampaignStatusViewModel {
         self.title = status.localizedTitle
 
         switch status {
-        case .created, .processing, .scheduled, .canceled:
+        case .created, .processing:
             self.textColor = UIColor(
                 light: .muriel(name: .yellow, .shade80),
                 dark: .muriel(name: .yellow, .shade10)
@@ -61,7 +61,7 @@ struct BlazeCampaignStatusViewModel {
                 light: .muriel(name: .yellow, .shade5),
                 dark: .muriel(name: .yellow, .shade90)
             )
-        case .rejected:
+        case .canceled, .rejected:
             self.textColor = UIColor(
                 light: .muriel(name: .red, .shade70),
                 dark: .muriel(name: .red, .shade10)
@@ -79,7 +79,7 @@ struct BlazeCampaignStatusViewModel {
                 light: .muriel(name: .green, .shade5),
                 dark: .muriel(name: .green, .shade90)
             )
-        case .finished:
+        case .scheduled, .finished:
             self.textColor = UIColor(
                 light: .muriel(name: .blue, .shade80),
                 dark: .muriel(name: .blue, .shade10).lightVariant() /// Explicitly using the light variant of blue


### PR DESCRIPTION
Fixes pe7hp4-nI-p2#comment-204

## Description
- Updates scheduled status to blue color
- Updates canceled status to red color

![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 12 34 40](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/a80ab014-4176-495a-9bc8-94a72b05fd36) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 12 34 47](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ac5a6545-b10d-429a-a78e-1891a40749da) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-10 at 12 35 06](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/99e38587-1fe2-4c51-8936-7e510746e019)
-- | -- | -- 


## How to test
1. Switch to a site with Blaze campaigns 
2. ✅ Verify that scheduled campaigns are blue, and canceled campaigns are red

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
