### PR TITLE
No Sites: Fix navigation to Me screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -563,7 +563,11 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
     func didTapAccountAndSettingsButton() {
         let meViewController = MeViewController()
-        showDetailViewController(meViewController, sender: self)
+        if MySitesCoordinator.isSplitViewEnabled {
+            showDetailViewController(meViewController, sender: self)
+        } else {
+            navigationController?.pushViewController(meViewController, animated: true)
+        }
     }
 
     @objc


### PR DESCRIPTION
Fixes #21690 

## Description
- Pushes Me view controller onto nav stack if split view isn't enabled

## How to test

Please test on both iPhone and iPad

- Launch the WordPress app
- Log into an account with no sites (or create a new account)
- In the No Sites view, tap on "Accounts and Settings"
- Verify that all rows can be tapped


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/dcee16c5-bb30-4d2b-a8aa-bc969769029f


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ef3d03f5-454b-429b-8ac7-eddc3661346a



## Regression Notes
1. Potential unintended areas of impact
navigating to the Me screen from the No Sites view on both iPhone and iPad

2. What I did to test those areas of impact (or what existing automated tests I relied on)
tested manually

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

