### PR TITLE
Jetpack Social: Remove reloading cards locally on social card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -217,15 +217,14 @@ private extension DashboardJetpackSocialCardCell {
         default:
             card = nil
         }
+
+        for subview in contentView.subviews {
+            subview.removeFromSuperview()
+        }
         if let card {
-            for subview in contentView.subviews {
-                subview.removeFromSuperview()
-            }
             contentView.addSubview(card)
             contentView.pinSubviewToAllEdges(card)
             contentView.layoutIfNeeded()
-        } else {
-            dashboardViewController?.reloadCardsLocally()
         }
     }
 


### PR DESCRIPTION
Fixes #21342
Ref: pcdRpT-3oR-p2#comment-5777

## Description

Removes the call to reload the cards locally and instead removes the subviews.

With this change, the card will still be displayed but as an empty card. This causes a visual artifact which isn't ideal, but the next time the cards are reloaded, it will disappear.

## Testing

> **Note**
> I was not able to reproduce this issue so these steps are from the bug report.

To test:
- Launch Jetpack and login
- Set up a widget on your home screen for Site A
- Open Jetpack and switch to another site, Site B
- Tap on the widget to open Site A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)