### PR TITLE
Fix a crash: Attempt to add script message handler when one already exists

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewController.swift
@@ -28,6 +28,7 @@ final class SupportChatBotViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        webView.configuration.userContentController.removeAllScriptMessageHandlers()
         webView.configuration.userContentController.add(self, name: Constants.supportCallback)
         webView.configuration.userContentController.add(self, name: Constants.errorCallback)
     }


### PR DESCRIPTION
Fixes #21656

The crash happens when calling: `webView.configuration.userContentController.add(self, name: Constants.supportCallback)` more than once in `SupportChatBotViewController`

Since this is a rare crash, and we will sunset this solution in the next couple of weeks, I didn't investigate further. 

To avoid the crash, always remove all script message handlers before adding new ones.

### To test:

1. Open Jetpack
2. Help & Support
3. Contact support
4. Ask a question
5. Tap Contact Support below the message
6. Confirm Zendesk ticket is created

## Regression Notes
1. Potential unintended areas of impact

Breaking functionality of supportCallback that creates a Zendesk ticket

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
