### PR TITLE
Lock Screen Widgets: Add more configurations

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/WidgetConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/WidgetConfiguration.swift
@@ -28,9 +28,22 @@ import Foundation
 
             /// Lock Screen
             @objc static let lockScreenTodayViewsKind = "WordPressLockScreenWidgetTodayViews"
-            @objc static let lockScreenTodayLikesCommentsKind = "WordPressLockScreenWidgetTodayLikesComments"
             @objc static let lockScreenTodayViewsProperties = "WordPressLockScreenWidgetTodayViewsProperties"
+
+            @objc static let lockScreenTodayLikesCommentsKind = "WordPressLockScreenWidgetTodayLikesComments"
             @objc static let lockScreenTodayLikesCommentsProperties = "WordPressLockScreenWidgetTodayLikesCommentsProperties"
+
+            @objc static let lockScreenTodayViewsVisitorsKind = "WordPressLockScreenWidgetTodayViewsVisitors"
+            @objc static let lockScreenTodayViewsVisitorsProperties = "WordPressLockScreenWidgetTodayViewsVisitorsProperties"
+
+            @objc static let lockScreenAllTimeViewsKind = "WordPressLockScreenWidgetAllTimeViews"
+            @objc static let lockScreenAllTimeViewsProperties = "WordPressLockScreenWidgetAllTimeViewsProperties"
+
+            @objc static let lockScreenAllTimeViewsVisitorsKind = "WordPressLockScreenWidgetAllTimeViewsVisitors"
+            @objc static let lockScreenAllTimeViewsVisitorsProperties = "WordPressLockScreenWidgetAllTimeViewsVisitorsProperties"
+
+            @objc static let lockScreenAllTimePostsBestViewsKind = "WordPressLockScreenWidgetAllTimePostsBestViews"
+            @objc static let lockScreenAllTimePostsBestViewsProperties = "WordPressLockScreenWidgetAllTimeBestViewsProperties"
         }
 
         // iOS13 Stats Today Widgets

--- a/WordPress/Jetpack/WidgetConfiguration.swift
+++ b/WordPress/Jetpack/WidgetConfiguration.swift
@@ -30,14 +30,17 @@ import Foundation
             @objc static let lockScreenTodayViewsKind = "JetpackLockScreenWidgetTodayViews"
             @objc static let lockScreenTodayViewsProperties = "JetpackLockScreenWidgetTodayViewsProperties"
 
-            @objc static let lockScreenAllTimeViewsKind = "JetpackLockScreenWidgetAllTimeViews"
-            @objc static let lockScreenAllTimeViewsProperties = "JetpackLockScreenWidgetAllTimeViewsProperties"
-
             @objc static let lockScreenTodayLikesCommentsKind = "JetpackLockScreenWidgetTodayLikesComments"
             @objc static let lockScreenTodayLikesCommentsProperties = "JetpackLockScreenWidgetTodayLikesCommentsProperties"
 
             @objc static let lockScreenTodayViewsVisitorsKind = "JetpackLockScreenWidgetTodayViewsVisitors"
             @objc static let lockScreenTodayViewsVisitorsProperties = "JetpackLockScreenWidgetTodayViewsVisitorsProperties"
+
+            @objc static let lockScreenAllTimeViewsKind = "JetpackLockScreenWidgetAllTimeViews"
+            @objc static let lockScreenAllTimeViewsProperties = "JetpackLockScreenWidgetAllTimeViewsProperties"
+
+            @objc static let lockScreenAllTimeViewsVisitorsKind = "JetpackLockScreenWidgetAllTimeViewsVisitors"
+            @objc static let lockScreenAllTimeViewsVisitorsProperties = "JetpackLockScreenWidgetAllTimeViewsVisitorsProperties"
         }
 
 

--- a/WordPress/Jetpack/WidgetConfiguration.swift
+++ b/WordPress/Jetpack/WidgetConfiguration.swift
@@ -35,6 +35,9 @@ import Foundation
 
             @objc static let lockScreenTodayLikesCommentsKind = "JetpackLockScreenWidgetTodayLikesComments"
             @objc static let lockScreenTodayLikesCommentsProperties = "JetpackLockScreenWidgetTodayLikesCommentsProperties"
+
+            @objc static let lockScreenTodayViewsVisitorsKind = "JetpackLockScreenWidgetTodayViewsVisitors"
+            @objc static let lockScreenTodayViewsVisitorsProperties = "JetpackLockScreenWidgetTodayViewsVisitorsProperties"
         }
 
 

--- a/WordPress/Jetpack/WidgetConfiguration.swift
+++ b/WordPress/Jetpack/WidgetConfiguration.swift
@@ -41,6 +41,9 @@ import Foundation
 
             @objc static let lockScreenAllTimeViewsVisitorsKind = "JetpackLockScreenWidgetAllTimeViewsVisitors"
             @objc static let lockScreenAllTimeViewsVisitorsProperties = "JetpackLockScreenWidgetAllTimeViewsVisitorsProperties"
+
+            @objc static let lockScreenAllTimePostsBestViewsKind = "JetpackLockScreenWidgetAllTimePostsBestViews"
+            @objc static let lockScreenAllTimePostsBestViewsProperties = "JetpackLockScreenWidgetAllTimeBestViewsProperties"
         }
 
 

--- a/WordPress/Jetpack/WidgetConfiguration.swift
+++ b/WordPress/Jetpack/WidgetConfiguration.swift
@@ -28,8 +28,12 @@ import Foundation
 
             /// Lock Screen
             @objc static let lockScreenTodayViewsKind = "JetpackLockScreenWidgetTodayViews"
-            @objc static let lockScreenTodayLikesCommentsKind = "JetpackLockScreenWidgetTodayLikesComments"
             @objc static let lockScreenTodayViewsProperties = "JetpackLockScreenWidgetTodayViewsProperties"
+
+            @objc static let lockScreenAllTimeViewsKind = "JetpackLockScreenWidgetAllTimeViews"
+            @objc static let lockScreenAllTimeViewsProperties = "JetpackLockScreenWidgetAllTimeViewsProperties"
+
+            @objc static let lockScreenTodayLikesCommentsKind = "JetpackLockScreenWidgetTodayLikesComments"
             @objc static let lockScreenTodayLikesCommentsProperties = "JetpackLockScreenWidgetTodayLikesCommentsProperties"
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -225,6 +225,8 @@
 		01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
 		01D2FF5E2AA733690038E040 /* LockScreenFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */; };
 		01D2FF5F2AA733690038E040 /* LockScreenFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */; };
+		01D2FF612AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */; };
+		01D2FF622AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */; };
 		01DBFD8729BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01DBFD8829BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01E61E5A29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */; };
@@ -5950,6 +5952,7 @@
 		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenFieldView.swift; sourceTree = "<group>"; };
+		01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
 		01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainsCardSearchView.swift; sourceTree = "<group>"; };
 		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
@@ -16266,6 +16269,7 @@
 				C9FE383F29C2A3D200D39841 /* LockScreenStatsWidgetConfig.swift */,
 				C9FE383C29C2A3D100D39841 /* LockScreenTodayViewsStatWidgetConfig.swift */,
 				0188FE4A2AA62F800093EDA5 /* LockScreenTodayLikesCommentsStatWidgetConfig.swift */,
+				01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -21065,6 +21069,7 @@
 				0107E0BC28F97D5000DE87DB /* StatsWidgetsView.swift in Sources */,
 				0107E0BD28F97D5000DE87DB /* AppLocalizedString.swift in Sources */,
 				0107E0BE28F97D5000DE87DB /* MultiStatsView.swift in Sources */,
+				01D2FF622AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */,
 				0107E0BF28F97D5000DE87DB /* FeatureFlagOverrideStore.swift in Sources */,
 				0107E11528FD7FE500DE87DB /* AppConfiguration.swift in Sources */,
 				0107E0C028F97D5000DE87DB /* WordPressHomeWidgetToday.swift in Sources */,
@@ -23005,6 +23010,7 @@
 				3F526D572539FAC60069706C /* StatsWidgetsView.swift in Sources */,
 				3F2656A125AF4DFA0073A832 /* AppLocalizedString.swift in Sources */,
 				3F568A0025420DE80048A9E4 /* MultiStatsView.swift in Sources */,
+				01D2FF612AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */,
 				3F6BC05C25B24773007369D3 /* FeatureFlagOverrideStore.swift in Sources */,
 				3FD675EA25C87A25009AB3C1 /* WordPressHomeWidgetToday.swift in Sources */,
 				3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		01D2FF622AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */; };
 		01D2FF642AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */; };
 		01D2FF652AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */; };
+		01D2FF672AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */; };
+		01D2FF682AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */; };
 		01DBFD8729BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01DBFD8829BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01E61E5A29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */; };
@@ -5956,6 +5958,7 @@
 		01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenFieldView.swift; sourceTree = "<group>"; };
 		01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenTodayViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
+		01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
 		01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainsCardSearchView.swift; sourceTree = "<group>"; };
 		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
@@ -16272,8 +16275,9 @@
 				C9FE383F29C2A3D200D39841 /* LockScreenStatsWidgetConfig.swift */,
 				C9FE383C29C2A3D100D39841 /* LockScreenTodayViewsStatWidgetConfig.swift */,
 				0188FE4A2AA62F800093EDA5 /* LockScreenTodayLikesCommentsStatWidgetConfig.swift */,
-				01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */,
 				01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */,
+				01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */,
+				01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -21072,6 +21076,7 @@
 				C9B477B729CD2EF7008CBF49 /* LockScreenUnconfiguredView.swift in Sources */,
 				0107E0BC28F97D5000DE87DB /* StatsWidgetsView.swift in Sources */,
 				0107E0BD28F97D5000DE87DB /* AppLocalizedString.swift in Sources */,
+				01D2FF682AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */,
 				0107E0BE28F97D5000DE87DB /* MultiStatsView.swift in Sources */,
 				01D2FF622AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */,
 				0107E0BF28F97D5000DE87DB /* FeatureFlagOverrideStore.swift in Sources */,
@@ -23014,6 +23019,7 @@
 				C9B477B629CD2EF7008CBF49 /* LockScreenUnconfiguredView.swift in Sources */,
 				3F526D572539FAC60069706C /* StatsWidgetsView.swift in Sources */,
 				3F2656A125AF4DFA0073A832 /* AppLocalizedString.swift in Sources */,
+				01D2FF672AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */,
 				3F568A0025420DE80048A9E4 /* MultiStatsView.swift in Sources */,
 				01D2FF612AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */,
 				3F6BC05C25B24773007369D3 /* FeatureFlagOverrideStore.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		01D2FF5F2AA733690038E040 /* LockScreenFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */; };
 		01D2FF612AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */; };
 		01D2FF622AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */; };
+		01D2FF642AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */; };
+		01D2FF652AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */; };
 		01DBFD8729BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01DBFD8829BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01E61E5A29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */; };
@@ -5953,6 +5955,7 @@
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenFieldView.swift; sourceTree = "<group>"; };
 		01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
+		01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenTodayViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
 		01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainsCardSearchView.swift; sourceTree = "<group>"; };
 		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
@@ -16270,6 +16273,7 @@
 				C9FE383C29C2A3D100D39841 /* LockScreenTodayViewsStatWidgetConfig.swift */,
 				0188FE4A2AA62F800093EDA5 /* LockScreenTodayLikesCommentsStatWidgetConfig.swift */,
 				01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */,
+				01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -21105,6 +21109,7 @@
 				0107E1852900059300DE87DB /* LocalizationConfiguration.swift in Sources */,
 				0107E0D328F97D5000DE87DB /* Tracks+StatsWidgets.swift in Sources */,
 				0107E0D428F97D5000DE87DB /* HomeWidgetData.swift in Sources */,
+				01D2FF652AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */,
 				0107E0D528F97D5000DE87DB /* HomeWidgetTodayData.swift in Sources */,
 				0107E0D628F97D5000DE87DB /* AllTimeWidgetStats.swift in Sources */,
 				0107E0D728F97D5000DE87DB /* Sites.intentdefinition in Sources */,
@@ -23046,6 +23051,7 @@
 				0107E1872900065500DE87DB /* LocalizationConfiguration.swift in Sources */,
 				98390AC3254C984700868F0A /* Tracks+StatsWidgets.swift in Sources */,
 				3FA53ED62565860900F4D9A2 /* HomeWidgetData.swift in Sources */,
+				01D2FF642AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */,
 				3FB34ACB25672A90001A74A6 /* HomeWidgetTodayData.swift in Sources */,
 				3F5C863B25C9EA8200BABE64 /* AllTimeWidgetStats.swift in Sources */,
 				3FD675D925C87A15009AB3C1 /* Sites.intentdefinition in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -231,6 +231,8 @@
 		01D2FF652AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */; };
 		01D2FF672AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */; };
 		01D2FF682AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */; };
+		01D2FF6A2AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF692AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift */; };
+		01D2FF6B2AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF692AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift */; };
 		01DBFD8729BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01DBFD8829BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01E61E5A29F03DEC002E544E /* DashboardDomainsCardSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */; };
@@ -5959,6 +5961,7 @@
 		01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenTodayViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
+		01D2FF692AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimePostsBestViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
 		01E61E5929F03DEC002E544E /* DashboardDomainsCardSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainsCardSearchView.swift; sourceTree = "<group>"; };
 		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
@@ -16278,6 +16281,7 @@
 				01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */,
 				01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */,
 				01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */,
+				01D2FF692AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift */,
 			);
 			path = Configs;
 			sourceTree = "<group>";
@@ -21075,6 +21079,7 @@
 				0107E0BB28F97D5000DE87DB /* StatsWidgetsService.swift in Sources */,
 				C9B477B729CD2EF7008CBF49 /* LockScreenUnconfiguredView.swift in Sources */,
 				0107E0BC28F97D5000DE87DB /* StatsWidgetsView.swift in Sources */,
+				01D2FF6B2AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift in Sources */,
 				0107E0BD28F97D5000DE87DB /* AppLocalizedString.swift in Sources */,
 				01D2FF682AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */,
 				0107E0BE28F97D5000DE87DB /* MultiStatsView.swift in Sources */,
@@ -23018,6 +23023,7 @@
 				3F2F0C16256C6B2C003351C7 /* StatsWidgetsService.swift in Sources */,
 				C9B477B629CD2EF7008CBF49 /* LockScreenUnconfiguredView.swift in Sources */,
 				3F526D572539FAC60069706C /* StatsWidgetsView.swift in Sources */,
+				01D2FF6A2AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift in Sources */,
 				3F2656A125AF4DFA0073A832 /* AppLocalizedString.swift in Sources */,
 				01D2FF672AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift in Sources */,
 				3F568A0025420DE80048A9E4 /* MultiStatsView.swift in Sources */,

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
@@ -13,7 +13,7 @@ struct LockScreenAllTimePostsBestViewsStatWidgetConfig: LockScreenStatsWidgetCon
     }
 
     var displayName: String {
-        LocalizableStrings.allTimeWidgetTitle
+        LocalizableStrings.allTimePostMostViewsWidgetPreviewTitle
     }
 
     var description: String {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
@@ -1,0 +1,56 @@
+import WidgetKit
+
+@available(iOS 16.0, *)
+struct LockScreenAllTimePostsBestViewsStatWidgetConfig: LockScreenStatsWidgetConfig {
+    typealias WidgetData = HomeWidgetAllTimeData
+    typealias ViewProvider = LockScreenMultiStatWidgetViewProvider
+
+    var supportFamilies: [WidgetFamily] {
+        guard AppConfiguration.isJetpack, FeatureFlag.lockScreenWidget.enabled else {
+            return []
+        }
+        return [.accessoryRectangular]
+    }
+
+    var displayName: String {
+        LocalizableStrings.allTimeWidgetTitle
+    }
+
+    var description: String {
+        LocalizableStrings.allTimePreviewDescription
+    }
+
+    var kind: String {
+        AppConfiguration.Widget.Stats.lockScreenAllTimePostsBestViewsKind
+    }
+
+    var countKey: String {
+        AppConfiguration.Widget.Stats.lockScreenAllTimePostsBestViewsProperties
+    }
+
+    var placeholderContent: HomeWidgetAllTimeData {
+        HomeWidgetAllTimeData(
+            siteID: 0,
+            siteName: "My WordPress Site",
+            url: "",
+            timeZone: TimeZone.current,
+            date: Date(),
+            stats: AllTimeWidgetStats(
+                views: 649,
+                visitors: 572,
+                posts: 5,
+                bestViews: 10
+            )
+        )
+    }
+
+    var viewProvider: ViewProvider<HomeWidgetAllTimeData> {
+        LockScreenMultiStatWidgetViewProvider<HomeWidgetAllTimeData>(
+            widgetKind: .today,
+            topTitle: LocalizableStrings.postsTitle,
+            topValue: \.stats.posts,
+            bottomTitle: LocalizableStrings.bestViewsTitle,
+            bottomValue: \.stats.bestViews
+        )
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
@@ -49,7 +49,7 @@ struct LockScreenAllTimePostsBestViewsStatWidgetConfig: LockScreenStatsWidgetCon
             widgetKind: .today,
             topTitle: LocalizableStrings.postsTitle,
             topValue: \.stats.posts,
-            bottomTitle: LocalizableStrings.bestViewsTitle,
+            bottomTitle: LocalizableStrings.bestViewsShortTitle,
             bottomValue: \.stats.bestViews
         )
     }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsStatWidgetConfig.swift
@@ -13,7 +13,7 @@ struct LockScreenAllTimeViewsStatWidgetConfig: LockScreenStatsWidgetConfig {
     }
 
     var displayName: String {
-        LocalizableStrings.allTimeWidgetTitle
+        LocalizableStrings.allTimeViewsWidgetPreviewTitle
     }
 
     var description: String {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsStatWidgetConfig.swift
@@ -1,0 +1,54 @@
+import WidgetKit
+
+@available(iOS 16.0, *)
+struct LockScreenAllTimeViewsStatWidgetConfig: LockScreenStatsWidgetConfig {
+    typealias WidgetData = HomeWidgetAllTimeData
+    typealias ViewProvider = LockScreenSingleStatWidgetViewProvider
+
+    var supportFamilies: [WidgetFamily] {
+        guard AppConfiguration.isJetpack, FeatureFlag.lockScreenWidget.enabled else {
+            return []
+        }
+        return [.accessoryRectangular]
+    }
+
+    var displayName: String {
+        LocalizableStrings.allTimeWidgetTitle
+    }
+
+    var description: String {
+        LocalizableStrings.allTimePreviewDescription
+    }
+
+    var kind: String {
+        AppConfiguration.Widget.Stats.lockScreenAllTimeViewsKind
+    }
+
+    var countKey: String {
+        AppConfiguration.Widget.Stats.lockScreenAllTimeViewsProperties
+    }
+
+    var placeholderContent: HomeWidgetAllTimeData {
+        HomeWidgetAllTimeData(
+            siteID: 0,
+            siteName: "My WordPress Site",
+            url: "",
+            timeZone: TimeZone.current,
+            date: Date(),
+            stats: AllTimeWidgetStats(
+                views: 649,
+                visitors: 572,
+                posts: 5,
+                bestViews: 10
+            )
+        )
+    }
+
+    var viewProvider: ViewProvider<HomeWidgetAllTimeData> {
+        LockScreenSingleStatWidgetViewProvider<HomeWidgetAllTimeData>(
+            title: LocalizableStrings.allTimeViewsTitle,
+            value: \.stats.views,
+            widgetKind: .allTime
+        )
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift
@@ -1,0 +1,56 @@
+import WidgetKit
+
+@available(iOS 16.0, *)
+struct LockScreenAllTimeViewsVisitorsStatWidgetConfig: LockScreenStatsWidgetConfig {
+    typealias WidgetData = HomeWidgetAllTimeData
+    typealias ViewProvider = LockScreenMultiStatWidgetViewProvider
+
+    var supportFamilies: [WidgetFamily] {
+        guard AppConfiguration.isJetpack, FeatureFlag.lockScreenWidget.enabled else {
+            return []
+        }
+        return [.accessoryRectangular]
+    }
+
+    var displayName: String {
+        LocalizableStrings.allTimeWidgetTitle
+    }
+
+    var description: String {
+        LocalizableStrings.allTimePreviewDescription
+    }
+
+    var kind: String {
+        AppConfiguration.Widget.Stats.lockScreenAllTimeViewsVisitorsKind
+    }
+
+    var countKey: String {
+        AppConfiguration.Widget.Stats.lockScreenAllTimeViewsVisitorsProperties
+    }
+
+    var placeholderContent: HomeWidgetAllTimeData {
+        HomeWidgetAllTimeData(
+            siteID: 0,
+            siteName: "My WordPress Site",
+            url: "",
+            timeZone: TimeZone.current,
+            date: Date(),
+            stats: AllTimeWidgetStats(
+                views: 649,
+                visitors: 572,
+                posts: 5,
+                bestViews: 10
+            )
+        )
+    }
+
+    var viewProvider: ViewProvider<HomeWidgetAllTimeData> {
+        LockScreenMultiStatWidgetViewProvider<HomeWidgetAllTimeData>(
+            widgetKind: .today,
+            topTitle: LocalizableStrings.viewsTitle,
+            topValue: \.stats.views,
+            bottomTitle: LocalizableStrings.visitorsTitle,
+            bottomValue: \.stats.visitors
+        )
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift
@@ -13,7 +13,7 @@ struct LockScreenAllTimeViewsVisitorsStatWidgetConfig: LockScreenStatsWidgetConf
     }
 
     var displayName: String {
-        LocalizableStrings.allTimeWidgetTitle
+        LocalizableStrings.allTimeViewsVisitorsWidgetPreviewTitle
     }
 
     var description: String {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayLikesCommentsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayLikesCommentsStatWidgetConfig.swift
@@ -13,7 +13,7 @@ struct LockScreenTodayLikesCommentsStatWidgetConfig: LockScreenStatsWidgetConfig
     }
 
     var displayName: String {
-        LocalizableStrings.todayWidgetTitle
+        LocalizableStrings.todayLikesCommentsWidgetPreviewTitle
     }
 
     var description: String {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayViewsStatWidgetConfig.swift
@@ -13,7 +13,7 @@ struct LockScreenTodayViewsStatWidgetConfig: LockScreenStatsWidgetConfig {
     }
 
     var displayName: String {
-        LocalizableStrings.todayWidgetTitle
+        LocalizableStrings.todayViewsWidgetPreviewTitle
     }
 
     var description: String {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayViewsVisitorsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayViewsVisitorsStatWidgetConfig.swift
@@ -13,7 +13,7 @@ struct LockScreenTodayViewsVisitorsStatWidgetConfig: LockScreenStatsWidgetConfig
     }
 
     var displayName: String {
-        LocalizableStrings.todayWidgetTitle
+        LocalizableStrings.todayViewsVisitorsWidgetPreviewTitle
     }
 
     var description: String {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayViewsVisitorsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenTodayViewsVisitorsStatWidgetConfig.swift
@@ -1,0 +1,56 @@
+import WidgetKit
+
+@available(iOS 16.0, *)
+struct LockScreenTodayViewsVisitorsStatWidgetConfig: LockScreenStatsWidgetConfig {
+    typealias WidgetData = HomeWidgetTodayData
+    typealias ViewProvider = LockScreenMultiStatWidgetViewProvider<WidgetData>
+
+    var supportFamilies: [WidgetFamily] {
+        guard AppConfiguration.isJetpack, FeatureFlag.lockScreenWidget.enabled else {
+            return []
+        }
+        return [.accessoryRectangular]
+    }
+
+    var displayName: String {
+        LocalizableStrings.todayWidgetTitle
+    }
+
+    var description: String {
+        LocalizableStrings.todayPreviewDescription
+    }
+
+    var kind: String {
+        AppConfiguration.Widget.Stats.lockScreenTodayViewsVisitorsKind
+    }
+
+    var countKey: String {
+        AppConfiguration.Widget.Stats.lockScreenTodayViewsVisitorsProperties
+    }
+
+    var placeholderContent: HomeWidgetTodayData {
+        HomeWidgetTodayData(
+            siteID: 0,
+            siteName: "My WordPress Site",
+            url: "",
+            timeZone: TimeZone.current,
+            date: Date(),
+            stats: TodayWidgetStats(
+                views: 649,
+                visitors: 572,
+                likes: 16,
+                comments: 8
+            )
+        )
+    }
+
+    var viewProvider: ViewProvider {
+        LockScreenMultiStatWidgetViewProvider(
+            widgetKind: .today,
+            topTitle: LocalizableStrings.viewsTitle,
+            topValue: \.stats.views,
+            bottomTitle: LocalizableStrings.visitorsTitle,
+            bottomValue: \.stats.visitors
+        )
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenFieldView.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenFieldView.swift
@@ -36,6 +36,7 @@ struct LockScreenFieldView: View {
             Text(title)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .font(.system(size: 10))
+                .minimumScaleFactor(0.9)
                 .allowsTightening(true)
                 .lineLimit(1)
         }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenMultiStatView.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenMultiStatView.swift
@@ -80,7 +80,7 @@ struct LockScreenMultiStatView_Previews: PreviewProvider {
             siteName: "My WordPress Site",
             updatedTime: Date(),
             primaryField: .init(title: "Views", value: 15),
-            secondaryField: .init(title: "Visitors", value: 5)
+            secondaryField: .init(title: "Most Views", value: 5)
         ),
         LockScreenMultiStatViewModel(
             siteName: "My WordPress Site with an extremely long name",

--- a/WordPress/WordPressStatsWidgets/StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/StatsWidgets.swift
@@ -13,6 +13,7 @@ struct WordPressStatsWidgets: WidgetBundle {
             LockScreenStatsWidget(config: LockScreenTodayLikesCommentsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenAllTimeViewsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenAllTimeViewsVisitorsStatWidgetConfig())
+            LockScreenStatsWidget(config: LockScreenAllTimePostsBestViewsStatWidgetConfig())
         }
     }
 }

--- a/WordPress/WordPressStatsWidgets/StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/StatsWidgets.swift
@@ -12,6 +12,7 @@ struct WordPressStatsWidgets: WidgetBundle {
             LockScreenStatsWidget(config: LockScreenTodayViewsVisitorsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenTodayLikesCommentsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenAllTimeViewsStatWidgetConfig())
+            LockScreenStatsWidget(config: LockScreenAllTimeViewsVisitorsStatWidgetConfig())
         }
     }
 }

--- a/WordPress/WordPressStatsWidgets/StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/StatsWidgets.swift
@@ -10,6 +10,7 @@ struct WordPressStatsWidgets: WidgetBundle {
         if #available(iOS 16.0, *) {
             LockScreenStatsWidget(config: LockScreenTodayViewsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenTodayLikesCommentsStatWidgetConfig())
+            LockScreenStatsWidget(config: LockScreenAllTimeViewsStatWidgetConfig())
         }
     }
 }

--- a/WordPress/WordPressStatsWidgets/StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/StatsWidgets.swift
@@ -9,6 +9,7 @@ struct WordPressStatsWidgets: WidgetBundle {
         WordPressHomeWidgetAllTime()
         if #available(iOS 16.0, *) {
             LockScreenStatsWidget(config: LockScreenTodayViewsStatWidgetConfig())
+            LockScreenStatsWidget(config: LockScreenTodayViewsVisitorsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenTodayLikesCommentsStatWidgetConfig())
             LockScreenStatsWidget(config: LockScreenAllTimeViewsStatWidgetConfig())
         }

--- a/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
@@ -21,6 +21,10 @@ enum LocalizableStrings {
                                                    value: "Views Today",
                                                    comment: "Title of the one-liner information consist of views field and today date range in lock screen today views widget")
 
+    static let allTimeViewsTitle = AppLocalizedString("widget.lockscreen.alltimeview.label",
+                                                      value: "All-Time Views",
+                                                      comment: "Title of the one-liner information consist of views field and all time date range in lock screen all time views widget")
+
     // Widgets content
     static let viewsTitle = AppLocalizedString("widget.today.views.label",
                                                value: "Views",

--- a/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
@@ -49,6 +49,10 @@ enum LocalizableStrings {
     static let bestViewsTitle = AppLocalizedString("widget.alltime.bestviews.label",
                                                    value: "Best views ever",
                                                    comment: "Title of best views ever label in all time widget")
+
+    static let bestViewsShortTitle = AppLocalizedString("widget.alltime.bestviewsshort.label",
+                                                        value: "Most Views",
+                                                        comment: "Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible.")
     // Unconfigured view
     static let unconfiguredViewTodayTitle = AppLocalizedString("widget.today.unconfigured.view.title",
                                                                value: "Log in to WordPress to see today's stats.",

--- a/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
@@ -17,6 +17,25 @@ enum LocalizableStrings {
                                                         comment: "Title of this week widget")
 
     // Lock Screen Widgets title
+    static let todayViewsWidgetPreviewTitle = AppLocalizedString("widget.todayViews.previewTitle",
+                                                            value: "Today's Views",
+                                                            comment: "Preview title of today's views widget")
+    static let todayViewsVisitorsWidgetPreviewTitle = AppLocalizedString("widget.todayViewsVisitors.previewTitle",
+                                                                         value: "Today's Views & Visitors",
+                                                                         comment: "Preview title of today's views and visitors widget")
+    static let todayLikesCommentsWidgetPreviewTitle = AppLocalizedString("widget.todayLikesComments.previewTitle",
+                                                                         value: "Today's Likes & Comments",
+                                                                         comment: "Preview title of today's likes and commnets widget")
+    static let allTimeViewsWidgetPreviewTitle = AppLocalizedString("widget.allTimeViews.previewTitle",
+                                                                   value: "All-Time Views",
+                                                                   comment: "Preview title of all-time views widget")
+    static let allTimeViewsVisitorsWidgetPreviewTitle = AppLocalizedString("widget.allTimeViewsVisitors.previewTitle",
+                                                                           value: "All-Time Views & Visitors",
+                                                                           comment: "Preview title of all-time views and visitors widget")
+    static let allTimePostMostViewsWidgetPreviewTitle = AppLocalizedString("widget.allTimePostViews.previewTitle",
+                                                                           value: "All-Time Posts & Most Views",
+                                                                           comment: "Preview title of all-time posts and most views widget")
+
     static let viewsInTodayTitle = AppLocalizedString("widget.lockscreen.todayview.label",
                                                    value: "Views Today",
                                                    comment: "Title of the one-liner information consist of views field and today date range in lock screen today views widget")


### PR DESCRIPTION
Fixes #21494 

Added:
- [Add All Time Views Lock Screen Widget](https://github.com/wordpress-mobile/WordPress-iOS/commit/0f678ea1a22db8477d52a593289bec5c8a414ea9)
- [Add Today Views and Visitors Lock Screen Widget](https://github.com/wordpress-mobile/WordPress-iOS/commit/d4e9786e3ddef261776912f8c61b6ec5b7c97729)
- [Add All Time Views and Visitors Lock Screen Widget](https://github.com/wordpress-mobile/WordPress-iOS/commit/4800c8c99afbdee05c399363c5dd87b13ada22bb)
- [Add All Time Posts and Best Views Stat Widget](https://github.com/wordpress-mobile/WordPress-iOS/commit/413e1fda559e1ba5467923a27827009c22cd4d49)

## To test

1. Enable lockScreenWidget feature flag in `FeatureFlag.swift`
2. Open Jetpack
3. Log into account
4. Go to lock screen, long press, customize, tap on widget area, select Jetpack app
5. Scroll through widgets
6. Confirm new widget configuration exists
7. Confirm their numbers match Stats
8. Confirm tapping on Today widget opens "Day" view
9. Confirm tapping on All time widget opens "Insights"view

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

## Video

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/454b4289-94eb-4e47-8558-463ac01e0523


