### PR TITLE
Use `XCTExpectFailure` instead of disabling a UI test

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -22,7 +22,6 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
-        "DashboardTests\/testPagesCardHeaderNavigation()",
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",

--- a/WordPress/UITests/Tests/DashboardTests.swift
+++ b/WordPress/UITests/Tests/DashboardTests.swift
@@ -29,6 +29,11 @@ class DashboardTests: XCTestCase {
     }
 
     func testPagesCardHeaderNavigation() throws {
+        XCTExpectFailure(
+            "This test has become unstable around 2023/08/19. We are working on a fix.",
+            options: .nonStrict()
+        )
+
         try LoginEpilogueScreen()
             .continueWithSelectedSite(WPUITestCredentials.testWPcomPaidSite)
             .scrollToPagesCard()


### PR DESCRIPTION
The idea behind this change is to surface the incorrect test in a clearer way than the checkboxes in the test plan do. Hopefully this will help keeping it top of mind in our collective development awareness and fixing it promptly.

Inspired by the internal discussion at pbzQyC-423-p2. See also #21384.

## Testing

Verify CI is green and reports the test as skipped.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.