### PR TITLE
Fix Stats menu option not visible for self-hosted sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 * [***] [Jetpack-only] Contact Support: Add a new chat-based support channel where users can get answers from a bot trained to help app users. Users can still create a support ticket to talk to a Happiness Engineer if they don't find the answer they're looking for [#21467]
 * [*] Fix a crash on the pages list when the authentication token is invalid. [#21471]
 * [**] Me tab: move Me to the bottom tab bar [https://github.com/wordpress-mobile/WordPress-iOS/pull/21348]
+* [*] Fix Stats menu option not visible for self-hosted sites without a Jetpack connection. [#21548]
 
 23.0.1
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1102,7 +1102,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *rows = [NSMutableArray array];
 
     // Stats row
-    if ([self.blog supports:BlogFeatureStats]) {
+    if ([self.blog isViewingStatsAllowed]) {
         [rows addObject:[self statsRow]];
     }
 
@@ -1219,7 +1219,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
     
-    if ([self.blog supports:BlogFeatureStats]) {
+    if ([self.blog isViewingStatsAllowed]) {
         [rows addObject:[self statsRow]];
     }
 
@@ -1261,7 +1261,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
     
-    if ([self.blog supports:BlogFeatureStats]) {
+    if ([self.blog isViewingStatsAllowed]) {
         [rows addObject:[self statsRow]];
     }
 


### PR DESCRIPTION
Fixes #21516

Self-hosted sites do not show the Stats option in the menu. This prevent users from installing and connecting Jetpack plugin through the app to view the Stats. 

This is a regression from https://github.com/wordpress-mobile/WordPress-iOS/pull/20623 which intended to hide Stats menu option for contributors. 

### Description

`[self.blog supports:BlogFeatureStats]` option not only checks if a user is allowed to view Stats but if Stats are enabled at a given moment. This prevents the Stats menu option from being shown for self-hosted sites with no Jetpack user connection established.

Use `[self.blog isViewingStatsAllowed`] instead to only check that checks if the current user has permission to view or install Stats. 

### To test

#### Admin

1. Login into self-hosted site with no Jetpack plugin with an **admin** account
2. Confirm Stats option exists
3. Open Stats
4. Go through Jetpack installation and connection flow
5. Confirm Stats are shown

#### Contributor

1. Login into the self-hosted site with no Jetpack plugin with a **contributor** account
2. Confirm Stats option does not exist


## Regression Notes
1. Potential unintended areas of impact

Breaking the intention of https://github.com/wordpress-mobile/WordPress-iOS/pull/20623 fix 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
