### PR TITLE
Reader: Update content style to sans-serif

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -531,6 +531,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Configure the webview
     private func configureWebView() {
+        webView.usesSansSerifStyle = FeatureFlag.readerImprovements.enabled
         webView.navigationDelegate = self
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -12,6 +12,8 @@ class ReaderWebView: WKWebView {
 
     var postURL: URL? = nil
 
+    var usesSansSerifStyle = false
+
     /// Make the webview transparent
     ///
     override func awakeFromNib() {
@@ -45,6 +47,7 @@ class ReaderWebView: WKWebView {
         <style>
         \(cssColors())
         \(cssStyles())
+        \(overrideStyles())
         </style>
         </head><body class="reader-full-post reader-full-post__story-content">
         \(content)
@@ -156,6 +159,25 @@ class ReaderWebView: WKWebView {
 
         let cssContent = try? String(contentsOf: cssURL)
         return cssContent ?? ""
+    }
+
+    private func overrideStyles() -> String {
+        guard usesSansSerifStyle else {
+            return String()
+        }
+
+        /// Some context: We are fetching the CSS file from a remote endpoint, but we store a local `reader.css` file
+        /// to override some styles for mobile-specific purposes.
+        ///
+        /// The `reader.css` forces the text to be displayed in Noto, but this method overrides it back to the
+        /// system font. Later when the `readerImprovements` flag is removed, we should remove this method and
+        /// update the CSS values in `reader.css` instead
+        return """
+            body.reader-full-post.reader-full-post__story-content {
+                font: -apple-system-body !important;
+                font-family: -apple-system, sans-serif !important;
+            }
+        """
     }
 
     /// Maps app colors to CSS colors to be applied in the webview


### PR DESCRIPTION
Refs #21644 
Depends on #21674 

This updates the Reader detail content to sans-serif. Here's a comparison:

Before | After
-|-
![before_serif](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/ef4a573c-272a-4e51-91cc-bd80afd5116f) | ![after_sansserif](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5e2a51d3-f9bc-4dad-8af2-fb95f13fab92)

Some notes:
- I haven't adjusted any spacing or padding for the elements. I only updated the font to sans-serif.
- Although the design uses the callout size, I used `body` because that is the closest & available type accessible from the CSS style that supports dynamic type size. (Here is the [full list of supported system values](https://webkit.org/blog/3709/using-the-system-font-in-web-content/).)

## To test

- Launch the Jetpack app
- Turn on the `readerImprovements` feature flag.
- Go to any post in the Reader.
- 🔎 Verify that the post body is now displayed in Apple's system font.

Additional testing:
- The devil is in the details... Try going into several posts to see if any content breaks the layout or looks weird. 
- Try opening an internal post that uses a lot of block types. Do they look alright? However, note that some blocks are not supported yet and may not be related to this PR. 
- Try switching to a large accessibility size (AX1 or above). The text should be properly adjusted according to the preferred content size.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The change is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
