### PR TITLE
Avoid WPMediaPickerViewController reloadItemsAtIndexPaths crash by wrapping the call in try-catch block

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -143,7 +143,7 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-  pod 'WPMediaPicker', '~> 1.8', '>= 1.8.9'
+  pod 'WPMediaPicker', '~> 1.8', '>= 1.8.10-beta.1'
   ## while PR is in review:
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -123,7 +123,7 @@ PODS:
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.2.0)
   - WordPressUI (1.14.0)
-  - WPMediaPicker (1.8.9)
+  - WPMediaPicker (1.8.10-beta.1)
   - wpxmlrpc (0.10.0)
   - ZendeskCommonUISDK (6.1.2)
   - ZendeskCoreSDK (2.5.1)
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPressKit (~> 8.5)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.14)
-  - WPMediaPicker (>= 1.8.9, ~> 1.8)
+  - WPMediaPicker (>= 1.8.10-beta.1, ~> 1.8)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -283,7 +283,7 @@ SPEC CHECKSUMS:
   WordPressKit: f33a89b148d9cce96933f0900701aff592a796f7
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: 09b5477f8678446f27e651cccb6b6401bd19d9a3
-  WPMediaPicker: 0ec0ee22f68e8cb9d83e71bdcf2e76d931ef7f91
+  WPMediaPicker: d669d11c38f78597edcb338a58a0d973ae51912a
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
   ZendeskCoreSDK: 19a18e5ef2edcb18f4dbc0ea0d12bd31f515712a
@@ -294,6 +294,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 7c2cb3345b7f74a702dad5416d46a9c446e9cf13
+PODFILE CHECKSUM: 25832366684a36de2e9c20ef39f83bb599f54b63
 
 COCOAPODS: 1.12.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -21,6 +21,7 @@
 * [*] Fix an issue in Reader topics cleanup that could cause the app to crash. [#21243]
 * [*] [internal] Fix incorrectly terminated background task [#21254]
 * [**] [internal] Refactor how image is downloaded in Gutenberg Editor and Aztec Editor. [#21227]
+* [**] Fixed an occassional crash when reloading Media picker. [#21337]
 
 22.9
 -----


### PR DESCRIPTION
Fixes #21102
Related MediaPicker-iOS PR: https://github.com/wordpress-mobile/MediaPicker-iOS/pull/414

This is a continuation of https://github.com/wordpress-mobile/WordPress-iOS/pull/21231 fix. We're applying the same temporary fix to another scenario where we get crashes

## To test:

The crashes themselves (https://github.com/wordpress-mobile/WordPress-iOS/issues/21102#issuecomment-1677259662) weren't reproducible anymore. 

1. Fresh install app
2. Login
3. My Site
4. Media
5. Confirm that the media appears and there's no crash

## Regression Notes
1. Potential unintended areas of impact

Instead of crashing, the media picker completely reloads, which could cause some performance issues

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing of media picker

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
