### PR TITLE
Posts & Pages: Update filter tab styling

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -502,8 +502,18 @@ private class TabBarButton: UIButton {
         setFont()
     }
 
+    override var isSelected: Bool {
+        didSet {
+            setFont()
+        }
+    }
+
     private func setFont() {
-        titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitBold, maximumPointSize: TabFont.maxSize)
+        if isSelected {
+            titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitBold, maximumPointSize: TabFont.maxSize)
+        } else {
+            titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, maximumPointSize: TabFont.maxSize)
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -25,7 +25,7 @@ extension UIColor {
     }
 
     static var filterBarSelected: UIColor {
-        return .primary
+        return .text
     }
 
     static var filterBarSelectedText: UIColor {


### PR DESCRIPTION
Fixes #21711 

## Description
- Updates filter tab styling to match new design specs (ref: eYeHXEMDbnFptE40xUqZ2T-fi-836%3A5909)

## How to test
- On the JP app, go to Posts and/or Pages
- Tap on the the different tabs
- Verify the horizontal bar under the selected tab is the same color as the selected tab text color
- Verify the unselected tab font is regular

Before | After (light) | After (dark)
-- | -- | --
![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 15 39 39](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/32871fca-945a-4c09-aa9e-2794c3bfb4be) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 15 19 15](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/52091beb-524d-4b3c-a72a-d1e87d05bcf8) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-11 at 15 20 10](https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/cd1043a5-730d-4fc9-840d-66e023b01229)


## Regression Notes
1. Potential unintended areas of impact
Screens using tabs - Stats, Reader, Notifications, etc

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)