### PR TITLE
[Domain Management] Add `DomainsFABMenuView`

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsFABMenuView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsFABMenuView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct DomainsFABMenuView: View {
+    enum Action: String, CaseIterable, Identifiable {
+        case addToSite
+        case purchase
+        case transfer
+
+        var id: String {
+            rawValue
+        }
+
+        var title: String {
+            switch self {
+            case .addToSite:
+                return NSLocalizedString(
+                    "domain.management.fab.add.domain.title",
+                    value: "Add domain to site",
+                    comment: "Domain Management FAB Add Domain title"
+                )
+            case .purchase:
+                return NSLocalizedString(
+                    "domain.management.fab.purchase.domain.title",
+                    value: "Purchase domain only",
+                    comment: "Domain Management FAB Purchase Domain title"
+                )
+            case .transfer:
+                return NSLocalizedString(
+                    "domain.management.fab.transfer.domain.title",
+                    value: "Transfer domain(s)",
+                    comment: "Domain Management FAB Transfer Domain title"
+                )
+            }
+        }
+    }
+
+    @Binding var selectedAction: Action
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            ForEach(Action.allCases) { action in
+                menuButton(action: action)
+                    .padding(.horizontal, Length.Padding.double)
+                if action != .transfer {
+                    Divider()
+                }
+            }
+        }
+        .fixedSize()
+        .padding(.vertical, Length.Padding.single)
+        .background(Color.DS.Background.primary)
+        .cornerRadius(Length.Padding.double)
+    }
+
+    private func menuButton(action: Action) -> some View {
+        Button {
+            self.selectedAction = action
+        } label: {
+            Text(action.title)
+                .foregroundColor(.DS.Foreground.primary)
+                .font(.title3)
+        }
+        .frame(height: Length.Hitbox.minTapDimension)
+    }
+}
+
+struct DomainsFABMenuView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.DS.Background.quaternary
+                .ignoresSafeArea()
+            DomainsFABMenuView(selectedAction: .constant(.addToSite))
+                .padding()
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -244,6 +244,8 @@
 		08216FD31CDBF96000304BA7 /* MenuItemTagsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FC31CDBF96000304BA7 /* MenuItemTagsViewController.m */; };
 		08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FC51CDBF96000304BA7 /* MenuItemTypeSelectionView.m */; };
 		08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FC71CDBF96000304BA7 /* MenuItemTypeViewController.m */; };
+		0824085D2AC3321D0044AB99 /* DomainsFABMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0824085C2AC3321D0044AB99 /* DomainsFABMenuView.swift */; };
+		0824085E2AC3321D0044AB99 /* DomainsFABMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0824085C2AC3321D0044AB99 /* DomainsFABMenuView.swift */; };
 		082635BB1CEA69280088030C /* MenuItemsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 082635BA1CEA69280088030C /* MenuItemsViewController.m */; };
 		0828D7FA1E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0828D7F91E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift */; };
 		082A645B291C2DD700668D2C /* Routes+Jetpack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082A645A291C2DD700668D2C /* Routes+Jetpack.swift */; };
@@ -5885,6 +5887,7 @@
 		08216FC51CDBF96000304BA7 /* MenuItemTypeSelectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemTypeSelectionView.m; sourceTree = "<group>"; };
 		08216FC61CDBF96000304BA7 /* MenuItemTypeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemTypeViewController.h; sourceTree = "<group>"; };
 		08216FC71CDBF96000304BA7 /* MenuItemTypeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemTypeViewController.m; sourceTree = "<group>"; };
+		0824085C2AC3321D0044AB99 /* DomainsFABMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainsFABMenuView.swift; sourceTree = "<group>"; };
 		082635B91CEA69280088030C /* MenuItemsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemsViewController.h; sourceTree = "<group>"; };
 		082635BA1CEA69280088030C /* MenuItemsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemsViewController.m; sourceTree = "<group>"; };
 		0828D7F91E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPAppAnalytics+Media.swift"; sourceTree = "<group>"; };
@@ -11436,6 +11439,7 @@
 				3FA62FD226FE2E4B0020793A /* ShapeWithTextView.swift */,
 				011896A429D5B72500D34BA9 /* DomainsDashboardCoordinator.swift */,
 				011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */,
+				0824085C2AC3321D0044AB99 /* DomainsFABMenuView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -21251,6 +21255,7 @@
 				7E40716223741376003627FA /* GutenbergNetworking.swift in Sources */,
 				17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */,
 				3F4D035028A56F9B00F0A4FD /* CircularImageButton.swift in Sources */,
+				0824085D2AC3321D0044AB99 /* DomainsFABMenuView.swift in Sources */,
 				0C8078AB2A4E01A5002ABF29 /* PagingFooterView.swift in Sources */,
 				B55FFCFA1F034F1A0070812C /* String+Ranges.swift in Sources */,
 				7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */,
@@ -24524,6 +24529,7 @@
 				FABB23802602FC2C00C8785C /* ReaderCommentsViewController.m in Sources */,
 				FABB23812602FC2C00C8785C /* MySiteViewController.swift in Sources */,
 				46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */,
+				0824085E2AC3321D0044AB99 /* DomainsFABMenuView.swift in Sources */,
 				F4D829622930E9F300038726 /* MigrationDeleteWordPressViewController.swift in Sources */,
 				4AA33F05299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift in Sources */,
 				FABB23822602FC2C00C8785C /* FooterContentGroup.swift in Sources */,


### PR DESCRIPTION
Fixes #21425

## Testing Steps
Please refer to the issue for AC.

- Disable `WordPressAppDelegate.swift` `willFinishLaunchingWithOptions ` and `didFinishLaunchingWithOptions` functions and observe the Preview. Manipulate the color scheme with `.environment(\.colorScheme, .dark)`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

Pretty standard SwiftUI View addition. All of below should work out of the box.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
