### PR TITLE
Disable one of the new video export test cases

### DIFF
--- a/WordPress/WordPressTest/ItemProviderMediaExporterTests.swift
+++ b/WordPress/WordPressTest/ItemProviderMediaExporterTests.swift
@@ -77,6 +77,8 @@ final class ItemProviderMediaExporterTests: XCTestCase {
     // MARK: - Video
 
     func testThatVideoIsExported() throws {
+        try XCTSkipIf(true, "This test takes too long. Replace the video with something that gets transcoded quicker.")
+
         // GIVEN a video
         let provider = try makeProvider(forResource: "test-video-device-gps", withExtension: "m4v", type: .mpeg4Movie)
 


### PR DESCRIPTION
Fixes build failure reported here: p1692800229451039-slack-C5ALGJYEP by disabling one of the tests introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/21343

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
