### PR TITLE
Add a `MediaRepository` type

### DIFF
--- a/WordPress/Classes/Services/MediaRepository.swift
+++ b/WordPress/Classes/Services/MediaRepository.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+final class MediaRepository {
+
+    enum Error: Swift.Error {
+        case mediaNotFound
+        case remoteAPIUnavailable
+        case unknown
+    }
+
+    private let coreDataStack: CoreDataStackSwift
+    private let remoteFactory: MediaServiceRemoteFactory
+
+    init(coreDataStack: CoreDataStackSwift, remoteFactory: MediaServiceRemoteFactory = .init()) {
+        self.coreDataStack = coreDataStack
+        self.remoteFactory = remoteFactory
+    }
+
+    /// Get the Media object from the server using the blog and the mediaID as the identifier of the resource
+    func getMedia(withID mediaID: NSNumber, in blogID: TaggedManagedObjectID<Blog>) async throws -> TaggedManagedObjectID<Media> {
+        let remote = try await coreDataStack.performQuery { [remoteFactory] context in
+            let blog = try context.existingObject(with: blogID)
+            return remoteFactory.remote(for: blog)
+        }
+        guard let remote else {
+            throw MediaRepository.Error.remoteAPIUnavailable
+        }
+
+        let remoteMedia: RemoteMedia? = try await withCheckedThrowingContinuation { continuation in
+            remote.getMediaWithID(
+                mediaID, success: continuation.resume(returning:),
+                failure: { continuation.resume(throwing: $0 ?? MediaRepository.Error.unknown) })
+        }
+        guard let remoteMedia else {
+            throw MediaRepository.Error.mediaNotFound
+        }
+
+        return try await coreDataStack.performAndSave { context in
+            let blog = try context.existingObject(with: blogID)
+            let media = Media.existingMediaWith(mediaID: mediaID, inBlog: blog) ?? Media.makeMedia(blog: blog)
+            MediaHelper.update(media: media, with: remoteMedia)
+            return try .init(unsaved: media)
+        }
+    }
+
+}
+
+@objc class MediaServiceRemoteFactory: NSObject {
+
+    @objc(remoteForBlog:)
+    func remote(for blog: Blog) -> MediaServiceRemote? {
+        if blog.supports(.wpComRESTAPI), let dotComID = blog.dotComID, let api = blog.wordPressComRestApi() {
+            return MediaServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
+        }
+
+        if let username = blog.username, let password = blog.password, let api = blog.xmlrpcApi {
+            return MediaServiceRemoteXMLRPC(api: api, username: username, password: password)
+        }
+
+        return nil
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1237,6 +1237,8 @@
 		4A072CD229093704006235BE /* AsyncBlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A072CD129093704006235BE /* AsyncBlockOperation.swift */; };
 		4A072CD329093704006235BE /* AsyncBlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A072CD129093704006235BE /* AsyncBlockOperation.swift */; };
 		4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */; };
+		4A1B4FE82A95A89F00EF6B1D /* MediaRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1B4FE72A95A89F00EF6B1D /* MediaRepository.swift */; };
+		4A1B4FE92A95A89F00EF6B1D /* MediaRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1B4FE72A95A89F00EF6B1D /* MediaRepository.swift */; };
 		4A1E77C6298897F6006281CC /* SharingSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1E77C5298897F6006281CC /* SharingSyncService.swift */; };
 		4A1E77C7298897F6006281CC /* SharingSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1E77C5298897F6006281CC /* SharingSyncService.swift */; };
 		4A1E77C92988997C006281CC /* PublicizeConnection+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1E77C82988997C006281CC /* PublicizeConnection+Creation.swift */; };
@@ -6896,6 +6898,7 @@
 		49E3445F1B568603958DA79D /* Pods-JetpackNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JetpackNotificationServiceExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-JetpackNotificationServiceExtension/Pods-JetpackNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		4A072CD129093704006235BE /* AsyncBlockOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncBlockOperation.swift; sourceTree = "<group>"; };
 		4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Fixture.swift"; sourceTree = "<group>"; };
+		4A1B4FE72A95A89F00EF6B1D /* MediaRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaRepository.swift; sourceTree = "<group>"; };
 		4A1E77C5298897F6006281CC /* SharingSyncService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingSyncService.swift; sourceTree = "<group>"; };
 		4A1E77C82988997C006281CC /* PublicizeConnection+Creation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicizeConnection+Creation.swift"; sourceTree = "<group>"; };
 		4A1E77CB2989F2F7006281CC /* WPAccount+DeduplicateBlogs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPAccount+DeduplicateBlogs.swift"; sourceTree = "<group>"; };
@@ -14201,6 +14204,7 @@
 				4A526BDD296BE9A50007B5BA /* CoreDataService.m */,
 				98921EF621372E12004949AA /* MediaCoordinator.swift */,
 				0815CF451E96F22600069916 /* MediaImportService.swift */,
+				4A1B4FE72A95A89F00EF6B1D /* MediaRepository.swift */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
 				5DA3EE151925090A00294E0B /* MediaService.m */,
 				FF5371621FDFF64F00619A3F /* MediaService.swift */,
@@ -21712,6 +21716,7 @@
 				176BB87F20D0068500751DCE /* FancyAlertViewController+SavedPosts.swift in Sources */,
 				086C117C2A2F6451004A3821 /* CompliancePopover.swift in Sources */,
 				E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */,
+				4A1B4FE82A95A89F00EF6B1D /* MediaRepository.swift in Sources */,
 				8071390727D039E70012DB21 /* DashboardSingleStatView.swift in Sources */,
 				C81CCD64243AECA100A83E27 /* TenorMediaObject.swift in Sources */,
 				B5C0CF3D204DA41000DB0362 /* NotificationReplyStore.swift in Sources */,
@@ -25779,6 +25784,7 @@
 				F195C42B26DFBDC2000EC884 /* BackgroundTasksCoordinator.swift in Sources */,
 				FABB25CB2602FC2C00C8785C /* BlogToBlogMigration87to88.swift in Sources */,
 				FABB25CC2602FC2C00C8785C /* WPStyleGuide+Themes.swift in Sources */,
+				4A1B4FE92A95A89F00EF6B1D /* MediaRepository.swift in Sources */,
 				FABB25CD2602FC2C00C8785C /* WPStyleGuide+Reader.swift in Sources */,
 				FABB25CE2602FC2C00C8785C /* Interpolation.swift in Sources */,
 				FE43DAB026DFAD1C00CFF595 /* CommentContentTableViewCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1290,6 +1290,7 @@
 		4AA33F022999D11A005B6E23 /* ReaderSiteTopic+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA33F002999D11A005B6E23 /* ReaderSiteTopic+Lookup.swift */; };
 		4AA33F04299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA33F03299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift */; };
 		4AA33F05299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA33F03299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift */; };
+		4AAD69082A6F68A5007FE77E /* MediaRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AAD69072A6F68A5007FE77E /* MediaRepositoryTests.swift */; };
 		4AD5656C28E3D0670054C676 /* ReaderPost+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656B28E3D0670054C676 /* ReaderPost+Helper.swift */; };
 		4AD5656D28E3D0670054C676 /* ReaderPost+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656B28E3D0670054C676 /* ReaderPost+Helper.swift */; };
 		4AD5656F28E413160054C676 /* Blog+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656E28E413160054C676 /* Blog+History.swift */; };
@@ -6931,6 +6932,7 @@
 		4AA33EFA2999AE3B005B6E23 /* ReaderListTopic+Creation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderListTopic+Creation.swift"; sourceTree = "<group>"; };
 		4AA33F002999D11A005B6E23 /* ReaderSiteTopic+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderSiteTopic+Lookup.swift"; sourceTree = "<group>"; };
 		4AA33F03299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTagTopic+Lookup.swift"; sourceTree = "<group>"; };
+		4AAD69072A6F68A5007FE77E /* MediaRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaRepositoryTests.swift; sourceTree = "<group>"; };
 		4AD5656B28E3D0670054C676 /* ReaderPost+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPost+Helper.swift"; sourceTree = "<group>"; };
 		4AD5656E28E413160054C676 /* Blog+History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+History.swift"; sourceTree = "<group>"; };
 		4AD5657128E543A30054C676 /* BlogQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogQueryTests.swift; sourceTree = "<group>"; };
@@ -15519,6 +15521,7 @@
 				F1BB660B274E704D00A319BE /* LikeUserHelperTests.swift */,
 				59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */,
 				F11023A0231863CE00C4E84A /* MediaServiceTests.swift */,
+				4AAD69072A6F68A5007FE77E /* MediaRepositoryTests.swift */,
 				E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */,
 				08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */,
 				E135965C1E7152D1006C6606 /* RecentSitesServiceTests.swift */,
@@ -23727,6 +23730,7 @@
 				F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */,
 				C738CB0D28623F07001BE107 /* QRLoginURLParserTests.swift in Sources */,
 				D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */,
+				4AAD69082A6F68A5007FE77E /* MediaRepositoryTests.swift in Sources */,
 				FEFC0F8C273131A6001F7F1D /* CommentService+RepliesTests.swift in Sources */,
 				40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */,
 				8BC6020D2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift in Sources */,

--- a/WordPress/WordPressTest/MediaRepositoryTests.swift
+++ b/WordPress/WordPressTest/MediaRepositoryTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+
+@testable import WordPress
+
+class MediaRepositoryTests: CoreDataTestCase {
+
+    private var repository: MediaRepository!
+    private var remote: MediaServiceRemoteStub!
+    private var blogID: TaggedManagedObjectID<Blog>!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let accountService = AccountService(coreDataStack: contextManager)
+        let accountID = accountService.createOrUpdateAccount(withUsername: "username", authToken: "token")
+        try accountService.setDefaultWordPressComAccount(XCTUnwrap(mainContext.existingObject(with: accountID) as? WPAccount))
+
+        let blog = try BlogBuilder(mainContext).withAccount(id: accountID).build()
+
+        contextManager.saveContextAndWait(mainContext)
+
+        blogID = .init(saved: blog)
+        remote = MediaServiceRemoteStub()
+        repository = MediaRepository(coreDataStack: contextManager, remoteFactory: MediaServiceRemoteFactoryStub(remote: remote))
+    }
+
+    func testGetMedia() async throws {
+        let remoteMedia = RemoteMedia()
+        remoteMedia.caption = "This is a test image"
+        remote.getMediaResult = .success(remoteMedia)
+
+        let mediaID = try await repository.getMedia(withID: 1, in: blogID)
+        let caption = try await contextManager.performQuery { try $0.existingObject(with: mediaID).caption }
+        XCTAssertEqual(caption, "This is a test image")
+    }
+
+    func testGetMediaError() async throws {
+        let remoteMedia = RemoteMedia()
+        remoteMedia.caption = "This is a test image"
+        remote.getMediaResult = .failure(NSError.testInstance(code: 404))
+
+        do {
+            let mediaID = try await repository.getMedia(withID: 1, in: blogID)
+            XCTFail("The getMedia call should throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.code, 404)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+}
+
+private class MediaServiceRemoteFactoryStub: MediaServiceRemoteFactory {
+    let remote: MediaServiceRemote
+
+    init(remote: MediaServiceRemote) {
+        self.remote = remote
+    }
+
+    override func remote(for blog: Blog) -> MediaServiceRemote? {
+        remote
+    }
+}
+
+private class MediaServiceRemoteStub: NSObject, MediaServiceRemote {
+    var getMediaResult: Result<RemoteMedia, Error> = .failure(testError())
+
+    func getMediaWithID(_ mediaID: NSNumber!, success: ((RemoteMedia?) -> Void)!, failure: ((Error?) -> Void)!) {
+        switch getMediaResult {
+        case let .success(media): success(media)
+        case let .failure(error): failure(error)
+        }
+    }
+
+    func uploadMedia(_ media: RemoteMedia!, progress: AutoreleasingUnsafeMutablePointer<Progress?>!, success: ((RemoteMedia?) -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+
+    func update(_ media: RemoteMedia!, success: ((RemoteMedia?) -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+
+    func delete(_ media: RemoteMedia!, success: (() -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+
+    func getMediaLibrary(pageLoad: (([Any]?) -> Void)!, success: (([Any]?) -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+
+    func getMediaLibraryCount(forType mediaType: String!, withSuccess success: ((Int) -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+
+    func getMetadataFromVideoPressID(_ videoPressID: String!, isSitePrivate: Bool, success: ((WordPressKit.RemoteVideoPressVideo?) -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+
+    func getVideoPressToken(_ videoPressID: String!, success: ((String?) -> Void)!, failure: ((Error?) -> Void)!) {
+        fatalError("Unimplemented")
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/21419, this PR adds a `MediaRepository` type which will replace `MediaService` eventually.

This PR only implements a "get media by id" function, which is not used anywhere yet. I'll create follow up PR that'll use it to replace the `MediaService.getMediaWithID` function.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
Unit tests for `MediaRepository`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A