### PR TITLE
Unified Menu: Custom feature announcement

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
@@ -131,7 +131,7 @@ private extension WhatIsNewScenePresenter {
     }
 
     private func shouldUseDashboardCustomView() -> Bool {
-        return self.store.appVersionName == "19.6"
+        return self.store.appVersionName == "23.3"
     }
 
     enum WhatIsNewStrings {

--- a/WordPress/Classes/ViewRelated/WhatsNew/Views/DashboardCustomAnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Views/DashboardCustomAnnouncementCell.swift
@@ -52,9 +52,9 @@ class DashboardCustomAnnouncementCell: AnnouncementTableViewCell {
         NSLayoutConstraint.activate([
             imageBackgroundView.heightAnchor.constraint(equalToConstant: Appearance.announcementImageHeight),
             imageBackgroundView.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
-            announcementImageView.heightAnchor.constraint(equalTo: imageBackgroundView.heightAnchor),
-            announcementImageView.centerXAnchor.constraint(equalTo: imageBackgroundView.centerXAnchor),
-            announcementImageView.centerYAnchor.constraint(equalTo: imageBackgroundView.centerYAnchor)
+            announcementImageView.topAnchor.constraint(equalTo: imageBackgroundView.topAnchor),
+            announcementImageView.bottomAnchor.constraint(equalTo: imageBackgroundView.bottomAnchor),
+            announcementImageView.centerXAnchor.constraint(equalTo: imageBackgroundView.centerXAnchor)
         ])
     }
 
@@ -67,7 +67,20 @@ class DashboardCustomAnnouncementCell: AnnouncementTableViewCell {
     func configure(feature: WordPressKit.Feature) {
 
         if let url = URL(string: feature.iconUrl) {
-            announcementImageView.af_setImage(withURL: url)
+            announcementImageView.af_setImage(withURL: url, completion: { [weak self] response in
+
+                guard let self,
+                      let width = response.value?.size.width,
+                      let height = response.value?.size.height else {
+                    return
+                }
+
+                let aspectRatio = width / height
+
+                NSLayoutConstraint.activate([
+                    self.announcementImageView.widthAnchor.constraint(equalTo: self.announcementImageView.heightAnchor, multiplier: aspectRatio)
+                ])
+            })
         }
         headingLabel.text = feature.subtitle
     }


### PR DESCRIPTION
Closes p1694774422290089/1694595084.422579-slack-C04SFL0RP51

## Description

- Preserves width : height aspect ratio when scaling images for custom feature announcements
- Configure 23.3 to use custom feature announcements

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/88544bf9-5e9b-4d8c-a819-870c46e992d8" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/937bba44-8228-42bb-9516-ec79a89caa57" width=200>
-- | --

## How to test

- On Xcode, change the Jetpack app version to `123.3`
- Change the app version in `WhatIsNewScenePresenter.swift L134` to `123.3`
- Run the Jetpack app
- Verify the custom feature announcement is displayed
- Run the WordPress app
- Verify no announcement is displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
