### PR TITLE
Fix error on screenshots test

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -6,6 +6,7 @@ import XCTest
 class JetpackScreenshotGeneration: XCTestCase {
     let scanWaitTime: UInt32 = 5
 
+    @MainActor
     override func setUpWithError() throws {
         super.setUp()
 

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -6,6 +6,7 @@ import XCTest
 class WordPressScreenshotGeneration: XCTestCase {
     let imagesWaitTime: UInt32 = 10
 
+    @MainActor
     override func setUpWithError() throws {
         super.setUp()
 


### PR DESCRIPTION
### Description
This PR fixes the error when building screenshots test. This was most likely due to the change in https://github.com/wordpress-mobile/WordPress-iOS/pull/21346 (cc: @mokagio). 

This change just ensures that the screenshots test can be built (I know @pachlava checks this for PR reviews 😄) and doesn't touch anything else.

### Testing
Screenshots tests should build locally