### PR TITLE
[UI Tests] Disable tests involving media picker for maintenance.

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -23,6 +23,10 @@
       "parallelizable" : true,
       "skippedTests" : [
         "EditorAztecTests",
+        "EditorGutenbergTests\/testAddGalleryBlock()",
+        "EditorGutenbergTests\/testAddMediaBlocks()",
+        "EditorGutenbergTests\/testAddRemoveFeaturedImage()",
+        "EditorGutenbergTests\/testBasicPostPublishWithCategoryAndTag()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",
         "SignupTests\/testEmailSignup()",


### PR DESCRIPTION
### Description

This PR disables UI Tests for maintenance to support the new media picker (https://github.com/wordpress-mobile/WordPress-iOS/issues/21190). 

Tests disabled:
```
EditorGutenbergTests.testAddGalleryBlock()
EditorGutenbergTests.testAddMediaBlocks()
EditorGutenbergTests.testAddRemoveFeaturedImage()
EditorGutenbergTests.testBasicPostPublishWithCategoryAndTag()
```
