### PR TITLE
Reader: Add new post detail header

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -74,7 +74,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private let featuredImage: ReaderDetailFeaturedImageView = .loadFromNib()
 
     /// The actual header
-    private let header: ReaderDetailHeaderView = .loadFromNib()
+    private lazy var header: UIView & ReaderDetailHeader = {
+        guard FeatureFlag.readerImprovements.enabled else {
+            return ReaderDetailHeaderView.loadFromNib()
+        }
+        return ReaderDetailNewHeaderViewHost()
+    }()
 
     /// Bottom toolbar
     private let toolbar: ReaderDetailToolbar = .loadFromNib()
@@ -597,7 +602,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         headerContainerView.translatesAutoresizingMaskIntoConstraints = false
 
         headerContainerView.pinSubviewToAllEdges(header)
-        headerContainerView.heightAnchor.constraint(equalTo: header.heightAnchor).isActive = true
+
+        if !FeatureFlag.readerImprovements.enabled {
+            headerContainerView.heightAnchor.constraint(equalTo: header.heightAnchor).isActive = true
+        }
     }
 
     private func fetchLikes() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -78,7 +78,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         guard FeatureFlag.readerImprovements.enabled else {
             return ReaderDetailHeaderView.loadFromNib()
         }
-        return ReaderDetailNewHeaderViewHost(isLoggedIn: AccountHelper.isDotcomAvailable())
+        return ReaderDetailNewHeaderViewHost()
     }()
 
     /// Bottom toolbar

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -78,7 +78,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         guard FeatureFlag.readerImprovements.enabled else {
             return ReaderDetailHeaderView.loadFromNib()
         }
-        return ReaderDetailNewHeaderViewHost()
+        return ReaderDetailNewHeaderViewHost(isLoggedIn: AccountHelper.isDotcomAvailable())
     }()
 
     /// Bottom toolbar

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -9,7 +9,7 @@ protocol ReaderDetailHeaderViewDelegate: AnyObject {
     func didSelectTopic(_ topic: String)
 }
 
-class ReaderDetailHeaderView: UIStackView, NibLoadable {
+class ReaderDetailHeaderView: UIStackView, NibLoadable, ReaderDetailHeader {
     @IBOutlet weak var headerView: UIView!
     @IBOutlet weak var blavatarImageView: UIImageView!
     @IBOutlet weak var blogURLLabel: UILabel!

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -252,6 +252,11 @@ struct ReaderDetailNewHeaderView: View {
             }
             .frame(width: Constants.authorImageLength, height: Constants.authorImageLength)
             .clipShape(Circle())
+            .overlay {
+                Circle()
+                    .stroke(Color(uiColor: .systemBackground), lineWidth: 1.0)
+            }
+            .offset(x: 2.0, y: 2.0)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -27,8 +27,6 @@ class ReaderDetailNewHeaderViewHost: UIView {
     // TODO: Find out if we still need this.
     var useCompatibilityMode: Bool = false
 
-    private let isLoggedIn: Bool
-
     private var postObjectID: TaggedManagedObjectID<ReaderPost>? = nil
 
     // TODO: Populate this with values from the ReaderPost.
@@ -41,9 +39,7 @@ class ReaderDetailNewHeaderViewHost: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(isLoggedIn: Bool) {
-        self.isLoggedIn = isLoggedIn
-
+    init() {
         super.init(frame: .zero)
         setupView()
     }
@@ -74,7 +70,6 @@ class ReaderDetailNewHeaderViewHost: UIView {
 extension ReaderDetailNewHeaderViewHost: ReaderDetailHeader {
     func configure(for post: ReaderPost) {
         viewModel.configure(with: TaggedManagedObjectID(post),
-                            isLoggedIn: isLoggedIn,
                             completion: refreshContainerLayout)
     }
 
@@ -106,7 +101,6 @@ class ReaderDetailHeaderViewModel: ObservableObject {
 
     // Follow/Unfollow states
     @Published var isFollowingSite = false
-    @Published var showsFollowButton = false
     @Published var isFollowButtonInteractive = true
 
     @Published var siteIconURL: URL? = nil
@@ -123,9 +117,7 @@ class ReaderDetailHeaderViewModel: ObservableObject {
         self.coreDataStack = coreDataStack
     }
 
-    func configure(with objectID: TaggedManagedObjectID<ReaderPost>,
-                   isLoggedIn: Bool,
-                   completion: (() -> Void)?) {
+    func configure(with objectID: TaggedManagedObjectID<ReaderPost>, completion: (() -> Void)?) {
         postObjectID = objectID
         coreDataStack.performQuery { [weak self] context -> Void in
             guard let self,
@@ -133,7 +125,6 @@ class ReaderDetailHeaderViewModel: ObservableObject {
                 return
             }
 
-            self.showsFollowButton = isLoggedIn
             self.isFollowingSite = post.isFollowing
 
             self.siteIconURL = post.siteIconForDisplay(ofSize: Int(ReaderDetailNewHeaderView.Constants.siteIconLength))
@@ -232,10 +223,8 @@ struct ReaderDetailNewHeaderView: View {
     var headerRow: some View {
         HStack(spacing: 8.0) {
             authorStack
-            if viewModel.showsFollowButton {
-                Spacer()
-                followButton(isPhone: WPDeviceIdentification.isiPhone())
-            }
+            Spacer()
+            followButton(isPhone: WPDeviceIdentification.isiPhone())
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -247,7 +247,8 @@ struct ReaderDetailNewHeaderView: View {
                     .font(.callout)
                     .fontWeight(.semibold)
                     .foregroundStyle(.primary)
-                authorAndTimestampText
+                    .lineLimit(1)
+                authorAndTimestampView
             }
         }
         .onTapGesture {
@@ -306,29 +307,27 @@ struct ReaderDetailNewHeaderView: View {
             })
     }
 
-    var authorAndTimestampText: some View {
-        guard viewModel.showsAuthorName,
-              !viewModel.authorName.isEmpty else {
-            return timestampText
-        }
+    var authorAndTimestampView: some View {
+        HStack(spacing: 0) {
+            if viewModel.showsAuthorName, !viewModel.authorName.isEmpty {
+                Text(viewModel.authorName)
+                    .font(.footnote)
+                    .foregroundColor(Color(.text))
+                    .lineLimit(1)
 
-        var texts: [Text] = [
-            Text(viewModel.authorName)
-                .font(.footnote)
-                .foregroundColor(Color(.text)),
-
-            Text(" • ")
-                .font(.footnote)
-                .foregroundColor(Color(.secondaryLabel)),
+                Text(" • ")
+                    .font(.footnote)
+                    .foregroundColor(Color(.secondaryLabel))
+                    .lineLimit(1)
+                    .layoutPriority(1)
+            }
 
             timestampText
-        ]
+                .lineLimit(1)
+                .layoutPriority(1)
 
-        if direction == .rightToLeft {
-            texts.reverse()
+            Spacer()
         }
-
-        return texts.reduce(Text(""), +)
     }
 
     var timestampText: Text {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -209,6 +209,10 @@ struct ReaderDetailNewHeaderView: View {
         return colorScheme == .light ? color.darkVariant() : color.lightVariant()
     }
 
+    var innerBorderOpacity: CGFloat {
+        return colorScheme == .light ? 0.1 : 0.2
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16.0) {
             headerRow
@@ -270,7 +274,7 @@ struct ReaderDetailNewHeaderView: View {
                 // adds an inward border with low opacity to preserve the avatar's shape.
                 Circle()
                     .strokeBorder(Color(uiColor: avatarInnerBorderColor), lineWidth: 0.5)
-                    .opacity(0.1)
+                    .opacity(innerBorderOpacity)
             }
 
             AsyncImage(url: avatarURL) { image in
@@ -284,7 +288,7 @@ struct ReaderDetailNewHeaderView: View {
                 // adds an inward border with low opacity to preserve the avatar's shape.
                 Circle()
                     .strokeBorder(Color(uiColor: avatarInnerBorderColor), lineWidth: 0.5)
-                    .opacity(0.1)
+                    .opacity(innerBorderOpacity)
             }
             .background {
                 // adds a border between the the author avatar and the site icon.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -1,0 +1,365 @@
+import SwiftUI
+import WordPressUI
+import Gridicons
+
+/// A protocol conformed by both `ReaderDetailHeaderView` and `ReaderDetailNewHeaderViewHost`.
+/// This is a temporary solution to abstract and simplify usage in the view controller.
+///
+/// NOTE: This protocol should be removed once the `readerImprovements` flag is deleted.
+///
+protocol ReaderDetailHeader: NSObjectProtocol {
+    var delegate: ReaderDetailHeaderViewDelegate? { get set }
+    var useCompatibilityMode: Bool { get set }
+
+    func configure(for post: ReaderPost)
+    func refreshFollowButton()
+}
+
+// MARK: - SwiftUI View Host
+
+class ReaderDetailNewHeaderViewHost: UIView {
+    weak var delegate: ReaderDetailHeaderViewDelegate?
+
+    // TODO: Find out if we still need this.
+    var useCompatibilityMode: Bool = false
+
+    // TODO: Populate this with values from the ReaderPost.
+    private lazy var viewModel: ReaderDetailHeaderViewModel = {
+        $0.topicDelegate = self
+        $0.headerDelegate = delegate
+        return $0
+    }(ReaderDetailHeaderViewModel())
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    func setupView() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        let headerView = ReaderDetailNewHeaderView(viewModel: viewModel) { [weak self] in
+            guard let swiftUIView = self?.subviews.first else {
+                return
+            }
+            swiftUIView.invalidateIntrinsicContentSize()
+            self?.layoutIfNeeded()
+        }
+
+        let view = UIView.embedSwiftUIView(headerView)
+        addSubview(view)
+        pinSubviewToAllEdges(view)
+    }
+}
+
+// MARK: ReaderDetailHeader
+
+extension ReaderDetailNewHeaderViewHost: ReaderDetailHeader {
+    func configure(for post: ReaderPost) {
+        // TODO: Check if it's possible to move this to `init`.
+    }
+
+    func refreshFollowButton() {
+        viewModel.isFollowingSite = true
+    }
+}
+
+// MARK: ReaderTopicCollectionViewCoordinatorDelegate
+
+extension ReaderDetailNewHeaderViewHost: ReaderTopicCollectionViewCoordinatorDelegate {
+    func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didSelectTopic topic: String) {
+        delegate?.didSelectTopic(topic)
+    }
+
+    func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState) {
+        // no op
+    }
+}
+
+// MARK: - SwiftUI View Model
+
+// TODO: Hook with real data
+class ReaderDetailHeaderViewModel: ObservableObject {
+    weak var headerDelegate: ReaderDetailHeaderViewDelegate?
+    weak var topicDelegate: ReaderTopicCollectionViewCoordinatorDelegate?
+
+    @Published var isFollowingSite = false
+    @Published var showsFollowButton = true
+    @Published var isFollowButtonInteractive = true
+
+    let siteIconURL: URL? = URL(string: "https://cyclingmole.com/wp-content/uploads/2021/11/cropped-favicon-1.jpg")
+    let authorAvatarURL: URL? = URL(string: "https://2.gravatar.com/avatar/2fdc6c9e9d38a9b422210e1728a677c8466d101518d20b81490db476f59b08cf?s=96&d=https%3A%2F%2F2.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D96&r=G")
+    let authorName: String = "Penelope Greenway"
+    let relativePostTime: String = "1h ago"
+    let siteName: String = "Nature's Canvas"
+    let postTitle: String = "Untamed Beauty: Discovering the Wonders of the Wild"
+    let tags: [String] = ["daily prompt", "travel", "music", "photography", "shadow dancing", "ultimate gifts"]
+
+    func didTapAuthorSection() {
+        headerDelegate?.didTapBlogName()
+    }
+
+    func didTapFollowButton() {
+        guard let headerDelegate else {
+            return
+        }
+
+        isFollowButtonInteractive = false
+        isFollowingSite.toggle()
+
+        headerDelegate.didTapFollowButton { [weak self] in
+            self?.isFollowButtonInteractive = true
+        }
+    }
+}
+
+// MARK: - SwiftUI
+
+/// The updated header version for Reader Details.
+///
+/// TODO: Rename this to `ReaderDetailHeaderView` once the `readerImprovements` flag is removed.
+///
+struct ReaderDetailNewHeaderView: View {
+
+    @SwiftUI.Environment(\.layoutDirection) var direction
+
+    @ObservedObject var viewModel: ReaderDetailHeaderViewModel
+
+    /// A callback for the parent to react to collection view size changes.
+    var onTagsViewUpdated: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16.0) {
+            headerRow
+            Text(viewModel.postTitle)
+                .font(.title)
+                .fontWeight(.bold)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true) // prevents the title from being truncated.
+            if !viewModel.tags.isEmpty {
+                tagsView
+            }
+        }
+        // Added an extra 4.0 to top padding to account for a legacy layout issue with featured image.
+        // Bottom padding is 0 as there's already padding between the header container and the webView in the storyboard.
+        .padding(EdgeInsets(top: 12.0, leading: 16.0, bottom: 0.0, trailing: 16.0))
+    }
+
+    var headerRow: some View {
+        HStack(spacing: 8.0) {
+            authorStack
+            if viewModel.showsFollowButton {
+                Spacer()
+                followButton(isPhone: WPDeviceIdentification.isiPhone())
+            }
+        }
+    }
+
+    var authorStack: some View {
+        HStack(spacing: 8.0) {
+            if let siteIconURL = viewModel.siteIconURL,
+               let avatarURL = viewModel.authorAvatarURL {
+                avatarView(with: siteIconURL, avatarURL: avatarURL)
+            }
+            VStack(alignment: .leading) {
+                Text(viewModel.siteName)
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
+                authorText
+            }
+        }
+        .onTapGesture {
+            viewModel.didTapAuthorSection()
+        }
+    }
+
+    @ViewBuilder
+    func avatarView(with siteIconURL: URL, avatarURL: URL) -> some View {
+        ZStack(alignment: .bottomTrailing) {
+            AsyncImage(url: siteIconURL) { image in
+                image.resizable()
+            } placeholder: {
+                Image("post-blavatar-default").resizable()
+            }
+            .frame(width: Constants.siteIconLength, height: Constants.siteIconLength)
+            .clipShape(Circle())
+
+            AsyncImage(url: avatarURL) { image in
+                image.resizable()
+            } placeholder: {
+                Image("blavatar-default").resizable()
+            }
+            .frame(width: Constants.authorImageLength, height: Constants.authorImageLength)
+            .clipShape(Circle())
+        }
+    }
+
+    var tagsView: some View {
+        ReaderDetailTagsWrapperView(topics: viewModel.tags, delegate: viewModel.topicDelegate)
+            .background(GeometryReader { geometry in
+                // The host view does not react properly after the collection view finished its layout.
+                // This informs any size changes to the host view so that it can readjust correctly.
+                Color.clear
+                    .onChange(of: geometry.size) { newValue in
+                        onTagsViewUpdated?()
+                    }
+            })
+    }
+
+    var authorText: some View {
+        var texts: [Text] = [
+            Text(viewModel.authorName)
+                .font(.footnote)
+                .foregroundColor(Color(.text)),
+
+            Text(" • ")
+                .font(.footnote)
+                .foregroundColor(Color(.secondaryLabel)),
+
+            // TODO: Process the logic for relative post time.
+            // TODO: Use the current relative time formatter.
+            Text(viewModel.relativePostTime)
+                .font(.footnote)
+                .foregroundColor(Color(.secondaryLabel))
+        ]
+
+        if direction == .rightToLeft {
+            texts.reverse()
+        }
+
+        return texts.reduce(Text(""), +)
+    }
+
+    /// TODO: Update when the Follow buttons are updated.
+    @ViewBuilder
+    private func followButton(isPhone: Bool = true) -> some View {
+        let style: LegacyFollowButtonStyle = viewModel.isFollowingSite ? .following : .follow
+
+        Button {
+            viewModel.didTapFollowButton()
+        } label: {
+            if isPhone {
+                // only shows the icon as the button.
+                Image(uiImage: .gridicon(style.gridiconType, size: style.iconButtonSize))
+                    .tint(style.tintColor)
+            } else {
+                // shows both the icon and the label.
+                Label {
+                    Text(style.buttonLabel)
+                        .font(.callout)
+                        .fontWeight(style.fontWeight)
+                } icon: {
+                    Image(uiImage: .gridicon(style.gridiconType, size: style.labelIconSize).imageWithTintColor(style.labelIconTintColor)!)
+                }
+                .padding(style.buttonPadding)
+                .background(style.labelBackgroundColor)
+                .tint(style.labelTintColor)
+                .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
+                .overlay {
+                    RoundedRectangle(cornerRadius: style.cornerRadius)
+                        .stroke(style.borderColor, lineWidth: style.borderWidth)
+                }
+            }
+        }
+        .accessibilityLabel(style.buttonLabel)
+        .accessibilityHint(style.accessibilityHint)
+        .disabled(!viewModel.isFollowButtonInteractive)
+    }
+}
+
+// MARK: Private Helpers
+
+private extension ReaderDetailNewHeaderView {
+
+    struct Constants {
+        static let siteIconLength: CGFloat = 40.0
+        static let authorImageLength: CGFloat = 20.0
+    }
+
+    /// "Legacy" follow button styling.
+    /// Mostly taken from `WPStyleGuide+Reader`'s `applyReaderFollowButtonStyle`
+    ///
+    /// TODO: Remove this when the new Follow buttons are added.
+    struct LegacyFollowButtonStyle {
+        // Style for the Follow button
+        static let follow = LegacyFollowButtonStyle(
+            gridiconType: .readerFollow,
+            tintColor: Color(uiColor: .primary),
+            fontWeight: .semibold,
+            labelBackgroundColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followBackgroundColor),
+            labelTintColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followTextColor),
+            labelIconTintColor: WPStyleGuide.FollowButton.Style.followTextColor,
+            borderWidth: 0.0,
+            buttonLabel: WPStyleGuide.FollowButton.Text.followStringForDisplay,
+            accessibilityHint: WPStyleGuide.FollowButton.Text.accessibilityHint
+        )
+
+        // Style for the Following button
+        static let following = LegacyFollowButtonStyle(
+            gridiconType: .readerFollowing,
+            tintColor: Color(uiColor: .gray(.shade20)),
+            fontWeight: .regular,
+            labelBackgroundColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followingBackgroundColor),
+            labelTintColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followingIconColor),
+            labelIconTintColor: WPStyleGuide.FollowButton.Style.followingTextColor,
+            borderWidth: 1.0,
+            buttonLabel: WPStyleGuide.FollowButton.Text.followingStringForDisplay,
+            accessibilityHint: WPStyleGuide.FollowButton.Text.accessibilityHint
+        )
+
+        let gridiconType: GridiconType
+
+        // iPhone-specific styling
+        let iconButtonSize = CGSize(width: 24, height: 24)
+        let tintColor: Color
+        let iconBackgroundColor: Color = .clear
+
+        // iPad-specific styling
+        let font: Font = .callout
+        let fontWeight: Font.Weight
+        let buttonPadding = EdgeInsets(top: 6.0, leading: 12.0, bottom: 6.0, trailing: 12.0)
+        let labelBackgroundColor: Color
+        let labelTintColor: Color
+        let labelIconTintColor: UIColor
+        let cornerRadius = 4.0
+        let borderColor = Color(uiColor: .primaryButtonBorder)
+        let borderWidth: CGFloat
+        let labelIconSize = CGSize(width: WPStyleGuide.fontSizeForTextStyle(.callout),
+                                   height: WPStyleGuide.fontSizeForTextStyle(.callout))
+
+        // localization-related
+        let buttonLabel: String
+        let accessibilityHint: String
+    }
+}
+
+// MARK: - TopicCollectionView UIViewRepresentable Wrapper
+
+fileprivate struct ReaderDetailTagsWrapperView: UIViewRepresentable {
+    private let topics: [String]
+    private weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
+
+    init(topics: [String], delegate: ReaderTopicCollectionViewCoordinatorDelegate?) {
+        self.topics = topics
+        self.delegate = delegate
+    }
+
+    func makeUIView(context: Context) -> UICollectionView {
+        let view = TopicsCollectionView(frame: .zero, collectionViewLayout: ReaderInterestsCollectionViewFlowLayout())
+        view.topics = topics
+        view.topicDelegate = delegate
+
+        // ensure that the collection view hugs its content.
+        view.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return view
+    }
+
+    func updateUIView(_ uiView: UICollectionView, context: Context) {
+        uiView.layoutIfNeeded()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -195,11 +195,19 @@ class ReaderDetailHeaderViewModel: ObservableObject {
 struct ReaderDetailNewHeaderView: View {
 
     @SwiftUI.Environment(\.layoutDirection) var direction
+    @SwiftUI.Environment(\.colorScheme) var colorScheme
 
     @ObservedObject var viewModel: ReaderDetailHeaderViewModel
 
     /// A callback for the parent to react to collection view size changes.
     var onTagsViewUpdated: (() -> Void)? = nil
+
+    /// Used for the inward border. We want the color to be inverted, such that the avatar can "preserve" its shape
+    /// when the image has low or almost no contrast with the background (imagine white avatar on white background).
+    var avatarInnerBorderColor: UIColor {
+        let color = UIColor.systemBackground
+        return colorScheme == .light ? color.darkVariant() : color.lightVariant()
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16.0) {
@@ -257,6 +265,12 @@ struct ReaderDetailNewHeaderView: View {
             }
             .frame(width: Constants.siteIconLength, height: Constants.siteIconLength)
             .clipShape(Circle())
+            .overlay {
+                // adds an inward border with low opacity to preserve the avatar's shape.
+                Circle()
+                    .strokeBorder(Color(uiColor: avatarInnerBorderColor), lineWidth: 0.5)
+                    .opacity(0.1)
+            }
 
             AsyncImage(url: avatarURL) { image in
                 image.resizable()
@@ -266,6 +280,13 @@ struct ReaderDetailNewHeaderView: View {
             .frame(width: Constants.authorImageLength, height: Constants.authorImageLength)
             .clipShape(Circle())
             .overlay {
+                // adds an inward border with low opacity to preserve the avatar's shape.
+                Circle()
+                    .strokeBorder(Color(uiColor: avatarInnerBorderColor), lineWidth: 0.5)
+                    .opacity(0.1)
+            }
+            .background {
+                // adds a border between the the author avatar and the site icon.
                 Circle()
                     .stroke(Color(uiColor: .systemBackground), lineWidth: 1.0)
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5551,6 +5551,8 @@
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFF2A4C9855008A48E0 /* Blog+PublicizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */; };
+		FEF28E822ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
+		FEF28E832ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
 		FEF4DC5528439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEF4DC5628439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEFA263E26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */; };
@@ -9356,6 +9358,7 @@
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
+		FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailNewHeaderView.swift; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
 		FEFA6AC22A83F4BE004EE5E6 /* PostHelper+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHelper+JetpackSocial.swift"; sourceTree = "<group>"; };
@@ -13859,6 +13862,7 @@
 				3223393D24FEC2A700BDD4BF /* ReaderDetailFeaturedImageView.xib */,
 				8B0CE7D02481CFE8004C4799 /* ReaderDetailHeaderView.swift */,
 				8B0CE7D22481CFF8004C4799 /* ReaderDetailHeaderView.xib */,
+				FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */,
 				98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */,
 				98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */,
 				98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */,
@@ -21487,6 +21491,7 @@
 				FAC1B81E29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */,
 				C81CCD84243BF7A600A83E27 /* NoResultsTenorConfiguration.swift in Sources */,
 				C9B477AE29CC35A0008CBF49 /* WidgetDataReader.swift in Sources */,
+				FEF28E822ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */,
 				9A8ECE0F2254A3260043C8DA /* JetpackRemoteInstallViewController.swift in Sources */,
 				1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */,
 				9A2CD5372146B8C700AE5055 /* Array+Page.swift in Sources */,
@@ -25134,6 +25139,7 @@
 				FABB252C2602FC2C00C8785C /* SiteDateFormatters.swift in Sources */,
 				FABB252D2602FC2C00C8785C /* PostEditor.swift in Sources */,
 				FABB252F2602FC2C00C8785C /* JetpackRestoreWarningCoordinator.swift in Sources */,
+				FEF28E832ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */,
 				FABB25302602FC2C00C8785C /* WPPickerView.m in Sources */,
 				FABB25312602FC2C00C8785C /* UIImageView+SiteIcon.swift in Sources */,
 				FABB25322602FC2C00C8785C /* ReaderSiteSearchService.swift in Sources */,


### PR DESCRIPTION
Refs #21644 

This adds the new post detail header, now in SwiftUI.

Before | After
-|-
![before_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b5a8d153-f331-4144-8f29-efde9caf6936) | ![after_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/0857008d-6657-4b76-a401-6cfb9ac87e61)
![before_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/3d49ad67-6885-4291-ac08-63cb74f44288) | ![after_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1cf8c7fe-8983-4b43-9bcf-a45a7294ef58)

In the code, I've found that there's a thing called an "attribution view" in Reader detail. I haven't figured out what it's used for, or what kind of posts display this view. Will try to figure this out later. 

Furthermore, I've practically recreated the legacy Follow button in SwiftUI, and turns out that in the Reader detail, the Follow button uses a different style for iPhone and iPad. This has been recreated in SwiftUI, although not 100% perfect. I think it should be okay since we will update the button again soon.

I've decided to break my large changes into 3 so it's more manageable to review and test. Some things are not included in this PR:

1. The Follow button is still using the legacy design.
2. The tags list is moved but still uses the legacy design.
3. Some accessibility/VoiceOver polish.
4. Action tab bar.
5. Sans-serif font for the body. Turns out this is quite trivial to do, so we'll be able to ship this in the iteration!

Note: there's also a weird legacy issue where the featured image overlaps into the header area by about 4px. I haven't figured out why this happened, and for now, I've added around 4px additional top padding to the new header. The downside is, this will mean 4px extra padding when the post does not have a featured image.

## To test

- Launch the Jetpack app.
- Turn on the `readerImprovements` feature flag.
- Navigate to Reader.
- Open any Reader post — pick two: one with feature image, and one without.
- 🔎 Verify that the new header design is shown.
- 🔎 Verify that the Follow/Unfollow button works.
- 🔎 Verify that tapping the blog name navigates you to the Site stream.
- Select a post that contains several tags, such that they are collapsed. 
- Tap on the "+" button in the tags list to expand the tags.
- 🔎 Verify that expanding/collapsing the tags works correctly.
- Rotate the device to landscape orientation.
- 🔎 Verify that the layout doesn't break.

Additional variations:
- Test in iPad.
- Test between light/dark schemes.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The feature flag gates all the new codes.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

7. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
