### PR TITLE
[Domain Focus] Add site agnostic card hide logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardCell.swift
@@ -71,7 +71,14 @@ final class DashboardGoogleDomainsCardCell: DashboardCollectionViewCell {
     private func configureMoreButton(with blog: Blog) {
         frameView.addMoreMenu(
             items:
-                [UIMenu(options: .displayInline, children: [BlogDashboardHelpers.makeHideCardAction(for: .googleDomains, blog: blog)])],
+                [
+                    UIMenu(
+                        options: .displayInline,
+                        children: [
+                            BlogDashboardHelpers.makeHideCardAction(for: .googleDomains, blog: blog, isSiteAgnostic: true)
+                        ]
+                    )
+                ],
             card: .googleDomains
         )
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardCell.swift
@@ -75,7 +75,7 @@ final class DashboardGoogleDomainsCardCell: DashboardCollectionViewCell {
                     UIMenu(
                         options: .displayInline,
                         children: [
-                            BlogDashboardHelpers.makeHideCardAction(for: .googleDomains, blog: blog, isSiteAgnostic: true)
+                            BlogDashboardHelpers.makeHideCardAction(for: .googleDomains, blog: blog)
                         ]
                     )
                 ],

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -84,8 +84,8 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    // TODO: Consider removing the default case to force defining this var for all future cards
-    // TODO: Add documentation
+    /// Specifies whether the card settings should be applied across
+    /// different sites or only to a particular site.
     var settingsType: SettingsType {
         switch self {
         case .googleDomains:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -84,6 +84,17 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
+    // TODO: Consider removing the default case to force defining this var for all future cards
+    // TODO: Add documentation
+    var settingsType: SettingsType {
+        switch self {
+        case .googleDomains:
+            return .siteGeneric
+        default:
+            return .siteSpecific
+        }
+    }
+
     func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil, mySiteSettings: DefaultSectionProvider = MySiteSettings()) -> Bool {
         switch self {
         case .jetpackInstall:
@@ -177,6 +188,11 @@ enum DashboardCard: String, CaseIterable {
                 return DashboardActivityLogCardCell.shouldShowCard(for: blog)
             }
         }
+    }
+
+    enum SettingsType {
+        case siteSpecific
+        case siteGeneric
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -1,15 +1,20 @@
 import Foundation
 
 struct BlogDashboardHelpers {
-    static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
+    static func makeHideCardAction(for card: DashboardCard, blog: Blog, isSiteAgnostic: Bool = false) -> UIAction {
         UIAction(
             title: Strings.hideThis,
             image: UIImage(systemName: "minus.circle"),
             attributes: [.destructive],
             handler: { _ in
                 BlogDashboardAnalytics.trackHideTapped(for: card)
-                BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-                    .setEnabled(false, for: card)
+                if isSiteAgnostic {
+                    BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
+                        .setEnabledSiteAgnostic(false, for: card)
+                } else {
+                    BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
+                        .setEnabled(false, for: card)
+                }
             })
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -8,8 +8,9 @@ struct BlogDashboardHelpers {
             attributes: [.destructive],
             handler: { _ in
                 BlogDashboardAnalytics.trackHideTapped(for: card)
-                BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-                    .setEnabled(false, for: card, forAllSites: isSiteAgnostic)
+                let siteID = isSiteAgnostic ? nil : blog.dotComID?.intValue
+                BlogDashboardPersonalizationService(siteID: siteID)
+                    .setEnabled(false, for: card)
             })
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -8,13 +8,8 @@ struct BlogDashboardHelpers {
             attributes: [.destructive],
             handler: { _ in
                 BlogDashboardAnalytics.trackHideTapped(for: card)
-                if isSiteAgnostic {
-                    BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-                        .setEnabledSiteAgnostic(false, for: card)
-                } else {
-                    BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-                        .setEnabled(false, for: card)
-                }
+                BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
+                    .setEnabled(false, for: card, forAllSites: isSiteAgnostic)
             })
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -1,15 +1,14 @@
 import Foundation
 
 struct BlogDashboardHelpers {
-    static func makeHideCardAction(for card: DashboardCard, blog: Blog, isSiteAgnostic: Bool = false) -> UIAction {
+    static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
         UIAction(
             title: Strings.hideThis,
             image: UIImage(systemName: "minus.circle"),
             attributes: [.destructive],
             handler: { _ in
                 BlogDashboardAnalytics.trackHideTapped(for: card)
-                let siteID = isSiteAgnostic ? nil : blog.dotComID?.intValue
-                BlogDashboardPersonalizationService(siteID: siteID)
+                BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
                     .setEnabled(false, for: card)
             })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -25,23 +25,25 @@ struct BlogDashboardPersonalizationService {
         getSettings(for: card)[siteID] != nil
     }
 
-    func setEnabled(_ isEnabled: Bool, for card: DashboardCard) {
+    /// Sets the enabled state for a given DashboardCard.
+    ///
+    /// This function updates the enabled state of a `DashboardCard`. Depending on the `forAllSites` flag,
+    /// it either sets the state for a specific site or sets it agnostically for all sites. After updating
+    /// the settings, a notification is posted to inform other parts of the application about this change.
+    ///
+    /// - Parameters:
+    ///   - isEnabled: A Boolean value indicating whether the `DashboardCard` should be enabled or disabled.
+    ///   - card: The `DashboardCard` whose setting needs to be updated.
+    ///   - forAllSites: A Boolean flag that determines if the setting should be applied site-agnostically.
+    ///                  Default is `false`, meaning the setting will be applied for a specific site.
+    ///                  If set to `true`, the setting will be applied irrespective of the site.
+    func setEnabled(_ isEnabled: Bool, for card: DashboardCard, forAllSites: Bool = false) {
         guard let key = makeKey(for: card) else { return }
-
         var settings = getSettings(for: card)
-        settings[siteID] = isEnabled
-        repository.set(settings, forKey: key)
 
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .blogDashboardPersonalizationSettingsChanged, object: self)
-        }
-    }
+        let keyValue = forAllSites ? Constants.siteAgnosticVisibilityKey : siteID
+        settings[keyValue] = isEnabled
 
-    func setEnabledSiteAgnostic(_ isEnabled: Bool, for card: DashboardCard) {
-        guard let key = makeKey(for: card) else { return }
-
-        var settings = getSettings(for: card)
-        settings[Constants.siteAgnosticVisibilityKey] = isEnabled
         repository.set(settings, forKey: key)
 
         DispatchQueue.main.async {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -22,7 +22,8 @@ struct BlogDashboardPersonalizationService {
     }
 
     func hasPreference(for card: DashboardCard) -> Bool {
-        getSettings(for: card)[siteID] != nil
+        let settings = getSettings(for: card)
+        return (settings[siteID] != nil) || (settings[Constants.siteAgnosticVisibilityKey] != nil)
     }
 
     /// Sets the enabled state for a given DashboardCard.

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -52,4 +52,42 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
             XCTAssertFalse(service.isEnabled(card))
         }
     }
+
+    func testSetEnabledSiteAgnosticReturnsFalseForTheSameSite() {
+        // Given
+        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+            .setEnabledSiteAgnostic(false, for: .googleDomains)
+
+        // When new service is created
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+
+        // Then settings are retained
+        XCTAssertFalse(service.isEnabled(.googleDomains))
+    }
+
+    func testSetEnabledSiteAgnosticReturnsFalseForDifferentSite() {
+        // Given
+        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+            .setEnabledSiteAgnostic(false, for: .googleDomains)
+
+        // When new service is created
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
+
+        // Then settings are retained
+        XCTAssertFalse(service.isEnabled(.googleDomains))
+    }
+
+    func testSetEnabledReturnsTrueWhenSiteAgnosticBoolIsTrue() {
+        // Given
+        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+            .setEnabled(true, for: .googleDomains)
+        BlogDashboardPersonalizationService(repository: repository, siteID: 9)
+            .setEnabledSiteAgnostic(true, for: .googleDomains)
+
+        // When new service is created
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+
+        // Then settings are retained
+        XCTAssert(service.isEnabled(.googleDomains))
+    }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -53,9 +53,9 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         }
     }
 
-    func testSetEnabledForAllSites() {
+    func testSetEnabledForAllSitesReturnsFalseForTheSameSite() {
         // Given
-        let service = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
 
         // When
         service.setEnabled(false, for: .googleDomains)
@@ -64,11 +64,10 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         XCTAssertFalse(service.isEnabled(.googleDomains))
     }
 
-    // TODO: Remove this test. It's irrelevant since services are no longer tied to sites.
     func testSetEnabledForAllSitesReturnsFalseForDifferentSite() {
         // Given
-        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
-        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
+        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
 
         // When
         service1.setEnabled(false, for: .googleDomains)
@@ -77,7 +76,7 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         XCTAssertFalse(service2.isEnabled(.googleDomains))
     }
 
-    // TODO: Remove this test. It's redundant, if we update it, it will be equivalent to testThatSettingsAreSavedPersistently + testSetEnabledForAllSites
+    // This test is redundant now
 //    func testSetEnabledReturnsTrueWhenForAllSitesBoolIsTrue() {
 //        // Given
 //        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
@@ -85,7 +84,7 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
 //
 //        // When
 //        service1.setEnabled(true, for: .googleDomains)
-//        service2.setEnabled(true, for: .googleDomains, forAllSites: true)
+//        service2.setEnabled(true, for: .googleDomains)
 //
 //        // Then settings are retained
 //        XCTAssert(service1.isEnabled(.googleDomains))
@@ -93,7 +92,7 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
 
     func testHasPreferenceReturnsTrueWhenValueSetForAllSites() {
         // Given
-        let service = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
 
         // When
         service.setEnabled(false, for: .googleDomains)
@@ -107,10 +106,10 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
 
         // When
-        service.setEnabled(false, for: .googleDomains)
+        service.setEnabled(false, for: .blaze)
 
         // Then
-        XCTAssert(service.hasPreference(for: .googleDomains))
+        XCTAssert(service.hasPreference(for: .blaze))
     }
 
     func testHasPreferenceReturnsFalseWhenNoPreferenceIsSet() {

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -53,41 +53,39 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         }
     }
 
-    func testSetEnabledSiteAgnosticReturnsFalseForTheSameSite() {
+    func testSetEnabledForAllSitesReturnsFalseForTheSameSite() {
         // Given
-        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
-            .setEnabledSiteAgnostic(false, for: .googleDomains)
-
-        // When new service is created
         let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
 
-        // Then settings are retained
+        // When
+        service.setEnabled(false, for: .googleDomains, forAllSites: true)
+
+        // Then
         XCTAssertFalse(service.isEnabled(.googleDomains))
     }
 
-    func testSetEnabledSiteAgnosticReturnsFalseForDifferentSite() {
+    func testSetEnabledForAllSitesReturnsFalseForDifferentSite() {
         // Given
-        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
-            .setEnabledSiteAgnostic(false, for: .googleDomains)
+        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
 
-        // When new service is created
-        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
+        // When
+        service1.setEnabled(false, for: .googleDomains, forAllSites: true)
 
         // Then settings are retained
-        XCTAssertFalse(service.isEnabled(.googleDomains))
+        XCTAssertFalse(service2.isEnabled(.googleDomains))
     }
 
-    func testSetEnabledReturnsTrueWhenSiteAgnosticBoolIsTrue() {
+    func testSetEnabledReturnsTrueWhenForAllSitesBoolIsTrue() {
         // Given
-        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
-            .setEnabled(true, for: .googleDomains)
-        BlogDashboardPersonalizationService(repository: repository, siteID: 9)
-            .setEnabledSiteAgnostic(true, for: .googleDomains)
+        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
 
-        // When new service is created
-        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        // When
+        service1.setEnabled(true, for: .googleDomains)
+        service2.setEnabled(true, for: .googleDomains, forAllSites: true)
 
         // Then settings are retained
-        XCTAssert(service.isEnabled(.googleDomains))
+        XCTAssert(service1.isEnabled(.googleDomains))
     }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -88,4 +88,32 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         // Then settings are retained
         XCTAssert(service1.isEnabled(.googleDomains))
     }
+
+    func testHasPreferenceReturnsTrueWhenValueSetForAllSites() {
+        // Given
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+
+        // When
+        service.setEnabled(false, for: .googleDomains, forAllSites: true)
+
+        // Then
+        XCTAssert(service.hasPreference(for: .googleDomains))
+    }
+
+    func testHasPreferenceReturnsTrueWhenValueSetForASite() {
+        // Given
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+
+        // When
+        service.setEnabled(false, for: .googleDomains)
+
+        // Then
+        XCTAssert(service.hasPreference(for: .googleDomains))
+    }
+
+    func testHasPreferenceReturnsFalseWhenNoPreferenceIsSet() {
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+
+        XCTAssertFalse(service.hasPreference(for: .googleDomains))
+    }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -53,48 +53,50 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         }
     }
 
-    func testSetEnabledForAllSitesReturnsFalseForTheSameSite() {
+    func testSetEnabledForAllSites() {
         // Given
-        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
 
         // When
-        service.setEnabled(false, for: .googleDomains, forAllSites: true)
+        service.setEnabled(false, for: .googleDomains)
 
         // Then
         XCTAssertFalse(service.isEnabled(.googleDomains))
     }
 
+    // TODO: Remove this test. It's irrelevant since services are no longer tied to sites.
     func testSetEnabledForAllSitesReturnsFalseForDifferentSite() {
         // Given
-        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
-        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
+        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
+        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
 
         // When
-        service1.setEnabled(false, for: .googleDomains, forAllSites: true)
+        service1.setEnabled(false, for: .googleDomains)
 
         // Then settings are retained
         XCTAssertFalse(service2.isEnabled(.googleDomains))
     }
 
-    func testSetEnabledReturnsTrueWhenForAllSitesBoolIsTrue() {
-        // Given
-        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
-        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
-
-        // When
-        service1.setEnabled(true, for: .googleDomains)
-        service2.setEnabled(true, for: .googleDomains, forAllSites: true)
-
-        // Then settings are retained
-        XCTAssert(service1.isEnabled(.googleDomains))
-    }
+    // TODO: Remove this test. It's redundant, if we update it, it will be equivalent to testThatSettingsAreSavedPersistently + testSetEnabledForAllSites
+//    func testSetEnabledReturnsTrueWhenForAllSitesBoolIsTrue() {
+//        // Given
+//        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+//        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
+//
+//        // When
+//        service1.setEnabled(true, for: .googleDomains)
+//        service2.setEnabled(true, for: .googleDomains, forAllSites: true)
+//
+//        // Then settings are retained
+//        XCTAssert(service1.isEnabled(.googleDomains))
+//    }
 
     func testHasPreferenceReturnsTrueWhenValueSetForAllSites() {
         // Given
-        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: nil)
 
         // When
-        service.setEnabled(false, for: .googleDomains, forAllSites: true)
+        service.setEnabled(false, for: .googleDomains)
 
         // Then
         XCTAssert(service.hasPreference(for: .googleDomains))

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -76,20 +76,6 @@ final class BlogDashboardPersonalizationServiceTests: XCTestCase {
         XCTAssertFalse(service2.isEnabled(.googleDomains))
     }
 
-    // This test is redundant now
-//    func testSetEnabledReturnsTrueWhenForAllSitesBoolIsTrue() {
-//        // Given
-//        let service1 = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
-//        let service2 = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
-//
-//        // When
-//        service1.setEnabled(true, for: .googleDomains)
-//        service2.setEnabled(true, for: .googleDomains)
-//
-//        // Then settings are retained
-//        XCTAssert(service1.isEnabled(.googleDomains))
-//    }
-
     func testHasPreferenceReturnsTrueWhenValueSetForAllSites() {
         // Given
         let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)


### PR DESCRIPTION
Refs: https://github.com/wordpress-mobile/WordPress-iOS/pull/21282

This PR adds the logic to hide a card from dashboard Site Agnostically.

## Testing
1. Install & Launch Jetpack
2. Enable the feature flag.
3. Navigate to MySite (either kill the app first or open a different tab and come back to My Site).
4. Tap More (...) button on the Google Domains Card
5. Tap "Hide"
6. Verify the card disappears regardless on what site you're viewing.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the new logic. The existing code wouldn't be affected as the added argument to the function has a default false boolean.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
Nothing changed in UI.