### PR TITLE
Fix an issue with a New Page action visible for Contributors

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 23.4
 -----
 * [*] Resolve the unresponsiveness of the compliance popover on iPhone SE devices when large fonts are enabled. [#21609]
+* [*] Fix an issue with a New Page action visible for Contributors [https://github.com/wordpress-mobile/WordPress-iOS/pull/21659]
 * [*] Block Editor: Prevent crash from invalid media URLs [https://github.com/WordPress/gutenberg/pull/54834]
 * [*] Block Editor: Limit inner blocks nesting depth to avoid call stack size exceeded crash [https://github.com/WordPress/gutenberg/pull/54382]
 * [**] Block Editor: Fallback to Twitter provider when embedding X URLs [https://github.com/WordPress/gutenberg/pull/54876]

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
@@ -33,7 +33,9 @@ extension MySiteViewController {
         }
 
         actions.append(PostAction(handler: newPost, source: source))
-        actions.append(PageAction(handler: newPage, source: source))
+        if blog?.supports(.pages) ?? false {
+            actions.append(PageAction(handler: newPage, source: source))
+        }
 
         let coordinator = CreateButtonCoordinator(self, actions: actions, source: source, blog: blog)
         return coordinator


### PR DESCRIPTION
Fix an issue with a New Page action visible for Contributors.

I used the same logic for determining eligibility as on the blog menu.

## To test:

- Get invited to a site as a Contributor
- Tap FAB on the My Site page
- Verify that the "New Page" action is not shown

## Regression Notes
1. Potential unintended areas of impact: FAB on home page
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x]  I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
