### PR TITLE
Dashboard: Update dashboard snapshots to use main thread

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -168,6 +168,12 @@ private extension BlogDashboardViewModel {
     }
 
     func applySnapshot(for cards: [DashboardCardModel]) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.applySnapshot(for: cards)
+            }
+            return
+        }
         let snapshot = createSnapshot(from: cards)
         dataSource?.apply(snapshot, animatingDifferences: false)
     }


### PR DESCRIPTION
Fixes #21342 
Ref: pcdRpT-3oR-p2#comment-5777

## Description

Forces all snapshots to be applied on the main thread. 

When applying a snapshot, we can use either a background thread or the main thread. The only condition is that we're consistent with where we call it. Since I can't tell which background threads call it, forcing it to the main thread is an easy solution.

## Testing

> **Note**
> I was not able to reproduce this issue so these steps are from the bug report.

To test:
- Launch Jetpack and login
- Set up a widget on your home screen for Site A
- Open Jetpack and switch to another site, Site B
- Tap on the widget to open Site A

## Regression Notes
1. Potential unintended areas of impact
Dashboard loading

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)