### PR TITLE
[Domain Focus] Enable Feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] [internal] Fix Core Data multithreaded access exception in Blogging Reminders [#21232]
 * [*] [internal] Remove one of the image loading subsystems for avatars and consolidate the cache [#21259]
 * [*] Fixed a crash that could occur when following sites in Reader. [#21341]
+* [**] [Jetpack-only] Add a "Domain Focus" Card to the Dashboard that opens a screen that allows tranfer of Google Domains. This card can also be hidden across all sites of the account by accesing the More button. [#20296]
 
 23.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [*] [internal] Fix Core Data multithreaded access exception in Blogging Reminders [#21232]
 * [*] [internal] Remove one of the image loading subsystems for avatars and consolidate the cache [#21259]
 * [*] Fixed a crash that could occur when following sites in Reader. [#21341]
-* [**] [Jetpack-only] Add a "Domain Focus" Card to the Dashboard that opens a screen that allows tranfer of Google Domains. This card can also be hidden across all sites of the account by accesing the More button. [#20296]
+* [**] [Jetpack-only] Add a "Domain Focus" Card to the Dashboard that opens a screen that allows tranfer of Google Domains. This card can also be hidden across all sites of the account by accesing the More button. [#21368]
 
 23.0
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -133,7 +133,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .compliancePopover:
             return true
         case .domainFocus:
-            return false
+            return true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -27,8 +27,9 @@ struct BlogDashboardPersonalizationService {
 
     /// Sets the enabled state for a given DashboardCard.
     ///
-    /// This function updates the enabled state of a `DashboardCard`. After updating
-    /// the settings, a notification is posted to inform other parts of the application about this change.
+    /// This function updates the enabled state of a `DashboardCard`. `DashboardCard.settingsType`,
+    /// the enabled state can be either site-specific or site-agnostic.
+    /// After updating the settings, a notification is posted to inform other parts of the application about this change.
     /// - Parameters:
     ///   - isEnabled: A Boolean value indicating whether the `DashboardCard` should be enabled or disabled.
     ///   - card: The `DashboardCard` whose setting needs to be updated.


### PR DESCRIPTION
Refs: https://github.com/wordpress-mobile/WordPress-iOS/pull/21282
Refs: https://github.com/wordpress-mobile/WordPress-iOS/pull/21329

### Enables the Feature Flag

To Test:
Refer the the linked PR's. 

This Feature should only be available on Jetpack App and not on WordPress App.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A