### PR TITLE
[UI Tests] - Update tests to use new menu screen

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -35,7 +35,7 @@ class JetpackScreenshotGeneration: XCTestCase {
     func testGenerateScreenshots() throws {
 
         let mySite = try MySiteScreen()
-        let mySiteMenu = try MySiteMenuScreen()
+        let mySiteMenu = try MySiteMoreMenuScreen()
 
         // Get Site Creation screenshot
         let mySitesScreen = try mySite.showSiteSwitcher()
@@ -58,7 +58,7 @@ class JetpackScreenshotGeneration: XCTestCase {
 
         // Open Menu to be able to access stats
         if XCUIDevice.isPhone {
-            try mySite.goToMenu()
+            try mySite.goToMoreMenu()
         }
 
         // Get Stats screenshot

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -35,11 +35,7 @@ class JetpackScreenshotGeneration: XCTestCase {
     func testGenerateScreenshots() throws {
 
         let mySite = try MySiteScreen()
-
-        // Open Home
-        if XCUIDevice.isPad {
-            mySite.goToHomeScreen()
-        }
+        let mySiteMenu = try MySiteMenuScreen()
 
         // Get Site Creation screenshot
         let mySitesScreen = try mySite.showSiteSwitcher()
@@ -62,11 +58,11 @@ class JetpackScreenshotGeneration: XCTestCase {
 
         // Open Menu to be able to access stats
         if XCUIDevice.isPhone {
-            mySite.goToMenu()
+            try mySite.goToMenu()
         }
 
         // Get Stats screenshot
-        let statsScreen = try mySite.goToStatsScreen()
+        let statsScreen = try mySiteMenu.goToStatsScreen()
         statsScreen
             .dismissCustomizeInsightsNotice()
             .thenTakeScreenshot(4, named: "Stats")

--- a/WordPress/UITests/Flows/EditorFlow.swift
+++ b/WordPress/UITests/Flows/EditorFlow.swift
@@ -16,7 +16,7 @@ class EditorFlow {
         if !SiteSettingsScreen.isLoaded() {
             try TabNavComponent()
                 .goToMySiteScreen()
-                .goToMenu()
+                .goToMoreMenu()
                 .goToSettingsScreen()
         }
         return try SiteSettingsScreen().toggleBlockEditor(to: state)

--- a/WordPress/UITests/Flows/EditorFlow.swift
+++ b/WordPress/UITests/Flows/EditorFlow.swift
@@ -16,6 +16,7 @@ class EditorFlow {
         if !SiteSettingsScreen.isLoaded() {
             try TabNavComponent()
                 .goToMySiteScreen()
+                .goToMenu()
                 .goToSettingsScreen()
         }
         return try SiteSettingsScreen().toggleBlockEditor(to: state)

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -9,7 +9,7 @@ class MainNavigationTests: XCTestCase {
 
         try LoginFlow
             .login(email: WPUITestCredentials.testWPcomUserEmail)
-            .goToMenu()
+            .goToMoreMenu()
     }
 
     override func tearDownWithError() throws {
@@ -21,7 +21,7 @@ class MainNavigationTests: XCTestCase {
     //
     // It would be wise to add similar tests for each item in the menu (then remove this comment).
     func testLoadsPeopleScreen() throws {
-        try MySiteMenuScreen()
+        try MySiteMoreMenuScreen()
             .goToPeople()
             .assertScreenIsLoaded()
     }

--- a/WordPress/UITests/Tests/MainNavigationTests.swift
+++ b/WordPress/UITests/Tests/MainNavigationTests.swift
@@ -21,8 +21,7 @@ class MainNavigationTests: XCTestCase {
     //
     // It would be wise to add similar tests for each item in the menu (then remove this comment).
     func testLoadsPeopleScreen() throws {
-        try MySiteScreen()
-            .assertScreenIsLoaded()
+        try MySiteMenuScreen()
             .goToPeople()
             .assertScreenIsLoaded()
     }

--- a/WordPress/UITests/Tests/MenuNavigationTests.swift
+++ b/WordPress/UITests/Tests/MenuNavigationTests.swift
@@ -18,7 +18,7 @@ final class MenuNavigationTests: XCTestCase {
     // This test is JP only.
     func testDomainsNavigation() throws {
         try MySiteScreen()
-            .goToMenu()
+            .goToMoreMenu()
             .goToDomainsScreen()
             .assertScreenIsLoaded()
     }

--- a/WordPress/UITests/Tests/PostTests.swift
+++ b/WordPress/UITests/Tests/PostTests.swift
@@ -34,6 +34,7 @@ class PostTests: XCTestCase {
             .post(action: .schedule)
 
         try MySiteScreen()
+            .goToMenu()
             .goToPostsScreen()
             .showOnly(.scheduled)
             .verifyPostExists(withTitle: postTitle)

--- a/WordPress/UITests/Tests/PostTests.swift
+++ b/WordPress/UITests/Tests/PostTests.swift
@@ -34,7 +34,7 @@ class PostTests: XCTestCase {
             .post(action: .schedule)
 
         try MySiteScreen()
-            .goToMenu()
+            .goToMoreMenu()
             .goToPostsScreen()
             .showOnly(.scheduled)
             .verifyPostExists(withTitle: postTitle)

--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -9,7 +9,7 @@ class StatsTests: XCTestCase {
 
         try LoginFlow
             .login(email: WPUITestCredentials.testWPcomUserEmail)
-            .goToMenu()
+            .goToMoreMenu()
             .goToStatsScreen()
             .switchTo(mode: "insights")
             .refreshStatsIfNeeded()

--- a/WordPress/UITestsFoundation/Screens/MySiteMenuScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteMenuScreen.swift
@@ -1,0 +1,124 @@
+import ScreenObject
+import XCTest
+
+public class MySiteMenuScreen: ScreenObject {
+
+    private let activityLogButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Activity Log Row"]
+    }
+
+    private let postsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Blog Post Row"]
+    }
+
+    private let mediaButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Media Row"]
+    }
+
+    private let mySiteNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["my-site-navigation-bar"]
+    }
+
+    private let statsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Stats Row"]
+    }
+
+    private let domainsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Domains Row"]
+    }
+
+    private let jetpackScanButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Scan Row"]
+    }
+
+    private let jetpackBackupButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Backup Row"]
+    }
+
+    private let settingsButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["Settings Row"]
+    }
+
+    private let peopleButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["People Row"]
+    }
+
+    var activityLogButton: XCUIElement { activityLogButtonGetter(app) }
+    var domainsButton: XCUIElement { domainsButtonGetter(app) }
+    var jetpackBackupButton: XCUIElement { jetpackBackupButtonGetter(app) }
+    var jetpackScanButton: XCUIElement { jetpackScanButtonGetter(app) }
+    var mediaButton: XCUIElement { mediaButtonGetter(app) }
+    var mySiteNavigationBar: XCUIElement { mySiteNavigationBarGetter(app) }
+    var peopleButton: XCUIElement { peopleButtonGetter(app) }
+    var postsButton: XCUIElement { postsButtonGetter(app) }
+    var settingsButton: XCUIElement { settingsButtonGetter(app) }
+    var statsButton: XCUIElement { statsButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                activityLogButtonGetter,
+                mySiteNavigationBarGetter
+            ],
+            app: app
+        )
+    }
+
+    public func goToPostsScreen() throws -> PostsScreen {
+        postsButton.tap()
+        return try PostsScreen()
+    }
+
+    public func goToActivityLog() throws -> ActivityLogScreen {
+        activityLogButton.tap()
+        return try ActivityLogScreen()
+    }
+
+    public func goToJetpackScan() throws -> JetpackScanScreen {
+        jetpackScanButton.tap()
+        return try JetpackScanScreen()
+    }
+
+    public func goToJetpackBackup() throws -> JetpackBackupScreen {
+        jetpackBackupButton.tap()
+        return try JetpackBackupScreen()
+    }
+
+    public func goToMediaScreen() throws -> MediaScreen {
+        mediaButton.tap()
+        return try MediaScreen()
+    }
+
+    public func goToStatsScreen() throws -> StatsScreen {
+        statsButton.tap()
+        return try StatsScreen()
+    }
+
+    @discardableResult
+    public func goToSettingsScreen() throws -> SiteSettingsScreen {
+        settingsButton.tap()
+        return try SiteSettingsScreen()
+    }
+
+    public func goToDomainsScreen() throws -> DomainsScreen {
+        domainsButton.tap()
+        return try DomainsScreen()
+    }
+
+    @discardableResult
+    public func goToMenu() -> Self {
+        app.tables.cells.staticTexts["More"].tap()
+
+        return self
+    }
+
+    @discardableResult
+    public func goToPeople() throws -> PeopleScreen {
+        peopleButton.tap()
+        return try PeopleScreen()
+    }
+
+    public static func isLoaded() -> Bool {
+        (try? MySiteMenuScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/UITestsFoundation/Screens/MySiteMenuScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteMenuScreen.swift
@@ -1,7 +1,7 @@
 import ScreenObject
 import XCTest
 
-public class MySiteMenuScreen: ScreenObject {
+public class MySiteMoreMenuScreen: ScreenObject {
 
     private let activityLogButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["Activity Log Row"]
@@ -106,7 +106,7 @@ public class MySiteMenuScreen: ScreenObject {
     }
 
     @discardableResult
-    public func goToMenu() -> Self {
+    public func goToMoreMenu() -> Self {
         app.tables.cells.staticTexts["More"].tap()
 
         return self
@@ -119,6 +119,6 @@ public class MySiteMenuScreen: ScreenObject {
     }
 
     public static func isLoaded() -> Bool {
-        (try? MySiteMenuScreen().isLoaded) ?? false
+        (try? MySiteMoreMenuScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -8,24 +8,8 @@ public class MySiteScreen: ScreenObject {
     static let freeToPaidPlansCardId = "dashboard-free-to-paid-plans-card-contentview"
     static let pagesCardId = "dashboard-pages-card-frameview"
 
-    private let activityLogButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Activity Log Row"]
-    }
-
-    private let postsButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Blog Post Row"]
-    }
-
     private let readerButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Reader"]
-    }
-
-    private let mediaButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Media Row"]
-    }
-
-    private let statsButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Stats Row"]
     }
 
     private let createButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -36,12 +20,8 @@ public class MySiteScreen: ScreenObject {
         $0.buttons["SwitchSiteButton"]
     }
 
-    private let homeButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Home"]
-    }
-
-    private let segmentedControlMenuButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Menu"]
+    private let moreMenuButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables.cells.staticTexts["More"]
     }
 
     private let freeToPaidPlansCardButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -92,27 +72,10 @@ public class MySiteScreen: ScreenObject {
         $0.alerts.buttons.element(boundBy: 1)
     }
 
-    private let jetpackScanButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Scan Row"]
-    }
-
-    private let jetpackBackupButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Backup Row"]
-    }
-
-    private let settingsButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["Settings Row"]
-    }
-
-    private let peopleButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.cells["People Row"]
-    }
-
     private let noticeTitleGetter: (XCUIApplication) -> XCUIElement = {
         $0.otherElements["notice_title_and_message"]
     }
 
-    var activityLogButton: XCUIElement { activityLogButtonGetter(app) }
     var activityLogCard: XCUIElement { activityLogCardGetter(app) }
     var activityLogCardHeaderButton: XCUIElement { activityLogCardHeaderButtonGetter(app) }
     var blogDetailsRemoveSiteButton: XCUIElement { blogDetailsRemoveSiteButtonGetter(app) }
@@ -120,31 +83,21 @@ public class MySiteScreen: ScreenObject {
     var createButton: XCUIElement { createButtonGetter(app) }
     var domainsButton: XCUIElement { domainsButtonGetter(app) }
     var freeToPaidPlansCardButton: XCUIElement { freeToPaidPlansCardButtonGetter(app) }
-    var homeButton: XCUIElement { homeButtonGetter(app) }
-    var jetpackBackupButton: XCUIElement { jetpackBackupButtonGetter(app) }
-    var jetpackScanButton: XCUIElement { jetpackScanButtonGetter(app) }
-    var mediaButton: XCUIElement { mediaButtonGetter(app) }
+    var moreMenuButton: XCUIElement { moreMenuButtonGetter(app) }
     var noticeTitle: XCUIElement { noticeTitleGetter(app) }
     var pagesCard: XCUIElement { pagesCardGetter(app) }
     var pagesCardCreatePageButton: XCUIElement { pagesCardCreatePageButtonGetter(app) }
     var pagesCardHeaderButton: XCUIElement { pagesCardHeaderButtonGetter(app) }
     var pagesCardMoreButton: XCUIElement { pagesCardMoreButtonGetter(app) }
-    var peopleButton: XCUIElement { peopleButtonGetter(app) }
-    var postsButton: XCUIElement { postsButtonGetter(app) }
     var readerButton: XCUIElement { readerButtonGetter(app)}
     var removeSiteAlert: XCUIElement { removeSiteAlertGetter(app) }
     var removeSiteButton: XCUIElement { removeSiteButtonGetter(app) }
-    var segmentedControlMenuButton: XCUIElement { segmentedControlMenuButtonGetter(app) }
-    var settingsButton: XCUIElement { settingsButtonGetter(app) }
-    var statsButton: XCUIElement { statsButtonGetter(app) }
     var switchSiteButton: XCUIElement { switchSiteButtonGetter(app)}
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 switchSiteButtonGetter,
-                postsButtonGetter,
-                mediaButtonGetter,
                 createButtonGetter
             ],
             app: app
@@ -164,52 +117,9 @@ public class MySiteScreen: ScreenObject {
         removeButton.tap()
     }
 
-    public func goToActivityLog() throws -> ActivityLogScreen {
-        activityLogButton.tap()
-        return try ActivityLogScreen()
-    }
-
-    public func goToJetpackScan() throws -> JetpackScanScreen {
-        jetpackScanButton.tap()
-        return try JetpackScanScreen()
-    }
-
-    public func goToJetpackBackup() throws -> JetpackBackupScreen {
-        jetpackBackupButton.tap()
-        return try JetpackBackupScreen()
-    }
-
-    public func goToPostsScreen() throws -> PostsScreen {
-        goToMenu()
-        postsButton.tap()
-        return try PostsScreen()
-    }
-
-    public func goToMediaScreen() throws -> MediaScreen {
-        mediaButton.tap()
-        return try MediaScreen()
-    }
-
-    public func goToStatsScreen() throws -> StatsScreen {
-        statsButton.tap()
-        return try StatsScreen()
-    }
-
-    @discardableResult
-    public func goToSettingsScreen() throws -> SiteSettingsScreen {
-        settingsButton.tap()
-        return try SiteSettingsScreen()
-    }
-
     public func goToCreateSheet() throws -> ActionSheetComponent {
         createButton.tap()
         return try ActionSheetComponent()
-    }
-
-    @discardableResult
-    public func goToHomeScreen() -> Self {
-        homeButton.tap()
-        return self
     }
 
     public func goToDomainsScreen() throws -> DomainsScreen {
@@ -218,20 +128,15 @@ public class MySiteScreen: ScreenObject {
     }
 
     @discardableResult
-    public func goToMenu() -> Self {
+    public func goToMenu() throws -> MySiteMenuScreen {
+
         // On iPad, the menu items are already listed on screen, so we don't need to tap the menu button
-        guard XCUIDevice.isPhone && !segmentedControlMenuButton.isSelected else {
-            return self
+        guard XCUIDevice.isPhone && !moreMenuButton.isSelected else {
+            return try MySiteMenuScreen()
         }
 
-        segmentedControlMenuButton.tap()
-        return self
-    }
-
-    @discardableResult
-    public func goToPeople() throws -> PeopleScreen {
-        peopleButton.tap()
-        return try PeopleScreen()
+        moreMenuButton.tap()
+        return try MySiteMenuScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -128,15 +128,15 @@ public class MySiteScreen: ScreenObject {
     }
 
     @discardableResult
-    public func goToMenu() throws -> MySiteMenuScreen {
+    public func goToMoreMenu() throws -> MySiteMoreMenuScreen {
 
         // On iPad, the menu items are already listed on screen, so we don't need to tap the menu button
         guard XCUIDevice.isPhone && !moreMenuButton.isSelected else {
-            return try MySiteMenuScreen()
+            return try MySiteMoreMenuScreen()
         }
 
         moreMenuButton.tap()
-        return try MySiteMenuScreen()
+        return try MySiteMoreMenuScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2062,6 +2062,7 @@
 		80F6D05D28EE88FC00953C1A /* JetpackNotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 80F6D05428EE866A00953C1A /* JetpackNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		80F8DAC1282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */; };
 		80F8DAC2282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */; };
+		80FDF4182AAADDF2000287B1 /* MySiteMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FDF4172AAADDF2000287B1 /* MySiteMenuScreen.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -7459,6 +7460,7 @@
 		80F6D05828EE86F800953C1A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		80F6D05928EE86F800953C1A /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
 		80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPAnalytics+QuickStart.swift"; sourceTree = "<group>"; };
+		80FDF4172AAADDF2000287B1 /* MySiteMenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySiteMenuScreen.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -11812,6 +11814,7 @@
 				F97DA41F23D67B820050E791 /* MediaScreen.swift */,
 				BE6DD3311FD6803700E55192 /* MeTabScreen.swift */,
 				BE8707162006B774004FB5A4 /* MySiteScreen.swift */,
+				80FDF4172AAADDF2000287B1 /* MySiteMenuScreen.swift */,
 				BE6DD32D1FD67EDA00E55192 /* MySitesScreen.swift */,
 				BE87071A2006E65C004FB5A4 /* NotificationsScreen.swift */,
 				3F30A6AF299B412E0004452F /* PeopleScreen.swift */,
@@ -23116,6 +23119,7 @@
 				3F2F854026FAE9DC000FCDA5 /* BlockEditorScreen.swift in Sources */,
 				3FB5C2B327059AC8007D0ECE /* XCUIElement+Scroll.swift in Sources */,
 				D8599FEA2A2930CE00065193 /* PagesScreen.swift in Sources */,
+				80FDF4182AAADDF2000287B1 /* MySiteMenuScreen.swift in Sources */,
 				3F2F854726FAED51000FCDA5 /* MediaPickerAlbumListScreen.swift in Sources */,
 				3FE39A3626F8370D006E2B3A /* MySitesScreen.swift in Sources */,
 				3F762E9926784CC90088CD45 /* XCUIElementQuery+Utils.swift in Sources */,


### PR DESCRIPTION
### Description
The `Menu` screen is now separated from `MySiteScreen`. In this PR, all methods related to the `Menu` screen are removed from `MySiteScreen` into its own screen `MySiteMenuScreen` so that we can continue to chain methods in test classes while validating that the test is on the right screen.

### Testing
CI should be 🟢 