### PR TITLE
Remove MRProgress

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -115,7 +115,6 @@ abstract_target 'Apps' do
   pod 'AppCenter', app_center_version, configurations: app_center_configurations
   pod 'AppCenter/Distribute', app_center_version, configurations: app_center_configurations
 
-  pod 'MRProgress', '0.8.3'
   pod 'Starscream', '3.0.6'
   pod 'SVProgressHUD', '2.2.5'
   pod 'ZendeskSupportSDK', '5.3.0'
@@ -428,16 +427,4 @@ post_install do |installer|
   yellow_marker = "\033[33m"
   reset_marker = "\033[0m"
   puts "#{yellow_marker}The abstract target warning below is expected. Feel free to ignore it.#{reset_marker}"
-
-  # Fix a compiling issue in Xcode 15 beta.
-  # This line in particular https://github.com/mrackwitz/MRProgress/blob/0.8.3/src/Components/MRProgressOverlayView.m#L811
-  # The error message is "Multiple methods named 'setProgress:' found with mismatched result, parameter type or attributes"
-  # We are going to replace the `id` with `MRProgressView *` (or any other type that has a method `setProgress:` that takes a float argument).
-  mrprogress_filepath = "#{project_root}/Pods/MRProgress/src/Components/MRProgressOverlayView.m"
-  File.chmod(0o644, mrprogress_filepath)
-  lines = File.readlines(mrprogress_filepath)
-  if lines[810] == "        [((id)self.modeView) setProgress:self.progress];\n"
-    lines[810] = "        [((MRProgressView *)self.modeView) setProgress:self.progress];\n"
-    File.write(mrprogress_filepath, lines.join)
-  end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,34 +45,6 @@ PODS:
   - Kanvas (1.4.4)
   - MediaEditor (1.2.2):
     - CropViewController (~> 2.5.3)
-  - MRProgress (0.8.3):
-    - MRProgress/ActivityIndicator (= 0.8.3)
-    - MRProgress/Blur (= 0.8.3)
-    - MRProgress/Circular (= 0.8.3)
-    - MRProgress/Icons (= 0.8.3)
-    - MRProgress/NavigationBarProgress (= 0.8.3)
-    - MRProgress/Overlay (= 0.8.3)
-  - MRProgress/ActivityIndicator (0.8.3):
-    - MRProgress/Stopable
-  - MRProgress/Blur (0.8.3):
-    - MRProgress/Helper
-  - MRProgress/Circular (0.8.3):
-    - MRProgress/Helper
-    - MRProgress/ProgressBaseClass
-    - MRProgress/Stopable
-  - MRProgress/Helper (0.8.3)
-  - MRProgress/Icons (0.8.3)
-  - MRProgress/NavigationBarProgress (0.8.3):
-    - MRProgress/ProgressBaseClass
-  - MRProgress/Overlay (0.8.3):
-    - MRProgress/ActivityIndicator
-    - MRProgress/Blur
-    - MRProgress/Circular
-    - MRProgress/Helper
-    - MRProgress/Icons
-  - MRProgress/ProgressBaseClass (0.8.3)
-  - MRProgress/Stopable (0.8.3):
-    - MRProgress/Helper
   - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.4)"
   - OCMock (3.4.3)
@@ -157,7 +129,6 @@ DEPENDENCIES:
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
-  - MRProgress (= 0.8.3)
   - NSObject-SafeExpectations (~> 0.0.4)
   - "NSURL+IDN (~> 0.4)"
   - OCMock (~> 3.4.3)
@@ -197,7 +168,6 @@ SPEC REPOS:
     - JTAppleCalendar
     - Kanvas
     - MediaEditor
-    - MRProgress
     - NSObject-SafeExpectations
     - "NSURL+IDN"
     - OCMock
@@ -263,7 +233,6 @@ SPEC CHECKSUMS:
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae
-  MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
@@ -294,6 +263,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: e54eeda47b03e4225509b2162f40d720a5708616
+PODFILE CHECKSUM: 84696d620643641ef8db3ddce7eae79ea144286e
 
 COCOAPODS: 1.12.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] [internal] Fix a crash when disconnecting the app from the "Connected Applications" on WordPress.com. [#21375]
 * [*] Fix an issue where the "Take Photo" flow was not working without the "All Photos" access [#21398](https://github.com/wordpress-mobile/WordPress-iOS/pull/21398)
 * [*] Fix a couple of small issues with media uploads error handling [#21411](https://github.com/wordpress-mobile/WordPress-iOS/pull/21411)
+* [**] [internal] Replace the progress indicator implementation in uploading featured image from "Post Settings" [#21438]
 
 23.1
 -----

--- a/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
@@ -9,7 +9,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 NSProgressUserInfoKey const WPProgressImageThumbnailKey = @"WPProgressImageThumbnailKey";
 @interface WPProgressTableViewCell ()
 
-@property (nonatomic, strong) IBOutlet MRActivityIndicatorView * progressView;
+@property (nonatomic, strong) MRActivityIndicatorView * progressView;
 
 @end
 
@@ -26,6 +26,12 @@ NSProgressUserInfoKey const WPProgressImageThumbnailKey = @"WPProgressImageThumb
         self.accessoryView = _progressView;
     }
     return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    NSAssert(false, @"WPProgressTableViewCell can't be created using a nib");
+    return [super initWithCoder:coder];
 }
 
 - (void)dealloc

--- a/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
@@ -1,9 +1,5 @@
 #import "WPProgressTableViewCell.h"
 #import "WordPress-Swift.h"
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wstrict-prototypes"
-#import "MRProgress.h"
-#pragma clang diagnostic pop
 
 static void *ProgressObserverContext = &ProgressObserverContext;
 

--- a/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
@@ -1,4 +1,5 @@
 #import "WPProgressTableViewCell.h"
+#import "WordPress-Swift.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 #import "MRProgress.h"
@@ -9,7 +10,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 NSProgressUserInfoKey const WPProgressImageThumbnailKey = @"WPProgressImageThumbnailKey";
 @interface WPProgressTableViewCell ()
 
-@property (nonatomic, strong) MRActivityIndicatorView * progressView;
+@property (nonatomic, strong) StoppableProgressIndicatorView * progressView;
 
 @end
 
@@ -21,7 +22,7 @@ NSProgressUserInfoKey const WPProgressImageThumbnailKey = @"WPProgressImageThumb
 {
     self = [super initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:reuseIdentifier];
     if (self) {
-        _progressView = [[MRActivityIndicatorView alloc] initWithFrame:CGRectMake(10.0,0.0,40.0,40.0)];
+        _progressView = [[StoppableProgressIndicatorView alloc] initWithFrame:CGRectMake(10.0,0.0,40.0,40.0)];
         _progressView.hidden = YES;
         self.accessoryView = _progressView;
     }

--- a/WordPress/Classes/ViewRelated/Views/StoppableProgressIndicatorView.swift
+++ b/WordPress/Classes/ViewRelated/Views/StoppableProgressIndicatorView.swift
@@ -1,0 +1,117 @@
+import Foundation
+import UIKit
+
+private let rotationAnimationKey = "rotation"
+
+@objcMembers class StoppableProgressIndicatorView: UIView {
+
+    private let progressIndicator: CAShapeLayer
+    let stopButton: UIControl
+
+    var hidesWhenStopped: Bool = true {
+        didSet {
+            if hidesWhenStopped, !isAnimating {
+                isHidden = true
+            }
+        }
+    }
+
+    var mayStop: Bool {
+        get { !stopButton.isHidden }
+        set { stopButton.isHidden = !newValue }
+    }
+
+    var isAnimating: Bool {
+        progressIndicator.animation(forKey: rotationAnimationKey) != nil
+    }
+
+    private var resumeAnimation: Bool = true
+
+    override init(frame: CGRect) {
+        stopButton = UIControl(frame: .zero)
+        progressIndicator = CAShapeLayer()
+        progressIndicator.isHidden = true
+        progressIndicator.lineWidth = 2
+        super.init(frame: frame)
+
+        layer.addSublayer(progressIndicator)
+        addSubview(stopButton)
+        stopButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stopButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stopButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stopButton.widthAnchor.constraint(equalTo: stopButton.heightAnchor),
+            stopButton.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.3),
+        ])
+
+        updateAppearance()
+        NotificationCenter.default.addObserver(self, selector: #selector(enterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func tintColorDidChange() {
+        super.tintColorDidChange()
+        updateAppearance()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        progressIndicator.frame = layer.bounds
+        resetIndicatorShape()
+    }
+
+    func startAnimating() {
+        if isAnimating {
+            return
+        }
+
+        isHidden = false
+        progressIndicator.isHidden = false
+        resumeAnimation = true
+
+        let rotation = CABasicAnimation(keyPath: "transform.rotation")
+        rotation.toValue = CGFloat.pi * 2
+        rotation.duration = 1
+        rotation.repeatCount = Float.infinity
+        progressIndicator.add(rotation, forKey: rotationAnimationKey)
+    }
+
+    func stopAnimating() {
+        resumeAnimation = false
+        progressIndicator.removeAnimation(forKey: rotationAnimationKey)
+        progressIndicator.isHidden = true
+
+        if hidesWhenStopped {
+            isHidden = true
+        }
+    }
+
+    func enterForeground() {
+        if resumeAnimation {
+            startAnimating()
+        }
+    }
+
+    private func resetIndicatorShape() {
+        let bounds = progressIndicator.bounds
+        let path = CGMutablePath()
+        path.addArc(
+            center: CGPoint(x: bounds.midX, y: bounds.midY),
+            radius: (bounds.width - progressIndicator.lineWidth) / 2,
+            startAngle: -CGFloat.pi / 2,
+            endAngle: -CGFloat.pi / 2 + CGFloat.pi * 1.8,
+            clockwise: false
+        )
+        progressIndicator.path = path
+    }
+
+    private func updateAppearance() {
+        stopButton.backgroundColor = tintColor
+        progressIndicator.strokeColor = tintColor.cgColor
+        progressIndicator.fillColor = nil
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1283,6 +1283,8 @@
 		4AD5657028E413160054C676 /* Blog+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656E28E413160054C676 /* Blog+History.swift */; };
 		4AD5657228E543A30054C676 /* BlogQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5657128E543A30054C676 /* BlogQueryTests.swift */; };
 		4AEF2DD929A84B2C00345734 /* ReaderSiteServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEF2DD829A84B2C00345734 /* ReaderSiteServiceTests.swift */; };
+		4AFB1A812A9C08CE007CE165 /* StoppableProgressIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB1A802A9C08CE007CE165 /* StoppableProgressIndicatorView.swift */; };
+		4AFB1A822A9C08CE007CE165 /* StoppableProgressIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB1A802A9C08CE007CE165 /* StoppableProgressIndicatorView.swift */; };
 		4AFB8FBF2824999500A2F4B2 /* ContextManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManager+Helpers.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4BB2296498BE66D515E3D610 /* Pods_JetpackShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23052F0F1F9B2503E33D0A26 /* Pods_JetpackShareExtension.framework */; };
@@ -6859,6 +6861,7 @@
 		4AD5656E28E413160054C676 /* Blog+History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+History.swift"; sourceTree = "<group>"; };
 		4AD5657128E543A30054C676 /* BlogQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogQueryTests.swift; sourceTree = "<group>"; };
 		4AEF2DD829A84B2C00345734 /* ReaderSiteServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteServiceTests.swift; sourceTree = "<group>"; };
+		4AFB1A802A9C08CE007CE165 /* StoppableProgressIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppableProgressIndicatorView.swift; sourceTree = "<group>"; };
 		4AFB8FBE2824999400A2F4B2 /* ContextManager+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContextManager+Helpers.swift"; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		4D670B9448DF9991366CF42D /* Pods_WordPressStatsWidgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressStatsWidgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -9864,6 +9867,7 @@
 				FADFBD25265F580500039C41 /* MultilineButton.swift */,
 				808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */,
 				0C8078AA2A4E01A5002ABF29 /* PagingFooterView.swift */,
+				4AFB1A802A9C08CE007CE165 /* StoppableProgressIndicatorView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -22572,6 +22576,7 @@
 				FE7B9A8A2A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift in Sources */,
 				E15632CC1EB9ECF40035A099 /* TableViewKeyboardObserver.swift in Sources */,
 				E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */,
+				4AFB1A812A9C08CE007CE165 /* StoppableProgressIndicatorView.swift in Sources */,
 				B522C4F81B3DA79B00E47B59 /* NotificationSettingsViewController.swift in Sources */,
 				FEC26033283FC902003D886A /* RootViewCoordinator+BloggingPrompt.swift in Sources */,
 				93E63369272AC532009DACF8 /* LoginEpilogueChooseSiteTableViewCell.swift in Sources */,
@@ -24802,6 +24807,7 @@
 				FABB23C52602FC2C00C8785C /* JetpackScanViewController.swift in Sources */,
 				FABB23C62602FC2C00C8785C /* ReaderSubscribingNotificationAction.swift in Sources */,
 				FABB23C72602FC2C00C8785C /* GutenbergMediaInserterHelper.swift in Sources */,
+				4AFB1A822A9C08CE007CE165 /* StoppableProgressIndicatorView.swift in Sources */,
 				FABB23C92602FC2C00C8785C /* JetpackState.swift in Sources */,
 				FABB23CA2602FC2C00C8785C /* EditPostViewController.swift in Sources */,
 				0141929D2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */,


### PR DESCRIPTION
## Background

The last change to [the MRProgress library](https://github.com/mrackwitz/MRProgress) is 7 years ago. I had to do https://github.com/wordpress-mobile/WordPress-iOS/pull/21235 recently to make it compile on Xcode 15. Considering it's only used in one place (changing a post's feature image), I have implemented the view we needed and removed the library from the codebase.

## Changes

The new `StoppableProgressIndicatorView` type is our replacement of `MRActivityIndicatorView`. To make the diff as small as possible, I have made the new type's API compatible with the `MRProgress` one.

The view is used to display a progress indicator while the feature image is being uploaded. Here is a side by side appearance comparison:

| `MRActivityIndicatorView`  | `StoppableProgressIndicatorView` |
| ------------- | ------------- |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1101828/4191a69c-aadc-4edc-91ad-f78a4824736b"/>  | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1101828/4b4a4f30-67ff-45b6-adba-c83bd5802223" />  |

## Test Instructions

Go to a post's "Post Settings" and update the post's featured image. Verify different kinds of operations: stop, cancel, re-upload the image, etc.

If you want to inspect the progress indicator animation, you can make following local changes to keep the animation forever:
1. Checkout the second commit https://github.com/wordpress-mobile/WordPress-iOS/commit/3d8e4a0c28d67ea1d8b4aba8e659be9fa2a7e91b
2. Save the following diff into a file
3. Run `git appply /path/to/diff`
4. Launch the app using Xcode

<details>

```diff
diff --git a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
index b63441d4c3..5eea64113d 100644
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -795,29 +795,7 @@ FeaturedImageViewControllerDelegate>
 
 - (UITableViewCell *)configureFeaturedImageCellForIndexPath:(NSIndexPath *)indexPath
 {
-    if (!self.apost.featuredImage && !self.isUploadingMedia) {
-        return [self cellForSetFeaturedImage];
-
-    } else if (self.isUploadingMedia || self.apost.featuredImage.remoteStatus == MediaRemoteStatusPushing) {
-        // Is featured Image set on the post and it's being pushed to the server?
-        if (!self.isUploadingMedia) {
-            self.isUploadingMedia = YES;
-            [self setupObservingOfMedia:self.apost.featuredImage];
-        }
-        self.featuredImage = nil;
-        return [self cellForFeaturedImageUploadProgressAtIndexPath:indexPath];
-
-    } else if (self.apost.featuredImage && self.apost.featuredImage.remoteStatus == MediaRemoteStatusFailed) {
-        // Do we have an feature image set and for some reason the upload failed?
-        return [self cellForFeaturedImageError];
-    } else {
-        NSURL *featuredURL = [self urlForFeaturedImage];
-        if (!featuredURL) {
-            return [self cellForSetFeaturedImage];
-        }
-
-        return [self cellForFeaturedImageWithURL:featuredURL atIndexPath:indexPath];
-    }
+    return [self cellForFeaturedImageUploadProgressAtIndexPath:indexPath];
 }
 
 - (UITableViewCell *)configureStickyPostCellForIndexPath:(NSIndexPath *)indexPath
@@ -861,7 +839,10 @@ FeaturedImageViewControllerDelegate>
 {
     self.progressCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewProgressCellIdentifier forIndexPath:indexPath];
     [WPStyleGuide configureTableViewCell:self.progressCell];
-    [self.progressCell setProgress:self.featuredImageProgress];
+
+    NSProgress *progress = [NSProgress discreteProgressWithTotalUnitCount:1000];
+    progress.cancellationHandler = ^(){};
+    [self.progressCell setProgress:progress];
     self.progressCell.tag = PostSettingsRowFeaturedLoading;
     return self.progressCell;
 }

```

</details>

## Regression Notes
1. Potential unintended areas of impact
None.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
The "Test Instructions"

6. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)