### PR TITLE
Checkout Gutenberg source code when generating `strings`

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -142,10 +142,12 @@ platform :ios do
     gutenberg_clone_name = 'Gutenberg-Strings-Clone'
     Dir.mktmpdir do |tempdir|
       Dir.chdir(tempdir) do
-        sh("git clone --depth 1 https://github.com/#{GITHUB_ORG}/#{REPO_NAME} #{gutenberg_clone_name}")
+        repo_url = "https://github.com/#{GITHUB_ORG}/#{REPO_NAME}"
+        UI.message("Cloning Gutenberg from #{repo_url} into #{gutenberg_clone_name}. This might take a few minutes…")
+        sh("git clone --depth 1 #{repo_url} #{gutenberg_clone_name}")
         Dir.chdir(gutenberg_clone_name) do
           if GUTENBERG_CONFIG[:tag]
-            sh("git fetch origin refs/tags/#{GUTENBERG_CONFIG[:tag]}:refs/tags/#{GUTENBERG_CONFIG[:tag]} --verbose")
+            sh("git fetch origin refs/tags/#{GUTENBERG_CONFIG[:tag]}:refs/tags/#{GUTENBERG_CONFIG[:tag]}")
             sh("git checkout refs/tags/#{GUTENBERG_CONFIG[:tag]}")
           else
             sh("git fetch origin #{ref}")

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -110,8 +110,6 @@ UPLOAD_TO_APP_STORE_COMMON_PARAMS = {
   app_rating_config_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'metadata', 'ratings_config.json')
 }.freeze
 
-
-
 #################################################
 # Lanes
 #################################################
@@ -126,25 +124,56 @@ platform :ios do
   lane :generate_strings_file_for_glotpress do |options|
     cocoapods
 
-    wordpress_en_lproj = File.join('WordPress', 'Resources', 'en.lproj')
-    ios_generate_strings_file_from_code(
-      paths: ['WordPress/', 'Pods/WordPress*/', 'Pods/WPMediaPicker/', 'WordPressShared/WordPressShared/', 'Pods/Gutenberg/'],
-      exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],
-      routines: ['AppLocalizedString'],
-      output_dir: wordpress_en_lproj
-    )
+    # On top of fetching the latest Pods, we also need to fetch the source for the Gutenberg code.
+    # To get it, we need to manually clone the repo, since Gutenberg is distributed via XCFramework.
+    # XCFrameworks are binary targets and cannot extract strings via genstrings from there.
+    require_relative './../../Gutenberg/version'
 
-    # Merge various manually-maintained `.strings` files into the previously generated `Localizable.strings` so their extra keys are also imported in GlotPress.
-    # Note: We will re-extract the translations back during `download_localized_strings_and_metadata` (via a call to `ios_extract_keys_from_strings_files`)
-    ios_merge_strings_files(
-      paths_to_merge: MANUALLY_MAINTAINED_STRINGS_FILES,
-      destination: File.join(wordpress_en_lproj, 'Localizable.strings')
-    )
+    ref = GUTENBERG_CONFIG[:tag] || GUTENBERG_CONFIG[:commit]
 
-    git_commit(path: [wordpress_en_lproj], message: 'Update strings for localization', allow_nothing_to_commit: true) unless options[:skip_commit]
+    UI.user_error!('Could not find Gutenberg ref to clone the repository in order to access its strings.') if ref.nil?
+
+    UI.user_error!('Could not find GitHub organization name to clone Gutenberg in order to access its strings.') unless defined?(GITHUB_ORG)
+
+    UI.user_error!('Could not find GitHub repository name to clone Gutenberg in order to access its strings.') unless defined?(REPO_NAME)
+
+    # Create a temporary directory to clone Gutenberg into.
+    # We'll run the rest of the automation from within the block, but notice that only the Gutenbreg cloning happens within the temporary directory.
+    gutenberg_clone_name = 'Gutenberg-Strings-Clone'
+    Dir.mktmpdir do |tempdir|
+      Dir.chdir(tempdir) do
+        sh("git clone --depth 1 https://github.com/#{GITHUB_ORG}/#{REPO_NAME} #{gutenberg_clone_name}")
+        Dir.chdir(gutenberg_clone_name) do
+          if GUTENBERG_CONFIG[:tag]
+            sh("git fetch origin refs/tags/#{GUTENBERG_CONFIG[:tag]}:refs/tags/#{GUTENBERG_CONFIG[:tag]} --verbose")
+            sh("git checkout refs/tags/#{GUTENBERG_CONFIG[:tag]}")
+          else
+            sh("git fetch origin #{ref}")
+            sh("git checkout #{ref}")
+          end
+        end
+      end
+
+      # Notice that we are no longer in the tempdir, so the paths below are back to being relative to the project root folder.
+      # However, we are still in the tempdir block, so that once the automation is done, the tempdir will be automatically deleted.
+      wordpress_en_lproj = File.join('WordPress', 'Resources', 'en.lproj')
+      ios_generate_strings_file_from_code(
+        paths: ['WordPress/', 'Pods/WordPress*/', 'Pods/WPMediaPicker/', 'WordPressShared/WordPressShared/', File.join(tempdir, gutenberg_clone_name)],
+        exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],
+        routines: ['AppLocalizedString'],
+        output_dir: wordpress_en_lproj
+      )
+
+      # Merge various manually-maintained `.strings` files into the previously generated `Localizable.strings` so their extra keys are also imported in GlotPress.
+      # Note: We will re-extract the translations back during `download_localized_strings_and_metadata` (via a call to `ios_extract_keys_from_strings_files`)
+      ios_merge_strings_files(
+        paths_to_merge: MANUALLY_MAINTAINED_STRINGS_FILES,
+        destination: File.join(wordpress_en_lproj, 'Localizable.strings')
+      )
+
+      git_commit(path: [wordpress_en_lproj], message: 'Update strings for localization', allow_nothing_to_commit: true) unless options[:skip_commit]
+    end
   end
-
-
 
   # Updates the `AppStoreStrings.po` files (WP+JP) with the latest content from the `release_notes.txt` files and the other text sources
   #


### PR DESCRIPTION
We generate `strings` for translation using the app and dependencies source code, via `genstrings` and [release-toolkit](https://github.com/wordpress-mobile/release-toolkit/blob/d30bc3a8520207e11309015e28a0f95191fab0e4/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_generate_strings_file_from_code.rb#L8).

This process broke for Gutenberg since moving the dependency to XCFramework distribution. That is because we now download a compiled binary and not the source code.

As a temporary workaround to restore the missing strings and generate any new ones, this PR fetches the repo at the version specified in `Gutenberg/version.rb` in a temporary folder and points the strings generation process to it.

In the long run, we might want to move that logic at the release-toolkit level. For example, I can see [WooCommerce-Shared](https://github.com/woocommerce/WooCommerce-Shared/) needing this workflow, too. But for the moment, we urgently want to address the issue in Jetpack and WordPress iOS, so I think a local change on which we can iterate upon is a better option.

## Testing

I opened https://github.com/wordpress-mobile/WordPress-iOS/pull/21417 to show the result of running this update automation. It looks to me like all the strings are back where they belong. @dcalhoun @geriux @twstokes @derekblank could you take a look, too?

To verify locally:

- Create a new branch from this one
- Run `bundle exec update Gutenberg`, just to make sure the subsequent `cocoapods` call in the automation won't run into cache-sync issues. This is not something to be mindful of normally, but due to having checked out an older version of the repo to make the hotfix
- Run `bundle exec fastlane generate_strings_for_glotpress`
- Notice the automation checks out the repo and eventually makes the same commit as #21417

You can also change the value in `Gutenber/version.rb` from `tag` to `commit`, and/or comment out the other constants to verify it fails "gracefully".

---

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.