### PR TITLE
Fix an issue with non-admins being able to see the plugin menu item

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Resolve the unresponsiveness of the compliance popover on iPhone SE devices when large fonts are enabled. [#21609]
 * [*] Block Editor: Prevent crash from invalid media URLs [https://github.com/WordPress/gutenberg/pull/54834]
 * [*] Block Editor: Limit inner blocks nesting depth to avoid call stack size exceeded crash [https://github.com/WordPress/gutenberg/pull/54382]
+* [*] Fix an issue with non-admins being able to see the plugin menu on the Atomic sites [https://github.com/wordpress-mobile/WordPress-iOS/pull/21657]
 * [**] Block Editor: Fallback to Twitter provider when embedding X URLs [https://github.com/WordPress/gutenberg/pull/54876]
 
 23.3

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -558,7 +558,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeaturePlans:
             return [self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePluginManagement:
-            return [self supportsPluginManagement];
+            return [self supportsPluginManagement] && [self isAdmin];
         case BlogFeatureJetpackImageSettings:
             return [self supportsJetpackImageSettings];
         case BlogFeatureJetpackSettings:
@@ -686,8 +686,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
     BOOL isTransferrable = self.isHostedAtWPcom
     && self.hasBusinessPlan
-    && self.siteVisibility != SiteVisibilityPrivate
-    && self.isAdmin;
+    && self.siteVisibility != SiteVisibilityPrivate;
 
     BOOL supports = isTransferrable || hasRequiredJetpack;
 
@@ -696,8 +695,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     if(!supports && !self.account){
         supports = !self.isHostedAtWPcom
         && self.wordPressOrgRestApi
-        && [self hasRequiredWordPressVersion:@"5.5"]
-        && self.isAdmin;
+        && [self hasRequiredWordPressVersion:@"5.5"];
     }
 
     return supports;


### PR DESCRIPTION
Fixes an issue with non-Admins, e.g. Contributors, being able to see the "Plugins" menu item.

## To test:

Follow the same testing steps as in https://github.com/wordpress-mobile/WordPress-Android/pull/19241

## Regression Notes
1. Potential unintended areas of impact: blog menu
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
