### PR TITLE
Add TaggedManagedObjectID type

### DIFF
--- a/WordPress/Classes/Utility/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/TaggedManagedObjectID.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// `TaggedManagedObjectID` is a `NSManagedObjectID` wrapper that also contains the model type of the `NSManagedObjectID`.
+/// `TaggedManagedObjectID` is an `NSManagedObjectID` wrapper that also contains the model type of the `NSManagedObjectID`.
 ///
-/// By using this strongly typed `NSManagedObjectID`, we can declare APIs that're bound to specific model types, thus
+/// By using this strongly typed `NSManagedObjectID`, we can declare APIs that are bound to specific model types, thus
 /// preventing an incorrect object id being used as argument.
 ///
 /// Take the following function as an example,
@@ -18,12 +18,12 @@ import Foundation
 /// func getPost(fromBlogID: TaggedManagedObjectID<Blog>)
 /// ```
 ///
-/// Now the type `Blog` is built into the function signature, and Swift compiler would report an error if we call it using
-/// `getPost(fromBlogID: themeObjectID)`.
+/// Now the type `Blog` is built into the function signature, and the Swift compiler would report an error if we call it
+/// using `getPost(fromBlogID: themeObjectID)`.
 ///
 /// The type name is inspired by the swift-tagged library. The reason we don't use that library is the library exposes
 /// a public initliaser `init(rawValue:)` which is not what we want. With this public initialiser available for all users,
-/// We can't perform the validation described in `init(objectID:)`.
+/// we can't perform the validation described in `init(objectID:)`.
 ///
 /// - SeeAlso: swift-tagged: https://github.com/pointfreeco/swift-tagged
 struct TaggedManagedObjectID<Model: NSManagedObject>: Equatable {

--- a/WordPress/Classes/Utility/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/TaggedManagedObjectID.swift
@@ -27,18 +27,7 @@ import Foundation
 ///
 /// - SeeAlso: swift-tagged: https://github.com/pointfreeco/swift-tagged
 struct TaggedManagedObjectID<Model: NSManagedObject>: Equatable {
-    var objectID: NSManagedObjectID
-
-    // This initialzer is declared as `private`, because we want to prevent mismatch between `Model` and the type
-    // that the `objectID` represents.
-    //
-    // When this private initialzer is called, we need to ensure the following requirements are satisfied at runtime:
-    // - The `objectID` is a permanent id.
-    // - The model associated with the given `objectID` is indeed `Model`.
-    private init(objectID: NSManagedObjectID) {
-        precondition(!objectID.isTemporaryID, "The `objectID` is not a permanent id. Call `obtainPermanentIDs` first.")
-        self.objectID = objectID
-    }
+    let objectID: NSManagedObjectID
 
     /// Create an `TaggedManagedObjectID` instance of an object that's already saved.
     init(saved object: Model) {
@@ -55,6 +44,17 @@ struct TaggedManagedObjectID<Model: NSManagedObject>: Equatable {
         }
 
         self = TaggedManagedObjectID<Model>(objectID: objectID)
+    }
+
+    // This initialzer is declared as `private`, because we want to prevent mismatch between `Model` and the type
+    // that the `objectID` represents.
+    //
+    // When this private initialzer is called, we need to ensure the following requirements are satisfied at runtime:
+    // - The `objectID` is a permanent id.
+    // - The model associated with the given `objectID` is indeed `Model`.
+    private init(objectID: NSManagedObjectID) {
+        precondition(!objectID.isTemporaryID, "The `objectID` is not a permanent id. Call `obtainPermanentIDs` first.")
+        self.objectID = objectID
     }
 }
 

--- a/WordPress/Classes/Utility/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/TaggedManagedObjectID.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// `TaggedManagedObjectID` is a `NSManagedObjectID` wrapper that also contains the model type of the `NSManagedObjectID`.
+///
+/// By using this strongly typed `NSManagedObjectID`, we can declare APIs that're bound to specific model types, thus
+/// preventing an incorrect object id being used as argument.
+///
+/// Take the following function as an example,
+/// ```
+/// func getPost(fromBlogID blogID: NSManagedObjectID)
+/// ```
+///
+/// We can call the function with any `NSManagedObjectID`: `getPost(fromBlogID: themeObjectID)`. This usage is obviously
+/// incorrect, but we won't be able to catch this error until something goes wrong at rumtime.
+///
+/// However, we can change the declaration to
+/// ```
+/// func getPost(fromBlogID: TaggedManagedObjectID<Blog>)
+/// ```
+///
+/// Now the type `Blog` is built into the function signature, and Swift compiler would report an error if we call it using
+/// `getPost(fromBlogID: themeObjectID)`.
+///
+/// The type name is inspired by the swift-tagged library. The reason we don't use that library is the library exposes
+/// a public initliaser `init(rawValue:)` which is not what we want. With this public initialiser available for all users,
+/// We can't perform the validation described in `init(objectID:)`.
+///
+/// - SeeAlso: swift-tagged: https://github.com/pointfreeco/swift-tagged
+struct TaggedManagedObjectID<Model: NSManagedObject>: Equatable {
+    var objectID: NSManagedObjectID
+
+    // This initialzer is declared as `private`, because we want to prevent mismatch between `Model` and the type
+    // that the `objectID` represents.
+    //
+    // When this private initialzer is called, we need to ensure the following requirements are satisfied at runtime:
+    // - The `objectID` is a permanent id.
+    // - The model associated with the given `objectID` is indeed `Model`.
+    private init(objectID: NSManagedObjectID) {
+        precondition(!objectID.isTemporaryID, "The `objectID` is not a permanent id. Call `obtainPermanentIDs` first.")
+        self.objectID = objectID
+    }
+
+    /// Create an `TaggedManagedObjectID` instance of an object that's already saved.
+    init(saved object: Model) {
+        self = TaggedManagedObjectID<Model>(objectID: object.objectID)
+    }
+
+    /// Create an `TaggedManagedObjectID` instance of an object that's not yet saved.
+    init(unsaved object: Model) throws {
+        var objectID = object.objectID
+        if objectID.isTemporaryID {
+            let context = object.managedObjectContext!
+            try context.obtainPermanentIDs(for: [object])
+            objectID = object.objectID
+        }
+
+        self = TaggedManagedObjectID<Model>(objectID: objectID)
+    }
+}
+
+extension NSManagedObjectContext {
+
+    /// Find the object associated with this object id in the given `context`.
+    ///
+    /// - SeeAlso: `NSManagedObjectContext.existingObject(with:)`
+    func existingObject<Model>(with id: TaggedManagedObjectID<Model>) throws -> Model {
+        do {
+            var result: Result<Model, Error>!
+
+            // Catch an Objective-C `NSInvalidArgumentException` exception from `existingObject(with:)`.
+            // See https://github.com/wordpress-mobile/WordPress-iOS/issues/20630
+            try WPException.objcTry {
+                result = Result {
+                    let object = try self.existingObject(with: id.objectID)
+                    guard let model = object as? Model else {
+                        fatalError("Expecting \(Model.self) type from the object id (\(id.objectID), but got \(object)")
+                    }
+                    return model
+                }
+            }
+
+            return try result.get()
+        } catch {
+            throw error
+        }
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1241,6 +1241,9 @@
 		4A2172FF28F688890006F4F1 /* Blog+Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2172FD28F688890006F4F1 /* Blog+Media.swift */; };
 		4A266B8F282B05210089CF3D /* JSONObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B8E282B05210089CF3D /* JSONObjectTests.swift */; };
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
+		4A2C73E12A943D9000ACE79E /* TaggedManagedObjectID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73E02A943D8F00ACE79E /* TaggedManagedObjectID.swift */; };
+		4A2C73E22A943D9000ACE79E /* TaggedManagedObjectID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73E02A943D8F00ACE79E /* TaggedManagedObjectID.swift */; };
+		4A2C73E42A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */; };
 		4A358DE629B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE729B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE929B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */; };
@@ -6820,6 +6823,8 @@
 		4A2172FD28F688890006F4F1 /* Blog+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Media.swift"; sourceTree = "<group>"; };
 		4A266B8E282B05210089CF3D /* JSONObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectTests.swift; sourceTree = "<group>"; };
 		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
+		4A2C73E02A943D8F00ACE79E /* TaggedManagedObjectID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaggedManagedObjectID.swift; sourceTree = "<group>"; };
+		4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaggedManagedObjectIDTests.swift; sourceTree = "<group>"; };
 		4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicizeService+Lookup.swift"; sourceTree = "<group>"; };
 		4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingButton+Lookup.swift"; sourceTree = "<group>"; };
 		4A526BDD296BE9A50007B5BA /* CoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataService.m; sourceTree = "<group>"; };
@@ -15341,6 +15346,7 @@
 			children = (
 				93E9050319E6F242005513C9 /* ContextManagerTests.swift */,
 				B5ECA6CC1DBAAD510062D7E0 /* CoreDataHelperTests.swift */,
+				4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */,
 				931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */,
 				FE320CC4294705990046899B /* ReaderPostBackupTests.swift */,
 			);
@@ -15488,6 +15494,7 @@
 				4A9B81E22921AE02007A05D1 /* ContextManager.swift */,
 				E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */,
 				B5ECA6C91DBAA0020062D7E0 /* CoreDataHelper.swift */,
+				4A2C73E02A943D8F00ACE79E /* TaggedManagedObjectID.swift */,
 				24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */,
 			);
 			name = CoreData;
@@ -21345,6 +21352,7 @@
 				F48D44B6298992C30051EAA6 /* BlockedSite.swift in Sources */,
 				FF8791BB1FBAF4B500AD86E6 /* MediaService+Swift.swift in Sources */,
 				D8212CB920AA77AD008E8AE8 /* ReaderActionHelpers.swift in Sources */,
+				4A2C73E12A943D9000ACE79E /* TaggedManagedObjectID.swift in Sources */,
 				B52C4C7D199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift in Sources */,
 				E64384831C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift in Sources */,
 				F504D2B025D60C5900A2764C /* StoryPoster.swift in Sources */,
@@ -23508,6 +23516,7 @@
 				8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */,
 				DC13DB7E293FD09F00E33561 /* StatsInsightsStoreTests.swift in Sources */,
 				ACACE3AE28D729FA000992F9 /* NoResultsViewControllerTests.swift in Sources */,
+				4A2C73E42A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift in Sources */,
 				8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */,
@@ -24560,6 +24569,7 @@
 				FABB232A2602FC2C00C8785C /* SharingButton.swift in Sources */,
 				0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */,
 				FABB232B2602FC2C00C8785C /* PostActionSheet.swift in Sources */,
+				4A2C73E22A943D9000ACE79E /* TaggedManagedObjectID.swift in Sources */,
 				FABB232C2602FC2C00C8785C /* PublicizeConnection.swift in Sources */,
 				FABB232D2602FC2C00C8785C /* TenorPageable.swift in Sources */,
 				FABB232E2602FC2C00C8785C /* AccountService+MergeDuplicates.swift in Sources */,

--- a/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
+++ b/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
@@ -40,13 +40,7 @@ class TaggedManagedObjectIDTests: CoreDataTestCase {
 
         let newContext = contextManager.newDerivedContext()
 
-        let expectation = expectation(description: "The query should fail because the model is not saved")
-        do {
-            _ = try newContext.existingObject(with: id)
-        } catch {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 0.1)
+        XCTAssertThrowsError(try newContext.existingObject(with: id), "The query should fail because the model is not saved")
     }
 
     func testEqutable() throws {

--- a/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
+++ b/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+
+@testable import WordPress
+
+class TaggedManagedObjectIDTests: CoreDataTestCase {
+
+    func testQuerySaved() throws {
+        let post = PostBuilder(contextManager.mainContext).with(title: "Test post").build()
+        try contextManager.mainContext.save()
+
+        let id = TaggedManagedObjectID(saved: post)
+        let result = try contextManager.mainContext.existingObject(with: id)
+        XCTAssertEqual(result.postTitle, "Test post")
+    }
+
+    func testQueryUnsaved() throws {
+        let post = PostBuilder(contextManager.mainContext).with(title: "Test post").build()
+        let id = try TaggedManagedObjectID(unsaved: post)
+
+        try contextManager.mainContext.save()
+
+        let newContext = contextManager.newDerivedContext()
+        let result = try newContext.existingObject(with: id)
+        XCTAssertEqual(result.postTitle, "Test post")
+    }
+
+    func testQueryUnsavedUsingTheSameContext() throws {
+        let context = contextManager.mainContext
+        let post = PostBuilder(context).with(title: "Test post").build()
+        let id = try TaggedManagedObjectID(unsaved: post)
+
+        let result = try context.existingObject(with: id)
+        XCTAssertEqual(result.postTitle, "Test post")
+    }
+
+    func testQueryUnsavedUsingDifferentContext() throws {
+        let post = PostBuilder(contextManager.mainContext).build()
+        let id = try TaggedManagedObjectID(unsaved: post)
+
+        let newContext = contextManager.newDerivedContext()
+
+        let expectation = expectation(description: "The query should fail because the model is not saved")
+        do {
+            _ = try newContext.existingObject(with: id)
+        } catch {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testEqutable() throws {
+        let post = PostBuilder(contextManager.mainContext).with(title: "Test post").build()
+        let unsaveID = try TaggedManagedObjectID(unsaved: post)
+        try contextManager.mainContext.save()
+        let savedID = TaggedManagedObjectID(saved: post)
+
+        XCTAssertEqual(unsaveID, savedID)
+        XCTAssertEqual(TaggedManagedObjectID(saved: post), savedID)
+    }
+
+    // This is not really a test. More like a demostration of how to workaround Swift compiler's covariance support.
+    func testCovariance() throws {
+        let post = PostBuilder(contextManager.mainContext).with(author: "WordPress.com").build()
+        try contextManager.mainContext.save()
+
+        let postID: TaggedManagedObjectID<Post> = .init(saved: post)
+        let abstractPostID: TaggedManagedObjectID<AbstractPost> = .init(saved: post)
+
+        // This line does not compile without the second `author(of:in:)` overload.
+        try XCTAssertEqual(author(of: postID, in: contextManager.mainContext), "WordPress.com")
+        try XCTAssertEqual(author(of: abstractPostID, in: contextManager.mainContext), "WordPress.com")
+    }
+
+    // This function does not accept `TaggedManagedObjectID<Post>` argument, because `TaggedManagedObjectID<Post>` is
+    // not a subtype of `TaggedManagedObjectID<AbstractPost>` even though `Post` is a subtype of `AbstractPost`.
+    //
+    // But sometimes, we do want to declare a function that accepts object id of all `AbstractPost` types. In those cases,
+    // we can declare them in another way: see the function below.
+    private func author(of id: TaggedManagedObjectID<AbstractPost>, in context: NSManagedObjectContext) throws -> String? {
+        try context.existingObject(with: id).author
+    }
+
+    // This function accepts all `TaggedManagedObjectID` instances that are created from all `AbstractPost` types.
+    private func author<T: AbstractPost>(of id: TaggedManagedObjectID<T>, in context: NSManagedObjectContext) throws -> String? {
+        try context.existingObject(with: id).author
+    }
+
+}

--- a/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
+++ b/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
@@ -53,6 +53,45 @@ class TaggedManagedObjectIDTests: CoreDataTestCase {
         XCTAssertEqual(TaggedManagedObjectID(saved: post), savedID)
     }
 
+}
+
+// MARK: – Covariance workaround demo
+
+extension TaggedManagedObjectIDTests {
+
+    // Covariance is the ability to use a more derived type (a subclass) in place of a less derived type (a superclass).
+    //
+    // When we declare a generic type like `TaggedManagedObjectID<Model>`, we lose type-hierarchy information of the
+    // generic parameter `Model`. That means the compiler will not accept a `TaggedManagedObjectID<Post>` instance for
+    // a parameter defined as `TaggedManagedObjectID<AbstractPost>` even though `Post` is a subtype of `AbstractPost`.
+    //
+    // However, Swift compiler has special treatment for its standard library types like `Array` and `Set`: You can pass
+    // an `Array<Post>` instance for a parameter defined as `Array<AbstractPost>`.
+    //
+    // Here is a `swift repl` output to demostrate this Swift feature:
+    //
+    // ```
+    // $ swift repl
+    // Welcome to Apple Swift version 5.8.1 (swiftlang-5.8.0.124.5 clang-1403.0.22.11.100).
+    // Type :help for assistance.
+    //   1> class Parent {}
+    //   2> class Child: Parent {}
+    //   3> print(Child() is Parent)
+    // true
+    //   4> struct Foo<T> {}
+    //   5> print(Foo<Child>() is Foo<Parent>)
+    // false
+    //   6> print(Array<Child>() is Array<Parent>)
+    // true
+    // ```
+    //
+    // We don't get any special treatment from Swift compiler, so we'll have to make our own workaround, since it's
+    // not uncommon to declare a function which accepts `NSManagedObjectID` instances of a certain type and its subtypes.
+    //
+    // Below is a demonstration of how to work around this limitation by using a generic function.
+
+    // If this test compiles, then the overload definition (see below) works.
+
     // This is not really a test. More like a demostration of how to workaround Swift compiler's covariance support.
     func testCovariance() throws {
         let post = PostBuilder(contextManager.mainContext).with(author: "WordPress.com").build()


### PR DESCRIPTION
This PR is extracted from https://github.com/wordpress-mobile/WordPress-iOS/pull/21163

-----

One downside of [`NSManagedObjectContext.existingObject(with:)`](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext/1506686-existingobject) is the returned object is not strongly typed, but we almost always want to use the concrete model type. Using `as!` to cast, sometimes feels right, but may cause crash at runtime.

Also when passing a `NSManagedObjectID` instance into functions, we lost a important information: the type of the stored model object. That means if you have a function `getPost(using objectId: NSManagedObjectID)`, you can pass call it using _any_ `NSManagedObjectID`, i.e `getPost(using: blog.objectID)` which is problematic.

This PR adds a `TaggedManagedObjectID<Model>` to solve the above issues. It's a wrapper of `NSManagedObjectID`, but also knows the model type of the wrapped `NSManagedObjectID`.

The `TaggedManagedObjectID` initializer makes sure
1. Its `NSManagedObjectID` instance is a permanent object id, so that we can use a `TaggedManagedObjectID` instance to find the real object later on.
3. The model associated with its `NSManagedObjectID` instance is indeed the declared generic `Model` type. This is so that we can prevent usages like `TaggedManagedObjectID<Blog>(objectID: theme.objectID)`

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A