### PR TITLE
Replace `fix_gbm_pods` Rake task with one to `pod update` Gutenberg

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -115,22 +115,14 @@ bundle exec fastlane run configure_apply force:true
       fold('install.cocoapods') do
         pod %w[install]
       rescue StandardError
-        puts "Attempting to fix Gutenberg-Mobile local podspecs failing to install — since that is one of the most common reason for `pod install` to fail — then retrying…\n\n"
-        Rake::Task['dependencies:pod:fix_gbm_pods'].invoke
+        puts "`pod install` failed. Will attempt to update the Gutenberg-Mobile XCFramework — a common reason for the failure — then retrying…\n\n"
+        Rake::Task['dependencies:pod:update_gutenberg'].invoke
         pod %w[install]
       end
     end
 
-    task :fix_gbm_pods do
-      require 'yaml'
-
-      deps = YAML.load_file('Podfile.lock')['DEPENDENCIES']
-      gbm_pod_regex = %r{(.*) \(from `https://raw\.githubusercontent\.com/wordpress-mobile/gutenberg-mobile/.*/third-party-podspecs/.*\.podspec\.json`\)}
-      gbm_pods = deps.map do |pod|
-        gbm_pod_regex.match(pod)&.captures&.first
-      end.compact
-
-      pod ['update', *gbm_pods]
+    task :update_gutenberg do
+      pod %w[update Gutenberg]
     end
 
     task :clean do

--- a/Rakefile
+++ b/Rakefile
@@ -112,7 +112,7 @@ bundle exec fastlane run configure_apply force:true
     end
 
     task :install do
-      fold('install.cocoapds') do
+      fold('install.cocoapods') do
         pod %w[install]
       rescue StandardError
         puts "Attempting to fix Gutenberg-Mobile local podspecs failing to install — since that is one of the most common reason for `pod install` to fail — then retrying…\n\n"
@@ -134,7 +134,7 @@ bundle exec fastlane run configure_apply force:true
     end
 
     task :clean do
-      fold('clean.cocoapds') do
+      fold('clean.cocoapods') do
         FileUtils.rm_rf('Pods')
       end
     end


### PR DESCRIPTION
This task came up in an internal discussion and I noticed that it's obsolete because we changed the Gutenberg integration strategy — from a pod that fetches many dependencies to one pod with only a binary.

I updated it to use `pod update` because it can happen that CocoaPods fails because the cached version is out of date and `pod install` can do anything about it.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.