### PR TITLE
Media: Add progress reporting

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -180,7 +180,7 @@ class MediaCoordinator: NSObject {
 
         processing(media)
 
-        totalProgress.addChild(creationProgress, withPendingUnitCount: MediaExportProgressUnits.quarterDone)
+        totalProgress.addChild(creationProgress, withPendingUnitCount: MediaExportProgressUnits.exportDone)
         coordinator.track(progress: totalProgress, of: media, withIdentifier: media.uploadID)
 
         return media
@@ -209,7 +209,7 @@ class MediaCoordinator: NSObject {
             }
         )
 
-        totalProgress.addChild(creationProgress, withPendingUnitCount: MediaExportProgressUnits.quarterDone)
+        totalProgress.addChild(creationProgress, withPendingUnitCount: MediaExportProgressUnits.exportDone)
     }
 
     private func handleMediaImportResult(coordinator: MediaProgressCoordinator, totalProgress: Progress, analyticsInfo: MediaAnalyticsInfo?, media: Media?, error: Error?) -> Void {
@@ -230,7 +230,7 @@ class MediaCoordinator: NSObject {
         trackUploadOf(media, analyticsInfo: analyticsInfo)
 
         let uploadProgress = uploadMedia(media)
-        totalProgress.addChild(uploadProgress, withPendingUnitCount: MediaExportProgressUnits.threeQuartersDone)
+        totalProgress.addChild(uploadProgress, withPendingUnitCount: MediaExportProgressUnits.uploadDone)
     }
 
     /// Retry the upload of a media object that previously has failed.

--- a/WordPress/Classes/Utility/Media/MediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaExporter.swift
@@ -3,8 +3,8 @@ import Foundation
 enum MediaExportProgressUnits {
     static let done: Int64 = 100
     static let halfDone: Int64 = MediaExportProgressUnits.done / 2
-    static let quarterDone: Int64 = MediaExportProgressUnits.done / 4
-    static let threeQuartersDone: Int64 = (MediaExportProgressUnits.done / 4) * 3
+    static let exportDone: Int64 = 5 // Export with a new ItemProvider API is very fast
+    static let uploadDone: Int64 = 95
 }
 /// The MediaExport class represents the result of an MediaExporter.
 ///


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

Add progress reporting during upload. This is something I missed from the previous collection view cell.  I'm now reviewing the cell and the remaining pieces of `MediaThumbnailService`.

To test:


https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/53c57995-73d5-4671-9661-a65cda0a9426



## Regression Notes
1. Potential unintended areas of impact: The only changes affects the production code is the tuning of the proportion of processing/upload during progress reporting
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
