### PR TITLE
Media: Implement empty state view

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCell.swift
@@ -4,19 +4,24 @@ import Combine
 final class MediaCollectionCell: UICollectionViewCell {
     private let imageView = UIImageView()
     private let overlayView = CircularProgressView()
+    private let placeholderView = UIView()
     private var viewModel: MediaCollectionCellViewModel?
     private var cancellables: [AnyCancellable] = []
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        backgroundColor = .secondarySystemBackground
+        placeholderView.backgroundColor = .secondarySystemBackground
 
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
         imageView.accessibilityIgnoresInvertColors = true
 
         overlayView.backgroundColor = .neutral(.shade70).withAlphaComponent(0.5)
+
+        contentView.addSubview(placeholderView)
+        placeholderView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.pinSubviewToAllEdges(placeholderView)
 
         contentView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -39,7 +44,8 @@ final class MediaCollectionCell: UICollectionViewCell {
         viewModel = nil
 
         imageView.image = nil
-        backgroundColor = .secondarySystemBackground
+        imageView.alpha = 0
+        placeholderView.alpha = 1
     }
 
     func configure(viewModel: MediaCollectionCellViewModel) {
@@ -48,7 +54,8 @@ final class MediaCollectionCell: UICollectionViewCell {
         if let image = viewModel.getCachedThubmnail() {
             // Display with no animations. It should happen often thanks to prefetchig
             imageView.image = image
-            backgroundColor = .clear
+            imageView.alpha = 1
+            placeholderView.alpha = 0
         } else {
             let mediaID = viewModel.mediaID
             viewModel.onImageLoaded = { [weak self] in
@@ -74,11 +81,10 @@ final class MediaCollectionCell: UICollectionViewCell {
         guard viewModel?.mediaID == mediaID else { return }
 
         // TODO: Display an asset-specific placeholder on error
-        imageView.alpha = 0
-        UIView.animate(withDuration: 0.15, delay: 0, options: [.allowUserInteraction]) {
-            self.imageView.image = image
+        imageView.image = image
+        UIView.animate(withDuration: 0.15, delay: 0, options: [.beginFromCurrentState, .allowUserInteraction]) {
             self.imageView.alpha = 1
-            self.backgroundColor = .clear
+            self.placeholderView.alpha = 0
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellViewModel.swift
@@ -129,9 +129,9 @@ final class MediaCollectionCellViewModel {
             self.overlayState = .indeterminate
         case .failed:
             self.overlayState = .retry
-        case .sync, .stub, .local:
+        case .sync:
             self.overlayState = nil
-        @unknown default:
+        default:
             break
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -306,7 +306,7 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
 
 // MARK: - MediaViewController (NoResults)
 
-extension MediaViewController: NoResultsViewHost, NoResultsViewControllerDelegate {
+extension MediaViewController: NoResultsViewHost {
     private func showLoadingView() {
         noResultsViewController.configureForFetching()
         displayNoResults(on: view)
@@ -314,15 +314,12 @@ extension MediaViewController: NoResultsViewHost, NoResultsViewControllerDelegat
 
     private func showEmptyView() {
         noResultsViewController.configureForNoAssets(userCanUploadMedia: blog.userCanUploadMedia)
+        noResultsViewController.buttonMenu = mediaPickerController.makeMenu(for: self)
         displayNoResults(on: view)
     }
 
     private func showErrorView() {
         configureAndDisplayNoResults(on: view, title: Strings.syncFailed)
-    }
-
-    func actionButtonPressed() {
-        // TODO: implement somehow (pass the menu)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -70,6 +70,8 @@ import Reachability
     /// sets an additional/alternate handler for the dismiss button that can be directly injected
     var dismissButtonHandler: (() -> Void)?
 
+    var buttonMenu: UIMenu?
+
     // MARK: - View
 
     override func viewDidLoad() {
@@ -362,6 +364,12 @@ private extension NoResultsViewController {
             actionButton?.titleLabel?.adjustsFontForContentSizeCategory = true
             actionButton?.accessibilityIdentifier = accessibilityIdentifier(for: buttonText)
             actionButton.isHidden = false
+            if let buttonMenu {
+                actionButton.menu = buttonMenu
+                actionButton.showsMenuAsPrimaryAction = true
+            } else {
+                actionButton.showsMenuAsPrimaryAction = false
+            }
         } else {
             actionButton.isHidden = true
         }


### PR DESCRIPTION
Part of #21457
 
- Add picker menu for add media button in an empty state view
- Fix how empty state updates when media library contents changes
- Fix collection view cell placeholder rendering and animations

P.S. I noticed there is an issue that the details screen isn't automatically popped when you delete an asset. I put it in my backlog.

## To test:

Follow the steps from the video:

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/44137f30-e0d3-401d-b510-d34eae0f3d8a

## Regression Notes
1. Potential unintended areas of impact: n/a (doesn't affect the production code)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual testing
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
