### PR TITLE
Fix Zendesk identity creation flow in chat

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -18,7 +18,7 @@ extension NSNotification.Name {
 }
 
 protocol ZendeskUtilsProtocol {
-    func createNewRequest(description: String, tags: [String], completion: @escaping (Bool) -> ())
+    func createNewRequest(in viewController: UIViewController, description: String, tags: [String], completion: @escaping (Bool) -> ())
 }
 
 /// This class provides the functionality to communicate with Zendesk for Help Center and support ticket interaction,
@@ -323,7 +323,8 @@ protocol ZendeskUtilsProtocol {
 // MARK: - Create Request
 
 extension ZendeskUtils {
-    func createNewRequest(description: String, tags: [String], completion: @escaping (Bool) -> ()) {
+    func createNewRequest(in viewController: UIViewController, description: String, tags: [String], completion: @escaping (Bool) -> ()) {
+        presentInController = viewController
         ZendeskUtils.createIdentity { [weak self] success, newIdentity in
             guard let self, success else {
                 completion(false)

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -182,7 +182,7 @@ extension SupportChatBotViewController {
     func createTicket(with history: SupportChatHistory) {
         SVProgressHUD.show(withStatus: Strings.ticketCreationLoadingMessage)
 
-        viewModel.contactSupport(including: history) { [weak self] success in
+        viewModel.contactSupport(including: history, in: self) { [weak self] success in
             SVProgressHUD.dismiss()
 
             guard let self else { return }

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewModel.swift
@@ -10,8 +10,9 @@ struct SupportChatBotViewModel {
         self.zendeskUtils = zendeskUtils
     }
 
-    func contactSupport(including history: SupportChatHistory, completion: @escaping (Bool) -> ()) {
+    func contactSupport(including history: SupportChatHistory, in viewController: UIViewController, completion: @escaping (Bool) -> ()) {
         zendeskUtils.createNewRequest(
+            in: viewController,
             description: formattedMessageHistory(from: history),
             tags: ["DocsBot"],
             completion: completion

--- a/WordPress/WordPressTest/SupportChatBotViewModelTests.swift
+++ b/WordPress/WordPressTest/SupportChatBotViewModelTests.swift
@@ -45,7 +45,7 @@ final class SupportChatBotViewModelTests: XCTestCase {
         Please contact support
         """
 
-        sut.contactSupport(including: history) { _ in }
+        sut.contactSupport(including: history, in: UIViewController()) { _ in }
 
         XCTAssertEqual(zendeskUtils.description, expectedDescription)
         XCTAssertEqual(zendeskUtils.tags, ["DocsBot"])
@@ -56,7 +56,7 @@ private class ZendeskUtilsSpy: ZendeskUtilsProtocol {
     var description: String?
     var tags: [String]?
 
-    func createNewRequest(description: String, tags: [String], completion: @escaping (Bool) -> ()) {
+    func createNewRequest(in viewController: UIViewController, description: String, tags: [String], completion: @escaping (Bool) -> ()) {
         self.description = description
         self.tags = tags
     }


### PR DESCRIPTION
When the user creates a Zendesk ticket via the chatbot, the app asks the user for their identity (email and name) if they haven't set it yet. This flow wasn't working in the scenario where these weren't set. The fix involves passing in the view controller to use to present the identity form (an alert) on top of.

## To test

1. Go to the Help screen
2. Tap "Contact support"
3. Chat with the bot
4. Tap one of the "Contact support" buttons and create a ticket
5. Expect a ticket to be created (before this fix, the app would be stuck with an activity indicator)

## Regression Notes
1. Potential unintended areas of impact: The ticket creation flow from within the chatbot interface
2. What I did to test those areas of impact (or what existing automated tests I relied on): Manual testing
3. What automated tests I added (or what prevented me from doing so): Testing to ensure the view controller is set involves making `presentInController` non-private, which isn't desirable. There's no other good way of ensuring it's set, without refactoring the code to introduce protocols at the presentation of the view controller. Given these complexities, I left automated tested out of this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: Not applicable because this isn't a UI change