### PR TITLE
Address support bot feedback

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -191,7 +191,7 @@ extension SupportChatBotViewController {
                                                         value: "Send a message...",
                                                         comment: "Placeholder text for the chat input field.")
         static let firstMessage = NSLocalizedString("support.chatBot.firstMessage",
-                                                    value: "What can we help you with?",
+                                                    value: "Hi there, I'm the Jetpack AI Assistant.\\n\\nWhat can we help you with?\\n\\nIf I can't answer your question, I'll help you open a support ticket with our team!",
                                                     comment: "Initial message shown to the user when the chat starts.")
         static let sources = NSLocalizedString("support.chatBot.sources",
                                                value: "Sources",

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.css
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.css
@@ -12,6 +12,9 @@ a.floating-button {
 
 .docsbot-chat-input-form {
     margin-bottom: 0px;
+    height: 48px !important;
+    display: flex;
+    align-items: center;
 }
 
 .docsbot-chat-bot-message-container span {
@@ -23,7 +26,7 @@ a.floating-button {
 }
 
 .docsbot-chat-input {
-    height: 48px !important;
+    height: auto !important;
 }
 
 .docsbot-chat-btn-send-icon {

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.css
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.css
@@ -44,3 +44,7 @@ a.floating-button {
 .docsbot-chat-suggested-questions-container button {
     height: 48px;
 }
+
+.docsbot-chat-bot-message-support {
+    margin-bottom: 20px;
+}

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.css
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.css
@@ -33,6 +33,10 @@ a.floating-button {
   width: 24px; !important;
 }
 
+.docsbot-chat-btn-send {
+    fill: rgb(16, 135, 0) !important;
+}
+
 .docsbot-chat-bot-message-meta {
     margin-top: 16px;
 }


### PR DESCRIPTION
Addresses #21557

## To test

### Update first message

The bot now starts off its initial message with "Hi there, I'm the Jetpack AI Assistant." so users know they're talking to a bot, not a human. It also clarifies it will help the user connect with a human if needed.

⚠️ The old text still shows up because even in English it's set in `en.lproj/Localizable.strings` (as [I think translations might have already been merged](https://github.com/wordpress-mobile/WordPress-iOS/commit/a34593f4479e8c9af461d352c1cbb7404d93230c#diff-feb40ce2daef453a62d2c8ebf3ef7df4aca1d73b0c76c95c42bca6e0a05f57e2R8696)), so it won't reflect the change until the translation process is run again. Given we're in the second week of the beta, I think this change will miss Monday's release to production. I could manually update the strings file in this PR to mitigate this for English locales, but the issue would still be present for other locales.

### Fix layout issues

#### The word ‘Send a message’ is not vertically centered in the text box

I tested this change with single and multi-line next and it appears to be working well. Here's the before (on the left) and after (on the right) showing the vertical alignment for single-line text:

| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/9c7798c3-14d0-40c2-9493-4ab5b54c8811" width="600" /> |
| - |

#### Make the message send icon (paper airplane) Jetpack Green 50

This changes the icon's color (both in the enabled and disabled states). Here's a before and after of the enabled state (the disabled state is derived by setting opacity to 50%):

| Before | After |
| - | - |
| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/6387737f-13eb-4573-bf4c-79a3993eb7b3"> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/b2c65392-98bf-46c4-8132-947994c09efa"> |

#### Add more space below "Contact support" button

Here's the before on the left and the after on the right:

| <img width="695" alt="Screenshot 2023-09-13 at 19 39 06" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/a8f0b03e-cf98-4648-a4fa-ec8daa44dd5d"> |
| - |


## Regression Notes
1. Potential unintended areas of impact

These changes have the potential to break the chat screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing of the chat screen.

3. What automated tests I added (or what prevented me from doing so)

Adding tests isn't worth it at this stage since it's a web view and doing so would be difficult and bring little benefit 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
