### PR TITLE
Fix Compliance Pop over issue on smaller devices

### DIFF
--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
@@ -15,13 +15,8 @@ struct CompliancePopover: View {
 
     var body: some View {
         if shouldScroll {
-            GeometryReader { reader in
-                ScrollView(showsIndicators: false) {
-                    contentVStack
-                    // Fixes the issue of scroll view content size not sizing properly.
-                    // Without this, on large dynamic fonts, the view is not properly scrollable.
-                    Spacer().frame(height: reader.size.height - screenHeight + Constants.verticalScrollBuffer)
-                }
+            ScrollView(showsIndicators: false) {
+                contentVStack
             }
         } else {
             contentVStack
@@ -35,9 +30,9 @@ struct CompliancePopover: View {
             analyticsToggle
             footnote
             buttonsHStack
+            Spacer()
         }
-        .padding(Length.Padding.small)
-        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, Length.Padding.small)
     }
 
     private var titleText: some View {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
@@ -8,7 +8,6 @@ struct CompliancePopover: View {
     var goToSettingsAction: (() -> ())?
     var saveAction: (() -> ())?
     var shouldScroll: Bool = false
-    var screenHeight: CGFloat = 0
 
     @StateObject
     var viewModel: CompliancePopoverViewModel

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -25,7 +25,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
                     return
                 }
                 Task {
-                    if await self.shouldShowPrivacyBanner(countryCode: countryCode) {
+                    if self.shouldShowPrivacyBanner(countryCode: countryCode) {
                         await self.presentPopover(on: viewController)
                     }
                 }
@@ -43,7 +43,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
         presentingViewController?.dismiss(animated: true)
     }
 
-    private func shouldShowPrivacyBanner(countryCode: String) async -> Bool {
+    private func shouldShowPrivacyBanner(countryCode: String) -> Bool {
         let isCountryInEU = Self.gdprCountryCodes.contains(countryCode)
         return isCountryInEU && !defaults.didShowCompliancePopup
     }

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -2,71 +2,44 @@ import UIKit
 import SwiftUI
 import WordPressUI
 
-final class CompliancePopoverViewController: UIViewController {
+final class CompliancePopoverViewController: UIHostingController<CompliancePopover> {
 
     // MARK: - Dependencies
 
     private let viewModel: CompliancePopoverViewModel
-
-    // MARK: - Views
-    private let hostingController: UIHostingController<CompliancePopover>
-
-    private var contentView: UIView {
-        return hostingController.view
-    }
-
     private var bannerIntrinsicHeight: CGFloat = 0
 
     init(viewModel: CompliancePopoverViewModel) {
         self.viewModel = viewModel
-        hostingController = UIHostingController(rootView: CompliancePopover(viewModel: self.viewModel))
-        super.init(nibName: nil, bundle: nil)
+        super.init(rootView: CompliancePopover(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - View Lifecycle
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        self.addContentView()
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = true
-        hostingController.rootView.goToSettingsAction = {
-            self.viewModel.didTapSettings()
-        }
-        hostingController.rootView.saveAction = {
-            self.viewModel.didTapSave()
-        }
-        viewModel.didDisplayPopover()
-    }
-
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        let targetSize = CGSize(width: view.bounds.width, height: 0)
-        let contentViewSize = contentView.systemLayoutSizeFitting(targetSize)
-        self.contentView.frame = .init(origin: .zero, size: contentViewSize)
-        self.preferredContentSize = contentView.bounds.size
 
-        self.hostingController.rootView.screenHeight = self.view.frame.height
-        self.hostingController.rootView.shouldScroll = (contentViewSize.height + 100) > self.view.frame.height
-    }
-
-    private func addContentView() {
-        self.hostingController.willMove(toParent: self)
-        self.addChild(hostingController)
-        self.view.addSubview(contentView)
-        self.hostingController.didMove(toParent: self)
+        // Make the banner scrollable when the banner height is bigger than the screen height.
+        // Send it in the next run loop to avoid a recursive `viewDidLayoutSubviews`.
+        if bannerIntrinsicHeight == 0 {
+            bannerIntrinsicHeight = view.intrinsicContentSize.height + Length.Padding.small
+            DispatchQueue.main.async {
+                self.rootView.shouldScroll = self.bannerIntrinsicHeight > self.view.frame.height
+            }
+        }
     }
 }
 
 // MARK: - DrawerPresentable
 extension CompliancePopoverViewController: DrawerPresentable {
     var collapsedHeight: DrawerHeight {
-        if traitCollection.verticalSizeClass == .compact {
-            return .maxHeight
-        }
-        return .intrinsicHeight
+        return .contentHeight(bannerIntrinsicHeight)
+    }
+
+    var expandedHeight: DrawerHeight {
+        return .contentHeight(bannerIntrinsicHeight)
     }
 
     var allowsUserTransition: Bool {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -18,6 +18,17 @@ final class CompliancePopoverViewController: UIHostingController<CompliancePopov
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        rootView.goToSettingsAction = {
+            self.viewModel.didTapSettings()
+        }
+        rootView.saveAction = {
+            self.viewModel.didTapSave()
+        }
+        viewModel.didDisplayPopover()
+    }
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 


### PR DESCRIPTION
Fixes #21555 

This PR refactors the compliance popover display logic to align it with WooCommerce-iOS implementation. Now the should work with every device size and system font size without issues.

## Testing Steps

I was only able to reproduce this issue on iPhone SE (or any smaller screen device). So I recommend testing on iPhone SE Simulator or Device.

1. Install Jetpack & Login
2. The popover should be displayed and the buttons should be interactable.
3. Delete the app and change the system font size to something large.
4. Install Jetpack & Login again
5. Verify if the popover looks correct and scroll is enabled if the content is large enough.

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
