### PR TITLE
Fix flaky test when tapping View post button on testBasicPostPublishWithCategoryAndTag()

### DIFF
--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -36,18 +36,15 @@ public func pullToRefresh(app: XCUIApplication = XCUIApplication()) {
     top.press(forDuration: 0.01, thenDragTo: bottom)
 }
 
-public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10, timeout: TimeInterval = 10) {
-    guard element.waitForIsHittable(timeout: timeout) else {
-        XCTFail("Expected element (\(element)) was not hittable after \(timeout) seconds.")
-        return
-    }
-
+public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10) {
     var retries = 0
     while retries < maxRetries {
         if element.isHittable {
             element.tap()
             break
         }
+
+        usleep(500000) // a 0.5 second delay before retrying
         retries += 1
     }
 }

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -47,6 +47,10 @@ public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10) {
         usleep(500000) // a 0.5 second delay before retrying
         retries += 1
     }
+
+    if retries == maxRetries {
+        XCTFail("Expected element (\(element)) was not hittable after \(maxRetries) tries.")
+    }
 }
 
 extension ScreenObject {

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -257,6 +257,7 @@ public class BlockEditorScreen: ScreenObject {
     public func postAndViewEpilogue(action: postAction) throws -> EditorPublishEpilogueScreen {
         try post(action: action)
         waitAndTap(noticeViewButton)
+
         return try EditorPublishEpilogueScreen()
     }
 
@@ -264,6 +265,7 @@ public class BlockEditorScreen: ScreenObject {
         let postButton = app.buttons[action.rawValue]
         let postNowButton = app.buttons["\(action.rawValue) Now"]
         var tries = 0
+
         // This loop to check for Publish/Schedule Now Button is an attempt to confirm that the postButton.tap() call took effect.
         // The tests would fail sometimes in the pipeline with no apparent reason.
         repeat {
@@ -271,7 +273,10 @@ public class BlockEditorScreen: ScreenObject {
             tries += 1
         } while !postNowButton.waitForIsHittable(timeout: 3) && tries <= 3
 
-        try confirmPost(button: postNowButton, action: action)
+        postNowButton.tap()
+        guard action == .publish else { return }
+
+        dismissBloggingRemindersAlertIfNeeded()
     }
 
     @discardableResult
@@ -403,12 +408,6 @@ public class BlockEditorScreen: ScreenObject {
         chooseFromDeviceButton.tap()
 
         return try PHPickerScreen()
-    }
-
-    private func confirmPost(button: XCUIElement, action: postAction) throws {
-        button.tap()
-        guard action == .publish else { return }
-        dismissBloggingRemindersAlertIfNeeded()
     }
 
     public func dismissBloggingRemindersAlertIfNeeded() {


### PR DESCRIPTION
### Description
`testBasicPostPublishWithCategoryAndTag()` is one of the flakiest tests now, often failing with this error:
```
failed - Expected element ("View" Button) was not hittable after 10.0 seconds.
```

I have not seen this error when the test runs locally, so it seems to be a CI timing issue where the prompt has disappeared from the screen before the test could tap/interact with it. Removing the guard to check that the button is hittable. Instead, immediately attempt to tap the button. If the button does not exist, wait for 0.5 seconds before trying to tap again.

### Testing
CI should be 🟢 and `testBasicPostPublishWithCategoryAndTag()` should pass without a retry