### PR TITLE
Contact Support: Prevent chat bot message text from scaling to avoid different message sizes

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget_page.css
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget_page.css
@@ -1,3 +1,8 @@
+html {
+  -webkit-text-size-adjust: none !important;
+  text-size-adjust: none !important;
+}
+
 body {
     margin: 0 !important;
 }


### PR DESCRIPTION
Prevent chat bot message text from scaling to avoid different message sizes. 

There was a global style enabled that would scale text sizes in some situations. However, it causes message sizes to be different which is not desirable. On iOS, text size changes when switching from vertical into horizontal orientation. Check Text-size-adjust section in https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/

## To test:
1. Enable Contact Support via ChatBot feature flag
2. Help & Support -> Contact Support
3. Ask a question
4. Change to horizontal orientation
5. The text for all the messages should remain in the same size

## Regression Notes
1. Potential unintended areas of impact

None 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-31 at 11 31 05](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/c6ab922d-fe35-4855-b485-ad0d778fc5f0) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-31 at 11 35 14](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/81599ee8-1b5c-4cd5-865e-fe4f55d6705d) |

