### PR TITLE
[UI Tests] Fix testPagesCardHeaderNavigation() by defining a visible area.

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -22,7 +22,6 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
-        "DashboardTests\/testPagesCardHeaderNavigation()",
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",

--- a/WordPress/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
+++ b/WordPress/UITestsFoundation/XCUIApplication+ScrollDownToElement.swift
@@ -21,10 +21,10 @@ extension XCUIApplication {
     /// Scrolls down to element until it becomes hittable.
     /// After that attempts to scroll it to the screen top.
     func scrollDownToElement(element: XCUIElement, maxScrolls: Int = 10) {
-        for _ in 0..<maxScrolls {
-            if !element.isFullyVisibleOnScreen() {
-                scrollDown()
-            }
+        var scrollCount = 0
+        while !element.isWithinVisibleArea() && scrollCount < maxScrolls {
+            scrollDown()
+            scrollCount += 1
         }
     }
 

--- a/WordPress/UITestsFoundation/XCUIElement+Utils.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Utils.swift
@@ -9,4 +9,21 @@ public extension XCUIElement {
 
         startCoordinate.press(forDuration: 0.01, thenDragTo: destination)
     }
+
+    // Returns true if the XCUIElement is within a visible area,
+    // defined by the vertical space between two other elements
+    // and the device screen width.
+    func isWithinVisibleArea(_ topElement: XCUIElement = XCUIApplication().navigationBars.firstMatch,
+                             _ bottomElement: XCUIElement = XCUIApplication().tabBars.firstMatch,
+                             app: XCUIApplication = XCUIApplication()) -> Bool {
+        guard exists && frame.isEmpty == false && isHittable else { return false }
+
+        let deviceScreenFrame = app.windows.element(boundBy: 0).frame
+        let deviceScreenWidth = deviceScreenFrame.size.width
+        let visibleAreaTop = topElement.frame.origin.y + topElement.frame.size.height
+        let visibleAreaHeight = bottomElement.frame.origin.y - visibleAreaTop
+        let visibleAreaFrame = CGRect(x: 0, y: visibleAreaTop, width: deviceScreenWidth, height: visibleAreaHeight)
+
+        return visibleAreaFrame.contains(frame)
+    }
 }


### PR DESCRIPTION
### Description
`testPagesCardHeaderNavigation()` started failing because the Pages card is scrolled into the device screen rectangle, so `isFullyVisibleOnScreen() `returned TRUE. However, part of the card was behind the Main Navigation Tab Bar, then the test failed because 'Create another page' button was not hittable.

<img width="723" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/28b0da68-b653-45bb-9b38-d9c8e8c9c1bb">

### Solution
This PR adds a XCUIElement extension that defines a visible area defined by the vertical space between two elements and the device screen width and checks if the target element (Pages card in this case) is inside it. Please check the diagram below as reference for the calculations.

<img width="365" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/71119d92-92e0-4605-89c6-5a829ee1ce3e">

### Testing
Ci should be 🟢 