### PR TITLE
Me tab: Add extra check for email existence

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -13,11 +13,12 @@ extension WPTabBarController {
     @objc func configureMeTabImage(placeholderImage: UIImage) {
         meNavigationController?.tabBarItem.image = placeholderImage
 
-        guard let account = defaultAccount() else {
+        guard let account = defaultAccount(),
+              let email = account.email else {
             return
         }
 
-        ImageDownloader.shared.downloadGravatarImage(with: account.email) { [weak self] image in
+        ImageDownloader.shared.downloadGravatarImage(with: email) { [weak self] image in
             guard let image else {
                 return
             }


### PR DESCRIPTION
Fixes #21600

## RCA
The app crashes if the account email is nil. The crash exception type is EXC_BREAKPOINT (SIGTRAP), and points to L20 in  `WPTabBarController+MeTab.swift`:

```
ImageDownloader.shared.downloadGravatarImage(with: account.email) { [weak self] image in
```

Technically empty email addresses aren't allowed, but clearly there are some edge cases where the email is nil. Both Calypso and the iOS app throw an error if a user tries to enter an empty account email.

Calypso error | iOS error
-- | --
<img width="1022" alt="Screenshot 2023-09-19 at 12 11 26" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/de644bf4-13d4-43c3-82f3-e02cd7994069"> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/8f57064a-dd15-4106-ba05-6499b85e9569" width=200>

## Notes

I'm targeting 23.3 because I think this is an edge case. I'll continue monitoring the crash on Sentry.

## Testing steps

None - I'm not aware of a way to set the account email to nil

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

