### PR TITLE
Jetpack Social: Open WordPress connections page for Mastodon

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -21,6 +21,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case siteEditorMVP
     case contactSupportChatbot
     case jetpackSocialImprovements
+    case jetpackSocialMastodonPopup
 
     var defaultValue: Bool {
         switch self {
@@ -62,6 +63,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .jetpackSocialImprovements:
             return AppConfiguration.isJetpack
+        case .jetpackSocialMastodonPopup:
+            return true
         }
     }
 
@@ -106,6 +109,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "contact_support_chatbot"
         case .jetpackSocialImprovements:
             return "jetpack_social_improvements_v1"
+        case .jetpackSocialMastodonPopup:
+            return "jp_social_mastodon_connect_via_web"
         }
     }
 
@@ -149,6 +154,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Contact Support via DocsBot"
         case .jetpackSocialImprovements:
             return "Jetpack Social Improvements v1"
+        case .jetpackSocialMastodonPopup:
+            return "Jetpack Social Mastodon Popup"
         }
     }
 


### PR DESCRIPTION
Fixes #21624 
Ref: pcdRpT-3QQ-p2#comment-6379

## Description

When you attempt to set up a Mastodon social connection, you receive an error due to a missing `instance` variable. This PR introduces a pop-up message and directs the user to their WordPress connections page in an external browser.

## Demo

https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/b7cdf49c-85bd-40b6-b4fb-30566990357b

## Testing

> **Note**
> When the site is launched to the external browser, the user will not be logged in automatically.

To test:

- Launch Jetpack and login
- Select a blog that allows social connections
- Tap on `...` `More`
- Tap on `Social`
- Tap on `Mastodon`
- Tap on `Connect`
- 🔎 **Verify** a pop-up message appears with the following text:
  - `You can connect your Mastodon account on the WordPress.com website. When you're done, return to the app to change your Sharing settings.`
- Tap on `Go to web`
- 🔎 **Verify** an external browser launches to: `https://wordpress.com/marketing/connections/<hostname>`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
