### PR TITLE
Contact Support: Prevent memory leaks by removing script message handlers

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -12,8 +12,6 @@ final class SupportChatBotViewController: UIViewController {
     private weak var delegate: SupportChatBotCreatedTicketDelegate?
     private lazy var webView: WKWebView = {
         let contentController = WKUserContentController()
-        contentController.add(self, name: Constants.supportCallback)
-        contentController.add(self, name: Constants.errorCallback)
         let config = WKWebViewConfiguration()
         config.userContentController = contentController
         let webView = WKWebView(frame: .zero, configuration: config)
@@ -25,6 +23,20 @@ final class SupportChatBotViewController: UIViewController {
         self.viewModel = viewModel
         self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        webView.configuration.userContentController.add(self, name: Constants.supportCallback)
+        webView.configuration.userContentController.add(self, name: Constants.errorCallback)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        /// Message handlers need to be removed to prevent memory leaks
+        webView.configuration.userContentController.removeAllScriptMessageHandlers()
     }
 
     override func loadView() {


### PR DESCRIPTION
## Description

SupportChatBotViewController is not deallocated after dismissing it. It is caused by scriptMessageHandler which requires to be manually removed.

### Solution

- Remove message handlers on `viewWillDisappear` 
- Add message handlers on `viewWillAppear`, to re-add them if view controller was dismissed by switching tabs rather than coming back

### To test:

1. Enable Contact Support feature flag
2. Go to Help & Support
3. Contact Support
4. Come back
5. Open memory debugger
6. Confirm `SupportChatBotViewController` is deallocated

#### Additional cases
1. Open Contact Support
2. Switch between Me and other tabs
3. Come back to Me tab
4. Ask a question
5. Select contact support
6. Confirm ticket is created
7. Confirm `SupportChatBotViewController` is deallocated after it's dismissed

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
