### PR TITLE
Reader: Rename `ReaderPostCardCell` to `OldReaderPostCardCell`

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/OldReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/OldReaderPostCardCell.swift
@@ -9,19 +9,20 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
 }
 
 @objc public protocol ReaderPostCellDelegate: NSObjectProtocol {
-    func readerCell(_ cell: ReaderPostCardCell, headerActionForProvider provider: ReaderPostContentProvider)
-    func readerCell(_ cell: ReaderPostCardCell, commentActionForProvider provider: ReaderPostContentProvider)
-    func readerCell(_ cell: ReaderPostCardCell, followActionForProvider provider: ReaderPostContentProvider)
-    func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider)
-    func readerCell(_ cell: ReaderPostCardCell, shareActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView)
-    func readerCell(_ cell: ReaderPostCardCell, likeActionForProvider provider: ReaderPostContentProvider)
-    func readerCell(_ cell: ReaderPostCardCell, menuActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView)
-    func readerCell(_ cell: ReaderPostCardCell, attributionActionForProvider provider: ReaderPostContentProvider)
-    func readerCell(_ cell: ReaderPostCardCell, reblogActionForProvider provider: ReaderPostContentProvider)
-    func readerCellImageRequestAuthToken(_ cell: ReaderPostCardCell) -> String?
+    func readerCell(_ cell: OldReaderPostCardCell, headerActionForProvider provider: ReaderPostContentProvider)
+    func readerCell(_ cell: OldReaderPostCardCell, commentActionForProvider provider: ReaderPostContentProvider)
+    func readerCell(_ cell: OldReaderPostCardCell, followActionForProvider provider: ReaderPostContentProvider)
+    func readerCell(_ cell: OldReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider)
+    func readerCell(_ cell: OldReaderPostCardCell, shareActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView)
+    func readerCell(_ cell: OldReaderPostCardCell, likeActionForProvider provider: ReaderPostContentProvider)
+    func readerCell(_ cell: OldReaderPostCardCell, menuActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView)
+    func readerCell(_ cell: OldReaderPostCardCell, attributionActionForProvider provider: ReaderPostContentProvider)
+    func readerCell(_ cell: OldReaderPostCardCell, reblogActionForProvider provider: ReaderPostContentProvider)
+    func readerCellImageRequestAuthToken(_ cell: OldReaderPostCardCell) -> String?
 }
 
-@objc open class ReaderPostCardCell: UITableViewCell {
+// TODO: Delete this class when Reader Improvements v1 feature flag (`readerImprovements`) is removed
+@objc open class OldReaderPostCardCell: UITableViewCell {
 
     // MARK: - Properties
 
@@ -218,7 +219,7 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
 
 // MARK: - Configuration
 
-private extension ReaderPostCardCell {
+private extension OldReaderPostCardCell {
 
     struct Constants {
         static let featuredMediaCornerRadius: CGFloat = 4
@@ -342,7 +343,7 @@ private extension ReaderPostCardCell {
 
 // MARK: - Header Configuration
 
-private extension ReaderPostCardCell {
+private extension OldReaderPostCardCell {
 
     func configureHeader() {
 
@@ -369,7 +370,7 @@ private extension ReaderPostCardCell {
         let mediaRequestAuthenticator = MediaRequestAuthenticator()
         let host = MediaHost(with: contentProvider, failure: { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            DDLogError("ReaderPostCardCell MediaHost error: \(error.localizedDescription)")
+            DDLogError("OldReaderPostCardCell MediaHost error: \(error.localizedDescription)")
         })
 
         mediaRequestAuthenticator.authenticatedRequest(
@@ -438,7 +439,7 @@ private extension ReaderPostCardCell {
 
 // MARK: - Card Configuration
 
-private extension ReaderPostCardCell {
+private extension OldReaderPostCardCell {
 
     func configureFeaturedImageView() {
         // Round the corners, and add a border
@@ -524,7 +525,7 @@ private extension ReaderPostCardCell {
 
 // MARK: - Button Configuration
 
-private extension ReaderPostCardCell {
+private extension OldReaderPostCardCell {
 
     enum CardAction: Int {
         case comment = 1
@@ -683,7 +684,7 @@ private extension ReaderPostCardCell {
 
 // MARK: - Button Actions
 
-extension ReaderPostCardCell {
+extension OldReaderPostCardCell {
 
     // MARK: - Header Tapped
 
@@ -753,7 +754,7 @@ extension ReaderPostCardCell {
 
 // MARK: - ReaderCardDiscoverAttributionViewDelegate
 
-extension ReaderPostCardCell: ReaderCardDiscoverAttributionViewDelegate {
+extension OldReaderPostCardCell: ReaderCardDiscoverAttributionViewDelegate {
     public func attributionActionSelectedForVisitingSite(_ view: ReaderCardDiscoverAttributionView) {
         delegate?.readerCell(self, attributionActionForProvider: contentProvider!)
     }
@@ -761,7 +762,7 @@ extension ReaderPostCardCell: ReaderCardDiscoverAttributionViewDelegate {
 
 // MARK: - Accessibility
 
-extension ReaderPostCardCell: Accessible {
+extension OldReaderPostCardCell: Accessible {
     func prepareForVoiceOver() {
         prepareCardForVoiceOver()
         prepareHeaderButtonForVoiceOver()
@@ -773,7 +774,7 @@ extension ReaderPostCardCell: Accessible {
     }
 }
 
-private extension ReaderPostCardCell {
+private extension OldReaderPostCardCell {
 
     func prepareCardForVoiceOver() {
         accessibilityLabel = cardAccessibilityLabel()
@@ -962,7 +963,7 @@ private extension ReaderPostCardCell {
 
 
 /// Extension providing getters to some private outlets, for testability
-extension ReaderPostCardCell {
+extension OldReaderPostCardCell {
 
     func getHeaderButtonForTesting() -> UIButton {
         return headerBlogButton
@@ -989,7 +990,7 @@ extension ReaderPostCardCell {
     }
 }
 
-extension ReaderPostCardCell: GhostableView {
+extension OldReaderPostCardCell: GhostableView {
     public func ghostAnimationWillStart() {
         borderedView.isGhostableDisabled = true
         attributionView.isHidden = true
@@ -1009,7 +1010,7 @@ extension ReaderPostCardCell: GhostableView {
     }
 }
 
-extension ReaderPostCardCell: ReaderTopicCollectionViewCoordinatorDelegate {
+extension OldReaderPostCardCell: ReaderTopicCollectionViewCoordinatorDelegate {
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState) {
         layoutIfNeeded()
 

--- a/WordPress/Classes/ViewRelated/Reader/OldReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/OldReaderPostCardCell.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" id="IB3-vN-rW4" customClass="ReaderPostCardCell" customModule="WordPress">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" id="IB3-vN-rW4" customClass="OldReaderPostCardCell" customModule="WordPress">
             <rect key="frame" x="0.0" y="0.0" width="320" height="484"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="IB3-vN-rW4" id="519-Nh-f7o">
@@ -25,19 +25,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="484"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vth-Nl-tJe">
-                                <rect key="frame" x="16" y="331.66666666666669" width="32" height="32"/>
+                                <rect key="frame" x="16" y="332.66666666666669" width="32" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="grC-7j-rBx">
-                                <rect key="frame" x="103.33333333333333" y="331.66666666666669" width="31.999999999999986" height="32"/>
+                                <rect key="frame" x="103.33333333333333" y="332.66666666666669" width="31.999999999999986" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BfA-lS-oeX">
-                                <rect key="frame" x="184.66666666666666" y="331.66666666666669" width="32" height="32"/>
+                                <rect key="frame" x="184.66666666666666" y="332.66666666666669" width="32" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="74d-A6-ibb">
-                                <rect key="frame" x="272" y="331.66666666666669" width="32" height="32"/>
+                                <rect key="frame" x="272" y="332.66666666666669" width="32" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWd-ZJ-3Hc">
@@ -165,10 +165,10 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="0hd-Lx-knp" userLabel="Title / Summary / Attr / Action Stack View">
-                                <rect key="frame" x="16" y="233.99999999999997" width="288" height="121.66666666666666"/>
+                                <rect key="frame" x="16" y="233.99999999999997" width="288" height="122.66666666666666"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="gTo-Tc-GMR">
-                                        <rect key="frame" x="0.0" y="0.0" width="288" height="45.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="46.333333333333336"/>
                                         <subviews>
                                             <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zf5-cD-Pd2" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
@@ -178,7 +178,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Summary" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1n-gR-1xw" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="31.999999999999996" width="288" height="13.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="31.999999999999996" width="288" height="14.333333333333332"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -187,7 +187,7 @@
                                         </subviews>
                                     </stackView>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nU7-76-6MV" customClass="ReaderCardDiscoverAttributionView" customModule="WordPress">
-                                        <rect key="frame" x="0.0" y="57.333333333333321" width="288" height="20.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="58.333333333333321" width="288" height="20.333333333333336"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tUL-YG-fIa" customClass="CircularImageView" customModule="WordPress">
                                                 <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -220,7 +220,7 @@
                                         </connections>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Wzi-SV-nkT">
-                                        <rect key="frame" x="0.0" y="89.666666666666686" width="288" height="32"/>
+                                        <rect key="frame" x="0.0" y="90.666666666666686" width="288" height="32"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YRe-Q4-Aq4" customClass="PostMetaButton">
                                                 <rect key="frame" x="0.0" y="0.0" width="44" height="32"/>
@@ -294,7 +294,7 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" verticalHuggingPriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="Aav-jm-io6" userLabel="View (Spacer)">
-                                <rect key="frame" x="16" y="363.66666666666669" width="288" height="101.33333333333331"/>
+                                <rect key="frame" x="16" y="364.66666666666669" width="288" height="100.33333333333331"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                         </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -41,7 +41,7 @@ final class ReaderCellConfiguration {
             return
         }
 
-        guard let postCell = cell as? ReaderPostCardCell else {
+        guard let postCell = cell as? OldReaderPostCardCell else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -27,14 +27,14 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         super.init()
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, headerActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, headerActionForProvider provider: ReaderPostContentProvider) {
         guard let post = provider as? ReaderPost, let origin = origin else {
             return
         }
         ReaderHeaderAction().execute(post: post, origin: origin)
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, commentActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, commentActionForProvider provider: ReaderPostContentProvider) {
         guard let post = provider as? ReaderPost, let origin = origin else {
             return
         }
@@ -50,14 +50,14 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         ReaderCommentAction().execute(post: post, origin: origin, source: .postCard)
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, followActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, followActionForProvider provider: ReaderPostContentProvider) {
         guard let post = provider as? ReaderPost else {
             return
         }
         toggleFollowingForPost(post)
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
         if let origin = origin as? ReaderStreamViewController, origin.contentType == .saved {
             if let post = provider as? ReaderPost {
                 removedPosts.add(post)
@@ -71,14 +71,14 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         }
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, shareActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView) {
+    func readerCell(_ cell: OldReaderPostCardCell, shareActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView) {
         guard let post = provider as? ReaderPost else {
             return
         }
         sharePost(post, fromView: sender)
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, likeActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, likeActionForProvider provider: ReaderPostContentProvider) {
         guard let post = provider as? ReaderPost else {
             return
         }
@@ -88,7 +88,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         })
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, menuActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView) {
+    func readerCell(_ cell: OldReaderPostCardCell, menuActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView) {
         guard let post = provider as? ReaderPost,
               let origin = origin,
               let followCommentsService = FollowCommentsService(post: post) else {
@@ -109,21 +109,21 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         WPAnalytics.trackReader(.postCardMoreTapped)
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, attributionActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, attributionActionForProvider provider: ReaderPostContentProvider) {
         guard let post = provider as? ReaderPost else {
             return
         }
         showAttributionForPost(post)
     }
 
-    func readerCell(_ cell: ReaderPostCardCell, reblogActionForProvider provider: ReaderPostContentProvider) {
+    func readerCell(_ cell: OldReaderPostCardCell, reblogActionForProvider provider: ReaderPostContentProvider) {
         guard let post = provider as? ReaderPost, let origin = origin else {
             return
         }
         ReaderReblogAction().execute(readerPost: post, origin: origin, reblogSource: .list)
     }
 
-    func readerCellImageRequestAuthToken(_ cell: ReaderPostCardCell) -> String? {
+    func readerCellImageRequestAuthToken(_ cell: OldReaderPostCardCell) -> String? {
         return imageRequestAuthToken
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -1,12 +1,12 @@
 protocol ReaderSavedPostCellActionsDelegate: AnyObject {
-    func willRemove(_ cell: ReaderPostCardCell)
+    func willRemove(_ cell: OldReaderPostCardCell)
 }
 
 
 /// Specialises ReaderPostCellActions to provide specific overrides for the ReaderSavedPostsViewController
 final class ReaderSavedPostCellActions: ReaderPostCellActions {
 
-    override func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
+    override func readerCell(_ cell: OldReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
         if let post = provider as? ReaderPost {
             removedPosts.add(post)
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
@@ -18,10 +18,10 @@ extension ReaderStreamViewController {
 
         ghostableTableView.separatorStyle = .none
 
-        let postCardTextCellNib = UINib(nibName: "ReaderPostCardCell", bundle: Bundle.main)
-        ghostableTableView.register(postCardTextCellNib, forCellReuseIdentifier: "ReaderPostCardCell")
+        let postCardTextCellNib = UINib(nibName: "OldReaderPostCardCell", bundle: Bundle.main)
+        ghostableTableView.register(postCardTextCellNib, forCellReuseIdentifier: "OldReaderPostCardCell")
 
-        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: "ReaderPostCardCell", rowsPerSection: [10])
+        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: "OldReaderPostCardCell", rowsPerSection: [10])
         let style = GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
                                beatStartColor: .placeholderElement,
                                beatEndColor: .placeholderElementFaded)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1644,7 +1644,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         // Check to see if we need to load more.
         syncMoreContentIfNeeded(for: tableView, indexPathForVisibleRow: indexPath)
 
-        guard cell.isKind(of: ReaderPostCardCell.self) || cell.isKind(of: ReaderCrossPostCell.self) else {
+        guard cell.isKind(of: OldReaderPostCardCell.self) || cell.isKind(of: ReaderCrossPostCell.self) else {
             return
         }
 
@@ -2009,7 +2009,7 @@ extension ReaderStreamViewController: ReaderContentViewController {
 
 // MARK: - Saved Posts Delegate
 extension ReaderStreamViewController: ReaderSavedPostCellActionsDelegate {
-    func willRemove(_ cell: ReaderPostCardCell) {
+    func willRemove(_ cell: OldReaderPostCardCell) {
         if let cellIndex = tableView.indexPath(for: cell) {
             tableView.reloadRows(at: [cellIndex], with: .fade)
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
@@ -1,7 +1,7 @@
 /// Registration and dequeuing of cells for table views in Reader
 final class ReaderTableConfiguration {
     private let footerViewNibName = "PostListFooterView"
-    private let readerCardCellNibName = "ReaderPostCardCell"
+    private let readerCardCellNibName = "OldReaderPostCardCell"
     private let readerCardCellReuseIdentifier = "ReaderCardCellReuseIdentifier"
     private let readerBlockedCellNibName = "ReaderBlockedSiteCell"
     private let readerBlockedCellReuseIdentifier = "ReaderBlockedCellReuseIdentifier"
@@ -65,8 +65,8 @@ final class ReaderTableConfiguration {
         return tableView.dequeueReusableCell(withIdentifier: readerCrossPostCellReuseIdentifier) as! ReaderCrossPostCell
     }
 
-    func postCardCell(_ tableView: UITableView) -> ReaderPostCardCell {
-        return tableView.dequeueReusableCell(withIdentifier: readerCardCellReuseIdentifier) as! ReaderPostCardCell
+    func postCardCell(_ tableView: UITableView) -> OldReaderPostCardCell {
+        return tableView.dequeueReusableCell(withIdentifier: readerCardCellReuseIdentifier) as! OldReaderPostCardCell
     }
 
     func gapMarkerCell(_ tableView: UITableView) -> ReaderGapMarkerCell {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3013,7 +3013,7 @@
 		CECEEB562823164800A28ADE /* MediaCacheSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECEEB542823164800A28ADE /* MediaCacheSettingsViewController.swift */; };
 		D0E2AA7C4D4CB1679173958E /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 213A62FF811EBDB969FA7669 /* Pods_WordPressShareExtension.framework */; };
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
-		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
+		D809E686203F0215001AA0DE /* OldReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* OldReaderPostCardCellTests.swift */; };
 		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
 		D80BC79E20746B4100614A59 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79D20746B4100614A59 /* MediaPickingContext.swift */; };
 		D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */; };
@@ -8350,7 +8350,7 @@
 		D42A30853435E728881904E8 /* Pods_JetpackIntents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_JetpackIntents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D67306CD28F2440FF6B0065C /* Pods-JetpackIntents.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JetpackIntents.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-JetpackIntents/Pods-JetpackIntents.debug.xcconfig"; sourceTree = "<group>"; };
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
-		D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellTests.swift; sourceTree = "<group>"; };
+		D809E685203F0215001AA0DE /* OldReaderPostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldReaderPostCardCellTests.swift; sourceTree = "<group>"; };
 		D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryMediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		D80BC79D20746B4100614A59 /* MediaPickingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryStrings.swift; sourceTree = "<group>"; };
@@ -16965,7 +16965,7 @@
 				3236F79F24B61B780088E8F3 /* Select Interests */,
 				8BDA5A6C247C2F8400AB124C /* ReaderDetailViewControllerTests.swift */,
 				8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */,
-				D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */,
+				D809E685203F0215001AA0DE /* OldReaderPostCardCellTests.swift */,
 				748437ED1F1D4A7300E8DDAF /* RichContentFormatterTests.swift */,
 				E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */,
 				8B7F51CA24EED8A8008CF5B5 /* ReaderTrackerTests.swift */,
@@ -23329,7 +23329,7 @@
 				B59D40A61DB522DF003D2D79 /* NSAttributedStringTests.swift in Sources */,
 				F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */,
 				C738CB0D28623F07001BE107 /* QRLoginURLParserTests.swift in Sources */,
-				D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */,
+				D809E686203F0215001AA0DE /* OldReaderPostCardCellTests.swift in Sources */,
 				4AAD69082A6F68A5007FE77E /* MediaRepositoryTests.swift in Sources */,
 				FEFC0F8C273131A6001F7F1D /* CommentService+RepliesTests.swift in Sources */,
 				40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1335,8 +1335,8 @@
 		5D42A405175E76A7005CFF05 /* WPImageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D42A402175E76A2005CFF05 /* WPImageViewController.m */; };
 		5D4E30D11AA4B41A000D9904 /* WPStyleGuide+Pages.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D4E30D01AA4B41A000D9904 /* WPStyleGuide+Pages.m */; };
 		5D51ADAF19A832AF00539C0B /* WordPress-20-21.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 5D51ADAE19A832AF00539C0B /* WordPress-20-21.xcmappingmodel */; };
-		5D5A6E931B613CA400DAF819 /* ReaderPostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5A6E911B613CA400DAF819 /* ReaderPostCardCell.swift */; };
-		5D5A6E941B613CA400DAF819 /* ReaderPostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D5A6E921B613CA400DAF819 /* ReaderPostCardCell.xib */; };
+		5D5A6E931B613CA400DAF819 /* OldReaderPostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5A6E911B613CA400DAF819 /* OldReaderPostCardCell.swift */; };
+		5D5A6E941B613CA400DAF819 /* OldReaderPostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D5A6E921B613CA400DAF819 /* OldReaderPostCardCell.xib */; };
 		5D62BAD718AA88210044E5F7 /* PageSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D62BAD618AA88210044E5F7 /* PageSettingsViewController.m */; };
 		5D69DBC4165428CA00A2D1F7 /* n.caf in Resources */ = {isa = PBXBuildFile; fileRef = 5D69DBC3165428CA00A2D1F7 /* n.caf */; };
 		5D6C4AF61B603CA3005E3C43 /* WPTableViewActivityCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D6C4AF51B603CA3005E3C43 /* WPTableViewActivityCell.xib */; };
@@ -3960,7 +3960,7 @@
 		FABB1FEF2602FC2C00C8785C /* MediaQuotaCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FF00889C204DFF77007CCE66 /* MediaQuotaCell.xib */; };
 		FABB1FF02602FC2C00C8785C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931DF4D818D09A2F00540BDD /* InfoPlist.strings */; };
 		FABB1FF22602FC2C00C8785C /* ReaderSavedPostUndoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */; };
-		FABB1FF32602FC2C00C8785C /* ReaderPostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D5A6E921B613CA400DAF819 /* ReaderPostCardCell.xib */; };
+		FABB1FF32602FC2C00C8785C /* OldReaderPostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D5A6E921B613CA400DAF819 /* OldReaderPostCardCell.xib */; };
 		FABB1FF52602FC2C00C8785C /* RevisionsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4349B0AE218A477F0034118A /* RevisionsTableViewCell.xib */; };
 		FABB1FF72602FC2C00C8785C /* Revisions.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 439F4F37219B636500F8D0C7 /* Revisions.storyboard */; };
 		FABB1FF82602FC2C00C8785C /* ActivityDetailViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* ActivityDetailViewController.storyboard */; };
@@ -4259,7 +4259,7 @@
 		FABB217D2602FC2C00C8785C /* WPMediaPicker+MediaPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A34A9825DEF47D00C9654B /* WPMediaPicker+MediaPicker.swift */; };
 		FABB217E2602FC2C00C8785C /* JetpackInstallError+Blocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8ECE0B2254A3260043C8DA /* JetpackInstallError+Blocking.swift */; };
 		FABB217F2602FC2C00C8785C /* QuickStartTourState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AF2F962107D3800069C012 /* QuickStartTourState.swift */; };
-		FABB21802602FC2C00C8785C /* ReaderPostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5A6E911B613CA400DAF819 /* ReaderPostCardCell.swift */; };
+		FABB21802602FC2C00C8785C /* OldReaderPostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5A6E911B613CA400DAF819 /* OldReaderPostCardCell.swift */; };
 		FABB21812602FC2C00C8785C /* DiffContentValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A38DC66218899FB006A409B /* DiffContentValue.swift */; };
 		FABB21822602FC2C00C8785C /* FormattableTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B320F4097A00DF8486 /* FormattableTextContent.swift */; };
 		FABB21832602FC2C00C8785C /* WordPress-61-62.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E10520571F2B1CC900A948F6 /* WordPress-61-62.xcmappingmodel */; };
@@ -6939,8 +6939,8 @@
 		5D4E30CF1AA4B41A000D9904 /* WPStyleGuide+Pages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "WPStyleGuide+Pages.h"; path = "../Post/WPStyleGuide+Pages.h"; sourceTree = "<group>"; };
 		5D4E30D01AA4B41A000D9904 /* WPStyleGuide+Pages.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "WPStyleGuide+Pages.m"; path = "../Post/WPStyleGuide+Pages.m"; sourceTree = "<group>"; };
 		5D51ADAE19A832AF00539C0B /* WordPress-20-21.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-20-21.xcmappingmodel"; sourceTree = "<group>"; };
-		5D5A6E911B613CA400DAF819 /* ReaderPostCardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCell.swift; sourceTree = "<group>"; };
-		5D5A6E921B613CA400DAF819 /* ReaderPostCardCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderPostCardCell.xib; sourceTree = "<group>"; };
+		5D5A6E911B613CA400DAF819 /* OldReaderPostCardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldReaderPostCardCell.swift; sourceTree = "<group>"; };
+		5D5A6E921B613CA400DAF819 /* OldReaderPostCardCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OldReaderPostCardCell.xib; sourceTree = "<group>"; };
 		5D62BAD518AA88210044E5F7 /* PageSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageSettingsViewController.h; sourceTree = "<group>"; };
 		5D62BAD618AA88210044E5F7 /* PageSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PageSettingsViewController.m; sourceTree = "<group>"; };
 		5D62BAD818AAAE9B0044E5F7 /* PostSettingsViewController_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostSettingsViewController_Internal.h; sourceTree = "<group>"; usesTabs = 0; };
@@ -12289,6 +12289,8 @@
 			isa = PBXGroup;
 			children = (
 				329F8E4C24DD74F0002A5311 /* Tags View */,
+				5D5A6E911B613CA400DAF819 /* OldReaderPostCardCell.swift */,
+				5D5A6E921B613CA400DAF819 /* OldReaderPostCardCell.xib */,
 				E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */,
 				E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */,
 				5D2B30B81B7411C700DA15F3 /* ReaderCardDiscoverAttributionView.swift */,
@@ -12297,14 +12299,12 @@
 				E6D3E84A1BEBD888002692E8 /* ReaderCrossPostCell.xib */,
 				E6A3384F1BB0A70F00371587 /* ReaderGapMarkerCell.swift */,
 				E6A3384D1BB0A50900371587 /* ReaderGapMarkerCell.xib */,
-				5D5A6E911B613CA400DAF819 /* ReaderPostCardCell.swift */,
-				5D5A6E921B613CA400DAF819 /* ReaderPostCardCell.xib */,
-				D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */,
-				D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */,
-				8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */,
-				8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */,
 				3234BB322530EA980068DA40 /* ReaderRecommendedSiteCardCell.swift */,
 				3234BB332530EA980068DA40 /* ReaderRecommendedSiteCardCell.xib */,
+				D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */,
+				D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */,
+				8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */,
+				8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */,
 			);
 			name = Cards;
 			sourceTree = "<group>";
@@ -19041,7 +19041,7 @@
 				FE23EB4926E7C91F005A1698 /* richCommentTemplate.html in Resources */,
 				1761F18826209AEE000815EF /* pride-icon-app-76x76.png in Resources */,
 				17222D8A261DDDF90047B163 /* black-classic-icon-app-76x76@2x.png in Resources */,
-				5D5A6E941B613CA400DAF819 /* ReaderPostCardCell.xib in Resources */,
+				5D5A6E941B613CA400DAF819 /* OldReaderPostCardCell.xib in Resources */,
 				1761F17F26209AEE000815EF /* open-source-icon-app-76x76@2x.png in Resources */,
 				17222DA7261DDDF90047B163 /* spectrum-icon-app-60x60@2x.png in Resources */,
 				1761F18C26209AEE000815EF /* hot-pink-icon-app-60x60@3x.png in Resources */,
@@ -19576,7 +19576,7 @@
 				FABB1FF02602FC2C00C8785C /* InfoPlist.strings in Resources */,
 				FABB1FF22602FC2C00C8785C /* ReaderSavedPostUndoCell.xib in Resources */,
 				F41E4EAB28F20DF9001880C6 /* stroke-light-icon-app-60@2x.png in Resources */,
-				FABB1FF32602FC2C00C8785C /* ReaderPostCardCell.xib in Resources */,
+				FABB1FF32602FC2C00C8785C /* OldReaderPostCardCell.xib in Resources */,
 				B026DAB12A96D9E900995410 /* support_chat_error_handler.js in Resources */,
 				FABB1FF52602FC2C00C8785C /* RevisionsTableViewCell.xib in Resources */,
 				FABB1FF72602FC2C00C8785C /* Revisions.storyboard in Resources */,
@@ -21082,7 +21082,7 @@
 				9A8ECE132254A3260043C8DA /* JetpackInstallError+Blocking.swift in Sources */,
 				43AF2F972107D3810069C012 /* QuickStartTourState.swift in Sources */,
 				FA4B202F29A619130089FE68 /* BlazeFlowCoordinator.swift in Sources */,
-				5D5A6E931B613CA400DAF819 /* ReaderPostCardCell.swift in Sources */,
+				5D5A6E931B613CA400DAF819 /* OldReaderPostCardCell.swift in Sources */,
 				9A38DC6B218899FB006A409B /* DiffContentValue.swift in Sources */,
 				7E4123C020F4097B00DF8486 /* FormattableTextContent.swift in Sources */,
 				E10520581F2B1CC900A948F6 /* WordPress-61-62.xcmappingmodel in Sources */,
@@ -23859,7 +23859,7 @@
 				805CC0BD29668987002941DC /* JetpackBrandedScreen.swift in Sources */,
 				FABB217E2602FC2C00C8785C /* JetpackInstallError+Blocking.swift in Sources */,
 				FABB217F2602FC2C00C8785C /* QuickStartTourState.swift in Sources */,
-				FABB21802602FC2C00C8785C /* ReaderPostCardCell.swift in Sources */,
+				FABB21802602FC2C00C8785C /* OldReaderPostCardCell.swift in Sources */,
 				0878580428B4CF950069F96C /* UserPersistentRepositoryUtility.swift in Sources */,
 				F1585419267D3B5700A2E966 /* BloggingRemindersScheduler.swift in Sources */,
 				FABB21812602FC2C00C8785C /* DiffContentValue.swift in Sources */,

--- a/WordPress/WordPressTest/OldReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/OldReaderPostCardCellTests.swift
@@ -152,9 +152,9 @@ class MockContentProvider: NSObject, ReaderPostContentProvider {
     }
 }
 
-final class ReaderPostCardCellTests: XCTestCase {
+final class OldReaderPostCardCellTests: XCTestCase {
 
-    private var cell: ReaderPostCardCell?
+    private var cell: OldReaderPostCardCell?
     private var mock: ReaderPostContentProvider?
 
     private struct TestConstants {
@@ -168,7 +168,7 @@ final class ReaderPostCardCellTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mock = MockContentProvider()
-        cell = Bundle.loadRootViewFromNib(type: ReaderPostCardCell.self)
+        cell = Bundle.loadRootViewFromNib(type: OldReaderPostCardCell.self)
         cell?.configureCell(mock!)
     }
 

--- a/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
@@ -73,8 +73,8 @@ final class ReaderPostCellActionsTests: CoreDataTestCase {
         return topic
     }
 
-    private func makeCell() -> ReaderPostCardCell {
-        return Bundle.loadRootViewFromNib(type: ReaderPostCardCell.self)!
+    private func makeCell() -> OldReaderPostCardCell {
+        return Bundle.loadRootViewFromNib(type: OldReaderPostCardCell.self)!
     }
 
     private func makePost() -> ReaderPost {


### PR DESCRIPTION
Part of #21645 

## Description

Renames `ReaderPostCardCell` to `OldReaderPostCardCell`, there are no changes to functionality with it.

## Testing

To test:
- Launch Jetpack and login
- Tap on the Reader tab
- 🔎 **Verify** the reader post cell loads correctly and works as it previously did

## Regression Notes
1. Potential unintended areas of impact
Reader post card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
