### PR TITLE
Remove Domain Purchasing during Site Creation A/B experiment

### DIFF
--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -53,7 +53,7 @@ final class DomainsServiceAdapter: SiteAddressService {
 
     /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
     private var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+        FeatureFlag.siteCreationDomainPurchasing.enabled
     }
 
     /**

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -4,7 +4,6 @@ import AutomatticTracks
 // Jetpack is not supported
 enum ABTest: String, CaseIterable {
     case unknown = "unknown"
-    case siteCreationDomainPurchasing = "jpios_site_creation_domain_purchasing_v1"
 
     /// Returns a variation for the given experiment
     var variation: Variation {

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -4,7 +4,7 @@ extension WPAnalytics {
 
     /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
     private static var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+        FeatureFlag.siteCreationDomainPurchasing.enabled
     }
 
     static func domainsProperties(for blog: Blog, origin: DomainPurchaseWebViewViewOrigin? = .menu) -> [AnyHashable: Any] {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -123,7 +123,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .jetpackIndividualPluginSupport:
             return AppConfiguration.isJetpack
         case .siteCreationDomainPurchasing:
-            return true
+            return false
         case .readerUserBlocking:
             return true
         case .personalizeHomeTab:

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/EnhancedSiteCreationAnalyticsEvent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/EnhancedSiteCreationAnalyticsEvent.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-enum EnhancedSiteCreationAnalyticsEvent: String {
-    case domainPurchasingExperiment = "enhanced_site_creation_domain_purchasing_experiment"
-}

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -30,19 +30,6 @@ class SiteCreationAnalyticsHelper {
     // MARK: - Lifecycle
     static func trackSiteCreationAccessed(source: String) {
         WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
-
-        if FeatureFlag.siteCreationDomainPurchasing.enabled {
-            let domainPurchasingExperimentProperties: [String: String] = {
-                var dict: [String: String] = [Self.variationKey: ABTest.siteCreationDomainPurchasing.variation.tracksProperty]
-
-                if case let .customTreatment(name) = ABTest.siteCreationDomainPurchasing.variation {
-                    dict[Self.customTreatmentNameKey] = name
-                }
-
-                return dict
-            }()
-            Self.track(.domainPurchasingExperiment, properties: domainPurchasingExperimentProperties)
-        }
     }
 
     // MARK: - Site Intent
@@ -156,10 +143,6 @@ class SiteCreationAnalyticsHelper {
     }
 
     // MARK: - Common
-    private static func track(_ event: EnhancedSiteCreationAnalyticsEvent, properties: [String: String] = [:]) {
-        let event = AnalyticsEvent(name: event.rawValue, properties: properties)
-        WPAnalytics.track(event)
-    }
 
     private static func commonProperties(_ properties: Any?...) -> [AnyHashable: Any] {
         var result: [AnyHashable: Any] = [:]

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -6,7 +6,7 @@ final class AddressTableViewCell: UITableViewCell {
     // MARK: - Dependencies
 
     private var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+        FeatureFlag.siteCreationDomainPurchasing.enabled
     }
 
     // MARK: - Views

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -57,7 +57,7 @@ final class SiteCreator {
 
     /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
     var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled && ABTest.siteCreationDomainPurchasing.isTreatmentVariation
+        FeatureFlag.siteCreationDomainPurchasing.enabled
     }
 
     /// Flag indicating whether the domain checkout flow should appear or not.

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3594,8 +3594,6 @@
 		F446B843296F2DED008B94B7 /* MigrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E79300296EEE320025E8E0 /* MigrationState.swift */; };
 		F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */; };
 		F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = F44FB6D02878A1020001E3CE /* user-suggestions.json */; };
-		F45326D829F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */; };
-		F45326D929F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */; };
 		F4552086299D147B00D9F6A8 /* BlockedSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48D44B5298992C30051EAA6 /* BlockedSite.swift */; };
 		F465976E28E4669200D5F49A /* cool-green-icon-app-76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */; };
 		F465976F28E4669200D5F49A /* cool-green-icon-app-76.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */; };
@@ -8937,7 +8935,6 @@
 		F44F6ABD2937428B00DC94A2 /* MigrationEmailService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
 		F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsListViewModelTests.swift; sourceTree = "<group>"; };
 		F44FB6D02878A1020001E3CE /* user-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-suggestions.json"; sourceTree = "<group>"; };
-		F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnhancedSiteCreationAnalyticsEvent.swift; sourceTree = "<group>"; };
 		F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76@2x.png"; sourceTree = "<group>"; };
 		F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76.png"; sourceTree = "<group>"; };
 		F465976B28E4669200D5F49A /* cool-green-icon-app-60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-60@3x.png"; sourceTree = "<group>"; };
@@ -12606,7 +12603,6 @@
 				738B9A5D21B8632E0005062B /* UITableView+Header.swift */,
 				738B9A5B21B85EB00005062B /* UIView+ContentLayout.swift */,
 				46D6114E2555DAED00B0B7BB /* SiteCreationAnalyticsHelper.swift */,
-				F45326D729F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -21194,7 +21190,6 @@
 				80A2154629D15B88002FE8EB /* RemoteConfigOverrideStore.swift in Sources */,
 				F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */,
 				4629E4212440C5B20002E15C /* GutenbergCoverUploadProcessor.swift in Sources */,
-				F45326D829F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */,
 				FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */,
 				982DDF94263238A6002B3904 /* LikeUserPreferredBlog+CoreDataClass.swift in Sources */,
 				F5844B6B235EAF3D007C6557 /* PartScreenPresentationController.swift in Sources */,
@@ -23937,7 +23932,6 @@
 				8B55F9EE2614D977007D618E /* UnifiedPrologueStatsContentView.swift in Sources */,
 				FABB21932602FC2C00C8785C /* GutenbergTenorMediaPicker.swift in Sources */,
 				3F8B45A029283D6C00730FA4 /* DashboardMigrationSuccessCell.swift in Sources */,
-				F45326D929F6B8A6005F9F31 /* EnhancedSiteCreationAnalyticsEvent.swift in Sources */,
 				FA98B61A29A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */,
 				FABB21942602FC2C00C8785C /* AztecPostViewController.swift in Sources */,
 				F1585442267D3BF900A2E966 /* CalendarDayToggleButton.swift in Sources */,


### PR DESCRIPTION
## Description
This PR removes the Site Creation Domain Purchasing experiment code for cleanup. To avoid releasing this to all users, the feature flag is turned off. 

## Testing Instructions
### Feature Flag Disabled

1. Install Jetpack and log in.
2. Head to "My Site" > "Chevron Down" button to display "My Sites" screen.
3. Tap "+" button, then "Create WordPress.com site"
4. Go through the flow until your reach the "Choose a domain" screen.
5. ✅ Make sure there isn't an option to purchase a domain

### Feature Flag Enabled

1. Install Jetpack and log in.
2. Enable the "Site Creation Domain Purchasing" feature flag
3. Head to "My Site" > "Chevron Down" button to display "My Sites" screen.
4. Tap "+" button, then "Create WordPress.com site"
5. Go through the flow until your reach the "Choose a domain" screen.
6. ✅ Make sure there's an option to purchase a domain

## Regression Notes
1. Potential unintended areas of impact
Incorrectly enabling Domain Purchasing to users

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
