### PR TITLE
Integrate gutenberg-mobile release 1.103.3

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,14 +1,4 @@
 ref:
-  # This should have either a commit or tag key.
-  # If both are set, tag will take precedence.
-  #
-  # We have automation that reads and updates this file.
-  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
-  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
-  #
-  # Example:
-  #
-  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
-  tag: v1.103.2
+  commit: 11a5598445844ee3e8aebdff1f43afa728a5bd11
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,4 +1,14 @@
 ref:
-  commit: 11a5598445844ee3e8aebdff1f43afa728a5bd11
+  # This should have either a commit or tag key.
+  # If both are set, tag will take precedence.
+  #
+  # We have automation that reads and updates this file.
+  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
+  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
+  #
+  # Example:
+  #
+  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
+  tag: v1.103.3
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile
+++ b/Podfile
@@ -38,7 +38,7 @@ def aztec
   # pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: ''
   # pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', tag: ''
   # pod 'WordPress-Editor-iOS', path: '../AztecEditor-iOS'
-  pod 'WordPress-Editor-iOS', '~> 1.19.8'
+  pod 'WordPress-Editor-iOS', '~> 1.19.9'
 end
 
 def wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-11a5598445844ee3e8aebdff1f43afa728a5bd11.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.3.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -203,7 +203,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-11a5598445844ee3e8aebdff1f43afa728a5bd11.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.3.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -230,7 +230,7 @@ SPEC CHECKSUMS:
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: e538cef5a2daad5938fb0fd5d9ef98132891b9a7
+  Gutenberg: 01cc96b06500fb2f064b884b140ce12c5712c635
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -77,9 +77,9 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.52.4)
   - UIDeviceIdentifier (2.3.0)
-  - WordPress-Aztec-iOS (1.19.8)
-  - WordPress-Editor-iOS (1.19.8):
-    - WordPress-Aztec-iOS (= 1.19.8)
+  - WordPress-Aztec-iOS (1.19.9)
+  - WordPress-Editor-iOS (1.19.9):
+    - WordPress-Aztec-iOS (= 1.19.9)
   - WordPressAuthenticator (6.4.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
@@ -139,7 +139,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
-  - WordPress-Editor-iOS (~> 1.19.8)
+  - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 6.3)
   - WordPressKit (~> 8.5)
   - WordPressShared (~> 2.2)
@@ -247,8 +247,8 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: 1cc5cd61ba9bacb2194e340aeb47a2a37fda00b3
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
-  WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
+  WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
+  WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: 5929076e39dd5aeebeb3ea1e985d6a53f73a984f
   WordPressKit: f33a89b148d9cce96933f0900701aff592a796f7
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
@@ -264,6 +264,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: ecda009f9b2ab8373b422cc4a4f4957dab257ddf
+PODFILE CHECKSUM: 85caeca8902757a0b8629aa64fd8d992efcf1484
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 3.0, >= 1.5)
   - GTMSessionFetcher/Core (1.7.2)
-  - Gutenberg (1.103.2)
+  - Gutenberg (1.103.3)
   - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.9):
     - CropViewController
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.2.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-11a5598445844ee3e8aebdff1f43afa728a5bd11.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -203,7 +203,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.103.2.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-11a5598445844ee3e8aebdff1f43afa728a5bd11.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -230,7 +230,7 @@ SPEC CHECKSUMS:
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   GTMAppAuth: 0ff230db599948a9ad7470ca667337803b3fc4dd
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  Gutenberg: 76cc01d6227fa712e605eb40c7fd1bfd6f0ece56
+  Gutenberg: e538cef5a2daad5938fb0fd5d9ef98132891b9a7
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae


### PR DESCRIPTION
## Description
This PR incorporates the 1.103.3 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6202
 
**⚠️ NOTE:** This PR includes changes from https://github.com/wordpress-mobile/WordPress-iOS/pull/21554 to fix a crash in Aztec when using iOS 17 (https://github.com/wordpress-mobile/WordPress-iOS/pull/21574/commits/7dd4904d04d80895107318cf756caf23dce59130).

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.