### PR TITLE
Plans in Site Creation: Feature Flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -20,6 +20,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case contactSupportChatbot
     case jetpackSocialImprovements
     case domainManagement
+    case plansInSiteCreation
 
     var defaultValue: Bool {
         switch self {
@@ -58,6 +59,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .jetpackSocialImprovements:
             return AppConfiguration.isJetpack
         case .domainManagement:
+            return false
+        case .plansInSiteCreation:
             return false
         }
     }
@@ -101,6 +104,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "jetpack_social_improvements_v1"
         case .domainManagement:
             return "domain_management"
+        case .plansInSiteCreation:
+            return "plans_in_site_creation"
         }
     }
 
@@ -142,6 +147,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Jetpack Social Improvements v1"
         case .domainManagement:
             return "Domain Management"
+        case .plansInSiteCreation:
+            return "Plans in Site Creation"
         }
     }
 


### PR DESCRIPTION
Fixes #21616

To test:

1. Open Jetpack app
2. Me
3. App Settings
4. Debug
5. Feature Flags
6. Confirm Plans in Site Creation feature flag exists

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
