### PR TITLE
Prevent crash when sending `nil` site ID to ReaderHelpers.dispatchToggleFollowSiteMessage

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] [internal] Fix Core Data multithreaded access exception in Blogging Reminders [#21232]
 * [*] [internal] Remove one of the image loading subsystems for avatars and consolidate the cache [#21259]
+* [*] Fixed a crash that could occur when following sites in Reader. [#21341]
 
 23.0
 -----

--- a/WordPress/Classes/Models/ReaderSiteTopic+Lookup.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic+Lookup.swift
@@ -16,8 +16,12 @@ extension ReaderSiteTopic {
     ///
     /// - Parameter siteID: The site id of the topic
     @objc(lookupWithSiteID:inContext:)
-    static func objc_lookup(withSiteID siteID: NSNumber, in context: NSManagedObjectContext) -> ReaderSiteTopic? {
-        try? lookup(withSiteID: siteID, in: context)
+    static func objc_lookup(withSiteID siteID: NSNumber?, in context: NSManagedObjectContext) -> ReaderSiteTopic? {
+        guard let siteID else {
+            DDLogError("Obj-C lookupWithSiteID called with a nil siteID")
+            return nil
+        }
+        return try? lookup(withSiteID: siteID, in: context)
     }
 
     /// Find a site topic by its feed id

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -366,18 +366,23 @@ struct ReaderPostMenuButtonTitles {
     }
 
     class func dispatchToggleFollowSiteMessage(post: ReaderPost, follow: Bool, success: Bool) {
+        guard let siteID = post.siteID else {
+            /// This is a workaround to prevent a crash from occurring when trying to pass a `nil` site ID to dispatchToggleFollowSiteMessage.
+            /// The root issue is that post.siteID should never be nil when this method is called.
+            CrashLogging.main.logMessage("Expected siteID to exist", level: .error)
+            return
+        }
+
         let blogName = {
             guard let blogNameForDisplay = post.blogNameForDisplay() else {
-                if let siteID = post.siteID, let postID = post.postID {
-                    CrashLogging.main.logMessage("Expected blogNameForDisplay() to exist",
-                                                 properties: ["siteID": siteID, "postID": postID],
+                CrashLogging.main.logMessage("Expected blogNameForDisplay() to exist",
+                                                 properties: ["siteID": siteID, "postID": post.postID ?? "nil"],
                                                  level: .error)
-                }
                 return NoticeMessages.unknownSiteText
             }
             return blogNameForDisplay
         }()
-        dispatchToggleFollowSiteMessage(siteTitle: blogName, siteID: post.siteID, follow: follow, success: success)
+        dispatchToggleFollowSiteMessage(siteTitle: blogName, siteID: siteID, follow: follow, success: success)
     }
 
     class func dispatchToggleFollowSiteMessage(site: ReaderSiteTopic, follow: Bool, success: Bool) {


### PR DESCRIPTION
## Description

This is an attempt to prevent the crash in https://github.com/wordpress-mobile/WordPress-iOS/issues/21307, but does not resolve the root issue. A new Sentry error is sent in place of the (hopefully prevented) crash.

Related: https://github.com/wordpress-mobile/WordPress-iOS/pull/21140

## Testing

Follow and unfollow sites in Reader in the following areas and expect the app to not crash:

| Area 1 | Area 2 | Area 3 |
| - | - | - |
| ![IMG_0438](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/5891f323-03e2-4c0a-98c1-0c12653db114) | ![IMG_0439](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/85ae6c73-74f5-4667-956b-d8e3123b8607) | ![IMG_0440](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/d8464fc5-9176-4a84-9a2a-7c2cbde79c2f) |

Some different ways to reach these areas:
- Tapping posts in Reader Discover or search results
- Tapping site titles in Reader Discover or search results

## Regression Notes
1. Potential unintended areas of impact
- None identified

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manually tested the steps above

3. What automated tests I added (or what prevented me from doing so)
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
