### PR TITLE
Fix a crash when opening a page for editing

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -177,7 +177,7 @@ class EditorMediaUtility {
             return try object.get()
         }
 
-        let post = try safeExistingObject(postObjectID) as! Post
+        let post = try safeExistingObject(postObjectID) as! AbstractPost
 
         let imageMaxDimension = max(requestSize.width, requestSize.height)
         //use height zero to maintain the aspect ratio when fetching


### PR DESCRIPTION
Fixes #21326

To test:
- See the ticket

## Regression Notes
1. Potential unintended areas of impact: Post/Page Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
