### PR TITLE
Fix an issue with missing search in WP Media picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
@@ -220,6 +220,8 @@ extension SiteIconPickerPresenter: ImagePickerControllerDelegate {
     }
 }
 
+extension SiteIconPickerPresenter: MediaPickerViewControllerDelegate {}
+
 extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -55,6 +55,8 @@ extension PostSettingsViewController: PHPickerViewControllerDelegate, ImagePicke
     }
 }
 
+extension PostSettingsViewController: MediaPickerViewControllerDelegate {}
+
 // MARK: - PostSettingsViewController (Featured Image Upload)
 
 extension PostSettingsViewController {


### PR DESCRIPTION
Fixes an issue with a missing search bar in Media picker when changing Site Icon or Avatar.

## RCA

`SiteIconPickerPresenter` had a complex `WPMediaPickerViewControllerDelegate` implementation that was enabling search bar only for the Media picker screen using `self.mediaLibraryDataSource.dataSourceType == .mediaLibrary. The new Media picker supports _only_ WordPress Media, so this customization is no longer needed.

## To test

- Follow the steps from the video and verify that the site icon and avatar get updated
- Verify that "Cancel" also works

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/ba3008b6-9a14-48d4-bf30-bdb7030fac71

## Regression Notes
1. Potential unintended areas of impact: Site Icon picker and Avatar picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
