### PR TITLE
Unified Menu: Disable announcement for iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
@@ -11,11 +11,19 @@ class WhatIsNewScenePresenter: ScenePresenter {
     private let store: AnnouncementsStore
 
     private func shouldPresentWhatIsNew(on viewController: UIViewController) -> Bool {
-        viewController is AppSettingsViewController ||
+        if UIDevice.isPad() && versionsDisabledForIpad.contains(self.store.appVersionName) {
+            return false
+        }
+
+        return viewController is AppSettingsViewController ||
             (AppRatingUtility.shared.didUpgradeVersion &&
-                UserDefaults.standard.announcementsVersionDisplayed != Bundle.main.shortVersionString() &&
-                self.store.announcements.first?.isLocalized == true)
+             UserDefaults.standard.announcementsVersionDisplayed != Bundle.main.shortVersionString() &&
+             self.store.announcements.first?.isLocalized == true)
     }
+
+    private var versionsDisabledForIpad = [
+        "23.3"
+    ]
 
     var versionHasAnnouncements: Bool {
         store.versionHasAnnouncements


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/WordPress-iOS/pull/21605#issuecomment-1725884647

## Description
- Disables the 23.3 feature announcement for iPad

## Notes
- Currently there isn't a way to configure device types on the mobile announce tool. Sine the 23.3 feature announcement should only be displayed on iPhone, we're hardcoding the version

## How to test
- Comment out line 19 in `WhatIsNewScenePresenter.swift`
- Do a fresh install of the Jetpack app on iPhone
- Verify the custom feature announcement is displayed
- D a fresh install of the Jetpack app on iPad
- Verify no announcement is displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
