### PR TITLE
Reader: Centers the footer spinner in its view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,12 +13,15 @@
             <rect key="frame" x="0.0" y="0.0" width="300" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="F4q-47-pPM">
+                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="F4q-47-pPM">
                     <rect key="frame" x="140" y="12" width="20" height="20"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </activityIndicatorView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="F4q-47-pPM" firstAttribute="centerY" secondItem="TCZ-n9-coy" secondAttribute="centerY" id="Uel-Nf-Lff"/>
+                <constraint firstItem="F4q-47-pPM" firstAttribute="centerX" secondItem="TCZ-n9-coy" secondAttribute="centerX" id="e75-fm-R2o"/>
+            </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>


### PR DESCRIPTION
Fixes #

I don't see an open issue for this (maybe I've missed it?), I've just seen it happen when scrolling the reader and it bugs me so I wanted to patch it. 

When scrolling to the bottom of a stream the spinner in the footer is not centered in the view.  This PR adds constraints to the footer's xib so the spinner will be centered. 

## Before
![Simulator Screenshot - iPhone 14 Pro - 2023-08-25 at 12 21 11](https://github.com/wordpress-mobile/WordPress-iOS/assets/1435271/12819a02-89bc-4e4b-a1af-c02012b467a7)


## After
![Simulator Screenshot - iPhone 14 Pro - 2023-08-25 at 12 29 22](https://github.com/wordpress-mobile/WordPress-iOS/assets/1435271/4382cb15-4dbc-40c4-8f9a-d8a4b3073ef7)



## To test:

Confirm the glitch by visiting the reader stream of your choice and scrolling all the way to the bottom to trigger loading more.  Note the placement of the spinner.

Confirm the fix by switching to this branch and repeating the same steps.  Note the spinner is centered. 

Bonus: Test on an iPad, changing orientation to confirm the spinner is always centered. 


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
