### PR TITLE
Media: Implement sync of assets

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -45,6 +45,7 @@ enum FeatureFlag: Int, CaseIterable {
     case domainFocus
     case nativePhotoPicker
     case readerImprovements // pcdRpT-3Eb-p2
+    case mediaModernization
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -142,6 +143,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .nativePhotoPicker:
             return true
         case .readerImprovements:
+            return false
+        case .mediaModernization:
             return false
         }
     }
@@ -251,6 +254,8 @@ extension FeatureFlag {
             return "Native Photo Picker"
         case .readerImprovements:
             return "Reader Improvements v1"
+        case .mediaModernization:
+            return "Media Modernization"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCell.swift
@@ -47,8 +47,10 @@ final class MediaCollectionCell: UICollectionViewCell {
             viewModel.onLoadingFinished = { [weak self] image in
                 guard let self, self.viewModel?.mediaID == mediaID else { return }
                 // TODO: Display an asset-specific placeholder on error
-                UIView.animate(withDuration: 0.2) {
+                self.imageView.alpha = 0
+                UIView.animate(withDuration: 0.2, delay: 0, options: [.allowUserInteraction]) {
                     self.imageView.image = image
+                    self.imageView.alpha = 1
                     self.backgroundColor = image == nil ? .systemGroupedBackground : .clear
                 }
             }

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellViewModel.swift
@@ -19,7 +19,7 @@ final class MediaCollectionCellViewModel {
     init(media: Media,
          service: MediaImageService = .shared,
          cache: MemoryCache = .shared) {
-        self.mediaID = TaggedManagedObjectID(saved: media)
+        self.mediaID = TaggedManagedObjectID(media)
         self.media = media
         self.mediaType = media.mediaType
         self.service = service

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -4,16 +4,49 @@ import PhotosUI
 final class MediaViewController: UIViewController, NSFetchedResultsControllerDelegate, UICollectionViewDataSource, UICollectionViewDataSourcePrefetching {
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
     private lazy var flowLayout = UICollectionViewFlowLayout()
+    private lazy var refreshControl = UIRefreshControl()
     private lazy var fetchController = makeFetchController()
 
+    private var isSyncing = false
     private var pendingChanges: [(UICollectionView) -> Void] = []
     private var viewModels: [NSManagedObjectID: MediaCollectionCellViewModel] = [:]
+    private let blog: Blog
+    private let coordinator = MediaCoordinator.shared
+
+    init(blog: Blog) {
+        self.blog = blog
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = Strings.title
+        QuickStartTourGuide.shared.visited(.mediaScreen)
 
+        title = Strings.title
+        extendedLayoutIncludesOpaqueBars = true
+
+        configureCollectionView()
+
+        fetchController.delegate = self
+        do {
+            try fetchController.performFetch()
+        } catch {
+            WordPressAppDelegate.crashLogging?.logError(error) // Should never happen
+        }
+
+        if collectionView.numberOfItems(inSection: 0) == 0 {
+            showLoadingView()
+        }
+
+        syncMedia()
+    }
+
+    private func configureCollectionView() {
         collectionView.register(MediaCollectionCell.self, forCellWithReuseIdentifier: Constants.cellID)
 
         view.addSubview(collectionView)
@@ -22,13 +55,8 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
 
         collectionView.dataSource = self
         collectionView.prefetchDataSource = self
-
-        fetchController.delegate = self
-        do {
-            try fetchController.performFetch()
-        } catch {
-            WordPressAppDelegate.crashLogging?.logError(error) // Should never happen
-        }
+        collectionView.refreshControl = refreshControl
+        refreshControl.addTarget(self, action: #selector(syncMedia), for: .valueChanged)
     }
 
     override func viewDidLayoutSubviews() {
@@ -49,10 +77,55 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         flowLayout.itemSize = CGSize(width: cellWidth, height: cellWidth)
     }
 
+    // MARK: - Refresh
+
+    private var pendingRefreshWorkItem: DispatchWorkItem?
+
+    @objc private func syncMedia() {
+        guard !isSyncing else { return }
+        isSyncing = true
+
+        coordinator.syncMedia(for: blog, success: { [weak self] in
+            // The success callback is called before the changes get merged
+            // in the main context, so the app needs to wait until the
+            // fetch controller updates. Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/9922
+            let work = DispatchWorkItem {
+                self?.didFinishRefreshing(error: nil)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250), execute: work)
+            self?.pendingRefreshWorkItem = work
+        }, failure: { [weak self] error in
+            DispatchQueue.main.async {
+                self?.didFinishRefreshing(error: error)
+            }
+        })
+    }
+
+    private func didFinishRefreshing(error: Error?) {
+        isSyncing = false
+        refreshControl.endRefreshing()
+        pendingRefreshWorkItem = nil
+
+        hideNoResults()
+        let isEmpty = collectionView.numberOfItems(inSection: 0) == 0
+        if let error {
+            if isEmpty {
+                showErrorView()
+            } else {
+                WPError.showNetworkingNotice(title: Strings.syncFailed, error: error as NSError)
+            }
+        } else {
+            if isEmpty {
+                showEmptyView()
+            }
+        }
+    }
+
     // MARK: - NSFetchedResultsController
 
     private func makeFetchController() -> NSFetchedResultsController<Media> {
         let request = NSFetchRequest<Media>(entityName: Media.self.entityName())
+        request.predicate = NSPredicate(format: "blog == %@", blog)
         request.sortDescriptors = [
             NSSortDescriptor(keyPath: \Media.creationDate, ascending: false),
             // Disambiguate in case media are uploaded at the same time, which
@@ -102,6 +175,12 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
             }
         }
         pendingChanges = []
+
+        if let workItem = pendingRefreshWorkItem {
+            workItem.cancel()
+            didFinishRefreshing(error: nil)
+            pendingRefreshWorkItem = nil
+        }
     }
 
     // MARK: - UICollectionViewDataSource
@@ -154,6 +233,28 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
     }
 }
 
+// MARK: - MediaViewController (NoResults)
+
+extension MediaViewController: NoResultsViewHost, NoResultsViewControllerDelegate {
+    private func showLoadingView() {
+        noResultsViewController.configureForFetching()
+        displayNoResults(on: view)
+    }
+
+    private func showEmptyView() {
+        noResultsViewController.configureForNoAssets(userCanUploadMedia: blog.userCanUploadMedia)
+        displayNoResults(on: view)
+    }
+
+    private func showErrorView() {
+        configureAndDisplayNoResults(on: view, title: Strings.syncFailed)
+    }
+
+    func actionButtonPressed() {
+        // TODO: Implement "Add Media" button
+    }
+}
+
 private enum Constants {
     static let minColumnWidth: CGFloat = 96
     static let minCellSpacing: CGFloat = 2
@@ -162,4 +263,12 @@ private enum Constants {
 
 private enum Strings {
     static let title = NSLocalizedString("media.title", value: "Media", comment: "Media screen navigation title")
+    static let syncFailed = NSLocalizedString("media.syncFailed", value: "Unable to sync media", comment: "Title of error prompt shown when a sync fails.")
+}
+
+extension Blog {
+    var userCanUploadMedia: Bool {
+        // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
+        capabilities != nil ? isUploadingFilesAllowed() : true
+    }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -784,13 +784,6 @@ extension MediaLibraryViewController: UIViewControllerRestoration {
     }
 }
 
-fileprivate extension Blog {
-    var userCanUploadMedia: Bool {
-        // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
-        return capabilities != nil ? isUploadingFilesAllowed() : true
-    }
-}
-
 // MARK: Stock Photos Picker Delegate
 
 extension MediaLibraryViewController: StockPhotosPickerDelegate {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -61,9 +61,14 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     }
 
     static func showForBlog(_ blog: Blog, from sourceController: UIViewController) {
-        let controller = MediaLibraryViewController(blog: blog)
-        controller.navigationItem.largeTitleDisplayMode = .never
-        sourceController.navigationController?.pushViewController(controller, animated: true)
+        if FeatureFlag.mediaModernization.enabled {
+            let controller = MediaViewController(blog: blog)
+            sourceController.show(controller, sender: nil)
+        } else {
+            let controller = MediaLibraryViewController(blog: blog)
+            controller.navigationItem.largeTitleDisplayMode = .never
+            sourceController.navigationController?.pushViewController(controller, animated: true)
+        }
 
         QuickStartTourGuide.shared.visited(.mediaScreen)
     }


### PR DESCRIPTION
Part of #21457

- Implement sync of Media library
- Add "Media Modernization" feature flag
- Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/9922

## To test:

- Fresh install
- Enable "Media Modernization" feature flag
- Open the new Media screen and verify that the assets are synced
- Upload an asset on the web, return to the app and use PTR to sync the library

This PR also covers error and empty scenarios.

## Regression Notes
1. Potential unintended areas of impact: n/a (no production code changes)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
