### PR TITLE
Fix the navigation to Privacy Settings screen from the Compliance Popover

### DIFF
--- a/WordPress/Classes/System/RootViewPresenter+AppSettingsNavigation.swift
+++ b/WordPress/Classes/System/RootViewPresenter+AppSettingsNavigation.swift
@@ -20,9 +20,11 @@ extension RootViewPresenter {
             guard let self else {
                 return
             }
-            self.showMeScene(animated: context.animated) { meViewController in
+            CATransaction.perform {
+                self.showMeScreen()
                 self.popMeTabToRoot()
-                completion(meViewController)
+            } completion: {
+                completion(self.meViewController)
             }
         }
     }

--- a/WordPress/Classes/System/RootViewPresenter+AppSettingsNavigation.swift
+++ b/WordPress/Classes/System/RootViewPresenter+AppSettingsNavigation.swift
@@ -22,7 +22,6 @@ extension RootViewPresenter {
             }
             CATransaction.perform {
                 self.showMeScreen()
-                self.popMeTabToRoot()
             } completion: {
                 completion(self.meViewController)
             }
@@ -33,11 +32,7 @@ extension RootViewPresenter {
     private func navigateToAppSettings() -> ViewControllerNavigationAction {
         return .init { context, completion in
             let me: MeViewController = try context.fromViewController()
-            CATransaction.perform {
-                me.navigateToAppSettings()
-            } completion: {
-                completion(self.appSettingsViewController(from: me))
-            }
+            me.navigateToAppSettings(completion: completion)
         }
     }
 
@@ -49,24 +44,6 @@ extension RootViewPresenter {
                 completion(privacySettings)
             }
         }
-    }
-
-    // MARK: - Helpers
-
-    // This code is error-prone and could be avoided if `MeViewController.navigateToAppSettings` returns the `AppSettingsViewController` instance.
-    private func appSettingsViewController(from meViewController: UIViewController?) -> AppSettingsViewController? {
-        guard let meViewController else {
-            return nil
-        }
-        return meViewController.navigationController?.topViewController as? AppSettingsViewController ?? { () -> AppSettingsViewController? in
-            guard let viewControllers = meViewController.splitViewController?.viewControllers,
-                  viewControllers.count >= 1,
-                  let appSettings = (viewControllers[1] as? UINavigationController)?.topViewController
-            else {
-                return nil
-            }
-            return appSettings as? AppSettingsViewController
-        }()
     }
 }
 

--- a/WordPress/Classes/System/RootViewPresenter+AppSettingsNavigation.swift
+++ b/WordPress/Classes/System/RootViewPresenter+AppSettingsNavigation.swift
@@ -36,7 +36,7 @@ extension RootViewPresenter {
             CATransaction.perform {
                 me.navigateToAppSettings()
             } completion: {
-                completion(me.navigationController?.topViewController)
+                completion(self.appSettingsViewController(from: me))
             }
         }
     }
@@ -49,6 +49,24 @@ extension RootViewPresenter {
                 completion(privacySettings)
             }
         }
+    }
+
+    // MARK: - Helpers
+
+    // This code is error-prone and could be avoided if `MeViewController.navigateToAppSettings` returns the `AppSettingsViewController` instance.
+    private func appSettingsViewController(from meViewController: UIViewController?) -> AppSettingsViewController? {
+        guard let meViewController else {
+            return nil
+        }
+        return meViewController.navigationController?.topViewController as? AppSettingsViewController ?? { () -> AppSettingsViewController? in
+            guard let viewControllers = meViewController.splitViewController?.viewControllers,
+                  viewControllers.count >= 1,
+                  let appSettings = (viewControllers[1] as? UINavigationController)?.topViewController
+            else {
+                return nil
+            }
+            return appSettings as? AppSettingsViewController
+        }()
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21619

## Description

This PR resolves an issue where the navigation from the "Compliance Popover" to "Me > App Settings > Privacy Settings" was broken.

| iPhone | iPad | 
| ------- | ---- |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/f6c85197-6d53-425c-b915-c1a545b78b46" /> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/a34ac6cf-c1f2-4c68-a4df-0e72ef4a6a4a" /> |

## Test Instructions

You can force display the Compliance Popover by making the following code changes:
1. Open `CompliancePopoverCoordinator.swift` file.
2. Force `shouldShowPrivacyBanner` method to return `true`.
3. Comment this line `!defaults.didShowCompliancePopup` in `presentIfNeeded` method.

### Simplified + iPad
- Delete the Jetpack app and freshly install WordPress (need to delete Jetpack, since Jetpack takes precedence over WordPress for deep linking)
- Go to the debug menu and enable the phase four feature flag (this enables the simplified app UI type)
- Head to back to "My Site".
- Wait for the Compliance Popover to appear.
- Tap "Go to Settings".
- **Expect** this navigation "Me > App Settings > Privacy Settings" to occur.

### Simplified + iPhone
- Delete the Jetpack app and freshly install WordPress (need to delete Jetpack, since Jetpack takes precedence over WordPress for deep linking)
- Go to the debug menu and enable the phase four feature flag (this enables the simplified app UI type)
- Head to back to "My Site".
- Wait for the Compliance Popover to appear.
- Tap "Go to Settings".
- **Expect** this navigation "Me > App Settings > Privacy Settings" to occur.

### Normal (or Static Screens) + iPad
- Freshly install Jetpack
- Wait for the Compliance Popover to appear.
- Tap "Go to Settings".
- **Expect** this navigation "Me > App Settings > Privacy Settings" to occur.

### Normal (or Static Screens) + iPhone
- Freshly install Jetpack
- Wait for the Compliance Popover to appear.
- Tap "Go to Settings".
- **Expect** this navigation "Me > App Settings > Privacy Settings" to occur.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
