### PR TITLE
Fix flaky testReplyNotification test

### DIFF
--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -53,6 +53,23 @@ public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10) {
     }
 }
 
+public func tapUntilExpectedElementAppear( toTap elementToTap: XCUIElement, toAppear elementToAppear: XCUIElement, maxRetries: Int = 10) {
+    var retries = 0
+    while retries < maxRetries {
+        if !elementToAppear.exists {
+            elementToTap.tap()
+            break
+        }
+
+        usleep(500000) // a 0.5 second delay before retrying
+        retries += 1
+    }
+
+    if retries == maxRetries {
+        XCTFail("Expected element (\(elementToAppear)) still does not exists after \(maxRetries) tries.")
+    }
+}
+
 public func waitForElementToDisappear( _ element: XCUIElement, maxRetries: Int = 10) {
     var retries = 0
     while retries < maxRetries {

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -53,11 +53,11 @@ public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10) {
     }
 }
 
-public func tapUntilExpectedElementAppear( toTap elementToTap: XCUIElement, toAppear elementToAppear: XCUIElement, maxRetries: Int = 10) {
+public func tap(element: XCUIElement, untilAppears elementToAppear: XCUIElement, maxRetries: Int = 10) {
     var retries = 0
     while retries < maxRetries {
         if !elementToAppear.exists {
-            elementToTap.tap()
+            element.tap()
             break
         }
 

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -66,7 +66,7 @@ public func tap(element: XCUIElement, untilAppears elementToAppear: XCUIElement,
     }
 
     if retries == maxRetries {
-        XCTFail("Expected element (\(elementToAppear)) still does not exists after \(maxRetries) tries.")
+        XCTFail("Expected element (\(elementToAppear)) still does not exist after \(maxRetries) tries.")
     }
 }
 

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -84,7 +84,7 @@ public class NotificationsScreen: ScreenObject {
     }
 
     public func replyToComment(withText text: String) -> Self {
-        tapUntilExpectedElementAppear(toTap: replyCommentButton, toAppear: replyTextView)
+        tap(element: replyCommentButton, untilAppears: replyTextView)
         replyTextView.typeText(text)
         replyButton.tap()
 

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -84,7 +84,7 @@ public class NotificationsScreen: ScreenObject {
     }
 
     public func replyToComment(withText text: String) -> Self {
-        waitAndTap(replyCommentButton)
+        tapUntilExpectedElementAppear(toTap: replyCommentButton, toAppear: replyTextView)
         replyTextView.typeText(text)
         replyButton.tap()
 


### PR DESCRIPTION
### Description
`NotificationTests testReplyNotification` is currently the flakiest UI test in CI. Based on the screenshot, this test often fail because the text field does not appear after the tap. This PR updates the step by retrying the tap before typing into the text field so that the test can be sure that text field exists before attempting to type. 


### Testing
CI should be green and `testReplyNotification` shouldn't be flaky in CI.
