### PR TITLE
Contact Support: Configure and localize strings

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -11,6 +11,7 @@ struct WPLoggingStack {
     let eventLogging: EventLogging
 
     private let eventLoggingDataProvider = EventLoggingDataProvider.fromDDFileLogger(WPLogger.shared().fileLogger)
+    // swiftlint:disable:next weak_delegate
     private let eventLoggingDelegate = EventLoggingDelegate()
 
     private let enterForegroundObserver: AnyCancellable

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -64,7 +64,17 @@ final class SupportChatBotViewController: UIViewController {
                 options: {
                     color: "#9dd977",
                     supportLink: "#",
-                    questions: \(encodedQuestions())
+                    questions: \(encodedQuestions()),
+                    labels: {
+                        inputPlaceholder: "\(Strings.inputPlaceholder)",
+                        firstMessage: "\(Strings.firstMessage)",
+                        sources: "\(Strings.sources)",
+                        helpful: "\(Strings.helpful)",
+                        unhelpful: "\(Strings.unhelpful)",
+                        getSupport: "\(Strings.getSupport)",
+                        suggestions: "\(Strings.suggestions)",
+                        thinking: "\(Strings.thinking)",
+                      },
                 },
             })
         })();
@@ -118,6 +128,31 @@ extension SupportChatBotViewController {
             NSLocalizedString("support.chatBot.questionFive", value: "I forgot my login information", comment: "An example question shown to a user seeking support"),
             NSLocalizedString("support.chatBot.questionSix", value: "How can I use my custom domain in the app?", comment: "An example question shown to a user seeking support"),
         ]
+        static let inputPlaceholder = NSLocalizedString("support.chatBot.inputPlaceholder",
+                                                        value: "Send a message...",
+                                                        comment: "Placeholder text for the chat input field.")
+        static let firstMessage = NSLocalizedString("support.chatBot.firstMessage",
+                                                    value: "What can I help you with? If I can't answer your question I'll help you open a support ticket with our team!",
+                                                    comment: "Initial message shown to the user when the chat starts.")
+        static let sources = NSLocalizedString("support.chatBot.sources",
+                                               value: "Sources",
+                                               comment: "Button title referring to the sources of information.")
+        static let helpful = NSLocalizedString("chat.rateHelpful",
+                                               value: "Rate as helpful",
+                                               comment: "Option for users to rate a chat bot answer as helpful.")
+        static let unhelpful = NSLocalizedString("support.chatBot.reportInaccuracy",
+                                                 value: "Report as innacurate",
+                                                 comment: "Option for users to report a chat bot answer as inaccurate.")
+        static let getSupport = NSLocalizedString("support.chatBot.contactSupport",
+                                                  value: "Contact support",
+                                                  comment: "Button for users to contact the support team directly.")
+        static let suggestions = NSLocalizedString("support.chatBot.suggestionsPrompt",
+                                                   value: "Not sure what to ask?",
+                                                   comment: "Prompt for users suggesting to select a default question from the list to start a support chat.")
+        static let thinking = NSLocalizedString("support.chatBot.botThinkingIndicator",
+                                                value: "Thinking...",
+                                                comment: "Indicator that the chat bot is processing user's input.")
+
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -2,7 +2,7 @@ import WebKit
 import WordPressFlux
 import SVProgressHUD
 
-protocol SupportChatBotCreatedTicketDelegate: class {
+protocol SupportChatBotCreatedTicketDelegate: AnyObject {
     func onTicketCreated()
 }
 

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -141,7 +141,7 @@ extension SupportChatBotViewController {
                                                value: "Rate as helpful",
                                                comment: "Option for users to rate a chat bot answer as helpful.")
         static let unhelpful = NSLocalizedString("support.chatBot.reportInaccuracy",
-                                                 value: "Report as innacurate",
+                                                 value: "Report as inaccurate",
                                                  comment: "Option for users to report a chat bot answer as inaccurate.")
         static let getSupport = NSLocalizedString("support.chatBot.contactSupport",
                                                   value: "Contact support",

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -63,11 +63,23 @@ final class SupportChatBotViewController: UIViewController {
                   },
                 options: {
                     color: "#9dd977",
-                    supportLink: "#"
+                    supportLink: "#",
+                    questions: \(encodedQuestions())
                 },
             })
         })();
         """
+    }
+
+    /// Encoding array of Swift strings into JS string representing an array
+    private func encodedQuestions() -> String {
+        do {
+            let encodedQuestions = try JSONEncoder().encode(Strings.questions)
+            return String(data: encodedQuestions, encoding: .utf8) ?? ""
+        } catch {
+            DDLogError("Couldn't encode default questions for support chat bot: \(error)")
+            return ""
+        }
     }
 }
 
@@ -98,6 +110,14 @@ extension SupportChatBotViewController {
         static let ticketCreationLoadingMessage = NSLocalizedString("support.chatBot.ticketCreationLoading", value: "Creating support ticket...", comment: "Notice informing user that their support ticket is being created.")
         static let ticketCreationSuccessMessage = NSLocalizedString("support.chatBot.ticketCreationSuccess", value: "Ticket created", comment: "Notice informing user that their support ticket has been created.")
         static let ticketCreationFailureMessage = NSLocalizedString("support.chatBot.ticketCreationFailure", value: "Error submitting support ticket", comment: "Notice informing user that there was an error submitting their support ticket.")
+        static let questions: [String] = [
+            NSLocalizedString("support.chatBot.questionOne", value: "What is my site address?", comment: "An example question shown to a user seeking support"),
+            NSLocalizedString("support.chatBot.questionTwo", value: "Help, my site is down!", comment: "An example question shown to a user seeking support"),
+            NSLocalizedString("support.chatBot.questionThree", value: "I can't upload photos/videos", comment: "An example question shown to a user seeking support"),
+            NSLocalizedString("support.chatBot.questionFour", value: "Why can't I login?", comment: "An example question shown to a user seeking support"),
+            NSLocalizedString("support.chatBot.questionFive", value: "I forgot my login information", comment: "An example question shown to a user seeking support"),
+            NSLocalizedString("support.chatBot.questionSix", value: "How can I use my custom domain in the app?", comment: "An example question shown to a user seeking support"),
+        ]
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewModel.swift
@@ -11,15 +11,31 @@ struct SupportChatBotViewModel {
     }
 
     func contactSupport(including history: SupportChatHistory, completion: @escaping (Bool) -> ()) {
-        let messageHistoryDescription = "Jetpack Mobile Bot transcript:\n>\n" + history.messages
-            .map { "Question:\n>\n\($0.question)\n>\nAnswer:\n>\n\($0.answer)" }
-            .joined(separator: "\n>\n")
-
         zendeskUtils.createNewRequest(
-            description: messageHistoryDescription,
+            description: formattedMessageHistory(from: history),
             tags: ["DocsBot"],
             completion: completion
         )
+    }
+
+    private func formattedMessageHistory(from history: SupportChatHistory) -> String {
+        let transcript = NSLocalizedString("support.chatBot.zendesk.transcript",
+                                           value: "Jetpack Mobile Bot transcript",
+                                           comment: "A title for a text that displays a transcript from a conversation between Jetpack Mobile Bot (chat bot) and a user")
+
+        let question = NSLocalizedString("support.chatBot.zendesk.question",
+                                         value: "Question",
+                                         comment: "A title for a text that displays a transcript of user's question in a support chat")
+
+        let answer = NSLocalizedString("support.chatBot.zendesk.answer",
+                                       value: "Answer",
+                                       comment: "A title for a text that displays a transcript of an answer in a support chat")
+
+        let messageHistoryDescription = "\(transcript):\n>\n" + history.messages
+            .map { "\(question):\n>\n\($0.question)\n>\n\(answer):\n>\n\($0.answer)" }
+            .joined(separator: "\n>\n")
+
+        return messageHistoryDescription
     }
 }
 


### PR DESCRIPTION
Fixes #21315

As a part of this PR:
- Added default localized questions (ref: p1691995098426809/1691983515.736389-slack-C05ALSVN5K5)
- Localized labels within a chatbot
- Localized Zendesk transcript

## To test:

#### Default questions

1. Open Jetpack
2. Help & Support
3. Confirm 6 default questions immediately appear 

#### Custom labels

1. Open Jetpack
2. Help & Support
3. Confirm custom labels appear, such as: "What can I help you with? If I can't answer your question I'll help you open a support ticket with our team!" on top of the chat

## Regression Notes
1. Potential unintended areas of impact

None

6. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

7. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
