### PR TITLE
Jetpack Focus: Adds frequency logic to the phase 4 overlay

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -33,6 +33,7 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
     case blazeNonDismissibleStep
     case blazeFlowCompletedStep
     case wordPressPluginOverlayMaxShown
+    case phaseFourOverlayFrequency
 
     var key: String {
         switch self {
@@ -54,6 +55,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "blaze_completed_step_hash"
         case .wordPressPluginOverlayMaxShown:
             return "wp_plugin_overlay_max_shown"
+        case .phaseFourOverlayFrequency:
+            return "phase_four_overlay_frequency_in_days"
         }
     }
 
@@ -77,6 +80,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "step-5"
         case .wordPressPluginOverlayMaxShown:
             return 3
+        case .phaseFourOverlayFrequency:
+            return 0
         }
     }
 
@@ -100,6 +105,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "Blaze Completed Step"
         case .wordPressPluginOverlayMaxShown:
             return "WP Plugin Overlay Max Frequency"
+        case .phaseFourOverlayFrequency:
+            return "Phase Four Overlay Frequency"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -81,7 +81,7 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
         case .wordPressPluginOverlayMaxShown:
             return 3
         case .phaseFourOverlayFrequency:
-            return 0
+            return -1
         }
     }
 

--- a/WordPress/Classes/Utility/OverlayFrequencyTracker.swift
+++ b/WordPress/Classes/Utility/OverlayFrequencyTracker.swift
@@ -76,6 +76,9 @@ class OverlayFrequencyTracker {
         guard let lastSavedGenericDate = lastSavedGenericDate else {
             return true // First overlay ever
         }
+        if frequencyConfig.generalInDays < 0 {
+            return false // Negative frequency means overlay should be shown once
+        }
         let secondsSinceLastSavedGenericDate = -lastSavedGenericDate.timeIntervalSinceNow
         let generalFreqPassed = secondsSinceLastSavedGenericDate > frequencyConfig.generalInSeconds
         if generalFreqPassed == false {
@@ -86,6 +89,9 @@ class OverlayFrequencyTracker {
             return true // This specific overlay was never shown, so we can show it
         }
 
+        if frequencyConfig.featureSpecificInDays < 0 {
+            return false // Negative frequency means overlay should be shown once
+        }
         let secondsSinceLastSavedSourceDate = -lastSavedSourceDate.timeIntervalSinceNow
         let featureSpecificFreqPassed = secondsSinceLastSavedSourceDate > frequencyConfig.featureSpecificInSeconds
         // Check if this specific overlay was shown recently

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1076,7 +1076,9 @@ private extension MySiteViewController {
         if isViewOnScreen(), !willDisplayPostSignupFlow {
             let didReloadUI = RootViewCoordinator.shared.reloadUIIfNeeded(blog: self.blog)
             if !didReloadUI {
-                JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .appOpen, blog: self.blog)
+                let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
+                let source: JetpackFeaturesRemovalCoordinator.JetpackOverlaySource = phase == .four ? .phaseFourOverlay : .appOpen
+                JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: source, blog: self.blog)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -167,6 +167,8 @@ final class JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayVi
             fallthrough
         case (.appOpen, _):
             fallthrough
+        case (.phaseFourOverlay, _):
+            fallthrough
         case (.disabledEntryPoint, _):
             return Constants.allFeaturesLogosAnimationLtr
         }
@@ -189,6 +191,8 @@ final class JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayVi
         case (.login, _):
             fallthrough
         case (.appOpen, _):
+            fallthrough
+        case (.phaseFourOverlay, _):
             fallthrough
         case (.disabledEntryPoint, _):
             return Constants.allFeaturesLogosAnimationRtl

--- a/WordPress/WordPressTest/OverlayFrequencyTrackerTests.swift
+++ b/WordPress/WordPressTest/OverlayFrequencyTrackerTests.swift
@@ -179,5 +179,26 @@ final class OverlayFrequencyTrackerTests: XCTestCase {
         XCTAssertTrue(readerTracker.shouldShow(forced: false)) // After generic frequency have passed
     }
 
+    func testNegativeFrequencyIsTreatedAsShowOnce() {
+        // Given
+        let key = OverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-phase_four_overlay"
+        let genericKey = OverlayFrequencyTracker.Constants.lastDateKeyPrefix
+        let tracker = OverlayFrequencyTracker(source: JetpackFeaturesRemovalCoordinator.JetpackOverlaySource.phaseFourOverlay,
+                                              type: .featuresRemoval,
+                                              frequencyConfig: .init(featureSpecificInDays: 0, generalInDays: -1),
+                                              persistenceStore: mockUserDefaults)
+
+        // When & Then
+        XCTAssertTrue(tracker.shouldShow(forced: false))
+
+        // Given
+        let distantDate = Date.distantPast
+        mockUserDefaults.set(distantDate, forKey: key)
+        mockUserDefaults.set(distantDate, forKey: genericKey)
+
+        // When & Then
+        XCTAssertFalse(tracker.shouldShow(forced: false))
+    }
+
 
 }


### PR DESCRIPTION
Ref: pcdRpT-2O8-p2#comment-5477
## Description
This PR adds the logic to show the Phase 4  Features Removal Overlay with a frequency. Previously, this overlay was shown only once. The frequency is controlled using a remote config param.

## Testing Instructions
```
📢  To facilitate testing, change the `secondsInDay` value in `OverlayFrequencyTracker.swift:L122` to `10`.
```
### Default Frequency (Shown once)

1. Fresh install the WordPress app
2. Login
3. Navigate to the Debug Menu
4. Enable the "Jetpack Features Removal Phase Four" feature flag
5. Navigate back to My Site
6. ✅ Make sure an overlay is displayed
7. Dismiss the overlay
8. Wait for some time
9. Minimize the app
10. Open the app
11. ✅ Make sure an overlay is not displayed

### Custom Frequency (Shown multiple times)

1. Open the WordPress app
2. Navigate to the Debug Menu
3. From the Feature Flags screen, Enable the "Jetpack Features Removal Phase Four" feature flag
4. From the Remote Config screen, Change the "Phase Four Overlay Frequency" value to `5`
5. Navigate back to My Site
6. ✅ Make sure an overlay is displayed
7. Dismiss the overlay
8. Before 50 seconds have passed minimize and reopen the app (This step assumes that you changed the `secondsInDay` value to be `10`)
9. ✅ Make sure an overlay is not displayed
10. Wait for 50 seconds to pass
11. Minimize and reopen the app
12. ✅ Make sure an overlay is displayed

## Regression Notes
1. Potential unintended areas of impact
Not showing the phase 4 overlay

2. What I did to test those areas of impact (or what existing automated tests I relied on)
`OverlayFrequencyTrackerTests` & Tested manually

3. What automated tests I added (or what prevented me from doing so)
`OverlayFrequencyTrackerTests.testNegativeFrequencyIsTreatedAsShowOnce`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.