### PR TITLE
Fix quick start not terminating on hide this issue

### DIFF
--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.h
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.h
@@ -10,9 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Displays an action sheet with an option to remove current quickstart tours from the provided blog.
 /// Displayed as an action sheet on iPhone and as a popover on iPad
 /// @param blog Blog to remove quickstart from
-/// @param sourceView View used as sourceView for the sheet's popoverPresentationController
-/// @param sourceRect rect used as sourceRect for the sheet's popoverPresentationController
-- (void)removeQuickStartFromBlog:(Blog *)blog sourceView:(UIView *)sourceView sourceRect:(CGRect)sourceRect;
+- (void)removeQuickStartFromBlog:(Blog *)blog;
 
 @end
 

--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
@@ -10,27 +10,18 @@
     [NoticesDispatch lock];
     NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
     NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
-    NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
     NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
 
-    UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
-    [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull __unused action) {
-        [WPAnalytics trackQuickStartStat:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped blog: blog];
-        [NoticesDispatch unlock];
-    }];
-    [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull __unused action) {
+    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleActionSheet];
+    removeSheet.popoverPresentationController.sourceView = sourceView;
+    removeSheet.popoverPresentationController.sourceRect = sourceRect;
+    [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull __unused action) {
         [WPAnalytics trackQuickStartStat:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped blog: blog];
         [[QuickStartTourGuide shared] removeFrom:blog];
         [NoticesDispatch unlock];
     }];
-
-    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
-    removeSheet.popoverPresentationController.sourceView = sourceView;
-    removeSheet.popoverPresentationController.sourceRect = sourceRect;
-    [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull __unused action) {
-        [self presentViewController:removeConfirmation animated:YES completion:nil];
-    }];
     [removeSheet addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull __unused action) {
+        [WPAnalytics trackQuickStartStat:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped blog: blog];
         [NoticesDispatch unlock];
     }];
 

--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
@@ -5,16 +5,15 @@
 
 @implementation UIViewController (RemoveQuickStart)
 
-- (void)removeQuickStartFromBlog:(Blog *)blog sourceView:(UIView *)sourceView sourceRect:(CGRect)sourceRect
+- (void)removeQuickStartFromBlog:(Blog *)blog
 {
     [NoticesDispatch lock];
     NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
     NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
     NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
 
-    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleActionSheet];
-    removeSheet.popoverPresentationController.sourceView = sourceView;
-    removeSheet.popoverPresentationController.sourceRect = sourceRect;
+    UIAlertControllerStyle alertStyle = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) ? UIAlertControllerStyleAlert : UIAlertControllerStyleActionSheet;
+    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:alertStyle];
     [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull __unused action) {
         [WPAnalytics trackQuickStartStat:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped blog: blog];
         [[QuickStartTourGuide shared] removeFrom:blog];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
@@ -78,7 +78,7 @@ final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
         }
         WPAnalytics.track(.dashboardCardItemTapped, properties: ["type": DashboardCard.personalize.rawValue], blog: blog)
         let viewController = UIHostingController(rootView: NavigationView {
-            BlogDashboardPersonalizationView(viewModel: .init(blog: blog, service: .init(siteID: siteID), quickStartType: blog.quickStartType))
+            BlogDashboardPersonalizationView(viewModel: .init(blog: blog, service: .init(siteID: siteID)))
         }.navigationViewStyle(.stack)) // .stack is required for iPad
         if UIDevice.isPad() {
             viewController.modalPresentationStyle = .formSheet

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -72,7 +72,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                       let blog = self.blog else {
                     return
                 }
-                viewController.removeQuickStart(from: blog, sourceView: self.cardFrameView, sourceRect: sourceRect)
+                viewController.removeQuickStart(from: blog)
             }
         ], card: .quickStart)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -65,12 +65,8 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
     }
 
     private func configureOnEllipsisButtonTap(sourceRect: CGRect, blog: Blog) {
-        if FeatureFlag.personalizeHomeTab.enabled {
-            cardFrameView.addMoreMenu(items: [
-                BlogDashboardHelpers.makeHideCardAction(for: .quickStart, blog: blog)
-            ], card: .quickStart)
-        } else {
-            cardFrameView.onEllipsisButtonTap = { [weak self] in
+        cardFrameView.addMoreMenu(items: [
+            BlogDashboardHelpers.makeHideCardAction { [weak self] in
                 guard let self = self,
                       let viewController = self.viewController,
                       let blog = self.blog else {
@@ -78,7 +74,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                 }
                 viewController.removeQuickStart(from: blog, sourceView: self.cardFrameView, sourceRect: sourceRect)
             }
-        }
+        ], card: .quickStart)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -158,7 +158,6 @@ enum DashboardCard: String, CaseIterable {
         .scheduledPosts,
         .blaze,
         .prompts,
-        .quickStart,
         .pages,
         .activityLog
     ]

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -2,15 +2,20 @@ import Foundation
 
 struct BlogDashboardHelpers {
     static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
+        makeHideCardAction {
+            BlogDashboardAnalytics.trackHideTapped(for: card)
+            BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
+                .setEnabled(false, for: card)
+        }
+    }
+
+    static func makeHideCardAction(_ handler: @escaping () -> Void) -> UIAction {
         UIAction(
             title: Strings.hideThis,
             image: UIImage(systemName: "minus.circle"),
             attributes: [.destructive],
-            handler: { _ in
-                BlogDashboardAnalytics.trackHideTapped(for: card)
-                BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-                    .setEnabled(false, for: card)
-            })
+            handler: { _ in handler() }
+        )
     }
 
     private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -114,6 +114,9 @@ private func makeKey(for card: DashboardCard) -> String? {
     case .pages:
         return "pages-card-enabled-site-settings"
     case .quickStart:
+        // The "Quick Start" cell used to use `BlogDashboardPersonalizationService`.
+        // It no longer does, but it's important to keep the flag around for
+        // users that hidden it using this flag.
         return "quick-start-card-enabled-site-settings"
     case .jetpackBadge, .jetpackInstall, .jetpackSocial, .failure, .ghost, .personalize, .empty:
         return nil

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.swift
@@ -1,7 +1,6 @@
 import Gridicons
 
 class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
-    typealias EllipsisCallback = (BlogDetailsSectionHeaderView) -> Void
     @IBOutlet private var titleLabel: UILabel?
 
     @objc @IBOutlet private(set) var ellipsisButton: UIButton? {
@@ -16,7 +15,7 @@ class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
         }
     }
 
-    @objc var ellipsisButtonDidTouch: EllipsisCallback?
+    @objc var ellipsisButtonDidTouch: (() -> Void)?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -24,6 +23,6 @@ class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
     }
 
     @IBAction func ellipsisTapped() {
-        ellipsisButtonDidTouch?(self)
+        ellipsisButtonDidTouch?()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1694,10 +1694,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     BlogDetailsSectionHeaderView *view = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
     [view setTitle:title];
-    view.ellipsisButtonDidTouch = ^(BlogDetailsSectionHeaderView *header) {
-        [weakSelf removeQuickStartFromBlog:weakSelf.blog
-                                sourceView:header
-                                sourceRect:header.ellipsisButton.frame];
+    view.ellipsisButtonDidTouch = ^{
+        [weakSelf removeQuickStartFromBlog:weakSelf.blog];
     };
     return view;
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationViewModel.swift
@@ -4,18 +4,18 @@ final class BlogDashboardPersonalizationViewModel: ObservableObject {
     let quickActions: [DashboardPersonalizationQuickActionViewModel]
     let cards: [BlogDashboardPersonalizationCardCellViewModel]
 
-    init(blog: Blog, service: BlogDashboardPersonalizationService, quickStartType: QuickStartType) {
+    init(blog: Blog, service: BlogDashboardPersonalizationService) {
         self.quickActions = DashboardQuickAction.personalizableActions
             .filter { $0.isEligible(for: blog) }
             .map {
                 DashboardPersonalizationQuickActionViewModel(action: $0, service: service)
             }
-        self.cards = DashboardCard.personalizableCards.compactMap {
-            if $0 == .quickStart && quickStartType == .undefined {
-                return nil
-            }
-            let title = $0.getLocalizedTitle(quickStartType: quickStartType)
-            return BlogDashboardPersonalizationCardCellViewModel(card: $0, title: title, service: service)
+        self.cards = DashboardCard.personalizableCards.map {
+            BlogDashboardPersonalizationCardCellViewModel(
+                card: $0,
+                title: $0.getLocalizedTitle(),
+                service: service
+            )
         }
     }
 }
@@ -67,7 +67,7 @@ final class BlogDashboardPersonalizationCardCellViewModel: ObservableObject, Ide
 }
 
 private extension DashboardCard {
-    func getLocalizedTitle(quickStartType: QuickStartType) -> String {
+    func getLocalizedTitle() -> String {
         switch self {
         case .prompts:
             return NSLocalizedString("personalizeHome.dashboardCard.prompts", value: "Blogging prompts", comment: "Card title for the pesonalization menu")
@@ -83,17 +83,7 @@ private extension DashboardCard {
             return NSLocalizedString("personalizeHome.dashboardCard.activityLog", value: "Recent activity", comment: "Card title for the pesonalization menu")
         case .pages:
             return NSLocalizedString("personalizeHome.dashboardCard.pages", value: "Pages", comment: "Card title for the pesonalization menu")
-        case .quickStart:
-            switch quickStartType {
-            case .undefined:
-                assertionFailure(".quickStart card should only appear in the personalization menu if there are remaining steps")
-                return ""
-            case .existingSite:
-                return NSLocalizedString("personalizeHome.dashboardCard.getToKnowTheApp", value: "Get to know the app", comment: "Card title for the pesonalization menu")
-            case .newSite:
-                return NSLocalizedString("personalizeHome.dashboardCard.nextSteps", value: "Next steps", comment: "Card title for the pesonalization menu")
-            }
-        case .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .freeToPaidPlansDashboardCard, .domainRegistration, .jetpackSocial, .googleDomains:
+        case .quickStart, .ghost, .failure, .personalize, .jetpackBadge, .jetpackInstall, .empty, .freeToPaidPlansDashboardCard, .domainRegistration, .jetpackSocial, .googleDomains:
             assertionFailure("\(self) card should not appear in the personalization menus")
             return "" // These cards don't appear in the personalization menus
         }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationViewModelTests.swift
@@ -14,7 +14,7 @@ final class BlogDashboardPersonalizationViewModelTests: CoreDataTestCase {
         super.setUp()
 
         blog = BlogBuilder(contextManager.mainContext).build()
-        viewModel = BlogDashboardPersonalizationViewModel(blog: blog, service: service, quickStartType: .undefined)
+        viewModel = BlogDashboardPersonalizationViewModel(blog: blog, service: service)
     }
 
     func testThatCardStateIsToggled() throws {
@@ -37,14 +37,6 @@ final class BlogDashboardPersonalizationViewModelTests: CoreDataTestCase {
         for card in viewModel.cards {
             XCTAssertTrue(!card.title.isEmpty)
         }
-    }
-
-    func testThatQuickStartCardsIsNotDisplayedWhenTourIsActive() {
-        // Given
-        viewModel = BlogDashboardPersonalizationViewModel(blog: blog, service: service, quickStartType: .newSite)
-
-        // Then
-        XCTAssertTrue(viewModel.cards.contains(where: { $0.id == .quickStart }))
     }
 
     func testThatQuickStartCardsIsNotDisplayedWhenNoTourIsActive() {


### PR DESCRIPTION
Fixes #21603 and removes double-confirmation on "Hide this" ([before.mp4](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/45e0b2e5-3770-4049-8719-cb72746ba75e), [after.mp4](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/9e402cca-7ea1-43aa-8e60-1adf65f3e352)).

## To test:

> [!IMPORTANT]
> Make sure to test on both iPad and iPhone

### Test Case 1

- Install the current production version
- Start Quick Start
- Tap “Hide This” to hide Quick Start
- Upgrade the app to the version from the branch
- Verify that Quick Start cell is still not visible

### Test Case 2

- Create a new site and start one of the Quick Start tours (or enable it from the debug menu)
- Open “Personalize Home Tab” screen
- Verify that the Quick Start tour card is not present on the list

### Test Case 3

- Complete the steps from the [defect](https://github.com/wordpress-mobile/WordPress-iOS/issues/21603)

## Regression Notes
1. Potential unintended areas of impact: Personalization screen and Quick Start tours
2. What I did to test those areas of impact (or what existing automated tests I relies on): manual
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
