### PR TITLE
Integrate gutenberg-mobile release 1.102.1

### DIFF
--- a/Gutenberg/version.rb
+++ b/Gutenberg/version.rb
@@ -11,7 +11,7 @@
 #
 #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 GUTENBERG_CONFIG = {
-  commit: '692c3d555b54e292681f6ddfe85c80a496245c46'
+  commit: 'ea2272fc9d98828381f13a7e19750455ea1089ef'
   # tag: 'v1.102.0'
 }
 

--- a/Gutenberg/version.rb
+++ b/Gutenberg/version.rb
@@ -11,8 +11,8 @@
 #
 #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 GUTENBERG_CONFIG = {
-  # commit: ''
-  tag: 'v1.102.0'
+  commit: '692c3d555b54e292681f6ddfe85c80a496245c46'
+  # tag: 'v1.102.0'
 }
 
 GITHUB_ORG = 'wordpress-mobile'

--- a/Gutenberg/version.rb
+++ b/Gutenberg/version.rb
@@ -11,8 +11,8 @@
 #
 #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 GUTENBERG_CONFIG = {
-  commit: 'ea2272fc9d98828381f13a7e19750455ea1089ef'
-  # tag: 'v1.102.0'
+  # commit: ''
+  tag: 'v1.102.1'
 }
 
 GITHUB_ORG = 'wordpress-mobile'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -153,7 +153,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.1.0)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-ea2272fc9d98828381f13a7e19750455ea1089ef.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.102.1.podspec`)
   - JTAppleCalendar (~> 8.0.2)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -232,7 +232,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-ea2272fc9d98828381f13a7e19750455ea1089ef.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.102.1.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -259,7 +259,7 @@ SPEC CHECKSUMS:
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: 494b84379128242cd18c50bdf7cd2a73ea5d83d1
+  Gutenberg: 246ad56a1bd09eb48eb35510f1a1aa5948ef21a4
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -153,7 +153,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.1.0)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-692c3d555b54e292681f6ddfe85c80a496245c46.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-ea2272fc9d98828381f13a7e19750455ea1089ef.podspec`)
   - JTAppleCalendar (~> 8.0.2)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -232,7 +232,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-692c3d555b54e292681f6ddfe85c80a496245c46.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-ea2272fc9d98828381f13a7e19750455ea1089ef.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -259,7 +259,7 @@ SPEC CHECKSUMS:
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: 87761fc57982ed6c2568d0296c57595d727d8664
+  Gutenberg: 494b84379128242cd18c50bdf7cd2a73ea5d83d1
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (1.7.2)
-  - Gutenberg (1.102.0)
+  - Gutenberg (1.102.1)
   - JTAppleCalendar (8.0.3)
   - Kanvas (1.4.4)
   - MediaEditor (1.2.2):
@@ -153,7 +153,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.1.0)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.102.0.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-692c3d555b54e292681f6ddfe85c80a496245c46.podspec`)
   - JTAppleCalendar (~> 8.0.2)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -232,7 +232,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.102.0.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-692c3d555b54e292681f6ddfe85c80a496245c46.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -259,7 +259,7 @@ SPEC CHECKSUMS:
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: 315b07b2b9307335c0424b06626fae5e58b16729
+  Gutenberg: 87761fc57982ed6c2568d0296c57595d727d8664
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] [internal] Remove one of the image loading subsystems for avatars and consolidate the cache [#21259]
 * [*] Fixed a crash that could occur when following sites in Reader. [#21341]
 * [**] [Jetpack-only] Add a "Domain Focus" Card to the Dashboard that opens a screen that allows tranfer of Google Domains. This card can also be hidden across all sites of the account by accesing the More button. [#21368]
+* [**] Fix Voice Over and assistive keyboards [https://github.com/WordPress/gutenberg/pull/53895]
 
 23.0
 -----


### PR DESCRIPTION
## Description
This PR incorporates the 1.102.1 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6110

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.