### PR TITLE
Fix an issue with widget data sometimes showing zeros

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -55,12 +55,15 @@ struct InsightStoreState {
 
     var allTimeStats: StatsAllTimesInsight? {
         didSet {
-            let allTimeWidgetStats = AllTimeWidgetStats(views: allTimeStats?.viewsCount,
-                                                        visitors: allTimeStats?.visitorsCount,
-                                                        posts: allTimeStats?.postsCount,
-                                                        bestViews: allTimeStats?.bestViewsPerDayCount)
-            storeAllTimeWidgetData(data: allTimeWidgetStats)
-            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetAllTimeData.self, stats: allTimeWidgetStats)
+            guard let stats = allTimeStats else {
+                return
+            }
+            let widgetData = AllTimeWidgetStats(views: stats.viewsCount,
+                                                visitors: stats.visitorsCount,
+                                                posts: stats.postsCount,
+                                                bestViews: stats.bestViewsPerDayCount)
+            storeAllTimeWidgetData(data: widgetData)
+            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetAllTimeData.self, stats: widgetData)
         }
     }
     var allTimeStatus: StoreFetchingStatus = .idle
@@ -82,13 +85,16 @@ struct InsightStoreState {
 
     var todaysStats: StatsTodayInsight? {
         didSet {
-            let todayWidgetStats = TodayWidgetStats(views: todaysStats?.viewsCount,
-                                                    visitors: todaysStats?.visitorsCount,
-                                                    likes: todaysStats?.likesCount,
-                                                    comments: todaysStats?.commentsCount)
+            guard let stats = todaysStats else {
+                return
+            }
+            let widgetData = TodayWidgetStats(views: stats.viewsCount,
+                                              visitors: stats.visitorsCount,
+                                              likes: stats.likesCount,
+                                              comments: stats.commentsCount)
 
-            storeTodayWidgetData(data: todayWidgetStats)
-            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetTodayData.self, stats: todayWidgetStats)
+            storeTodayWidgetData(data: widgetData)
+            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetTodayData.self, stats: widgetData)
         }
     }
     var todaysStatsStatus: StoreFetchingStatus = .idle

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1397,13 +1397,14 @@ private extension PeriodStoreState {
         // - The summary period end date is the current date
 
         guard widgetUsingCurrentSite(),
-            summary?.period == .day,
-            summary?.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate() else {
+              let summary,
+            summary.period == .day,
+            summary.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate() else {
                 return
         }
 
         // Include an extra day. It's needed to get the dailyChange for the last day.
-        let summaryData = Array(summary?.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1) ?? [])
+        let summaryData = Array(summary.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1))
 
         let widgetData = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
         widgetData.saveData()


### PR DESCRIPTION
Fixes #21426

## To test:

There are no clear steps to reproduce in the ticket, but you can test it by adding the following guard to `allTimeStats` after you'd already populated the widget store with some data:

```swift
    var allTimeStats: StatsAllTimesInsight? {
        didSet {
            guard allTimeStats == nil else {
                return
            }
```

This is something that was overlooked during the stats cache change. Because it's now in memory, the data is empty when you launch the app. It overwrites the previously downloaded good data with zeros.

## Regression Notes
1. Potential unintended areas of impact: App Widget
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
