### PR TITLE
Clarify placeholders in `stats.insights.totalLikes.guideText.singular`

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -110,7 +110,7 @@ struct StatsTotalInsightsData {
         static let likesTotalGuideTextSingular = NSLocalizedString(
             "stats.insights.totalLikes.guideText.singular",
             value: "Your latest post %1$@ has received %2$@ like.",
-            comment: "A hint shown to the user in stats informing the user that one of their posts has received a like. The %1$@ placeholder will be replaced with the title of a post, and the %2$@ will be replaced by a number.")
+            comment: "A hint shown to the user in stats informing the user that one of their posts has received a like. The %1$@ placeholder will be replaced with the title of a post, and the %2$@ will be replaced by the numeral one.")
         static let likesTotalGuideTextPlural = NSLocalizedString(
             "stats.insights.totalLikes.guideText.plural",
             value: "Your latest post %1$@ has received %2$@ likes.",


### PR DESCRIPTION
One translator removed the placeholder for the second parameter (to be substituted for the numeral one) which our linter picked up. Removing placeholders will result in runtime crashes.

The idea with this `comment` update is to make it clearer that the placeholder should remain, just in case the translation is picked up by a new translator unfamiliar with the rule.

See also https://github.com/wordpress-mobile/WordPress-iOS/pull/21319/commits/8b451114a3d364a34569285972b2d8301e9e19b2

## Possible alternative

I considered updating the logic to use the word "one," that is remove the second placeholder. I didn't go down that path to keep the change minimal. I didn't research whether it had been considered already, but for what is worth I prefer the current option with the numeral one, as it's more consistent: "received 1 like, received 2 likes" vs "received one like, received 2 likes."
 
## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.