### PR TITLE
Disable sending Jetpack ASC metadata to GlotPress

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -233,12 +233,14 @@ platform :ios do
   #
   desc 'Updates the AppStoreStrings.po file for the Jetpack app with the latest data'
   lane :update_jetpack_appstore_strings do |options|
-    source_metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata', 'default')
-    custom_metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'appstoreres', 'jetpack_metadata', 'source')
+    # Commented out to silence RuboCop about unused vars.
+    # See details below for why that was done and why we should keep the definition in the codebase for future use.
+    # source_metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata', 'default')
+    # custom_metadata_folder = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'appstoreres', 'jetpack_metadata', 'source')
     version = options.fetch(:version, get_app_version)
 
     files = {
-      whats_new: JETPACK_RELEASE_NOTES_PATH,
+      whats_new: JETPACK_RELEASE_NOTES_PATH
       # We are currently iterating on the App Store copy for Jetpack.
       # It's therefore easier to update the English US metadata without triggering a translation.
       # Once we'll settle on a new copy, we'll re-enable reading these sources for the GlotPress po file.

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -239,16 +239,20 @@ platform :ios do
 
     files = {
       whats_new: JETPACK_RELEASE_NOTES_PATH,
-      app_store_name: File.join(source_metadata_folder, 'name.txt'),
-      app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
-      app_store_desc: File.join(source_metadata_folder, 'description.txt'),
-      app_store_keywords: File.join(source_metadata_folder, 'keywords.txt'),
-      'screenshot-text-1' => File.join(custom_metadata_folder, 'promo_screenshot_1.txt'),
-      'screenshot-text-2' => File.join(custom_metadata_folder, 'promo_screenshot_2.txt'),
-      'screenshot-text-3' => File.join(custom_metadata_folder, 'promo_screenshot_3.txt'),
-      'screenshot-text-4' => File.join(custom_metadata_folder, 'promo_screenshot_4.txt'),
-      'screenshot-text-5' => File.join(custom_metadata_folder, 'promo_screenshot_5.txt'),
-      'screenshot-text-6' => File.join(custom_metadata_folder, 'promo_screenshot_6.txt')
+      # We are currently iterating on the App Store copy for Jetpack.
+      # It's therefore easier to update the English US metadata without triggering a translation.
+      # Once we'll settle on a new copy, we'll re-enable reading these sources for the GlotPress po file.
+      #
+      # app_store_name: File.join(source_metadata_folder, 'name.txt'),
+      # app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
+      # app_store_desc: File.join(source_metadata_folder, 'description.txt'),
+      # app_store_keywords: File.join(source_metadata_folder, 'keywords.txt'),
+      # 'screenshot-text-1' => File.join(custom_metadata_folder, 'promo_screenshot_1.txt'),
+      # 'screenshot-text-2' => File.join(custom_metadata_folder, 'promo_screenshot_2.txt'),
+      # 'screenshot-text-3' => File.join(custom_metadata_folder, 'promo_screenshot_3.txt'),
+      # 'screenshot-text-4' => File.join(custom_metadata_folder, 'promo_screenshot_4.txt'),
+      # 'screenshot-text-5' => File.join(custom_metadata_folder, 'promo_screenshot_5.txt'),
+      # 'screenshot-text-6' => File.join(custom_metadata_folder, 'promo_screenshot_6.txt')
     }
 
     ios_update_metadata_source(


### PR DESCRIPTION
We are currently iterating on the App Store copy for Jetpack. It's therefore easier to update the English US metadata without triggering a translation. Once we'll settle on a new copy, we'll re-enable reading these sources for the GlotPress po file.

Internal ref pc5zdG-1kL-p2 cc @paulforgione

## Testing
I was concerned that removing the files from the configuration hash would result in the generated `.po` not having the matching entry, which in turn would have resulted in a deletion of such entries in GlotPress, which in turn would have resulted in all the localized metadata being temporarily lost.

Luckily, that was not the case.

You can verify this by:

1. Updating the content of `WordPress/Jetpack/Resources/release_notes.txt`.
2. Committing the change.
3. Running `bundle exec fastlane update_jetpack_appstore_strings`
4. Verify only the notes changed and that the other metadata entries remained unchanged.

Here's the diff for the commit generated on my machine:

```
diff --git a/WordPress/Jetpack/Resources/AppStoreStrings.po b/WordPress/Jetpack/Resources/AppStoreStrings.po
index 6310558668..d1ae0e1040 100644
--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -83,13 +83,7 @@ msgstr ""

 msgctxt "v23.4-whats-new"
 msgid ""
-"We’ve been squashing bugs! (It was a lot cleaner than it sounds.)\n"
-"\n"
-"- You can now embed URLs from X without getting a broken link. Pretty X-cellent, if you ask us.\n"
-"- Speaking of links—when you use an invalid media URL, the app will now display an error message instead of crashing. B>
-"- Contributors will now see the correct pop-up when submitting posts for review. Phew.\n"
-"- We fixed a problem where non-admin users could see the plugin menu for their site. Out of sight, out of mind.\n"
-"- In the block editor, the app will no longer crash when you nest too many blocks within blocks… within blocks… you get>
+"Test new notes\n"
 msgstr ""

 #. translators: This is a promo message that will be attached on top of the first screenshot in the App Store.
```

Another test worth running is:

1. Update one of the sources for the metadata we plan to change, e.g. `fastlane/jetpack_metadata/default/name.txt`
2. Commit the change
3. Run `bundle exec fastlane update_jetpack_appstore_strings`
4. Verify nothing changed, e.g. by checking that there are no new commits in the `git log`.

## Regression Notes

1. Potential unintended areas of impact – N.A.
6. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
7. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.