### PR TITLE
Refactor NotificationSettingDetailsViewController to align with the removal of `blog` property in NotificationSettings

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationSettings.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationSettings.swift
@@ -15,6 +15,19 @@ open class NotificationSettings {
     ///
     public let streams: [Stream]
 
+    /// Retrieves the associated `Blog` instance from the provided managed object context.
+    ///
+    /// Utilizes the `blogManagedObjectID` to safely fetch the associated `Blog` entity
+    /// from the given context. Always ensure that you are accessing the managed object
+    /// on the same thread or queue that the `NSManagedObjectContext` is associated with
+    /// to avoid potential threading issues.
+    func blog(in context: NSManagedObjectContext) -> Blog? {
+        guard let objectID = blogManagedObjectID else {
+            return nil
+        }
+        return try? context.existingObject(with: objectID) as? Blog
+    }
+
     /// The associated blog. This property is not thread-safe.
     ///
     /// If you need to access this property from a thread different from the one it was created on, don't access it directly. Instead, use the `blogManagedObjectID`

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -15,11 +15,11 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     /// NotificationSettings being rendered
     ///
-    private var settings: NotificationSettings?
+    private let settings: NotificationSettings
 
     /// Notification Stream to be displayed
     ///
-    private var stream: NotificationSettings.Stream?
+    private let stream: NotificationSettings.Stream
 
     /// TableView Sections to be rendered
     ///
@@ -283,11 +283,11 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     // MARK: - Disabled Push Notifications Handling
     private func isDeviceStreamDisabled() -> Bool {
-        return stream?.kind == .Device && pushNotificationsAuthorized == .denied
+        return stream.kind == .Device && pushNotificationsAuthorized == .denied
     }
 
     private func isDeviceStreamUnknown() -> Bool {
-        return stream?.kind == .Device && pushNotificationsAuthorized == .notDetermined
+        return stream.kind == .Device && pushNotificationsAuthorized == .notDetermined
     }
 
     private func openApplicationSettings() {
@@ -313,14 +313,14 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     // MARK: - Service Helpers
     private func saveSettingsIfNeeded() {
-        if newValues.count == 0 || settings == nil {
+        if newValues.count == 0 {
             return
         }
 
         let service = NotificationSettingsService(coreDataStack: ContextManager.shared)
 
-        service.updateSettings(settings!,
-            stream: stream!,
+        service.updateSettings(settings,
+            stream: stream,
             newValues: newValues,
             success: {
                 WPAnalytics.track(.notificationsSettingsUpdated, withProperties: ["success": true])


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/21076#discussion_r1266013556

## Description

This PR removes the `blog` property from `NotificationSettings` and replaces it with the thread-safe `blog(in context: NSManagedObjectContext)` method.

## Test Instructions
TBD

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

## PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
