### PR TITLE
Fix an issue with site icon not tappable after site creation

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
@@ -9,9 +9,6 @@ import PhotosUI
 extension SitePickerViewController {
 
     func makeSiteIconMenu() -> UIMenu? {
-        guard siteIconShouldAllowDroppedImages() else {
-            return nil
-        }
         return UIMenu(children: [
             UIDeferredMenuElement.uncached { [weak self] in
                 $0(self?.makeUpdateSiteIconActions() ?? [])
@@ -36,6 +33,10 @@ extension SitePickerViewController {
     }
 
     private func makeUpdateSiteIconActions() -> [UIAction] {
+        guard siteIconShouldAllowDroppedImages() else {
+            return [] // Not eligible to change the icon
+        }
+
         let presenter = makeSiteIconPresenter()
         let mediaMenu = MediaPickerMenu(viewController: self, filter: .images)
         var actions: [UIAction] = []


### PR DESCRIPTION
Fixes #21507

(No release notes since this is a regression)

## To test:

- Follow the steps from the ticket

## Regression Notes
1. Potential unintended areas of impact: Site Icon picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
