### PR TITLE
Fix unbounded growth of number media observers in Post Editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 23.2
 -----
 * [*] Remove the "New Photo Post" app quick action [#21369](https://github.com/wordpress-mobile/WordPress-iOS/pull/21369)
+* [*] (Internal) Fix unbounded growth of number media observers in Post Editor (performance issue) [#21352](https://github.com/wordpress-mobile/WordPress-iOS/pull/21352)
 
 23.1
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -154,9 +154,6 @@ class GutenbergMediaInserterHelper: NSObject {
     }
 
     func syncUploads() {
-        if mediaObserverReceipt != nil {
-            registerMediaObserver()
-        }
         for media in post.media {
             if media.remoteStatus == .failed {
                 gutenberg.mediaUploadUpdate(id: media.gutenbergUploadID, state: .uploading, progress: 0, url: media.absoluteThumbnailLocalURL, serverID: nil)


### PR DESCRIPTION
I was working on https://github.com/wordpress-mobile/WordPress-iOS/issues/21190 and noticed that the [media observer callback](https://github.com/wordpress-mobile/WordPress-iOS/blob/74bd0867f963a0fad2a7267f42f85034730b334a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift#L238) was getting called more times than expected:

```
2023-08-17 10:19:40.856161-0400 Jetpack[79340:16077759] thumbnailReady
2023-08-17 10:19:40.856599-0400 Jetpack[79340:16084149] obserersCount: 21
2023-08-17 10:19:40.856992-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.857318-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.857671-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.858153-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.858397-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.858612-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.858811-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.859026-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.859256-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.859446-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.859637-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.859839-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.860153-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.860423-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.860650-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.860856-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
2023-08-17 10:19:40.861054-0400 Jetpack[79340:16077759] mediathumbnailReady: -1680247048
```

It turned out, the longer you edit the post, the more media observers it adds. So, in my case, it was redrawing the image block 20 times instead of one 🫠

`GutenbergMediaInserterHelper` registers the observer on init and removes it on deinit.

## To test:

- Verify the media uploads function correctly (compare with the production version)

## Regression Notes
1. Potential unintended areas of impact: Media Uploads
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
