### PR TITLE
Jetpack Social: Fix showing no connections for unsupported service

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -9,7 +9,7 @@ extension PostSettingsViewController {
         let isJetpackSocialEnabled = RemoteFeatureFlag.jetpackSocialImprovements.enabled()
         let isNoConnectionViewHidden = UserPersistentStoreFactory.instance().bool(forKey: hideNoConnectionViewKey())
         let blogSupportsPublicize = apost.blog.supportsPublicize()
-        let blogHasNoConnections = publicizeConnections.count == 0
+        let blogHasNoConnections = publicizeConnections.count == 0 && unsupportedConnections.count == 0
         let blogHasServices = availableServices().count > 0
 
         return isJetpackSocialEnabled

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
@@ -14,6 +14,7 @@
 
 @property (nonnull, nonatomic, strong, readonly) AbstractPost *apost;
 @property (nonnull, nonatomic, strong, readonly) NSArray *publicizeConnections;
+@property (nonnull, nonatomic, strong, readonly) NSArray *unsupportedConnections;
 
 @property (nonatomic, weak, nullable) id<FeaturedImageDelegate> featuredImageDelegate;
 


### PR DESCRIPTION
Fixes #21331 

## Description

Fixes showing the no connections view when:

- The user has no supported connections
- The user has unsupported connections

## Testing

To test:
- Launch Jetpack and login
- Select a blog with only unsupported services
- Start a new blog post
- Open the post settings screen (`...` > `Post Settings`)
- **Verify** only the unsupported connections show

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
