### PR TITLE
Fix unresponsive compliance popover when fonts are enlarged 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 23.4
 -----
-
+* [*] Resolve the unresponsiveness of the compliance popover on iPhone SE devices when large fonts are enabled. [#21609]
 
 23.3
 -----

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
@@ -5,9 +5,6 @@ struct CompliancePopover: View {
         static let verticalScrollBuffer = Length.Padding.large
     }
 
-    var goToSettingsAction: (() -> ())?
-    var saveAction: (() -> ())?
-
     @StateObject
     var viewModel: CompliancePopoverViewModel
 
@@ -56,7 +53,7 @@ struct CompliancePopover: View {
 
     private var settingsButton: some View {
         Button(action: {
-            goToSettingsAction?()
+            self.viewModel.didTapSettings()
         }) {
             ZStack {
                 RoundedRectangle(cornerRadius: Length.Padding.single)
@@ -71,7 +68,7 @@ struct CompliancePopover: View {
 
     private var saveButton: some View {
         Button(action: {
-            saveAction?()
+            self.viewModel.didTapSave()
         }) {
             ZStack {
                 RoundedRectangle(cornerRadius: Length.Radius.minHeightButton)

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
@@ -7,28 +7,11 @@ struct CompliancePopover: View {
 
     var goToSettingsAction: (() -> ())?
     var saveAction: (() -> ())?
-    var shouldScroll: Bool = false
-    var screenHeight: CGFloat = 0
 
     @StateObject
     var viewModel: CompliancePopoverViewModel
 
     var body: some View {
-        if shouldScroll {
-            GeometryReader { reader in
-                ScrollView(showsIndicators: false) {
-                    contentVStack
-                    // Fixes the issue of scroll view content size not sizing properly.
-                    // Without this, on large dynamic fonts, the view is not properly scrollable.
-                    Spacer().frame(height: reader.size.height - screenHeight + Constants.verticalScrollBuffer)
-                }
-            }
-        } else {
-            contentVStack
-        }
-    }
-
-    private var contentVStack: some View {
         VStack(alignment: .leading, spacing: Length.Padding.double) {
             titleText
             subtitleText

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -25,7 +25,8 @@ final class CompliancePopoverViewController: UIViewController {
 
     init(viewModel: CompliancePopoverViewModel) {
         self.viewModel = viewModel
-        hostingController = UIHostingController(rootView: CompliancePopover(viewModel: self.viewModel))
+        let content = CompliancePopover(viewModel: viewModel)
+        self.hostingController = UIHostingController(rootView: content)
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -34,17 +35,11 @@ final class CompliancePopoverViewController: UIViewController {
     }
 
     // MARK: - View Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         self.addContentView()
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = true
-        hostingController.rootView.goToSettingsAction = {
-            self.viewModel.didTapSettings()
-        }
-        hostingController.rootView.saveAction = {
-            self.viewModel.didTapSave()
-        }
-        viewModel.didDisplayPopover()
+        self.viewModel.didDisplayPopover()
     }
 
     override func viewDidLayoutSubviews() {
@@ -79,6 +74,7 @@ final class CompliancePopoverViewController: UIViewController {
 }
 
 // MARK: - DrawerPresentable
+
 extension CompliancePopoverViewController: DrawerPresentable {
     var collapsedHeight: DrawerHeight {
         if traitCollection.verticalSizeClass == .compact {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -51,8 +51,9 @@ final class CompliancePopoverViewController: UIViewController {
         super.viewDidLayoutSubviews()
         // Calculate the size needed for the view to fit its content
         let targetSize = CGSize(width: view.bounds.width, height: 0)
+        self.contentView.frame = CGRect(origin: .zero, size: targetSize)
         let contentViewSize = contentView.systemLayoutSizeFitting(targetSize)
-        self.contentView.frame = .init(origin: .zero, size: contentViewSize)
+        self.contentView.frame.size = contentViewSize
 
         // Set the scrollView's content size to match the contentView's size
         //

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -23,6 +23,8 @@ final class CompliancePopoverViewController: UIViewController {
         return hostingController.view
     }
 
+    // MARK: - Init
+
     init(viewModel: CompliancePopoverViewModel) {
         self.viewModel = viewModel
         let content = CompliancePopover(viewModel: viewModel)

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -9,13 +9,19 @@ final class CompliancePopoverViewController: UIViewController {
     private let viewModel: CompliancePopoverViewModel
 
     // MARK: - Views
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.showsVerticalScrollIndicator = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     private let hostingController: UIHostingController<CompliancePopover>
 
     private var contentView: UIView {
         return hostingController.view
     }
-
-    private var bannerIntrinsicHeight: CGFloat = 0
 
     init(viewModel: CompliancePopoverViewModel) {
         self.viewModel = viewModel
@@ -43,19 +49,25 @@ final class CompliancePopoverViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        //
         let targetSize = CGSize(width: view.bounds.width, height: 0)
         let contentViewSize = contentView.systemLayoutSizeFitting(targetSize)
         self.contentView.frame = .init(origin: .zero, size: contentViewSize)
-        self.preferredContentSize = contentView.bounds.size
 
-        self.hostingController.rootView.screenHeight = self.view.frame.height
-        self.hostingController.rootView.shouldScroll = (contentViewSize.height + 100) > self.view.frame.height
+        //
+        self.scrollView.contentSize = contentViewSize
+
+        //
+        self.preferredContentSize = .init(width: contentViewSize.width, height: contentViewSize.height)
     }
 
     private func addContentView() {
+        self.view.addSubview(scrollView)
+        self.view.pinSubviewToAllEdges(scrollView)
         self.hostingController.willMove(toParent: self)
         self.addChild(hostingController)
-        self.view.addSubview(contentView)
+        self.contentView.translatesAutoresizingMaskIntoConstraints = true
+        self.scrollView.addSubview(contentView)
         self.hostingController.didMove(toParent: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -49,16 +49,21 @@ final class CompliancePopoverViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        //
+        // Calculate the size needed for the view to fit its content
         let targetSize = CGSize(width: view.bounds.width, height: 0)
         let contentViewSize = contentView.systemLayoutSizeFitting(targetSize)
         self.contentView.frame = .init(origin: .zero, size: contentViewSize)
 
+        // Set the scrollView's content size to match the contentView's size
         //
+        // Scroll is enabled / disabled automatically depending on whether the `contentSize` is bigger than the its size.
         self.scrollView.contentSize = contentViewSize
 
+        // Set the preferred content size for the view controller to match the contentView's size
         //
-        self.preferredContentSize = .init(width: contentViewSize.width, height: contentViewSize.height)
+        // This property should be updated when `DrawerPresentable.collapsedHeight` is `intrinsicHeight`.
+        // Because under the hood the `BottomSheetViewController` reads this property to layout its subviews.
+        self.preferredContentSize = contentViewSize
     }
 
     private func addContentView() {


### PR DESCRIPTION
Fixes #21555 

This PR resolves an issue where the compliance popover is not responsive on iPhone SE devices with large fonts turned on.

## Testing Steps

I was only able to reproduce this issue on iPhone SE (or any smaller screen device). So I recommend testing on iPhone SE Simulator or Device.

1. Install Jetpack & Login
2. The popover should be displayed and the buttons should be interactable.
3. Delete the app and change the system font size to something large.
4. Install Jetpack & Login again
5. Verify if the popover looks correct and scroll is enabled if the content is large enough.

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
