### PR TITLE
UI Modernization: Me tab split view tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -126,7 +126,8 @@ class MeViewController: UITableViewController {
     }
 
     private var appSettingsRow: NavigationItemRow {
-        let accessoryType: UITableViewCell.AccessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
+        let isDetailViewController = (splitViewController?.viewControllers.last as? UINavigationController)?.topViewController is MeViewController
+        let accessoryType: UITableViewCell.AccessoryType = isDetailViewController ? .disclosureIndicator : .none
 
         return NavigationItemRow(
             title: RowTitles.appSettings,
@@ -137,7 +138,8 @@ class MeViewController: UITableViewController {
     }
 
     fileprivate func tableViewModel(with account: WPAccount?) -> ImmuTable {
-        let accessoryType: UITableViewCell.AccessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
+        let isDetailViewController = (splitViewController?.viewControllers.last as? UINavigationController)?.topViewController is MeViewController
+        let accessoryType: UITableViewCell.AccessoryType = isDetailViewController ? .disclosureIndicator : .none
 
         let loggedIn = account != nil
 

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -254,7 +254,7 @@ class MeViewController: UITableViewController {
         return { [unowned self] row in
             if let myProfileViewController = self.myProfileViewController {
                 WPAppAnalytics.track(.openedMyProfile)
-                self.showDetailViewController(myProfileViewController, sender: self)
+                self.showOrPushController(myProfileViewController)
             }
         }
     }
@@ -266,7 +266,7 @@ class MeViewController: UITableViewController {
                 guard let controller = AccountSettingsViewController(account: account) else {
                     return
                 }
-                self.showDetailViewController(controller, sender: self)
+                self.showOrPushController(controller)
             }
         }
     }
@@ -286,20 +286,14 @@ class MeViewController: UITableViewController {
         return { [unowned self] row in
             WPAppAnalytics.track(.openedAppSettings)
             let controller = AppSettingsViewController()
-            self.showDetailViewController(controller, sender: self)
+            self.showOrPushController(controller)
         }
     }
 
     func pushHelp() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = SupportTableViewController(style: .insetGrouped)
-
-            // If iPad, show Support from Me view controller instead of navigation controller.
-             if !self.splitViewControllerIsHorizontallyCompact {
-                 controller.showHelpFromViewController = self
-             }
-
-            self.showDetailViewController(controller, sender: self)
+            self.showOrPushController(controller)
         }
     }
 
@@ -386,6 +380,17 @@ class MeViewController: UITableViewController {
             tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
             handler.tableView(self.tableView, didSelectRowAt: indexPath)
         }
+    }
+
+    private func showOrPushController(_ controller: UIViewController) {
+        let primaryViewController = (splitViewController?.viewControllers.first as? UINavigationController)?.topViewController
+        let shouldShowInDetailViewController = splitViewControllerIsHorizontallyCompact || primaryViewController is MeViewController
+        if shouldShowInDetailViewController {
+            self.showDetailViewController(controller, sender: self)
+            return
+        }
+
+        self.navigationController?.pushViewController(controller, animated: true, rightBarButton: self.navigationItem.rightBarButtonItem)
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -111,7 +111,8 @@ class MeViewController: UITableViewController {
         // Then we'll reload the table view model (prompting a table reload)
         handler.viewModel = tableViewModel(with: account)
 
-        if !splitViewControllerIsHorizontallyCompact {
+        let primaryViewController = (splitViewController?.viewControllers.first as? UINavigationController)?.topViewController
+        if !splitViewControllerIsHorizontallyCompact && primaryViewController is MeViewController {
             // And finally we'll reselect the selected row, if there is one
             tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
         }


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21273
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21283

## Description/
This addresses a navigation issue for WPiOS / iPad / simplified, where users should be able to go back to the Me screen by tapping on nav bar button.

- Updates navigation logic
   - Pushes subsequent view controller on to nav stack when Me screen is shown in the detail pane (i.e. on iPad, simplified app UI type on WordPress)
   - Shows subsequent view controller in the detail pane when Me screen is shown in the primary pane (i.e. on iPad, Jetpack)
- Displays disclosure indicators for Me screen items when Me screen is shown in the detail pane (i.e. on iPad, simplified app UI type)

Before | After
-- | --
![Simulator Screenshot - iPad Air (5th generation) - 2023-09-04 at 11 44 59](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/187b8ccc-9a3a-42a0-bd3f-a8bed241702d) | ![Simulator Screenshot - iPad Air (5th generation) - 2023-09-04 at 11 42 53](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/97339a47-4483-407b-988c-e56c6da66f6a)
![Simulator Screenshot - iPad Air (5th generation) - 2023-09-04 at 11 33 01](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/51daa256-4f46-4b8c-99ff-b548973a78b7) | ![Simulator Screenshot - iPad Air (5th generation) - 2023-09-05 at 14 17 43](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/3a70a254-159b-4405-b037-ee88ee8148b0)


## How to test

### WPiOS / iPad / simplified
- Run the WPiOS app on an iPad
- Enable Jetpack feature removal phase four via the debug menu
- Tap on the Me menu item
- Verify Me screen displays disclosure indicators for each row
- Tap on the following items and verify you can return to the Me screen by tapping on "< Me"
    - My Profile
    - Account Settings
    - App Settings
    - Help & Support 

### JPiOS / iPad
- Run the JPiOS app on an iPad
- Tap on the Me tab
- Verify Me screen hides disclosure indicators for each row
- Tap on the following items and verify they're displayed in the details view
    - My Profile
    - Account Settings
    - App Settings
    - Help & Support 

### JPiOS / iPhone
- Run the JPiOS app on an iPhone
- Tap on the Me tab
- Verify Me screen displays disclosure indicators for each row
- Tap on the following items and verify you can return to the Me screen by tapping on "< Me"
    - My Profile
    - Account Settings
    - App Settings
    - Help & Support 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
