### PR TITLE
Implement delete, trash, restore post in PostRepository

### DIFF
--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -63,7 +63,7 @@ final class PostRepository {
         }
     }
 
-    /// Permanently delete the given post from local database and the post's WrodPress site.
+    /// Permanently delete the given post from local database and the post's WordPress site.
     ///
     /// - Parameter postID: Object ID of the post
     func delete<P: AbstractPost>(_ postID: TaggedManagedObjectID<P>) async throws {
@@ -103,7 +103,7 @@ final class PostRepository {
         }
     }
 
-    /// Move the given post to the trash bin. The post will not be deleted from local database, unless it's delete on it's WordPress site.
+    /// Move the given post to the trash bin. The post will not be deleted from local database, unless it's delete on its WordPress site.
     ///
     /// - Parameter postID: Object ID of the post
     func trash<P: AbstractPost>(_ postID: TaggedManagedObjectID<P>) async throws {

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -63,4 +63,44 @@ final class PostRepository {
         }
     }
 
+    /// Permanently delete the given post from local database and the post's WrodPress site.
+    ///
+    /// - Parameter postID: Object ID of the post
+    func delete<P: AbstractPost>(_ postID: TaggedManagedObjectID<P>) async throws {
+        // Delete the original post instead if presents
+        let original: TaggedManagedObjectID<AbstractPost>? = try await coreDataStack.performQuery { context in
+            let post = try context.existingObject(with: postID)
+            if let original = post.original {
+                return TaggedManagedObjectID(original)
+            }
+            return nil
+        }
+        if let original {
+            DDLogInfo("Delete the original post object instead")
+            try await delete(original)
+            return
+        }
+
+        // First delete the post from local database.
+        let (remote, remotePost) = try await coreDataStack.performAndSave { [remoteFactory] context in
+            let post = try context.existingObject(with: postID)
+            context.deleteObject(post)
+            return (remoteFactory.forBlog(post.blog), PostHelper.remotePost(with: post))
+        }
+
+        // Then delete the post from the server
+        guard let remote, let remotePostID = remotePost.postID, remotePostID.int64Value > 0 else {
+            DDLogInfo("The post does not exist on the server")
+            return
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            remote.delete(
+                remotePost,
+                success: { continuation.resume(returning: ()) },
+                failure: { continuation.resume(throwing: $0!) }
+            )
+        }
+    }
+
 }

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -171,4 +171,60 @@ final class PostRepository {
         }
     }
 
+    /// Move the given post out of the trash bin.
+    ///
+    /// - Parameters:
+    ///   - postID: Object ID of the given post
+    ///   - status: The post's original status before it's moved to the trash bin.
+    func restore<P: AbstractPost>(_ postID: TaggedManagedObjectID<P>, to status: BasePost.Status) async throws {
+        // Restore the original post instead if presents
+        let original: TaggedManagedObjectID<AbstractPost>? = try await coreDataStack.performQuery { context in
+            let post = try context.existingObject(with: postID)
+            if let original = post.original {
+                return TaggedManagedObjectID(original)
+            }
+            return nil
+        }
+        if let original {
+            DDLogInfo("Trash the original post object instead")
+            try await restore(original, to: status)
+            return
+        }
+
+        // Update local database
+        let result: (PostServiceRemote, RemotePost)? = try await coreDataStack.performAndSave { [remoteFactory] context in
+            let post = try context.existingObject(with: postID)
+            post.status = status
+
+            if let remote = remoteFactory.forBlog(post.blog), !post.isRevision() && (post.postID?.int64Value ?? 0) > 0 {
+                return (remote, PostHelper.remotePost(with: post))
+            }
+            return nil
+        }
+
+        // Call WordPress API if needed
+        guard let (remote, remotePost) = result else { return }
+
+        let updatedRemotePost: RemotePost
+        do {
+            updatedRemotePost = try await withCheckedThrowingContinuation { continuation in
+                remote.restore(remotePost, success: { continuation.resume(returning: $0!) }, failure: { continuation.resume(throwing: $0!)} )
+            }
+        } catch {
+            DDLogError("Failed to restore post: \(error)")
+
+            // Put the post back in the trash bin.
+            try? await coreDataStack.performAndSave { context in
+                let post = try context.existingObject(with: postID)
+                post.status = .trash
+            }
+            throw error
+        }
+
+        try? await coreDataStack.performAndSave { context in
+            let post = try context.existingObject(with: postID)
+            PostHelper.update(post, with: updatedRemotePost, in: context)
+        }
+    }
+
 }


### PR DESCRIPTION
This PR ports [the delete trash and restore post functions in `PostService`](https://github.com/wordpress-mobile/WordPress-iOS/blob/67f9196d26f6c4bf100dd353d0f7b6c160f098ee/WordPress/Classes/Services/PostService.m#L446) to `PostRepository`. The new implementation's behaviour should match the existing ones. The restore function is the only exception, because it's built on top of this separate PR https://github.com/wordpress-mobile/WordPress-iOS/pull/21538.

This PR only adds the new implementation, without changing the existing `PostService` functions call sites.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
Unit tests for the new functions.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A