### PR TITLE
Media: Implement edit mode

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -129,6 +129,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         ABTest.start()
 
+        Media.removeTemporaryData()
         InteractiveNotificationsManager.shared.registerForUserNotifications()
         setupPingHub()
         setupBackgroundRefresh(application)

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCell.swift
@@ -6,6 +6,7 @@ final class MediaCollectionCell: UICollectionViewCell {
     private let overlayView = CircularProgressView()
     private let placeholderView = UIView()
     private var viewModel: MediaCollectionCellViewModel?
+    private var badgeView: MediaCollectionCellBadgeView?
     private var cancellables: [AnyCancellable] = []
 
     override init(frame: CGRect) {
@@ -46,6 +47,7 @@ final class MediaCollectionCell: UICollectionViewCell {
         imageView.image = nil
         imageView.alpha = 0
         placeholderView.alpha = 1
+        badgeView?.isHidden = true
     }
 
     func configure(viewModel: MediaCollectionCellViewModel) {
@@ -72,6 +74,17 @@ final class MediaCollectionCell: UICollectionViewCell {
             }
         }.store(in: &cancellables)
 
+        viewModel.$badgeText.sink { [weak self] text in
+            guard let self else { return }
+            if let text {
+                let badgeView = self.getBadgeView()
+                badgeView.isHidden = false
+                badgeView.textLabel.text = text
+            } else {
+                self.badgeView?.isHidden = true
+            }
+        }.store(in: &cancellables)
+
         viewModel.onAppear()
     }
 
@@ -86,5 +99,20 @@ final class MediaCollectionCell: UICollectionViewCell {
             self.imageView.alpha = 1
             self.placeholderView.alpha = 0
         }
+    }
+
+    private func getBadgeView() -> MediaCollectionCellBadgeView {
+        if let badgeView {
+            return badgeView
+        }
+        let badgeView = MediaCollectionCellBadgeView()
+        contentView.addSubview(badgeView)
+        badgeView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            badgeView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -4),
+            badgeView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4)
+        ])
+        self.badgeView = badgeView
+        return badgeView
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellBadgeView.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellBadgeView.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+final class MediaCollectionCellBadgeView: UIView {
+    let textLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        textLabel.textColor = .white
+        textLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+
+        let stack = UIStackView(arrangedSubviews: [textLabel])
+        stack.axis = .vertical
+        stack.alignment = .center
+
+        addSubview(stack)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        self.pinSubviewToAllEdges(stack, insets: .init(top: 3, left: 6, bottom: 3, right: 6))
+
+        backgroundColor = .primary
+
+        layer.borderColor = UIColor.white.cgColor
+        layer.borderWidth = 1.5
+
+        widthAnchor.constraint(greaterThanOrEqualToConstant: 24).isActive = true
+        heightAnchor.constraint(greaterThanOrEqualToConstant: 24).isActive = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        layer.cornerRadius = bounds.height / 2
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaCollectionCellViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 final class MediaCollectionCellViewModel {
     var onImageLoaded: ((UIImage) -> Void)?
     @Published private(set) var overlayState: CircularProgressView.State?
+    @Published var badgeText: String?
     let mediaID: TaggedManagedObjectID<Media>
     var mediaType: MediaType
 

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -14,7 +14,7 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
     private var isSyncing = false
     private var syncError: Error?
     private var pendingChanges: [(UICollectionView) -> Void] = []
-    private var selection = NSMutableOrderedSet() // Media
+    private var selection = NSMutableOrderedSet() // `Media`
     private var viewModels: [NSManagedObjectID: MediaCollectionCellViewModel] = [:]
     private let blog: Blog
     private let coordinator = MediaCoordinator.shared
@@ -32,12 +32,6 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         self.blog = blog
         self.mediaPickerController = MediaPickerController(blog: blog, coordinator: coordinator)
         super.init(nibName: nil, bundle: nil)
-        self.hidesBottomBarWhenPushed = true
-    }
-
-    override var hidesBottomBarWhenPushed: Bool {
-        set { }
-        get { true }
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -239,6 +239,8 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         toolbarItems.append(UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(buttonShareTapped)))
         self.toolbarItems = toolbarItems
         navigationController?.setToolbarHidden(!isEditing, animated: true)
+
+        updateToolbarItemsState()
     }
 
     private func setSelect(_ isSelected: Bool, for media: Media) {
@@ -256,6 +258,13 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
             } else {
                 assertionFailure("Invalid selection")
             }
+        }
+        updateToolbarItemsState()
+    }
+
+    private func updateToolbarItemsState() {
+        for toolbarItem in toolbarItems ?? [] {
+            toolbarItem.isEnabled = selection.count > 0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -47,6 +47,7 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         title = Strings.title
         extendedLayoutIncludesOpaqueBars = true
 
+        configureNavigationBar()
         configureCollectionView()
         refreshNavigationItems()
 
@@ -86,6 +87,14 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         collectionView.refreshControl = refreshControl
 
         refreshControl.addTarget(self, action: #selector(syncMedia), for: .valueChanged)
+    }
+
+    private func configureNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        navigationItem.standardAppearance = appearance
+        navigationItem.compactAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
+        navigationItem.compactScrollEdgeAppearance = appearance
     }
 
     private func refreshNavigationItems() {

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -32,6 +32,7 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         self.blog = blog
         self.mediaPickerController = MediaPickerController(blog: blog, coordinator: coordinator)
         super.init(nibName: nil, bundle: nil)
+        self.hidesBottomBarWhenPushed = true
     }
 
     required init?(coder: NSCoder) {
@@ -45,7 +46,6 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
 
         title = Strings.title
         extendedLayoutIncludesOpaqueBars = true
-        hidesBottomBarWhenPushed = true
 
         configureCollectionView()
         refreshNavigationItems()
@@ -97,7 +97,7 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
         }
 
         if isEditing {
-            let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(buttonDoneTapped))
+            let doneButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonDoneTapped))
             rightBarButtonItems.append(doneButton)
         } else {
             let selectButton = UIBarButtonItem(title: Strings.select, style: .plain, target: self, action: #selector(buttonSelectTapped))

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -89,22 +89,25 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
     }
 
     private func refreshNavigationItems() {
-        var rightBarButtonItems: [UIBarButtonItem] = []
+        navigationItem.hidesBackButton = isEditing
 
-        if !isEditing, blog.userCanUploadMedia {
-            configureAddMediaButton()
-            rightBarButtonItems.append(UIBarButtonItem(customView: buttonAddMedia))
-        }
+        navigationItem.rightBarButtonItems = {
+            var rightBarButtonItems: [UIBarButtonItem] = []
 
-        if isEditing {
-            let doneButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonDoneTapped))
-            rightBarButtonItems.append(doneButton)
-        } else {
-            let selectButton = UIBarButtonItem(title: Strings.select, style: .plain, target: self, action: #selector(buttonSelectTapped))
-            rightBarButtonItems.append(selectButton)
-        }
+            if !isEditing, blog.userCanUploadMedia {
+                configureAddMediaButton()
+                rightBarButtonItems.append(UIBarButtonItem(customView: buttonAddMedia))
+            }
 
-        navigationItem.rightBarButtonItems = rightBarButtonItems
+            if isEditing {
+                let doneButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonDoneTapped))
+                rightBarButtonItems.append(doneButton)
+            } else {
+                let selectButton = UIBarButtonItem(title: Strings.select, style: .plain, target: self, action: #selector(buttonSelectTapped))
+                rightBarButtonItems.append(selectButton)
+            }
+            return rightBarButtonItems
+        }()
     }
 
     private func configureAddMediaButton() {

--- a/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Library/MediaViewController.swift
@@ -44,6 +44,7 @@ final class MediaViewController: UIViewController, NSFetchedResultsControllerDel
 
         title = Strings.title
         extendedLayoutIncludesOpaqueBars = true
+        hidesBottomBarWhenPushed = true
 
         configureCollectionView()
         configureNavigationItems()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -377,6 +377,8 @@
 		0A9610F928B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
+		0C01A6EA2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */; };
+		0C01A6EB2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */; };
 		0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0AE75A2A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
@@ -6048,6 +6050,7 @@
 		0A69300A28B5AA5E00E98DE1 /* FullScreenCommentReplyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelTests.swift; sourceTree = "<group>"; };
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
+		0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCollectionCellBadgeView.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodCache.swift; sourceTree = "<group>"; };
@@ -10118,6 +10121,7 @@
 			children = (
 				0C748B4A2A9D71A000809E1A /* MediaViewController.swift */,
 				0CAE8EF12A9E9E8D0073EEB9 /* MediaCollectionCell.swift */,
+				0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */,
 				0CAE8EF52A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift */,
 				0C7762222AAFD39700E07A88 /* MediaPickerController.swift */,
 			);
@@ -21399,6 +21403,7 @@
 				8B36256625A60CCA00D7CCE3 /* BackupListViewController.swift in Sources */,
 				FAA4013427B52455009E1137 /* DashboardQuickActionCell.swift in Sources */,
 				32A218D8251109DB00D1AE6C /* ReaderReportPostAction.swift in Sources */,
+				0C01A6EA2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */,
 				FA681F8A25CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift in Sources */,
 				081E4B4C281C019A0085E89C /* TooltipAnchor.swift in Sources */,
 				3F851415260D0A3300A4B938 /* UnifiedPrologueEditorContentView.swift in Sources */,
@@ -24675,6 +24680,7 @@
 				FABB24032602FC2C00C8785C /* ReaderCSS.swift in Sources */,
 				FABB24042602FC2C00C8785C /* SafariActivity.m in Sources */,
 				FABB24052602FC2C00C8785C /* WordPress-37-38.xcmappingmodel in Sources */,
+				0C01A6EB2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */,
 				FABB24062602FC2C00C8785C /* UploadOperation.swift in Sources */,
 				FABB24072602FC2C00C8785C /* LayoutPickerAnalyticsEvent.swift in Sources */,
 				FABB24082602FC2C00C8785C /* ActivityRange.swift in Sources */,


### PR DESCRIPTION
Part of #21457

Adds "Edit" mode with "Delete" and "Share" options.

This is largely experimental, at least the "Share" option. It works similar to the way "Share" works on the details page: downloads the original file and shares it. But it has been optimized to support a large number of items: the data is never stored in memory, only on disk.

@osullivanchris I took some liberties with the design to make it look more like the Photos app and also make it a bit simpler to implement. It's still in a super early stage, so if you want to change something, please feel free to reach out to me. This is more about the technical details, not the design yet.

The design so far doesn't look ideal, as you can see:

<img width="360" alt="Screenshot 2023-09-14 at 6 27 29 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/52760a31-4bec-448a-98d3-e361cbe6b61c">   <img width="360" alt="Screenshot 2023-09-14 at 6 27 33 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/3bcceb2f-78c2-474d-aa49-51fee35e0cc3">

There is no "legal" way to hide the tab bar when showing the toolbar. But there is a way to hide it when the Media screen is pushed to the navigation stack. But (sigh) it's [currently broken](https://a8c.slack.com/archives/C04U3GCAVK2/p1694722392655109) because of the way the My Site screen is set up.

<img width="360" alt="Screenshot 2023-09-14 at 6 28 31 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/6f640118-f7a3-468f-ab71-cad281d8b2a8">   <img width="360" alt="Screenshot 2023-09-14 at 6 28 35 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/5080ab17-0739-4afc-9281-4b1e6d038fce">

And you can see the "Share" recording [here](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/3922ea5b-1bb3-457e-b331-4663a1c3dbb7).

## Open Questions

- Does the selection need to be ordered in case of editing? Maybe for sharing?

## To test:

- Verify that you can enter and exit the selection mode
- Verify that if you enter a selection mode, make a selection, and exit it, the selection is cleared
- Verify that you can change the order of selection
- Verify that you can delete items and that after the deletion, the selection is cleared
- Verify that you can share items of different media types

## Regression Notes
1. Potential unintended areas of impact: n/a (no production code changes)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual tests
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
