### PR TITLE
Rename `TaggedManagedObjectID` initialiser

### DIFF
--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -59,7 +59,7 @@ final class PostRepository {
 
             PostHelper.update(post, with: remotePost, in: context)
 
-            return try .init(unsaved: post)
+            return .init(post)
         }
     }
 

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -262,7 +262,7 @@ fileprivate extension SearchManager {
         let postRepository = PostRepository(coreDataStack: coreDataStack)
         Task { @MainActor in
             do {
-                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(saved: blog))
+                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
                 let post = try coreDataStack.mainContext.existingObject(with: postObjectID)
                 onSuccess(post)
             } catch {
@@ -284,7 +284,7 @@ fileprivate extension SearchManager {
         let postRepository = PostRepository(coreDataStack: coreDataStack)
         Task { @MainActor in
             do {
-                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(saved: blog))
+                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
                 let post = try coreDataStack.mainContext.existingObject(with: postObjectID)
                 onSuccess(post)
             } catch {

--- a/WordPress/Classes/Utility/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/TaggedManagedObjectID.swift
@@ -29,17 +29,27 @@ import Foundation
 struct TaggedManagedObjectID<Model: NSManagedObject>: Equatable {
     let objectID: NSManagedObjectID
 
-    /// Create an `TaggedManagedObjectID` instance of an object that's already saved.
+    @available(*, deprecated, message: "Use init(_:) instead")
     init(saved object: Model) {
-        self = TaggedManagedObjectID<Model>(objectID: object.objectID)
+        self.init(object)
     }
 
-    /// Create an `TaggedManagedObjectID` instance of an object that's not yet saved.
+    @available(*, deprecated, message: "Use init(_:) instead")
     init(unsaved object: Model) throws {
+        self.init(object)
+    }
+
+    /// Create an `TaggedManagedObjectID` instance of the given object.
+    init(_ object: Model) {
         var objectID = object.objectID
+
         if objectID.isTemporaryID {
             let context = object.managedObjectContext!
-            try context.obtainPermanentIDs(for: [object])
+            do {
+                try context.obtainPermanentIDs(for: [object])
+            } catch {
+                fatalError("Failed to obtain permanent id for \(objectID). Error: \(error)")
+            }
             objectID = object.objectID
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -158,7 +158,7 @@ private extension RevisionsTableViewController {
         let postRepository = PostRepository(coreDataStack: coreDataStack)
         Task { @MainActor in
             do {
-                let postID = try await postRepository.getPost(withID: revision.revisionId, from: .init(saved: blog))
+                let postID = try await postRepository.getPost(withID: revision.revisionId, from: .init(blog))
                 let post = try coreDataStack.mainContext.existingObject(with: postID)
 
                 await SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -372,7 +372,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         let postRepository = PostRepository(coreDataStack: coreDataStack)
         Task { @MainActor in
             do {
-                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(saved: blog))
+                let postObjectID = try await postRepository.getPost(withID: postID, from: .init(blog))
                 let apost = try coreDataStack.mainContext.existingObject(with: postObjectID)
 
                 guard let post = apost as? Post else {

--- a/WordPress/WordPressTest/PostRepositoryTests.swift
+++ b/WordPress/WordPressTest/PostRepositoryTests.swift
@@ -19,7 +19,7 @@ class PostRepositoryTests: CoreDataTestCase {
 
         contextManager.saveContextAndWait(mainContext)
 
-        blogID = .init(saved: blog)
+        blogID = .init(blog)
         remoteMock = PostServiceRESTMock()
         let remoteFactory = PostServiceRemoteFactoryMock()
         remoteFactory.remoteToReturn = remoteMock

--- a/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
+++ b/WordPress/WordPressTest/TaggedManagedObjectIDTests.swift
@@ -9,14 +9,14 @@ class TaggedManagedObjectIDTests: CoreDataTestCase {
         let post = PostBuilder(contextManager.mainContext).with(title: "Test post").build()
         try contextManager.mainContext.save()
 
-        let id = TaggedManagedObjectID(saved: post)
+        let id = TaggedManagedObjectID(post)
         let result = try contextManager.mainContext.existingObject(with: id)
         XCTAssertEqual(result.postTitle, "Test post")
     }
 
     func testQueryUnsaved() throws {
         let post = PostBuilder(contextManager.mainContext).with(title: "Test post").build()
-        let id = try TaggedManagedObjectID(unsaved: post)
+        let id = try TaggedManagedObjectID(post)
 
         try contextManager.mainContext.save()
 
@@ -28,7 +28,7 @@ class TaggedManagedObjectIDTests: CoreDataTestCase {
     func testQueryUnsavedUsingTheSameContext() throws {
         let context = contextManager.mainContext
         let post = PostBuilder(context).with(title: "Test post").build()
-        let id = try TaggedManagedObjectID(unsaved: post)
+        let id = try TaggedManagedObjectID(post)
 
         let result = try context.existingObject(with: id)
         XCTAssertEqual(result.postTitle, "Test post")
@@ -36,7 +36,7 @@ class TaggedManagedObjectIDTests: CoreDataTestCase {
 
     func testQueryUnsavedUsingDifferentContext() throws {
         let post = PostBuilder(contextManager.mainContext).build()
-        let id = try TaggedManagedObjectID(unsaved: post)
+        let id = try TaggedManagedObjectID(post)
 
         let newContext = contextManager.newDerivedContext()
 
@@ -45,12 +45,12 @@ class TaggedManagedObjectIDTests: CoreDataTestCase {
 
     func testEqutable() throws {
         let post = PostBuilder(contextManager.mainContext).with(title: "Test post").build()
-        let unsaveID = try TaggedManagedObjectID(unsaved: post)
+        let unsaveID = try TaggedManagedObjectID(post)
         try contextManager.mainContext.save()
-        let savedID = TaggedManagedObjectID(saved: post)
+        let savedID = TaggedManagedObjectID(post)
 
         XCTAssertEqual(unsaveID, savedID)
-        XCTAssertEqual(TaggedManagedObjectID(saved: post), savedID)
+        XCTAssertEqual(TaggedManagedObjectID(post), savedID)
     }
 
 }
@@ -97,8 +97,8 @@ extension TaggedManagedObjectIDTests {
         let post = PostBuilder(contextManager.mainContext).with(author: "WordPress.com").build()
         try contextManager.mainContext.save()
 
-        let postID: TaggedManagedObjectID<Post> = .init(saved: post)
-        let abstractPostID: TaggedManagedObjectID<AbstractPost> = .init(saved: post)
+        let postID: TaggedManagedObjectID<Post> = .init(post)
+        let abstractPostID: TaggedManagedObjectID<AbstractPost> = .init(post)
 
         // This line does not compile without the second `author(of:in:)` overload.
         try XCTAssertEqual(author(of: postID, in: contextManager.mainContext), "WordPress.com")


### PR DESCRIPTION
@kean made a suggestion to rename the existing initialisers to `init(_:)` and `init(obtainingPermanentID:)`. I do like the `init(obtainingPermanentID:)` one better than `init(unsaved:)`: It clearly communicates what's happening in that initialiser.

However, as I start making this renaming change, I feel like it becomes unclear which one to choose on the caller side. The two existing initialisers `init(unsaved:)` and `init(saved:)` are named in a way that's easier for the caller to pick.

The idea behind the two initialisers is, we should distinguish the two scenarios differently: getting object id from a saved object is guaranteed to success, but getting a permanent object id for a unsaved object may throw an error.

I have second thoughts about that idea now. First of all, we [crash the app intentionally](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.1.0.2/WordPress/Classes/Utility/ContextManager%2BErrorHandling.swift#L92) when `context.save()` fails. I don't know what errors the `obtainPermanentIDs` API may throw, but I imagine it's less likely to fail than `save`. Secondly, if the `obtainPermanentIDs` call fails (which maybe means SQLLite fails to update the database file), then the `save` call followed probably is going to fail too. Finally, there aren't many `save` crashes on Sentry.

Given all that, I think it should be safe to crash upon `obtainPermanentIDs` failure. By doing that,  we only need one initialiser `TaggedManagedObjectID.init(_ object: Model)`. Let me know what you all think.

BTW, I selfishly marked the existing two initialisers as deprecated, instead of removing them, because I have a few pending PR and changes that uses these APIs. I don't want them causing compiling issues when merged.

> **Note**
> The initialiser implementation changes are in the first commit. The second commit is updating all the call sites.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A