### PR TITLE
Pages List: Update a `precondition` check to be a `guard`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [*] [internal] Change how a post's revision is fetched from the post history screen. [#21440]
 * [**] [internal] Replace the progress indicator implementation in uploading featured image from "Post Settings" [#21438]
 * [***] [Jetpack-only] Contact Support: Add a new chat-based support channel where users can get answers from a bot trained to help app users. Users can still create a support ticket to talk to a Happiness Engineer if they don't find the answer they're looking for [#21467]
+* [*] Fix a crash on the pages list when the authentication token is invalid. [#21471]
 
 23.0.1
 -----

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -29,7 +29,9 @@ private func makeCookieNonceAuthenticator(blog: Blog) -> Authenticator? {
 }
 
 private func apiBase(blog: Blog) -> URL? {
-    precondition(blog.account == nil, ".com support has not been implemented yet")
+    guard blog.account == nil else {
+        return nil
+    }
     return try? blog.url(withPath: "wp-json/")?.asURL()
 }
 

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -30,6 +30,7 @@ private func makeCookieNonceAuthenticator(blog: Blog) -> Authenticator? {
 
 private func apiBase(blog: Blog) -> URL? {
     guard blog.account == nil else {
+        assertionFailure(".com support has not been implemented yet")
         return nil
     }
     return try? blog.url(withPath: "wp-json/")?.asURL()


### PR DESCRIPTION
Fixes #21407 

## Description 

When the user's auth token is invalid, the editor service will attempt to initialize a `WordPressOrgRestApi` class. Due to there still being an account with the blog, the `precondition` would cause a crash.

Since the initialize and `apiBase` function are already nullable, we can switch this `precondition` to a `guard` and then return `nil`.

## Testing

To test:

- Launch either WordPress or Jetpack and login
- Open your [connected applications](https://wordpress.com/me/security/connected-applications) on the web
- Disconnect iOS
- In the app, pull to refresh on the home dashboard
- When the sign in screen appears, hit cancel
- Tap on `Pages`
- 🔍 **Verify** the app does not crash

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
