### PR TITLE
Refactor media metadata editing screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+23.6
+-----
+* [**] [internal] Refactor the media metadata editing screen. [#21513]
+
 23.5
 -----
 * [*] Fix a crash when the blog's blogging prompt settings contain invalid JSON [#21677]

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -147,18 +147,7 @@ class MediaItemDocumentTableViewCell: WPTableViewCell {
             customImageView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
             customImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             customImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-            ])
-    }
-
-    @objc func showIconForMedia(_ media: Media) {
-        let dimension = CGFloat(MediaDocumentRow.customHeight! / 2)
-        let size = CGSize(width: dimension, height: dimension)
-
-        if media.mediaType == .audio {
-            customImageView.image = .gridicon(.audio, size: size)
-        } else {
-            customImageView.image = .gridicon(.pages, size: size)
-        }
+        ])
     }
 }
 
@@ -246,7 +235,7 @@ struct MediaDocumentRow: ImmuTableRow {
     static let cell = ImmuTableCell.class(MediaItemDocumentTableViewCell.self)
     static let customHeight: Float? = 96.0
 
-    let media: Media
+    let mediaType: MediaType
     let action: ImmuTableAction?
 
     func configureCell(_ cell: UITableViewCell) {
@@ -254,7 +243,11 @@ struct MediaDocumentRow: ImmuTableRow {
 
         if let cell = cell as? MediaItemDocumentTableViewCell {
             cell.customImageView.tintColor = cell.textLabel?.textColor
-            cell.showIconForMedia(media)
+
+            let dimension = CGFloat(MediaDocumentRow.customHeight! / 2)
+            let size = CGSize(width: dimension, height: dimension)
+            cell.customImageView.image = .gridicon(mediaType == .audio ? .audio : .pages, size: size)
+
             cell.accessibilityTraits = .button
             cell.accessibilityLabel = NSLocalizedString("Preview media", comment: "Accessibility label for media item preview for user's viewing an item in their media library")
             cell.accessibilityHint = NSLocalizedString("Tap to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -16,7 +16,10 @@ class MediaItemViewController: UITableViewController {
     // swiftlint:disable:next weak_delegate
     let delegate = DownloadDelegate()
 
-    private let media: Media
+    private let coreDataStack: CoreDataStackSwift
+    private let mediaID: TaggedManagedObjectID<Media>
+    // TODO: Rename this variable to `mediaInMainContext`
+    private var media: Media
 
     fileprivate var viewModel: ImmuTable!
     fileprivate var mediaMetadata: MediaMetadata {
@@ -25,12 +28,19 @@ class MediaItemViewController: UITableViewController {
         }
     }
 
-    init(media: Media) {
-        self.media = media
+    init(mediaID: TaggedManagedObjectID<Media>, coreDataStack: CoreDataStackSwift = ContextManager.shared) throws {
+        assert(Thread.isMainThread)
 
+        self.mediaID = mediaID
+        self.coreDataStack = coreDataStack
+        self.media = try coreDataStack.mainContext.existingObject(with: mediaID)
         self.mediaMetadata = MediaMetadata(media: media)
 
         super.init(style: .grouped)
+    }
+
+    convenience init(media: Media) {
+        try! self.init(mediaID: .init(media))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -234,7 +234,6 @@ class MediaItemViewController: UITableViewController {
         }
     }
 
-    private var documentInteractionController: UIDocumentInteractionController?
     private func presentDocumentViewControllerForMedia() {
         guard let remoteURL = media.remoteURL,
             let url = URL(string: remoteURL) else { return }
@@ -408,15 +407,6 @@ class MediaItemViewController: UITableViewController {
     }
 
     // MARK: - Sharing Logic
-
-    private func mediaURL() -> URL? {
-        guard let remoteURL = media.remoteURL,
-           let url = URL(string: remoteURL) else {
-            return nil
-        }
-
-        return url
-    }
 
     private func share(media: Any, sender: UIBarButtonItem) {
         share([media], sender: sender)

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -16,7 +16,7 @@ class MediaItemViewController: UITableViewController {
     // swiftlint:disable:next weak_delegate
     let delegate = DownloadDelegate()
 
-    @objc let media: Media
+    private let media: Media
 
     fileprivate var viewModel: ImmuTable!
     fileprivate var mediaMetadata: MediaMetadata {
@@ -25,7 +25,7 @@ class MediaItemViewController: UITableViewController {
         }
     }
 
-    @objc init(media: Media) {
+    init(media: Media) {
         self.media = media
 
         self.mediaMetadata = MediaMetadata(media: media)

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -22,6 +22,8 @@ class MediaItemViewController: UITableViewController {
     private var media: Media
 
     private let attributes: ReadonlyAttributes
+    private let canEditMetadata: Bool
+    private let canDeleteMedia: Bool
 
     fileprivate var viewModel: ImmuTable!
     fileprivate var mediaMetadata: MediaMetadata {
@@ -38,6 +40,8 @@ class MediaItemViewController: UITableViewController {
         self.media = try coreDataStack.mainContext.existingObject(with: mediaID)
         self.mediaMetadata = MediaMetadata(media: media)
         self.attributes = ReadonlyAttributes(media: media)
+        self.canDeleteMedia = media.blog.supports(.mediaDeletion)
+        self.canEditMetadata = media.blog.supports(.mediaMetadataEditing)
 
         super.init(style: .grouped)
     }
@@ -145,7 +149,7 @@ class MediaItemViewController: UITableViewController {
     }
 
     private func editableRowIfSupported(title: String, value: String, action: @escaping ((ImmuTableRow) -> ())) -> ImmuTableRow {
-        if media.blog.supports(BlogFeature.mediaMetadataEditing) {
+        if canEditMetadata {
             return EditableTextRow(title: title, value: value, action: action)
         } else {
             return TextRow(title: title, value: value)
@@ -188,7 +192,7 @@ class MediaItemViewController: UITableViewController {
                                             action: #selector(trashTapped(_:)))
             trashItem.accessibilityLabel = NSLocalizedString("Trash", comment: "Accessibility label for trash buttons in nav bars")
 
-            if media.blog.supports(.mediaDeletion) {
+            if canDeleteMedia {
                 navigationItem.rightBarButtonItems = [ shareItem, trashItem ]
             } else {
                 navigationItem.rightBarButtonItems = [ shareItem ]

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -125,9 +125,9 @@ class MediaItemViewController: UITableViewController {
 
     private var metadataRows: [ImmuTableRow] {
         /// A String containing the pixel size of the asset (width X height)
-        let dimensions = "\(media.width ?? 0) ✕ \(media.height ?? 0)"
+        let dimensions = "\(attributes.width) ✕ \(attributes.height)"
         /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
-        let fileType = (media.filename as? NSString)?.pathExtension ?? ""
+        let fileType = (attributes.filename as NSString).pathExtension
 
         var rows = [ImmuTableRow]()
         rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: attributes.filename))
@@ -531,12 +531,16 @@ private struct ReadonlyAttributes {
     let mediaType: MediaType
     let filename: String
     let creationDate: Date
+    let width: NSNumber
+    let height: NSNumber
     let siteDotComID: NSNumber?
 
     init(media: Media) {
         mediaType = media.mediaType
         filename = media.filename ?? ""
         creationDate = media.creationDate ?? Date(timeIntervalSinceReferenceDate: 0)
+        width = media.width ?? 0
+        height = media.height ?? 0
         siteDotComID = media.blog.dotComID
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -27,6 +27,8 @@ class MediaItemViewController: UITableViewController {
     fileprivate var mediaMetadata: MediaMetadata {
         didSet {
             updateNavigationItem()
+            updateTitle()
+            reloadViewModel()
         }
     }
 
@@ -353,8 +355,6 @@ class MediaItemViewController: UITableViewController {
         guard let media = try? coreDataStack.mainContext.existingObject(with: mediaID) else { return }
 
         mediaMetadata = MediaMetadata(media: media)
-        reloadViewModel()
-        updateTitle()
     }
 
     @objc private func saveTapped() {
@@ -382,9 +382,7 @@ class MediaItemViewController: UITableViewController {
             let editableRow = row as! EditableTextRow
             self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image title", comment: "Hint for image title on image settings."),
                                         onValueChanged: { value in
-                self?.title = value
                 self?.mediaMetadata.title = value
-                self?.reloadViewModel()
             })
         }
     }
@@ -395,7 +393,6 @@ class MediaItemViewController: UITableViewController {
             self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Caption", comment: "Hint for image caption on image settings."),
                                         onValueChanged: { value in
                 self?.mediaMetadata.caption = value
-                self?.reloadViewModel()
             })
         }
     }
@@ -405,8 +402,7 @@ class MediaItemViewController: UITableViewController {
             let editableRow = row as! EditableTextRow
             self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Description", comment: "Hint for image description on image settings."),
                                         onValueChanged: { value in
-                self?.mediaMetadata.desc  = value
-                self?.reloadViewModel()
+                self?.mediaMetadata.desc = value
             })
         }
     }
@@ -416,8 +412,7 @@ class MediaItemViewController: UITableViewController {
             let editableRow = row as! EditableTextRow
             self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Alt", comment: "Hint for image alt on image settings."),
                                          onValueChanged: { value in
-                                            self?.mediaMetadata.alt  = value
-                                            self?.reloadViewModel()
+                                            self?.mediaMetadata.alt = value
             })
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -124,15 +124,18 @@ class MediaItemViewController: UITableViewController {
     }
 
     private var metadataRows: [ImmuTableRow] {
-        let presenter = MediaMetadataPresenter(media: media)
+        /// A String containing the pixel size of the asset (width X height)
+        let dimensions = "\(media.width ?? 0) ✕ \(media.height ?? 0)"
+        /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
+        let fileType = (media.filename as? NSString)?.pathExtension ?? ""
 
         var rows = [ImmuTableRow]()
         rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: attributes.filename))
-        rows.append(TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: presenter.fileType ?? ""))
+        rows.append(TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: fileType))
 
         switch attributes.mediaType {
         case .image, .video:
-            rows.append(TextRow(title: NSLocalizedString("Dimensions", comment: "Label for the dimensions in pixels for a media asset (image / video)"), value: presenter.dimensions))
+            rows.append(TextRow(title: NSLocalizedString("Dimensions", comment: "Label for the dimensions in pixels for a media asset (image / video)"), value: dimensions))
         default: break
         }
 
@@ -486,30 +489,6 @@ extension MediaItemViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = viewModel.rowAtIndexPath(indexPath)
         row.action?(row)
-    }
-}
-
-/// Provides some extra formatting for a Media asset's metadata, used
-/// to present it in the MediaItemViewController
-///
-private struct MediaMetadataPresenter {
-    let media: Media
-
-    /// A String containing the pixel size of the asset (width X height)
-    var dimensions: String {
-        let width = media.width ?? 0
-        let height = media.height ?? 0
-
-        return "\(width) ✕ \(height)"
-    }
-
-    /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
-    var fileType: String? {
-        guard let filename = media.filename else {
-            return nil
-        }
-
-        return (filename as NSString).pathExtension.uppercased()
     }
 }
 


### PR DESCRIPTION
I want to change how the "updating media" functions work in `MediaRepository`. The end result in my head does not work well with this screen which is the only place that calls the "updating media" function. So, I decided to refactor this screen first, before changing the update media function.

The idea of this refactor is, we don't store `Media` instance as a stored property in the view controller. Instead, we query it as needed (usually from the main context, we are dealing with UIKit after all). By doing that, we can make it less convenient to change the `Media` instance in the main context.

## Automatic exit upon deletion

The current implementation proactively checks if the media is deleted upon user interactions (saving, sharing, etc.). Since the media instance is no longer stored, I have changed the approach to automatically exit the screen when received a notification that indicates the media item has been deleted. This should be the only "feature change" in this refactor.

It's a bit hard to test this change though. Because it's pretty hard to trigger the notification observer code path (same as the removed proactive checks).

There are two paths that users can enter the media item editing screen.
1. Via the Media screen (a.k.a Media Picker).
2. From the Stats, directly view/edit an media item (it has to be video), bypassing the Media screen.

The second path is what I derived from the code. I hasn't got back my my Premium subscription and can't upload an video to my WordPress.com site, so I can't verify that the path is actually viable at the moment.

Once we are in the media item editing screen, in order to make the media item become deleted, we'll have to delete it from the WordPress.com site and trigger a sync. That's almost impossible to do: The only place the app syncs the Media Library is upon entering the Media screen.

On top of that, the Media screen has an feature where it pops its subsequent view controllers if the selected media item is deleted. So, it's kind of redundant to implement this media deletion in the media item editing screen again. But I guess we should still have it, since it's possible to enter the screen without going through the Media screen (the second path).

Anyways, we can make the following code change to make it easier for us to test this delete detection code.
1. Apply the following diff
2. Run the app and go to the Media screen
3. On WordPress.com site's Media Library, delete an image
4. On the app's Media screen, tap the deleted image
5. Wait for 5 seconds, the screen should automatically exit with an message like "the media item has been deleted".

<details>

```diff
diff --git a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
index 2aadc9b832..a32e26f210 100644
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -78,6 +78,16 @@ class MediaItemViewController: UITableViewController {
             }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if let media = try? coreDataStack.mainContext.existingObject(with: mediaID) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5)) {
+                MediaCoordinator.shared.syncMedia(for: media.blog)
+            }
+        }
+    }
+
     private func updateTitle() {
         title = mediaMetadata.title
     }
diff --git a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
index 725407309f..e50d9071da 100644
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -404,7 +404,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
                 navigationController.topViewController != strongSelf,
                 let asset = strongSelf.selectedAsset,
                 asset.isDeleted {
-                _ = strongSelf.navigationController?.popToViewController(strongSelf, animated: true)
+//                _ = strongSelf.navigationController?.popToViewController(strongSelf, animated: true)
             }
         })
     }
```

</details>

### Test Instructions

It's probably worth doing a full feature testing on this screen: saving, cancelling, sharing, and preview an media item. Verify the features on both WordPress.com sites and self-hosted sites(editing should be disabled on self-hosted sites), and with different kinds of media too.

> **Note**
> This PR changes probably 30% of the view controller. It might be easier to review the PR commit by commit.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the test instructions.

3. What automated tests I added (or what prevented me from doing so)
None. I'd love to add some unit tests, but the current structure is a bit difficult to test. It'd be nice to extract a view model out of the view controller, but I worry it's a much bigger and potentially unnecessary for the purpose of my `MediaRepository` refactor.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A