### PR TITLE
[UI Tests] Add support to disable AutoFill Passwords on iOS 17

### DIFF
--- a/WordPress/UITestsFoundation/TestObserver.swift
+++ b/WordPress/UITestsFoundation/TestObserver.swift
@@ -42,7 +42,11 @@ class TestObserver: NSObject, XCTestObservation {
         guard passwordOptions.waitForIsHittable() else { return false }
         passwordOptions.tap()
 
-        let autoFillPasswordsSwitch = settings.switches["AutoFill Passwords"]
+        var autoFillPasswordsText = "AutoFill Passwords"
+        if #available(iOS 17, *) {
+            autoFillPasswordsText += " and Passkeys"
+        }
+        let autoFillPasswordsSwitch = settings.switches[autoFillPasswordsText]
         guard autoFillPasswordsSwitch.waitForIsHittable() else { return false }
 
         if autoFillPasswordsSwitch.value as? String == "1" {


### PR DESCRIPTION
`AutoFill Passwords` switch changed in iOS/iPadOS 17 to `AutoFill Passwords and Passkeys`. This PR add support to iOS/iPadOS 17 by  selectin the appropriate string based on OS version.

| iOS/iPadOS 16 | iOS/iPadOS 17 |
| - | - |
| <img width="374" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/568a974a-4d37-4e61-8505-0b740dc37850"> | <img width="374" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/5574bca4-a478-4815-8d99-af45ff1f1487"> |
| <img width="499" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/e2254c6d-1654-4b99-bcf2-8fd728479ca1"> | <img width="523" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/2e43b8db-0815-418b-9aae-cf48bc75e8bb"> |

To Test:
If CI is 🟢, the changes in this PR didn't impact iOS/iPadOS 16.
You can also run on Xcode 15 - iOS/iPadOS 17 locally.


