### PR TITLE
[UI Test] Enhance EditorPostSettings Screen Object and reduce testCreateScheduledPost() flakiness.

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -35,8 +35,8 @@ public class EditorPostSettings: ScreenObject {
         $0.buttons["Next Month"]
     }
 
-    private let firstCalendarDayLabelGetter: (XCUIApplication) -> XCUIElement = {
-        $0.staticTexts["1"]
+    private let firstCalendarDayButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons.containing(.staticText, identifier: "1").element
     }
 
     private let doneButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -48,7 +48,7 @@ public class EditorPostSettings: ScreenObject {
     var dateSelector: XCUIElement { dateSelectorGetter(app) }
     var doneButton: XCUIElement { doneButtonGetter(app) }
     var featuredImageButton: XCUIElement { featuredImageButtonGetter(app) }
-    var firstCalendarDayLabel: XCUIElement { firstCalendarDayLabelGetter(app) }
+    var firstCalendarDayButton: XCUIElement { firstCalendarDayButtonGetter(app) }
     var nextMonthButton: XCUIElement { nextMonthButtonGetter(app) }
     var publishDateButton: XCUIElement { publishDateButtonGetter(app) }
     var settingsTable: XCUIElement { settingsTableGetter(app) }
@@ -137,7 +137,7 @@ public class EditorPostSettings: ScreenObject {
 
         // Selects the first day of the next month
         nextMonthButton.tap()
-        firstCalendarDayLabel.tap()
+        firstCalendarDayButton.tap()
 
         doneButton.tap()
         return self


### PR DESCRIPTION
### Description
`testCreateScheduledPost()` is currently [the least reliable ui test in iPad with ~85% at the time of writing](https://buildkite.com/organizations/automattic/analytics/suites/jetpack-ios-ui-tests-ipad/tests?branch=trunk&filter=reliability&period=28days). While working on another tests, `testCreateScheduledPost()` started consistently failing locally for me, so I could take a closer look. The error I've seen doesn't match all the errors in CI but fixing it is a good improvement at least.

The test fails when trying to select the day in the Calendar. The element being tapped is `staticText["1"]` which was not hittable in my case. Checking the hierarchy, `staticText["1"]` in under a button that is hittable. This PR changes the `firstCalendarDay` locator from `staticText["1"]` to a button containing `staticText["1"]`.

<img width="928" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/21460be1-4b8f-4d03-8ed2-b4b2ea4a2eb1">

### Testing
Run the test locally on iPhone and iPad.
CI must be 🟢.
