### PR TITLE
Do not show any blog cards when not signed in

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -75,7 +75,7 @@ final class BlogDashboardService {
     /// Fetch cards from local
     func fetchLocal(blog: Blog) -> [DashboardCardModel] {
 
-        guard let dotComID = blog.dotComID?.intValue else {
+        guard AccountHelper.isDotcomAvailable(), let dotComID = blog.dotComID?.intValue else {
             return []
         }
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -15,17 +15,6 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
     private let wpComID = 123456
 
-    // FIXME: Accessing WPAccount wordPressComRestApi will crash if WordPressAuthenticationManager has not been initialized!
-    //
-    // This issue doesn't manifest itself when running the whole test suite beceause of the lucky coincidence that a test running before this one sets it up.
-    // But try to comment this class setUp method and run only this test case and you'll get a crash.
-    override class func setUp() {
-        WordPressAuthenticationManager(
-            windowManager: WindowManager(window: UIWindow()),
-            remoteFeaturesStore: RemoteFeatureFlagStore()
-        ).initializeWordPressAuthenticator()
-    }
-
     override func setUp() {
         super.setUp()
 
@@ -432,7 +421,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
     private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true) -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
-
+        blog.account = try! WPAccount.lookupDefaultWordPressComAccount(in: context)
         blog.dotComID = id as NSNumber
         blog.isAdmin = isAdmin
         return blog


### PR DESCRIPTION
## Issue

The app unnecessarily re-syncs posts during logout. You can reproduce this issue by putting a breakpoint at [this line](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.3.1/WordPress/Classes/Services/PostService.m#L122), launch the app from Xcode and tap log out, and Xcode would stop at the breakpoint.

## Changes

The root cause is the app reloads the blog dashboard when handling account logout notification. The syncing posts API is made to prepare data to be presented in cards in the dashboard. This PR simply adds a condition to check if user has signed in, and basically asks the blog dashboard to show no cards if user hasn't signed in. And, no syncing posts API will be made because no cards need to be shown.

## Test Instructions

Verify [this line](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.3.1/WordPress/Classes/Services/PostService.m#L122) won't be called upon logout.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A