### PR TITLE
Reader: Update Tag stream header title to sans-serif

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -204,7 +204,7 @@ extension WPStyleGuide {
 
     @objc public class func applyReaderStreamHeaderTitleStyle(_ label: UILabel, usesNewStyle: Bool = false) {
         if usesNewStyle {
-            label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .semibold)
+            label.font = WPStyleGuide.fontForTextStyle(.title1, fontWeight: .bold)
         } else {
             label.font = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .bold)
         }


### PR DESCRIPTION
Depends on #21641 

Updates the title font to sans serif in the Reader's tag stream header. See screenshots:

Before | After
-|-
![before_short](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/9f17a8df-fcf0-4800-8381-beacbb844cef) | ![after_short](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/705e4e54-92f5-4d21-b034-9722b1f3d235)
![before_long](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/6c2a88c0-58ef-4927-9501-c1604fcf3fb9) | ![after_long](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1e456324-7b7d-46f8-a9e2-a314ad1712c8)

To test

- Launch Jetpack app.
- Turn on the Reader Improvements feature flag.
- Navigate to Reader > Discover tab.
- Tap any tag.
- Verify that the title is now displayed in sans serif style.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes are limited to the tag stream header.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
