### PR TITLE
Media: Add support for self-hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1888,9 +1888,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source
 {
     [self trackEvent:WPAnalyticsStatOpenedMediaLibrary fromSource:source];
-    MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
-    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self.presentationDelegate presentBlogDetailsViewController:controller];
+    if ([Feature enabled:FeatureFlagMediaModernization]) {
+        SiteMediaViewController *controller = [[SiteMediaViewController alloc] initWithBlog:self.blog];
+        [self.presentationDelegate presentBlogDetailsViewController:controller];
+    } else {
+        MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
+        controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+        [self.presentationDelegate presentBlogDetailsViewController:controller];
+    }
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementMediaScreen];
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -14,7 +14,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     private lazy var toolbarItemTitle = SiteMediaSelectionTitleView()
     private lazy var toolbarItemShare = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(buttonShareTapped))
 
-    init(blog: Blog) {
+    @objc init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)
 

--- a/WordPress/WordPressTest/MediaImageServiceTests.swift
+++ b/WordPress/WordPressTest/MediaImageServiceTests.swift
@@ -124,8 +124,11 @@ class MediaImageServiceTests: CoreDataTestCase {
         // WHEN
         let thumbnail = try await sut.thumbnail(for: media)
 
+        let expectedSize = MediaImageService.getThumbnailSize(for: media, size: .small)
+
         // THEN a thumbnail is downloaded using the remote URL as is
-        XCTAssertEqual(thumbnail.size, MediaImageService.getThumbnailSize(for: media, size: .small))
+        XCTAssertEqual(thumbnail.size.width, expectedSize.width, accuracy: 1.5)
+        XCTAssertEqual(thumbnail.size.height, expectedSize.height, accuracy: 1.5)
 
         // GIVEN local asset is deleted
         sut.flush()
@@ -134,7 +137,8 @@ class MediaImageServiceTests: CoreDataTestCase {
         let cachedThumbnail = try await sut.thumbnail(for: media)
 
         // THEN cached thumbnail is still available
-        XCTAssertEqual(cachedThumbnail.size, MediaImageService.getThumbnailSize(for: media, size: .small))
+        XCTAssertEqual(cachedThumbnail.size.width, expectedSize.width, accuracy: 1.5)
+        XCTAssertEqual(cachedThumbnail.size.height, expectedSize.height, accuracy: 1.5)
     }
 
     // MARK: - Target Size


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

- Add support for generating video thumbnails for self-hosted sites
- Integrate the new Media screen in the Blog Details screen

## To test:

- Create or open WP Admin on a self-hosted site 
- Open Media and upload a video file
- Open Media in the Jetpack or WordPress iOS apps
- Verify that the app displays a thumbnail for the video

## Regression Notes
1. Potential unintended areas of impact: n/a (new screen, no production code changes)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual and unit tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
