### PR TITLE
Jetpack Social: Add support for publicize metadata key format

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -39,6 +39,23 @@ class Post: AbstractPost {
         static let publicizeEnabledValue = "0"
     }
 
+    enum PublicizeMetadataSkipPrefix: String {
+        case keyring = "_wpas_skip_"
+        case connection = "_wpas_skip_publicize_"
+
+        /// Determines the prefix type from the given key.
+        ///
+        /// - Parameter key: String.
+        /// - Returns: A `PublicizeMetadataSkipPrefix` value, or nil if nothing matched.
+        static func prefix(of key: String) -> PublicizeMetadataSkipPrefix? {
+            // try to match the `keyring` format first, since it's a substring of the `connection` format.
+            guard key.hasPrefix(Self.keyring.rawValue) else {
+                return nil
+            }
+            return key.hasPrefix(Self.connection.rawValue) ? .connection : .keyring
+        }
+    }
+
     // MARK: - Properties
 
     fileprivate var storedContentPreviewForDisplay = ""

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -34,6 +34,7 @@ class Post: AbstractPost {
     struct Constants {
         static let publicizeIdKey = "id"
         static let publicizeValueKey = "value"
+        static let publicizeKeyKey = "key"
         static let publicizeDisabledValue = "1"
         static let publicizeEnabledValue = "0"
     }

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -202,14 +202,15 @@ class Post: AbstractPost {
         // we need to make sure that the values are kept in sync.
         if let connections = blog.connections as? Set<PublicizeConnection>,
            let connectionID = connections.first(where: { $0.keyringConnectionID == keyringID })?.connectionID,
-           let connectionEntry = disabledPublicizeConnections?[connectionID] {
+           let _ = disabledPublicizeConnections?[connectionID] {
             disablePublicizeConnection(keyedBy: connectionID)
 
             // additionally, if the keyring entry doesn't exist, there's no need create both formats.
             // we can just update the dictionary's key from connectionID to keyringID instead.
-            if disabledPublicizeConnections?[keyringID] == nil {
+            if disabledPublicizeConnections?[keyringID] == nil,
+               let updatedEntry = disabledPublicizeConnections?[connectionID] {
                 disabledPublicizeConnections?.removeValue(forKey: connectionID)
-                disabledPublicizeConnections?[keyringID] = connectionEntry
+                disabledPublicizeConnections?[keyringID] = updatedEntry
                 return
             }
         }

--- a/WordPress/Classes/Services/PostService+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostService+JetpackSocial.swift
@@ -39,14 +39,19 @@ extension PostService {
                         return Int(key.removingPrefix(SkipPrefix.keyring.rawValue))
 
                     case .connection:
-                        // If the key uses the new format, try to find an existing `PublicizeConnection` that
-                        // matches the connectionID, and return its keyringID.
+                        // If the key uses the new format, try to find an existing `PublicizeConnection` matching
+                        // the connectionID, and return its keyringID.
                         let entryConnectionID = Int(key.removingPrefix(SkipPrefix.connection.rawValue))
 
                         guard let connections = post.blog.connections as? Set<PublicizeConnection>,
                               let connectionID = entryConnectionID,
                               let connection = connections.first(where: { $0.connectionID.intValue == connectionID }) else {
-                            // otherwise, fall back to the connectionID extracted from the metadata key.
+                            /// Otherwise, fall back to the connectionID extracted from the metadata key.
+                            /// Note that entries with `connectionID` won't be detected by the Post's
+                            /// `publicizeConnectionDisabledForKeyringID` method.
+                            ///
+                            /// However, the Publicize methods in `Post.swift` will attempt to update the key into
+                            /// its `keyringID`, since the `PublicizeConnection` object is guaranteed to exist.
                             return entryConnectionID
                         }
 

--- a/WordPress/Classes/Services/PostService+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostService+JetpackSocial.swift
@@ -15,8 +15,20 @@ extension PostService {
         }
     }
 
-    /// RemotePost -> Post.
-    /// TODO: Docs.
+    /// Returns a dictionary format for the `Post`'s `disabledPublicizeConnection` property based on the given metadata.
+    ///
+    /// This will try to handle both Publicize skip key formats, `_wpas_skip_{keyringID}` and `_wpas_skip_publicize_{connectionID`.
+    /// Different to the previous implementation, this will use the `PublicizeConnection`'s `connectionID` as the
+    /// dictionary key if possible.
+    ///
+    /// There's a possibility that the keyringID obtained from remote doesn't match with any of the `PublicizeConnection`
+    /// that's stored locally, perhaps due to the app being out of sync. In this case, we'll fall back to the previous
+    /// implementation of using the `keyringID` as the dictionary key, and only storing `id` and `value`.
+    ///
+    /// - Parameters:
+    ///   - post: The associated `Post` object. Optional because Obj-C shouldn't be trusted.
+    ///   - metadata: The metadata dictionary for the post. Optional because Obj-C shouldn't be trusted.
+    /// - Returns: A dictionary for the `Post`'s `disabledPublicizeConnections` property.
     @objc(disabledPublicizeConnectionsForPost:andMetadata:)
     func disabledPublicizeConnections(for post: AbstractPost?, metadata: [StringDictionary]?) -> [NSNumber: StringDictionary] {
         guard let post,
@@ -32,11 +44,11 @@ extension PostService {
                 }
 
                 func getConnectionID() -> Int? {
-                    guard let prefix = PublicizeMetadataSkipPrefix.prefix(of: key) else {
+                    guard let prefixType = PublicizeMetadataSkipPrefix.prefix(of: key) else {
                         return nil
                     }
 
-                    switch prefix {
+                    switch prefixType {
                     case .connection:
                         // If the key already uses the new format, then return the `connectionID` segment.
                         return Int(key.removingPrefix(PublicizeMetadataSkipPrefix.connection.rawValue))
@@ -70,7 +82,10 @@ extension PostService {
             }
     }
 
-    // TODO: Docs.
+    /// Converts the `Post`'s `disabledPublicizeConnections` dictionary to metadata entries.
+    ///
+    /// - Parameter post: The associated `Post` object.
+    /// - Returns: An array of metadata dictionaries representing the `Post`'s disabled connections.
     @objc(publicizeMetadataEntriesForPost:)
     func publicizeMetadataEntries(for post: Post?) -> [StringDictionary] {
         guard let post,
@@ -78,18 +93,34 @@ extension PostService {
             return []
         }
 
-        return disabledConnectionsDictionary.map { (id: NSNumber, entry: StringDictionary) in
-            // each entry should have a `value`, an optional `id`, and an optional `key`.
-            // if the entry already has a key, then there's nothing to do.
+        return disabledConnectionsDictionary.compactMap { (id: NSNumber, entry: StringDictionary) in
+            // The previous implementation didn't properly parse `_wpas_skip_publicize_` keys, causing it
+            // to use 0 as the dictionary key. Although this will be ignored by the server, let's make sure
+            // it's not sent to the remote any longer.
+            guard id.intValue > 0 else {
+                return nil
+            }
+
+            // Each entry should have a `value`, an optional `id`, and an optional `key`.
+            // If the entry already has a key, then there's nothing to do.
             if let _ = entry[Keys.publicizeKeyKey] {
                 return entry
             }
 
-            // If the entry doesn't have an id, then this is likely using an old format.
-            // The dictionary key is most likely a keyringID.
-            var modifiedEntry = entry
-            modifiedEntry[Keys.publicizeKeyKey] = "\(id)"
-            return modifiedEntry
+            // If the key doesn't exist, this means that the dictionary is still using the old format.
+            // Try to add a key with the new format, ONLY if the metadata hasn't been synced to the remote.
+            let keyMetadata: String = {
+                guard entry[Keys.publicizeIdKey] == nil,
+                      let connections = post.blog.connections as? Set<PublicizeConnection>,
+                      let connection = connections.first(where: { $0.keyringConnectionID == id }) else {
+                    // Fall back to the old keyring format.
+                    return "\(PublicizeMetadataSkipPrefix.keyring.rawValue)\(id)"
+                }
+
+                return "\(PublicizeMetadataSkipPrefix.connection.rawValue)\(connection.connectionID)"
+            }()
+
+            return entry.merging([Keys.publicizeKeyKey: keyMetadata]) { _, newValue in newValue }
         }
     }
 

--- a/WordPress/Classes/Services/PostService+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostService+JetpackSocial.swift
@@ -16,12 +16,12 @@ extension PostService {
     /// - Returns: A dictionary for the `Post`'s `disabledPublicizeConnections` property.
     @objc(disabledPublicizeConnectionsForPost:andMetadata:)
     func disabledPublicizeConnections(for post: AbstractPost?, metadata: [[String: Any]]?) -> [NSNumber: StringDictionary] {
-        guard let post,
-              let metadata = metadata as? [[String: String]] else {
+        guard let post, let metadata else {
             return [:]
         }
 
         return metadata
+            .compactMap { $0 as? [String: String] }
             .filter { $0[Keys.publicizeKeyKey]?.hasPrefix(SkipPrefix.keyring.rawValue) ?? false }
             .reduce(into: [NSNumber: StringDictionary]()) { partialResult, entry in
                 // every metadata entry should have a key.

--- a/WordPress/Classes/Services/PostService+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostService+JetpackSocial.swift
@@ -15,9 +15,9 @@ extension PostService {
     ///   - metadata: The metadata dictionary for the post. Optional because Obj-C shouldn't be trusted.
     /// - Returns: A dictionary for the `Post`'s `disabledPublicizeConnections` property.
     @objc(disabledPublicizeConnectionsForPost:andMetadata:)
-    func disabledPublicizeConnections(for post: AbstractPost?, metadata: [StringDictionary]?) -> [NSNumber: StringDictionary] {
+    func disabledPublicizeConnections(for post: AbstractPost?, metadata: [[String: Any]]?) -> [NSNumber: StringDictionary] {
         guard let post,
-              let metadata else {
+              let metadata = metadata as? [[String: String]] else {
             return [:]
         }
 

--- a/WordPress/Classes/Services/PostService+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostService+JetpackSocial.swift
@@ -46,7 +46,7 @@ extension PostService {
                         guard let connections = post.blog.connections as? Set<PublicizeConnection>,
                               let connectionID = entryConnectionID,
                               let connection = connections.first(where: { $0.connectionID.intValue == connectionID }) else {
-                            // otherwise, fall back to the connection ID extracted from the metadata key.
+                            // otherwise, fall back to the connectionID extracted from the metadata key.
                             return entryConnectionID
                         }
 
@@ -55,7 +55,6 @@ extension PostService {
                 }
 
                 if let id = getDictionaryID() {
-                    // If the connectionID exists, then we'll use that as the dictionary key.
                     partialResult[NSNumber(value: id)] = entry
                 }
             }

--- a/WordPress/Classes/Services/PostService+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostService+JetpackSocial.swift
@@ -1,0 +1,96 @@
+extension PostService {
+    typealias StringDictionary = [String: String]
+    typealias Keys = Post.Constants
+
+    // TODO: Move to Post.
+    enum PublicizeMetadataSkipPrefix: String {
+        case keyring = "_wpas_skip_"
+        case connection = "_wpas_skip_publicize_"
+
+        static func prefix(of key: String) -> PublicizeMetadataSkipPrefix? {
+            guard key.hasPrefix(Self.keyring.rawValue) else {
+                return nil
+            }
+            return key.hasPrefix(Self.connection.rawValue) ? .connection : .keyring
+        }
+    }
+
+    /// RemotePost -> Post.
+    /// TODO: Docs.
+    @objc(disabledPublicizeConnectionsForPost:andMetadata:)
+    func disabledPublicizeConnections(for post: AbstractPost?, metadata: [StringDictionary]?) -> [NSNumber: StringDictionary] {
+        guard let post,
+              let metadata else {
+            return [:]
+        }
+
+        return metadata
+            .filter { $0[Keys.publicizeKeyKey]?.hasPrefix(PublicizeMetadataSkipPrefix.keyring.rawValue) ?? false }
+            .reduce(into: [NSNumber: StringDictionary]()) { partialResult, entry in
+                guard let key = entry[Post.Constants.publicizeKeyKey] else {
+                    return
+                }
+
+                func getConnectionID() -> Int? {
+                    guard let prefix = PublicizeMetadataSkipPrefix.prefix(of: key) else {
+                        return nil
+                    }
+
+                    switch prefix {
+                    case .connection:
+                        // If the key already uses the new format, then return the `connectionID` segment.
+                        return Int(key.removingPrefix(PublicizeMetadataSkipPrefix.connection.rawValue))
+
+                    case .keyring:
+                        // If the key uses a keyring format, try to find an existing `PublicizeConnection` that
+                        // matches the `keyringID`, and get its connectionID.
+                        guard let connections = post.blog.connections as? Set<PublicizeConnection>,
+                              let keyringID = Int(key.removingPrefix(PublicizeMetadataSkipPrefix.keyring.rawValue)) else {
+                            return nil
+                        }
+
+                        return connections.first { $0.keyringConnectionID.intValue == keyringID }?.connectionID.intValue
+                    }
+                }
+
+                // If the connectionID exists, then we'll use that as the dictionary key.
+                if let connectionID = getConnectionID() {
+                    partialResult[NSNumber(value: connectionID)] = entry
+                    return
+                }
+
+                // Fall back to the previous implementation if the keyring is not found on the blog's connections.
+                // The previous implementation only reads the `id` and `value`, and uses `keyringID` as the dictionary key.
+                if let entryKeyringID = Int(key.removingPrefix(PublicizeMetadataSkipPrefix.keyring.rawValue)) {
+                    var connectionDictionary = StringDictionary()
+                    connectionDictionary[Keys.publicizeIdKey] = entry[Keys.publicizeIdKey]
+                    connectionDictionary[Keys.publicizeValueKey] = entry[Keys.publicizeValueKey]
+                    partialResult[NSNumber(value: entryKeyringID)] = connectionDictionary
+                }
+            }
+    }
+
+    // TODO: Docs.
+    @objc(publicizeMetadataEntriesForPost:)
+    func publicizeMetadataEntries(for post: Post?) -> [StringDictionary] {
+        guard let post,
+              let disabledConnectionsDictionary = post.disabledPublicizeConnections else {
+            return []
+        }
+
+        return disabledConnectionsDictionary.map { (id: NSNumber, entry: StringDictionary) in
+            // each entry should have a `value`, an optional `id`, and an optional `key`.
+            // if the entry already has a key, then there's nothing to do.
+            if let _ = entry[Keys.publicizeKeyKey] {
+                return entry
+            }
+
+            // If the entry doesn't have an id, then this is likely using an old format.
+            // The dictionary key is most likely a keyringID.
+            var modifiedEntry = entry
+            modifiedEntry[Keys.publicizeKeyKey] = "\(id)"
+            return modifiedEntry
+        }
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5554,6 +5554,7 @@
 		FEFA6AC32A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */; };
 		FEFA6AC42A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */; };
 		FEFA6AC62A86824A004EE5E6 /* PostService+JetpackSocialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC52A86824A004EE5E6 /* PostService+JetpackSocialTests.swift */; };
+		FEFA6AC82A88D5FC004EE5E6 /* Post+JetpackSocialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC72A88D5FC004EE5E6 /* Post+JetpackSocialTests.swift */; };
 		FEFC0F892731182C001F7F1D /* CommentService+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */; };
 		FEFC0F8A2731182C001F7F1D /* CommentService+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */; };
 		FEFC0F8C273131A6001F7F1D /* CommentService+RepliesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F8B273131A6001F7F1D /* CommentService+RepliesTests.swift */; };
@@ -9318,6 +9319,7 @@
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
 		FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEFA6AC52A86824A004EE5E6 /* PostService+JetpackSocialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+JetpackSocialTests.swift"; sourceTree = "<group>"; };
+		FEFA6AC72A88D5FC004EE5E6 /* Post+JetpackSocialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+JetpackSocialTests.swift"; sourceTree = "<group>"; };
 		FEFC0F872730510F001F7F1D /* WordPress 136.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 136.xcdatamodel"; sourceTree = "<group>"; };
 		FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+Replies.swift"; sourceTree = "<group>"; };
 		FEFC0F8B273131A6001F7F1D /* CommentService+RepliesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+RepliesTests.swift"; sourceTree = "<group>"; };
@@ -12239,6 +12241,7 @@
 				D848CC1420FF33FC00A9038F /* NotificationContentRangeTests.swift */,
 				D826D67E211D21C700A5D8FE /* NullMockUserDefaults.swift */,
 				5960967E1CF7959300848496 /* PostTests.swift */,
+				FEFA6AC72A88D5FC004EE5E6 /* Post+JetpackSocialTests.swift */,
 				8BBBEBB124B8F8C0005E358E /* ReaderCardTests.swift */,
 				E6B9B8A91B94E1FE0001B92F /* ReaderPostTest.m */,
 				24C69A8A2612421900312D9A /* UserSettingsTests.swift */,
@@ -23326,6 +23329,7 @@
 				B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */,
 				575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */,
 				2481B20C260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m in Sources */,
+				FEFA6AC82A88D5FC004EE5E6 /* Post+JetpackSocialTests.swift in Sources */,
 				40ACCF14224E167900190713 /* FlagsTest.swift in Sources */,
 				E15027651E03E54100B847E3 /* PinghubTests.swift in Sources */,
 				E1B642131EFA5113001DC6D7 /* ModelTestHelper.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5551,6 +5551,8 @@
 		FEFA263E26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */; };
 		FEFA263F26C5AE9A009CCB7E /* ShareAppContentPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8226C3BD0900B69DE4 /* ShareAppContentPresenter.swift */; };
 		FEFA264026C5AE9E009CCB7E /* ShareAppTextActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8426C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift */; };
+		FEFA6AC32A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */; };
+		FEFA6AC42A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */; };
 		FEFC0F892731182C001F7F1D /* CommentService+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */; };
 		FEFC0F8A2731182C001F7F1D /* CommentService+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */; };
 		FEFC0F8C273131A6001F7F1D /* CommentService+RepliesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F8B273131A6001F7F1D /* CommentService+RepliesTests.swift */; };
@@ -9313,6 +9315,7 @@
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
+		FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEFC0F872730510F001F7F1D /* WordPress 136.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 136.xcdatamodel"; sourceTree = "<group>"; };
 		FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+Replies.swift"; sourceTree = "<group>"; };
 		FEFC0F8B273131A6001F7F1D /* CommentService+RepliesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+RepliesTests.swift"; sourceTree = "<group>"; };
@@ -13984,6 +13987,7 @@
 				8B5E1DD727EA5929002EBEE3 /* PostCoordinator+Dashboard.swift */,
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
+				FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */,
 				98E0829E2637545C00537BF1 /* PostService+Likes.swift */,
 				9A4F8F55218B88E000EEDCCC /* PostService+Revisions.swift */,
 				2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */,
@@ -20767,6 +20771,7 @@
 				B5722E421D51A28100F40C5E /* Notification.swift in Sources */,
 				1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */,
 				175CC17927230DC900622FB4 /* Bool+StringRepresentation.swift in Sources */,
+				FEFA6AC32A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */,
 				7E4A773920F80417001C706D /* ActivityPluginRange.swift in Sources */,
 				FA98A2502833F1DC003B9233 /* QuickStartChecklistConfigurable.swift in Sources */,
 				7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */,
@@ -24386,6 +24391,7 @@
 				FABB23112602FC2C00C8785C /* PostingActivityLegend.swift in Sources */,
 				8B92D69727CD51FA001F5371 /* DashboardGhostCardCell.swift in Sources */,
 				FABB23122602FC2C00C8785C /* WPImmuTableRows.swift in Sources */,
+				FEFA6AC42A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */,
 				800035BE291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift in Sources */,
 				08CBC77A29AE6CC4000026E7 /* SiteCreationEmptySiteTemplate.swift in Sources */,
 				FABB23132602FC2C00C8785C /* WordPress-87-88.xcmappingmodel in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5553,6 +5553,7 @@
 		FEFA264026C5AE9E009CCB7E /* ShareAppTextActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8426C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift */; };
 		FEFA6AC32A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */; };
 		FEFA6AC42A83F4BE004EE5E6 /* PostService+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */; };
+		FEFA6AC62A86824A004EE5E6 /* PostService+JetpackSocialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA6AC52A86824A004EE5E6 /* PostService+JetpackSocialTests.swift */; };
 		FEFC0F892731182C001F7F1D /* CommentService+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */; };
 		FEFC0F8A2731182C001F7F1D /* CommentService+Replies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */; };
 		FEFC0F8C273131A6001F7F1D /* CommentService+RepliesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFC0F8B273131A6001F7F1D /* CommentService+RepliesTests.swift */; };
@@ -9316,6 +9317,7 @@
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
 		FEFA6AC22A83F4BE004EE5E6 /* PostService+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+JetpackSocial.swift"; sourceTree = "<group>"; };
+		FEFA6AC52A86824A004EE5E6 /* PostService+JetpackSocialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+JetpackSocialTests.swift"; sourceTree = "<group>"; };
 		FEFC0F872730510F001F7F1D /* WordPress 136.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 136.xcdatamodel"; sourceTree = "<group>"; };
 		FEFC0F882731182C001F7F1D /* CommentService+Replies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+Replies.swift"; sourceTree = "<group>"; };
 		FEFC0F8B273131A6001F7F1D /* CommentService+RepliesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+RepliesTests.swift"; sourceTree = "<group>"; };
@@ -15279,6 +15281,7 @@
 				8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */,
 				8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */,
 				8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */,
+				FEFA6AC52A86824A004EE5E6 /* PostService+JetpackSocialTests.swift */,
 				08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */,
 				8BB185CD24B62CE100A4CCE8 /* ReaderCardServiceTests.swift */,
 				5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */,
@@ -23284,6 +23287,7 @@
 				436D5655212209D600CEAA33 /* RegisterDomainDetailsServiceProxyMock.swift in Sources */,
 				F1450CF92437EEBB00A28BFE /* MediaRequestAuthenticatorTests.swift in Sources */,
 				FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */,
+				FEFA6AC62A86824A004EE5E6 /* PostService+JetpackSocialTests.swift in Sources */,
 				0C391E642A312DB20040EA91 /* BlazeCampaignViewModelTests.swift in Sources */,
 				D821C817210036D9002ED995 /* ActivityContentFactoryTests.swift in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,

--- a/WordPress/WordPressTest/Post+JetpackSocialTests.swift
+++ b/WordPress/WordPressTest/Post+JetpackSocialTests.swift
@@ -1,0 +1,301 @@
+import XCTest
+
+@testable import WordPress
+
+class Post_JetpackSocialTests: CoreDataTestCase {
+    /**
+     - Checking for publicize:
+         - Normal case
+         - keyring not exist, connection exists
+         - both exists
+     - enabling:
+         - normal enabling, non-existing keyringID
+         - normal enabling, with existing keyringID
+         - enabling existing keyring id with existing connectionID entry.
+         - enabling NON-existing keyring id with existing connectionID entry.
+     - disabling:
+         - normal disabling, non-existing keyringID
+         - normal disabling, with existing keyringID
+         - disable existing keyring id with existing connectionID entry.
+         - disable NON-existing keyring id with existing connectionID entry.
+
+     */
+
+    private let keyringAndConnectionIDPairs = [
+        (100, 200),
+        (101, 201),
+        (102, 202)
+    ]
+
+    private lazy var connections: Set<PublicizeConnection> = {
+        let connectionsArray = keyringAndConnectionIDPairs.map { keyringID, connectionID in
+            let connection = PublicizeConnection(context: mainContext)
+            connection.keyringConnectionID = NSNumber(value: keyringID)
+            connection.connectionID = NSNumber(value: connectionID)
+            return connection
+        }
+        return Set(connectionsArray)
+    }()
+
+    private lazy var blog: Blog = {
+        BlogBuilder(mainContext).with(connections: connections).build()
+    }()
+
+    // MARK: - Checking for PublicizeConnection state
+
+    func testCheckPublicizeConnectionHavingOnlyKeyringIDEntry() {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .disabled]
+        ])
+
+        // When
+        let result = post.publicizeConnectionDisabledForKeyringID(keyringID)
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func testCheckPublicizeConnectionHavingOnlyConnectionIDEntry() {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let post = makePost(disabledConnections: [
+            connectionID: [.valueKey: .disabled]
+        ])
+
+        // When
+        let result = post.publicizeConnectionDisabledForKeyringID(keyringID)
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func testCheckPublicizeConnectionHavingDifferentKeyringAndConnectionEntries() {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .enabled],
+            connectionID: [.valueKey: .disabled]
+        ])
+        let post2 = makePost(disabledConnections: [
+            keyringID: [.valueKey: .disabled],
+            connectionID: [.valueKey: .enabled]
+        ])
+
+        // When
+        let result1 = post.publicizeConnectionDisabledForKeyringID(keyringID)
+        let result2 = post2.publicizeConnectionDisabledForKeyringID(keyringID)
+
+        // Then
+        // if either one of the value is true, then the method should return true. See: pctCYC-XT-p2#comment-1000
+        XCTAssertTrue(result1)
+        XCTAssertTrue(result2)
+    }
+
+    // MARK: - Disabling connections
+
+    func testDisableConnectionWithoutAnyEntries() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let post = makePost()
+
+        // When
+        post.disablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        let entry = try XCTUnwrap(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertEqual(entry[.valueKey], .disabled)
+    }
+
+    func testDisableConnectionWithPriorKeyringEntry() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .enabled]
+        ])
+
+        // When
+        post.disablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        let entry = try XCTUnwrap(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertEqual(entry[.valueKey], .disabled)
+    }
+
+    func testDisableConnectionWithPriorKeyringAndConnectionEntries() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .enabled],
+            connectionID: [.valueKey: .enabled]
+        ])
+
+        // When
+        post.disablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        // both entries' values should be updated.
+        let keyringEntry = try XCTUnwrap(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertEqual(keyringEntry[.valueKey], .disabled)
+
+        let connectionEntry = try XCTUnwrap(post.disabledPublicizeConnections?[connectionID])
+        XCTAssertEqual(connectionEntry[.valueKey], .disabled)
+    }
+
+    func testDisableConnectionHavingOnlyConnectionIDEntry() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let post = makePost(disabledConnections: [
+            connectionID: [.valueKey: .enabled]
+        ])
+
+        // When
+        post.disablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        // if the keyring entry doesn't exist, the dictionary key should be updated to the keyringID.
+        let keyringEntry = try XCTUnwrap(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertEqual(keyringEntry[.valueKey], .disabled)
+
+        // the connection entry should be deleted.
+        XCTAssertNil(post.disabledPublicizeConnections?[connectionID])
+    }
+
+    // MARK: - Enabling connections
+
+    // Note: unlikely case since there must be an entry in the `disabledPublicizeConnections` for the switch to be on.
+    func testEnableConnectionWithoutAnyEntries() {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let post = makePost()
+
+        // When
+        post.enablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        // Calling the enable method should do nothing.
+        XCTAssertNil(post.disabledPublicizeConnections)
+    }
+
+    func testEnableConnectionWithLocalKeyringEntry() {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .disabled]
+        ])
+
+        // When
+        post.enablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        // if the entry hasn't been synced yet, the entry will be deleted since all connections are enabled by default.
+        XCTAssertNil(post.disabledPublicizeConnections)
+    }
+
+    func testEnableConnectionWithSyncedKeyringEntry() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .disabled, .idKey: "24"] // having an id means the entry exists on backend.
+        ])
+
+        // When
+        post.enablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        let keyringEntry = try XCTUnwrap(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertEqual(keyringEntry[.valueKey], .enabled)
+    }
+
+    // both keyring entry and connection entry are synced
+    func testEnableConnectionWithPriorSyncedKeyringAndConnectionEntries() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .disabled, .idKey: "24"], // having an id means the entry exists on backend.
+            connectionID: [.valueKey: .disabled, .idKey: "26"]
+        ])
+
+        // When
+        post.enablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        // both entries should be updated.
+        let keyringEntry = try XCTUnwrap(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertEqual(keyringEntry[.valueKey], .enabled)
+
+        let connectionEntry = try XCTUnwrap(post.disabledPublicizeConnections?[connectionID])
+        XCTAssertEqual(connectionEntry[.valueKey], .enabled)
+    }
+
+    // the keyring entry is local, but the connection entry is synced.
+    func testEnableConnectionWithPriorLocalKeyringAndSyncedConnectionEntries() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let post = makePost(disabledConnections: [
+            keyringID: [.valueKey: .disabled],
+            connectionID: [.valueKey: .disabled, .idKey: "26"]
+        ])
+
+        // When
+        post.enablePublicizeConnectionWithKeyringID(keyringID)
+
+        // Then
+        // the local entry should be removed.
+        XCTAssertNil(post.disabledPublicizeConnections?[keyringID])
+
+        // but the synced entry should be updated.
+        let entry = try XCTUnwrap(post.disabledPublicizeConnections?[connectionID])
+        XCTAssertEqual(entry[.valueKey], .enabled)
+    }
+
+    func testEnableConnectionHavingOnlyConnectionEntry() throws {
+        // Given
+        let keyringID = NSNumber(value: 100)
+        let connectionID = NSNumber(value: 200)
+        let keyringID2 = NSNumber(value: 101)
+        let connectionID2 = NSNumber(value: 201)
+        let post = makePost(disabledConnections: [
+            connectionID: [.valueKey: .disabled, .idKey: "26"],
+            connectionID2: [.valueKey: .disabled]
+        ])
+
+        // When
+        post.enablePublicizeConnectionWithKeyringID(keyringID)
+        post.enablePublicizeConnectionWithKeyringID(keyringID2)
+
+        // Then
+        // there shouldn't be any entries keyed by the keyringIDs.
+        XCTAssertNil(post.disabledPublicizeConnections?[keyringID])
+        XCTAssertNil(post.disabledPublicizeConnections?[keyringID2])
+
+        // the entry with connectionID should be updated.
+        let entry = try XCTUnwrap(post.disabledPublicizeConnections?[connectionID])
+        XCTAssertEqual(entry[.valueKey], .enabled)
+
+        // and if the entry isn't synced, it should be deleted.
+        XCTAssertNil(post.disabledPublicizeConnections?[connectionID2])
+    }
+
+    // MARK: - Helpers
+
+    private func makePost(disabledConnections: [NSNumber: [String: String]] = [:]) -> Post {
+        PostBuilder(mainContext, blog: blog)
+            .with(disabledConnections: disabledConnections)
+            .build()
+    }
+}
+
+private extension String {
+    static let idKey = Post.Constants.publicizeIdKey
+    static let valueKey = Post.Constants.publicizeValueKey
+    static let disabled = Post.Constants.publicizeDisabledValue
+    static let enabled = Post.Constants.publicizeEnabledValue
+}

--- a/WordPress/WordPressTest/Post+JetpackSocialTests.swift
+++ b/WordPress/WordPressTest/Post+JetpackSocialTests.swift
@@ -3,23 +3,6 @@ import XCTest
 @testable import WordPress
 
 class Post_JetpackSocialTests: CoreDataTestCase {
-    /**
-     - Checking for publicize:
-         - Normal case
-         - keyring not exist, connection exists
-         - both exists
-     - enabling:
-         - normal enabling, non-existing keyringID
-         - normal enabling, with existing keyringID
-         - enabling existing keyring id with existing connectionID entry.
-         - enabling NON-existing keyring id with existing connectionID entry.
-     - disabling:
-         - normal disabling, non-existing keyringID
-         - normal disabling, with existing keyringID
-         - disable existing keyring id with existing connectionID entry.
-         - disable NON-existing keyring id with existing connectionID entry.
-
-     */
 
     private let keyringAndConnectionIDPairs = [
         (100, 200),
@@ -179,7 +162,7 @@ class Post_JetpackSocialTests: CoreDataTestCase {
 
         // Then
         // Calling the enable method should do nothing.
-        XCTAssertNil(post.disabledPublicizeConnections)
+        XCTAssertNil(post.disabledPublicizeConnections?[keyringID])
     }
 
     func testEnableConnectionWithLocalKeyringEntry() {
@@ -194,7 +177,7 @@ class Post_JetpackSocialTests: CoreDataTestCase {
 
         // Then
         // if the entry hasn't been synced yet, the entry will be deleted since all connections are enabled by default.
-        XCTAssertNil(post.disabledPublicizeConnections)
+        XCTAssertNil(post.disabledPublicizeConnections?[keyringID])
     }
 
     func testEnableConnectionWithSyncedKeyringEntry() throws {

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -171,6 +171,11 @@ class PostBuilder {
         return self
     }
 
+    func with(disabledConnections: [NSNumber: [String: String]]) -> PostBuilder {
+        post.disabledPublicizeConnections = disabledConnections
+        return self
+    }
+
     func `is`(sticked: Bool) -> PostBuilder {
         post.isStickyPost = sticked
         return self

--- a/WordPress/WordPressTest/PostService+JetpackSocialTests.swift
+++ b/WordPress/WordPressTest/PostService+JetpackSocialTests.swift
@@ -1,0 +1,188 @@
+import XCTest
+
+@testable import WordPress
+
+class PostService_JetpackSocialTests: CoreDataTestCase {
+    let connectionId = 123
+    let keyringId = 456
+
+    private lazy var service: PostService = {
+        .init(managedObjectContext: mainContext)
+    }()
+
+    // MARK: - RemotePost -> Post tests
+
+    func testMetadataWithConnectionIDKey() {
+        // Given
+        let connections = makeConnections(with: [(connectionId, keyringId)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog)
+        let metadataEntry: [String: String] = [
+            "id": "10",
+            "key": "_wpas_skip_publicize_123",
+            "value": "1"
+        ]
+
+        // When
+        let result = service.disabledPublicizeConnections(for: post, metadata: [metadataEntry])
+
+        // Then
+        // the keyring ID should be used as the key, while keeping the entry intact.
+        XCTAssertEqual(result[NSNumber(value: keyringId)], metadataEntry)
+    }
+
+    func testMetadataWithKeyringIDKey() {
+        // Given
+        let connections = makeConnections(with: [(connectionId, keyringId)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog)
+        let metadataEntry: [String: String] = [
+            "id": "10",
+            "key": "_wpas_skip_456",
+            "value": "1"
+        ]
+
+        // When
+        let result = service.disabledPublicizeConnections(for: post, metadata: [metadataEntry])
+
+        // Then
+        // the keyring ID should be used as the key, while keeping the entry intact.
+        XCTAssertEqual(result[NSNumber(value: keyringId)], metadataEntry)
+    }
+
+    func testMetadataWithConnectionIDKeyNotMatchingAnyPublicizeConnections() {
+        // Given
+        let connections = makeConnections(with: [(connectionId, keyringId)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog)
+        let metadataEntry: [String: String] = [
+            "id": "10",
+            "key": "_wpas_skip_publicize_500", // connectionId different from the one in local.
+            "value": "1"
+        ]
+
+        // When
+        let result = service.disabledPublicizeConnections(for: post, metadata: [metadataEntry])
+
+        // Then
+        // the connection ID should be used as key.
+        XCTAssertEqual(result[NSNumber(value: 500)], metadataEntry)
+    }
+
+    // MARK: - Post -> RemotePost tests
+
+    func testDisabledConnectionsWithId() throws {
+        // Given
+        let connectionId2 = 234
+        let keyringId2 = 567
+        let presetDisabledConnections: [NSNumber: [String: String]] = [
+            NSNumber(value: keyringId): ["id": "10", "value": "1"],
+            NSNumber(value: keyringId2): ["id": "11", "key": "_wpas_skip_\(keyringId2)", "value": "0"]
+        ]
+        let connections = makeConnections(with: [(connectionId, keyringId), (connectionId2, keyringId2)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog, disabledConnections: presetDisabledConnections)
+
+        // When
+        let entries = service.publicizeMetadataEntries(for: post)
+
+        // Then
+        XCTAssertEqual(entries.count, 2)
+
+        // keyless entries with id should default to the _wpas_skip_ format, despite having a matching connection.
+        let _ = try XCTUnwrap(entries.first(where: { $0["key"] == "_wpas_skip_\(keyringId)" }))
+
+        // entries with keys should be passed as is.
+        let _ = try XCTUnwrap(entries.first(where: { $0["key"] == "_wpas_skip_\(keyringId2)" }))
+    }
+
+    // should convert to publicize format.
+    func testKeylessDisabledConnectionsWithoutId() throws {
+        // Given
+        let connectionId2 = 234
+        let keyringId2 = 567
+        let presetDisabledConnections: [NSNumber: [String: String]] = [
+            NSNumber(value: keyringId): ["value": "1"],
+            NSNumber(value: keyringId2): ["key": "_wpas_skip_\(keyringId2)", "value": "0"]
+        ]
+        let connections = makeConnections(with: [(connectionId, keyringId), (connectionId2, keyringId2)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog, disabledConnections: presetDisabledConnections)
+
+        // When
+        let entries = service.publicizeMetadataEntries(for: post)
+
+        // Then
+        XCTAssertEqual(entries.count, 2)
+
+        // local entries should be updated to the _wpas_skip_publicize format.
+        let _ = try XCTUnwrap(entries.first(where: { $0["key"] == "_wpas_skip_publicize_\(connectionId)" }))
+
+        // it's unlikely for a no-id entry to have a key, since it's assigned by the PostService when syncing.
+        // but in this unlikely case, the key should be sent as is.
+        let _ = try XCTUnwrap(entries.first(where: { $0["key"] == "_wpas_skip_\(keyringId2)" }))
+    }
+
+    func testDisabledConnectionsWithoutIdAndNoMatchingPublicizeConnection() {
+        let nonExistentKeyringId = 3942
+        let presetDisabledConnections = [NSNumber(value: nonExistentKeyringId): ["value": "1"]]
+        let connections = makeConnections(with: [(connectionId, keyringId)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog, disabledConnections: presetDisabledConnections)
+
+        // When
+        let entries = service.publicizeMetadataEntries(for: post)
+
+        // Then
+        XCTAssertEqual(entries.count, 1)
+
+        // local entries with no matching PublicizeConnection should default to _wpas_skip format.
+        XCTAssertEqual(entries.first?["key"], "_wpas_skip_\(nonExistentKeyringId)")
+    }
+
+    func testInvalidDisabledConnectionEntry() {
+        let presetDisabledConnections = [NSNumber(value: 0): ["value": "1"]]
+        let connections = makeConnections(with: [(connectionId, keyringId)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog, disabledConnections: presetDisabledConnections)
+
+        // When
+        let entries = service.publicizeMetadataEntries(for: post)
+
+        // Then
+        // Dictionary entries keyed by 0 should be ignored. This is a bug from previous implementation.
+        XCTAssertEqual(entries.count, 0)
+    }
+
+    // MARK: - Test Helpers
+
+    private func makeConnections(with pairs: [(connectionID: Int, keyringID: Int)]) -> Set<PublicizeConnection> {
+        return Set(pairs.map {
+            let connection = PublicizeConnection(context: mainContext)
+            connection.connectionID = NSNumber(value: $0.connectionID)
+            connection.keyringConnectionID = NSNumber(value: $0.keyringID)
+
+            return connection
+        })
+    }
+
+    private func makeBlog(connections: Set<PublicizeConnection>? = nil) -> Blog {
+        var builder = BlogBuilder(mainContext)
+
+        if let connections {
+            builder = builder.with(connections: connections)
+        }
+
+        return builder.build()
+    }
+
+    private func makePost(for blog: Blog, disabledConnections: [NSNumber: [String: String]]? = nil) -> Post {
+        var builder = PostBuilder(mainContext, blog: blog)
+
+        if let disabledConnections {
+            builder = builder.with(disabledConnections: disabledConnections)
+        }
+
+        return builder.build()
+    }
+}

--- a/WordPress/WordPressTest/PostService+JetpackSocialTests.swift
+++ b/WordPress/WordPressTest/PostService+JetpackSocialTests.swift
@@ -69,6 +69,25 @@ class PostService_JetpackSocialTests: CoreDataTestCase {
         XCTAssertEqual(result[NSNumber(value: 500)], metadataEntry)
     }
 
+    func testMetadataEntriesWithNonStringValues() {
+        // Given
+        let connections = makeConnections(with: [(connectionId, keyringId)])
+        let blog = makeBlog(connections: connections)
+        let post = makePost(for: blog)
+        let metadataEntry: [String: Any] = [
+            "id": "10",
+            "key": "sharing_disabled",
+            "value": [123]
+        ]
+
+        // When
+        let result = service.disabledPublicizeConnections(for: post, metadata: [metadataEntry])
+
+        // Then
+        // invalid entries should be ignored.
+        XCTAssertTrue(result.isEmpty)
+    }
+
     // MARK: - Post -> RemotePost tests
 
     func testDisabledConnectionsWithId() throws {


### PR DESCRIPTION
Refs pctCYC-XT-p2

As titled, this PR adds support for `_wpas_skip_publicize` key prefix by parsing them and storing the `key` metadata into `disabledPublicizeConnections` when syncing from the remote.

Some other modifications:

- We will keep using `keyringID` as the dictionary key for `disabledPublicizeConnections`, to avoid modifying the call sites. 
- While syncing posts, we'll store the `key` field in `disabledPublicizeConnections` (in addition to the `id` and `value`). This way, to some extent, `PostService` won't have to decide which prefix to use when uploading the post.
  - When receiving `_wpas_skip_publicize` keys, we'll need to query the local `PublicizeConnection` and find the one matching the `connectionID`, since we'll need the `keyringID` to be used as the key.
  - In case the object is not found, the `connectionID` will be used as the dictionary key. This will get sorted out during editing and uploading.
- When uploading posts, local entries from the previous version likely won't have a `key`. In this case, we'll try to assign `_wpas_skip_publicize` if the keyringID matches any of the `PublicizeConnection` stored locally. Otherwise, we'll fall back to the `_wpas_skip` format.
- When editing posts, checking if a connection is disabled will now check for two entries: one keyed by the connection's `keyringID`, and the other keyed by `connectionID`. If both entries exist, the return value will be the result of an OR operation between the two values. For more details, refer to pctCYC-XT-p2#comment-1000.
- When enabling or disabling posts, if the connection has two entries (keyringID and connectionID), the values will be applied into both of them so they stay in sync.


## To test

### Unit tests

I've added some unit tests for the changes. Please make sure that they are passing 🟢

### Manual tests

#### Case 1: Creating a draft from iOS

1. Launch the Jetpack app.
3. Switch to a site with existing Social connections.
4. Create a post draft.
5. Go to Post Settings, and disable one of the connections.
6. Save draft.
7. Go to Calypso, and open the draft post from iOS.
8. Tap the Jetpack sidebar.
9. 🔎 Verify that the connection is disabled.
10. Enable the connection, and save the draft from the web.
11. 🔎 Verify that the connection is now enabled.
12. Go back to the iOS app, refresh, and open the draft again.
13. Go to Post Settings.
14. 🔎 Verify that the connection is now enabled.

#### Case 2: Creating a draft from the web

1. Prepare a site with one or more Social connections.
2. Go to Calypso, and create a draft post.
4. From the Jetpack sidebar menu, disable one of the connections and save the draft.
5. Launch the Jetpack app.
6. Open the draft post created on the web.
7. Go to Post Settings.
8. 🔎  Verify that the connection appears disabled.
9. Enable the connection, and save the draft.
10. 🔎 Verify in Calypso that the connection for the draft post is now enabled.

## Regression Notes
1. Potential unintended areas of impact
This impacts syncing, uploading, and editing processes for `Post`. Most often used in My Sites > Posts.

11. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes, and added some unit tests.

12. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A. Changes do not include UI.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)