### PR TITLE
test: Mitigate media block test flakiness

### DIFF
--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -102,11 +102,6 @@ class EditorGutenbergTests: XCTestCase {
     func testAddMediaBlocks() throws {
         try BlockEditorScreen()
             .addImage()
-            .verifyImageBlockDisplayed()
-
-        try XCTSkipIf(!XCUIDevice.isPad, "Test currently fails on iPhone in CI for add video and audio from URL - Tapping on the coordinate location results in a blank screen. Skipping rest of test on iPhone while investigation is in progress")
-
-        try BlockEditorScreen()
             .addVideoFromUrl(urlPath: videoUrlPath)
             .addAudioFromUrl(urlPath: audioUrlPath)
             .verifyMediaBlocksDisplayed()

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -193,13 +193,19 @@ public class BlockEditorScreen: ScreenObject {
 
     @discardableResult
     public func verifyMediaBlocksDisplayed() -> Self {
-        let imagePredicate = NSPredicate(format: "label == 'Image caption. Empty'")
-        let videoPredicate = NSPredicate(format: "label == 'Video caption. Empty'")
-        let audioPredicate = NSPredicate(format: "label == 'Audio Player'")
+        let imageBlock = NSPredicate(format: "label == 'Image Block. Row 1'")
+        let imageCaption = NSPredicate(format: "label == 'Image caption. Empty'")
+        let videoBlock = NSPredicate(format: "label == 'Video Block. Row 2'")
+        let videoCaption = NSPredicate(format: "label == 'Video caption. Empty'")
+        let audioBlock = NSPredicate(format: "label == 'Audio Block. Row 3'")
+        let audioPlayer = NSPredicate(format: "label == 'Audio Player'")
 
-        XCTAssertTrue(app.buttons.containing(imagePredicate).firstMatch.exists)
-        XCTAssertTrue(app.buttons.containing(videoPredicate).firstMatch.exists)
-        XCTAssertTrue(app.buttons.containing(audioPredicate).firstMatch.exists)
+        XCTAssertTrue(app.buttons.containing(imageBlock).firstMatch.exists)
+        XCTAssertTrue(app.buttons.containing(imageCaption).firstMatch.exists)
+        XCTAssertTrue(app.buttons.containing(videoBlock).firstMatch.exists)
+        XCTAssertTrue(app.buttons.containing(audioBlock).firstMatch.exists)
+        XCTAssertTrue(app.buttons.containing(videoCaption).firstMatch.exists)
+        XCTAssertTrue(app.buttons.containing(audioPlayer).firstMatch.exists)
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -202,9 +202,9 @@ public class BlockEditorScreen: ScreenObject {
 
     @discardableResult
     public func verifyMediaBlocksDisplayed() -> Self {
-        let imagePredicate = NSPredicate(format: "label == 'Image Block. Row 1'")
-        let videoPredicate = NSPredicate(format: "label == 'Video Block. Row 2'")
-        let audioPredicate = NSPredicate(format: "label == 'Audio Block. Row 3'")
+        let imagePredicate = NSPredicate(format: "label == 'Image caption. Empty'")
+        let videoPredicate = NSPredicate(format: "label == 'Video caption. Empty'")
+        let audioPredicate = NSPredicate(format: "label == 'Audio Player'")
 
         XCTAssertTrue(app.buttons.containing(imagePredicate).firstMatch.exists)
         XCTAssertTrue(app.buttons.containing(videoPredicate).firstMatch.exists)

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -191,15 +191,6 @@ public class BlockEditorScreen: ScreenObject {
         tapTopOfScreen()
     }
 
-    // Can be removed once `testAddMediaBlocks()` test is fixed on iPhone
-    @discardableResult
-    public func verifyImageBlockDisplayed() -> Self {
-        let imagePredicate = NSPredicate(format: "label == 'Image Block. Row 1'")
-        XCTAssertTrue(app.buttons.containing(imagePredicate).firstMatch.waitForExistence(timeout: 5))
-
-        return self
-    }
-
     @discardableResult
     public func verifyMediaBlocksDisplayed() -> Self {
         let imagePredicate = NSPredicate(format: "label == 'Image caption. Empty'")

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -186,7 +186,7 @@ public class BlockEditorScreen: ScreenObject {
     private func addMediaBlockFromUrl(blockType: String, UrlPath: String) {
         addBlock(blockType)
         insertFromUrlButton.tap()
-        app.textFields.element.typeText(UrlPath)
+        type(text: UrlPath, in: app.textFields.element)
         // to dismiss media block URL prompt
         tapTopOfScreen()
     }


### PR DESCRIPTION
Relates to https://github.com/wordpress-mobile/gutenberg-mobile/issues/6233. Partially reverts https://github.com/wordpress-mobile/WordPress-iOS/pull/21582. 

Mitigate media block test flakiness by pasting URLs rather than typing them. The
rapid rate at which XCTests type resulted in dropped URL characters leading to
invalid media URLs. This is undoubtedly a performance issue that could be
addressed directly, but pasting the URL feels like an appropriate solution for
resolving the test issue for now.

To test: ensure the CI tasks succeed.

## Regression Notes
1. Potential unintended areas of impact
    Other automated tests could begin failing.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verifying CI tasks succeed.
3. What automated tests I added (or what prevented me from doing so)
    Improved the robustness of media block tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
