### PR TITLE
[UI Tests] - Add Save a Post from Reader Test

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -574,12 +574,14 @@ private extension NoResultsViewController {
     func configureForAccessibility() {
         // Reset
         view.isAccessibilityElement = false
+        view.accessibilityIdentifier = nil
         view.accessibilityLabel = nil
         view.accessibilityElements = nil
         view.accessibilityTraits = .none
 
         if displayTitleViewOnly {
             view.isAccessibilityElement = true
+            view.accessibilityIdentifier = .noResultsTitleViewAccessibilityIdentifier
             view.accessibilityLabel = titleLabel.text
             view.accessibilityTraits = .staticText
         } else {
@@ -587,10 +589,18 @@ private extension NoResultsViewController {
 
             labelStackView.accessibilityTraits = .staticText
             labelStackView.isAccessibilityElement = true
+            labelStackView.accessibilityIdentifier = .noResultsLabelStackViewAccessibilityIdentifier
             labelStackView.accessibilityLabel = [
                 titleLabel.text,
                 subtitleTextView.isHidden ? nil : subtitleTextView.attributedText.string
             ].compactMap { $0 }.joined(separator: ". ")
         }
     }
+}
+
+// MARK: - Accessibility Identifiers
+
+private extension String {
+    static let noResultsTitleViewAccessibilityIdentifier = "no-results-title-view"
+    static let noResultsLabelStackViewAccessibilityIdentifier = "no-results-label-stack-view"
 }

--- a/WordPress/UITests/README.md
+++ b/WordPress/UITests/README.md
@@ -52,7 +52,7 @@ The following flows are covered/planned to be covered by UI tests. Tests that ar
     - [x] View Last Post in Safari
     - [x] Add Comment to Post
     - [x] Follow New Topic on Discover Tab
-    - [ ] Save a Post
+    - [x] Save a Post
     - [ ] Like a Post 
 9. Jetpack Settings
     - [ ] Open and View Jetpack Settings Options

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -47,12 +47,14 @@ class ReaderTests: XCTestCase {
     }
 
     func testSavePost() throws {
+        // Get saved post label
         let (updatedReaderScreen, savedPostLabel) = try ReaderScreen()
             .openSavedPosts()
             .verifySavedPosts(state: .withoutSavedPosts)
             .openFollowing()
             .saveFirstPost()
 
+        // Open saved posts tab and validate that the correct saved post is displayed
         updatedReaderScreen
             .openSavedPosts()
             .verifySavedPosts(state: .withSavedPosts, postLabel: savedPostLabel)

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -17,28 +17,24 @@ class ReaderTests: XCTestCase {
         takeScreenshotOfFailedTest()
     }
 
-    let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
-
-    let commentContent = "Test comment."
-
     func testViewPost() throws {
         try ReaderScreen()
             .openLastPost()
-            .verifyPostContentEquals(expectedPostContent)
+            .verifyPostContentEquals(.expectedPostContent)
     }
 
     func testViewPostInSafari() throws {
         try ReaderScreen()
             .openLastPostInSafari()
-            .verifyPostContentEquals(expectedPostContent)
+            .verifyPostContentEquals(.expectedPostContent)
     }
 
     func testAddCommentToPost() throws {
         try ReaderScreen()
             .openLastPostComments()
             .verifyCommentsListEmpty()
-            .replyToPost(commentContent)
-            .verifyCommentSent(commentContent)
+            .replyToPost(.commentContent)
+            .verifyCommentSent(.commentContent)
     }
 
     func testFollowNewTopicOnDiscover() throws {
@@ -49,4 +45,23 @@ class ReaderTests: XCTestCase {
             .followTopic()
             .verifyTopicFollowed()
     }
+
+    func testSavePost() throws {
+        let (updatedReaderScreen, savedPostLabel) = try ReaderScreen()
+            .openSavedPosts()
+            .verifySavedPosts(state: .withoutSavedPosts)
+            .openFollowing()
+            .saveFirstPost()
+
+        updatedReaderScreen
+            .openSavedPosts()
+            .verifySavedPosts(state: .withSavedPosts, postLabel: savedPostLabel)
+    }
+}
+
+private extension String {
+    static let commentContent = "🤖👍 #Testing 123 це тестовий коментар"
+    static let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
+    static let withoutSavedPosts = "without posts"
+    static let withSavedPosts = "with posts"
 }

--- a/WordPress/UITestsFoundation/FancyAlertComponent.swift
+++ b/WordPress/UITestsFoundation/FancyAlertComponent.swift
@@ -29,10 +29,6 @@ public class FancyAlertComponent: ScreenObject {
     }
 
     public func acceptAlert() {
-        XCTAssert(defaultAlertButton.waitForExistence(timeout: 3))
-        XCTAssert(defaultAlertButton.waitForIsHittable(timeout: 3))
-
-        XCTAssert(defaultAlertButton.isHittable)
         defaultAlertButton.tap()
     }
 

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -15,6 +15,10 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Reader"]
     }
 
+    private let savedButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Saved"]
+    }
+
     private let visitButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Visit"]
     }
@@ -43,13 +47,24 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["topics-card-cell-button"]
     }
 
+    private let noResultsViewGetter: (XCUIApplication) -> XCUIElement = {
+        $0.staticTexts["no-results-label-stack-view"]
+    }
+
+    private let savePostButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Save post"]
+    }
+
     var backButton: XCUIElement { backButtonGetter(app) }
     var discoverButton: XCUIElement { discoverButtonGetter(app) }
     var dismissButton: XCUIElement { dismissButtonGetter(app) }
     var followButton: XCUIElement { followButtonGetter(app) }
     var followingButton: XCUIElement { followingButtonGetter(app) }
+    var noResultsView: XCUIElement { noResultsViewGetter(app) }
     var readerButton: XCUIElement { readerButtonGetter(app) }
     var readerTable: XCUIElement { readerTableGetter(app) }
+    var savePostButton: XCUIElement { savePostButtonGetter(app) }
+    var savedButton: XCUIElement { savedButtonGetter(app) }
     var topicCellButton: XCUIElement { topicCellButtonGetter(app) }
     var topicNavigationBar: XCUIElement { topicNavigationBarGetter(app) }
     var visitButton: XCUIElement { visitButtonGetter(app) }
@@ -131,10 +146,22 @@ public class ReaderScreen: ScreenObject {
         return self
     }
 
+    public func openSavedPosts() -> Self {
+        savedButton.tap()
+
+        return self
+    }
+
     public func verifyTopicLoaded() -> Self {
         XCTAssertTrue(topicNavigationBar.waitForExistence(timeout: 3))
         XCTAssertTrue(readerButton.waitForExistence(timeout: 3))
         XCTAssertTrue(followButton.waitForExistence(timeout: 3))
+
+        return self
+    }
+
+    public func openFollowing() -> Self {
+        followingButton.tap()
 
         return self
     }
@@ -152,4 +179,33 @@ public class ReaderScreen: ScreenObject {
 
         return self
     }
+
+    public func saveFirstPost() -> (ReaderScreen, String) {
+        XCTAssertTrue(readerTable.waitForExistence(timeout: 3))
+        let postLabel = readerTable.cells.firstMatch.label
+        savePostButton.firstMatch.tap()
+
+        return (self, postLabel)
+    }
+
+    @discardableResult
+    public func verifySavedPosts(state: String, postLabel: String? = nil) -> Self {
+        if readerTable.cells.count > 0 {
+            XCTAssertEqual(readerTable.cells.firstMatch.label, postLabel, "Post displayed does not match saved post!")
+            XCTAssertEqual(readerTable.cells.count, 1, "There should only be 1 post!")
+            XCTAssertEqual(state, .withSavedPosts)
+        } else {
+            XCTAssertTrue(noResultsView.waitForExistence(timeout: 3))
+            XCTAssertTrue(readerTable.label == .emptyListLabel)
+            XCTAssertEqual(state, .withoutSavedPosts)
+        }
+
+        return self
+    }
+}
+
+private extension String {
+    static let emptyListLabel = "Empty list"
+    static let withoutSavedPosts = "without posts"
+    static let withSavedPosts = "with posts"
 }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -180,10 +180,15 @@ public class ReaderScreen: ScreenObject {
         return self
     }
 
-    public func saveFirstPost() -> (ReaderScreen, String) {
+    public func saveFirstPost() throws -> (ReaderScreen, String) {
         XCTAssertTrue(readerTable.waitForExistence(timeout: 3))
         let postLabel = readerTable.cells.firstMatch.label
         savePostButton.firstMatch.tap()
+
+        // An alert about saved post is displayed the first time a post is saved
+        if let alert = try? FancyAlertComponent() {
+            alert.acceptAlert()
+        }
 
         return (self, postLabel)
     }


### PR DESCRIPTION
### Description
This PR adds a new test `testSavePost()` as part of the Reader test class. The flow of the test as follows: Go to Reader > Go to `Saved` tab > Verify that there are no saved posts > Go back to `Following` tab > Save the first post >  Go back to `Saved` tab and verify that the saved post is displayed.

This test also follows a similar approach as in the test added in https://github.com/wordpress-mobile/WordPress-iOS/pull/21382 where the first part of the test returns a value that will be used in the second part of the test. 

Other changes/clean-ups that were done that I thought were reasonable to be part of this PR:
1. Moved all strings to a private extension for better maintenance of strings on the test class
2. Updated `commentContent` value to include numbers, emoji, and characters other than English to ensure that the text field accepts those
3. Remove all the "waits" in `FancyAlertComponent().acceptAlert()` as I checked that all the times it's called, the check for that element already happens as part of `init` / `isLoaded`, so those waits weren't necessary:
```
    t =    40.28s Confirm first element from `expectedElementGetters` is loaded on screen UITestsFoundation.FancyAlertComponent
    t =    41.32s     Checking `Expect predicate `isHittable == 1` for object "fancy-alert-view-default-button" Button`
    t =    41.32s         Find the "fancy-alert-view-default-button" Button
    t =    41.44s         Capturing element debug description
```

### Testing
New test `testSavePost()` should work as expected