### PR TITLE
Integrate PHPickerViewController in Gravatar flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
@@ -37,7 +37,7 @@ extension SitePickerViewController {
 
     private func makeUpdateSiteIconActions() -> [UIAction] {
         let presenter = makeSiteIconPresenter()
-        let mediaMenu = MediaPickerMenu(viewConroller: self, filter: .images)
+        let mediaMenu = MediaPickerMenu(viewController: self, filter: .images)
         var actions: [UIAction] = []
         if FeatureFlag.nativePhotoPicker.enabled {
             actions += [

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
@@ -1,0 +1,95 @@
+import Foundation
+import UIKit
+import PhotosUI
+import SVProgressHUD
+
+final class AvatarMenuController: PHPickerViewControllerDelegate, ImagePickerControllerDelegate {
+    private weak var presentingViewController: UIViewController?
+
+    var onAvatarSelected: ((UIImage) -> Void)?
+
+    init(viewController: UIViewController) {
+        self.presentingViewController = viewController
+    }
+
+    func makeMenu() -> UIMenu {
+        guard let presentingViewController else {
+            assertionFailure("Presenting view controller missing")
+            return UIMenu()
+        }
+        let mediaPickerMenu = MediaPickerMenu(viewConroller: presentingViewController, filter: .images)
+        return UIMenu(title: Strings.menuTitle, children: [
+            mediaPickerMenu.makePhotosAction(delegate: self),
+            mediaPickerMenu.makeCameraAction(camera: .front, delegate: self)
+        ])
+    }
+
+    // MARK: - PHPickerViewControllerDelegate
+
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        guard let result = results.first else {
+            presentingViewController?.dismiss(animated: true)
+            return
+        }
+        MediaPickerMenu.loadImage(for: result) { [weak self] image, _ in
+            if let image {
+                self?.showCropViewController(with: image)
+            } else {
+                self?.showError()
+            }
+        }
+    }
+
+    // MARK: - ImagePickerControllerDelegate
+
+    func imagePicker(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        presentingViewController?.dismiss(animated: true) {
+            if let image = info[.originalImage] as? UIImage {
+                self.showCropViewController(with: image)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func showCropViewController(with image: UIImage) {
+        guard let topViewController else {
+            return
+        }
+        let cropViewController = ImageCropViewController(image: image)
+        cropViewController.shouldShowCancelButton = true
+        cropViewController.onCancel = { [weak topViewController] in
+            topViewController?.dismiss(animated: true)
+        }
+        cropViewController.onCompletion = { [weak self] image, _ in
+            self?.didComplete(with: image)
+        }
+        let navigationController = UINavigationController(rootViewController: cropViewController)
+        topViewController.present(navigationController, animated: true)
+    }
+
+    private func didComplete(with avatar: UIImage?) {
+        presentingViewController?.dismiss(animated: true) {
+            if let avatar {
+                self.onAvatarSelected?(avatar)
+            }
+        }
+    }
+
+    private func showError() {
+        SVProgressHUD.showDismissibleError(withStatus: Strings.errorTitle)
+    }
+
+    private func dismiss() {
+        presentingViewController?.dismiss(animated: true)
+    }
+
+    private var topViewController: UIViewController? {
+        presentingViewController?.topmostPresentedViewController
+    }
+}
+
+private enum Strings {
+    static let errorTitle = NSLocalizedString("avatarMenu.failedToSetAvatarAlertMessage", value: "Unable to load the image. Please choose a different one or try again later", comment: "Alert message when something goes wrong with the selected iamge.")
+    static let menuTitle = NSLocalizedString("avatarMenu.title", value: "Update Gravatar", comment: "Title for menu that is shown when you tap your gravatar")
+}

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
@@ -90,6 +90,6 @@ final class AvatarMenuController: PHPickerViewControllerDelegate, ImagePickerCon
 }
 
 private enum Strings {
-    static let errorTitle = NSLocalizedString("avatarMenu.failedToSetAvatarAlertMessage", value: "Unable to load the image. Please choose a different one or try again later", comment: "Alert message when something goes wrong with the selected iamge.")
+    static let errorTitle = NSLocalizedString("avatarMenu.failedToSetAvatarAlertMessage", value: "Unable to load the image. Please choose a different one or try again later.", comment: "Alert message when something goes wrong with the selected image.")
     static let menuTitle = NSLocalizedString("avatarMenu.title", value: "Update Gravatar", comment: "Title for menu that is shown when you tap your gravatar")
 }

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
@@ -17,7 +17,7 @@ final class AvatarMenuController: PHPickerViewControllerDelegate, ImagePickerCon
             assertionFailure("Presenting view controller missing")
             return UIMenu()
         }
-        let mediaPickerMenu = MediaPickerMenu(viewConroller: presentingViewController, filter: .images)
+        let mediaPickerMenu = MediaPickerMenu(viewController: presentingViewController, filter: .images)
         return UIMenu(title: Strings.menuTitle, children: [
             mediaPickerMenu.makePhotosAction(delegate: self),
             mediaPickerMenu.makeCameraAction(camera: .front, delegate: self)

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
@@ -5,7 +5,9 @@ class MyProfileHeaderView: UITableViewHeaderFooterView {
     @IBOutlet var gravatarImageView: CircularImageView!
     @IBOutlet var gravatarButton: UIButton!
 
-    var onAddUpdatePhoto: (() -> Void)?
+    // A fake button displayed on top of gravatarImageView.
+    let imageViewButton = UIButton(type: .system)
+
     let activityIndicator = UIActivityIndicatorView(style: .medium)
     var showsActivityIndicator: Bool {
         get {
@@ -48,10 +50,6 @@ class MyProfileHeaderView: UITableViewHeaderFooterView {
         configureGravatarButton()
     }
 
-    @IBAction func onProfileWasPressed(_ sender: UIButton) {
-        onAddUpdatePhoto?()
-    }
-
     /// Overrides the current Gravatar Image (set via Email) with a given image reference.
     /// Plus, the internal image cache is updated, to prevent undesired glitches upon refresh.
     ///
@@ -79,8 +77,9 @@ class MyProfileHeaderView: UITableViewHeaderFooterView {
         gravatarImageView.pinSubviewAtCenter(activityIndicator)
         layoutIfNeeded()
 
-        let recognizer = UITapGestureRecognizer(target: self, action: #selector(onProfileWasPressed(_:)))
-        gravatarImageView.addGestureRecognizer(recognizer)
+        gravatarImageView.addSubview(imageViewButton)
+        imageViewButton.translatesAutoresizingMaskIntoConstraints = false
+        imageViewButton.pinSubviewToAllEdges(gravatarImageView)
     }
 
     private func configureGravatarButton() {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22152" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22127"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,11 +13,11 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="134"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fcx-xK-EJj" id="YeK-MX-Gye">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="133.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="134"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="5Te-sl-4HZ">
-                        <rect key="frame" x="20" y="20" width="335" height="93.5"/>
+                        <rect key="frame" x="20" y="20" width="335" height="94"/>
                         <subviews>
                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="Sgx-sT-G82" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="135.5" y="0.0" width="64" height="64"/>
@@ -28,13 +26,10 @@
                                     <constraint firstAttribute="width" constant="64" id="pwi-AC-YZf"/>
                                 </constraints>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hfE-Wp-Ea1">
-                                <rect key="frame" x="127.5" y="74" width="80" height="19.5"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hfE-Wp-Ea1">
+                                <rect key="frame" x="127.5" y="74" width="80" height="20"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <state key="normal" title="Button text"/>
-                                <connections>
-                                    <action selector="onProfileWasPressed:" destination="fcx-xK-EJj" eventType="touchUpInside" id="6bg-EF-94L"/>
-                                </connections>
                             </button>
                         </subviews>
                     </stackView>
@@ -50,7 +45,7 @@
                 <outlet property="gravatarButton" destination="hfE-Wp-Ea1" id="Kld-Tp-PVI"/>
                 <outlet property="gravatarImageView" destination="Sgx-sT-G82" id="bYR-Zw-IG4"/>
             </connections>
-            <point key="canvasLocation" x="-141" y="73"/>
+            <point key="canvasLocation" x="-225.59999999999999" y="65.667166416791616"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -20,13 +20,13 @@ struct MediaPickerMenu {
     /// Initializes the options.
     ///
     /// - parameters:
-    ///   - presentingViewController: The view controller to use for presentation.
+    ///   - viewController: The view controller to use for presentation.
     ///   - filter: By default, `nil` – allow all content types.
     ///   - isMultipleSelectionEnabled: By default, `false`.
-    init(viewConroller: UIViewController,
+    init(viewController: UIViewController,
          filter: MediaFilter? = nil,
          isMultipleSelectionEnabled: Bool = false) {
-        self.presentingViewController = viewConroller
+        self.presentingViewController = viewController
         self.filter = filter
         self.isMultipleSelectionEnabled = isMultipleSelectionEnabled
     }

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22152" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22127"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -58,11 +58,8 @@
                             <constraint firstAttribute="width" secondItem="GYR-3W-aku" secondAttribute="height" multiplier="1:1" id="CCT-Ge-nHv"/>
                         </constraints>
                     </imageView>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11G-E4-8Jh">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11G-E4-8Jh">
                         <rect key="frame" x="20" y="32" width="72" height="72"/>
-                        <connections>
-                            <action selector="gravatarTapped" destination="uln-Hd-OJc" eventType="touchUpInside" id="kQu-u7-vJd"/>
-                        </connections>
                     </button>
                 </subviews>
                 <constraints>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -133,7 +133,7 @@ extension LoginEpilogueTableViewController {
                 removeSeparatorFor(cell)
                 if let info = epilogueUserInfo {
                     cell.stopSpinner()
-                    cell.configure(userInfo: info)
+                    cell.configure(userInfo: info, viewController: self)
                 } else {
                     cell.startSpinner()
                 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -17,7 +17,7 @@ protocol SignupEpilogueTableViewControllerDataSource: AnyObject {
     var username: String? { get }
 }
 
-class SignupEpilogueTableViewController: UITableViewController, EpilogueUserInfoCellViewControllerProvider {
+class SignupEpilogueTableViewController: UITableViewController {
 
     // MARK: - Properties
 
@@ -103,9 +103,8 @@ class SignupEpilogueTableViewController: UITableViewController, EpilogueUserInfo
             }
 
             if let epilogueUserInfo = epilogueUserInfo {
-                cell.configure(userInfo: epilogueUserInfo, showEmail: true, allowGravatarUploads: true)
+                cell.configure(userInfo: epilogueUserInfo, showEmail: true, allowGravatarUploads: true, viewController: self)
             }
-            cell.viewControllerProvider = self
             userInfoCell = cell
             return cell
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -435,6 +435,8 @@
 		0C8FC9A82A8BFAAE0059DCE4 /* NSItemProvider+Exportable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8FC9A62A8BFAAD0059DCE4 /* NSItemProvider+Exportable.swift */; };
 		0C8FC9AA2A8C57000059DCE4 /* ItemProviderMediaExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8FC9A92A8C57000059DCE4 /* ItemProviderMediaExporterTests.swift */; };
 		0C8FC9AC2A8C57930059DCE4 /* test-webp.webp in Resources */ = {isa = PBXBuildFile; fileRef = 0C8FC9AB2A8C57930059DCE4 /* test-webp.webp */; };
+		0CA1C8C12A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
+		0CA1C8C22A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -6115,6 +6117,7 @@
 		0C8FC9A62A8BFAAD0059DCE4 /* NSItemProvider+Exportable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+Exportable.swift"; sourceTree = "<group>"; };
 		0C8FC9A92A8C57000059DCE4 /* ItemProviderMediaExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemProviderMediaExporterTests.swift; sourceTree = "<group>"; };
 		0C8FC9AB2A8C57930059DCE4 /* test-webp.webp */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-webp.webp"; sourceTree = "<group>"; };
+		0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarMenuController.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
@@ -11103,6 +11106,7 @@
 			children = (
 				B53B02B21CAC3AAC003190A0 /* GravatarPickerViewController.swift */,
 				43FF64EE20DAA0840060A69A /* GravatarUploader.swift */,
+				0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */,
 			);
 			path = Gravatar;
 			sourceTree = "<group>";
@@ -22353,6 +22357,7 @@
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
 				465B097A24C877E500336B6C /* GutenbergLightNavigationController.swift in Sources */,
 				8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */,
+				0CA1C8C12A940EE300F691EE /* AvatarMenuController.swift in Sources */,
 				931215E8267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift in Sources */,
 				F17A2A1E23BFBD72001E96AC /* UIView+ExistingConstraints.swift in Sources */,
 				F1450CF32437DA3E00A28BFE /* MediaRequestAuthenticator.swift in Sources */,
@@ -24278,6 +24283,7 @@
 				93CDC72226CD342900C8A3A8 /* DestructiveAlertHelper.swift in Sources */,
 				DC76668426FD9AC9009254DD /* TimeZoneRow.swift in Sources */,
 				8B8E50B727A4692000C89979 /* DashboardPostListErrorCell.swift in Sources */,
+				0CA1C8C22A940EE300F691EE /* AvatarMenuController.swift in Sources */,
 				FABB22622602FC2C00C8785C /* ErrorStateViewConfiguration.swift in Sources */,
 				46B1A16C26A774E500F058AE /* CollapsableHeaderView.swift in Sources */,
 				FABB22632602FC2C00C8785C /* UIFont+Weight.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21190.

- Update the Gravatar flows to use PHPickerViewController
- Adds support for WebP (the existing solution doesn’t support it)

## Tests

> [!IMPORTANT]
> - Enable the "Native Photo Picker" feature flag before testing

**Update Gravatar (Profile)**

- Open "My Profile"
- Tap “Take Photo”
- Verify that the front facing camera opens by default
- Take a photo and verify that crop screen opens
- Crop and use the photo; verify that it gets uploaded

Verify that the "Choose from Device" flow also works

**Creating new Account**

- Create a new account with email
- Verify the same "Update Gravatar" steps from the first test

This is the screen/flow you are looking for:

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/cdecb6cf-8ac5-401b-9626-61a8960ce1ac


## Regression Notes
1. Potential unintended areas of impact: Gravatar update flow
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): h/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
