### PR TITLE
Update OCMock to the latest version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -79,7 +79,7 @@ end
 
 def shared_test_pods
   pod 'OHHTTPStubs/Swift', '~> 9.1.0'
-  pod 'OCMock', '~> 3.4.3'
+  pod 'OCMock', '~> 3.4'
   gutenberg_pod
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -117,7 +117,7 @@ DEPENDENCIES:
   - MediaEditor (>= 1.2.2, ~> 1.2)
   - NSObject-SafeExpectations (~> 0.0.4)
   - "NSURL+IDN (~> 0.4)"
-  - OCMock (~> 3.4.3)
+  - OCMock (~> 3.4)
   - OHHTTPStubs/Swift (~> 9.1.0)
   - Reachability (= 3.2)
   - SDWebImage (~> 5.11.1)
@@ -241,6 +241,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 6923d1ced869ffdb698231230e921bacec62ca10
+PODFILE CHECKSUM: ff013961e9c5df73aba2f55dc135b66dbafb584d
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
This is a routine update to make sure we have up-to-date dependencies. There is no feature of these new version we use.

(_The first version of this PR updated CocoaLumberjack, too. But that one turned out to introduce an issue, so I removed it._)

If CI is green, we should be reasonably confident in merging.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.