### PR TITLE
Add release notes when uploading build to TestFlight

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,8 @@ PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 WORKSPACE_PATH = File.join(PROJECT_ROOT_FOLDER, 'WordPress.xcworkspace')
 DERIVED_DATA_PATH = File.join(PROJECT_ROOT_FOLDER, 'DerivedData')
 BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'Artifacts')
+WORDPRESS_RELEASE_NOTES_PATH = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt')
+JETPACK_RELEASE_NOTES_PATH = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
 
 # Env file paths to load
 ENV_FILE_NAME = '.wpios-env.default'

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -173,7 +173,7 @@ platform :ios do
     create_release(
       repository: GITHUB_REPO,
       version: version,
-      release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
+      release_notes_file_path: WORDPRESS_RELEASE_NOTES_PATH,
       release_assets: archive_zip_path.to_s,
       prerelease: options[:beta_release]
     )

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -151,11 +151,7 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-      team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
-      api_key_path: APP_STORE_CONNECT_KEY_PATH
-    )
+    upload_build_to_testflight(whats_new_path: WORDPRESS_RELEASE_NOTES_PATH)
 
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
@@ -201,11 +197,7 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-      team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
-      api_key_path: APP_STORE_CONNECT_KEY_PATH
-    )
+    upload_build_to_testflight(whats_new_path: JETPACK_RELEASE_NOTES_PATH)
 
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
@@ -428,5 +420,14 @@ platform :ios do
 
   def buildkite_ci?
     ENV.fetch('BUILDKITE', false)
+  end
+
+  def upload_build_to_testflight(whats_new_path:)
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true,
+      team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
+      api_key_path: APP_STORE_CONNECT_KEY_PATH,
+      changelog: File.read(whats_new_path)
+    )
   end
 end

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -203,7 +203,7 @@ platform :ios do
 
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
-      team_id: '299112',
+      team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
       api_key_path: APP_STORE_CONNECT_KEY_PATH
     )
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -151,7 +151,7 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    testflight(
+    upload_to_testflight(
       skip_waiting_for_build_processing: true,
       team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
       api_key_path: APP_STORE_CONNECT_KEY_PATH
@@ -201,7 +201,7 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    testflight(
+    upload_to_testflight(
       skip_waiting_for_build_processing: true,
       team_id: '299112',
       api_key_path: APP_STORE_CONNECT_KEY_PATH

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -167,7 +167,7 @@ platform :ios do
     version = options.fetch(:version, get_app_version)
 
     files = {
-      whats_new: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
+      whats_new: WORDPRESS_RELEASE_NOTES_PATH,
       app_store_name: File.join(source_metadata_folder, 'name.txt'),
       app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
       app_store_desc: File.join(source_metadata_folder, 'description.txt'),
@@ -203,7 +203,7 @@ platform :ios do
     version = options.fetch(:version, get_app_version)
 
     files = {
-      whats_new: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt'),
+      whats_new: JETPACK_RELEASE_NOTES_PATH,
       app_store_name: File.join(source_metadata_folder, 'name.txt'),
       app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
       app_store_desc: File.join(source_metadata_folder, 'description.txt'),
@@ -271,7 +271,7 @@ platform :ios do
     # (will require changes in the `update_appstore_strings` lane, the Release Scenario, the MC tool to generate the announcement post…)
     #
     # In the meantime, just copy the file to the right place for `deliver` to find, for the `default` pseudo-locale which is used as fallback
-    release_notes_source = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt')
+    release_notes_source = WORDPRESS_RELEASE_NOTES_PATH
     FileUtils.cp(release_notes_source, File.join(metadata_directory, 'default', 'release_notes.txt'))
 
     # Download metadata translations from GlotPress
@@ -293,7 +293,7 @@ platform :ios do
     # (will require changes in the `update_appstore_strings` lane, the Release Scenario, the MC tool to generate the announcement post…)
     #
     # In the meantime, just copy the file to the right place for `deliver` to find, for the `default` pseudo-locale which is used as fallback
-    release_notes_source = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
+    release_notes_source = JETPACK_RELEASE_NOTES_PATH
     FileUtils.cp(release_notes_source, File.join(metadata_directory, 'default', 'release_notes.txt'))
 
     # Download metadata translations from GlotPress

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -251,8 +251,8 @@ end
 #
 def extracted_release_notes_file_path(app:)
   paths = {
-    wordpress: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
-    jetpack: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
+    wordpress: WORDPRESS_RELEASE_NOTES_PATH,
+    jetpack: JETPACK_RELEASE_NOTES_PATH
   }
   paths[app.to_sym] || UI.user_error!("Invalid app name passed to lane: #{app}")
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -190,7 +190,7 @@ platform :ios do
   # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_beta_build do |options|
-    branch = options[:branch] || release_branch_name
+    branch = compute_release_branch_name(options: options)
     trigger_buildkite_release_build(branch: branch, beta: true)
   end
 
@@ -199,7 +199,7 @@ platform :ios do
   # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_release_build do |options|
-    branch = options[:branch] || release_branch_name
+    branch = compute_release_branch_name(options: options)
     trigger_buildkite_release_build(branch: branch, beta: false)
   end
 end
@@ -282,6 +282,18 @@ def prompt_for_confirmation(message:, bypass:)
   return true if bypass
 
   UI.confirm(message)
+end
+
+def compute_release_branch_name(options:)
+  branch_option = :branch
+  branch_name = options[branch_option]
+
+  if branch_name.nil?
+    branch_name = release_branch_name
+    UI.message("No branch given via option '#{branch_option}'. Defaulting to #{branch_name}.")
+  end
+
+  branch_name
 end
 
 def release_branch_name


### PR DESCRIPTION
I finally got tired of copy pasting all the time. Can't believe it took me this long to do it, actually. It was a _pebble in the stone_ kind of situation, but given how many betas I've shipped since first noticing it, not addressing it for this long was indeed unresponsible.

## Testing

~~I'll keep this a draft until I'll submit a new beta using this code and only then, once verified, ask for a review.~~

I used this branch to trigger the beta build and verify that the release notes were uploaded:

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/c280c75f-434e-44c8-b24f-0d41b53e218b)


---

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.