### PR TITLE
Add a PostRepository type

### DIFF
--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -4,6 +4,7 @@ final class PostRepository {
 
     enum Error: Swift.Error {
         case postNotFound
+        case remoteAPIUnavailable
         case unknown
     }
 
@@ -27,9 +28,8 @@ final class PostRepository {
             return remoteFactory.forBlog(blog)
         }
 
-        // TODO: In which case would remote be nil?
         guard let remote else {
-            throw PostRepository.Error.unknown
+            throw PostRepository.Error.remoteAPIUnavailable
         }
 
         let remotePost: RemotePost? = try await withCheckedThrowingContinuation { continuation in

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+final class PostRepository {
+
+    enum Error: Swift.Error {
+        case postNotFound
+        case unknown
+    }
+
+    private let coreDataStack: CoreDataStackSwift
+    private let remoteFactory: PostServiceRemoteFactory
+
+    init(coreDataStack: CoreDataStackSwift, remoteFactory: PostServiceRemoteFactory = PostServiceRemoteFactory()) {
+        self.coreDataStack = coreDataStack
+        self.remoteFactory = remoteFactory
+    }
+
+    /// Sync a specific post from the API
+    ///
+    /// - Parameters:
+    ///   - postID: The ID of the post to sync
+    ///   - blogID: The blog that has the post.
+    /// - Returns: The stored post object id.
+    func getPost(withID postID: NSNumber, from blogID: TaggedManagedObjectID<Blog>) async throws -> TaggedManagedObjectID<AbstractPost> {
+        let remote = try await coreDataStack.performQuery { [remoteFactory] context in
+            let blog = try context.existingObject(with: blogID)
+            return remoteFactory.forBlog(blog)
+        }
+
+        // TODO: In which case would remote be nil?
+        guard let remote else {
+            throw PostRepository.Error.unknown
+        }
+
+        let remotePost: RemotePost? = try await withCheckedThrowingContinuation { continuation in
+            remote.getPostWithID(
+                postID,
+                success: { continuation.resume(returning: $0) },
+                failure: { continuation.resume(throwing: $0 ?? PostRepository.Error.unknown ) }
+            )
+        }
+
+        guard let remotePost else {
+            throw PostRepository.Error.postNotFound
+        }
+
+        return try await coreDataStack.performAndSave { context in
+            let blog = try context.existingObject(with: blogID)
+
+            let post: AbstractPost
+            if let existingPost = blog.lookupPost(withID: postID, in: context) {
+                post = existingPost
+            } else {
+                if remotePost.type == PostServiceType.page.rawValue {
+                    post = blog.createPage()
+                } else {
+                    post = blog.createPost()
+                }
+            }
+
+            PostHelper.update(post, with: remotePost, in: context)
+
+            return try .init(unsaved: post)
+        }
+    }
+
+}

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -5,7 +5,6 @@ final class PostRepository {
     enum Error: Swift.Error {
         case postNotFound
         case remoteAPIUnavailable
-        case unknown
     }
 
     private let coreDataStack: CoreDataStackSwift
@@ -36,7 +35,7 @@ final class PostRepository {
             remote.getPostWithID(
                 postID,
                 success: { continuation.resume(returning: $0) },
-                failure: { continuation.resume(throwing: $0 ?? PostRepository.Error.unknown ) }
+                failure: { continuation.resume(throwing: $0!) }
             )
         }
 

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -42,7 +42,7 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
 - (void)getPostWithID:(NSNumber *)postID
               forBlog:(Blog *)blog
               success:(void (^)(AbstractPost *post))success
-              failure:(void (^)(NSError *))failure;
+              failure:(void (^)(NSError *))failure __attribute__((deprecated("Use `PostRepository` instead")));
 
 /**
  Sync an initial batch of posts from the specified blog.

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -204,6 +204,13 @@ extension CoreDataStack {
         }
     }
 
+    func performQuery<T>(_ block: @escaping (NSManagedObjectContext) throws -> T) async rethrows -> T {
+        let context = newDerivedContext()
+        return try await context.perform {
+            try block(context)
+        }
+    }
+
     // MARK: - Database Migration
 
     /// Creates a copy of the current open store and saves it to the specified destination

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1248,6 +1248,7 @@
 		4A2C73EF2A9577C000ACE79E /* PostHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73EC2A9577C000ACE79E /* PostHelper.m */; };
 		4A2C73F42A95856000ACE79E /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73F32A95856000ACE79E /* PostRepository.swift */; };
 		4A2C73F52A95856000ACE79E /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73F32A95856000ACE79E /* PostRepository.swift */; };
+		4A2C73F72A9585B000ACE79E /* PostRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73F62A9585B000ACE79E /* PostRepositoryTests.swift */; };
 		4A358DE629B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE729B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE929B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */; };
@@ -6832,6 +6833,7 @@
 		4A2C73EC2A9577C000ACE79E /* PostHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostHelper.m; sourceTree = "<group>"; };
 		4A2C73ED2A9577C000ACE79E /* PostHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostHelper.h; sourceTree = "<group>"; };
 		4A2C73F32A95856000ACE79E /* PostRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRepository.swift; sourceTree = "<group>"; };
+		4A2C73F62A9585B000ACE79E /* PostRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRepositoryTests.swift; sourceTree = "<group>"; };
 		4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicizeService+Lookup.swift"; sourceTree = "<group>"; };
 		4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingButton+Lookup.swift"; sourceTree = "<group>"; };
 		4A526BDD296BE9A50007B5BA /* CoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataService.m; sourceTree = "<group>"; };
@@ -15409,6 +15411,7 @@
 				7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */,
 				570B037622F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift */,
 				57569CF1230485680052EE14 /* PostAutoUploadInteractorTests.swift */,
+				4A2C73F62A9585B000ACE79E /* PostRepositoryTests.swift */,
 				57D66B9C234BB78B005A2D74 /* PostServiceWPComTests.swift */,
 				57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */,
 				575802122357C41200E4C63C /* MediaCoordinatorTests.swift */,
@@ -23641,6 +23644,7 @@
 				0118969129D1F2FE00D34BA9 /* DomainsDashboardCardHelperTests.swift in Sources */,
 				C8567498243F41CA001A995E /* MockTenorService.swift in Sources */,
 				1D19C56629C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift in Sources */,
+				4A2C73F72A9585B000ACE79E /* PostRepositoryTests.swift in Sources */,
 				4A9314DC297790C300360232 /* PeopleServiceTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1246,6 +1246,8 @@
 		4A2C73E42A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */; };
 		4A2C73EE2A9577C000ACE79E /* PostHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73EC2A9577C000ACE79E /* PostHelper.m */; };
 		4A2C73EF2A9577C000ACE79E /* PostHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73EC2A9577C000ACE79E /* PostHelper.m */; };
+		4A2C73F42A95856000ACE79E /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73F32A95856000ACE79E /* PostRepository.swift */; };
+		4A2C73F52A95856000ACE79E /* PostRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73F32A95856000ACE79E /* PostRepository.swift */; };
 		4A358DE629B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE729B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE929B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */; };
@@ -6829,6 +6831,7 @@
 		4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaggedManagedObjectIDTests.swift; sourceTree = "<group>"; };
 		4A2C73EC2A9577C000ACE79E /* PostHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostHelper.m; sourceTree = "<group>"; };
 		4A2C73ED2A9577C000ACE79E /* PostHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostHelper.h; sourceTree = "<group>"; };
+		4A2C73F32A95856000ACE79E /* PostRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRepository.swift; sourceTree = "<group>"; };
 		4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicizeService+Lookup.swift"; sourceTree = "<group>"; };
 		4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingButton+Lookup.swift"; sourceTree = "<group>"; };
 		4A526BDD296BE9A50007B5BA /* CoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataService.m; sourceTree = "<group>"; };
@@ -14094,6 +14097,7 @@
 				93FA59DC18D88C1C001446BC /* PostCategoryService.m */,
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
 				8B5E1DD727EA5929002EBEE3 /* PostCoordinator+Dashboard.swift */,
+				4A2C73F32A95856000ACE79E /* PostRepository.swift */,
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
 				98E0829E2637545C00537BF1 /* PostService+Likes.swift */,
@@ -21277,6 +21281,7 @@
 				98AA9F2127EA890800B3A98C /* FeatureIntroductionViewController.swift in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,
 				B56695B01D411EEB007E342F /* KeyboardDismissHelper.swift in Sources */,
+				4A2C73F42A95856000ACE79E /* PostRepository.swift in Sources */,
 				F5B9D7F0245BA938002BB2C7 /* FancyAlertViewController+CreateButtonAnnouncement.swift in Sources */,
 				FF54D4641D6F3FA900A0DC4D /* GutenbergSettings.swift in Sources */,
 				3FAF9CC526D03C7400268EA2 /* DomainSuggestionViewControllerWrapper.swift in Sources */,
@@ -24425,6 +24430,7 @@
 				4A1E77CD2989F2F7006281CC /* WPAccount+DeduplicateBlogs.swift in Sources */,
 				FA98B61D29A3DB840071AAE8 /* BlazeHelper.swift in Sources */,
 				FABB22C32602FC2C00C8785C /* ReaderTagsFooter.swift in Sources */,
+				4A2C73F52A95856000ACE79E /* PostRepository.swift in Sources */,
 				98DCF4A6275945E00008630F /* ReaderDetailNoCommentCell.swift in Sources */,
 				FABB22C42602FC2C00C8785C /* ReaderPostCellActions.swift in Sources */,
 				FABB22C52602FC2C00C8785C /* ActivityStore.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 @testable import WordPress
 
@@ -83,6 +84,11 @@ final class BlogBuilder {
     func with(visible: Bool) -> Self {
         blog.visible = visible
 
+        return self
+    }
+
+    func withAccount(id: NSManagedObjectID) throws -> Self {
+        blog.account = try XCTUnwrap(context.existingObject(with: id) as? WPAccount)
         return self
     }
 

--- a/WordPress/WordPressTest/PostRepositoryTests.swift
+++ b/WordPress/WordPressTest/PostRepositoryTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+
+@testable import WordPress
+
+class PostRepositoryTests: CoreDataTestCase {
+
+    private var remoteMock: PostServiceRESTMock!
+    private var repository: PostRepository!
+    private var blogID: TaggedManagedObjectID<Blog>!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let accountService = AccountService(coreDataStack: contextManager)
+        let accountID = accountService.createOrUpdateAccount(withUsername: "username", authToken: "token")
+        try accountService.setDefaultWordPressComAccount(XCTUnwrap(mainContext.existingObject(with: accountID) as? WPAccount))
+
+        let blog = try BlogBuilder(mainContext).withAccount(id: accountID).build()
+
+        contextManager.saveContextAndWait(mainContext)
+
+        blogID = .init(saved: blog)
+        remoteMock = PostServiceRESTMock()
+        let remoteFactory = PostServiceRemoteFactoryMock()
+        remoteFactory.remoteToReturn = remoteMock
+        repository = PostRepository(coreDataStack: contextManager, remoteFactory: remoteFactory)
+    }
+
+    func testGetPost() async throws {
+        let post = RemotePost(siteID: 1, status: "publish", title: "Post: Test", content: "This is a test post")
+        post?.type = "post"
+        remoteMock.remotePostToReturnOnGetPostWithID = post
+        let postID = try await repository.getPost(withID: 1, from: blogID)
+        let isPage = try await contextManager.performQuery { try $0.existingObject(with: postID) is Page }
+        let title = try await contextManager.performQuery { try $0.existingObject(with: postID).postTitle }
+        let content = try await contextManager.performQuery { try $0.existingObject(with: postID).content }
+        XCTAssertFalse(isPage)
+        XCTAssertEqual(title, "Post: Test")
+        XCTAssertEqual(content, "This is a test post")
+    }
+
+    func testGetPage() async throws {
+        let post = RemotePost(siteID: 1, status: "publish", title: "Post: Test", content: "This is a test post")
+        post?.type = "page"
+        remoteMock.remotePostToReturnOnGetPostWithID = post
+        let postID = try await repository.getPost(withID: 1, from: blogID)
+        let isPage = try await contextManager.performQuery { try $0.existingObject(with: postID) is Page }
+        let title = try await contextManager.performQuery { try $0.existingObject(with: postID).postTitle }
+        let content = try await contextManager.performQuery { try $0.existingObject(with: postID).content }
+        XCTAssertTrue(isPage)
+        XCTAssertEqual(title, "Post: Test")
+        XCTAssertEqual(content, "This is a test post")
+    }
+
+}
+
+// These mock classes are copied from PostServiceWPComTests. We can't simply remove the `private` in the original class
+// definition, because Xcode would complian about 'WordPress' module not found.
+
+private class PostServiceRemoteFactoryMock: PostServiceRemoteFactory {
+    var remoteToReturn: PostServiceRemote?
+
+    override func forBlog(_ blog: Blog) -> PostServiceRemote? {
+        return remoteToReturn
+    }
+
+    override func restRemoteFor(siteID: NSNumber, context: NSManagedObjectContext) -> PostServiceRemoteREST? {
+        return remoteToReturn as? PostServiceRemoteREST
+    }
+}
+
+private class PostServiceRESTMock: PostServiceRemoteREST {
+    enum StubbedBehavior {
+        case success(RemotePost?)
+        case fail
+    }
+
+    var remotePostToReturnOnGetPostWithID: RemotePost?
+    var remotePostsToReturnOnSyncPostsOfType = [RemotePost]()
+    var remotePostToReturnOnUpdatePost: RemotePost?
+    var remotePostToReturnOnCreatePost: RemotePost?
+    var remotePostToReturnOnTrashPost: RemotePost?
+
+    var autoSaveStubbedBehavior = StubbedBehavior.success(nil)
+
+    // related to fetching likes
+    var fetchLikesShouldSucceed: Bool = true
+    var remoteUsersToReturnOnGetLikes = [RemoteLikeUser]()
+    var totalLikes: NSNumber = 1
+
+    private(set) var invocationsCountOfCreatePost = 0
+    private(set) var invocationsCountOfAutoSave = 0
+    private(set) var invocationsCountOfUpdate = 0
+
+    override func getPostWithID(_ postID: NSNumber!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
+        success(self.remotePostToReturnOnGetPostWithID)
+    }
+
+    override func getPostsOfType(_ postType: String!, options: [AnyHashable: Any]! = [:], success: (([RemotePost]?) -> Void)!, failure: ((Error?) -> Void)!) {
+        success(self.remotePostsToReturnOnSyncPostsOfType)
+    }
+
+    override func update(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
+        self.invocationsCountOfUpdate += 1
+        success(self.remotePostToReturnOnUpdatePost)
+    }
+
+    override func createPost(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
+        self.invocationsCountOfCreatePost += 1
+        success(self.remotePostToReturnOnCreatePost)
+    }
+
+    override func trashPost(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
+        success(self.remotePostToReturnOnTrashPost)
+    }
+
+    override func autoSave(_ post: RemotePost, success: ((RemotePost?, String?) -> Void)!, failure: ((Error?) -> Void)!) {
+        self.invocationsCountOfAutoSave += 1
+
+        switch self.autoSaveStubbedBehavior {
+        case .fail:
+            failure(nil)
+        case .success(let remotePost):
+            success(remotePost, nil)
+        }
+    }
+
+    override func getLikesForPostID(_ postID: NSNumber,
+                                    count: NSNumber,
+                                    before: String?,
+                                    excludeUserIDs: [NSNumber]?,
+                                    success: (([RemoteLikeUser], NSNumber) -> Void)!,
+                                    failure: ((Error?) -> Void)!) {
+        if self.fetchLikesShouldSucceed {
+            success(self.remoteUsersToReturnOnGetLikes, self.totalLikes)
+        } else {
+            failure(nil)
+        }
+    }
+}


### PR DESCRIPTION
## `PostService` & `MediaService`

I have been refactoring many service types to use `CoreDataStack` instead of a `NSManagedObjectContext` instance directly. `PostSerivce` and `MediaService` are the two remaining ones that are much complicated than others. Not necessarily because their implementation, but how they are use in various places in the app. At this point, using the main context in `PostService` and `MediaService` becomes a requirement, otherwise things are going to break.

That's the exact problem we'd like to move away from. However, instead of refactoring them in one go, I want to take a precautionary approach: refactoring their methods one by one by moving them to a new type. The most complicated part would be saving post and uploading media. I can't foresee the problems I'm going to ran into, but my gut feeling is we may need a dedicated type to handle the saving part reliably.

Also, the new types will be pure Swift implementations, so that we can take advantage of Swift's safety and language features.

### async performQuery

This PR adds a new async version of the `performQuery` function. The main drive is so that we can use `performQuery` in an async API, without making `performQuery` waits unnecessarily.

A major difference between this version and the existing non-async version is it uses a background context. The main reason is, I don't think we _need_ the main context for query. A background context is perfectly suited for query too. Later we can even change the non-async `performQuery` to use a background context instead—which should not break the app. But since it's used in lots of places thus has a larger impact, I'll leave it in a dedicated PR.

### Changes in this PR

This PR only add the new `PostRepository` type, without changing existing code. I will open follow up PRs to replace the `PostService.getPostWithID` with the new `PostRepository.getPost` function.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
A few unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A