### PR TITLE
Jetpack Social: Exclude unshared private connections from other users

### DIFF
--- a/WordPress/Classes/Services/SharingSyncService.swift
+++ b/WordPress/Classes/Services/SharingSyncService.swift
@@ -28,18 +28,27 @@ import WordPressKit
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
     @objc open func syncPublicizeConnectionsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
-        let blogObjectID = blog.objectID
-        guard let remote = remoteForBlog(blog) else {
+        guard let remote = remoteForBlog(blog),
+              let blogID = blog.dotComID else {
             failure?(Error.siteWithNoRemote as NSError)
             return
         }
 
-        remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
+        remote.getPublicizeConnections(blogID, success: { [blogObjectID = blog.objectID] remoteConnections in
+            let currentUserID: NSNumber = self.coreDataStack.performQuery { context in
+                guard let blog = try? context.existingObject(with: blogObjectID) as? Blog,
+                      let accountID = blog.account?.userID else {
+                    return NSNumber(value: 0)
+                }
+                return accountID
+            }
+
+            // Ensure that we're only processing shared or owned connections
+            let authorizedConnections = remoteConnections.filter { $0.shared || $0.userID.isEqual(to: currentUserID) }
 
             // Process the results
-            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
-        },
-        failure: failure)
+            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: authorizedConnections, onComplete: success)
+        }, failure: failure)
     }
 
     /// Called when syncing Publicize connections. Merges synced and cached data, removing

--- a/WordPress/WordPressTest/SharingServiceTests.swift
+++ b/WordPress/WordPressTest/SharingServiceTests.swift
@@ -1,7 +1,33 @@
 import XCTest
+import WordPressKit
+import OHHTTPStubs
+
 @testable import WordPress
 
 class SharingServiceTests: CoreDataTestCase {
+
+    private let userID = 101
+    private let blogID = 10
+
+    private lazy var account: WPAccount = {
+        AccountBuilder(contextManager)
+            .with(id: Int64(userID))
+            .with(username: "username")
+            .with(authToken: "authToken")
+            .build()
+    }()
+
+    private lazy var blog: Blog = {
+        let blog = BlogBuilder(mainContext).with(blogID: blogID).build()
+        blog.account = account
+
+        // ensure that the changes are persisted to the stack.
+        contextManager.saveContextAndWait(mainContext)
+        return blog
+    }()
+
+    // MARK: Sync Publicize Connections
+
     func testSyncingPublicizeConnectionsForNonDotComBlogCallsACompletionBlock() throws {
         let blog = Blog.createBlankBlog(in: mainContext)
         blog.account = nil
@@ -16,5 +42,41 @@ class SharingServiceTests: CoreDataTestCase {
         }
 
         waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testSyncingPublicizeConnectionsExcludesUnsharedConnections() async throws {
+        // Given
+        let service = SharingSyncService(coreDataStack: contextManager)
+
+        stub(condition: isPath("/rest/v1.1/sites/\(blogID)/publicize-connections") && isMethodGET()) { _ in
+            HTTPStubsResponse(jsonObject: [
+                "connections": [
+                    ["ID": 1000, "shared": "0", "user_ID": 101] as [String: Any], // owned connection
+                    ["ID": 1001, "shared": "1", "user_ID": 201] as [String: Any], // shared connection
+                    ["ID": 1002, "shared": "0", "user_ID": 301] as [String: Any], // private connection from others
+                ]
+            ], statusCode: 200, headers: nil)
+        }
+
+        // When
+        try await withCheckedThrowingContinuation { continuation in
+            service.syncPublicizeConnectionsForBlog(blog) {
+                continuation.resume()
+            } failure: { error in
+                continuation.resume(throwing: error!)
+            }
+        }
+
+        // Then
+        let connections = try XCTUnwrap(blog.connections as? Set<PublicizeConnection>)
+
+        // the one with ID `1002` should be skipped since it's an unshared private connection from another user.
+        XCTAssertEqual(connections.count, 2)
+
+        // connections owned by the user should be available.
+        XCTAssertTrue(connections.contains(where: { $0.connectionID.isEqual(to: NSNumber(value: 1000)) }))
+
+        // shared connections owned by others should also be available.
+        XCTAssertTrue(connections.contains(where: { $0.connectionID.isEqual(to: NSNumber(value: 1001)) }))
     }
 }


### PR DESCRIPTION
Fixes #20744 

Since the endpoint returns all connections for the site, this PR filters any connections from other users that are not shared by checking the `shared` value and comparing the `userID` field to the current user's ID.

## To test

- Add your secondary WP.com account as an administrator in your test site.
- From your secondary account, create a new Social connection. This can be done either from the app or the web.
- Make sure that the sharing option is unchecked for this connection.
- Launch the Jetpack app.
- Log in with your primary WP.com account.
- Switch to the test site that has been prepared.
- Go to My Site > Social.
- 🔎 Verify that the private connection from your secondary account is not visible.

## Regression Notes
1. Potential unintended areas of impact
Some connections might not be shown correctly, or the user might be in a state where they don't have a proper account ID yet.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes, and added new tests.

3. What automated tests I added (or what prevented me from doing so)
Unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A. This PR doesn't introduce any visual changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
