### PR TITLE
Plans in Site Creation: Show full free domain explanation label in domain selection view

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell+ViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell+ViewModel.swift
@@ -65,7 +65,7 @@ extension AddressTableViewCell.ViewModel {
         )
         static let freeWithPaidPlan = NSLocalizedString(
             "domain.suggestions.row.free-with-plan",
-            value: "Free for a year with a plan",
+            value: "Free for the first year with annual paid plans",
             comment: "The text to display for paid domains that are free for the first year with the paid plan in 'Site Creation > Choose a domain' screen"
         )
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -9,6 +9,17 @@ final class AddressTableViewCell: UITableViewCell {
         RemoteFeatureFlag.plansInSiteCreation.enabled()
     }
 
+    override var accessibilityLabel: String? {
+        get {
+            return [domainLabel.text,
+                    trailingLabel.text,
+                    leadingLabel.text]
+                .compactMap { $0 }
+                .joined(separator: ".\n")
+        }
+        set {}
+    }
+
     // MARK: - Views
 
     private var borders = [UIView]()
@@ -82,9 +93,7 @@ final class AddressTableViewCell: UITableViewCell {
             "Selects this domain to use for your site.",
             comment: "Accessibility hint for a domain in the Site Creation domains list."
         )
-        if domainPurchasingEnabled {
-            self.accessibilityElements = [domainLabel, leadingLabel, trailingLabel]
-        } else {
+        if !domainPurchasingEnabled {
             self.selectedBackgroundView?.backgroundColor = .clear
         }
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -22,7 +22,7 @@ final class AddressTableViewCell: UITableViewCell {
         return label
     }()
 
-    private let tagsLabel: UILabel = {
+    private let leadingLabel: UILabel = {
         let label = UILabel()
         label.adjustsFontForContentSizeCategory = true
         label.font = Appearance.tagFont
@@ -52,7 +52,7 @@ final class AddressTableViewCell: UITableViewCell {
         return view
     }()
 
-    private let costLabel: UILabel = {
+    private let trailingLabel: UILabel = {
         let label = UILabel()
         label.adjustsFontForContentSizeCategory = true
         label.font = Appearance.domainFont
@@ -83,27 +83,27 @@ final class AddressTableViewCell: UITableViewCell {
             comment: "Accessibility hint for a domain in the Site Creation domains list."
         )
         if domainPurchasingEnabled {
-            self.accessibilityElements = [domainLabel, tagsLabel, costLabel]
+            self.accessibilityElements = [domainLabel, leadingLabel, trailingLabel]
         } else {
             self.selectedBackgroundView?.backgroundColor = .clear
         }
     }
 
     private func setupSubviews() {
-        let domainAndTag = Self.stackedViews([domainLabel, tagsLabel], axis: .vertical, alignment: .fill, distribution: .fill, spacing: 2)
-        let main = Self.stackedViews([domainAndTag, costLabel], axis: .horizontal, alignment: .center, distribution: .fill, spacing: 4)
-        tagsLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        tagsLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        let domainAndTag = Self.stackedViews([domainLabel, leadingLabel], axis: .vertical, alignment: .fill, distribution: .fill, spacing: 2)
+        let main = Self.stackedViews([domainAndTag, trailingLabel], axis: .horizontal, alignment: .center, distribution: .fill, spacing: 4)
         domainLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         domainLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        costLabel.setContentHuggingPriority(.required, for: .horizontal)
-        costLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        leadingLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        leadingLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        trailingLabel.setContentHuggingPriority(.required, for: .horizontal)
+        trailingLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         main.translatesAutoresizingMaskIntoConstraints = false
         main.isLayoutMarginsRelativeArrangement = true
         main.directionalLayoutMargins = Appearance.contentMargins
         self.contentView.addSubview(main)
         self.contentView.pinSubviewToAllEdges(main)
-        self.updatePriceLabelTextAlignment()
+        self.updateTrailingLabelTextAlignment()
         self.contentView.addSubview(dotView)
         self.contentView.addSubview(checkmarkImageView)
         self.selectedBackgroundView = {
@@ -127,7 +127,7 @@ final class AddressTableViewCell: UITableViewCell {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.layoutDirection != previousTraitCollection?.layoutDirection {
-            self.updatePriceLabelTextAlignment()
+            self.updateTrailingLabelTextAlignment()
         }
     }
 
@@ -136,26 +136,26 @@ final class AddressTableViewCell: UITableViewCell {
     /// This is the new update method and it's called when `domainPurchasing` feature flag is enabled.
     func update(with viewModel: ViewModel) {
         self.domainLabel.text = viewModel.domain
-        self.tagsLabel.attributedText = Self.tagsAttributedString(tags: viewModel.tags, cost: viewModel.cost)
-        self.costLabel.attributedText = Self.costAttributedString(cost: viewModel.cost)
+        self.leadingLabel.attributedText = Self.leadingAttributedString(tags: viewModel.tags, cost: viewModel.cost)
+        self.trailingLabel.attributedText = Self.trailingAttributedString(cost: viewModel.cost)
         self.dotView.backgroundColor = Appearance.dotColor(viewModel.tags.first)
     }
 
-    /// Updates the `costLabel` text alignment.
-    private func updatePriceLabelTextAlignment() {
+    /// Updates the `trailingLabel` text alignment.
+    private func updateTrailingLabelTextAlignment() {
         switch traitCollection.layoutDirection {
         case .rightToLeft:
             // swiftlint:disable:next natural_text_alignment
-            self.costLabel.textAlignment = .left
+            self.trailingLabel.textAlignment = .left
         default:
             // swiftlint:disable:next inverse_text_alignment
-            self.costLabel.textAlignment = .right
+            self.trailingLabel.textAlignment = .right
         }
     }
 
     // MARK: - Helpers
 
-    private static func tagsAttributedString(tags: [ViewModel.Tag], cost: ViewModel.Cost) -> NSAttributedString? {
+    private static func leadingAttributedString(tags: [ViewModel.Tag], cost: ViewModel.Cost) -> NSAttributedString? {
         let attributedString = NSMutableAttributedString()
         for (index, tag) in tags.enumerated() {
             let attributes: [NSAttributedString.Key: Any] = [
@@ -173,7 +173,6 @@ final class AddressTableViewCell: UITableViewCell {
             ]
 
             let newline = attributedString.length > 0 ? "\n" : ""
-
             attributedString.append(.init(string: "\(newline)\(ViewModel.Strings.freeWithPaidPlan)", attributes: firstYearAttributes))
             return attributedString
         default:
@@ -183,7 +182,7 @@ final class AddressTableViewCell: UITableViewCell {
         return attributedString
     }
 
-    private static func costAttributedString(cost: ViewModel.Cost) -> NSAttributedString {
+    private static func trailingAttributedString(cost: ViewModel.Cost) -> NSAttributedString {
         switch cost {
         case .free:
             let attributes: [NSAttributedString.Key: Any] = [

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -66,7 +66,7 @@ final class AddressTableViewCell: UITableViewCell {
     private let trailingLabel: UILabel = {
         let label = UILabel()
         label.adjustsFontForContentSizeCategory = true
-        label.font = Appearance.domainFont
+        label.font = Appearance.regularCostFont
         label.textColor = Appearance.domainTextColor
         label.numberOfLines = 2
         return label
@@ -181,8 +181,7 @@ final class AddressTableViewCell: UITableViewCell {
         switch cost {
         case .freeWithPaidPlan:
             let firstYearAttributes: [NSAttributedString.Key: Any] = [
-                .foregroundColor: Appearance.saleCostTextColor,
-                .font: Appearance.smallCostFont
+                .foregroundColor: Appearance.saleCostTextColor
             ]
 
             let newline = attributedString.length > 0 ? "\n" : ""
@@ -199,14 +198,12 @@ final class AddressTableViewCell: UITableViewCell {
         switch cost {
         case .free:
             let attributes: [NSAttributedString.Key: Any] = [
-                .foregroundColor: UIColor.label,
-                .font: Appearance.regularCostFont
+                .foregroundColor: UIColor.label
             ]
             return NSAttributedString(string: ViewModel.Strings.free, attributes: attributes)
         case .regular(let cost):
             var attributes: [NSAttributedString.Key: Any] = [
-                .foregroundColor: UIColor.label,
-                .font: Appearance.regularCostFont
+                .foregroundColor: UIColor.label
             ]
             let attributedString = NSMutableAttributedString(string: cost, attributes: attributes)
             attributes[.font] = Appearance.smallCostFont
@@ -233,7 +230,6 @@ final class AddressTableViewCell: UITableViewCell {
         case .freeWithPaidPlan(let cost):
             let costAttributes: [NSAttributedString.Key: Any] = [
                 .foregroundColor: UIColor.secondaryLabel,
-                .font: Appearance.regularCostFont,
                 .strikethroughStyle: NSUnderlineStyle.single.rawValue
             ]
             let attributedString = NSMutableAttributedString(string: cost, attributes: costAttributes)

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressTableViewCell.swift
@@ -127,7 +127,11 @@ final class AddressTableViewCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         [dotView, checkmarkImageView].forEach { view in
-            view.center = CGPoint(x: Appearance.contentMargins.leading / 2, y: bounds.midY)
+            if traitCollection.layoutDirection == .leftToRight {
+                view.center = CGPoint(x: Appearance.contentMargins.leading / 2, y: bounds.midY)
+            } else {
+                view.center = CGPoint(x: contentView.frame.width - Appearance.contentMargins.leading / 2, y: bounds.midY)
+            }
         }
     }
 


### PR DESCRIPTION
Addressing the issue of not showing the full "Free for the first year with annual paid plans" (https://github.com/wordpress-mobile/WordPress-iOS/pull/21654#discussion_r1340635422) localized text.

With the changes, I prioritize showing as much information as possible and avoiding cutting off any text:

- Changed the text back to "Free for the first year with annual paid plans"
- Moved this long text to the left side under the domain name, as is the case on Android (https://github.com/wordpress-mobile/WordPress-Android/pull/19283) and the Web
- Adjusted priorities, so the left side would expand as long as price fits, and then wrap to another line

| short domain - short price | long domain - long price | short domain - long price | short - dark mode | short - dynamic type |
| --- | --- | --- | --- | --- |
| ![short domain - short price](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/7d3e1ef9-a75d-436a-be9e-cca7fc906cb0) | ![long domain - long price](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/ef2d34e0-27ce-4ddf-b774-b46395acde11) | ![short domain - long price](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/27e50d3d-8bf9-4b5f-920c-070926eed04c) | ![short - dark mode](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/49377456-25d3-401c-a412-ceac06b0b8bb) | ![short - dynamic type](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/5398355f-9f44-4292-b70c-f00b7095da4e) |

- Additionally, made VoiceOver improvements

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/41040a8c-8cd1-4ce5-8445-762202c8da92

- And added right-to-left language fixes

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/59a03f63-b3e2-4de8-9ed7-24488175f821" width="250" alt="image">

### To test:

1. Enable "Plans in Site creation feature flag"
2. Create new site (either with a fresh account, or via site selector)
3. Search for domains
4. Confirm that "Free for the first year with annual paid plans" label is shown

#### Regression

1. Disable "Plans in Site creation feature flag"
2. Create new site (either with a fresh account, or via site selector)
3. Search for domains
4. Confirm that free domains are continued to be shown in a one-line cell

## Regression Notes
1. Potential unintended areas of impact

Breaking already existing UI for the cell

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
