### PR TITLE
UI Modernization: Update FAB

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -12,7 +12,7 @@ import WordPressFlux
     }
 
     var button: FloatingActionButton = {
-        let button = FloatingActionButton(image: .gridicon(.create))
+        let button = FloatingActionButton(image: .gridicon(.plus))
         button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
         button.accessibilityIdentifier = "floatingCreateButton"
         return button

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -17,7 +17,6 @@ class FloatingActionButton: UIButton {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        layer.backgroundColor = UIColor.primary.cgColor
         tintColor = .white
         refreshShadow()
     }
@@ -30,6 +29,7 @@ class FloatingActionButton: UIButton {
         super.draw(rect)
 
         layer.cornerRadius = rect.size.width / 2
+        layer.backgroundColor = UIColor(light: .label, dark: .systemGray2).cgColor
     }
 
     private func refreshShadow() {


### PR DESCRIPTION
Closes #21284

## Description
- Updates FAB color (light: .label, dark: .systemGray2)
- Update FAB icon to simple plus icon

Light | Dark
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/43fbbbdb-e32f-4407-83af-31a5a77071c1" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/06a9d65f-96cc-4ab1-9910-544c2115d3d3" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
