### PR TITLE
Reader: Add a11y labels and hints for `ReaderPostCardCell`

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -33,6 +33,7 @@ class ReaderPostCardCell: UITableViewCell {
             configureLabels()
             configureImages()
             configureButtons()
+            configureAccessibility()
         }
     }
 
@@ -84,6 +85,30 @@ class ReaderPostCardCell: UITableViewCell {
         struct FeaturedImage {
             static let cornerRadius: CGFloat = 5.0
             static let heightAspectMultiplier: CGFloat = 239.0 / 358.0
+        }
+
+        struct Accessibility {
+            static let siteStackViewHint = NSLocalizedString("reader.post.header.accessibility.hint",
+                                                             value: "Opens the site details for the post.",
+                                                             comment: "Accessibility hint for the site header on the reader post card cell")
+            static let reblogButtonHint = NSLocalizedString("reader.post.button.reblog.accessibility.hint",
+                                                            value: "Reblogs the post.",
+                                                            comment: "Accessibility hint for the reblog button on the reader post card cell")
+            static let commentButtonHint = NSLocalizedString("reader.post.button.comment.accessibility.hint",
+                                                             value: "Opens the comments for the post.",
+                                                             comment: "Accessibility hint for the comment button on the reader post card cell")
+            static let likeButtonHint = NSLocalizedString("reader.post.button.like.accessibility.hint",
+                                                          value: "Likes the post.",
+                                                          comment: "Accessibility hint for the like button on the reader post card cell")
+            static let likedButtonHint = NSLocalizedString("reader.post.button.like.accessibility.hint",
+                                                          value: "Unlikes the post.",
+                                                          comment: "Accessibility hint for the liked button on the reader post card cell")
+            static let menuButtonLabel = NSLocalizedString("reader.post.button.menu.accessibility.label",
+                                                           value: "More",
+                                                           comment: "Accessibility label for the more menu button on the reader post card cell")
+            static let menuButtonHint = NSLocalizedString("reader.post.button.menu.accessibility.hint",
+                                                          value: "Opens a menu with more actions.",
+                                                          comment: "Accessibility hint for the site header on the reader post card cell")
         }
 
         static let iconImageSize: CGFloat = 20.0
@@ -433,6 +458,27 @@ private extension ReaderPostCardCell {
         likeButton.setImage(isLiked ? Constants.likedButtonImage : Constants.likeButtonImage, for: .normal)
         likeButton.tintColor = isLiked ? .jetpackGreen : .secondaryLabel
         likeButton.setTitleColor(likeButton.tintColor, for: .normal)
+    }
+
+    // MARK: - Accessibility
+
+    func configureAccessibility() {
+        siteStackView.isAccessibilityElement = true
+        siteStackView.accessibilityLabel = [viewModel?.siteTitle, viewModel?.shortPostDate].compactMap { $0 }.joined(separator: ", ")
+        siteStackView.accessibilityHint = Constants.Accessibility.siteStackViewHint
+        siteStackView.accessibilityTraits = .button
+
+        postCountsLabel.accessibilityLabel = [viewModel?.likeCount, viewModel?.commentCount].compactMap { $0 }.joined(separator: ", ")
+
+        reblogButton.accessibilityHint = Constants.Accessibility.reblogButtonHint
+        commentButton.accessibilityHint = Constants.Accessibility.commentButtonHint
+        likeButton.accessibilityHint = viewModel?.isPostLiked == true ? Constants.Accessibility.likedButtonHint : Constants.Accessibility.likeButtonHint
+        menuButton.accessibilityLabel = Constants.Accessibility.menuButtonLabel
+        menuButton.accessibilityHint = Constants.Accessibility.menuButtonHint
+        accessibilityElements = [
+            siteStackView, postTitleLabel, postSummaryLabel, postCountsLabel,
+            reblogButton, commentButton, likeButton, menuButton
+        ]
     }
 
     // MARK: - Cell reuse

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCellViewModel.swift
@@ -22,12 +22,16 @@ struct ReaderPostCardCellViewModel {
         return contentProvider.blogNameForDisplay?()
     }
 
+    var shortPostDate: String? {
+        contentProvider.dateForDisplay()?.toShortString()
+    }
+
     var postDate: String? {
-        guard let dateForDisplay = contentProvider.dateForDisplay()?.toShortString() else {
+        guard let shortPostDate else {
             return nil
         }
         let postDateFormat = isRTL ? "%@ •" : "• %@"
-        return siteTitle != nil ? String(format: postDateFormat, dateForDisplay) : dateForDisplay
+        return siteTitle != nil ? String(format: postDateFormat, shortPostDate) : shortPostDate
     }
 
     var postTitle: String? {
@@ -50,18 +54,24 @@ struct ReaderPostCardCellViewModel {
         contentProvider.contentPreviewForDisplay()
     }
 
+    var commentCount: String? {
+        guard isCommentsEnabled else {
+            return nil
+        }
+        let count = contentProvider.commentCount()?.intValue ?? 0
+        return WPStyleGuide.commentCountForDisplay(count)
+    }
+
+    var likeCount: String? {
+        guard isLikesEnabled else {
+            return nil
+        }
+        let count = contentProvider.likeCount()?.intValue ?? 0
+        return WPStyleGuide.likeCountForDisplay(count)
+    }
+
     var postCounts: String? {
-        let commentCount = contentProvider.commentCount()?.intValue ?? 0
-        let likeCount = contentProvider.likeCount()?.intValue ?? 0
-        var countStrings = [String]()
-
-        if isLikesEnabled {
-            countStrings.append(WPStyleGuide.likeCountForDisplay(likeCount))
-        }
-
-        if isCommentsEnabled {
-            countStrings.append(WPStyleGuide.commentCountForDisplay(commentCount))
-        }
+        let countStrings = [likeCount, commentCount].compactMap { $0 }
         return countStrings.count > 0 ? countStrings.joined(separator: " • ") : nil
     }
 


### PR DESCRIPTION
Part of #21645 

## Description

Adds accessibility labels and hints to the ReaderPostCardCell's UI.

## Testing

To test:
- Use a real device and enable VoiceOver
- Launch Jetpack and Login
- Navigate to the Reader tab
- Swipe through a post's cell and 🔎  **verify** each element is read properly

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
