### PR TITLE
Blaze Manage Campaigns: Preserve image aspect for campaign thumbnail

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
@@ -70,6 +70,7 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
     private lazy var featuredImageView: CachedAnimatedImageView = {
         let imageView = CachedAnimatedImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = Metrics.featuredImageCornerRadius
         return imageView


### PR DESCRIPTION
## Description
- Sets content mode to `scaleAspectFill` to preserve image aspect

Before | After 
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/7fb56324-02bd-4861-bed1-519958073f8c" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/05932510-82d0-4268-b153-3af90f4246df" width=200>
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/fc07eee0-050c-4ca7-806a-c76bf8473e6c" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/93b6dcb1-197a-4218-ba53-572dbaa2ae02" width=200>



## To test
1. Switch to a site with Blaze campaigns
2. ✅ Verify that the thumbnail image in the dashboard card preserves the image aspect
3. Navigate to the Blaze campaigns list screen (Dashboard card > tap title)
4. ✅ Verify that the thumbnail image preseves the image aspect

## Regression Notes
1. Potential unintended areas of impact
n/a

5. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
