### PR TITLE
Reader: Temporarily fix Reader Tag header misalignment

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -613,6 +613,7 @@ import Combine
             headerView.isHidden = tableHeaderView.isHidden
         }
         tableView.tableHeaderView = headerView
+        streamHeader = header as? ReaderStreamHeader
 
         // This feels somewhat hacky, but it is the only way I found to insert a stack view into the header without breaking the autolayout constraints.
         let centerConstraint = headerView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor)

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -47,10 +47,6 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Likes"]
     }
 
-    private let topicNavigationBarGetter: (XCUIApplication) -> XCUIElement = {
-        $0.navigationBars["Topic"]
-    }
-
     private let topicCellButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["topics-card-cell-button"]
     }
@@ -76,7 +72,6 @@ public class ReaderScreen: ScreenObject {
     var savePostButton: XCUIElement { savePostButtonGetter(app) }
     var savedButton: XCUIElement { savedButtonGetter(app) }
     var topicCellButton: XCUIElement { topicCellButtonGetter(app) }
-    var topicNavigationBar: XCUIElement { topicNavigationBarGetter(app) }
     var visitButton: XCUIElement { visitButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
@@ -163,7 +158,6 @@ public class ReaderScreen: ScreenObject {
     }
 
     public func verifyTopicLoaded(file: StaticString = #file, line: UInt = #line) -> Self {
-        XCTAssertTrue(topicNavigationBar.waitForExistence(timeout: 3), file: file, line: line)
         XCTAssertTrue(readerButton.waitForExistence(timeout: 3), file: file, line: line)
         XCTAssertTrue(followButton.waitForExistence(timeout: 3), file: file, line: line)
 


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-iOS/commit/0b0c869

The new Reader Tag stream header appears misaligned, and the changes in `ReaderStreamViewController` in commit https://github.com/wordpress-mobile/WordPress-iOS/commit/0b0c869 seem to have something to do with this. Looks like the container view is not inheriting the superview's layout margins? 

Since we might change this again once we work on the reader cards, for now I've modified the changes to only apply when dealing with a site topic. Here are some comparisons:

• | Before | After
-|-|-
Portrait | ![before_portrait](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/2b950422-9f47-4a0a-ac8b-c86884462020) | ![after_portrait](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/90e9e3bd-db1f-4aa1-b92b-ea3af5f72464)
Landscape | ![before_landscape](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/78fbe588-1e0c-4197-b4de-d0a9e97db79a) |  ![after_landscape](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f61506be-956a-4dff-a2ea-0f7de68c2830)

## To test

- Launch the Jetpack app.
- Turn on the Reader Improvements feature flag.
- Navigate to Reader > Discover tab.
- Tap any tag.
- Verify that the tag stream header aligns correctly with the content.

## Regression Notes
1. Potential unintended areas of impact
This could also affect Site stream header.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
