### PR TITLE
Add Remote Feature Flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -21,6 +21,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case siteEditorMVP
     case contactSupportChatbot
     case jetpackSocialImprovements
+    case domainManagement
 
     var defaultValue: Bool {
         switch self {
@@ -62,6 +63,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .jetpackSocialImprovements:
             return AppConfiguration.isJetpack
+        case .domainManagement:
+            return false
         }
     }
 
@@ -106,6 +109,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "contact_support_chatbot"
         case .jetpackSocialImprovements:
             return "jetpack_social_improvements_v1"
+        case .domainManagement:
+            return "domain_management"
         }
     }
 
@@ -149,6 +154,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Contact Support via DocsBot"
         case .jetpackSocialImprovements:
             return "Jetpack Social Improvements v1"
+        case .domainManagement:
+            return "Domain Management"
         }
     }
 


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/21577

1. Install JP Go to Debug Settings
2. Validate if Domain Management feature flag is listed and is toggled off by default.

## Regression Notes
1. Potential unintended areas of impact
N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

4. What automated tests I added (or what prevented me from doing so)
N/A