### PR TITLE
Update the tags list style in Reader detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -461,6 +461,7 @@ fileprivate struct ReaderDetailTagsWrapperView: UIViewRepresentable {
 
         // ensure that the collection view hugs its content.
         view.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return view
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -2,6 +2,38 @@ import Foundation
 import WordPressShared
 
 class ReaderInterestsStyleGuide {
+
+    struct Metrics {
+        let interestsLabelMargin: CGFloat
+        let cellCornerRadius: CGFloat
+        let cellSpacing: CGFloat
+        let cellHeight: CGFloat
+        let maxCellWidthMultiplier: CGFloat
+        let borderWidth: CGFloat
+        let borderColor: UIColor
+
+        /// The legacy metrics for the cell style before `readerImprovements` feature
+        static let legacy = Metrics(
+            interestsLabelMargin: 8.0,
+            cellCornerRadius: 4.0,
+            cellSpacing: 6.0,
+            cellHeight: 26.0,
+            maxCellWidthMultiplier: 0.8,
+            borderWidth: 0,
+            borderColor: .clear
+        )
+
+        static let latest = Metrics(
+            interestsLabelMargin: 16.0,
+            cellCornerRadius: 5.0,
+            cellSpacing: 8.0,
+            cellHeight: 34.0,
+            maxCellWidthMultiplier: 0.8,
+            borderWidth: 1.0,
+            borderColor: .separator
+        )
+    }
+
     // MARK: - View Styles
     public class func applyTitleLabelStyles(label: UILabel) {
         label.font = WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .medium)
@@ -32,7 +64,7 @@ class ReaderInterestsStyleGuide {
     public class func applyCompactCellLabelStyle(label: UILabel) {
         label.font = Self.compactCellLabelTitleFont
         label.textColor = .text
-        label.backgroundColor = .quaternaryBackground
+        label.backgroundColor = FeatureFlag.readerImprovements.enabled ? .clear : .quaternaryBackground
     }
 
     // MARK: - Next Button

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -19,17 +19,6 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     private struct Constants {
         static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()
         static let overflowReuseIdentifier = "OverflowItem"
-
-        static let metrics: ReaderInterestsStyleGuide.Metrics = {
-            return FeatureFlag.readerImprovements.enabled ? .latest : .legacy
-        }()
-
-        static let interestsLabelMargin: CGFloat = 8
-
-        static let cellCornerRadius: CGFloat = 4
-        static let cellSpacing: CGFloat = 6
-        static let cellHeight: CGFloat = 26
-        static let maxCellWidthMultiplier: CGFloat = 0.8
     }
 
     private struct Strings {
@@ -41,6 +30,10 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
          static let accessbilityHint: String = NSLocalizedString("Tap to view posts for this tag", comment: "Accessibility hint to inform the user what action the post tag chip performs")
     }
+
+    private lazy var metrics: ReaderInterestsStyleGuide.Metrics = {
+        return FeatureFlag.readerImprovements.enabled ? .latest : .legacy
+    }()
 
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
 
@@ -105,8 +98,8 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
         layout.delegate = self
         layout.maxNumberOfDisplayedLines = 1
-        layout.itemSpacing = Constants.metrics.cellSpacing
-        layout.cellHeight = Constants.metrics.cellHeight
+        layout.itemSpacing = metrics.cellSpacing
+        layout.cellHeight = metrics.cellHeight
         layout.allowsCentering = false
     }
 
@@ -120,9 +113,9 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         var size = title.size(withAttributes: attributes)
 
         // Prevent 1 token from being too long
-        let maxWidth = collectionView.bounds.width * Constants.maxCellWidthMultiplier
+        let maxWidth = collectionView.bounds.width * metrics.maxCellWidthMultiplier
         let width = min(size.width, maxWidth)
-        size.width = width + (Constants.metrics.interestsLabelMargin * 2)
+        size.width = width + (metrics.interestsLabelMargin * 2)
 
         return size
     }
@@ -130,12 +123,12 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     private func configure(cell: ReaderInterestsCollectionViewCell, with title: String) {
         ReaderInterestsStyleGuide.applyCompactCellLabelStyle(label: cell.label)
 
-        if Constants.metrics.borderWidth > 0 {
-            cell.layer.borderColor = Constants.metrics.borderColor.cgColor
-            cell.layer.borderWidth = Constants.metrics.borderWidth
+        if metrics.borderWidth > 0 {
+            cell.layer.borderColor = metrics.borderColor.cgColor
+            cell.layer.borderWidth = metrics.borderWidth
         }
 
-        cell.layer.cornerRadius = Constants.metrics.cellCornerRadius
+        cell.layer.cornerRadius = metrics.cellCornerRadius
         cell.label.text = title
         cell.label.accessibilityHint = Strings.accessbilityHint
         cell.label.accessibilityTraits = .button

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -20,6 +20,10 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()
         static let overflowReuseIdentifier = "OverflowItem"
 
+        static let metrics: ReaderInterestsStyleGuide.Metrics = {
+            return FeatureFlag.readerImprovements.enabled ? .latest : .legacy
+        }()
+
         static let interestsLabelMargin: CGFloat = 8
 
         static let cellCornerRadius: CGFloat = 4
@@ -101,16 +105,15 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
         layout.delegate = self
         layout.maxNumberOfDisplayedLines = 1
-        layout.itemSpacing = Constants.cellSpacing
-        layout.cellHeight = Constants.cellHeight
+        layout.itemSpacing = Constants.metrics.cellSpacing
+        layout.cellHeight = Constants.metrics.cellHeight
         layout.allowsCentering = false
     }
 
-    private func sizeForCell(title: String, of collectionView: UICollectionView)-> CGSize {
+    private func sizeForCell(title: String, of collectionView: UICollectionView) -> CGSize {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: ReaderInterestsStyleGuide.compactCellLabelTitleFont
         ]
-
 
         let title: NSString = title as NSString
 
@@ -119,7 +122,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         // Prevent 1 token from being too long
         let maxWidth = collectionView.bounds.width * Constants.maxCellWidthMultiplier
         let width = min(size.width, maxWidth)
-        size.width = width + (Constants.interestsLabelMargin * 2)
+        size.width = width + (Constants.metrics.interestsLabelMargin * 2)
 
         return size
     }
@@ -127,7 +130,12 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     private func configure(cell: ReaderInterestsCollectionViewCell, with title: String) {
         ReaderInterestsStyleGuide.applyCompactCellLabelStyle(label: cell.label)
 
-        cell.layer.cornerRadius = Constants.cellCornerRadius
+        if Constants.metrics.borderWidth > 0 {
+            cell.layer.borderColor = Constants.metrics.borderColor.cgColor
+            cell.layer.borderWidth = Constants.metrics.borderWidth
+        }
+
+        cell.layer.cornerRadius = Constants.metrics.cellCornerRadius
         cell.label.text = title
         cell.label.accessibilityHint = Strings.accessbilityHint
         cell.label.accessibilityTraits = .button
@@ -181,7 +189,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
 
         configure(cell: cell, with: title)
 
-        if layout.isExpanded {
+        if layout.isExpanded || FeatureFlag.readerImprovements.enabled {
             cell.label.backgroundColor = .clear
         }
 


### PR DESCRIPTION
Refs #21644

As titled, this updates the tags list style. Additionally, this also fixes an issue where the new header view stretches out of its container when the device returns to portrait mode with the tags list expanded. More details at https://github.com/wordpress-mobile/WordPress-iOS/pull/21674#pullrequestreview-1660923880.

<img width="369" alt="Screenshot 2023-10-12 at 03 07 21" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/aacbe7cf-33e8-437f-b002-9f6b01a566da">

## To test

- Launch the Jetpack app.
- Ensure the `readerImprovements` feature flag is enabled.
- Go to Reader > Discover and select any post that preferably contains multiple tags.
- Tap on the `+N` button to expand the tags.
- 🔎 Verify that the tags are expanded.
- Rotate the device to landscape. 
- 🔎 Verify that the tags list is displayed correctly.
- Rotate the device back to portrait.
- 🔎 Verify that the tags list is displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes are hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
