### PR TITLE
Simulate signing in using WP.com account in BlogDashboardServiceTests

### DIFF
--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -18,6 +18,12 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     override func setUp() {
         super.setUp()
 
+        contextManager.useAsSharedInstance(untilTestFinished: self)
+
+        // Simulate the app is signed in with a WP.com account
+        let accountService = AccountService(coreDataStack: contextManager)
+        _ = accountService.createOrUpdateAccount(withUsername: "username", authToken: "token")
+
         remoteServiceMock = DashboardServiceRemoteMock()
         persistenceMock = BlogDashboardPersistenceMock()
         repositoryMock = InMemoryUserDefaults()


### PR DESCRIPTION
Given `BlogDashboardService` instances are used when the app is signed in, the test case `BlogDashboardServiceTests` should pass when there is indeed a `WPAccount` record in the database. However, that's not the case, because one test `testThatWhenAllCardsAreHiddenEmptyStateIsShown` fails when I add a `WPAccount` instance during `setUp` (see the changes in this PR).

The purpose of this PR is not proposing a change. It's more about surfacing a potential issue that the test `testThatWhenAllCardsAreHiddenEmptyStateIsShown` may not be reliable. @momo-ozawa @hassaanelgarem it looks like [you two recently worked on `BlogDashboardService`](https://github.com/wordpress-mobile/WordPress-iOS/commits/trunk/WordPress/Classes/ViewRelated/Blog/Blog%20Dashboard/Service/BlogDashboardService.swift), do you mind having a look at this test case and see how to make it pass when there is an user signed in?

<!--

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

-->