### PR TITLE
Remove restorableStatus property from AbstractPost

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 23.3
 -----
-
+* [**] [internal] Refactor the "Undo" action after moving a post or page to trash. [#21538]
 
 23.2
 -----

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -37,10 +37,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, assign) BOOL metaIsLocal;
 @property (nonatomic, assign) BOOL metaPublishImmediately;
 /**
- Used to store the post's status before its sent to the trash.
- */
-@property (nonatomic, strong) NSString *restorableStatus;
-/**
  This array will contain a list of revision IDs.
  */
 @property (nonatomic, strong, nullable) NSArray *revisions;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -39,8 +39,6 @@
 @dynamic autosaveModifiedDate;
 @dynamic autosaveIdentifier;
 
-@synthesize restorableStatus;
-
 + (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
 {
     NSSet *keyPaths = [super keyPathsForValuesAffectingValueForKey:key];

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -157,6 +157,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
  @param failure A failure block
  */
 - (void)restorePost:(AbstractPost *)post
+           toStatus:(NSString *)status
            success:(nullable void (^)(void))success
            failure:(void (^)(NSError * _Nullable error))failure;
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1008,8 +1008,9 @@ class AbstractPostListViewController: UIViewController,
         // if the post was recently deleted, update the status helper and reload the cell to display a spinner
         let postObjectID = apost.objectID
 
-        let restorableStatus = recentlyTrashedPostRestorableStatus[postObjectID]
-        recentlyTrashedPostRestorableStatus.removeValue(forKey: postObjectID)
+        guard let restorableStatus = recentlyTrashedPostRestorableStatus.removeValue(forKey: postObjectID) else {
+            return
+        }
 
         if filterSettings.currentPostListFilter().filterType != .draft {
             // Needed or else the post will remain in the published list.
@@ -1019,7 +1020,7 @@ class AbstractPostListViewController: UIViewController,
 
         let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 
-        postService.restore(apost, success: { [weak self] in
+        postService.restore(apost, toStatus: restorableStatus.rawValue, success: { [weak self] in
 
             guard let strongSelf = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1009,6 +1009,7 @@ class AbstractPostListViewController: UIViewController,
         let postObjectID = apost.objectID
 
         guard let restorableStatus = recentlyTrashedPostRestorableStatus.removeValue(forKey: postObjectID) else {
+            DDLogError("Can't find the original post status when attempting to restore a post")
             return
         }
 


### PR DESCRIPTION
## Issue

`AbstractPost` has a property `retoreableStatus` to store the original post status before it's moved to trash, so that we user decides to undo the action, we can know the post's original status.

![undo](https://github.com/wordpress-mobile/WordPress-iOS/assets/1101828/c3f4a641-c796-4c68-95f8-9cc2091c35f9)

The problem with this property is [it's synthesized](https://github.com/wordpress-mobile/WordPress-iOS/blob/67f9196d26f6c4bf100dd353d0f7b6c160f098ee/WordPress/Classes/Models/AbstractPost.m#L42) which means its value won't be stored in Core Data database. The `PostService` code that reads and updates it gives the false sense that the property is available across all context. But in really, it's only available is bound to one single context. This issue hasn't caused any actual problem because currently all `PostService` instances are initiated using the main context.

In the upcoming refactor of moving the "restore post" function to `PostRepository`, we'll use a background context to update Post objects, that means their `retoreableStatus` value would get lost. This PR refactors this "undo moving to trash" action to preemptively fix the potential issue.

## Solution

At the moment, we actually store posts that have been moved to trash in [the view controller instance](https://github.com/wordpress-mobile/WordPress-iOS/blob/67f9196d26f6c4bf100dd353d0f7b6c160f098ee/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift#L133). This PR expands the existing variable to store the original post status too.

## Test Instructions

Move posts that are in Published, Draft, and Schedule status to trash and verify that the "undo" action is available after the move and tapping it can restore the trashed posts to "Draft".

## Regression Notes
1. Potential unintended areas of impact
N/A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the "Test Instructions"

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A