### PR TITLE
Remove the New Photo Post app shortcut

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+23.2
+-----
+* [*] Remove the "New Photo Post" app quick action [#21369](https://github.com/wordpress-mobile/WordPress-iOS/pull/21369)
+
 23.1
 -----
 * [*] Block editor: Hide undo/redo buttons when using the HTML editor [#21253]

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -17,7 +17,6 @@ open class WP3DTouchShortcutCreator: NSObject {
     enum LoggedIn3DTouchShortcutIndex: Int {
         case notifications = 0,
         stats,
-        newPhotoPost,
         newPost
     }
 
@@ -27,7 +26,6 @@ open class WP3DTouchShortcutCreator: NSObject {
     fileprivate let logInShortcutIconImageName = "icon-shortcut-signin"
     fileprivate let notificationsShortcutIconImageName = "icon-shortcut-notifications"
     fileprivate let statsShortcutIconImageName = "icon-shortcut-stats"
-    fileprivate let newPhotoPostShortcutIconImageName = "icon-shortcut-new-photo"
     fileprivate let newPostShortcutIconImageName = "icon-shortcut-new-post"
 
     public init(shortcutsProvider: ApplicationShortcutsProvider) {
@@ -92,19 +90,13 @@ open class WP3DTouchShortcutCreator: NSObject {
                                                              icon: UIApplicationShortcutIcon(templateImageName: statsShortcutIconImageName),
                                                          userInfo: [WP3DTouchShortcutHandler.applicationShortcutUserInfoIconKey: WP3DTouchShortcutHandler.ShortcutIdentifier.Stats.rawValue as NSSecureCoding])
 
-        let newPhotoPostShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.NewPhotoPost.type,
-                                                          localizedTitle: NSLocalizedString("New Photo Post", comment: "New Photo Post 3D Touch Shortcut"),
-                                                       localizedSubtitle: defaultBlogName,
-                                                                    icon: UIApplicationShortcutIcon(templateImageName: newPhotoPostShortcutIconImageName),
-                                                                userInfo: [WP3DTouchShortcutHandler.applicationShortcutUserInfoIconKey: WP3DTouchShortcutHandler.ShortcutIdentifier.NewPhotoPost.rawValue as NSSecureCoding])
-
         let newPostShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.NewPost.type,
                                                      localizedTitle: NSLocalizedString("New Post", comment: "New Post 3D Touch Shortcut"),
                                                   localizedSubtitle: defaultBlogName,
                                                                icon: UIApplicationShortcutIcon(templateImageName: newPostShortcutIconImageName),
                                                            userInfo: [WP3DTouchShortcutHandler.applicationShortcutUserInfoIconKey: WP3DTouchShortcutHandler.ShortcutIdentifier.NewPost.rawValue as NSSecureCoding])
 
-        return [notificationsShortcut, statsShortcut, newPhotoPostShortcut, newPostShortcut]
+        return [notificationsShortcut, statsShortcut, newPostShortcut]
     }
 
     @objc fileprivate func createLoggedInShortcuts() {
@@ -126,7 +118,6 @@ open class WP3DTouchShortcutCreator: NSObject {
             }
 
             if AppConfiguration.allowsNewPostShortcut {
-                visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPhotoPost.rawValue])
                 visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPost.rawValue])
             }
 

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -5,7 +5,6 @@ open class WP3DTouchShortcutHandler: NSObject {
     enum ShortcutIdentifier: String {
         case LogIn
         case NewPost
-        case NewPhotoPost
         case Stats
         case Notifications
 
@@ -33,11 +32,7 @@ open class WP3DTouchShortcutHandler: NSObject {
                 return true
             case ShortcutIdentifier.NewPost.type:
                 WPAnalytics.track(.shortcutNewPost)
-                rootViewPresenter.showPostTab(animated: false, toMedia: false)
-                return true
-            case ShortcutIdentifier.NewPhotoPost.type:
-                WPAnalytics.track(.shortcutNewPhotoPost)
-                rootViewPresenter.showPostTab(animated: false, toMedia: true)
+                rootViewPresenter.showPostTab(animated: false)
                 return true
             case ShortcutIdentifier.Stats.type:
                 WPAnalytics.track(.shortcutStats)

--- a/WordPress/Classes/System/RootViewPresenter+EditorNavigation.swift
+++ b/WordPress/Classes/System/RootViewPresenter+EditorNavigation.swift
@@ -19,7 +19,7 @@ extension RootViewPresenter {
         if Blog.count(in: context) == 0 {
             mySitesCoordinator.showAddNewSite()
         } else {
-            showPostTab(animated: true, toMedia: false, completion: afterDismiss)
+            showPostTab(animated: true, completion: afterDismiss)
         }
     }
 
@@ -28,12 +28,11 @@ extension RootViewPresenter {
         if Blog.count(in: context) == 0 {
             mySitesCoordinator.showAddNewSite()
         } else {
-            showPostTab(animated: true, toMedia: false, blog: blog)
+            showPostTab(animated: true, blog: blog)
         }
     }
 
     func showPostTab(animated: Bool,
-                     toMedia openToMedia: Bool,
                      blog: Blog? = nil,
                      completion afterDismiss: (() -> Void)? = nil) {
         if rootViewController.presentedViewController != nil {
@@ -47,7 +46,6 @@ extension RootViewPresenter {
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
         editor.showImmediately = !animated
-        editor.openWithMediaPicker = openToMedia
         editor.afterDismiss = afterDismiss
 
         let properties = [WPAppAnalyticsKeyTapSource: "create_button", WPAppAnalyticsKeyPostType: "post"]

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -56,10 +56,6 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     var editorSession: PostEditorAnalyticsSession
 
-    /// Indicates if Aztec was launched for Photo Posting
-    ///
-    var isOpenedDirectlyForPhotoPost = false
-
     var postIsReblogged: Bool = false
 
     let navigationBarManager = PostEditorNavigationBarManager()
@@ -548,10 +544,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         // Setup Autolayout
         configureConstraints()
         view.setNeedsUpdateConstraints()
-
-        if isOpenedDirectlyForPhotoPost {
-            presentMediaPickerFullScreen(animated: false)
-        }
 
         if !editorSession.started {
             editorSession.start()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -100,8 +100,6 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     var onClose: ((Bool, Bool) -> Void)?
 
-    var isOpenedDirectlyForPhotoPost: Bool = false
-
     var postIsReblogged: Bool = false
 
     var isEditorClosing: Bool = false
@@ -138,29 +136,6 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
             gutenberg.appendMedia(id: mediaID, url: mediaURL, type: .image)
         }
         mediaToInsertOnPost = []
-    }
-
-    private func showMediaSelectionOnStart() {
-        isOpenedDirectlyForPhotoPost = false
-        mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
-                                                       filter: .image,
-                                                       dataSourceType: .device,
-                                                       allowMultipleSelection: false,
-                                                       callback: {(asset) in
-                                                        guard let phAsset = asset as? [PHAsset] else {
-                                                            return
-                                                        }
-                                                        self.mediaInserterHelper.insertFromDevice(assets: phAsset, callback: { media in
-                                                            guard let media = media,
-                                                                let mediaInfo = media.first,
-                                                                let mediaID = mediaInfo.id,
-                                                                let mediaURLString = mediaInfo.url,
-                                                                let mediaURL = URL(string: mediaURLString) else {
-                                                                return
-                                                            }
-                                                            self.gutenberg.appendMedia(id: mediaID, url: mediaURL, type: .image)
-                                                        })
-        })
     }
 
     private func editMedia(with mediaUrl: URL, callback: @escaping MediaPickerDidPickMediaCallback) {
@@ -969,9 +944,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
         if isFirstGutenbergLayout {
             insertPrePopulatedMedia()
-            if isOpenedDirectlyForPhotoPost {
-                showMediaSelectionOnStart()
-            }
             focusTitleIfNeeded()
             mediaInserterHelper.refreshMediaStatus()
         }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -9,8 +9,6 @@ class EditPostViewController: UIViewController {
 
     /// appear instantly, without animations
     @objc var showImmediately: Bool = false
-    /// appear with the media picker open
-    @objc var openWithMediaPicker: Bool = false
     /// appear with the post epilogue visible
     @objc var openWithPostPost: Bool = false
     /// appear with media pre-inserted into the post
@@ -157,9 +155,6 @@ class EditPostViewController: UIViewController {
     }
 
     private func showEditor(_ editor: EditorViewController) {
-        editor.isOpenedDirectlyForPhotoPost = openWithMediaPicker
-        // only open the media picker once.
-        openWithMediaPicker = false
         editor.onClose = { [weak self, weak editor] changesSaved, showPostEpilogue in
             guard let strongSelf = self else {
                 editor?.dismiss(animated: true) {}

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -26,10 +26,6 @@ protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
     ///
     var post: AbstractPost { get set }
 
-    /// Whether the editor should open directly to the media picker.
-    ///
-    var isOpenedDirectlyForPhotoPost: Bool { get set }
-
     /// Initializer
     ///
     /// - Parameters:


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21190

We needed to either update this feature to support the new native photo picker or remove it. Because nobody was using it (<30 uses in the last 12 months), we decided to remove. Makes for a clearer shortcuts menu. Discussion: p1692303663191839-slack-C04SFL0RP51.

This is how this feature used to work:

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/dba25b3f-1011-4d8a-9ad6-4b6674efd126

## To test:

- Verify that the remaining shortcuts still work

## Regression Notes
1. Potential unintended areas of impact: App Shortcuts (or, technically, "Quick Actions")
2. What I did to test those areas of impact (or what existing automated tests I relied on): Manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
