### PR TITLE
Integrate gutenberg-mobile release 1.106.0

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,4 +1,14 @@
 ref:
-  commit: b559166c87fbd69190eb33f9a3b340754d1a7c4d
+  # This should have either a commit or tag key.
+  # If both are set, tag will take precedence.
+  #
+  # We have automation that reads and updates this file.
+  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
+  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
+  #
+  # Example:
+  #
+  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
+  tag: v1.106.0
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -1,14 +1,4 @@
 ref:
-  # This should have either a commit or tag key.
-  # If both are set, tag will take precedence.
-  #
-  # We have automation that reads and updates this file.
-  # Leaving commented keys is discouraged, because as the automation would ignore them and the resulting updates would be noisy
-  # If you want to use a local version, please use the LOCAL_GUTENBERG environment variable when calling CocoaPods.
-  #
-  # Example:
-  #
-  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
-  tag: v1.105.0
+  commit: b559166c87fbd69190eb33f9a3b340754d1a7c4d
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - FSInteractiveMap (0.1.0)
   - Gifu (3.3.1)
   - Gridicons (1.2.0)
-  - Gutenberg (1.105.0)
+  - Gutenberg (1.106.0)
   - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.9):
     - CropViewController
@@ -111,7 +111,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.105.0.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b559166c87fbd69190eb33f9a3b340754d1a7c4d.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -184,7 +184,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.105.0.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b559166c87fbd69190eb33f9a3b340754d1a7c4d.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -207,7 +207,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 8c216a2ee60fcfacffd470d05ffbd7fbf01886eb
+  Gutenberg: 3b1386da1a29d60c3c84c4d7c1e04d0b482f3244
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -111,7 +111,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b559166c87fbd69190eb33f9a3b340754d1a7c4d.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -184,7 +184,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b559166c87fbd69190eb33f9a3b340754d1a7c4d.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -207,7 +207,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 3b1386da1a29d60c3c84c4d7c1e04d0b482f3244
+  Gutenberg: 46edef6239e4fa8c032aee57f67c9a258edf0cc1
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 23.5
 -----
 * [*] Fix a crash when the blog's blogging prompt settings contain invalid JSON [#21677]
-
+* [*] Block Editor: Split formatted text on triple Enter [https://github.com/WordPress/gutenberg/pull/53354]
+* [*] Block Editor: Quote block: Ensure border is visible with block-based themes in dark [https://github.com/WordPress/gutenberg/pull/54964]
 
 23.4
 -----


### PR DESCRIPTION
## Description
This PR incorporates the 1.106.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6280

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.