### PR TITLE
[UI Tests] - Fix flaky like notification test (Second try)

### DIFF
--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -116,7 +116,11 @@ public class NotificationsScreen: ScreenObject {
 
 
     public func likeComment() -> Self {
-        likeCommentButton.tap()
+        let isCommentTextDisplayed = app.webViews.staticTexts.firstMatch.waitForExistence(timeout: 5)
+
+        if isCommentTextDisplayed {
+            likeCommentButton.tap()
+        }
 
         return self
     }


### PR DESCRIPTION
### Description
The first attempt https://github.com/wordpress-mobile/WordPress-iOS/pull/21420 at fixing this did not completely prevent the flakiness from happening, I had a closer look at the issue and found what could be the actual issue.

The test is flaky on iPhone and iPad but more so on iPad. I found that the text for comment notification is a `WebView`
![Screenshot 2023-09-01 at 11 21 22 AM](https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/8352fa00-fa61-4ceb-ab7b-7bff510c3e64) and looking at the test more closely while it's running sometimes the text renders slower than the rest of page. In the times when this test is flaky, the attempts to tap on the like button failed, but it does not report an error for that. Looking at the logs, we can see that there is this vague error `Ignoring failure to get hierarchy for remote element in process 70583 (Error getting main window kAXErrorServerNotFound)`, which is when the screen is re-rendering to include the `WebView` element, here's a recording of the test to see the slowness in the rendering of the `WebView` (scroll to near the end to see it):

https://github.com/wordpress-mobile/WordPress-iOS/assets/17252150/266e91de-93ee-4bb7-98bf-74c02fa084a3


To handle the `WebView`,  I added a wait to ensure that the text on the comment notification is fully loaded before tapping the like button. 

### Testing
`testLikeNotification()` should pass the first time on iPhone and iPad. I also ran the tests multiple times in CI to ensure that the fix worked this time.