### PR TITLE
Media: Add support for remaining asset types

### DIFF
--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -64,7 +64,7 @@ final class MediaImageService: NSObject {
         return try? await Task.detached {
             let imageURL = try self.getCachedThumbnailURL(for: mediaID, size: size)
             let data = try Data(contentsOf: imageURL)
-            return try decompressedImage(from: data)
+            return try makeImage(from: data)
         }.value
     }
 
@@ -116,7 +116,7 @@ final class MediaImageService: NSObject {
 
         let image = try? await Task.detached {
             let data = try Data(contentsOf: export.url)
-            return try decompressedImage(from: data)
+            return try makeImage(from: data)
         }.value
 
         // The order is important to ensure `export.url` still exists when creating an image
@@ -150,7 +150,7 @@ final class MediaImageService: NSObject {
         }
 
         return try await Task.detached {
-            try decompressedImage(from: data)
+            try makeImage(from: data)
         }.value
     }
 
@@ -254,7 +254,13 @@ private extension Media {
             }
             // Download a non-retina version for GIFs: makes a massive difference
             // in terms of size. Example: 2.4 MB -> 350 KB.
-            let targetSize = remoteURL.isGif ? targetSize.scaled(by: 1.0 / UIScreen.main.scale) : targetSize
+            let scale = UIScreen.main.scale
+            var targetSize = targetSize
+            if remoteURL.isGif {
+                targetSize = targetSize
+                    .scaled(by: 1.0 / scale)
+                    .scaled(by: min(2, scale))
+            }
             if !isEligibleForPhoton {
                 return WPImageURLHelper.imageURLWithSize(targetSize, forImageURL: remoteURL)
             } else {
@@ -275,9 +281,12 @@ private extension Media {
 
 // Forces decompression (or bitmapping) to happen in the background.
 // It's very expensive for some image formats, such as JPEG.
-private func decompressedImage(from data: Data) throws -> UIImage {
+private func makeImage(from data: Data) throws -> UIImage {
     guard let image = UIImage(data: data) else {
         throw URLError(.cannotDecodeContentData)
+    }
+    if data.isMatchingMagicNumbers(Data.gifMagicNumbers) {
+        return AnimatedImageWrapper(gifData: data) ?? image
     }
     guard isDecompressionNeeded(for: data) else {
         return image
@@ -298,6 +307,9 @@ private func isDecompressionNeeded(for data: Data) -> Bool {
 private extension Data {
     // JPEG magic numbers https://en.wikipedia.org/wiki/JPEG
     static let jpegMagicNumbers: [UInt8] = [0xFF, 0xD8, 0xFF]
+
+    // GIF magic numbers https://en.wikipedia.org/wiki/GIF
+    static let gifMagicNumbers: [UInt8] = [0x47, 0x49, 0x46]
 
     func isMatchingMagicNumbers(_ numbers: [UInt8?]) -> Bool {
         guard self.count >= numbers.count else {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -260,6 +260,13 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
             pendingChanges.append({ $0.deleteItems(at: [indexPath]) })
             if let media = anObject as? Media {
                 setSelect(false, for: media)
+
+                if let viewController = navigationController?.topViewController,
+                   viewController !== self,
+                    let detailsViewController = viewController as? MediaItemViewController,
+                   detailsViewController.media.objectID == media.objectID {
+                    navigationController?.popViewController(animated: true)
+                }
             } else {
                 assertionFailure("Invalid object: \(anObject)")
             }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -27,7 +27,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     private var syncError: Error?
     private var pendingChanges: [(UICollectionView) -> Void] = []
     private var selection = NSMutableOrderedSet() // `Media`
-    private var viewModels: [NSManagedObjectID: MediaCollectionCellViewModel] = [:]
+    private var viewModels: [NSManagedObjectID: SiteMediaCollectionCellViewModel] = [:]
     private let blog: Blog
     private let filter: Set<MediaType>?
     private let isShowingPendingUploads: Bool
@@ -95,7 +95,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     private func configureCollectionView() {
-        collectionView.register(MediaCollectionCell.self, forCellWithReuseIdentifier: Constants.cellID)
+        collectionView.register(SiteMediaCollectionCell.self, forCellWithReuseIdentifier: Constants.cellID)
 
         view.addSubview(collectionView)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -303,7 +303,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.cellID, for: indexPath) as! MediaCollectionCell
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.cellID, for: indexPath) as! SiteMediaCollectionCell
         let media = fetchController.object(at: indexPath)
         let viewModel = getViewModel(for: media)
         cell.configure(viewModel: viewModel)
@@ -392,11 +392,11 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     // MARK: - Helpers
 
     // Create ViewModel lazily to avoid fetching more managed objects than needed.
-    private func getViewModel(for media: Media) -> MediaCollectionCellViewModel {
+    private func getViewModel(for media: Media) -> SiteMediaCollectionCellViewModel {
         if let viewModel = viewModels[media.objectID] {
             return viewModel
         }
-        let viewModel = MediaCollectionCellViewModel(media: media)
+        let viewModel = SiteMediaCollectionCellViewModel(media: media)
         viewModels[media.objectID] = viewModel
         return viewModel
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -95,7 +95,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     private func configureCollectionView() {
-        collectionView.register(SiteMediaCollectionCell.self, forCellWithReuseIdentifier: Constants.cellID)
+        collectionView.register(cell: SiteMediaCollectionCell.self)
 
         view.addSubview(collectionView)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
@@ -310,7 +310,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.cellID, for: indexPath) as! SiteMediaCollectionCell
+        let cell = collectionView.dequeue(cell: SiteMediaCollectionCell.self, for: indexPath)!
         let media = fetchController.object(at: indexPath)
         let viewModel = getViewModel(for: media)
         cell.configure(viewModel: viewModel)
@@ -457,10 +457,6 @@ extension SiteMediaCollectionViewController: NoResultsViewHost {
         case emptySearch
         case failed
     }
-}
-
-private enum Constants {
-    static let cellID = "cellID"
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/MediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/MediaCollectionCell.swift
@@ -53,16 +53,21 @@ final class MediaCollectionCell: UICollectionViewCell {
     func configure(viewModel: MediaCollectionCellViewModel) {
         self.viewModel = viewModel
 
-        if let image = viewModel.getCachedThubmnail() {
-            // Display with no animations. It should happen often thanks to prefetchig
-            imageView.image = image
-            imageView.alpha = 1
-            placeholderView.alpha = 0
-        } else {
-            let mediaID = viewModel.mediaID
-            viewModel.onImageLoaded = { [weak self] in
-                self?.didLoadImage($0, for: mediaID)
+        switch viewModel.mediaType {
+        case .image, .video:
+            if let image = viewModel.getCachedThubmnail() {
+                // Display with no animations. It should happen often thanks to prefetchig
+                imageView.image = image
+                imageView.alpha = 1
+                placeholderView.alpha = 0
+            } else {
+                let mediaID = viewModel.mediaID
+                viewModel.onImageLoaded = { [weak self] in
+                    self?.didLoadImage($0, for: mediaID)
+                }
             }
+        default:
+            break
         }
 
         viewModel.$overlayState.sink { [overlayView] in

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -6,6 +6,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
     private let overlayView = CircularProgressView()
     private let placeholderView = UIView()
     private var durationView: SiteMediaVideoDurationView?
+    private var documentInfoView: SiteMediaDocumentInfoView?
     private var badgeView: SiteMediaCollectionCellBadgeView?
 
     private var viewModel: SiteMediaCollectionCellViewModel?
@@ -51,6 +52,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
         placeholderView.alpha = 1
         badgeView?.isHidden = true
         durationView?.isHidden = true
+        documentInfoView?.isHidden = true
     }
 
     func configure(viewModel: SiteMediaCollectionCellViewModel) {
@@ -69,7 +71,10 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
                     self?.didLoadImage($0, for: mediaID)
                 }
             }
-        default:
+        case .document, .powerpoint, .audio:
+            getDocumentInfoView().configure(viewModel)
+            getDocumentInfoView().isHidden = false
+        @unknown default:
             break
         }
 
@@ -119,6 +124,23 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
     }
 
     // MARK: - Helpers
+
+    private func getDocumentInfoView() -> SiteMediaDocumentInfoView {
+        if let documentInfoView {
+            return documentInfoView
+        }
+        let documentInfoView = SiteMediaDocumentInfoView()
+        contentView.addSubview(documentInfoView)
+        documentInfoView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            documentInfoView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor, constant: 0),
+            documentInfoView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 0),
+            documentInfoView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 4),
+            documentInfoView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -4)
+        ])
+        self.documentInfoView = documentInfoView
+        return documentInfoView
+    }
 
     private func getDurationView() -> SiteMediaVideoDurationView {
         if let durationView {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -2,7 +2,7 @@ import UIKit
 import Combine
 import Gifu
 
-final class SiteMediaCollectionCell: UICollectionViewCell {
+final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
     private let imageView = GIFImageView()
     private let overlayView = CircularProgressView()
     private let placeholderView = UIView()

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -48,6 +48,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
         viewModel?.onDisappear()
         viewModel = nil
 
+        imageView.prepareForReuse()
         imageView.image = nil
         imageView.alpha = 0
         placeholderView.alpha = 1

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -1,8 +1,9 @@
 import UIKit
 import Combine
+import Gifu
 
 final class SiteMediaCollectionCell: UICollectionViewCell {
-    private let imageView = UIImageView()
+    private let imageView = GIFImageView()
     private let overlayView = CircularProgressView()
     private let placeholderView = UIView()
     private var durationView: SiteMediaVideoDurationView?
@@ -61,10 +62,8 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
         switch viewModel.mediaType {
         case .image, .video:
             if let image = viewModel.getCachedThubmnail() {
-                // Display with no animations. It should happen often thanks to prefetchig
-                imageView.image = image
-                imageView.alpha = 1
-                placeholderView.alpha = 0
+                // Display with no animations. It should happen often thanks to prefetching.
+                setImage(image)
             } else {
                 let mediaID = viewModel.mediaID
                 viewModel.onImageLoaded = { [weak self] in
@@ -118,7 +117,15 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
         assert(Thread.isMainThread)
 
         guard viewModel?.mediaID == mediaID else { return }
-        imageView.image = image
+        setImage(image)
+    }
+
+    private func setImage(_ image: UIImage) {
+        if let gif = image as? AnimatedImageWrapper, let data = gif.gifData {
+            imageView.animate(withGIFData: data)
+        } else {
+            imageView.image = image
+        }
         imageView.alpha = 1
         placeholderView.alpha = 0
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -1,12 +1,12 @@
 import UIKit
 import Combine
 
-final class MediaCollectionCell: UICollectionViewCell {
+final class SiteMediaCollectionCell: UICollectionViewCell {
     private let imageView = UIImageView()
     private let overlayView = CircularProgressView()
     private let placeholderView = UIView()
-    private var viewModel: MediaCollectionCellViewModel?
-    private var badgeView: MediaCollectionCellBadgeView?
+    private var viewModel: SiteMediaCollectionCellViewModel?
+    private var badgeView: SiteMediaCollectionCellBadgeView?
     private var cancellables: [AnyCancellable] = []
 
     override init(frame: CGRect) {
@@ -50,7 +50,7 @@ final class MediaCollectionCell: UICollectionViewCell {
         badgeView?.isHidden = true
     }
 
-    func configure(viewModel: MediaCollectionCellViewModel) {
+    func configure(viewModel: SiteMediaCollectionCellViewModel) {
         self.viewModel = viewModel
 
         switch viewModel.mediaType {
@@ -106,11 +106,11 @@ final class MediaCollectionCell: UICollectionViewCell {
         }
     }
 
-    private func getBadgeView() -> MediaCollectionCellBadgeView {
+    private func getBadgeView() -> SiteMediaCollectionCellBadgeView {
         if let badgeView {
             return badgeView
         }
-        let badgeView = MediaCollectionCellBadgeView()
+        let badgeView = SiteMediaCollectionCellBadgeView()
         contentView.addSubview(badgeView)
         badgeView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -108,6 +108,8 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
             }
         }.store(in: &cancellables)
 
+        configureAccessibility(viewModel)
+
         viewModel.onAppear()
     }
 
@@ -128,6 +130,14 @@ final class SiteMediaCollectionCell: UICollectionViewCell {
         }
         imageView.alpha = 1
         placeholderView.alpha = 0
+    }
+
+    // MARK: - Accessibility
+
+    private func configureAccessibility(_ viewModel: SiteMediaCollectionCellViewModel) {
+        isAccessibilityElement = true
+        accessibilityLabel = viewModel.accessibilityLabel
+        accessibilityHint = viewModel.accessibilityHint
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellBadgeView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellBadgeView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class MediaCollectionCellBadgeView: UIView {
+final class SiteMediaCollectionCellBadgeView: UIView {
     let textLabel = UILabel()
 
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -172,7 +172,7 @@ private enum Strings {
     static let accessibilityLabelImage = NSLocalizedString("siteMedia.accessibilityLabelImage", value: "Image, %@", comment: "Accessibility label for image thumbnails in the media collection view. The parameter is the creation date of the image.")
     static let accessibilityLabelVideo = NSLocalizedString("siteMedia.accessibilityLabelVideo", value: "Video, %@", comment: "Accessibility label for video thumbnails in the media collection view. The parameter is the creation date of the video.")
     static let accessibilityLabelAudio = NSLocalizedString("siteMedia.accessibilityLabelAudio", value: "Audio, %@", comment: "Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio.")
-    static let accessibilityLabelDocument = NSLocalizedString("siteMedia.accessibilityLabelAudio", value: "Audio, %@", comment: "Accessibility label for other media items in the media collection view. The parameter is the filename file.")
+    static let accessibilityLabelDocument = NSLocalizedString("siteMedia.accessibilityLabelDocument", value: "Document, %@", comment: "Accessibility label for other media items in the media collection view. The parameter is the filename file.")
     static let accessibilityHint = NSLocalizedString("siteMedia.cellAccessibilityHint", value: "Select media.", comment: "Accessibility hint for actions when displaying media items.")
 }
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class MediaCollectionCellViewModel {
+final class SiteMediaCollectionCellViewModel {
     var onImageLoaded: ((UIImage) -> Void)?
     @Published private(set) var overlayState: CircularProgressView.State?
     @Published var badgeText: String?

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -5,8 +5,9 @@ final class SiteMediaCollectionCellViewModel {
     @Published private(set) var overlayState: CircularProgressView.State?
     @Published private(set) var durationText: String?
     @Published var badgeText: String?
+    var filename: String? { media.filename }
     let mediaID: TaggedManagedObjectID<Media>
-    var mediaType: MediaType
+    let mediaType: MediaType
 
     private let media: Media
     private let service: MediaImageService
@@ -29,7 +30,7 @@ final class SiteMediaCollectionCellViewModel {
         self.service = service
         self.cache = cache
 
-        if media.mediaType == .video || media.mediaType == .audio {
+        if media.mediaType == .video {
             observations.append(media.observe(\.length, options: [.initial, .new]) { [weak self] media, _ in
                 // Using `rounded()` to match the behavior of the Photos app
                 self?.durationText = makeString(forDuration: media.duration().rounded())

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -144,7 +144,45 @@ final class SiteMediaCollectionCellViewModel {
             break
         }
     }
+
+    // MARK: - Accessibility
+
+    var accessibilityLabel: String? {
+        let formattedDate = media.creationDate.map(accessibilityDateFormatter.string) ?? Strings.accessibilityUnknownCreationDate
+
+        switch mediaType {
+        case .image:
+            return String(format: Strings.accessibilityLabelImage, formattedDate)
+        case .video:
+            return String(format: Strings.accessibilityLabelVideo, formattedDate)
+        case .audio:
+            return String(format: Strings.accessibilityLabelAudio, formattedDate)
+        case .document, .powerpoint:
+            return String(format: Strings.accessibilityLabelDocument, media.filename ?? formattedDate)
+        @unknown default:
+            return nil
+        }
+    }
+
+    var accessibilityHint: String { Strings.accessibilityHint }
 }
+
+private enum Strings {
+    static let accessibilityUnknownCreationDate = NSLocalizedString("siteMedia.accessibilityUnknownCreationDate", value: "Unknown creation date", comment: "Accessibility label to use when creation date from media asset is not know.")
+    static let accessibilityLabelImage = NSLocalizedString("siteMedia.accessibilityLabelImage", value: "Image, %@", comment: "Accessibility label for image thumbnails in the media collection view. The parameter is the creation date of the image.")
+    static let accessibilityLabelVideo = NSLocalizedString("siteMedia.accessibilityLabelVideo", value: "Video, %@", comment: "Accessibility label for video thumbnails in the media collection view. The parameter is the creation date of the video.")
+    static let accessibilityLabelAudio = NSLocalizedString("siteMedia.accessibilityLabelAudio", value: "Audio, %@", comment: "Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio.")
+    static let accessibilityLabelDocument = NSLocalizedString("siteMedia.accessibilityLabelAudio", value: "Audio, %@", comment: "Accessibility label for other media items in the media collection view. The parameter is the filename file.")
+    static let accessibilityHint = NSLocalizedString("siteMedia.cellAccessibilityHint", value: "Select media.", comment: "Accessibility hint for actions when displaying media items.")
+}
+
+private let accessibilityDateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.doesRelativeDateFormatting = true
+    formatter.dateStyle = .full
+    formatter.timeStyle = .short
+    return formatter
+}()
 
 // MARK: - Helpers (Duration Formatter)
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaDocumentInfoView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaDocumentInfoView.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+final class SiteMediaDocumentInfoView: UIView {
+    let iconView = UIImageView()
+    let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        iconView.tintColor = .label
+
+        titleLabel.font = .systemFont(ofSize: 12)
+        titleLabel.textColor = .label
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+
+        let stackView = UIStackView(arrangedSubviews: [iconView, titleLabel])
+        stackView.alignment = .center
+        stackView.axis = .vertical
+        stackView.spacing = 4
+
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        pinSubviewToAllEdges(stackView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(_ viewModel: SiteMediaCollectionCellViewModel) {
+        switch viewModel.mediaType {
+        case .document, .powerpoint:
+            iconView.image = .gridicon(.pages)
+            titleLabel.text = viewModel.filename
+        case .audio:
+            iconView.image = .gridicon(.audio)
+            titleLabel.text = viewModel.filename
+        default:
+            break
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaVideoDurationView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaVideoDurationView.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+final class SiteMediaVideoDurationView: UIView {
+    let textLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.33
+        layer.shadowRadius = 8
+
+        textLabel.font = .monospacedDigitSystemFont(ofSize: 13, weight: .semibold)
+        textLabel.textColor = UIColor.white
+
+        addSubview(textLabel)
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        // The insets are designed to make the shadow layer look good and don't take
+        // too much space in the video.
+        NSLayoutConstraint.activate([
+            textLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 32),
+            textLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            textLabel.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            textLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+        ])
+
+        clipsToBounds = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        layer.shadowPath = CGPath(ellipseIn: bounds.offsetBy(dx: bounds.width / 2, dy: bounds.height / 2), transform: nil)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -381,6 +381,8 @@
 		0C01A6EB2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */; };
 		0C0453282AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C0453292AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
+		0C04532B2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */; };
+		0C04532C2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */; };
 		0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0AE75A2A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
@@ -6060,6 +6062,7 @@
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
 		0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellBadgeView.swift; sourceTree = "<group>"; };
 		0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaVideoDurationView.swift; sourceTree = "<group>"; };
+		0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaDocumentInfoView.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaSelectionTitleView.swift; sourceTree = "<group>"; };
@@ -10118,6 +10121,7 @@
 				0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */,
 				0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */,
 				0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */,
+				0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -22460,6 +22464,7 @@
 				FE76C5E0293A63A800573C92 /* UIApplication+AppAvailability.swift in Sources */,
 				9A341E5621997A340036662E /* BlogAuthor.swift in Sources */,
 				C7234A3A2832BA240045C63F /* QRLoginCoordinator.swift in Sources */,
+				0C04532B2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */,
 				9A341E5721997A340036662E /* Blog+BlogAuthors.swift in Sources */,
 				F4D829702931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift in Sources */,
 				7E3AB3DB20F52654001F33B6 /* ActivityContentStyles.swift in Sources */,
@@ -24816,6 +24821,7 @@
 				FABB24482602FC2C00C8785C /* MyProfileViewController.swift in Sources */,
 				0C2C83FE2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift in Sources */,
 				FAD7626529F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift in Sources */,
+				0C04532C2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */,
 				3FE3D1FF26A6F56700F3CD10 /* Comment+Interface.swift in Sources */,
 				FABB24492602FC2C00C8785C /* CreateButtonActionSheet.swift in Sources */,
 				FABB244A2602FC2C00C8785C /* ReaderStreamViewController+Ghost.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -377,8 +377,8 @@
 		0A9610F928B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
-		0C01A6EA2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */; };
-		0C01A6EB2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */; };
+		0C01A6EA2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */; };
+		0C01A6EB2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */; };
 		0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0AE75A2A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
@@ -443,10 +443,10 @@
 		0C8FC9AC2A8C57930059DCE4 /* test-webp.webp in Resources */ = {isa = PBXBuildFile; fileRef = 0C8FC9AB2A8C57930059DCE4 /* test-webp.webp */; };
 		0CA1C8C12A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CA1C8C22A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
-		0CAE8EF22A9E9E8D0073EEB9 /* MediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* MediaCollectionCell.swift */; };
-		0CAE8EF32A9E9E8D0073EEB9 /* MediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* MediaCollectionCell.swift */; };
-		0CAE8EF62A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF52A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift */; };
-		0CAE8EF72A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF52A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift */; };
+		0CAE8EF22A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */; };
+		0CAE8EF32A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */; };
+		0CAE8EF62A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */; };
+		0CAE8EF72A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -6056,7 +6056,7 @@
 		0A69300A28B5AA5E00E98DE1 /* FullScreenCommentReplyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelTests.swift; sourceTree = "<group>"; };
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
-		0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCollectionCellBadgeView.swift; sourceTree = "<group>"; };
+		0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellBadgeView.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaSelectionTitleView.swift; sourceTree = "<group>"; };
@@ -6096,8 +6096,8 @@
 		0C8FC9A92A8C57000059DCE4 /* ItemProviderMediaExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemProviderMediaExporterTests.swift; sourceTree = "<group>"; };
 		0C8FC9AB2A8C57930059DCE4 /* test-webp.webp */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-webp.webp"; sourceTree = "<group>"; };
 		0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarMenuController.swift; sourceTree = "<group>"; };
-		0CAE8EF12A9E9E8D0073EEB9 /* MediaCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCollectionCell.swift; sourceTree = "<group>"; };
-		0CAE8EF52A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
+		0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCell.swift; sourceTree = "<group>"; };
+		0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
@@ -10110,9 +10110,9 @@
 		0C23F3332AC49C1000EE6117 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				0CAE8EF12A9E9E8D0073EEB9 /* MediaCollectionCell.swift */,
-				0C01A6E92AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift */,
-				0CAE8EF52A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift */,
+				0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */,
+				0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */,
+				0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */,
 				0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */,
 			);
 			path = Views;
@@ -21402,7 +21402,7 @@
 				80A2153D29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */,
 				1E485A90249B61440000A253 /* GutenbergRequestAuthenticator.swift in Sources */,
 				084FC3BC299155C900A17BCF /* JetpackOverlayCoordinator.swift in Sources */,
-				0CAE8EF62A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift in Sources */,
+				0CAE8EF62A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */,
 				8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */,
 				E1B912891BB01288003C25B9 /* PeopleViewController.swift in Sources */,
 				3FEC241525D73E8B007AFE63 /* ConfettiView.swift in Sources */,
@@ -21434,7 +21434,7 @@
 				8B36256625A60CCA00D7CCE3 /* BackupListViewController.swift in Sources */,
 				FAA4013427B52455009E1137 /* DashboardQuickActionCell.swift in Sources */,
 				32A218D8251109DB00D1AE6C /* ReaderReportPostAction.swift in Sources */,
-				0C01A6EA2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */,
+				0C01A6EA2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */,
 				FA681F8A25CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift in Sources */,
 				081E4B4C281C019A0085E89C /* TooltipAnchor.swift in Sources */,
 				3F851415260D0A3300A4B938 /* UnifiedPrologueEditorContentView.swift in Sources */,
@@ -21789,7 +21789,7 @@
 				C3234F5427EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */,
 				983DBBAB22125DD500753988 /* StatsTableFooter.swift in Sources */,
 				85D239AE1AE5A5FC0074768D /* BlogSyncFacade.m in Sources */,
-				0CAE8EF22A9E9E8D0073EEB9 /* MediaCollectionCell.swift in Sources */,
+				0CAE8EF22A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */,
 				8B0732F3242BF99B00E7FBD3 /* PrepublishingNavigationController.swift in Sources */,
 				5D97C2F315CAF8D8009B44DD /* UINavigationController+KeyboardFix.m in Sources */,
 				4034FDEA2007C42400153B87 /* ExpandableCell.swift in Sources */,
@@ -23671,7 +23671,7 @@
 				FABB21032602FC2C00C8785C /* JetpackActivityLogViewController.swift in Sources */,
 				17870A712816F2A000D1C627 /* StatsLatestPostSummaryInsightsCell.swift in Sources */,
 				C33A5ADC2935848F00961E3A /* MigrationAppDetection.swift in Sources */,
-				0CAE8EF32A9E9E8D0073EEB9 /* MediaCollectionCell.swift in Sources */,
+				0CAE8EF32A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */,
 				80D9D00429EF4C7F00FE3400 /* DashboardPageCreationCell.swift in Sources */,
 				DC772AF6282009BA00664C02 /* StatsLineChartView.swift in Sources */,
 				FABB21042602FC2C00C8785C /* FormattableMediaContent.swift in Sources */,
@@ -24714,7 +24714,7 @@
 				FABB24032602FC2C00C8785C /* ReaderCSS.swift in Sources */,
 				FABB24042602FC2C00C8785C /* SafariActivity.m in Sources */,
 				FABB24052602FC2C00C8785C /* WordPress-37-38.xcmappingmodel in Sources */,
-				0C01A6EB2AB37F0F009F7145 /* MediaCollectionCellBadgeView.swift in Sources */,
+				0C01A6EB2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */,
 				FABB24062602FC2C00C8785C /* UploadOperation.swift in Sources */,
 				FABB24072602FC2C00C8785C /* LayoutPickerAnalyticsEvent.swift in Sources */,
 				FABB24082602FC2C00C8785C /* ActivityRange.swift in Sources */,
@@ -25415,7 +25415,7 @@
 				F1C740C026B1D4D2005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
 				801D94F02919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift in Sources */,
 				FABB25FF2602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowDefinitions.swift in Sources */,
-				0CAE8EF72A9E9EE30073EEB9 /* MediaCollectionCellViewModel.swift in Sources */,
+				0CAE8EF72A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */,
 				98E082A02637545C00537BF1 /* PostService+Likes.swift in Sources */,
 				FABB26002602FC2C00C8785C /* GravatarProfile.swift in Sources */,
 				FABB26012602FC2C00C8785C /* ReaderShareAction.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -379,6 +379,8 @@
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
 		0C01A6EA2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */; };
 		0C01A6EB2AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */; };
+		0C0453282AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
+		0C0453292AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0AE75A2A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
@@ -6057,6 +6059,7 @@
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
 		0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellBadgeView.swift; sourceTree = "<group>"; };
+		0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaVideoDurationView.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaSelectionTitleView.swift; sourceTree = "<group>"; };
@@ -10114,6 +10117,7 @@
 				0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellBadgeView.swift */,
 				0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */,
 				0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */,
+				0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -22640,6 +22644,7 @@
 				938CF3DC1EF1BE6800AF838E /* CocoaLumberjack.swift in Sources */,
 				740BD8351A0D4C3600F04D18 /* WPUploadStatusButton.m in Sources */,
 				7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */,
+				0C0453282AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */,
 				837B49D9283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift in Sources */,
 				436D56212117312700CEAA33 /* RegisterDomainDetailsViewModel+SectionDefinitions.swift in Sources */,
 				F53FF3A823EA723D001AD596 /* ActionRow.swift in Sources */,
@@ -24734,6 +24739,7 @@
 				084FC3BD299155CA00A17BCF /* JetpackOverlayCoordinator.swift in Sources */,
 				C7F7ABD6261CED7A00CE547F /* JetpackAuthenticationManager.swift in Sources */,
 				FABB24142602FC2C00C8785C /* ThemeBrowserSectionHeaderView.swift in Sources */,
+				0C0453292AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */,
 				FABB24152602FC2C00C8785C /* SiteIconPickerPresenter.swift in Sources */,
 				C79C307D26EA919F00E88514 /* ReferrerDetailsViewModel.swift in Sources */,
 				8BBC778C27B5531700DBA087 /* BlogDashboardPersistence.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

There are multiple changes in this PR, so please bear with me. Once this is merged, the new screens will cover 100% of the original MediaLibraryViewController functionally (and a little bit more). I've been commenting out the re-implement lines as I was working on this project, so this is how I know.

Changes:

- Add support for remaining document types: video, document, audio
- Add GIF rendering and increase the scale of requested GIFs to the max of 2x. Downscaling too much resulted in artifacts during playback.
- Add accessibility support
- Pop details view controller if media is deleted

I have a couple of more performance improvements in mind, but these will be done later.

<img width="320" alt="Screenshot 2023-09-29 at 5 30 49 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/2b2be5b1-597a-4994-afd5-24e67950d831">   <img width="320" alt="Screenshot 2023-09-29 at 5 30 51 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/5716529a-95b3-4d34-9c4d-98aca6b44440">

## To test:

- Verify that the existing video assets display the duration
- Verify that when you upload a new video, it displays the duration
- Verify that documents and audio have a respective icon and their filenames displayed
- Verify that cells are accessibility elements (copied from the previous version)
- Verify that after going to the details page and deleting the asset on it, the details page gets popped from the stack (see [recording](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/5c88d4ba-4ced-4cb0-b5fb-0a2dfac06cbb))
- Verify that GIFs are now animated (we already had the files, so I thought, why not just animate them; it wasn't supported before)

## Regression Notes
1. Potential unintended areas of impact: n/a (no production code changed)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
