### PR TITLE
Contact Support: Hide keyboard after submitting the message to workaround scrolling issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.js
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.js
@@ -48,6 +48,7 @@ DocsBotAI.init = function (c) {
  */
 window.prepareDocsBotForPresentation = function () {
   var chatBotSelector = "#docsbotai-root";
+  var sendButtonSelector = ".docsbot-chat-btn-send";
 
   // Begin observation once chat bot is mounted
   onElementMounted(chatBotSelector, document, function (element) {
@@ -60,6 +61,16 @@ window.prepareDocsBotForPresentation = function () {
       linkElem.setAttribute("rel", "stylesheet");
       linkElem.setAttribute("href", "support_chat_widget.css");
       shadowRoot.appendChild(linkElem);
+
+      // Hide keyboard after sending the message to reveal the whole content
+      // https://github.com/wordpress-mobile/WordPress-iOS/issues/21549
+      onElementMounted(sendButtonSelector, shadowRoot, function (sendButton) {
+        sendButton.addEventListener("click", function () {
+          setTimeout(() => {
+            document.activeElement.blur();
+          }, 0);
+        });
+      });
     });
   });
 

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.js
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/support_chat_widget.js
@@ -66,7 +66,7 @@ window.prepareDocsBotForPresentation = function () {
       // https://github.com/wordpress-mobile/WordPress-iOS/issues/21549
       onElementMounted(sendButtonSelector, shadowRoot, function (sendButton) {
         sendButton.addEventListener("click", function () {
-          setTimeout(() => {
+          setTimeout(function () {
             document.activeElement.blur();
           }, 0);
         });


### PR DESCRIPTION
Partially addresses cft issue: #21549

This is a soft workaround for the mobile Safari issue that doesn't resize the viewport when the keyboard appears, causing all the content to shift up. It results in top messages hiding and double scroll appearing. This fix does not solve the whole issue but limits the chances of users not seeing the full content after asking a question.

I couldn't find a reliable way to solve the issue without resorting to tons of little hacks. This would be very unstable given we do not own chatbot code. 

### More details

> The unwanted behavior that causes problems turns out to be a long-running "feature" on mobile Safari https://bugs.webkit.org/show_bug.cgi?id=141832
> 
> The viewport size does not change; instead, the whole view goes up when the keyboard appears, causing unwanted behavior for the messaging interface. This is intentional from the mobile Safari side since this solution performs better than resizing and keeps 60fps.
> 
> [There're workarounds](https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d), none of which sound robust:
> 
> * Trick Safari by momentarily placing the input field high enough on the page, and then returning to the place when the keyboard appears
> * Trick Safari by focusing on a dummy input field which is high on the page when user taps on a real input field
> * Calculate window heights when the keyboard appears and add additional padding
> 
> Even found [a matrix client adding various workarounds for this issue](https://github.com/vector-im/hydrogen-web/pull/279) which is used by [Automattic's chatrix](https://github.com/Automattic/chatrix).


https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/1a9fd5b6-49e6-4026-a1f5-e616b1a35a03


## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
