### PR TITLE
Move helper functions from PostService to PostHelper

### DIFF
--- a/WordPress/Classes/Services/PostHelper.h
+++ b/WordPress/Classes/Services/PostHelper.h
@@ -10,6 +10,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext;
 
+/**
+ Creates a RemotePost from an AbstractPost to be used for API calls.
+
+ @param post The AbstractPost used to create the RemotePost
+ */
++ (RemotePost *)remotePostWithPost:(AbstractPost *)post;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -11,7 +11,7 @@
     post.postID = remotePost.postID;
     // Used to populate author information for self-hosted sites.
     BlogAuthor *author = [post.blog getAuthorWithId:remotePost.authorID];
-    
+
     post.author = remotePost.authorDisplayName ?: author.displayName;
     post.authorID = remotePost.authorID;
     post.date_created_gmt = remotePost.date;
@@ -21,13 +21,13 @@
     post.content = remotePost.content;
     post.status = remotePost.status;
     post.password = remotePost.password;
-    
+
     if (remotePost.postThumbnailID != nil) {
         post.featuredImage = [Media existingOrStubMediaWithMediaID: remotePost.postThumbnailID inBlog:post.blog];
     } else {
         post.featuredImage = nil;
     }
-    
+
     post.pathForDisplayImage = remotePost.pathForDisplayImage;
     if (post.pathForDisplayImage.length == 0) {
         [post updatePathForDisplayImageBasedOnContent];
@@ -36,21 +36,21 @@
     post.mt_excerpt = remotePost.excerpt;
     post.wp_slug = remotePost.slug;
     post.suggested_slug = remotePost.suggestedSlug;
-    
+
     if ([remotePost.revisions wp_isValidObject]) {
         post.revisions = [remotePost.revisions copy];
     }
-    
+
     if (remotePost.postID != previousPostID) {
         [self updateCommentsForPost:post];
     }
-    
+
     post.autosaveTitle = remotePost.autosave.title;
     post.autosaveExcerpt = remotePost.autosave.excerpt;
     post.autosaveContent = remotePost.autosave.content;
     post.autosaveModifiedDate = remotePost.autosave.modifiedDate;
     post.autosaveIdentifier = remotePost.autosave.identifier;
-    
+
     if ([post isKindOfClass:[Page class]]) {
         Page *pagePost = (Page *)post;
         pagePost.parentID = remotePost.parentID;
@@ -63,7 +63,7 @@
         postPost.postType = remotePost.type;
         postPost.isStickyPost = (remotePost.isStickyPost != nil) ? remotePost.isStickyPost.boolValue : NO;
         [self updatePost:postPost withRemoteCategories:remotePost.categories inContext:managedObjectContext];
-        
+
         NSString *publicID = nil;
         NSString *publicizeMessage = nil;
         NSString *publicizeMessageID = nil;
@@ -88,7 +88,7 @@
         postPost.publicizeMessageID = publicizeMessageID;
         postPost.disabledPublicizeConnections = [self disabledPublicizeConnectionsForPost:post andMetadata:remotePost.metadata];
     }
-    
+
     post.statusAfterSync = post.status;
 }
 
@@ -144,7 +144,7 @@
     }
     remotePost.excerpt = post.mt_excerpt;
     remotePost.slug = post.wp_slug;
-    
+
     if ([post isKindOfClass:[Page class]]) {
         Page *pagePost = (Page *)post;
         remotePost.parentID = pagePost.parentID;
@@ -158,7 +158,7 @@
         }];
         remotePost.categories = [self remoteCategoriesForPost:postPost];
         remotePost.metadata = [self remoteMetadataForPost:postPost];
-        
+
         // Because we can't get what's the self-hosted non Jetpack site capabilities
         // only Admin users are allowed to set a post as sticky.
         // This doesn't affect WPcom sites.
@@ -166,9 +166,9 @@
         BOOL canMarkPostAsSticky = ([post.blog supports:BlogFeatureWPComRESTAPI] || post.blog.isAdmin);
         remotePost.isStickyPost = canMarkPostAsSticky ? @(postPost.isStickyPost) : nil;
     }
-    
+
     remotePost.isFeaturedImageChanged = post.isFeaturedImageChanged;
-    
+
     return remotePost;
 }
 
@@ -190,13 +190,13 @@
 
 + (NSArray *)remoteMetadataForPost:(Post *)post {
     NSMutableArray *metadata = [NSMutableArray arrayWithCapacity:4];
-    
+
     if (post.publicID) {
         NSMutableDictionary *publicDictionary = [NSMutableDictionary dictionaryWithCapacity:1];
         publicDictionary[@"id"] = [post.publicID numericValue];
         [metadata addObject:publicDictionary];
     }
-    
+
     if (post.publicizeMessageID || post.publicizeMessage.length) {
         NSMutableDictionary *publicizeMessageDictionary = [NSMutableDictionary dictionaryWithCapacity:3];
         if (post.publicizeMessageID) {
@@ -206,16 +206,16 @@
         publicizeMessageDictionary[@"value"] = post.publicizeMessage.length ? post.publicizeMessage : @"";
         [metadata addObject:publicizeMessageDictionary];
     }
-    
+
     [metadata addObjectsFromArray:[PostHelper publicizeMetadataEntriesForPost:post]];
-    
+
     if (post.bloggingPromptID) {
         NSMutableDictionary *promptDictionary = [NSMutableDictionary dictionaryWithCapacity:3];
         promptDictionary[@"key"] = @"_jetpack_blogging_prompt_key";
         promptDictionary[@"value"] = post.bloggingPromptID;
         [metadata addObject:promptDictionary];
     }
-    
+
     return metadata;
 }
 

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -160,13 +160,6 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
            success:(nullable void (^)(void))success
            failure:(void (^)(NSError * _Nullable error))failure;
 
-/**
- Creates a RemotePost from an AbstractPost to be used for API calls.
-
- @param post The AbstractPost used to create the RemotePost
- */
-+ (RemotePost *)remotePostWithPost:(AbstractPost *)post;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -165,7 +165,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
 
  @param post The AbstractPost used to create the RemotePost
  */
-- (RemotePost *)remotePostWithPost:(AbstractPost *)post;
++ (RemotePost *)remotePostWithPost:(AbstractPost *)post;
 
 @end
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -191,7 +191,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
            failure:(nullable void (^)(NSError * _Nullable error))failure
 {
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
-    RemotePost *remotePost = [self remotePostWithPost:post];
+    RemotePost *remotePost = [PostService remotePostWithPost:post];
 
     post.remoteStatus = AbstractPostRemoteStatusPushing;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
@@ -379,7 +379,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
                              failure:(void (^)(NSError * _Nullable error))failure
 {
     NSManagedObjectID *postObjectID = post.objectID;
-    RemotePost *remotePost = [self remotePostWithPost:post];
+    RemotePost *remotePost = [PostService remotePostWithPost:post];
 
     AutosaveSuccessBlock autosaveSuccessBlock = [self wrappedAutosaveSuccessBlock:postObjectID success:success];
     AutosaveFailureBlock setPostAsFailedAndCallFailureBlock = [self wrappedAutosaveFailureBlock:post failure:failure];
@@ -452,7 +452,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     void (^privateBlock)(void) = ^void() {
         NSNumber *postID = post.postID;
         if ([postID longLongValue] > 0) {
-            RemotePost *remotePost = [self remotePostWithPost:post];
+            RemotePost *remotePost = [PostService remotePostWithPost:post];
             id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
             [remote deletePost:remotePost success:success failure:failure];
         }
@@ -546,7 +546,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
         }
     };
     
-    RemotePost *remotePost = [self remotePostWithPost:post];
+    RemotePost *remotePost = [PostService remotePostWithPost:post];
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
     [remote trashPost:remotePost success:successBlock failure:failureBlock];
 }
@@ -617,7 +617,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
         }
     };
     
-    RemotePost *remotePost = [self remotePostWithPost:post];
+    RemotePost *remotePost = [PostService remotePostWithPost:post];
     if (post.restorableStatus) {
         remotePost.status = post.restorableStatus;
     } else {
@@ -719,7 +719,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     return [remote dictionaryWithRemoteOptions:options];
 }
 
-- (RemotePost *)remotePostWithPost:(AbstractPost *)post
++ (RemotePost *)remotePostWithPost:(AbstractPost *)post
 {
     RemotePost *remotePost = [RemotePost new];
     remotePost.postID = post.postID;
@@ -769,14 +769,14 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     return remotePost;
 }
 
-- (NSArray *)remoteCategoriesForPost:(Post *)post
++ (NSArray *)remoteCategoriesForPost:(Post *)post
 {
     return [[post.categories allObjects] wp_map:^id(PostCategory *category) {
         return [self remoteCategoryWithCategory:category];
     }];
 }
 
-- (RemotePostCategory *)remoteCategoryWithCategory:(PostCategory *)category
++ (RemotePostCategory *)remoteCategoryWithCategory:(PostCategory *)category
 {
     RemotePostCategory *remoteCategory = [RemotePostCategory new];
     remoteCategory.categoryID = category.categoryID;
@@ -785,7 +785,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     return remoteCategory;
 }
 
-- (NSArray *)remoteMetadataForPost:(Post *)post {
++ (NSArray *)remoteMetadataForPost:(Post *)post {
     NSMutableArray *metadata = [NSMutableArray arrayWithCapacity:4];
 
     if (post.publicID) {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -191,7 +191,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
            failure:(nullable void (^)(NSError * _Nullable error))failure
 {
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
-    RemotePost *remotePost = [PostService remotePostWithPost:post];
+    RemotePost *remotePost = [PostHelper remotePostWithPost:post];
 
     post.remoteStatus = AbstractPostRemoteStatusPushing;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
@@ -379,7 +379,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
                              failure:(void (^)(NSError * _Nullable error))failure
 {
     NSManagedObjectID *postObjectID = post.objectID;
-    RemotePost *remotePost = [PostService remotePostWithPost:post];
+    RemotePost *remotePost = [PostHelper remotePostWithPost:post];
 
     AutosaveSuccessBlock autosaveSuccessBlock = [self wrappedAutosaveSuccessBlock:postObjectID success:success];
     AutosaveFailureBlock setPostAsFailedAndCallFailureBlock = [self wrappedAutosaveFailureBlock:post failure:failure];
@@ -452,7 +452,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     void (^privateBlock)(void) = ^void() {
         NSNumber *postID = post.postID;
         if ([postID longLongValue] > 0) {
-            RemotePost *remotePost = [PostService remotePostWithPost:post];
+            RemotePost *remotePost = [PostHelper remotePostWithPost:post];
             id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
             [remote deletePost:remotePost success:success failure:failure];
         }
@@ -546,7 +546,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
         }
     };
     
-    RemotePost *remotePost = [PostService remotePostWithPost:post];
+    RemotePost *remotePost = [PostHelper remotePostWithPost:post];
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
     [remote trashPost:remotePost success:successBlock failure:failureBlock];
 }
@@ -617,7 +617,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
         }
     };
     
-    RemotePost *remotePost = [PostService remotePostWithPost:post];
+    RemotePost *remotePost = [PostHelper remotePostWithPost:post];
     if (post.restorableStatus) {
         remotePost.status = post.restorableStatus;
     } else {
@@ -717,103 +717,6 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
                                               withOptions:(nonnull PostServiceSyncOptions *)options
 {
     return [remote dictionaryWithRemoteOptions:options];
-}
-
-+ (RemotePost *)remotePostWithPost:(AbstractPost *)post
-{
-    RemotePost *remotePost = [RemotePost new];
-    remotePost.postID = post.postID;
-    remotePost.date = post.date_created_gmt;
-    remotePost.dateModified = post.dateModified;
-    remotePost.title = post.postTitle ?: @"";
-    remotePost.content = post.content;
-    remotePost.status = post.status;
-    if (post.featuredImage) {
-        remotePost.postThumbnailID = post.featuredImage.mediaID;
-    }
-    remotePost.password = post.password;
-    remotePost.type = @"post";
-    remotePost.authorAvatarURL = post.authorAvatarURL;
-    // If a Post's authorID is 0 (the default Core Data value)
-    // or nil, don't send it to the API.
-    if (post.authorID.integerValue != 0) {
-        remotePost.authorID = post.authorID;
-    }
-    remotePost.excerpt = post.mt_excerpt;
-    remotePost.slug = post.wp_slug;
-
-    if ([post isKindOfClass:[Page class]]) {
-        Page *pagePost = (Page *)post;
-        remotePost.parentID = pagePost.parentID;
-        remotePost.type = @"page";
-    }
-    if ([post isKindOfClass:[Post class]]) {
-        Post *postPost = (Post *)post;
-        remotePost.format = postPost.postFormat;        
-        remotePost.tags = [[postPost.tags componentsSeparatedByString:@","] wp_map:^id(NSString *obj) {
-            return [obj stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
-        }];
-        remotePost.categories = [self remoteCategoriesForPost:postPost];
-        remotePost.metadata = [self remoteMetadataForPost:postPost];
-
-        // Because we can't get what's the self-hosted non Jetpack site capabilities
-        // only Admin users are allowed to set a post as sticky.
-        // This doesn't affect WPcom sites.
-        //
-        BOOL canMarkPostAsSticky = ([post.blog supports:BlogFeatureWPComRESTAPI] || post.blog.isAdmin);
-        remotePost.isStickyPost = canMarkPostAsSticky ? @(postPost.isStickyPost) : nil;
-    }
-
-    remotePost.isFeaturedImageChanged = post.isFeaturedImageChanged;
-
-    return remotePost;
-}
-
-+ (NSArray *)remoteCategoriesForPost:(Post *)post
-{
-    return [[post.categories allObjects] wp_map:^id(PostCategory *category) {
-        return [self remoteCategoryWithCategory:category];
-    }];
-}
-
-+ (RemotePostCategory *)remoteCategoryWithCategory:(PostCategory *)category
-{
-    RemotePostCategory *remoteCategory = [RemotePostCategory new];
-    remoteCategory.categoryID = category.categoryID;
-    remoteCategory.name = category.categoryName;
-    remoteCategory.parentID = category.parentID;
-    return remoteCategory;
-}
-
-+ (NSArray *)remoteMetadataForPost:(Post *)post {
-    NSMutableArray *metadata = [NSMutableArray arrayWithCapacity:4];
-
-    if (post.publicID) {
-        NSMutableDictionary *publicDictionary = [NSMutableDictionary dictionaryWithCapacity:1];
-        publicDictionary[@"id"] = [post.publicID numericValue];
-        [metadata addObject:publicDictionary];
-    }
-
-    if (post.publicizeMessageID || post.publicizeMessage.length) {
-        NSMutableDictionary *publicizeMessageDictionary = [NSMutableDictionary dictionaryWithCapacity:3];
-        if (post.publicizeMessageID) {
-            publicizeMessageDictionary[@"id"] = post.publicizeMessageID;
-        }
-        publicizeMessageDictionary[@"key"] = @"_wpas_mess";
-        publicizeMessageDictionary[@"value"] = post.publicizeMessage.length ? post.publicizeMessage : @"";
-        [metadata addObject:publicizeMessageDictionary];
-    }
-
-    [metadata addObjectsFromArray:[PostHelper publicizeMetadataEntriesForPost:post]];
-
-    if (post.bloggingPromptID) {
-        NSMutableDictionary *promptDictionary = [NSMutableDictionary dictionaryWithCapacity:3];
-        promptDictionary[@"key"] = @"_jetpack_blogging_prompt_key";
-        promptDictionary[@"value"] = post.bloggingPromptID;
-        [metadata addObject:promptDictionary];
-    }
-
-    return metadata;
 }
 
 - (NSArray *)entriesWithKeyLike:(NSString *)key inMetadata:(NSArray *)metadata

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -301,7 +301,7 @@ class PostServiceWPComTests: CoreDataTestCase {
         try! mainContext.save()
 
         // When
-        let remotePost = self.service.remotePost(with: post)
+        let remotePost = PostHelper.remotePost(with: post)
 
         // Then
         XCTAssertNil(remotePost.authorID)
@@ -315,7 +315,7 @@ class PostServiceWPComTests: CoreDataTestCase {
         try! mainContext.save()
 
         // When
-        let remotePost = self.service.remotePost(with: post)
+        let remotePost = PostHelper.remotePost(with: post)
 
         // Then
         XCTAssertNil(remotePost.authorID)
@@ -330,7 +330,7 @@ class PostServiceWPComTests: CoreDataTestCase {
         try! mainContext.save()
 
         // When
-        let remotePost = self.service.remotePost(with: post)
+        let remotePost = PostHelper.remotePost(with: post)
 
         // Then
         XCTAssertEqual(remotePost.authorID, expectedAuthorID)


### PR DESCRIPTION
This PR simply moves some instance functions of `PostService` to static functions of `PostHelper`. No implementation are changed.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A