### PR TITLE
Reader: Add border to icon images and featured image

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -8,6 +8,7 @@ class ReaderPostCardCell: UITableViewCell {
     private let siteStackView = UIStackView()
     private let siteIconContainerView = UIView()
     private let siteIconImageView = UIImageView()
+    private let siteIconBorderView = UIView()
     private let avatarContainerView = UIView()
     private let avatarImageView = UIImageView()
     private let siteTitleLabel = UILabel()
@@ -136,6 +137,7 @@ class ReaderPostCardCell: UITableViewCell {
         static let borderColor = UIColor(light: .systemBackground.darkVariant().withAlphaComponent(0.1),
                                          dark: .systemBackground.lightVariant().withAlphaComponent(0.2))
         static let borderWidth: CGFloat = 0.5
+        static let imageSeparatorBorderWidth: CGFloat = 1.0
         static let separatorHeight: CGFloat = 0.5
     }
 
@@ -156,12 +158,8 @@ private extension ReaderPostCardCell {
         setupContentView()
         setupContentStackView()
 
-        setupIconImage(avatarImageView,
-                       containerView: avatarContainerView,
-                       image: Constants.avatarPlaceholder)
-        setupIconImage(siteIconImageView,
-                       containerView: siteIconContainerView,
-                       image: Constants.siteIconPlaceholder)
+        setupAvatarImage()
+        setupSiteIconImage()
         setupSiteTitle()
         setupPostDate()
         setupSiteStackView()
@@ -189,6 +187,30 @@ private extension ReaderPostCardCell {
         contentView.addSubview(contentStackView)
     }
 
+    func setupAvatarImage() {
+        setupIconImage(avatarImageView,
+                       containerView: avatarContainerView,
+                       image: Constants.avatarPlaceholder)
+        avatarContainerView.addSubview(avatarImageView)
+        siteStackView.addArrangedSubview(avatarContainerView)
+    }
+
+    func setupSiteIconImage() {
+        setupIconImage(siteIconImageView,
+                       containerView: siteIconContainerView,
+                       image: Constants.siteIconPlaceholder)
+        siteIconImageView.layer.masksToBounds = false
+        siteIconBorderView.translatesAutoresizingMaskIntoConstraints = false
+        siteIconBorderView.layer.frame = CGRect(x: 0, y: 0, width: Constants.iconImageSize, height: Constants.iconImageSize)
+        siteIconBorderView.layer.cornerRadius = Constants.iconImageSize / 2.0
+        siteIconBorderView.layer.borderWidth = Constants.borderWidth + Constants.imageSeparatorBorderWidth
+        siteIconBorderView.layer.borderColor = UIColor.listForeground.cgColor
+        siteIconBorderView.layer.masksToBounds = true
+        siteIconBorderView.addSubview(siteIconImageView)
+        siteIconContainerView.addSubview(siteIconBorderView)
+        siteStackView.addArrangedSubview(siteIconContainerView)
+    }
+
     func setupIconImage(_ imageView: UIImageView, containerView: UIView, image: UIImage?) {
         containerView.translatesAutoresizingMaskIntoConstraints = false
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -199,8 +221,6 @@ private extension ReaderPostCardCell {
         imageView.layer.borderWidth = Constants.borderWidth
         imageView.layer.borderColor = Constants.borderColor.cgColor
         imageView.backgroundColor = .listForeground
-        containerView.addSubview(imageView)
-        siteStackView.addArrangedSubview(containerView)
     }
 
     func setupSiteTitle() {
@@ -320,7 +340,7 @@ private extension ReaderPostCardCell {
         NSLayoutConstraint.activate(
             contentViewConstraints()
             + iconImageConstraints(avatarImageView, containerView: avatarContainerView)
-            + iconImageConstraints(siteIconImageView, containerView: siteIconContainerView)
+            + siteIconImageConstraints()
             + featuredImageContraints()
             + buttonStackViewConstraints()
             + buttonConstraints()
@@ -347,6 +367,21 @@ private extension ReaderPostCardCell {
             imageView.widthAnchor.constraint(equalToConstant: Constants.iconImageSize),
             imageView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
             imageView.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
+        ]
+    }
+
+    func siteIconImageConstraints() -> [NSLayoutConstraint] {
+        return [
+            siteIconContainerView.heightAnchor.constraint(greaterThanOrEqualTo: siteIconBorderView.heightAnchor),
+            siteIconContainerView.widthAnchor.constraint(greaterThanOrEqualTo: siteIconBorderView.widthAnchor),
+            siteIconBorderView.heightAnchor.constraint(equalToConstant: Constants.iconImageSize + Constants.borderWidth + Constants.imageSeparatorBorderWidth),
+            siteIconBorderView.widthAnchor.constraint(equalToConstant: Constants.iconImageSize + Constants.borderWidth + Constants.imageSeparatorBorderWidth),
+            siteIconBorderView.centerXAnchor.constraint(equalTo: siteIconContainerView.centerXAnchor),
+            siteIconBorderView.centerYAnchor.constraint(equalTo: siteIconContainerView.centerYAnchor),
+            siteIconImageView.heightAnchor.constraint(equalToConstant: Constants.iconImageSize),
+            siteIconImageView.widthAnchor.constraint(equalToConstant: Constants.iconImageSize),
+            siteIconImageView.centerXAnchor.constraint(equalTo: siteIconBorderView.centerXAnchor),
+            siteIconImageView.centerYAnchor.constraint(equalTo: siteIconBorderView.centerYAnchor),
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -133,6 +133,9 @@ class ReaderPostCardCell: UITableViewCell {
         static let likedButtonText = NSLocalizedString("reader.post.button.liked",
                                                        value: "Liked",
                                                        comment: "Text for the 'Liked' button on the reader post card cell.")
+        static let borderColor = UIColor(light: .systemBackground.darkVariant().withAlphaComponent(0.1),
+                                         dark: .systemBackground.lightVariant().withAlphaComponent(0.2))
+        static let borderWidth: CGFloat = 0.5
         static let separatorHeight: CGFloat = 0.5
     }
 
@@ -193,6 +196,9 @@ private extension ReaderPostCardCell {
         imageView.layer.masksToBounds = true
         imageView.image = image
         imageView.contentMode = .scaleAspectFill
+        imageView.layer.borderWidth = Constants.borderWidth
+        imageView.layer.borderColor = Constants.borderColor.cgColor
+        imageView.backgroundColor = .listForeground
         containerView.addSubview(imageView)
         siteStackView.addArrangedSubview(containerView)
     }
@@ -244,6 +250,8 @@ private extension ReaderPostCardCell {
         featuredImageView.layer.cornerRadius = Constants.FeaturedImage.cornerRadius
         featuredImageView.layer.masksToBounds = true
         featuredImageView.contentMode = .scaleAspectFill
+        featuredImageView.layer.borderWidth = Constants.borderWidth
+        featuredImageView.layer.borderColor = Constants.borderColor.cgColor
         contentStackView.addArrangedSubview(featuredImageView)
     }
 


### PR DESCRIPTION
Part of #21645
Ref: p1696503321444809-slack-C05N140C8H5
## Description

Adds a border around the avatar view, site icon view, and featured image view.

## Screenshots

| Light | Dark |
|------|------|
| ![Light](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/17029bd1-8076-461f-ae81-4052e17a4435) | ![Screenshot 2023-10-09 at 3 58 56 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/a6781b9b-418f-4b07-a83a-e41e266957d0) |

## Testing

To test:
- Launch Jetpack and login
- Enable the feature flag `Reader Improvements v1` if necessary
- Navigate to the Reader
- 🔎 **Verify** There's a border around the image views
- Navigate away and change to either light/dark theme (`CGColor` is not dynamic like `UIColor` so the view needs to be recreated for the correct color)
- Navigate back and 🔎 **verify** there's a border around the image views

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)