### PR TITLE
Dashboard: add context menu to site link

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -238,6 +238,15 @@ fileprivate extension BlogDetailHeaderView {
             configuration.titleLineBreakMode = .byTruncatingTail
             button.configuration = configuration
 
+            button.menu = UIMenu(children: [
+                UIAction(title: Strings.openInBrowser, image: UIImage(systemName: "link"), handler: { [weak button] _ in
+                    button?.sendActions(for: .touchUpInside)
+                }),
+                UIAction(title: Strings.actionCopyURL, image: UIImage(systemName: "doc.on.doc"), handler: { [weak button] _ in
+                    UIPasteboard.general.url = URL(string: button?.titleLabel?.text ?? "")
+                })
+            ])
+
             button.accessibilityHint = NSLocalizedString("Tap to view your site", comment: "Accessibility hint for button used to view the user's site")
             button.translatesAutoresizingMaskIntoConstraints = false
             return button
@@ -346,4 +355,10 @@ fileprivate extension BlogDetailHeaderView {
             ])
         }
     }
+}
+
+private enum Strings {
+    static let openInBrowser = NSLocalizedString("blogHeader.actionOpenInBrowser", value: "Open in Browser", comment: "Context menu button title")
+    static let actionCopyURL = NSLocalizedString("blogHeader.actionCopyURL", value: "Copy URL", comment: "Context menu button title")
+
 }


### PR DESCRIPTION
Part of #21492

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/d8f5aaea-5147-4207-81a7-e31ce8c0dddf

## To test:

- Follow the steps from the video
- Verify that the URL is copied
- Verify that simply tapping on the link opens it in a browser

## Regression Notes
1. Potential unintended areas of impact: Site Title
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
