### PR TITLE
Plans in Site Creation: Update Domain Selection view

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - WordPressKit (~> 8.0-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.5.1):
+  - WordPressKit (8.5.2):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -227,7 +227,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: 132ccf00a41443e0ebd792d9a36ff5697a8f5414
-  WordPressKit: f33a89b148d9cce96933f0900701aff592a796f7
+  WordPressKit: 2fb06e93da3e8e7bea518188bfbf4d462ba103f9
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   WPMediaPicker: 332812329cbdc672cdb385b8ac3a389f668d3012

--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -53,7 +53,7 @@ final class DomainsServiceAdapter: SiteAddressService {
 
     /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
     private var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled
+        RemoteFeatureFlag.plansInSiteCreation.enabled()
     }
 
     /**

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -4,7 +4,7 @@ extension WPAnalytics {
 
     /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
     private static var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled
+        RemoteFeatureFlag.plansInSiteCreation.enabled()
     }
 
     static func domainsProperties(for blog: Blog, origin: DomainPurchaseWebViewViewOrigin? = .menu) -> [AnyHashable: Any] {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,7 +8,6 @@ enum FeatureFlag: Int, CaseIterable {
     case siteIconCreator
     case statsNewInsights
     case betaSiteDesigns
-    case siteCreationDomainPurchasing
     case personalizeHomeTab
     case commentModerationUpdate
     case compliancePopover
@@ -35,8 +34,6 @@ enum FeatureFlag: Int, CaseIterable {
         case .statsNewInsights:
             return AppConfiguration.statsRevampV2Enabled
         case .betaSiteDesigns:
-            return false
-        case .siteCreationDomainPurchasing:
             return false
         case .personalizeHomeTab:
             return AppConfiguration.isJetpack
@@ -86,8 +83,6 @@ extension FeatureFlag {
             return "New Cards for Stats Insights"
         case .betaSiteDesigns:
             return "Fetch Beta Site Designs"
-        case .siteCreationDomainPurchasing:
-            return "Site Creation Domain Purchasing"
         case .personalizeHomeTab:
             return "Personalize Home Tab"
         case .commentModerationUpdate:

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell+ViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell+ViewModel.swift
@@ -11,6 +11,7 @@ extension AddressTableViewCell {
             case free
             case regular(cost: String)
             case onSale(cost: String, sale: String)
+            case freeWithPaidPlan(cost: String)
         }
 
         enum Tag {
@@ -62,6 +63,11 @@ extension AddressTableViewCell.ViewModel {
             value: "Sale",
             comment: "The 'Sale' label under the domain name in 'Choose a domain' screen"
         )
+        static let freeWithPaidPlan = NSLocalizedString(
+            "domain.suggestions.row.free-with-plan",
+            value: "Free for a year with a plan",
+            comment: "The text to display for paid domains that are free for the first year with the paid plan in 'Site Creation > Choose a domain' screen"
+        )
     }
 }
 
@@ -78,13 +84,9 @@ extension AddressTableViewCell.ViewModel {
         } else if let formatter = Self.currencyFormatter(code: model.currencyCode),
                   let costValue = model.cost,
                   let formattedCost = formatter.string(from: .init(value: costValue)) {
-            if let saleCost = model.saleCost, let formattedSaleCost = formatter.string(from: .init(value: saleCost)) {
-                cost = .onSale(cost: formattedCost, sale: formattedSaleCost)
-            } else {
-                cost = .regular(cost: formattedCost)
-            }
+            cost = .freeWithPaidPlan(cost: formattedCost)
         } else {
-            cost = .regular(cost: model.costString)
+            cost = .freeWithPaidPlan(cost: model.costString)
         }
 
         // Configure tags

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -54,7 +54,7 @@ final class AddressTableViewCell: UITableViewCell {
         label.adjustsFontForContentSizeCategory = true
         label.font = Appearance.domainFont
         label.textColor = Appearance.domainTextColor
-        label.numberOfLines = 2
+        label.numberOfLines = 3
         return label
     }()
 
@@ -102,6 +102,7 @@ final class AddressTableViewCell: UITableViewCell {
             view.backgroundColor = UIColor(light: .secondarySystemBackground, dark: .tertiarySystemBackground)
             return view
         }()
+        costLabel.widthAnchor.constraint(lessThanOrEqualTo: contentView.widthAnchor, multiplier: 0.5).isActive = true
     }
 
     // MARK: - Layout
@@ -196,6 +197,19 @@ final class AddressTableViewCell: UITableViewCell {
             let attributedString = NSMutableAttributedString(string: cost, attributes: costAttributes)
             attributedString.append(NSAttributedString(string: " \(sale)", attributes: saleAttributes))
             attributedString.append(.init(string: "\n\(ViewModel.Strings.firstYear)", attributes: firstYearAttributes))
+            return attributedString
+        case .freeWithPaidPlan(let cost):
+            let costAttributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: UIColor.secondaryLabel,
+                .font: Appearance.smallCostFont,
+                .strikethroughStyle: NSUnderlineStyle.single.rawValue
+            ]
+            let firstYearAttributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: Appearance.saleCostTextColor,
+                .font: Appearance.smallCostFont
+            ]
+            let attributedString = NSMutableAttributedString(string: cost, attributes: costAttributes)
+            attributedString.append(.init(string: "\n\(ViewModel.Strings.freeWithPaidPlan)", attributes: firstYearAttributes))
             return attributedString
         }
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -6,7 +6,7 @@ final class AddressTableViewCell: UITableViewCell {
     // MARK: - Dependencies
 
     private var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled
+        RemoteFeatureFlag.plansInSiteCreation.enabled()
     }
 
     // MARK: - Views

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
@@ -273,6 +273,8 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     }
 
     private func handleData(_ data: [DomainSuggestion], _ invalidQuery: Bool) {
+        let data = sortFreeAndPaidSuggestions(data)
+
         setAddressHintVisibility(isHidden: true)
         let resultsHavePreviousSelection = data.contains { (suggestion) -> Bool in self.selectedDomain?.domainName == suggestion.domainName }
         if !resultsHavePreviousSelection {
@@ -512,6 +514,34 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
                                                            comment: "Suggested domains")
         static let noMatch: String = NSLocalizedString("This domain is unavailable",
                                                        comment: "Notifies the user that the a domain matching the search term wasn't returned in the results")
+    }
+}
+
+// MARK: - Sorting
+
+private extension WebAddressWizardContent {
+    // Mimics the sorting on the web - two top domains, one free domain, and other domains
+    private func sortFreeAndPaidSuggestions(_ suggestions: [DomainSuggestion]) -> [DomainSuggestion] {
+        var topDomains: [DomainSuggestion] = []
+        var freeDomains: [DomainSuggestion] = []
+        var otherDomains: [DomainSuggestion] = []
+
+        for i in 0..<suggestions.count {
+            let suggestion = suggestions[i]
+            if freeDomains.isEmpty && suggestion.isFree {
+                freeDomains.append(suggestion)
+                continue
+            }
+
+            if topDomains.count < 2 && !suggestion.isFree {
+                topDomains.append(suggestion)
+                continue
+            }
+
+            otherDomains.append(suggestion)
+        }
+
+        return topDomains + freeDomains + otherDomains
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -57,7 +57,7 @@ final class SiteCreator {
 
     /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
     var domainPurchasingEnabled: Bool {
-        FeatureFlag.siteCreationDomainPurchasing.enabled
+        RemoteFeatureFlag.plansInSiteCreation.enabled()
     }
 
     /// Flag indicating whether the domain checkout flow should appear or not.


### PR DESCRIPTION
Fixes #21635
Depends on https://github.com/wordpress-mobile/WordPressKit-iOS/pull/627

## Description

- [x] Fetch free and paid domains the same way as on the web https://github.com/wordpress-mobile/WordPressKit-iOS/pull/627 (more context here: https://github.com/wordpress-mobile/WordPress-Android/issues/19264#issuecomment-1738762916)
- [x] Replace domain site creation feature flag with a new plans in site creation feature flag 
- [x] Sort domains the same way as on the web
- [x] Display a free with a plan label

## To test:

### New functionality
1. Enable "Plans in Site creation feature flag"
2. Create new site (either with a fresh account, or via site selector)
3. Search for domains
4. Compare results with wordpress.com/start/domains

### Regression

1. Disable "Plans in Site creation feature flag"
2. Create new site (either with a fresh account, or via site selector)
3. Search for domains 
4. Confirm only free domains are displayed 

## Regression Notes
1. Potential unintended areas of impact

Affecting free domain selection in site creation

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text. (https://github.com/wordpress-mobile/WordPress-iOS/issues/21653)
- [ ] High contrast.
- [ ] VoiceOver. (https://github.com/wordpress-mobile/WordPress-iOS/issues/21653)
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

## Video
https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/81359cc1-d8de-41bb-b9f5-c658804ddb30



