### PR TITLE
Disable testPagesCardHeaderNavigation for fixing.

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -22,6 +22,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "DashboardTests\/testPagesCardHeaderNavigation()",
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",


### PR DESCRIPTION
### Description
This PR disables `testPagesCardHeaderNavigation()` to reduce the noise while working on a proper fix.

### Testing
CI must be 🟢.