### PR TITLE
Catch crash when creating media

### DIFF
--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -79,7 +79,9 @@ class MediaImportService: NSObject {
     ) -> (Media, Progress)? {
         assert(Thread.isMainThread, "\(#function) can only be called from the main thread")
 
-        guard let media = try? createMedia(with: exportable, blogObjectID: blog.objectID, postObjectID: post?.objectID, in: coreDataStack.mainContext) else {
+        let blogObjectID = TaggedManagedObjectID(blog)
+        let postObjectID = post.map { TaggedManagedObjectID($0) }
+        guard let media = try? createMedia(with: exportable, blogObjectID: blogObjectID, postObjectID: postObjectID, in: coreDataStack.mainContext) else {
             return nil
         }
 
@@ -132,8 +134,10 @@ class MediaImportService: NSObject {
         completion: @escaping (Media?, Error?) -> Void
     ) -> Progress {
         let createProgress = Progress.discreteProgress(totalUnitCount: 1)
+        let blogObjectID = TaggedManagedObjectID(blog)
+        let postObjectID = post.map { TaggedManagedObjectID($0) }
         coreDataStack.performAndSave({ context in
-            let media = try self.createMedia(with: exportable, blogObjectID: blog.objectID, postObjectID: post?.objectID, in: context)
+            let media = try self.createMedia(with: exportable, blogObjectID: blogObjectID, postObjectID: postObjectID, in: context)
             try context.obtainPermanentIDs(for: [media])
             return media.objectID
         }, completion: { (result: Result<NSManagedObjectID, Error>) in
@@ -164,9 +168,9 @@ class MediaImportService: NSObject {
         return createProgress
     }
 
-    private func createMedia(with exportable: ExportableAsset, blogObjectID: NSManagedObjectID, postObjectID: NSManagedObjectID?, in context: NSManagedObjectContext) throws -> Media {
-        let blogInContext = try context.existingObject(with: blogObjectID) as! Blog
-        let postInContext = try postObjectID.flatMap(context.existingObject(with:)) as? AbstractPost
+    private func createMedia(with exportable: ExportableAsset, blogObjectID: TaggedManagedObjectID<Blog>, postObjectID: TaggedManagedObjectID<AbstractPost>?, in context: NSManagedObjectContext) throws -> Media {
+        let blogInContext = try context.existingObject(with: blogObjectID)
+        let postInContext = try postObjectID.flatMap(context.existingObject(with:))
 
         let media = postInContext.flatMap(Media.makeMedia(post:)) ?? Media.makeMedia(blog: blogInContext)
         media.mediaType = exportable.assetMediaType


### PR DESCRIPTION
Fixes #21300

It should catch the crash, similar to how it was done in other places:

```
// Catch an Objective-C `NSInvalidArgumentException` exception from `existingObject(with:)`.
// See https://github.com/wordpress-mobile/WordPress-iOS/issues/20630
```

I haven't gotten to the bottom of this. This is likely a concurrency issue, but at least now it won't crash and the user will be able to retry.

## To test:

There is no way to reproduce it.

## Regression Notes
1. Potential unintended areas of impact: media upload
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
