### PR TITLE
Posts & Pages: Enable filter by author for pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -220,10 +220,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.verticalScrollIndicatorInsets.top = searchController.searchBar.bounds.height
     }
 
-    override func configureAuthorFilter() {
-        // Noop
-    }
-
     override func configureFooterView() {
         super.configureFooterView()
         tableView.tableFooterView = UIView(frame: .zero)

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -129,10 +129,7 @@ class PostListFilterSettings: NSObject {
     // MARK: - Author-related methods
 
     @objc func canFilterByAuthor() -> Bool {
-        if postType == .post {
-            return blog.isMultiAuthor && blog.userID != nil
-        }
-        return false
+        return blog.isMultiAuthor && blog.userID != nil
     }
 
     @objc func authorIDFilter() -> NSNumber? {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -307,18 +307,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         ghostableTableView.register(postCompactCellNib, forCellReuseIdentifier: postCompactCellIdentifier)
     }
 
-    override func configureAuthorFilter() {
-        guard filterSettings.canFilterByAuthor() else {
-            return
-        }
-
-        let authorFilter = AuthorFilterButton()
-        authorFilter.addTarget(self, action: #selector(showAuthorSelectionPopover(_:)), for: .touchUpInside)
-        filterTabBar.accessoryView = authorFilter
-
-        updateAuthorFilter()
-    }
-
     override func configureSearchController() {
         super.configureSearchController()
 
@@ -391,41 +379,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     override func lastSyncDate() -> Date? {
         return blog?.lastPostsSync
-    }
-
-    // MARK: - Actions
-
-    @objc
-    private func showAuthorSelectionPopover(_ sender: UIView) {
-        let filterController = AuthorFilterViewController(initialSelection: filterSettings.currentPostAuthorFilter(),
-                                                          gravatarEmail: blog.account?.email) { [weak self] filter in
-                                                            if filter != self?.filterSettings.currentPostAuthorFilter() {
-                                                                UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: sender)
-                                                            }
-
-                                                            self?.filterSettings.setCurrentPostAuthorFilter(filter)
-                                                            self?.updateAuthorFilter()
-                                                            self?.refreshAndReload()
-                                                            self?.syncItemsWithUserInteraction(false)
-                                                            self?.dismiss(animated: true)
-        }
-
-        ForcePopoverPresenter.configurePresentationControllerForViewController(filterController, presentingFromView: sender)
-        filterController.popoverPresentationController?.permittedArrowDirections = .up
-
-        present(filterController, animated: true)
-    }
-
-    private func updateAuthorFilter() {
-        guard let accessoryView = filterTabBar.accessoryView as? AuthorFilterButton else {
-            return
-        }
-
-        if filterSettings.currentPostAuthorFilter() == .everyone {
-            accessoryView.filterType = .everyone
-        } else {
-            accessoryView.filterType = .user(gravatarEmail: blog.account?.email)
-        }
     }
 
     // MARK: - Data Model Interaction


### PR DESCRIPTION
Fixes #16592

## Description
- Enables the author filter for multi-author sites for both posts and pages

## Notes
- For some reason, filtering by author was disabled for pages on iOS. Web / Android supports filtering by author for both posts and pages

## How to test 
- Freshly install the app
- Switch to a multi-author site
- Go to the Posts List screen
- Verify the author filter is displayed
- Go to the Pages List screen
- Verify the author filter is displayed


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/212b8de2-5cad-403d-966f-b7cce71fcb36



## Regression Notes
1. Potential unintended areas of impact
Pages list, Posts list

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a - moved logic to base class

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

