### PR TITLE
Lock Screen Widgets: Refresh widgets when app state changes

### DIFF
--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -21,18 +21,17 @@ class StatsWidgetsStore {
 
         if let newTodayData = refreshStats(type: HomeWidgetTodayData.self) {
             HomeWidgetTodayData.write(items: newTodayData)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
+            WidgetCenter.shared.reloadTodayTimelines()
         }
 
         if let newAllTimeData = refreshStats(type: HomeWidgetAllTimeData.self) {
             HomeWidgetAllTimeData.write(items: newAllTimeData)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
+            WidgetCenter.shared.reloadAllTimeTimelines()
         }
 
         if let newThisWeekData = refreshStats(type: HomeWidgetThisWeekData.self) {
             HomeWidgetThisWeekData.write(items: newThisWeekData)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
+            WidgetCenter.shared.reloadThisWeekTimelines()
         }
     }
 
@@ -43,20 +42,19 @@ class StatsWidgetsStore {
         if !HomeWidgetTodayData.cacheDataExists() {
             DDLogInfo("StatsWidgets: Writing initialization data into HomeWidgetTodayData.plist")
             HomeWidgetTodayData.write(items: initializeHomeWidgetData(type: HomeWidgetTodayData.self))
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
+            WidgetCenter.shared.reloadTodayTimelines()
         }
 
         if !HomeWidgetThisWeekData.cacheDataExists() {
             DDLogInfo("StatsWidgets: Writing initialization data into HomeWidgetThisWeekData.plist")
             HomeWidgetThisWeekData.write(items: initializeHomeWidgetData(type: HomeWidgetThisWeekData.self))
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
+            WidgetCenter.shared.reloadThisWeekTimelines()
         }
 
         if !HomeWidgetAllTimeData.cacheDataExists() {
             DDLogInfo("StatsWidgets: Writing initialization data into HomeWidgetAllTimeData.plist")
             HomeWidgetAllTimeData.write(items: initializeHomeWidgetData(type: HomeWidgetAllTimeData.self))
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
+            WidgetCenter.shared.reloadAllTimeTimelines()
         }
     }
 
@@ -82,10 +80,11 @@ class StatsWidgetsStore {
             T.write(items: homeWidgetCache)
             return
         }
-        var widgetKind = ""
-        if widgetType == HomeWidgetTodayData.self, let stats = stats as? TodayWidgetStats {
 
-            widgetKind = AppConfiguration.Widget.Stats.todayKind
+        var widgetReload: (() -> ())?
+
+        if widgetType == HomeWidgetTodayData.self, let stats = stats as? TodayWidgetStats {
+            widgetReload = WidgetCenter.shared.reloadTodayTimelines
 
             homeWidgetCache[siteID.intValue] = HomeWidgetTodayData(siteID: siteID.intValue,
                                                                    siteName: blog.title ?? oldData.siteName,
@@ -96,7 +95,7 @@ class StatsWidgetsStore {
 
 
         } else if widgetType == HomeWidgetAllTimeData.self, let stats = stats as? AllTimeWidgetStats {
-            widgetKind = AppConfiguration.Widget.Stats.allTimeKind
+            widgetReload = WidgetCenter.shared.reloadAllTimeTimelines
 
             homeWidgetCache[siteID.intValue] = HomeWidgetAllTimeData(siteID: siteID.intValue,
                                                                      siteName: blog.title ?? oldData.siteName,
@@ -106,6 +105,7 @@ class StatsWidgetsStore {
                                                                      stats: stats) as? T
 
         } else if widgetType == HomeWidgetThisWeekData.self, let stats = stats as? ThisWeekWidgetStats {
+            widgetReload = WidgetCenter.shared.reloadThisWeekTimelines
 
             homeWidgetCache[siteID.intValue] = HomeWidgetThisWeekData(siteID: siteID.intValue,
                                                                       siteName: blog.title ?? oldData.siteName,
@@ -116,10 +116,7 @@ class StatsWidgetsStore {
         }
 
         T.write(items: homeWidgetCache)
-        WidgetCenter.shared.reloadTimelines(ofKind: widgetKind)
-        if widgetKind == AppConfiguration.Widget.Stats.todayKind {
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
-        }
+        widgetReload?()
     }
 }
 
@@ -250,7 +247,7 @@ extension StatsWidgetsStore {
             let stats = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
             StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetThisWeekData.self, stats: stats)
         case .week:
-            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
+            WidgetCenter.shared.reloadThisWeekTimelines()
         default:
             break
         }
@@ -278,10 +275,9 @@ private extension StatsWidgetsStore {
         HomeWidgetAllTimeData.delete()
 
         userDefaults?.setValue(nil, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
-        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
-        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
-        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
-        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
+        WidgetCenter.shared.reloadTodayTimelines()
+        WidgetCenter.shared.reloadThisWeekTimelines()
+        WidgetCenter.shared.reloadAllTimeTimelines()
     }
 
     /// Observes WPSigninDidFinishNotification and wordpressLoginFinishedJetpackLogin notifications and initializes the widget.

--- a/WordPress/Classes/ViewRelated/Widgets/WidgetCenter+JetpackWidgets.swift
+++ b/WordPress/Classes/ViewRelated/Widgets/WidgetCenter+JetpackWidgets.swift
@@ -6,6 +6,7 @@ extension WidgetCenter {
         WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
         WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
         WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayLikesCommentsKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsVisitorsKind)
     }
 
     func reloadThisWeekTimelines() {
@@ -14,5 +15,8 @@ extension WidgetCenter {
 
     func reloadAllTimeTimelines() {
         WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenAllTimeViewsKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenAllTimeViewsVisitorsKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenAllTimePostsBestViewsKind)
     }
 }

--- a/WordPress/Classes/ViewRelated/Widgets/WidgetCenter+JetpackWidgets.swift
+++ b/WordPress/Classes/ViewRelated/Widgets/WidgetCenter+JetpackWidgets.swift
@@ -1,0 +1,18 @@
+import Foundation
+import WidgetKit
+
+extension WidgetCenter {
+    func reloadTodayTimelines() {
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayViewsKind)
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.lockScreenTodayLikesCommentsKind)
+    }
+
+    func reloadThisWeekTimelines() {
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
+    }
+
+    func reloadAllTimeTimelines() {
+        WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -189,6 +189,8 @@
 		0148CC2B2859C87000CF5D96 /* BlogServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */; };
 		014ACD142A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */; };
 		014ACD152A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */; };
+		01545D102AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01545D0F2AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift */; };
+		01545D112AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01545D0F2AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift */; };
 		015BA4EB29A788A300920F4B /* StatsTotalInsightsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */; };
 		018635842A8109DE00915532 /* SupportChatBotViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018635832A8109DE00915532 /* SupportChatBotViewController.swift */; };
 		018635852A8109DE00915532 /* SupportChatBotViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018635832A8109DE00915532 /* SupportChatBotViewController.swift */; };
@@ -5933,6 +5935,7 @@
 		0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsStoreTests.swift; sourceTree = "<group>"; };
 		0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceMock.swift; sourceTree = "<group>"; };
 		014ACD132A1E5033008A706C /* WebKitViewController+SandboxStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebKitViewController+SandboxStore.swift"; sourceTree = "<group>"; };
+		01545D0F2AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WidgetCenter+JetpackWidgets.swift"; sourceTree = "<group>"; };
 		015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTotalInsightsCellTests.swift; sourceTree = "<group>"; };
 		018635832A8109DE00915532 /* SupportChatBotViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportChatBotViewController.swift; sourceTree = "<group>"; };
 		018635862A8109F900915532 /* SupportChatBotViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportChatBotViewModel.swift; sourceTree = "<group>"; };
@@ -9879,6 +9882,14 @@
 			path = Support;
 			sourceTree = "<group>";
 		};
+		01545D0E2AA9E65C0015DD3A /* Widgets */ = {
+			isa = PBXGroup;
+			children = (
+				01545D0F2AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift */,
+			);
+			path = Widgets;
+			sourceTree = "<group>";
+		};
 		018635822A81098300915532 /* SupportChatBot */ = {
 			isa = PBXGroup;
 			children = (
@@ -13642,6 +13653,7 @@
 				987E79C9261F8857000192B7 /* User Profile Sheet */,
 				031662E60FFB14C60045D052 /* Views */,
 				3F662C4824DC9F8300CAEA95 /* WhatsNew */,
+				01545D0E2AA9E65C0015DD3A /* Widgets */,
 				D86572182186C36E0023A99C /* Wizards */,
 			);
 			path = ViewRelated;
@@ -21512,6 +21524,7 @@
 				982DDF94263238A6002B3904 /* LikeUserPreferredBlog+CoreDataClass.swift in Sources */,
 				F5844B6B235EAF3D007C6557 /* PartScreenPresentationController.swift in Sources */,
 				E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */,
+				01545D102AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift in Sources */,
 				7E4123C120F4097B00DF8486 /* FormattableContentRange.swift in Sources */,
 				08D978581CD2AF7D0054F19A /* MenuItemSourceHeaderView.m in Sources */,
 				011F52C82A16551A00B04114 /* FreeToPaidPlansCoordinator.swift in Sources */,
@@ -25339,6 +25352,7 @@
 				FABB248E2602FC2C00C8785C /* AztecAttachmentDelegate.swift in Sources */,
 				803DE81428FFAE36007D4E9C /* RemoteConfigStore.swift in Sources */,
 				086C117D2A2F6451004A3821 /* CompliancePopover.swift in Sources */,
+				01545D112AA9E6770015DD3A /* WidgetCenter+JetpackWidgets.swift in Sources */,
 				FA98A2512833F1DC003B9233 /* QuickStartChecklistConfigurable.swift in Sources */,
 				931F312D2714302A0075433B /* PublicizeServicesState.swift in Sources */,
 				FABB24902602FC2C00C8785C /* StatsPeriodAsyncOperation.swift in Sources */,

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimePostsBestViewsStatWidgetConfig.swift
@@ -46,7 +46,7 @@ struct LockScreenAllTimePostsBestViewsStatWidgetConfig: LockScreenStatsWidgetCon
 
     var viewProvider: ViewProvider<HomeWidgetAllTimeData> {
         LockScreenMultiStatWidgetViewProvider<HomeWidgetAllTimeData>(
-            widgetKind: .today,
+            widgetKind: .allTime,
             topTitle: LocalizableStrings.postsTitle,
             topValue: \.stats.posts,
             bottomTitle: LocalizableStrings.bestViewsShortTitle,

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift
@@ -46,7 +46,7 @@ struct LockScreenAllTimeViewsVisitorsStatWidgetConfig: LockScreenStatsWidgetConf
 
     var viewProvider: ViewProvider<HomeWidgetAllTimeData> {
         LockScreenMultiStatWidgetViewProvider<HomeWidgetAllTimeData>(
-            widgetKind: .today,
+            widgetKind: .allTime,
             topTitle: LocalizableStrings.viewsTitle,
             topValue: \.stats.views,
             bottomTitle: LocalizableStrings.visitorsTitle,


### PR DESCRIPTION
Fixes #21515

Different widgets need to be explicitly reloaded using `reloadTimelines(ofKind..)` method

## To test:

#### Before testing

1. Open Jetpack
2. Log into the account
3. Enable Lock Screen Widget feature flag
4. Open Lock screen, long tap, tap Customize, select Widget area
5. Tap on Jetpack
6. Add different types of widgets

### Logged out

1. Complete "before testing" steps
2. Go back to the app
3. Logout
4. Confirm widgets show "Please login" option

### No site

1. Complete "before testing" steps
2. Go back to the app
3. Logout
4. Log into the account with no sites
5. Confirm widgets show "No site" message

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

4. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
Does not apply
