### PR TITLE
Jetpack Social: Fix no connections social dashboard card appearing

### DIFF
--- a/WordPress/Classes/Services/JetpackSocialService.swift
+++ b/WordPress/Classes/Services/JetpackSocialService.swift
@@ -89,7 +89,6 @@ import CoreData
             switch result {
             case .success:
                 success?()
-                NotificationCenter.default.post(name: .jetpackSocialUpdated, object: nil)
             case .failure(let error):
                 failure?(error as NSError)
             }

--- a/WordPress/Classes/Services/SharingSyncService.swift
+++ b/WordPress/Classes/Services/SharingSyncService.swift
@@ -33,15 +33,11 @@ import WordPressKit
             failure?(Error.siteWithNoRemote as NSError)
             return
         }
-        let onComplete = {
-            success?()
-            NotificationCenter.default.post(name: .jetpackSocialUpdated, object: nil)
-        }
 
         remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
 
             // Process the results
-            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: onComplete)
+            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
         },
         failure: failure)
     }


### PR DESCRIPTION
Fixes: #21333 

## Description

When a user sets up a connection on a screen that is pushed onto the home dashboard, the no connections card does not disappear. This is because the cards do not get reloaded with new data.

To fix this, I added an observer to watch for the main context changing. When that happens, if there is an update to the `blog` object, the display state of the card gets updated.

## Testing

To test:
- Launch Jetpack and login
- Select a blog with no connections
- 🔍 **Verify** the no connections dashboard card is shown
- Start a new blog post
- Type something in to enable the `Publish` button
- Tap on `Publish`
- In the pre-publishing sheet, tap on `Connect accounts`
- Set up a social connection
- Navigate all the way back to the home dashboard
- 🔍 **Verify** the no connections dashboard card is now gone

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
