### PR TITLE
Lock Screen Widgets: VoiceOver improvements

### DIFF
--- a/WordPress/JetpackStatsWidgets/LockScreenWidgets/Views/LockScreenMultiStatView.swift
+++ b/WordPress/JetpackStatsWidgets/LockScreenWidgets/Views/LockScreenMultiStatView.swift
@@ -33,6 +33,7 @@ struct LockScreenMultiStatView: View {
                     EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8)
                 )
             }
+            .accessibilityElement(children: .combine)
         } else {
             Text("Not implemented for widget family \(family.debugDescription)")
         }

--- a/WordPress/JetpackStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
+++ b/WordPress/JetpackStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
@@ -19,6 +19,7 @@ struct LockScreenSingleStatView: View {
                     EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8)
                 )
             }
+            .accessibilityElement(children: .combine)
         } else {
             Text("Not implemented for widget family \(family.debugDescription)")
         }


### PR DESCRIPTION
Grouping elements together so the widget information would be read out all at once. Otherwise, the elements on the widget are too small to properly interact with.

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/99f4a77c-1cf2-4267-8616-8bfc8cfe9366


## To test:

1. Enable `lockScreenWidget` feature flag in `FeatureFlag.swift`
2. Open Jetpack, log into wp.com account
3. Add Lock Screen widgets
4. Enable voice over
5. Confirm that the information is read out clearly

## Regression Notes

1. Potential unintended areas of impact

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
