### PR TITLE
Make WireMock fetch/reset use `try async` for networking

### DIFF
--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 // These tests are Jetpack only.
 class DashboardTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/EditorAztecTests.swift
+++ b/WordPress/UITests/Tests/EditorAztecTests.swift
@@ -4,6 +4,7 @@ import XCTest
 class EditorAztecTests: XCTestCase {
     private var editorScreen: AztecEditorScreen!
 
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class EditorGutenbergTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/LoginTests.swift
+++ b/WordPress/UITests/Tests/LoginTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 class LoginTests: XCTestCase {
 
+    @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
         setUpTestSuite()

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class MainNavigationTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/MenuNavigationTests.swift
+++ b/WordPress/UITests/Tests/MenuNavigationTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class MenuNavigationTests: XCTestCase {
 
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/NUXTests.swift
+++ b/WordPress/UITests/Tests/NUXTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class NUXTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
         setUpTestSuite()

--- a/WordPress/UITests/Tests/NotificationTests.swift
+++ b/WordPress/UITests/Tests/NotificationTests.swift
@@ -13,9 +13,9 @@ private extension String {
 }
 
 class NotificationTests: XCTestCase {
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         setUpTestSuite()
-        WireMock.setUpScenario(scenario: "comment_flow")
+        try await WireMock.setUpScenario(scenario: "comment_flow")
 
         try LoginFlow.login(email: WPUITestCredentials.testWPcomUserEmail)
     }

--- a/WordPress/UITests/Tests/NotificationTests.swift
+++ b/WordPress/UITests/Tests/NotificationTests.swift
@@ -13,6 +13,13 @@ private extension String {
 }
 
 class NotificationTests: XCTestCase {
+
+    // @MainActor annotation because setUpTestSuite() calls app.terminate and app.launch which
+    // require running on the main thread.
+    //
+    // It would be more appropriate to make setUpTestSuite() require @MainActor itself, but that
+    // necessitates a bigger restructuring of the code.
+    @MainActor
     override func setUp() async throws {
         setUpTestSuite()
         try await WireMock.setUpScenario(scenario: "comment_flow")

--- a/WordPress/UITests/Tests/NotificationTests.swift
+++ b/WordPress/UITests/Tests/NotificationTests.swift
@@ -14,11 +14,6 @@ private extension String {
 
 class NotificationTests: XCTestCase {
 
-    // @MainActor annotation because setUpTestSuite() calls app.terminate and app.launch which
-    // require running on the main thread.
-    //
-    // It would be more appropriate to make setUpTestSuite() require @MainActor itself, but that
-    // necessitates a bigger restructuring of the code.
     @MainActor
     override func setUp() async throws {
         setUpTestSuite()

--- a/WordPress/UITests/Tests/PostTests.swift
+++ b/WordPress/UITests/Tests/PostTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class PostTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
         setUpTestSuite()

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class ReaderTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/SignupTests.swift
+++ b/WordPress/UITests/Tests/SignupTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 class SignupTests: XCTestCase {
 
+    @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
         setUpTestSuite()

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class StatsTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
 

--- a/WordPress/UITests/Tests/SupportScreenTests.swift
+++ b/WordPress/UITests/Tests/SupportScreenTests.swift
@@ -2,6 +2,8 @@ import UITestsFoundation
 import XCTest
 
 class SupportScreenTests: XCTestCase {
+
+    @MainActor
     override func setUpWithError() throws {
         setUpTestSuite()
     }

--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -3,6 +3,9 @@ import XCTest
 
 extension XCTestCase {
 
+    // Require main actor isolation because of the calls to app.terminate() and app.activate()
+    // which require running on the main thread.
+    @MainActor
     public func setUpTestSuite(
         for app: XCUIApplication = XCUIApplication(),
         removeBeforeLaunching: Bool = false,

--- a/WordPress/UITestsFoundation/WireMock.swift
+++ b/WordPress/UITestsFoundation/WireMock.swift
@@ -8,48 +8,32 @@ public class WireMock {
         return Foundation.URL(string: "http://\(host):\(port)/")!
     }
 
-    public static func setUpScenario(scenario: String) {
-        resetScenario(scenario: scenario)
+    public static func setUpScenario(scenario: String) async throws {
+        try await resetScenario(scenario: scenario)
 
-        fetchScenarios { (data, error) in
-            guard error == nil else {
-                print("Error fetching scenarios: \(error!)")
-                return
-            }
-        }
+        _ = try await fetchScenarios()
     }
 
-    private static func fetchScenarios(completion: @escaping ([String: Any]?, Error?) -> Void) {
-        let url = Foundation.URL(string: "\(WireMock.URL())__admin/scenarios")!
+    private static func fetchScenarios() async throws -> [String: Any] {
+        let (data, _) = try await URLSession.shared.data(from: Foundation.URL(string: "\(WireMock.URL())__admin/scenarios")!)
 
-        let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
-            do {
-                if let json = try JSONSerialization.jsonObject(with: data!, options: []) as? [String: Any] {
-                    completion(json, nil)
-                }
-            } catch {
-                completion(nil, error)
-            }
+        guard let scenarios = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "org.wordpress.UITestsFoundation",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not deserialized WireMock JSON response."]
+            )
         }
 
-        task.resume()
+        return scenarios
     }
 
-    private static func resetScenario(scenario: String) {
-        let url = Foundation.URL(string: "\(WireMock.URL())__admin/scenarios/\(scenario)/state")!
-
-        var request = URLRequest(url: url)
+    private static func resetScenario(scenario: String) async throws {
+        var request = URLRequest(url: Foundation.URL(string: "\(WireMock.URL())__admin/scenarios/\(scenario)/state")!)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = Data()
 
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
-            guard error == nil else {
-                print("Error resetting scenarios: \(error!)")
-                return
-            }
-        }
-
-        task.resume()
+        _ = try await URLSession.shared.data(for: request)
     }
 }


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/WordPress-iOS/pull/21288#discussion_r1290866950

## Testing

I opened this one quickly, only verified it _builds_ on my machine. Waiting to see what CI does with the tests 🤞 

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.