### PR TITLE
Fix split view support on large iPhones

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -248,6 +248,7 @@ extension BlogDashboardViewController {
                                                         trailing: horizontalInset)
 
         section.interGroupSpacing = Constants.cellSpacing
+        section.contentInsetsReference = .readableContent
 
         return section
     }
@@ -322,7 +323,7 @@ extension BlogDashboardViewController {
     private enum Constants {
         static let estimatedWidth: CGFloat = 100
         static let estimatedHeight: CGFloat = 44
-        static let horizontalSectionInset: CGFloat = 20
+        static let horizontalSectionInset: CGFloat = 12
         static let verticalSectionInset: CGFloat = 20
         static var bottomSectionInset: CGFloat {
             // Make room for FAB on iPhone

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -131,7 +131,7 @@ extension DashboardQuickActionsCardCell: BlogDetailsPresentationDelegate {
     }
 
     func presentBlogDetailsViewController(_ viewController: UIViewController) {
-        self.parentViewController?.showDetailViewController(viewController, sender: nil)
+        self.blogDetailsViewController?.show(viewController, sender: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -384,6 +384,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self.tableView registerClass:[MigrationSuccessCell class] forCellReuseIdentifier:BlogDetailsMigrationSuccessCellIdentifier];
     [self.tableView registerClass:[JetpackBrandingMenuCardCell class] forCellReuseIdentifier:BlogDetailsJetpackBrandingCardCellIdentifier];
     [self.tableView registerClass:[JetpackRemoteInstallTableViewCell class] forCellReuseIdentifier:BlogDetailsJetpackInstallCardCellIdentifier];
+    
+    self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
 
     self.hasLoggedDomainCreditPromptShownEvent = NO;
 
@@ -409,7 +411,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [self observeWillEnterForegroundNotification];
 
-    if (self.splitViewControllerIsHorizontallyCompact) {
+    if (!self.splitViewControllerIsHorizontallyCompact) {
         self.restorableSelectedIndexPath = nil;
     }
 
@@ -994,7 +996,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     BOOL isValidIndexPath = self.restorableSelectedIndexPath.section < self.tableView.numberOfSections &&
                             self.restorableSelectedIndexPath.row < [self.tableView numberOfRowsInSection:self.restorableSelectedIndexPath.section];
-    if (isValidIndexPath && ![self splitViewControllerIsHorizontallyCompact]) {
+    if (isValidIndexPath && [self isSplitViewDisplayed]) {
         // And finally we'll reselect the selected row, if there is one
         [self.tableView selectRowAtIndexPath:self.restorableSelectedIndexPath
                                     animated:NO
@@ -1038,7 +1040,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self shouldShowQuickStartChecklist]) {
         [marr addNullableObject:[self quickStartSectionViewModel]];
     }
-    if ([self isDashboardEnabled] && ![self splitViewControllerIsHorizontallyCompact] && [MySitesCoordinator isSplitViewEnabled]) {
+    if ([self isDashboardEnabled] && [self isSplitViewDisplayed]) {
         [marr addNullableObject:[self homeSectionViewModel]];
     }
 
@@ -1075,6 +1077,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     // Assign non mutable copy.
     self.tableSections = [NSArray arrayWithArray:marr];
+}
+
+- (Boolean)isSplitViewDisplayed {
+    return ![self splitViewControllerIsHorizontallyCompact] && [MySitesCoordinator isSplitViewEnabled];
 }
 
 /// This section is available on Jetpack only.
@@ -1511,7 +1517,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showInitialDetailsForBlog
 {
-    if ([self splitViewControllerIsHorizontallyCompact]) {
+    if (![self isSplitViewDisplayed]) {
         return;
     }
 
@@ -1617,7 +1623,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [WPStyleGuide configureTableViewDestructiveActionCell:cell];
     } else {
         if (row.showsDisclosureIndicator) {
-            cell.accessoryType = [self splitViewControllerIsHorizontallyCompact] ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
+            cell.accessoryType = [self isSplitViewDisplayed] ? UITableViewCellAccessoryNone : UITableViewCellAccessoryDisclosureIndicator;
         } else {
             cell.accessoryType = UITableViewCellAccessoryNone;
         }
@@ -1654,7 +1660,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (row.showsSelectionState) {
         self.restorableSelectedIndexPath = indexPath;
     } else {
-        if ([self splitViewControllerIsHorizontallyCompact]) {
+        if (![self isSplitViewDisplayed]) {
             // Deselect current row when not in split view layout
             [tableView deselectRowAtIndexPath:indexPath animated:YES];
         } else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1038,7 +1038,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self shouldShowQuickStartChecklist]) {
         [marr addNullableObject:[self quickStartSectionViewModel]];
     }
-    if ([self isDashboardEnabled] && ![self splitViewControllerIsHorizontallyCompact]) {
+    if ([self isDashboardEnabled] && ![self splitViewControllerIsHorizontallyCompact] && [MySitesCoordinator isSplitViewEnabled]) {
         [marr addNullableObject:[self homeSectionViewModel]];
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -411,7 +411,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [self observeWillEnterForegroundNotification];
 
-    if (!self.splitViewControllerIsHorizontallyCompact) {
+    if (!self.isSplitViewDisplayed) {
         self.restorableSelectedIndexPath = nil;
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -893,11 +893,15 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
     }
 
     func presentBlogDetailsViewController(_ viewController: UIViewController) {
-        switch currentSection {
-        case .dashboard:
-            blogDashboardViewController?.showDetailViewController(viewController, sender: blogDashboardViewController)
-        case .siteMenu:
-            blogDetailsViewController?.showDetailViewController(viewController, sender: blogDetailsViewController)
+        if MySitesCoordinator.isSplitViewEnabled {
+            switch currentSection {
+            case .dashboard:
+                blogDashboardViewController?.showDetailViewController(viewController, sender: blogDashboardViewController)
+            case .siteMenu:
+                blogDetailsViewController?.showDetailViewController(viewController, sender: blogDetailsViewController)
+            }
+        } else {
+            blogDetailsViewController?.show(viewController, sender: nil)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -31,7 +31,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     private func getSection(for blog: Blog) -> Section {
         if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() &&
             blog.isAccessibleThroughWPCom() &&
-            splitViewControllerIsHorizontallyCompact {
+            (splitViewControllerIsHorizontallyCompact || !MySitesCoordinator.isSplitViewEnabled) {
             return .dashboard
         } else {
             return .siteMenu

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -36,7 +36,17 @@ class MySitesCoordinator: NSObject {
     ///
     @objc
     var rootViewController: UIViewController {
-        return splitViewController
+        if MySitesCoordinator.isSplitViewEnabled {
+            return splitViewController
+        } else {
+            // `hidesBottomBarWhenPushed` doesn't work with `UISplitViewController`,
+            // so it we have to use `UINavigationController` directly.
+            return navigationController
+        }
+    }
+
+    @objc class var isSplitViewEnabled: Bool {
+        UIDevice.current.userInterfaceIdiom == .pad
     }
 
     @objc
@@ -65,6 +75,7 @@ class MySitesCoordinator: NSObject {
         navigationController.tabBarItem.accessibilityLabel = NSLocalizedString("My Site", comment: "The accessibility value of the my site tab.")
         navigationController.tabBarItem.accessibilityIdentifier = "mySitesTabButton"
         navigationController.tabBarItem.title = NSLocalizedString("My Site", comment: "The accessibility value of the my site tab.")
+        navigationController.extendedLayoutIncludesOpaqueBars = true
 
         return navigationController
     }()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21579

Removing Split View from My Site on iPhone. Reasoning in https://github.com/wordpress-mobile/WordPress-iOS/issues/21579. Blessed by Chris.

## To test:

### Jetpack

**Basics**

- Open the app on iPhone Plus or Pro Max
- Rotate the My Site tab to the landscape mode
- Verify that it no longer shows the split view
- Verify that the details page navigations work and take full advantage of the screen width
- Verify that the navigation under the "More" section also work
- Verify that you can open all of the details screens from the dashboard

**More Menu**

- Open More menu
- Verify that the menu use [readable content guide](https://developer.apple.com/documentation/uikit/uiview/1622644-readablecontentguide) so that they are nice and readable
- Verify that you can open all of the details screens from the dashboard

**Launch in Landscape**

- Open the app already in landscape
- Verify that on iPhone, the Home page appears (not the More menu)
- Open the More menu and verify that it doesn't display the Home button

**Readable Content Guide**

- Verify that the dashboard cards use [readable content guide](https://developer.apple.com/documentation/uikit/uiview/1622644-readablecontentguide) so that they are nice and readable

<img width="600" alt="Screenshot 2023-09-15 at 4 52 48 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/933ae1e2-58b2-441a-b521-72a043ad1907">

P.S. The header position is probably not ideal, but I wanted to limit the scope of the changes because the soft freeze is coming.

<hr/>

### WordPress

**Basics**

- Open the app
- Verify that the menu use [readable content guide](https://developer.apple.com/documentation/uikit/uiview/1622644-readablecontentguide) so that they are nice and readable
- Verify that you can open all of the details screens from the dashboard
- Verify that the cells have disclosure indicators in both landscape and portrait
- Verify that when you launch the app in landscape mode it doesn't restore previous selection

## Regression Notes
1. Potential unintended areas of impact: My Site
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
