### PR TITLE
Jetpack Social: Hide Jetpack Social for private posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+JetpackSocial.swift
@@ -17,6 +17,7 @@ extension PostSettingsViewController {
         && blogSupportsPublicize
         && blogHasNoConnections
         && blogHasServices
+        && !isPostPrivate
     }
 
     @objc func createNoConnectionView() -> UIView {
@@ -45,6 +46,7 @@ extension PostSettingsViewController {
         && blogSupportsPublicize
         && blogHasConnections
         && blogHasSharingLimit
+        && !isPostPrivate
     }
 
     @objc func createRemainingSharesView() -> UIView {
@@ -91,6 +93,10 @@ extension PostSettingsViewController {
 // MARK: - Private methods
 
 private extension PostSettingsViewController {
+
+    var isPostPrivate: Bool {
+        apost.status == .publishPrivate
+    }
 
     func hideNoConnectionViewKey() -> String {
         guard let dotComID = apost.blog.dotComID?.stringValue else {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -624,6 +624,10 @@ FeaturedImageViewControllerDelegate>
 
 - (NSInteger)numberOfRowsForShareSection
 {
+    if ([self.apost.status isEqualToString:@"private"]) {
+        return 0;
+    }
+    
     if (self.apost.blog.supportsPublicize && self.publicizeConnections.count > 0) {
         // One row per publicize connection plus an extra row for the publicze message
         return self.publicizeConnections.count + 1;

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -5,7 +5,7 @@ extension PrepublishingViewController {
     /// Determines whether the account and the post's blog is eligible to see the Jetpack Social row.
     func canDisplaySocialRow(isJetpack: Bool = AppConfiguration.isJetpack,
                              isFeatureEnabled: Bool = RemoteFeatureFlag.jetpackSocialImprovements.enabled()) -> Bool {
-        guard isJetpack && isFeatureEnabled else {
+        guard isJetpack && isFeatureEnabled && !isPostPrivate else {
             return false
         }
 
@@ -83,6 +83,15 @@ private extension PrepublishingViewController {
                 return false
             }
             return !connections.isEmpty
+        }
+    }
+
+    var isPostPrivate: Bool {
+        coreDataStack.performQuery { [postObjectID = post.objectID] context in
+            guard let post = (try? context.existingObject(with: postObjectID)) as? Post else {
+                return false
+            }
+            return post.status == .publishPrivate
         }
     }
 


### PR DESCRIPTION
Fixes #21290 

## Description

Hides Jetpack social when the post is private in the pre-publishing sheet and post settings screen.

## Testing

To test:
- Launch Jetpack and login
- Select a blog with no social connections
- Create a new post
- Open the `Post Settings` screen (`...` > `Post Settings`)
- 🔍 **Verify** the no social connections view is shown
- Tap on `Visibility`
- Select `Private`
- 🔍 **Verify** the no social connections view is not shown
- Navigate back to the post
- Type something in to enable the `Publish` button and tap on it
- 🔍 **Verify** the no social connections view is not shown
- Tap on `Visibility`
- Select `Public`
- 🔍 **Verify** the no social connections view is shown
- Discard the post
- Switch to a blog which has social connections or set one up
- Repeat the above steps but verify with the social sharing views

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
