### PR TITLE
Remove heic support from media exporter

### DIFF
--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -24,11 +24,11 @@ final class ItemProviderMediaExporter: MediaExporter {
             if let imageOptions {
                 exporter.options = imageOptions
             }
-            // If image format is not supported, switch to `.heic`.
+            // If image format is not supported, switch to `.jpeg`.
             if exporter.options.exportImageType == nil,
                let type = provider.registeredTypeIdentifiers.first,
                !ItemProviderMediaExporter.supportedImageTypes.contains(type) {
-                exporter.options.exportImageType = UTType.heic.identifier
+                exporter.options.exportImageType = UTType.jpeg.identifier
             }
             let exportProgress = exporter.export(onCompletion: onCompletion, onError: onError)
             progress.addChild(exportProgress, withPendingUnitCount: MediaExportProgressUnits.halfDone)
@@ -89,15 +89,15 @@ final class ItemProviderMediaExporter: MediaExporter {
     ///
     /// One notable format missing from the list is `.webp`, which is not supported
     /// by `CGImageDestinationCreateWithURL` and, in turn, `MediaImageExporter`.
+    /// If the format is not supported, the app falls back to `.jpeg`.
     ///
-    /// If the format is not supported, the app fallbacks to `.heic` which is
-    /// similar to `.webp`: more efficient than traditional formats and supports
-    /// opacity, unlike `.jpeg`.
+    /// Despire wp.com supporting `.heic`, self-hosted sites don't (yet),
+    /// so, just to be safe, the app converts them to `.jpeg`. This should be
+    /// revisited in the future as hopefully `.heic` support is added.
     private static let supportedImageTypes: Set<String> = Set([
         UTType.png,
         UTType.jpeg,
         UTType.gif,
-        UTType.heic,
         UTType.svg
     ].map(\.identifier))
 


### PR DESCRIPTION
Fixes #21617

## To test:

- Create a self-hosted site (or use an existing one)
- Open the app and go to Media
- Upload a photo taken on an iPhone/iPad (has to be in `.heic` format)
- Verify that the photo got uploaded
- Open the WP admin page and verify that the photo is [displayed](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0d25648b-c154-4a65-99e7-8cd026ded430) and has `.jpeg` format

The app uses the same logic for uploads in all areas of the app, but it may also be worth checking other screens, at least the editor.

## Regression Notes
1. Potential unintended areas of impact: Media uploads
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
