### PR TITLE
Fix crash when configuring gravatar icon when account email is nil

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesViewModel.swift
@@ -14,8 +14,8 @@ struct NoSitesViewModel {
     init(appUIType: RootViewCoordinator.AppUIType?, account: WPAccount?) {
         self.appUIType = appUIType
         self.displayName = account?.displayName ?? "-"
-        if let account {
-            self.gravatarURL = Gravatar.gravatarUrl(for: account.email)
+        if let email = account?.email {
+            self.gravatarURL = Gravatar.gravatarUrl(for: email)
         } else {
             self.gravatarURL = nil
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -13,11 +13,12 @@ extension WPTabBarController {
     @objc func configureMeTabImage(placeholderImage: UIImage) {
         meNavigationController?.tabBarItem.image = placeholderImage
 
-        guard let account = defaultAccount() else {
+        guard let account = defaultAccount(),
+              let email = account.email else {
             return
         }
 
-        ImageDownloader.shared.downloadGravatarImage(with: account.email) { [weak self] image in
+        ImageDownloader.shared.downloadGravatarImage(with: email) { [weak self] image in
             guard let image else {
                 return
             }


### PR DESCRIPTION
Fixes #21600 

## Description
- Cherry-pick changes from https://github.com/wordpress-mobile/WordPress-iOS/pull/21607, which was merged into `release/23.3`
- Add another check for NoSitesView

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.