### PR TITLE
Fix #21520: keyboard overlaps crop view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
@@ -189,16 +189,19 @@ final class SiteIconPickerPresenter: NSObject {
 
 extension SiteIconPickerPresenter: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        guard let presentingViewController = picker.presentingViewController else {
+            return
+        }
+        presentingViewController.dismiss(animated: true)
+
         guard let result = results.first else {
-            picker.presentingViewController?.dismiss(animated: true)
             return
         }
         WPAnalytics.track(.siteSettingsSiteIconGalleryPicked)
-        self.showLoadingMessage()
         self.originalMedia = nil
         PHPickerResult.loadImage(for: result) { [weak self] image, error in
             if let image {
-                self?.showImageCropViewController(image, presentingViewController: picker)
+                self?.showImageCropViewController(image, presentingViewController: presentingViewController)
             } else {
                 DDLogError("Failed to load image: \(String(describing: error))")
                 self?.showErrorLoadingImageMessage()

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/AvatarMenuController.swift
@@ -27,8 +27,9 @@ final class AvatarMenuController: PHPickerViewControllerDelegate, ImagePickerCon
     // MARK: - PHPickerViewControllerDelegate
 
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        presentingViewController?.dismiss(animated: true)
+
         guard let result = results.first else {
-            presentingViewController?.dismiss(animated: true)
             return
         }
         PHPickerResult.loadImage(for: result) { [weak self] image, _ in


### PR DESCRIPTION
Fixes #21520

Since `PHPickerViewController` is not a regular view controller and runs out of process, none of the known ways to dismiss a keyboard, such as `view.endEditing(true)` work. The only solution I found was to dismiss the picker entirely before presenting the crop screen. But I think it leads to a worse user experience because if you don't like what you see and want to select a new image, you have to start over. So I suggest ignoring this defect.

## To test:

- Follow the steps from the defect

## Regression Notes
1. Potential unintended areas of impact: Site Icon and Avatar pickers
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
