### PR TITLE
Fix regression in Zendesk identity

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -331,6 +331,7 @@ protocol ZendeskUtilsProtocol {
 
 extension ZendeskUtils {
     func createNewRequest(in viewController: UIViewController, description: String, tags: [String], completion: @escaping ZendeskNewRequestCompletion) {
+        presentInController = viewController
         ZendeskUtils.createIdentity { [weak self] success, newIdentity in
             guard let self, success else {
                 completion(.failure(.noIdentity))


### PR DESCRIPTION
When the user creates a Zendesk ticket via the chatbot, the app asks the user for their identity (email and name) if they haven't set it yet. This flow wasn't working in the scenario where these weren't set. The fix involves passing in the view controller to use to present the identity form (an alert) on top.

This PR re-adds the fix https://github.com/wordpress-mobile/WordPress-iOS/pull/21363 (see discussion thread p1693345057204499-slack-C05ALSVN5K5).

## To test

1. Start with a clean install to ensure the app does not have the user's support email/username set
2. Enable the `Contact Support via DocsBot` feature flag (App Settings > Debug > Feature Flags)
3. Go to the Me screen
4. Tap "Help & Support"
5. Tap "Contact support"
6. Chat with the bot
7. Tap one of the "Contact support" buttons and create a ticket
8. Expect a ticket to be created (before this fix, the app would be stuck with an activity indicator)

## Regression Notes
1. Potential unintended areas of impact: The ticket creation flow from within the chatbot interface
2. What I did to test those areas of impact (or what existing automated tests I relied on): Manual testing
3. What automated tests I added (or what prevented me from doing so): Testing to ensure the view controller is set involves making `presentInController` non-private, which isn't desirable. There's no other good way of ensuring it's set, without refactoring the code to introduce protocols at the presentation of the view controller. Given these complexities, I left automated testing out of this PR. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: Not applicable because this isn't a UI change