### PR TITLE
build: Reference RNAztec pod within Gutenberg submodule

### DIFF
--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -53,9 +53,11 @@ def gutenberg_pod
 end
 
 def gutenberg_local_pod
-  options = { path: local_gutenberg_path }
+  options_gb = { path: local_gutenberg_path }
+  options_aztec = { path: "#{ local_gutenberg_path }/gutenberg/packages/react-native-aztec/" }
 
-  raise "Could not find Gutenberg pod at #{options[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable." unless File.exist?(options[:path])
+  raise "Could not find Gutenberg pod at #{options_gb[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable." unless File.exist?(options_gb[:path])
+  raise "Could not find RNTAztecView pod at #{options_aztec[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable." unless File.exist?(options_aztec[:path])
 
   puts "[Gutenberg] Installing pods using local Gutenberg version from #{local_gutenberg_path}"
 
@@ -63,10 +65,10 @@ def gutenberg_local_pod
 
   use_react_native! path: react_native_path
 
-  pod 'Gutenberg', options
-  pod 'RNTAztecView', options
+  pod 'Gutenberg', options_gb
+  pod 'RNTAztecView', options_aztec
 
-  gutenberg_dependencies(options:)
+  gutenberg_dependencies(options: options_gb)
 end
 
 def gutenberg_dependencies(options:)

--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -53,17 +53,8 @@ def gutenberg_pod
 end
 
 def gutenberg_local_pod
-  options_gb = { path: local_gutenberg_path }
-  options_aztec = { path: "#{local_gutenberg_path}/gutenberg/packages/react-native-aztec/" }
-
-  unless File.exist?(options_gb[:path])
-    raise "Could not find Gutenberg pod at #{options_gb[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable."
-  end
-  unless File.exist?(options_aztec[:path])
-    raise "Could not find RNTAztecView pod at #{options_aztec[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable."
-  end
-
-  puts "[Gutenberg] Installing pods using local Gutenberg version from #{local_gutenberg_path}"
+  options_gb = gutenberg_pod_options(name: 'Gutenberg', path: local_gutenberg_path)
+  options_aztec = gutenberg_pod_options(name: 'RNTAztecView', path: "#{local_gutenberg_path}/gutenberg/packages/react-native-aztec/")
 
   react_native_path = require_react_native_helpers!(gutenberg_path: local_gutenberg_path)
 
@@ -73,6 +64,13 @@ def gutenberg_local_pod
   pod 'RNTAztecView', options_aztec
 
   gutenberg_dependencies(options: options_gb)
+end
+
+def gutenberg_pod_options(name:, path:)
+  raise "Could not find #{name} pod at #{path}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable." unless File.exist?(path)
+
+  puts "[Gutenberg] Installing pods using local #{name} version from #{path}"
+  { path: }
 end
 
 def gutenberg_dependencies(options:)

--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -54,7 +54,7 @@ end
 
 def gutenberg_local_pod
   options_gb = gutenberg_pod_options(name: 'Gutenberg', path: local_gutenberg_path)
-  options_aztec = gutenberg_pod_options(name: 'RNTAztecView', path: "#{local_gutenberg_path}/gutenberg/packages/react-native-aztec/")
+  options_aztec = gutenberg_pod_options(name: 'RNTAztecView', path: "#{local_gutenberg_path}/gutenberg/packages/react-native-aztec")
 
   react_native_path = require_react_native_helpers!(gutenberg_path: local_gutenberg_path)
 

--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -54,10 +54,14 @@ end
 
 def gutenberg_local_pod
   options_gb = { path: local_gutenberg_path }
-  options_aztec = { path: "#{ local_gutenberg_path }/gutenberg/packages/react-native-aztec/" }
+  options_aztec = { path: "#{local_gutenberg_path}/gutenberg/packages/react-native-aztec/" }
 
-  raise "Could not find Gutenberg pod at #{options_gb[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable." unless File.exist?(options_gb[:path])
-  raise "Could not find RNTAztecView pod at #{options_aztec[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable." unless File.exist?(options_aztec[:path])
+  unless File.exist?(options_gb[:path])
+    raise "Could not find Gutenberg pod at #{options_gb[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable."
+  end
+  unless File.exist?(options_aztec[:path])
+    raise "Could not find RNTAztecView pod at #{options_aztec[:path]}. You can configure the path using the #{LOCAL_GUTENBERG_KEY} environment variable."
+  end
 
   puts "[Gutenberg] Installing pods using local Gutenberg version from #{local_gutenberg_path}"
 


### PR DESCRIPTION
The RNAztec podspec in the `gutenberg-submodule` was removed in favor of
the one within the `gutenberg` submodule. This change was made in the
following:

https://github.com/wordpress-mobile/gutenberg-mobile/pull/6200

To test:

Verify installing pods works with and without the `LOCAL_GUTENBERG` flag.

- `bundle exec pod install`
- `LOCAL_GUTENBERG=true bundle exec pod install`
- `LOCAL_GUTENBERG=<path-to-gutenberg-mobile> bundle exec pod install`

## Regression Notes
1. Potential unintended areas of impact
    Build scripts could begin failing.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Ran the relevant Pod scripts locally.
3. What automated tests I added (or what prevented me from doing so)
    Did not believe this was worthwhile for internal scripts.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
