### PR TITLE
Fix `AddMediaBlocks` UI test after changes introduced in Gutenberg Mobile `1.104.0`

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -191,8 +191,9 @@ public class BlockEditorScreen: ScreenObject {
     private func addMediaBlockFromUrl(blockType: String, UrlPath: String) {
         addBlock(blockType)
         insertFromUrlButton.tap()
-        app.textFields.element.typeText(UrlPath)
-        applyButton.tap()
+        app.textFields["Type a URL"].typeText(UrlPath)
+        // Tap on the modal, which is the parent of the TextField element, to dismiss it.
+        app.otherElements.containing(.textField, identifier: "Type a URL").firstMatch.tap()
     }
 
     @discardableResult


### PR DESCRIPTION
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
