### PR TITLE
Contact Support: Navigation improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -142,15 +142,10 @@ extension SupportChatBotViewController {
     }
 
     func showTicketCreatedSuccessNotice() {
-        let notice = Notice(title: Strings.ticketCreationSuccessMessage,
-                            feedbackType: .success,
-                            actionTitle: "See ticket",
-                            actionHandler: { [weak self] _ in
-            guard let self else { return }
-
-            self.delegate?.onTicketCreated()
-        })
+        let notice = Notice(title: Strings.ticketCreationSuccessMessage, feedbackType: .success)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
+
+        delegate?.onTicketCreated()
     }
 
     func showTicketCreatedFailureNotice() {

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -79,6 +79,22 @@ extension SupportChatBotViewController: WKNavigationDelegate {
             }
         })
     }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        switch navigationAction.navigationType {
+        case .linkActivated:
+            if let url = navigationAction.request.url {
+                // Open links tapped from within the chat in the system browser
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                decisionHandler(.cancel)
+            } else {
+                decisionHandler(.allow)
+            }
+        default:
+            decisionHandler(.allow)
+        }
+    }
+
 }
 
 // MARK: - Support Callback


### PR DESCRIPTION
## Description

Fixes: #21276 

### Opening links

Before the change, Source links or links from within the chat messages wouldn't open at all on iOS. The solution is to open them in the system browser so the state of the chat could be preserved and users could more easily navigate the support docs.

I noticed that some of the provided links are broken but it's not a part of this PR to investigate that (p1692109164682589-slack-C05ALSVN5K5)

### Opening Zendesk tickets

We decided to open Zendesk ticket view immediately when a new ticket is created. Reference: https://github.com/wordpress-mobile/WordPress-Android/pull/18961#issuecomment-1678527652

### To test:

#### Link opening

1. Open Jetpack
2. Help & Support -> Contact Support
3. Ask chat bot to provide some helpful links
4. Tap on links
5. Make sure they open in the system browser
6. Come back to the chat and select "Sources" at the bottom of the message
7. Make sure links open in the system browser

#### Zendesk tickets

Success scenario:

1. Open Jetpack
2. Help & Support -> Contact Support
3. Ask a question
4. Tap contact support
5. Apps shows a loading indicator
6. App shows a success indicator and at the same time automatically navigates to tickets view


## Regression Notes
1. Potential unintended areas of impact

None, it helps avoid any unintended consequences of opening links from within the web view

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

4. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

## VIdeo

#### Link opening

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/07537e8a-9433-4a36-9be5-15ac717b326d

#### Zendesk tickets

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/2389edc1-5378-4c20-a640-4d4c38ca7f93


