### PR TITLE
Use optional chaining to prevent crash in `GutenbergViewController`

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1086,7 +1086,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidRequestSendEventToHost(_ eventName: String, properties: [AnyHashable: Any]) -> Void {
-        post.managedObjectContext!.perform {
+        post.managedObjectContext?.perform {
             WPAnalytics.trackBlockEditorEvent(eventName, properties: properties, blog: self.post.blog)
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21114

## Description

As per the description in https://github.com/wordpress-mobile/WordPress-iOS/issues/21114, a crash was happening when the `post`'s `managedObjectContext` is nil on this line:

https://github.com/wordpress-mobile/WordPress-iOS/blob/6f8b307145cc8003ea96f9d55d5d9ef7f5d51633/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift#L1087-L1089

It would be ideal to find where the `post` is nil. However, attempts to reproduce the crash and root cause of the issue haven't yielded results as of yet. 

As a workaround, optional chaining is added to the problematic code in this PR. This will prevent a crash at times when `managedObjectContext` is nil. As the editor event shouldn't fire when the `managedObjectContext` is nil anyway, there should be no change to any existing functionality.

## Testing

The fix should not change existing functionality, however it'd be useful to perform regression testing: 

* Launch the block editor.
* Insert a block.
* ℹ️ Expected: `wpios_editor_block_inserted` event is triggered with the relevant properties.

## Regression Notes

1. Potential unintended areas of impact

The event could stop being triggered as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually confirmed that the event still fires after a block is inserted into the editor.

3. What automated tests I added (or what prevented me from doing so)

There are no existing tests related to `WPAnalyticsEvent`. As I work primarily as a React Native developer, I do not feel confident in creating the necessary structure for such tests from scratch.

<hr />

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.