### PR TITLE
Integrate gutenberg-mobile release 1.103.2

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,14 +1,4 @@
 ref:
-  # This should have either a commit or tag key.
-  # If both are set, tag will take precedence.
-  #
-  # We have automation that reads and updates this file.
-  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
-  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
-  #
-  # Example:
-  #
-  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
-  tag: v1.103.1
+  commit: 614aa1a3832d2c253af109fe670c7b4004051748
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,4 +1,14 @@
 ref:
-  commit: 614aa1a3832d2c253af109fe670c7b4004051748
+  # This should have either a commit or tag key.
+  # If both are set, tag will take precedence.
+  #
+  # We have automation that reads and updates this file.
+  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
+  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
+  #
+  # Example:
+  #
+  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
+  tag: v1.103.2
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (1.7.2)
-  - Gutenberg (1.103.1)
+  - Gutenberg (1.103.2)
   - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.9):
     - CropViewController
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.1.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-614aa1a3832d2c253af109fe670c7b4004051748.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -203,7 +203,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.1.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-614aa1a3832d2c253af109fe670c7b4004051748.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -230,7 +230,7 @@ SPEC CHECKSUMS:
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: 4dc5d0ede9bf17fb00045ab9d1d12f32a80ca55e
+  Gutenberg: a10d736100f96b9701595e007f7a0ea01cb8d1c8
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-614aa1a3832d2c253af109fe670c7b4004051748.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.2.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -203,7 +203,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-614aa1a3832d2c253af109fe670c7b4004051748.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.2.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -230,7 +230,7 @@ SPEC CHECKSUMS:
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: a10d736100f96b9701595e007f7a0ea01cb8d1c8
+  Gutenberg: 76cc01d6227fa712e605eb40c7fd1bfd6f0ece56
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae


### PR DESCRIPTION
## Description
This PR incorporates the 1.103.2 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6183

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.