### PR TITLE
Me Screen: Fix buttons not working for new users on the WordPress app

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -548,7 +548,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
     func didTapAccountAndSettingsButton() {
         let meViewController = MeViewController()
-        showDetailViewController(meViewController, sender: self)
+        let navigationController = UINavigationController(rootViewController: meViewController)
+        showDetailViewController(navigationController, sender: self)
     }
 
     @objc


### PR DESCRIPTION
Fixes #21750
## Description
This PR fixes an issue where most buttons in the "Me" screen didn't react to taps, after signing up on the WordPress app.

## Testing Instructions

1. Run the WordPress app
2. Create a new account
3. After landing on the simplified UI tap on the "Account & Settings" button
4. The Me screen should be displayed modally
5. Tap on "My Profile"
6. ✅ Make sure the button and you're navigated to the Profile screen
7. ✅ Make sure the rest of the buttons in the Me screen work as expected

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
