### PR TITLE
Me tab: Fix crash when switching between tabs when nav bar is visible

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -172,6 +172,8 @@ class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewD
         return UIHostingController(rootView: noSiteView)
     }()
 
+    private var isNavigationBarHidden = false
+
     // MARK: - View Lifecycle
 
     override func viewDidLoad() {
@@ -410,14 +412,21 @@ class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewD
 
     private func configureNavBarAppearance(animated: Bool) {
         if scrollView.contentOffset.y >= 60 {
-            navigationController?.setNavigationBarHidden(false, animated: animated)
+            if isNavigationBarHidden {
+                navigationController?.setNavigationBarHidden(false, animated: animated)
+            }
+            isNavigationBarHidden = false
         } else {
-            navigationController?.setNavigationBarHidden(true, animated: animated)
+            if !isNavigationBarHidden {
+                navigationController?.setNavigationBarHidden(true, animated: animated)
+            }
+            isNavigationBarHidden = true
         }
     }
 
     private func resetNavBarAppearance() {
         navigationController?.setNavigationBarHidden(false, animated: false)
+        isNavigationBarHidden = false
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -196,7 +196,7 @@ class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewD
             showBlogDetailsForMainBlogOrNoSites()
         }
 
-        setupNavBarAppearance()
+        configureNavBarAppearance(animated: false)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -222,8 +222,6 @@ class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewD
         FancyAlertViewController.presentCustomAppIconUpgradeAlertIfNecessary(from: self)
 
         trackNoSitesVisibleIfNeeded()
-
-        setupNavBarAppearance()
 
         createFABIfNeeded()
         fetchPrompt(for: blog)
@@ -410,8 +408,12 @@ class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewD
         navigationController?.navigationBar.accessibilityIdentifier = "my-site-navigation-bar"
     }
 
-    private func setupNavBarAppearance() {
-        navigationController?.setNavigationBarHidden(true, animated: false)
+    private func configureNavBarAppearance(animated: Bool) {
+        if scrollView.contentOffset.y >= 60 {
+            navigationController?.setNavigationBarHidden(false, animated: animated)
+        } else {
+            navigationController?.setNavigationBarHidden(true, animated: animated)
+        }
     }
 
     private func resetNavBarAppearance() {
@@ -419,11 +421,7 @@ class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewD
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y >= 60 {
-            navigationController?.setNavigationBarHidden(false, animated: true)
-        } else {
-            navigationController?.setNavigationBarHidden(true, animated: true)
-        }
+        configureNavBarAppearance(animated: true)
     }
 
     // MARK: - Account


### PR DESCRIPTION
Fixes #21510

## Description

Fixes a crash on WPiOS that manifests when switching between tabs

## How to test

Please test both WP and JP apps.

- Switch to My Site
- Scroll down so the nav bar is visible
- Switch to any tab
- Switch back to My Site
- Verify the app doesn't crash

### WPiOS
https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/c8bfcdee-3176-46a6-806a-3ed54f6ea7e1

### JPiOS
https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/cc3509d8-b99d-4cf8-98e0-fd83e30f45f4


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

