### PR TITLE
Fix an issue with widget data sometimes showing zeros

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] Fixed a crash that could occur when following sites in Reader. [#21341]
 * [**] [Jetpack-only] Add a "Domain Focus" Card to the Dashboard that opens a screen that allows tranfer of Google Domains. This card can also be hidden across all sites of the account by accesing the More button. [#21368]
 * [**] Fix Voice Over and assistive keyboards [https://github.com/WordPress/gutenberg/pull/53895]
+* [*] Fix an issue with widget data sometimes showing zeros [https://github.com/wordpress-mobile/WordPress-iOS/pull/21430]
 
 23.0
 -----

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -55,12 +55,15 @@ struct InsightStoreState {
 
     var allTimeStats: StatsAllTimesInsight? {
         didSet {
-            let allTimeWidgetStats = AllTimeWidgetStats(views: allTimeStats?.viewsCount,
-                                                        visitors: allTimeStats?.visitorsCount,
-                                                        posts: allTimeStats?.postsCount,
-                                                        bestViews: allTimeStats?.bestViewsPerDayCount)
-            storeAllTimeWidgetData(data: allTimeWidgetStats)
-            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetAllTimeData.self, stats: allTimeWidgetStats)
+            guard let stats = allTimeStats else {
+                return
+            }
+            let widgetData = AllTimeWidgetStats(views: stats.viewsCount,
+                                                visitors: stats.visitorsCount,
+                                                posts: stats.postsCount,
+                                                bestViews: stats.bestViewsPerDayCount)
+            storeAllTimeWidgetData(data: widgetData)
+            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetAllTimeData.self, stats: widgetData)
         }
     }
     var allTimeStatus: StoreFetchingStatus = .idle
@@ -82,13 +85,16 @@ struct InsightStoreState {
 
     var todaysStats: StatsTodayInsight? {
         didSet {
-            let todayWidgetStats = TodayWidgetStats(views: todaysStats?.viewsCount,
-                                                    visitors: todaysStats?.visitorsCount,
-                                                    likes: todaysStats?.likesCount,
-                                                    comments: todaysStats?.commentsCount)
+            guard let stats = todaysStats else {
+                return
+            }
+            let widgetData = TodayWidgetStats(views: stats.viewsCount,
+                                              visitors: stats.visitorsCount,
+                                              likes: stats.likesCount,
+                                              comments: stats.commentsCount)
 
-            storeTodayWidgetData(data: todayWidgetStats)
-            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetTodayData.self, stats: todayWidgetStats)
+            storeTodayWidgetData(data: widgetData)
+            StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetTodayData.self, stats: widgetData)
         }
     }
     var todaysStatsStatus: StoreFetchingStatus = .idle

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1397,13 +1397,14 @@ private extension PeriodStoreState {
         // - The summary period end date is the current date
 
         guard widgetUsingCurrentSite(),
-            summary?.period == .day,
-            summary?.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate() else {
+              let summary,
+            summary.period == .day,
+            summary.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate() else {
                 return
         }
 
         // Include an extra day. It's needed to get the dailyChange for the last day.
-        let summaryData = Array(summary?.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1) ?? [])
+        let summaryData = Array(summary.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1))
 
         let widgetData = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
         widgetData.saveData()


### PR DESCRIPTION
Please refer to the original PR https://github.com/wordpress-mobile/WordPress-iOS/pull/21429. This one is a cherry-pick.