### PR TITLE
Allow the Pages list to listen to Core Data changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -42,7 +42,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let tableViewHandler = PageListTableViewHandler(tableView: self.tableView, blog: self.blog)
         tableViewHandler.cacheRowHeights = false
         tableViewHandler.delegate = self
-        tableViewHandler.listensForContentChanges = false
         tableViewHandler.updateRowAnimation = .none
         return tableViewHandler
     }()


### PR DESCRIPTION
Refs #16370

This fixes the issue where the Pages list doesn't refresh after making changes (e.g. adding a new page). As mentioned in https://github.com/wordpress-mobile/WordPress-iOS/issues/20647#issuecomment-1603357554, this was a legacy part of the codebase where the view controller is configured to not listen to Core Data changes.

This PR simply removes that line, so the view controller now subscribes to Core Data changes. The `listensForContentChanges` property defaults to true if the table handler has a delegate: 

https://github.com/wordpress-mobile/WordPress-iOS/blob/ddb7cd7bc436170f6814d9e9d4f77417153e4309/WordPress/Classes/Utility/WPTableViewHandler.m#L55-L58


## To Test

1. Go to My Sites > Pages.
2. Go to the Draft section.
3. Create a new page.
4. Save the page as a draft.
5. 🔎 Verify that the new draft appears on the list.

## Regression Notes
1. Potential unintended areas of impact
Core Data traffic for this screen will increase with this change.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

7. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A, this doesn't introduce any UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
