### PR TITLE
Upgrade Aztec to include iOS 17 crash fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -34,11 +34,11 @@ def aztec
   ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
   ## When using a commit number (during development) you should provide the same commit number for both pods.
   ##
-  # pod 'WordPress-Aztec-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: ''
-  # pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: ''
+  pod 'WordPress-Aztec-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: '00875730d92e22031aec8ae47f0b24042da64aed'
+  pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: '00875730d92e22031aec8ae47f0b24042da64aed'
   # pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', tag: ''
   # pod 'WordPress-Editor-iOS', path: '../AztecEditor-iOS'
-  pod 'WordPress-Editor-iOS', '~> 1.19.8'
+  # pod 'WordPress-Editor-iOS', '~> 1.19.8'
 end
 
 def wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -139,7 +139,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
-  - WordPress-Editor-iOS (~> 1.19.8)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `00875730d92e22031aec8ae47f0b24042da64aed`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `00875730d92e22031aec8ae47f0b24042da64aed`)
   - WordPressAuthenticator (~> 6.3)
   - WordPressKit (~> 8.5)
   - WordPressShared (~> 2.2)
@@ -183,8 +184,6 @@ SPEC REPOS:
     - SVProgressHUD
     - SwiftLint
     - UIDeviceIdentifier
-    - WordPress-Aztec-iOS
-    - WordPress-Editor-iOS
     - WordPressKit
     - WordPressShared
     - WPMediaPicker
@@ -204,6 +203,12 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.2.podspec
+  WordPress-Aztec-iOS:
+    :commit: 00875730d92e22031aec8ae47f0b24042da64aed
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: 00875730d92e22031aec8ae47f0b24042da64aed
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -213,6 +218,12 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
+  WordPress-Aztec-iOS:
+    :commit: 00875730d92e22031aec8ae47f0b24042da64aed
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: 00875730d92e22031aec8ae47f0b24042da64aed
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -264,6 +275,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: b99ef82bab1e59cf8ae03a030caae5e2a50d5522
+PODFILE CHECKSUM: dfe08e206cc77e20bf5437d53fb30ae6fe8b1655
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
Fixes #21261

### To test:

1. On web, create a new post with the Classic Editor
2. Insert two images from the web editor (I used the first two from the iPhone Simulator library)
3. Publish the post or save as draft
4. Open the post in the Classic Editor (Aztec) in the app running iOS 17
5. Place the cursor after the second image and press backspace until all content is erased

Repeat the test with iOS 16.

## Regression Notes
1. Potential unintended areas of impact
    - Classic Editor
    - Block Editor (since it relies on Aztec)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests
    - https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1373/commits/1bd24f9415d3ee550cb6d6d88c01458b8cc56300

3. What automated tests I added (or what prevented me from doing so)
    - https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1373/commits/1bd24f9415d3ee550cb6d6d88c01458b8cc56300

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [ ] ~I have considered adding accessibility improvements for my changes.~
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
