### PR TITLE
Use PostRepository.getPost in Stats Insights

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -368,17 +368,24 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
-        postService.getPostWithID(postID, for: blog, success: { apost in
-            guard let post = apost as? Post else {
-                DDLogInfo("Failed to get post with id \(postID)")
-                return
-            }
+        let coreDataStack = ContextManager.shared
+        let postRepository = PostRepository(coreDataStack: coreDataStack)
+        Task { @MainActor in
+            do {
+                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(saved: blog))
+                let apost = try coreDataStack.mainContext.existingObject(with: postObjectID)
 
-            let shareController = PostSharingController()
-            shareController.sharePost(post, fromView: fromView, inViewController: self)
-        }, failure: { error in
-            DDLogInfo("Error getting post with id \(postID): \(error.localizedDescription)")
-        })
+                guard let post = apost as? Post else {
+                    DDLogInfo("Failed to get post with id \(postID)")
+                    return
+                }
+
+                let shareController = PostSharingController()
+                shareController.sharePost(post, fromView: fromView, inViewController: self)
+            } catch {
+                DDLogInfo("Error getting post with id \(postID): \(error.localizedDescription)")
+            }
+        }
     }
 
     func showPostingActivityDetails() {


### PR DESCRIPTION
What says in the title. The new `PostRepository` type was introduced in #21419.

> **Note**
> It might be easier to review by turning on the "Hide whitespace" option.

## Test Instructions

1. Navigate to "Me" -> "App Settings" -> "Debug" -> "Feature Flags"
2. Disable "New Cards for Stats Insights"
3. Go to "My Site" -> Stats
4. Scroll to the "Latest Post Summary" card and tap the "Share Post" button in the card.
5. Verify the information on the presented share sheet is correct.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The "Test Instructions"

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A