### PR TITLE
Fix a crash when OAuth token becomes invalid

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Remove the "New Photo Post" app quick action [#21369](https://github.com/wordpress-mobile/WordPress-iOS/pull/21369)
 * [*] (Internal) Fix unbounded growth of number media observers in Post Editor (performance issue) [#21352](https://github.com/wordpress-mobile/WordPress-iOS/pull/21352)
+* [**] [internal] Fix a crash when disconnecting the app from the "Connected Applications" on WordPress.com. [#21375]
 
 23.1
 -----

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -173,9 +173,12 @@
                 [weakSelf setAuthToken:nil];
                 [WordPressAuthenticationManager showSigninForWPComFixingAuthToken];
                 if (weakSelf.isDefaultWordPressComAccount) {
-                    // According to WordPressAppDelegate.handleDefaultAccountChangedNotification(_:), passing a
-                    // non-nil object indicates this notification is sent from log in flow. However, this workflow here,
-                    // where the current account's OAuth token becomes invalid, is more closer to a log out than log in.
+                    // At the time of writing, there is an implicit assumption on what the object parameter value means.
+                    // For example, the WordPressAppDelegate.handleDefaultAccountChangedNotification(_:) subscriber inspects the object parameter to decide whether the notification was sent as a result of a login.
+                    // If the object is non-nil, then the method considers the source a login.
+                    //
+                    // The code path in which we are is that of an invalid token, and that's neither a login nor a logout, it's more appropriate to consider it a logout.
+                    // That's because if the token is invalid the app will soon received errors from the API and it's therefore better to force the user to login again.
                     [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
                 }
             }];

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -173,7 +173,10 @@
                 [weakSelf setAuthToken:nil];
                 [WordPressAuthenticationManager showSigninForWPComFixingAuthToken];
                 if (weakSelf.isDefaultWordPressComAccount) {
-                    [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:weakSelf];
+                    // According to WordPressAppDelegate.handleDefaultAccountChangedNotification(_:), passing a
+                    // non-nil object indicates this notification is sent from log in flow. However, this workflow here,
+                    // where the current account's OAuth token becomes invalid, is more closer to a log out than log in.
+                    [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
                 }
             }];
         } else {


### PR DESCRIPTION
## Issue

When the signed in account's oauth token becomes invalid, the app would goes into a code path where the app refreshes some information using the current account's data.

On a development build, this issue causes an assertion to fail and causes the app to crash. And the app would continue to crash upon re-launch.

On the App Store build, the app does not crash immediately. But since the app is now in a incorrect state, it causes other issues. For example, goes into Media would cause a crash (I'm not sure what's the exact crash site though.)

Here are steps to reproduce this issue:
1. Launch the app and sign in using WordPress.com acount.
2. Go to wordpress.com and sign in using the same account.
3. Go to https://wordpress.com/me/security/connected-applications and disconnect "WordPress for iOS"
4. Go to the app and switch tabs.
5. If you are using a development build that's launched from Xcode, the app crashes at this step, and continues to crash upon re-launch.
6. If you are using the App Store build, navigate to My Site -> Menu -> Media and the app would crash. Or, go around and click a few other things to see there will be more crashes.

## Root cause

The crash happens at [this assertion](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.0.0.3/WordPress/Classes/Services/TodayExtensionService.m#L17) where the function expects oauth token to not be empty. The oauth token is set to nil by [this "invalid token handler"](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.0.0.3/WordPress/Classes/Models/WPAccount.m#L173). And the `TodayExtensionService` function is called by [a notification handler](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.0.0.3/WordPress/Classes/System/WordPressAppDelegate.swift#L810) of [the "account did change" notification](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.0.0.3/WordPress/Classes/Models/WPAccount.m#L176).

To fix this issue, I have changed the notification to not send the account object. As mentioned in the code comment, that's to simulate a workflow that's closer to log out.

## Test Instructions

Verify the issue has gone away in a development build. I think the expected behaviour upon token becoming invalid is, the app prompts the user to sign in upon every interaction, because the app doesn't work without user signing in successfully.

## Regression Notes
1. Potential unintended areas of impact
This change may affect areas that are required to reflect current app state, i.e. app extensions, sign in, and sign out.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verify the crash no longer happens. When the app showed the sign in form after I disconnected the app from the website, I dismissed the sign in form and clicked a few other things, to check if there is any other issue. I can't find any.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A