### PR TITLE
Address Ruby 3 RuboCop violations

### DIFF
--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -66,7 +66,7 @@ def gutenberg_local_pod
   pod 'Gutenberg', options
   pod 'RNTAztecView', options
 
-  gutenberg_dependencies(options: options)
+  gutenberg_dependencies(options:)
 end
 
 def gutenberg_dependencies(options:)
@@ -83,9 +83,9 @@ def gutenberg_dependencies(options:)
 
   computed_dependencies = DEPENDENCIES.dup
 
-  react_native_version = react_native_version!(gutenberg_path: gutenberg_path)
+  react_native_version = react_native_version!(gutenberg_path:)
   # We need to apply a workaround for the RNReanimated library when using React Native 0.71+.
-  apply_rnreanimated_workaround!(dependencies: computed_dependencies, gutenberg_path: gutenberg_path) unless react_native_version[1] < 71
+  apply_rnreanimated_workaround!(dependencies: computed_dependencies, gutenberg_path:) unless react_native_version[1] < 71
 
   computed_dependencies.each do |pod_name|
     pod pod_name, podspec: "#{podspec_prefix}/#{pod_name}.#{podspec_extension}"
@@ -143,7 +143,7 @@ def local_gutenberg_path
 end
 
 def require_react_native_helpers!(gutenberg_path:)
-  react_native_path = react_native_path!(gutenberg_path: gutenberg_path)
+  react_native_path = react_native_path!(gutenberg_path:)
 
   require_relative File.join(react_native_path, 'scripts', 'react_native_pods')
 
@@ -159,7 +159,7 @@ def react_native_path!(gutenberg_path:)
 end
 
 def react_native_version!(gutenberg_path:)
-  react_native_path = react_native_path!(gutenberg_path: gutenberg_path)
+  react_native_path = react_native_path!(gutenberg_path:)
   package_json_path = File.join(react_native_path, 'package.json')
   package_json_content = File.read(package_json_path)
   package_json_version = JSON.parse(package_json_content)['version']

--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,7 @@ bundle exec fastlane run configure_apply force:true
       require 'yaml'
 
       deps = YAML.load_file('Podfile.lock')['DEPENDENCIES']
-      gbm_pod_regex = %r{(.*) \(from `https://raw\.githubusercontent\.com/wordpress-mobile/gutenberg-mobile/.*/third-party-podspecs/.*\.podspec\.json`\)}.freeze
+      gbm_pod_regex = %r{(.*) \(from `https://raw\.githubusercontent\.com/wordpress-mobile/gutenberg-mobile/.*/third-party-podspecs/.*\.podspec\.json`\)}
       gbm_pods = deps.map do |pod|
         gbm_pod_regex.match(pod)&.captures&.first
       end.compact

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -88,7 +88,7 @@ platform :ios do
 
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?(xctestrun_path)
 
-    inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+    inject_buildkite_analytics_environment(xctestrun_path:) if buildkite_ci?
     # Our current configuration allows for either running the Jetpack UI tests or the WordPress unit tests.
     #
     # Their scheme and xctestrun name pairing are:
@@ -105,7 +105,7 @@ platform :ios do
 
     run_tests(
       workspace: WORKSPACE_PATH,
-      scheme: scheme,
+      scheme:,
       device: options[:device],
       deployment_target_version: options[:ios_version],
       ensure_devices_found: true,
@@ -168,7 +168,7 @@ platform :ios do
     version = options[:beta_release] ? ios_get_build_version : get_app_version
     create_release(
       repository: GITHUB_REPO,
-      version: version,
+      version:,
       release_notes_file_path: WORDPRESS_RELEASE_NOTES_PATH,
       release_assets: archive_zip_path.to_s,
       prerelease: options[:beta_release]
@@ -333,9 +333,9 @@ platform :ios do
 
     # Build
     gym(
-      scheme: scheme,
+      scheme:,
       workspace: WORKSPACE_PATH,
-      configuration: configuration,
+      configuration:,
       clean: true,
       output_directory: BUILD_PRODUCTS_PATH,
       output_name: output_app_name,
@@ -361,7 +361,7 @@ platform :ios do
       app_name: appcenter_app_name,
       file: lane_context[SharedValues::IPA_OUTPUT_PATH],
       dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
-      release_notes: release_notes,
+      release_notes:,
       destinations: 'Collaborators',
       notify_testers: false
     )
@@ -377,7 +377,7 @@ platform :ios do
     # Post PR Comment
     comment_body = prototype_build_details_comment(
       app_display_name: output_app_name,
-      app_icon: app_icon,
+      app_icon:,
       app_center_org_name: APPCENTER_OWNER_NAME,
       metadata: { Configuration: configuration },
       fold: true

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -25,7 +25,7 @@ platform :ios do
     register_device(
       name: device_name,
       udid: device_id,
-      team_id: team_id,
+      team_id:,
       api_key_path: APP_STORE_CONNECT_KEY_PATH
     )
 
@@ -36,13 +36,13 @@ platform :ios do
 
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
     add_development_certificates_to_provisioning_profiles(
-      team_id: team_id,
+      team_id:,
       app_identifier: all_bundle_ids
     )
 
     # Add all devices to the provisioning profiles
     add_all_devices_to_provisioning_profiles(
-      team_id: team_id,
+      team_id:,
       app_identifier: all_bundle_ids
     )
   end
@@ -173,9 +173,9 @@ def update_code_signing_enterprise(readonly:, app_identifiers:)
     type: 'enterprise',
     # Enterprise builds belong to the "internal" team
     team_id: get_required_env('INT_EXPORT_TEAM_ID'),
-    readonly: readonly,
-    app_identifiers: app_identifiers,
-    api_key_path: api_key_path
+    readonly:,
+    app_identifiers:,
+    api_key_path:
   )
 end
 
@@ -184,8 +184,8 @@ def update_code_signing_app_store(readonly:, app_identifiers:)
     type: 'appstore',
     # App Store builds belong to the "external" team
     team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
-    readonly: readonly,
-    app_identifiers: app_identifiers,
+    readonly:,
+    app_identifiers:,
     api_key_path: APP_STORE_CONNECT_KEY_PATH
   )
 end
@@ -197,11 +197,11 @@ def update_code_signing(type:, team_id:, readonly:, app_identifiers:, api_key_pa
     storage_mode: 'google_cloud',
     google_cloud_bucket_name: 'a8c-fastlane-match',
     google_cloud_keys_file: File.join(SECRETS_DIR, 'google_cloud_keys.json'),
-    type: type,
-    team_id: team_id,
-    readonly: readonly,
+    type:,
+    team_id:,
+    readonly:,
     app_identifier: app_identifiers,
-    api_key_path: api_key_path
+    api_key_path:
   )
 end
 

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -312,7 +312,7 @@ platform :ios do
     # Download metadata translations from GlotPress
     download_localized_app_store_metadata(
       glotpress_project_url: GLOTPRESS_WORDPRESS_APP_STORE_METADATA_PROJECT_URL,
-      metadata_directory: metadata_directory,
+      metadata_directory:,
       locales: WORDPRESS_METADATA_GLOTPRESS_LOCALE_CODES,
       commit_message: 'Update WordPress metadata translations'
     )
@@ -335,7 +335,7 @@ platform :ios do
     download_localized_app_store_metadata(
       glotpress_project_url: GLOTPRESS_JETPACK_APP_STORE_METADATA_PROJECT_URL,
       locales: JETPACK_METADATA_GLOTPRESS_LOCALE_CODES,
-      metadata_directory: metadata_directory,
+      metadata_directory:,
       commit_message: 'Update Jetpack metadata translations'
     )
   end
@@ -357,7 +357,7 @@ platform :ios do
 
     gp_downloadmetadata(
       project_url: glotpress_project_url,
-      target_files: target_files,
+      target_files:,
       locales: locales_map,
       download_path: metadata_directory
     )
@@ -418,7 +418,7 @@ platform :ios do
       **UPLOAD_TO_APP_STORE_COMMON_PARAMS,
       app_identifier: WORDPRESS_BUNDLE_IDENTIFIER,
       screenshots_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'promo-screenshots'),
-      skip_screenshots: skip_screenshots
+      skip_screenshots:
     )
   end
 
@@ -439,7 +439,7 @@ platform :ios do
       app_identifier: JETPACK_BUNDLE_IDENTIFIER,
       metadata_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata'),
       screenshots_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_promo_screenshots'),
-      skip_screenshots: skip_screenshots
+      skip_screenshots:
     )
   end
 
@@ -456,22 +456,22 @@ platform :ios do
     UI.message('Checking app strings translation status...')
     check_translation_progress(
       glotpress_url: GLOTPRESS_APP_STRINGS_PROJECT_URL,
-      abort_on_violations: abort_on_violations,
-      skip_confirm: skip_confirm
+      abort_on_violations:,
+      skip_confirm:
     )
 
     UI.message('Checking WordPress release notes strings translation status...')
     check_translation_progress(
       glotpress_url: GLOTPRESS_WORDPRESS_APP_STORE_METADATA_PROJECT_URL,
-      abort_on_violations: abort_on_violations,
-      skip_confirm: skip_confirm
+      abort_on_violations:,
+      skip_confirm:
     )
 
     UI.message('Checking Jetpack release notes strings translation status...')
     check_translation_progress(
       glotpress_url: GLOTPRESS_JETPACK_APP_STORE_METADATA_PROJECT_URL,
-      abort_on_violations: abort_on_violations,
-      skip_confirm: skip_confirm
+      abort_on_violations:,
+      skip_confirm:
     )
   end
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -42,7 +42,7 @@ platform :ios do
       release_notes_file_path: release_notes_source_path,
       extracted_notes_file_path: extracted_release_notes_file_path(app: :jetpack)
     )
-    ios_update_release_notes(new_version: new_version)
+    ios_update_release_notes(new_version:)
 
     if prompt_for_confirmation(
       message: 'Ready to push changes to remote to let the automation configure it on GitHub?',
@@ -190,8 +190,8 @@ platform :ios do
   # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_beta_build do |options|
-    branch = compute_release_branch_name(options: options)
-    trigger_buildkite_release_build(branch: branch, beta: true)
+    branch = compute_release_branch_name(options:)
+    trigger_buildkite_release_build(branch:, beta: true)
   end
 
   # Triggers a stable release build on CI
@@ -199,8 +199,8 @@ platform :ios do
   # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_release_build do |options|
-    branch = compute_release_branch_name(options: options)
-    trigger_buildkite_release_build(branch: branch, beta: false)
+    branch = compute_release_branch_name(options:)
+    trigger_buildkite_release_build(branch:, beta: false)
   end
 end
 
@@ -217,7 +217,7 @@ def trigger_buildkite_release_build(branch:, beta:)
   buildkite_trigger_build(
     buildkite_organization: 'automattic',
     buildkite_pipeline: 'wordpress-ios',
-    branch: branch,
+    branch:,
     environment: { BETA_RELEASE: beta },
     pipeline_file: 'release-builds.yml',
     message: beta ? 'Beta Builds' : 'Release Builds'

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -51,7 +51,7 @@ platform :ios do
 
     scan(
       workspace: WORKSPACE_PATH,
-      scheme: scheme,
+      scheme:,
       build_for_testing: true,
       derived_data_path: DERIVED_DATA_PATH
     )
@@ -73,11 +73,11 @@ platform :ios do
     dark_mode_values.each do |dark_mode_enabled|
       capture_ios_screenshots(
         workspace: WORKSPACE_PATH,
-        scheme: scheme,
+        scheme:,
         test_without_building: true,
         derived_data_path: DERIVED_DATA_PATH,
-        output_directory: output_directory,
-        languages: languages,
+        output_directory:,
+        languages:,
         dark_mode: dark_mode_enabled,
         override_status_bar: true,
 
@@ -240,7 +240,7 @@ platform :ios do
       if already_exists
         Actions.execute_action(step_name) { UI.message "A simulator for device type #{device_type_id} already exists" }
       else
-        sh('xcrun', 'simctl', 'create', device_name, device_type_id, step_name: step_name)
+        sh('xcrun', 'simctl', 'create', device_name, device_type_id, step_name:)
         # To get the UUID of the created Simulator, store the `sh` call above in a variable, e.g. `res = sh(...`, then call:
         # res.split("\n").find { |line| line.match?(/^[0-9A-F-]+$/) }&.chomp # UUID of the created simulator
       end


### PR DESCRIPTION
17ec957f28829e56c73498e6ce2b874626013541 (#21498) switched the expected Ruby version to 3.x (🎉)

Our Ruby linting automation only runs on diffed files so it didn't catch new violations that arose from the migration. The only reason I noticed, actually was because I just happened to modify the `Podfile` in df0aa0bd25a3cf4fa6313eb3534bd05c959a2a8 (#21344) and got a CI failure. I based this PR off #21344 because I had to fix one of the issues there in order for the linter to pass.

**To test:** checkout the branch and verify RuboCop doesn't find new violations:
<img width="2467" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/6b17283b-9606-48bc-82c0-a3fe2afa4796">

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.