### PR TITLE
Remove Gravatar editing support from the Me screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -441,34 +441,7 @@ class MeViewController: UITableViewController {
 
     // MARK: - Private Properties
 
-    fileprivate lazy var headerView: MeHeaderView = {
-        let headerView = MeHeaderView()
-        headerView.onGravatarPress = { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.presentGravatarPicker(from: strongSelf)
-        }
-        headerView.onDroppedImage = { [weak self] image in
-            let imageCropViewController = ImageCropViewController(image: image)
-            imageCropViewController.maskShape = .square
-            imageCropViewController.shouldShowCancelButton = true
-
-            imageCropViewController.onCancel = { [weak self] in
-                self?.dismiss(animated: true)
-                self?.updateGravatarStatus(.idle)
-            }
-            imageCropViewController.onCompletion = { [weak self] image, _ in
-                self?.dismiss(animated: true)
-                self?.uploadGravatarImage(image)
-            }
-
-            let navController = UINavigationController(rootViewController: imageCropViewController)
-            navController.modalPresentationStyle = .formSheet
-            self?.present(navController, animated: true)
-        }
-        return headerView
-    }()
+    fileprivate lazy var headerView = MeHeaderView()
 
     /// Shows an actionsheet with options to Log In or Create a WordPress site.
     /// This is a temporary stop-gap measure to preserve for users only logged
@@ -506,26 +479,6 @@ extension MeViewController: SearchableActivityConvertable {
         }
 
         return Set(keywordArray)
-    }
-}
-
-// MARK: - Gravatar uploading
-//
-extension MeViewController: GravatarUploader {
-    /// Update the UI based on the status of the gravatar upload
-    func updateGravatarStatus(_ status: GravatarUploaderStatus) {
-        switch status {
-        case .uploading(image: let newGravatarImage):
-            headerView.showsActivityIndicator = true
-            headerView.isUserInteractionEnabled = false
-            headerView.overrideGravatarImage(newGravatarImage)
-        case .finished:
-            reloadViewModel()
-            fallthrough
-        default:
-            headerView.showsActivityIndicator = false
-            headerView.isUserInteractionEnabled = true
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/Views/Header/MeHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Me/Views/Header/MeHeaderView.h
@@ -1,16 +1,10 @@
 #import <UIKit/UIKit.h>
 
-typedef void (^MeHeaderViewCallback)(void);
-typedef void (^MeHeaderViewDropCallback)(UIImage * _Nonnull image);
-
 @interface MeHeaderView : UIView
 
 @property (nonatomic, nullable, copy) NSString *displayName;
 @property (nonatomic, nonnull, copy) NSString *username;
 @property (nonatomic, nullable, copy) NSString *gravatarEmail;
-@property (nonatomic, nullable, copy) MeHeaderViewCallback onGravatarPress;
-@property (nonatomic, nullable, copy) MeHeaderViewDropCallback onDroppedImage;
-@property (nonatomic, assign) BOOL showsActivityIndicator;
 
 /// Overrides the current Gravatar Image (set via Email) with a given image reference.
 ///

--- a/WordPress/Classes/ViewRelated/Me/Views/Header/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/Views/Header/MeHeaderView.m
@@ -2,22 +2,17 @@
 #import "Blog.h"
 #import "WordPress-Swift.h"
 
-
-
 const CGFloat MeHeaderViewHeight = 154;
 const CGFloat MeHeaderViewGravatarSize = 64.0;
 const CGFloat MeHeaderViewLabelHeight = 20.0;
 const CGFloat MeHeaderViewVerticalMargin = 20.0;
 const CGFloat MeHeaderViewVerticalSpacing = 10.0;
-const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 
 @interface MeHeaderView () <UIDropInteractionDelegate>
 
 @property (nonatomic, strong) UIImageView *gravatarImageView;
 @property (nonatomic, strong) UILabel *displayNameLabel;
 @property (nonatomic, strong) UILabel *usernameLabel;
-@property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
-@property (nonatomic, strong) UIView *gravatarDropTarget;
 @property (nonatomic, strong) UIStackView *stackView;
 
 @end
@@ -39,12 +34,6 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 
         _stackView = [self newStackView];
         [self addSubview:_stackView];
-
-        _gravatarDropTarget = [self newDropTargetForGravatar];
-        [self addSubview:_gravatarDropTarget];
-
-        _activityIndicator = [self newSpinner];
-        [_gravatarImageView addSubview:_activityIndicator];
 
         [self configureConstraints];
     }
@@ -80,21 +69,6 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
     // Since this view is only visible to the current user, we should show all ratings
     [self.gravatarImageView downloadGravatarWithEmail:gravatarEmail rating:GravatarRatingsX];
     _gravatarEmail = gravatarEmail;
-}
-
-- (BOOL)showsActivityIndicator
-{
-    // Note: ActivityIndicator will be visible only while it's being animated
-    return [_activityIndicator isAnimating];
-}
-
-- (void)setShowsActivityIndicator:(BOOL)showsActivityIndicator
-{
-    if (showsActivityIndicator) {
-        [_activityIndicator startAnimating];
-    } else {
-        [_activityIndicator stopAnimating];
-    }
 }
 
 - (void)overrideGravatarImage:(UIImage *)gravatarImage
@@ -138,9 +112,6 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 
     [NSLayoutConstraint activateConstraints:constraints];
 
-    [self.gravatarDropTarget pinSubviewToAllEdgeMargins:self.gravatarImageView];
-    [self.gravatarImageView pinSubviewAtCenter:_activityIndicator];
-    
     [super setNeedsUpdateConstraints];
 }
 
@@ -197,126 +168,7 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
     imageView.clipsToBounds = YES;
     imageView.translatesAutoresizingMaskIntoConstraints = NO;
     imageView.userInteractionEnabled = YES;
-    
-    UILongPressGestureRecognizer *recognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
-                                                                                             action:@selector(handleHeaderPress:)];
-    recognizer.minimumPressDuration = MeHeaderViewMinimumPressDuration;
-    [imageView addGestureRecognizer:recognizer];
-    
     return imageView;
-}
-
-- (UIView *)newDropTargetForGravatar
-{
-    UIView *dropTarget = [UIView new];
-    [dropTarget setTranslatesAutoresizingMaskIntoConstraints:NO];
-    dropTarget.backgroundColor = [UIColor clearColor];
-    
-    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                                                action:@selector(handleHeaderPress:)];
-    singleTap.numberOfTapsRequired = 1;
-    [dropTarget addGestureRecognizer:singleTap];
-
-    UIDropInteraction *dropInteraction = [[UIDropInteraction alloc] initWithDelegate:self];
-    [dropTarget addInteraction:dropInteraction];
-    
-    return dropTarget;
-}
-
-- (UIActivityIndicatorView *)newSpinner
-{
-    UIActivityIndicatorView *indicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
-    indicatorView.hidesWhenStopped = YES;
-    indicatorView.translatesAutoresizingMaskIntoConstraints = NO;
-    
-    return indicatorView;
-}
-
-
-#pragma mark - UITapGestureRecognizer Handler
-
-- (IBAction)handleHeaderPress:(UIGestureRecognizer *)sender
-{
-    // Touch Down: Depress the gravatarImageView
-    if (sender.state == UIGestureRecognizerStateBegan) {
-        [_gravatarImageView depressSpringAnimation:nil];
-        return;
-    }
-    
-    // Touch Up: Normalize the gravatarImageView
-    if (sender.state == UIGestureRecognizerStateEnded) {
-        [_gravatarImageView normalizeSpringAnimation:nil];
-        
-        // Hit the callback only if we're still within Gravatar Bounds
-        CGPoint touchInGravatar = [sender locationInView:_gravatarImageView];
-        BOOL gravatarContainsTouch = CGRectContainsPoint(_gravatarImageView.bounds, touchInGravatar);
-
-        if (self.onGravatarPress && gravatarContainsTouch) {
-            self.onGravatarPress();
-        }
-    }
-}
-
-#pragma mark - Drop Interaction Handler
-
-- (BOOL)dropInteraction:(UIDropInteraction *)interaction
-       canHandleSession:(id<UIDropSession>)session
-{
-    BOOL isAnImage = [session canLoadObjectsOfClass:[UIImage self]];
-    BOOL isSingleImage = [session.items count] == 1;
-    return (isAnImage && isSingleImage);
-}
-
-- (void)dropInteraction:(UIDropInteraction *)interaction
-        sessionDidEnter:(id<UIDropSession>)session
-{
-    [self.gravatarImageView depressSpringAnimation:nil];
-}
-
-- (UIDropProposal *)dropInteraction:(UIDropInteraction *)interaction
-                   sessionDidUpdate:(id<UIDropSession>)session
-{
-    CGPoint dropLocation = [session locationInView:self.gravatarDropTarget];
-    
-    UIDropOperation dropOperation = UIDropOperationCancel;
-    
-    if (CGRectContainsPoint(self.gravatarDropTarget.bounds, dropLocation)) {
-        dropOperation = UIDropOperationCopy;
-    }
-    
-    UIDropProposal *dropProposal = [[UIDropProposal alloc] initWithDropOperation:dropOperation];
-    
-    return  dropProposal;
-}
-
-- (void)dropInteraction:(UIDropInteraction *)interaction
-            performDrop:(id<UIDropSession>)session
-{
-    [self setShowsActivityIndicator:YES];
-    [session loadObjectsOfClass:[UIImage self] completion:^(NSArray *images) {
-        UIImage *image = [images firstObject];
-        if (self.onDroppedImage) {
-            self.onDroppedImage(image);
-        }
-    }];
-}
-
-- (void)dropInteraction:(UIDropInteraction *)interaction
-           concludeDrop:(id<UIDropSession>)session
-{
-    [self.gravatarImageView normalizeSpringAnimation:nil];
-}
-
-- (void)dropInteraction:(UIDropInteraction *)interaction
-         sessionDidExit:(id<UIDropSession>)session
-{
-    [self.gravatarImageView normalizeSpringAnimation:nil];
-}
-
-- (void)dropInteraction:(UIDropInteraction *)interaction
-         sessionDidEnd:(id<UIDropSession>)session
-{
-    [self.gravatarImageView normalizeSpringAnimation:nil];
 }
 
 @end


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21190.

Discussed here: p1692351642416369/1692310034.174449-slack-C04SFL0RP51.

## To test:

- Verify that the avatar is no longer editable on the Me screen

## Regression Notes
1. Potential unintended areas of impact: Gravatar selection on the Me screen
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
