### PR TITLE
Media: Fix an issue with filename not being displayed during upload

### DIFF
--- a/WordPress/Classes/Extensions/NSURL+Exporters.swift
+++ b/WordPress/Classes/Extensions/NSURL+Exporters.swift
@@ -1,20 +1,22 @@
 import Foundation
-import Photos
-import MobileCoreServices
-import AVFoundation
+import UniformTypeIdentifiers
 
 extension NSURL: ExportableAsset {
-
     public var assetMediaType: MediaType {
         get {
-            let url = self as URL
-            if url.isImage {
+            guard let contentType = (self as URL).typeIdentifier.flatMap(UTType.init) else {
+                return .document
+            }
+            if contentType.conforms(to: .image) {
                 return .image
-            } else if url.isVideo {
+            }
+            if contentType.conforms(to: .video) || contentType.conforms(to: .movie) {
                 return .video
+            }
+            if contentType.conforms(to: .audio) {
+                return .audio
             }
             return .document
         }
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -31,6 +31,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     private let blog: Blog
     private let filter: Set<MediaType>?
     private let isShowingPendingUploads: Bool
+    private var isSelectionOrdered = false
     private let coordinator = MediaCoordinator.shared
 
     private var emptyViewState: EmptyViewState = .hidden {
@@ -129,9 +130,14 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
 
     // MARK: - Editing
 
-    func setEditing(_ isEditing: Bool, allowsMultipleSelection: Bool) {
+    func setEditing(
+        _ isEditing: Bool,
+        allowsMultipleSelection: Bool = true,
+        isSelectionOrdered: Bool = false
+    ) {
         guard self.isEditing != isEditing else { return }
         self.isEditing = isEditing
+        self.isSelectionOrdered = isSelectionOrdered
         self.collectionView.allowsMultipleSelection = isEditing && allowsMultipleSelection
 
         deselectAll()
@@ -142,14 +148,12 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
             selection.add(media)
         } else {
             selection.remove(media)
-            getViewModel(for: media).badgeText = nil
+            getViewModel(for: media).badge = nil
         }
-        var index = 1
         if collectionView.allowsMultipleSelection {
-            for media in selection {
+            for (index, media) in selection.enumerated() {
                 if let media = media as? Media {
-                    getViewModel(for: media).badgeText = index.description
-                    index += 1
+                    getViewModel(for: media).badge = isSelectionOrdered ? .ordered(index: index) : .unordered
                 } else {
                     assertionFailure("Invalid selection")
                 }
@@ -163,7 +167,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     private func deselectAll() {
         for media in selection {
             if let media = media as? Media {
-                getViewModel(for: media).badgeText = nil
+                getViewModel(for: media).badge = nil
             } else {
                 assertionFailure("Invalid selection")
             }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -84,7 +84,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     // MARK: - Selection
 
     private func startSelection() {
-        collectionViewController.setEditing(true, allowsMultipleSelection: allowsMultipleSelection)
+        collectionViewController.setEditing(true, allowsMultipleSelection: allowsMultipleSelection, isSelectionOrdered: true)
 
         if allowsMultipleSelection, toolbarItems == nil {
             var toolbarItems: [UIBarButtonItem] = []

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -176,6 +176,8 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
         coordinator.delete(media: selection, onProgress: updateProgress, success: { [weak self] in
             WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_of_items_deleted": deletedItemsCount], with: self?.blog)
             SVProgressHUD.showSuccess(withStatus: Strings.deletionSuccessMessage)
+
+            self?.setEditing(false)
         }, failure: {
             SVProgressHUD.showError(withStatus: Strings.deletionFailureMessage)
         })
@@ -195,6 +197,11 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
 
                 let activityViewController = UIActivityViewController(activityItems: fileURLs, applicationActivities: nil)
                 activityViewController.popoverPresentationController?.barButtonItem = barButtonItem
+                activityViewController.completionWithItemsHandler = { [weak self] _, isCompleted, _, _ in
+                    if isCompleted {
+                        self?.setEditing(false)
+                    }
+                }
                 present(activityViewController, animated: true, completion: nil)
             } catch {
                 // TODO: Add error handling

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -74,8 +74,8 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
             .sink { [weak self] in self?.didUpdateOverlayState($0) }
             .store(in: &cancellables)
 
-        viewModel.$badgeText
-            .sink { [weak self] in self?.didUpdateBadgeText($0) }
+        viewModel.$badge
+            .sink { [weak self] in self?.didUpdateBadge($0) }
             .store(in: &cancellables)
 
         viewModel.$durationText
@@ -102,11 +102,11 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         }
     }
 
-    private func didUpdateBadgeText(_ text: String?) {
-        if let text {
+    private func didUpdateBadge(_ badge: SiteMediaCollectionCellViewModel.BadgeType?) {
+        if let badge {
             let badgeView = getBadgeView()
             badgeView.isHidden = false
-            badgeView.textLabel.text = text
+            badgeView.setBadge(badge)
         } else {
             badgeView?.isHidden = true
         }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellBadgeView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellBadgeView.swift
@@ -7,7 +7,7 @@ final class SiteMediaCollectionCellBadgeView: UIView {
         super.init(frame: frame)
 
         textLabel.textColor = .white
-        textLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        textLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 15, weight: .semibold)
 
         let stack = UIStackView(arrangedSubviews: [textLabel])
         stack.axis = .vertical
@@ -34,5 +34,21 @@ final class SiteMediaCollectionCellBadgeView: UIView {
         super.layoutSubviews()
 
         layer.cornerRadius = bounds.height / 2
+    }
+
+    func setBadge(_ badge: SiteMediaCollectionCellViewModel.BadgeType) {
+        switch badge {
+        case .unordered:
+            textLabel.attributedText = NSAttributedString(attachment: {
+                let attachment = NSTextAttachment()
+                let configuration = UIImage.SymbolConfiguration(font: UIFont.systemFont(ofSize: 11, weight: .semibold))
+                attachment.image = UIImage(systemName: "checkmark", withConfiguration: configuration)?.withTintColor(.white, renderingMode: .alwaysTemplate)
+                return attachment
+            }(), attributes: [
+                NSAttributedString.Key.baselineOffset: 1 // It doesn't appear visually centered othwerwise
+            ])
+        case .ordered(let index):
+            textLabel.text = (index + 1).description
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -1,15 +1,18 @@
 import UIKit
 
 final class SiteMediaCollectionCellViewModel {
+    let mediaID: TaggedManagedObjectID<Media>
+
     var onImageLoaded: ((UIImage) -> Void)?
+
     @Published private(set) var overlayState: CircularProgressView.State?
     @Published private(set) var durationText: String?
+    @Published private(set) var documentInfo: SiteMediaDocumentInfoViewModel?
+
     @Published var badgeText: String?
-    var filename: String? { media.filename }
-    let mediaID: TaggedManagedObjectID<Media>
-    let mediaType: MediaType
 
     private let media: Media
+    private let mediaType: MediaType
     private let service: MediaImageService
     private let coordinator: MediaCoordinator
     private let cache: MemoryCache
@@ -35,23 +38,28 @@ final class SiteMediaCollectionCellViewModel {
         self.coordinator = coordinator
         self.cache = cache
 
-        if media.mediaType == .video {
+        observations.append(media.observe(\.remoteStatusNumber, options: [.initial, .new]) { [weak self] _, _ in
+            self?.updateOverlayState()
+        })
+
+        observations.append(media.observe(\.localURL, options: [.new]) { [weak self] media, _ in
+            self?.didUpdateLocalThumbnail()
+        })
+
+        switch mediaType {
+        case .document, .powerpoint, .audio:
+            observations.append(media.observe(\.filename, options: [.initial, .new]) { [weak self] media, _ in
+                self?.documentInfo = SiteMediaDocumentInfoViewModel.make(with: media)
+            })
+        default: break
+        }
+
+        if mediaType == .video {
             observations.append(media.observe(\.length, options: [.initial, .new]) { [weak self] media, _ in
                 // Using `rounded()` to match the behavior of the Photos app
                 self?.durationText = makeString(forDuration: media.duration().rounded())
             })
         }
-
-        observations.append(media.observe(\.remoteStatusNumber, options: [.new]) { [weak self] _, _ in
-            self?.updateOverlayState()
-        })
-
-        // No sure why but `.initial` didn't work.
-        self.updateOverlayState()
-
-        observations.append(media.observe(\.localURL, options: [.new]) { [weak self] media, _ in
-            self?.didUpdateLocalThumbnail()
-        })
     }
 
     // MARK: - View Lifecycle
@@ -80,9 +88,16 @@ final class SiteMediaCollectionCellViewModel {
         cancelThumbnailRequestIfNeeded()
     }
 
-    // MARK: - Thumbnail
+    // MARK: - Loading Thumbnail
+
+    private var supportsThumbnails: Bool {
+        mediaType == .image || mediaType == .video
+    }
 
     private func fetchThumbnailIfNeeded() {
+        guard supportsThumbnails else {
+            return
+        }
         guard isVisible || isPrefetchingNeeded else {
             return
         }
@@ -115,6 +130,9 @@ final class SiteMediaCollectionCellViewModel {
         if !Task.isCancelled {
             if let image {
                 onImageLoaded?(image)
+                documentInfo = nil
+            } else {
+                documentInfo = SiteMediaDocumentInfoViewModel.make(with: media)
             }
             imageTask = nil
         }
@@ -122,7 +140,8 @@ final class SiteMediaCollectionCellViewModel {
 
     /// Returns the image from the memory cache.
     func getCachedThubmnail() -> UIImage? {
-        cache.getImage(forKey: makeCacheKey(for: media))
+        guard supportsThumbnails else { return nil}
+        return cache.getImage(forKey: makeCacheKey(for: media))
     }
 
     private func makeCacheKey(for media: Media) -> String {
@@ -135,7 +154,7 @@ final class SiteMediaCollectionCellViewModel {
         fetchThumbnailIfNeeded()
     }
 
-    // MARK: - State
+    // MARK: - Upload State
 
     private func updateOverlayState() {
         switch media.remoteStatus {
@@ -190,6 +209,8 @@ final class SiteMediaCollectionCellViewModel {
 
     var accessibilityHint: String { Strings.accessibilityHint }
 }
+
+// MARK: - Helpers
 
 private enum Strings {
     static let accessibilityUnknownCreationDate = NSLocalizedString("siteMedia.accessibilityUnknownCreationDate", value: "Unknown creation date", comment: "Accessibility label to use when creation date from media asset is not know.")

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -9,7 +9,7 @@ final class SiteMediaCollectionCellViewModel {
     @Published private(set) var durationText: String?
     @Published private(set) var documentInfo: SiteMediaDocumentInfoViewModel?
 
-    @Published var badgeText: String?
+    @Published var badge: BadgeType?
 
     private let media: Media
     private let mediaType: MediaType
@@ -22,6 +22,11 @@ final class SiteMediaCollectionCellViewModel {
     private var imageTask: Task<Void, Never>?
     private var progressObserver: NSKeyValueObservation?
     private var observations: [NSKeyValueObservation] = []
+
+    enum BadgeType {
+        case unordered
+        case ordered(index: Int)
+    }
 
     deinit {
         imageTask?.cancel()

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaDocumentInfoView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaDocumentInfoView.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+struct SiteMediaDocumentInfoViewModel {
+    let image: UIImage
+    let title: String?
+}
+
 final class SiteMediaDocumentInfoView: UIView {
     let iconView = UIImageView()
     let titleLabel = UILabel()
@@ -27,16 +32,29 @@ final class SiteMediaDocumentInfoView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(_ viewModel: SiteMediaCollectionCellViewModel) {
-        switch viewModel.mediaType {
-        case .document, .powerpoint:
-            iconView.image = .gridicon(.pages)
-            titleLabel.text = viewModel.filename
-        case .audio:
-            iconView.image = .gridicon(.audio)
-            titleLabel.text = viewModel.filename
-        default:
-            break
-        }
+    func configure(_ viewModel: SiteMediaDocumentInfoViewModel) {
+        iconView.image = viewModel.image
+        titleLabel.text = viewModel.title
+    }
+}
+
+extension SiteMediaDocumentInfoViewModel {
+    static func make(with media: Media) -> SiteMediaDocumentInfoViewModel {
+        SiteMediaDocumentInfoViewModel(image: getIcon(for: media.mediaType), title: media.filename)
+    }
+}
+
+private func getIcon(for mediaType: MediaType) -> UIImage {
+    switch mediaType {
+    case .document, .powerpoint:
+        return .gridicon(.pages)
+    case .audio:
+        return .gridicon(.audio)
+    case .image:
+        return .gridicon(.camera)
+    case .video:
+        return .gridicon(.videoCamera)
+    @unknown default:
+        return .gridicon(.pages)
     }
 }

--- a/WordPress/WordPressTest/MediaImageServiceTests.swift
+++ b/WordPress/WordPressTest/MediaImageServiceTests.swift
@@ -93,11 +93,12 @@ class MediaImageServiceTests: CoreDataTestCase {
     func testSmallThumbnailForRemoteVideo() async throws {
         // GIVEN
         let media = Media(context: mainContext)
+        media.blog = makeEmptyBlog()
         media.mediaType = .video
         media.width = 1024
         media.height = 680
         media.remoteThumbnailURL = "https://example.files.wordpress.com/2023/09/video-thumbnail.jpg"
-        try mainContext.obtainPermanentIDs(for: [media])
+        try mainContext.save()
 
         // GIVEN remote image is mocked and is resized based on the parameters
         try mockResponse(withResource: "test-image", fileExtension: "jpg")
@@ -117,11 +118,12 @@ class MediaImageServiceTests: CoreDataTestCase {
         let videoURL = try XCTUnwrap(Bundle.test.url(forResource: "test-video-device-gps", withExtension: "m4v"))
 
         let media = Media(context: mainContext)
+        media.blog = makeEmptyBlog()
         media.mediaType = .video
         media.width = 640
         media.height = 360
         media.remoteURL = videoURL.absoluteString
-        try mainContext.obtainPermanentIDs(for: [media])
+        try mainContext.save()
 
         // WHEN
         let thumbnail = try await sut.thumbnail(for: media)


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

I ended up keeping largely the same approach because I wanted to minimize the number of reloads. But, at the same time, it should still be readable, so I shoved some less interesting bits into individual subviews.

I don't think it's ideal, but there is just too much complexity in these cells. It's not incidental complexity.

This PR fixes two issues:

- Fix an issue where the filename was not displayed when uploading files
- Fix an issue where the placeholder was not displayed when the thumbnail download fails 

I've also thrown in a couple of other minor changes to make it easier to test:
- Make assets selection unordered for deletion/sharing purposes
- Exit selection mode automatically after completing an action (like the native app does)
- Fix a unit tests that broke after integrating all of the previous changes

## Regression Notes
1. Potential unintended areas of impact: n/a (no production code changes)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
