### PR TITLE
Move merging posts helper function to PostHelper

### DIFF
--- a/WordPress/Classes/Services/PostHelper.h
+++ b/WordPress/Classes/Services/PostHelper.h
@@ -19,8 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSArray *)mergePosts:(NSArray <RemotePost *> *)remotePosts
                  ofType:(NSString *)syncPostType
-           withStatuses:(NSArray *)statuses
-               byAuthor:(NSNumber *)authorID
+           withStatuses:(nullable NSArray *)statuses
+               byAuthor:(nullable NSNumber *)authorID
                 forBlog:(Blog *)blog
           purgeExisting:(BOOL)purge
               inContext:(NSManagedObjectContext *)context;

--- a/WordPress/Classes/Services/PostHelper.h
+++ b/WordPress/Classes/Services/PostHelper.h
@@ -17,6 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (RemotePost *)remotePostWithPost:(AbstractPost *)post;
 
++ (NSArray *)mergePosts:(NSArray <RemotePost *> *)remotePosts
+                 ofType:(NSString *)syncPostType
+           withStatuses:(NSArray *)statuses
+               byAuthor:(NSNumber *)authorID
+                forBlog:(Blog *)blog
+          purgeExisting:(BOOL)purge
+              inContext:(NSManagedObjectContext *)context;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -148,12 +148,13 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
                                    DDLogError(@"Could not retrieve blog in context %@", (error ? [NSString stringWithFormat:@"with error: %@", error] : @""));
                                    return;
                                }
-                               NSArray *posts = [self mergePosts:[loadedPosts copy]
-                                                          ofType:postType
-                                                    withStatuses:options.statuses
-                                                        byAuthor:options.authorID
-                                                         forBlog:blogInContext
-                                                   purgeExisting:options.purgesLocalSync];
+                               NSArray *posts = [PostHelper mergePosts:[loadedPosts copy]
+                                                                ofType:postType
+                                                          withStatuses:options.statuses
+                                                              byAuthor:options.authorID
+                                                               forBlog:blogInContext
+                                                         purgeExisting:options.purgesLocalSync
+                                                             inContext:self.managedObjectContext];
 
                                [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
                                    // Call the completion block after context is saved. The callback is called on the context queue because `posts`
@@ -638,77 +639,6 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
 }
 
 #pragma mark - Helpers
-
-+ (NSArray *)mergePosts:(NSArray <RemotePost *> *)remotePosts
-                 ofType:(NSString *)syncPostType
-           withStatuses:(NSArray *)statuses
-               byAuthor:(NSNumber *)authorID
-                forBlog:(Blog *)blog
-          purgeExisting:(BOOL)purge
-              inContext:(NSManagedObjectContext *)context
-{
-    NSMutableArray *posts = [NSMutableArray arrayWithCapacity:remotePosts.count];
-    for (RemotePost *remotePost in remotePosts) {
-        AbstractPost *post = [blog lookupPostWithID:remotePost.postID inContext:context];
-        if (!post) {
-            if ([remotePost.type isEqualToString:PostServiceTypePage]) {
-                // Create a Page entity for posts with a remote type of "page"
-                post = [blog createPage];
-            } else {
-                // Create a Post entity for any other posts that have a remote post type of "post" or a custom post type.
-                post = [blog createPost];
-            }
-        }
-        [PostHelper updatePost:post withRemotePost:remotePost inContext:context];
-        [posts addObject:post];
-    }
-    
-    if (purge) {
-        // Set up predicate for fetching any posts that could be purged for the sync.
-        NSPredicate *predicate  = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];
-        if ([statuses count] > 0) {
-            NSPredicate *statusPredicate = [NSPredicate predicateWithFormat:@"status IN %@", statuses];
-            predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, statusPredicate]];
-        }
-        if (authorID) {
-            NSPredicate *authorPredicate = [NSPredicate predicateWithFormat:@"authorID = %@", authorID];
-            predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, authorPredicate]];
-        }
-        
-        NSFetchRequest *request;
-        if ([syncPostType isEqualToString:PostServiceTypeAny]) {
-            // If syncing "any" posts, set up the fetch for any AbstractPost entities (including child entities).
-            request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([AbstractPost class])];
-        } else if ([syncPostType isEqualToString:PostServiceTypePage]) {
-            // If syncing "page" posts, set up the fetch for any Page entities.
-            request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([Page class])];
-        } else {
-            // If not syncing "page" or "any" post, use the Post entity.
-            request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([Post class])];
-            // Include the postType attribute in the predicate.
-            NSPredicate *postTypePredicate = [NSPredicate predicateWithFormat:@"postType = %@", syncPostType];
-            predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, postTypePredicate]];
-        }
-        request.predicate = predicate;
-        
-        NSError *error;
-        NSArray *existingPosts = [context executeFetchRequest:request error:&error];
-        if (error) {
-            DDLogError(@"Error fetching existing posts for purging: %@", error);
-        } else {
-            NSSet *postsToKeep = [NSSet setWithArray:posts];
-            NSMutableSet *postsToDelete = [NSMutableSet setWithArray:existingPosts];
-            // Delete the posts not being updated.
-            [postsToDelete minusSet:postsToKeep];
-            for (AbstractPost *post in postsToDelete) {
-                DDLogInfo(@"Deleting Post: %@", post);
-                [context deleteObject:post];
-            }
-        }
-    }
-
-    return posts;
-}
 
 - (NSDictionary *)remoteSyncParametersDictionaryForRemote:(nonnull id <PostServiceRemote>)remote
                                               withOptions:(nonnull PostServiceSyncOptions *)options


### PR DESCRIPTION
Moving another helper function from `PostService` to `PostHelper`, so that it can be used later in `PostRepository`. This change prepares for the upcoming syncing post implementation in `PostRepository`.

You can review this PR commits by commits to see there is no real runtime changes.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A