### PR TITLE
Media: Improve MediaHost performance

### DIFF
--- a/WordPress/Classes/Networking/MediaHost.swift
+++ b/WordPress/Classes/Networking/MediaHost.swift
@@ -21,7 +21,7 @@ enum MediaHost: Equatable {
         isAtomic: Bool,
         siteID: Int?,
         username: String?,
-        authToken: String?,
+        authToken: @autoclosure () -> String?,
         failure: (Error) -> Void) {
 
         guard isPrivate else {
@@ -38,7 +38,7 @@ enum MediaHost: Equatable {
             return
         }
 
-        guard let authToken = authToken else {
+        guard let authToken = authToken() else {
             // This should actually not be possible.  We have no good way to
             // handle this.
             failure(Error.wpComPrivateSiteWithoutAuthToken)

--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -137,7 +137,10 @@ final class MediaImageService: NSObject {
             throw URLError(.badURL)
         }
 
-        let host = MediaHost(with: media.blog)
+        let blogID = TaggedManagedObjectID(media.blog)
+        let host = try await coreDataStack.performQuery { context in
+            MediaHost(with: try context.existingObject(with: blogID))
+        }
         let request = try await MediaRequestAuthenticator()
             .authenticatedRequest(for: imageURL, host: host)
         guard !Task.isCancelled else {

--- a/WordPress/WordPressTest/MediaImageServiceTests.swift
+++ b/WordPress/WordPressTest/MediaImageServiceTests.swift
@@ -31,12 +31,13 @@ class MediaImageServiceTests: CoreDataTestCase {
     func testSmallThumbnailForLocalImage() async throws {
         // GIVEN
         let media = Media(context: mainContext)
+        media.blog = makeEmptyBlog()
         media.mediaType = .image
         media.width = 1024
         media.height = 680
         let localURL = try makeLocalURL(forResource: "test-image", fileExtension: "jpg")
         media.absoluteLocalURL = localURL
-        try mainContext.obtainPermanentIDs(for: [media])
+        try mainContext.save()
 
         // WHEN
         let thumbnail = try await sut.thumbnail(for: media)
@@ -60,12 +61,13 @@ class MediaImageServiceTests: CoreDataTestCase {
     func testSmallThumbnailForRemoteImage() async throws {
         // GIVEN
         let media = Media(context: mainContext)
+        media.blog = makeEmptyBlog()
         media.mediaType = .image
         media.width = 1024
         media.height = 680
         let remoteURL = try XCTUnwrap(URL(string: "https://example.files.wordpress.com/2023/09/image.jpg"))
         media.remoteURL = remoteURL.absoluteString
-        try mainContext.obtainPermanentIDs(for: [media])
+        try mainContext.save()
 
         // GIVEN remote image is mocked and is resized based on the parameters
         try mockRemoteImage(withResource: "test-image", fileExtension: "jpg")
@@ -129,6 +131,13 @@ class MediaImageServiceTests: CoreDataTestCase {
     }
 
     // MARK: - Helpers
+
+    func makeEmptyBlog() -> Blog {
+        let blog = Blog.createBlankBlog(in: mainContext)
+        blog.url = "example.com/blog"
+        blog.xmlrpc = "test"
+        return blog
+    }
 
     /// `Media` is hardcoded to work with a specific direcoty URL managed by `MediaFileManager`
     func makeLocalURL(forResource name: String, fileExtension: String) throws -> URL {


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

`Blog/authToken` used when creating `MediaHost` reads from the keychain, which is unacceptably slow for the main thread. This PR moves the `MediaHost` creation to the background and marks `authToken` with `@autoclosure` so that it's never even called for the majority of the blogs.

## Regression Notes
1. Potential unintended areas of impact: Image Downloads
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
