### PR TITLE
Reset reader topic observer upon re-assignment

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -181,6 +181,14 @@ import Combine
                 siteID = nil
                 tagSlug = nil
             }
+
+            // Make sure the header is in-sync with the `readerTopic` object if it exists.
+            readerTopicChangesObserver?.cancel()
+            readerTopicChangesObserver = readerTopic?
+                .objectWillChange
+                .sink { [weak self] _ in
+                    self?.updateStreamHeaderIfNeeded()
+                }
         }
     }
 
@@ -206,7 +214,7 @@ import Combine
 
     let ghostableTableView = UITableView()
 
-    private var cancellables = Set<AnyCancellable>()
+    private var readerTopicChangesObserver: AnyCancellable?
 
     // MARK: - Factory Methods
 
@@ -361,14 +369,6 @@ import Combine
         } else if (siteID != nil || tagSlug != nil) && isShowingResultStatusView == false {
             displayLoadingStream()
         }
-
-        // Make sure the header is in-sync with the `readerTopic` object if it exists.
-        readerTopic?
-            .objectWillChange
-            .sink { [weak self] _ in
-                self?.updateStreamHeaderIfNeeded()
-            }
-            .store(in: &cancellables)
     }
 
 


### PR DESCRIPTION
## Issue

This is an issue that only appears on development build, not in App Store builds. Thanks @jostnes for catching the issue!

An assertion is triggered when viewing all saved post on a development build. To reproduce this issue:
1. Launch the app from Xcode.
2. Go to reader and tap the "save for later" button (the one with a bookmark image)
3. A toast shows up immediately, with a "View All" button in it.
4. Tap the "View All" button.
5. Unexpected behaviour: App crashes and Xcode stops at `ReaderStreamViewController.updateStreamHeaderIfNeeded`.

## Cause

To fix issue #20167, PR #20168 added an `readerTopic` observer in `viewDidLoad`, so that every changes on the `readerTopic` instance lead to a call to the `updateStreamHeaderIfNeeded` function which fixes the issue because the header view is now in-sync with the model state.

However, during the lifecycle of the `ReaderStreamViewController`, the `readerTopic` variable may get assigned to another instance. Since the observer is only registered once upon creating the view controller, when the `readerTopic` variable is re-assigned, the observe keeps observing the old instance's changes. When the old instance is changed, the `updateStreamHeaderIfNeeded` is called and checks the current `readerTopic` value which would fail the nil check assertion because the new value may be nil. And that's what happened in the described issue above.

What this PR does is moving the observing code to the `readerTopic` variable's `didSet` property observer, so that we can stop observing the old `readerTopic` instance and start observing the new instance. 

## Test Instructions

Verify the assertion does not get triggered anymore. Also, verify issue #20167 is still fixed.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The "Test Instructions"

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A