### PR TITLE
Add sample DocsBot ID

### DIFF
--- a/WordPress/Credentials/Secrets-example.swift
+++ b/WordPress/Credentials/Secrets-example.swift
@@ -23,4 +23,5 @@ class ApiCredentials: NSObject {
     static let appCenterAppId = ""
     static let encryptedLogKey = ""
     static let debuggingKey = ""
+    static let docsBotId = ""
 }


### PR DESCRIPTION
Fixes an issue where the project wouldn't compile if the app's credentials are not setup. The app should still compile with sample credentials.

To test:

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Built the project

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: Not applicable