### PR TITLE
UI Modernization: Black and white image for me tab icon

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -43,7 +43,21 @@ extension UITabBarItem {
 
     func configureGravatarImage(_ image: UIImage) {
         let gravatarIcon = image.gravatarIcon(size: 28.0)
-        self.image = gravatarIcon?.withAlpha(0.36)
+        self.image = gravatarIcon?.blackAndWhite?.withAlpha(0.36)
         self.selectedImage = gravatarIcon
+    }
+}
+
+extension UIImage {
+
+    var blackAndWhite: UIImage? {
+        let context = CIContext(options: nil)
+        guard let currentFilter = CIFilter(name: "CIPhotoEffectNoir") else { return nil }
+        currentFilter.setValue(CIImage(image: self), forKey: kCIInputImageKey)
+        if let output = currentFilter.outputImage,
+            let cgImage = context.createCGImage(output, from: output.extent) {
+            return UIImage(cgImage: cgImage, scale: scale, orientation: imageOrientation)
+        }
+        return nil
     }
 }


### PR DESCRIPTION
Addresses pcdRpT-3Gk-p2#comment-6176

## Description
Updates the Me tab icon deselected image to be in black and white

![Simulator Screenshot - iPhone 14 Pro - 2023-09-13 at 12 08 52](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/4a53e537-4f63-402e-9442-ba2b69f622bb) | ![Simulator Screenshot - iPhone 14 Pro - 2023-09-13 at 12 08 57](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ce0ebcd7-aa9f-44a3-8092-b76c49b453cf) | ![Simulator Screenshot - iPhone 14 Pro - 2023-09-13 at 13 39 58](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/cdfec8f3-f2d4-44cf-b123-cb6fbb88e404) | ![Simulator Screenshot - iPhone 14 Pro - 2023-09-13 at 13 40 06](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/363e40a6-7e99-4083-b02b-96de574bfefe)
-- | -- | -- | --

## How to test
- Switch to the My Site tab
- Verify the Me tab icon is black and white
- Switch to the Me tab
- Verify the Me tab icon is in the original color

## Regression Notes
1. Potential unintended areas of impact
Me tab icon

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)