### PR TITLE
Fix an issue with contributors seeing pre-publishing popup

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Resolve the unresponsiveness of the compliance popover on iPhone SE devices when large fonts are enabled. [#21609]
 * [*] Block Editor: Prevent crash from invalid media URLs [https://github.com/WordPress/gutenberg/pull/54834]
+* [*] Fix an issue with contributors seeing pre-publishing popup and a wrong confirmation message after submitting a post for review [https://github.com/wordpress-mobile/WordPress-iOS/pull/21658]
 * [*] Block Editor: Limit inner blocks nesting depth to avoid call stack size exceeded crash [https://github.com/WordPress/gutenberg/pull/54382]
 * [**] Block Editor: Fallback to Twitter provider when embedding X URLs [https://github.com/WordPress/gutenberg/pull/54876]
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -185,6 +185,7 @@ extension PublishingEditor {
         }
 
         if action.isAsync,
+           action != .submitForReview,
            let postStatus = self.post.original?.status ?? self.post.status,
            ![.publish, .publishPrivate].contains(postStatus) {
             WPAnalytics.track(.editorPostPublishTap)

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -163,7 +163,11 @@ class PostPostViewController: UIViewController {
         titleLabel.text = post.titleForDisplay().strippingHTML()
         titleLabel.accessibilityIdentifier = "postTitle"
 
-        if post.isScheduled() {
+        if let status = post.status, status == .pending {
+            postStatusLabel.text = AbstractPost.title(forStatus: status.rawValue)
+            postStatusLabel.accessibilityIdentifier = "pendingPostStatusLabel"
+            shareButton.isHidden = true
+        } else if post.isScheduled() {
             let format = NSLocalizedString("Scheduled for %@ on", comment: "Precedes the name of the blog a post was just scheduled on. Variable is the date post was scheduled for.")
             postStatusLabel.text = String(format: format, post.dateStringForDisplay())
             postStatusLabel.accessibilityIdentifier = "scheduledPostStatusLabel"


### PR DESCRIPTION
Fix an issue with contributors seeing publish popup.

<hr/>

**Before** the change, the user would see the following popup after clicking "Submit for review":

<img width="320" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/bb465531-c432-4369-a3ad-dc00ca48c2e9">

When they press "Publish Now", they'll see the following popup:

<img width="320" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/f3ede5a5-7a5b-4441-8af8-1a8c3b226941">

The post will actually be in "Pending Review" status"

<hr/>

**After** 

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/14ba276f-50c4-4dc2-94db-048027d63cd8

<hr/>

## To test:

- Get invited to a site as a Contributor
- Start writing a new poset
- Tap "Submit for Review"
- Verify that the post is submit for review and no "pre-publishing" popup is displayed
- Wait until the submissions succeeds
- Tap on the notification popup at the bottom
- Verify that it says "Pending Review" and has no "Share" button

## Regression Notes
1. Potential unintended areas of impact: Submitting posts for a review as a contributor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
