### PR TITLE
Fix an issue with image tint color in personalization screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationView.swift
@@ -43,7 +43,13 @@ private struct BlogDashboardPersonalizationQuickActionCell: View {
 
     var body: some View {
         Toggle(isOn: $viewModel.isOn) {
-            Label(title: { Text(viewModel.title) }, icon: { Image(uiImage: viewModel.image ?? UIImage()) })
+            Label(title: {
+                Text(viewModel.title)
+            }, icon: {
+                let image = viewModel.image ?? UIImage()
+                Image(uiImage: image.withRenderingMode(.alwaysTemplate))
+                    .foregroundColor(.primary)
+            })
         }
     }
 }


### PR DESCRIPTION
Fix an issue with image tint color in personalization screen

Reported by Chris. Looked like this:

<img width="320" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/5cf1f913-a927-4051-829a-a956de3bdd76">

## Regression Notes
1. Potential unintended areas of impact: Dashboard Personalization
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
