### PR TITLE
Move PHPickerResult.loadImage

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
@@ -196,7 +196,7 @@ extension SiteIconPickerPresenter: PHPickerViewControllerDelegate {
         WPAnalytics.track(.siteSettingsSiteIconGalleryPicked)
         self.showLoadingMessage()
         self.originalMedia = nil
-        MediaPickerMenu.loadImage(for: result) { [weak self] image, error in
+        PHPickerResult.loadImage(for: result) { [weak self] image, error in
             if let image {
                 self?.showImageCropViewController(image, presentingViewController: picker)
             } else {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
@@ -31,7 +31,7 @@ final class AvatarMenuController: PHPickerViewControllerDelegate, ImagePickerCon
             presentingViewController?.dismiss(animated: true)
             return
         }
-        MediaPickerMenu.loadImage(for: result) { [weak self] image, _ in
+        PHPickerResult.loadImage(for: result) { [weak self] image, _ in
             if let image {
                 self?.showCropViewController(with: image)
             } else {

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -37,7 +37,7 @@ struct MediaPickerMenu {
 extension MediaPickerMenu {
     /// Returns an action for picking photos from the device's Photos library.
     ///
-    /// - note: Use `MediaPicker.loadImage(for:)` to retrieve an image from the result.
+    /// - note: Use `PHPickerResult.loadImage(for:)` to retrieve an image from the result.
     func makePhotosAction(delegate: PHPickerViewControllerDelegate) -> UIAction {
         UIAction(
             title: Strings.pickFromPhotosLibrary,
@@ -64,45 +64,6 @@ extension MediaPickerMenu {
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = delegate
         presentingViewController?.present(picker, animated: true)
-    }
-
-    /// Retrieves an image for the given picker result.
-    ///
-    /// - parameter completion: The completion closure that gets called on the main thread.
-    static func loadImage(for result: PHPickerResult, _ completion: @escaping (UIImage?, Error?) -> Void) {
-        let provider = result.itemProvider
-        if provider.canLoadObject(ofClass: UIImage.self) {
-            provider.loadObject(ofClass: UIImage.self) { value, error in
-                DispatchQueue.main.async {
-                    if let image = value as? UIImage {
-                        completion(image, nil)
-                    } else {
-                        DDLogError("Failed to load image for provider with registered types \(provider.registeredTypeIdentifiers) with error \(String(describing: error))")
-
-                        completion(nil, error)
-                    }
-                }
-            }
-        } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
-            // This is required for certain image formats, such as WebP, for which
-            // NSItemProvider doesn't automatically provide the `UIImage` representation.
-            provider.loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
-                let image = data.flatMap(UIImage.init)
-                DispatchQueue.main.async {
-                    if let image {
-                        completion(image, nil)
-                    } else {
-                        DDLogError("Failed to load image for provider with registered types \(provider.registeredTypeIdentifiers) with error \(String(describing: error))")
-                        completion(nil, error)
-                    }
-                }
-            }
-        } else {
-            DDLogError("No image representation available for provider with registered types: \(provider.registeredTypeIdentifiers)")
-            DispatchQueue.main.async {
-                completion(nil, nil)
-            }
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/PHPickerController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Media/PHPickerController+Extensions.swift
@@ -29,3 +29,50 @@ extension PHPickerFilter {
         }
     }
 }
+
+extension PHPickerResult {
+    /// Retrieves an image for the given picker result.
+    ///
+    /// - parameter completion: The completion closure that gets called on the main thread.
+    static func loadImage(for result: PHPickerResult, _ completion: @escaping (UIImage?, Error?) -> Void) {
+        loadImage(for: result.itemProvider, completion)
+    }
+
+    /// Retrieves an image for the given picker result.
+    ///
+    /// - parameter completion: The completion closure that gets called on the main thread.
+    static func loadImage(for provider: NSItemProvider, _ completion: @escaping (UIImage?, Error?) -> Void) {
+        if provider.canLoadObject(ofClass: UIImage.self) {
+            provider.loadObject(ofClass: UIImage.self) { value, error in
+                DispatchQueue.main.async {
+                    if let image = value as? UIImage {
+                        completion(image, nil)
+                    } else {
+                        DDLogError("Failed to load image for provider with registered types \(provider.registeredTypeIdentifiers) with error \(String(describing: error))")
+
+                        completion(nil, error)
+                    }
+                }
+            }
+        } else if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+            // This is required for certain image formats, such as WebP, for which
+            // NSItemProvider doesn't automatically provide the `UIImage` representation.
+            provider.loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
+                let image = data.flatMap(UIImage.init)
+                DispatchQueue.main.async {
+                    if let image {
+                        completion(image, nil)
+                    } else {
+                        DDLogError("Failed to load image for provider with registered types \(provider.registeredTypeIdentifiers) with error \(String(describing: error))")
+                        completion(nil, error)
+                    }
+                }
+            }
+        } else {
+            DDLogError("No image representation available for provider with registered types: \(provider.registeredTypeIdentifiers)")
+            DispatchQueue.main.async {
+                completion(nil, nil)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Small refactoring: `MediaPiacker` wasn't the right place for `loadImage`. No functional changes.

To test: n/a

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
