### PR TITLE
Update SwiftLint to version 0.53.0 and fix `control_statement`

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -61,7 +61,7 @@ PODS:
   - Sodium (0.9.1)
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
-  - SwiftLint (0.52.4)
+  - SwiftLint (0.53.0)
   - UIDeviceIdentifier (2.3.0)
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
@@ -222,7 +222,7 @@ SPEC CHECKSUMS:
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  SwiftLint: 1cc5cd61ba9bacb2194e340aeb47a2a37fda00b3
+  SwiftLint: 5ce4d6a8ff83f1b5fd5ad5dbf30965d35af65e44
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef

--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -79,10 +79,9 @@ public class Comment: NSManagedObject {
             return canModerate
         }
 
-        guard let blog = blog,
-              (blog.isHostedAtWPcom || blog.isAtomic()) else {
-                  return true
-              }
+        guard let blog = blog, blog.isHostedAtWPcom || blog.isAtomic() else {
+            return true
+        }
         return canModerate
     }
 

--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -79,7 +79,7 @@ public class Comment: NSManagedObject {
             return canModerate
         }
 
-        guard let blog = blog, blog.isHostedAtWPcom || blog.isAtomic() else {
+        guard let blog, blog.isHostedAtWPcom || blog.isAtomic() else {
             return true
         }
         return canModerate

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -626,7 +626,7 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         // Otherwise a share notification
         let category = notification.request.content.categoryIdentifier
 
-        guard (category == ShareNoticeConstants.categorySuccessIdentifier || category == ShareNoticeConstants.categoryFailureIdentifier),
+        guard category == ShareNoticeConstants.categorySuccessIdentifier || category == ShareNoticeConstants.categoryFailureIdentifier,
             (userInfo.object(forKey: ShareNoticeUserInfoKey.originatedFromAppExtension) as? Bool) == true,
             let postUploadOpID = userInfo.object(forKey: ShareNoticeUserInfoKey.postUploadOpID) as? String  else {
                 return

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3198,7 +3198,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
     func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {
         guard let uploadID = attachment.uploadID,
             let media = mediaCoordinator.media(withIdentifier: uploadID, for: post),
-            (media.remoteStatus == .pushing || media.remoteStatus == .processing)
+            media.remoteStatus == .pushing || media.remoteStatus == .processing
         else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -60,7 +60,7 @@ class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
     }
 
     override var kind: FormattableContentKind {
-        if let firstMedia = media.first, (firstMedia.kind == .image || firstMedia.kind == .badge) {
+        if let firstMedia = media.first, firstMedia.kind == .image || firstMedia.kind == .badge {
             return .image
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
@@ -35,8 +35,7 @@ struct ReaderCSS {
     ///
     var address: String {
         guard let lastUpdated = store.object(forKey: type(of: self).updatedKey) as? Int,
-                (now - lastUpdated < expirationDaysInSeconds
-                || !isInternetReachable()) else {
+              now - lastUpdated < expirationDaysInSeconds || !isInternetReachable() else {
             saveCurrentDate()
             return url(appendingTimestamp: now)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -12,7 +12,7 @@ extension WPTabBarController {
     override open var childForStatusBarStyle: UIViewController? {
         guard
             let topViewController = readerNavigationController?.topViewController,
-            ((topViewController as? DefinesVariableStatusBarStyle) != nil)
+            (topViewController as? DefinesVariableStatusBarStyle) != nil
         else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/WhatsNew/Data store/AnnouncementsStore.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Data store/AnnouncementsStore.swift
@@ -121,7 +121,7 @@ class CachedAnnouncementsStore: AnnouncementsStore {
 }
 
 
-private extension CachedAnnouncementsStore {
+extension CachedAnnouncementsStore {
 
     func cacheIsValid(for announcements: [Announcement]) -> Bool {
         guard let minimumVersion = announcements.first?.minimumAppVersion,   // there should not be more than one announcement
@@ -133,6 +133,9 @@ private extension CachedAnnouncementsStore {
         }
         return true
     }
+}
+
+private extension CachedAnnouncementsStore {
 
     var cacheExpired: Bool {
         guard let date = cache.date,

--- a/WordPress/Classes/ViewRelated/WhatsNew/Data store/AnnouncementsStore.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Data store/AnnouncementsStore.swift
@@ -124,14 +124,15 @@ class CachedAnnouncementsStore: AnnouncementsStore {
 extension CachedAnnouncementsStore {
 
     func cacheIsValid(for announcements: [Announcement]) -> Bool {
-        guard let minimumVersion = announcements.first?.minimumAppVersion,   // there should not be more than one announcement
-              let maximumVersion = announcements.first?.maximumAppVersion,   // per version, but if there is, each of them must match the version
-              let targetVersions = announcements.first?.appVersionTargets,   // so we might as well choose the first
-              let version = versionProvider.version,
-              ((minimumVersion...maximumVersion).contains(version) || targetVersions.contains(version)) else {
+        // There should not be more than one announcement per version,
+        // but if there is, each of them must match the version,
+        // so we might as well choose the first.
+        guard let announcement = announcements.first, let version = versionProvider.version else {
             return false
         }
-        return true
+
+        return (announcement.minimumAppVersion...announcement.maximumAppVersion).contains(version)
+        || announcement.appVersionTargets.contains(version)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -969,6 +969,8 @@
 		3FB1929626C79EC6000F5AA3 /* Date+Formats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB1929426C79EC6000F5AA3 /* Date+Formats.swift */; };
 		3FB34ADA25672AA5001A74A6 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
 		3FB5C2B327059AC8007D0ECE /* XCUIElement+Scroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */; };
+		3FB6D13D2AD0F67300768C07 /* CachedAnnouncementsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB6D13C2AD0F67300768C07 /* CachedAnnouncementsStoreTests.swift */; };
+		3FB6D13F2AD2AC5A00768C07 /* Announcement+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB6D13E2AD2AC5A00768C07 /* Announcement+Fixture.swift */; };
 		3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */; };
@@ -6610,6 +6612,8 @@
 		3FB1929426C79EC6000F5AA3 /* Date+Formats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formats.swift"; sourceTree = "<group>"; };
 		3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetTodayData.swift; sourceTree = "<group>"; };
 		3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Scroll.swift"; sourceTree = "<group>"; };
+		3FB6D13C2AD0F67300768C07 /* CachedAnnouncementsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAnnouncementsStoreTests.swift; sourceTree = "<group>"; };
+		3FB6D13E2AD2AC5A00768C07 /* Announcement+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Announcement+Fixture.swift"; sourceTree = "<group>"; };
 		3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersAnimator.swift; sourceTree = "<group>"; };
 		3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueStatsContentView.swift; sourceTree = "<group>"; };
 		3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabItemsStore.swift; sourceTree = "<group>"; };
@@ -11313,7 +11317,9 @@
 		3F3D8549251E6406001CA4D2 /* Data store */ = {
 			isa = PBXGroup;
 			children = (
+				3FB6D13E2AD2AC5A00768C07 /* Announcement+Fixture.swift */,
 				3F3D854A251E6418001CA4D2 /* AnnouncementsDataStoreTests.swift */,
+				3FB6D13C2AD0F67300768C07 /* CachedAnnouncementsStoreTests.swift */,
 			);
 			path = "Data store";
 			sourceTree = "<group>";
@@ -23240,6 +23246,7 @@
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
 				0C6C4CD82A4F0F2C0049E762 /* Bundle+TestExtensions.swift in Sources */,
 				C38C5D8127F61D2C002F517E /* MenuItemTests.swift in Sources */,
+				3FB6D13D2AD0F67300768C07 /* CachedAnnouncementsStoreTests.swift in Sources */,
 				E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */,
 				0148CC292859127F00CF5D96 /* StatsWidgetsStoreTests.swift in Sources */,
 				7320C8BD2190C9FC0082FED5 /* UITextView+SummaryTests.swift in Sources */,
@@ -23260,6 +23267,7 @@
 				E66969CD1B9E2EBF00EC9C00 /* SafeReaderTopicToReaderTopic.m in Sources */,
 				DC3B9B2F27739887003F7249 /* TimeZoneSelectorViewModelTests.swift in Sources */,
 				E6A215901D1065F200DE5270 /* AbstractPostTest.swift in Sources */,
+				3FB6D13F2AD2AC5A00768C07 /* Announcement+Fixture.swift in Sources */,
 				D8BA274D20FDEA2E007A5C77 /* NotificationTextContentTests.swift in Sources */,
 				2481B1D5260D4E8B00AE59DB /* AccountBuilder.swift in Sources */,
 				E66969C81B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift in Sources */,

--- a/WordPress/WordPressTest/What's New/Data store/Announcement+Fixture.swift
+++ b/WordPress/WordPressTest/What's New/Data store/Announcement+Fixture.swift
@@ -1,0 +1,22 @@
+@testable import WordPressKit // Announcement is defined here
+
+extension Announcement {
+
+    static func fixture(
+        minimumAppVersion: String = "1.0",
+        maximumAppVersion: String = "2.0",
+        appVersionTargets: [String] = []
+    ) -> Announcement {
+        Announcement(
+            appVersionName: "0.0",
+            minimumAppVersion: minimumAppVersion,
+            maximumAppVersion: maximumAppVersion,
+            appVersionTargets: appVersionTargets,
+            detailsUrl: "http://wordpress.org",
+            announcementVersion: "1.0",
+            isLocalized: false,
+            responseLocale: "",
+            features: []
+        )
+    }
+}

--- a/WordPress/WordPressTest/What's New/Data store/CachedAnnouncementsStoreTests.swift
+++ b/WordPress/WordPressTest/What's New/Data store/CachedAnnouncementsStoreTests.swift
@@ -1,0 +1,100 @@
+import Nimble
+@testable import WordPress
+import XCTest
+
+class CachedAnnouncementsStoreTests: XCTestCase {
+
+    /// When the version is nil, the cache is never valid
+    func testCacheIsValid_noVersion() {
+        expect(makeStore(withVersion: .none).cacheIsValid(for: [])) == false
+        expect(makeStore(withVersion: .none).cacheIsValid(for: [.fixture(minimumAppVersion: "1.0", maximumAppVersion: "2.0")])) == false
+        expect(makeStore(withVersion: .none).cacheIsValid(for: [.fixture(appVersionTargets: ["1.1", "1.2"])])) == false
+    }
+
+    /// When the announcements list is empty, the cache is never valid
+    func testCacheIsValid_noAnnouncements() {
+        expect(makeStore(withVersion: .none).cacheIsValid(for: [])) == false
+        expect(makeStore(withVersion: "1.0").cacheIsValid(for: [])) == false
+    }
+
+    /// When the first announcement version bounds include the given version, the cache is valid
+    func testCacheIsValid_versionBounds() {
+        let announcemens = [
+            Announcement.fixture(minimumAppVersion: "1.0", maximumAppVersion: "2.0"),
+            Announcement.fixture(minimumAppVersion: "2.1", maximumAppVersion: "3.0")
+        ]
+
+        expect(makeStore(withVersion: "1.0").cacheIsValid(for: announcemens)) == true
+        expect(makeStore(withVersion: "1.1").cacheIsValid(for: announcemens)) == true
+        expect(makeStore(withVersion: "1.0.1").cacheIsValid(for: announcemens)) == true
+        expect(makeStore(withVersion: "2.0").cacheIsValid(for: announcemens)) == true
+
+        expect(makeStore(withVersion: "0.9").cacheIsValid(for: announcemens)) == false
+        expect(makeStore(withVersion: "2.1").cacheIsValid(for: announcemens)) == false
+    }
+
+    /// When the first announcement version targets includes the given version, the cache is valid
+    func testCacheIsValid_versionTargets() {
+        let announcements = [
+            Announcement.fixture(
+                minimumAppVersion: "3.0",
+                maximumAppVersion: "3.1",
+                appVersionTargets: ["0.9", "1.0", "2.1"]
+            ),
+            Announcement.fixture(
+                minimumAppVersion: "4.0",
+                maximumAppVersion: "4.1",
+                appVersionTargets: ["4.9", "5.0", "5.1"]
+            )
+        ]
+
+        expect(makeStore(withVersion: "0.9").cacheIsValid(for: announcements)) == true
+        expect(makeStore(withVersion: "1.0").cacheIsValid(for: announcements)) == true
+        expect(makeStore(withVersion: "2.1").cacheIsValid(for: announcements)) == true
+
+        expect(makeStore(withVersion: "0.8").cacheIsValid(for: announcements)) == false
+        expect(makeStore(withVersion: "1.1").cacheIsValid(for: announcements)) == false
+        expect(makeStore(withVersion: "2.2").cacheIsValid(for: announcements)) == false
+    }
+
+    /// When the first announcement version bounds does not include the given version,
+    /// the cache is never valid, regardless of the other announcements
+    func testCacheIsValid_otherAnnouncementBounds() {
+        let announcements = [
+            Announcement.fixture(minimumAppVersion: "2.0", maximumAppVersion: "3.0"),
+            Announcement.fixture(minimumAppVersion: "1.0", maximumAppVersion: "2.0")
+        ]
+        // These versions are valid for the second announcement, but the SUT only looks at the first.
+        expect(makeStore(withVersion: "1.0").cacheIsValid(for: announcements)) == false
+        expect(makeStore(withVersion: "1.1").cacheIsValid(for: announcements)) == false
+        expect(makeStore(withVersion: "1.0.1").cacheIsValid(for: announcements)) == false
+    }
+
+    /// When the first announcement version bounds and app version targets do not include the given version,
+    /// the cache is never valid, regardless of the other announcements
+    func testCacheIsValid_otherAnnouncementVersionTargets() {
+        let announcements = [
+            Announcement.fixture(
+                minimumAppVersion: "2.0",
+                maximumAppVersion: "3.0",
+                appVersionTargets: ["3.1", "3.2"]
+            ),
+            Announcement.fixture(
+                minimumAppVersion: "1.0",
+                maximumAppVersion: "1.5",
+                appVersionTargets: ["1.6", "1.7"]
+            )
+        ]
+        // These versions are valid for the second announcement, but the SUT only looks at the first.
+        expect(makeStore(withVersion: "1.6").cacheIsValid(for: announcements)) == false
+        expect(makeStore(withVersion: "1.7").cacheIsValid(for: announcements)) == false
+    }
+}
+
+func makeStore(withVersion version: String?) -> CachedAnnouncementsStore {
+    CachedAnnouncementsStore(
+        cache: MockAnnouncementsCache(),
+        service: MockAnnouncementsService(),
+        versionProvider: MockVersionProvider(version: version)
+    )
+}


### PR DESCRIPTION
I run into this while accidentally updating SwiftLint during unrelated work. Thought it would still be useful to keep it.

The new rule that our codebase violates is:

> Control Statement Violation: `if`, `for`, `guard`, `switch`, `while`, and `catch` statements shouldn't unnecessarily wrap their conditionals or arguments in parentheses (control_statement)

To test: See unit tests in CI.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.