### PR TITLE
Update JTAppleCalendar to address a compiling issue in Xcode 15

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -122,7 +122,7 @@ abstract_target 'Apps' do
   pod 'AlamofireImage', '3.5.2'
   pod 'AlamofireNetworkActivityIndicator', '~> 2.4'
   pod 'FSInteractiveMap', git: 'https://github.com/wordpress-mobile/FSInteractiveMap.git', tag: '0.2.0'
-  pod 'JTAppleCalendar', '~> 8.0.2'
+  pod 'JTAppleCalendar', '~> 8.0.5'
   pod 'CropViewController', '2.5.3'
   pod 'SDWebImage', '~> 5.11.1'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,7 +41,7 @@ PODS:
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (1.7.2)
   - Gutenberg (1.102.0)
-  - JTAppleCalendar (8.0.3)
+  - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.4)
   - MediaEditor (1.2.2):
     - CropViewController (~> 2.5.3)
@@ -154,7 +154,7 @@ DEPENDENCIES:
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.102.0.podspec`)
-  - JTAppleCalendar (~> 8.0.2)
+  - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
   - MRProgress (= 0.8.3)
@@ -260,7 +260,7 @@ SPEC CHECKSUMS:
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   Gutenberg: 315b07b2b9307335c0424b06626fae5e58b16729
-  JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
+  JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
@@ -294,6 +294,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 25832366684a36de2e9c20ef39f83bb599f54b63
+PODFILE CHECKSUM: 91e6d9b1f76f7e82a99373169d8c164b236bde2a
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
What says in the title.

I had updated this library before in https://github.com/wordpress-mobile/WordPress-iOS/pull/21236, but the changes were reverted, probably during a merge conflict. @mokagio, you actually warned me about this and suggested updating `Podfile`. Here I am, making a second attempt, but with `Podfile` updated. 😄 


## Regression Notes
None

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A