### PR TITLE
[UI Tests] Re-enable media picker tests with support to PHPicker

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -23,10 +23,6 @@
       "parallelizable" : true,
       "skippedTests" : [
         "EditorAztecTests",
-        "EditorGutenbergTests\/testAddGalleryBlock()",
-        "EditorGutenbergTests\/testAddMediaBlocks()",
-        "EditorGutenbergTests\/testAddRemoveFeaturedImage()",
-        "EditorGutenbergTests\/testBasicPostPublishWithCategoryAndTag()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",
         "SignupTests\/testEmailSignup()",

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -392,14 +392,10 @@ public class BlockEditorScreen: ScreenObject {
             .selectMultipleImages(numberOfImages)
     }
 
-    private func chooseFromDevice() throws -> MediaPickerAlbumScreen {
+    private func chooseFromDevice() throws -> PHPickerScreen {
         chooseFromDeviceButton.tap()
 
-        // Allow access to device media
-        app.tap() // trigger the media permissions alert handler
-
-        return try MediaPickerAlbumListScreen()
-                    .selectAlbum(atIndex: 0)
+        return try PHPickerScreen()
     }
 
     private func confirmPost(button: XCUIElement) throws {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -11,6 +11,10 @@ public class EditorPostSettings: ScreenObject {
         $0.cells["Categories"]
     }
 
+    private let chooseFromMediaButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Choose from Media"]
+    }
+
     private let tagsSectionGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["Tags"]
     }
@@ -44,6 +48,7 @@ public class EditorPostSettings: ScreenObject {
     }
 
     var categoriesSection: XCUIElement { categoriesSectionGetter(app) }
+    var chooseFromMediaButton: XCUIElement { chooseFromMediaButtonGetter(app) }
     var currentFeaturedImage: XCUIElement { currentFeaturedImageGetter(app) }
     var dateSelector: XCUIElement { dateSelectorGetter(app) }
     var doneButton: XCUIElement { doneButtonGetter(app) }
@@ -96,8 +101,8 @@ public class EditorPostSettings: ScreenObject {
 
     public func setFeaturedImage() throws -> EditorPostSettings {
         featuredImageButton.tap()
-        try MediaPickerAlbumListScreen()
-            .selectAlbum(atIndex: 0) // Select media library
+        chooseFromMediaButton.tap()
+        try MediaPickerAlbumScreen()
             .selectImage(atIndex: 0) // Select latest uploaded image
 
         return try EditorPostSettings()

--- a/WordPress/UITestsFoundation/Screens/Media/PHPickerScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/PHPickerScreen.swift
@@ -1,0 +1,48 @@
+import ScreenObject
+import XCTest
+
+public class PHPickerScreen: ScreenObject {
+
+    private let addButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Add"]
+    }
+
+    private let photosNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Photos"]
+    }
+
+    private let photosScrollViewGetter: (XCUIApplication) -> XCUIElement = {
+        $0.otherElements["Photos"].scrollViews.firstMatch
+    }
+
+    var addButton: XCUIElement { addButtonGetter(app) }
+    var photosNavigationBar: XCUIElement { photosNavigationBarGetter(app) }
+    var photosScrollView: XCUIElement { photosScrollViewGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetter: photosNavigationBarGetter,
+            app: app
+        )
+    }
+
+    public func selectImage(atIndex index: Int) {
+        let selectedImage = photosScrollView.images.element(boundBy: index)
+        XCTAssertTrue(selectedImage.waitForExistence(timeout: 5), "Selected image did not load")
+        selectedImage.tap()
+    }
+
+    public func selectMultipleImages(_ numberOfImages: Int) {
+        var index = 0
+        while index < numberOfImages {
+            selectImage(atIndex: index)
+            index += 1
+        }
+
+        addButton.tap()
+    }
+
+    public static func isLoaded(app: XCUIApplication = XCUIApplication()) -> Bool {
+        return (try? PHPickerScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3459,6 +3459,7 @@
 		EA85B7AF2A688AB00096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
 		EA85B7B02A688B1C0096E097 /* TestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA85B7A92A6860370096E097 /* TestObserver.swift */; };
 		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
+		EABE86612A995124004281A8 /* PHPickerScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EABE86602A995124004281A8 /* PHPickerScreen.swift */; };
 		EAD08D0E29D45E23001A72F9 /* CommentsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD08D0D29D45E23001A72F9 /* CommentsScreen.swift */; };
 		EAD2BF4227594DAB00A847BB /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD2BF4127594DAB00A847BB /* StatsTests.swift */; };
 		EB6DF027AF96D801F280E805 /* Pods_WordPressStatsWidgets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D670B9448DF9991366CF42D /* Pods_WordPressStatsWidgets.framework */; };
@@ -8835,6 +8836,7 @@
 		EA78189327596B2F00554DFA /* ContactUsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
 		EA85B7A92A6860370096E097 /* TestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObserver.swift; sourceTree = "<group>"; };
 		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
+		EABE86602A995124004281A8 /* PHPickerScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PHPickerScreen.swift; sourceTree = "<group>"; };
 		EAD08D0D29D45E23001A72F9 /* CommentsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsScreen.swift; sourceTree = "<group>"; };
 		EAD2BF4127594DAB00A847BB /* StatsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
 		EEF80689364FA9CAE10405E8 /* Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -11216,6 +11218,7 @@
 			children = (
 				CC5218992279CF3B008998CE /* MediaPickerAlbumListScreen.swift */,
 				CC52189B2279D295008998CE /* MediaPickerAlbumScreen.swift */,
+				EABE86602A995124004281A8 /* PHPickerScreen.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -22854,6 +22857,7 @@
 				3FE39A3B26F837FF006E2B3A /* PostsScreen.swift in Sources */,
 				3F2F855C26FAF227000FCDA5 /* LinkOrPasswordScreen.swift in Sources */,
 				3F2F855226FAF227000FCDA5 /* SignupCheckMagicLinkScreen.swift in Sources */,
+				EABE86612A995124004281A8 /* PHPickerScreen.swift in Sources */,
 				3FE39A4026F8386A006E2B3A /* SiteSettingsScreen.swift in Sources */,
 				D8E7529B2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift in Sources */,
 				3FE39A3526F83701006E2B3A /* LoginEpilogueScreen.swift in Sources */,


### PR DESCRIPTION
### Description
This PR adds support to the new media picker, https://github.com/wordpress-mobile/WordPress-iOS/issues/21190, and re-enables tests (listed below) impacted by the changes.
```
EditorGutenbergTests.testAddGalleryBlock()
EditorGutenbergTests.testAddMediaBlocks()
EditorGutenbergTests.testAddRemoveFeaturedImage()
EditorGutenbergTests.testBasicPostPublishWithCategoryAndTag()
```

### Testing
CI should be 🟢