### PR TITLE
Reader: Update reader follow button styles

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -236,7 +236,10 @@ struct ReaderDetailNewHeaderView: View {
         HStack(spacing: 8.0) {
             authorStack
             Spacer()
-            followButton(isPhone: WPDeviceIdentification.isiPhone())
+            ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
+                               isEnabled: viewModel.isFollowButtonInteractive) {
+                viewModel.didTapFollowButton()
+            }
         }
     }
 
@@ -339,42 +342,6 @@ struct ReaderDetailNewHeaderView: View {
             .font(.footnote)
             .foregroundColor(Color(.secondaryLabel))
     }
-
-    /// TODO: Update when the Follow buttons are updated.
-    @ViewBuilder
-    private func followButton(isPhone: Bool = true) -> some View {
-        let style: LegacyFollowButtonStyle = viewModel.isFollowingSite ? .following : .follow
-
-        Button {
-            viewModel.didTapFollowButton()
-        } label: {
-            if isPhone {
-                // only shows the icon as the button.
-                Image(uiImage: .gridicon(style.gridiconType, size: style.iconButtonSize))
-                    .tint(style.tintColor)
-            } else {
-                // shows both the icon and the label.
-                Label {
-                    Text(style.buttonLabel)
-                        .font(.callout)
-                        .fontWeight(style.fontWeight)
-                } icon: {
-                    Image(uiImage: .gridicon(style.gridiconType, size: style.labelIconSize).imageWithTintColor(style.labelIconTintColor)!)
-                }
-                .padding(style.buttonPadding)
-                .background(style.labelBackgroundColor)
-                .tint(style.labelTintColor)
-                .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
-                .overlay {
-                    RoundedRectangle(cornerRadius: style.cornerRadius)
-                        .stroke(style.borderColor, lineWidth: style.borderWidth)
-                }
-            }
-        }
-        .accessibilityLabel(style.buttonLabel)
-        .accessibilityHint(style.accessibilityHint)
-        .disabled(!viewModel.isFollowButtonInteractive)
-    }
 }
 
 // MARK: Private Helpers
@@ -386,61 +353,6 @@ fileprivate extension ReaderDetailNewHeaderView {
         static let authorImageLength: CGFloat = 20.0
     }
 
-    /// "Legacy" follow button styling.
-    /// Mostly taken from `WPStyleGuide+Reader`'s `applyReaderFollowButtonStyle`
-    ///
-    /// TODO: Remove this when the new Follow buttons are added.
-    struct LegacyFollowButtonStyle {
-        // Style for the Follow button
-        static let follow = LegacyFollowButtonStyle(
-            gridiconType: .readerFollow,
-            tintColor: Color(uiColor: .primary),
-            fontWeight: .semibold,
-            labelBackgroundColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followBackgroundColor),
-            labelTintColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followTextColor),
-            labelIconTintColor: WPStyleGuide.FollowButton.Style.followTextColor,
-            borderWidth: 0.0,
-            buttonLabel: WPStyleGuide.FollowButton.Text.followStringForDisplay,
-            accessibilityHint: WPStyleGuide.FollowButton.Text.accessibilityHint
-        )
-
-        // Style for the Following button
-        static let following = LegacyFollowButtonStyle(
-            gridiconType: .readerFollowing,
-            tintColor: Color(uiColor: .gray(.shade20)),
-            fontWeight: .regular,
-            labelBackgroundColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followingBackgroundColor),
-            labelTintColor: Color(uiColor: WPStyleGuide.FollowButton.Style.followingIconColor),
-            labelIconTintColor: WPStyleGuide.FollowButton.Style.followingTextColor,
-            borderWidth: 1.0,
-            buttonLabel: WPStyleGuide.FollowButton.Text.followingStringForDisplay,
-            accessibilityHint: WPStyleGuide.FollowButton.Text.accessibilityHint
-        )
-
-        let gridiconType: GridiconType
-
-        // iPhone-specific styling
-        let iconButtonSize = CGSize(width: 24, height: 24)
-        let tintColor: Color
-        let iconBackgroundColor: Color = .clear
-
-        // iPad-specific styling
-        let font: Font = .callout
-        let fontWeight: Font.Weight
-        let buttonPadding = EdgeInsets(top: 6.0, leading: 12.0, bottom: 6.0, trailing: 12.0)
-        let labelBackgroundColor: Color
-        let labelTintColor: Color
-        let labelIconTintColor: UIColor
-        let cornerRadius = 4.0
-        let borderColor = Color(uiColor: .primaryButtonBorder)
-        let borderWidth: CGFloat
-        let labelIconSize = CGSize(width: WPStyleGuide.fontSizeForTextStyle(.callout),
-                                   height: WPStyleGuide.fontSizeForTextStyle(.callout))
-
-        // localization-related
-        let buttonLabel: String
-        let accessibilityHint: String
-    }
 }
 
 // MARK: - TopicCollectionView UIViewRepresentable Wrapper

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ReaderFollowButton: View {
+
+    let isFollowing: Bool
+    let isEnabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        if isFollowing {
+            button.overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(Color(UIColor.separator), lineWidth: 1)
+            )
+        } else {
+            button
+        }
+    }
+
+    private var button: some View {
+        let text = isFollowing ? WPStyleGuide.FollowButton.Text.followingStringForDisplay : WPStyleGuide.FollowButton.Text.followStringForDisplay
+        let textColor: Color = isFollowing ? .secondary : Color(UIColor.invertedLabel)
+        let backgroundColor: Color = isFollowing ? .clear : Color(UIColor.label)
+        return Button {
+            action()
+        } label: {
+            Text(text)
+                .foregroundColor(textColor)
+                .font(.subheadline)
+        }
+        .disabled(!isEnabled)
+        .padding(.horizontal, 24.0)
+        .padding(.vertical, 8.0)
+        .background(backgroundColor)
+        .cornerRadius(5.0)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -326,6 +326,24 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
     private func post(_ notice: Notice) {
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
+
+    private func followButton(title: String) -> UIButton {
+        if FeatureFlag.readerImprovements.enabled {
+            let button = UIButton()
+            button.isSelected = true
+            WPStyleGuide.applyReaderFollowButtonStyle(button)
+            button.tintColor = .clear
+            button.sizeToFit()
+            return button
+        } else {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+            button.setImage(UIImage.gridicon(.readerFollowing), for: .normal)
+            button.imageView?.tintColor = UIColor.success
+            let unfollowSiteString = NSLocalizedString("Unfollow %@", comment: "Accessibility label for unfollowing a site")
+            button.accessibilityLabel = String(format: unfollowSiteString, title)
+            return button
+        }
+    }
 }
 
 // MARK: - No Results Handling
@@ -420,12 +438,8 @@ extension ReaderFollowedSitesViewController: WPTableViewHandlerDelegate {
         cell.imageView?.backgroundColor = UIColor.listForeground
 
         if showsAccessoryFollowButtons {
-            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
-            button.setImage(UIImage.gridicon(.readerFollowing), for: .normal)
-            button.imageView?.tintColor = UIColor.success
+            let button = followButton(title: site.title)
             button.addTarget(self, action: #selector(tappedAccessory(_:)), for: .touchUpInside)
-            let unfollowSiteString = NSLocalizedString("Unfollow %@", comment: "Accessibility label for unfollowing a site")
-            button.accessibilityLabel = String(format: unfollowSiteString, site.title)
             cell.accessoryView = button
             cell.accessibilityElements = [button]
         } else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
@@ -54,12 +54,13 @@ class ReaderRecommendedSiteCardCell: UITableViewCell {
         }
 
         let isCompact = traitCollection.horizontalSizeClass == .compact
+        let showLargeButton = !isCompact || FeatureFlag.readerImprovements.enabled
 
-        followButton.isHidden = !isCompact
-        iPadFollowButton.isHidden = isCompact
+        followButton.isHidden = showLargeButton
+        iPadFollowButton.isHidden = !showLargeButton
 
         // Update the info trailing constraint to prevent clipping
-        let button = isCompact ? followButton : iPadFollowButton
+        let button = showLargeButton ? iPadFollowButton : followButton
         let width = button?.frame.size.width ?? 0
         infoTrailingConstraint.constant = width + Constants.buttonMargin
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -71,9 +71,9 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="epE-Yr-j1l">
-                                        <rect key="frame" x="392" y="5" width="30" height="30"/>
+                                        <rect key="frame" x="392" y="3" width="30" height="34"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="30" id="ai0-Bv-Ahu"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="ai0-Bv-Ahu"/>
                                         </constraints>
                                         <connections>
                                             <action selector="didTapFollowButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="NxD-2g-dfT"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -87,8 +87,10 @@ struct ReaderSiteHeader: View {
             }
             countsDisplay
             if !viewModel.isFollowHidden {
-                followButton
-                    .padding(.top, 4)
+                ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
+                                   isEnabled: viewModel.isFollowEnabled) {
+                    viewModel.updateFollowStatus()
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -109,49 +111,6 @@ struct ReaderSiteHeader: View {
             }
             return $0 + text + Text(" ")
         })
-    }
-
-    @ViewBuilder
-    private var followButton: some View {
-        if viewModel.isFollowingSite {
-            Button {
-                viewModel.updateFollowStatus()
-            } label: {
-                Image(uiImage: Constants.followingIcon ?? UIImage())
-                    .padding(.leading, -2.0)
-                    .padding(.trailing, 2.0)
-                Text(WPStyleGuide.FollowButton.Text.followingStringForDisplay)
-                    .padding(.leading, 2.0)
-                    .padding(.trailing, -2.0)
-                    .foregroundColor(.secondary)
-                    .font(.callout)
-            }
-            .disabled(!viewModel.isFollowEnabled)
-            .padding(.horizontal, 12.0)
-            .padding(.vertical, 6.0)
-            .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(Color(UIColor.primaryButtonBorder), lineWidth: 1)
-            )
-        } else {
-            Button {
-                viewModel.updateFollowStatus()
-            } label: {
-                Image(uiImage: Constants.followIcon ?? UIImage())
-                    .padding(.leading, -2.0)
-                    .padding(.trailing, 2.0)
-                Text(WPStyleGuide.FollowButton.Text.followStringForDisplay)
-                    .padding(.leading, 2.0)
-                    .padding(.trailing, -2.0)
-                    .foregroundColor(.white)
-                    .font(.callout.weight(.semibold))
-            }
-            .disabled(!viewModel.isFollowEnabled)
-            .padding(.horizontal, 12.0)
-            .padding(.vertical, 6.0)
-            .background(Color(UIColor.primary))
-            .cornerRadius(4)
-        }
     }
 
     struct Constants {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -269,6 +269,10 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
+        guard !FeatureFlag.readerImprovements.enabled else {
+            applyNewReaderFollowButtonStyle(button)
+            return
+        }
         let side = WPStyleGuide.fontSizeForTextStyle(.callout)
         let size = CGSize(width: side, height: side)
 
@@ -298,17 +302,37 @@ extension WPStyleGuide {
         button.setImage(tintedFollowIcon, for: .normal)
         button.setImage(tintedFollowingIcon, for: .selected)
 
+        applyCommonReaderFollowButtonStyles(button)
+    }
+
+    public class func applyNewReaderFollowButtonStyle(_ button: UIButton) {
+        button.setTitleColor(.invertedLabel, for: .normal)
+        button.setTitleColor(.secondaryLabel, for: .selected)
+        button.backgroundColor = button.isSelected ? .clear : .label
+        button.layer.borderColor = UIColor.separator.cgColor
+        button.layer.cornerRadius = 5.0
+        button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
+
+        button.configuration = .plain()
+        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 24.0, bottom: 8.0, trailing: 24.0)
+        applyCommonReaderFollowButtonStyles(button)
+    }
+
+    private class func applyCommonReaderFollowButtonStyles(_ button: UIButton) {
         button.setTitle(FollowButton.Text.followStringForDisplay, for: .normal)
         button.setTitle(FollowButton.Text.followingStringForDisplay, for: .selected)
 
         button.layer.borderWidth = button.isSelected ? 1.0 : 0.0
-
         // Default accessibility label and hint.
         button.accessibilityLabel = button.isSelected ? FollowButton.Text.followingStringForDisplay : FollowButton.Text.followStringForDisplay
         button.accessibilityHint = FollowButton.Text.accessibilityHint
     }
 
     @objc public class func applyReaderIconFollowButtonStyle(_ button: UIButton) {
+        guard !FeatureFlag.readerImprovements.enabled else {
+            applyNewReaderFollowButtonStyle(button)
+            return
+        }
         let followIcon = UIImage.gridicon(.readerFollow)
         let followingIcon = UIImage.gridicon(.readerFollowing)
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2070,6 +2070,8 @@
 		837966A0299D51EC004A92B9 /* JetpackPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8379669E299D51EC004A92B9 /* JetpackPlugin.swift */; };
 		837966A2299E9C85004A92B9 /* JetpackInstallPluginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */; };
 		837966A3299E9C85004A92B9 /* JetpackInstallPluginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */; };
+		837A53D72AD8C3A400B941A2 /* ReaderFollowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837A53D62AD8C3A400B941A2 /* ReaderFollowButton.swift */; };
+		837A53D82AD8C3A400B941A2 /* ReaderFollowButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837A53D62AD8C3A400B941A2 /* ReaderFollowButton.swift */; };
 		837B49D7283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837B49D3283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift */; };
 		837B49D8283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837B49D3283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift */; };
 		837B49D9283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837B49D4283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift */; };
@@ -7432,6 +7434,7 @@
 		8379669B299C0C44004A92B9 /* JetpackRemoteInstallTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRemoteInstallTableViewCell.swift; sourceTree = "<group>"; };
 		8379669E299D51EC004A92B9 /* JetpackPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackPlugin.swift; sourceTree = "<group>"; };
 		837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallPluginHelper.swift; sourceTree = "<group>"; };
+		837A53D62AD8C3A400B941A2 /* ReaderFollowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowButton.swift; sourceTree = "<group>"; };
 		837B49C6283C28730061A657 /* WordPress 141.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 141.xcdatamodel"; sourceTree = "<group>"; };
 		837B49D3283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BloggingPromptSettings+CoreDataClass.swift"; sourceTree = "<group>"; };
 		837B49D4283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BloggingPromptSettings+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -12244,6 +12247,7 @@
 		5D08B8FC19647C0300D5B381 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				321955BE24BE234C00E3F316 /* ReaderInterestsCoordinator.swift */,
 				088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */,
 				E66EB6F81C1B7A76003DABC5 /* ReaderSpacerView.swift */,
 			);
@@ -16228,21 +16232,21 @@
 		CCB3A03814C8DD5100D43C3F /* Reader */ = {
 			isa = PBXGroup;
 			children = (
-				9870EF7827866DCE00F3BB54 /* Comments */,
 				8B7F51C724EED488008CF5B5 /* Analytics */,
-				5D1D04731B7A50B100CDE646 /* Reader.storyboard */,
-				321955BE24BE234C00E3F316 /* ReaderInterestsCoordinator.swift */,
-				FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */,
-				8BADF16324801B4B005AD038 /* Detail */,
-				32E1BFD824A66801007A08F0 /* Select Interests */,
-				F5A738C1244DF92300EDE065 /* Manage */,
-				F597768C243E1E140062BAD1 /* Filter */,
 				5D5A6E901B613C1800DAF819 /* Cards */,
+				9870EF7827866DCE00F3BB54 /* Comments */,
 				5D08B8FD19647C0800D5B381 /* Controllers */,
+				8BADF16324801B4B005AD038 /* Detail */,
+				F597768C243E1E140062BAD1 /* Filter */,
 				E6D2E16A1B8B41AC0000ED14 /* Headers */,
+				F5A738C1244DF92300EDE065 /* Manage */,
+				32E1BFD824A66801007A08F0 /* Select Interests */,
 				5D98A1491B6C09730085E904 /* Style */,
 				3F09CCA62428FE8600D00A8C /* Tab Navigation */,
 				5D08B8FC19647C0300D5B381 /* Views */,
+				5D1D04731B7A50B100CDE646 /* Reader.storyboard */,
+				837A53D62AD8C3A400B941A2 /* ReaderFollowButton.swift */,
+				FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */,
 			);
 			path = Reader;
 			sourceTree = "<group>";
@@ -22506,6 +22510,7 @@
 				324780E1247F2E2A00987525 /* NoResultsViewController+FollowedSites.swift in Sources */,
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
 				B07F133E2A16C69800AF7FCF /* PlanSelectionViewController.swift in Sources */,
+				837A53D72AD8C3A400B941A2 /* ReaderFollowButton.swift in Sources */,
 				9822A8412624CFB900FD8A03 /* UserProfileSiteCell.swift in Sources */,
 				9A38DC6D218899FB006A409B /* DiffAbstractValue.swift in Sources */,
 				17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */,
@@ -24684,6 +24689,7 @@
 				FABB23B22602FC2C00C8785C /* StatsChildRowsView.swift in Sources */,
 				FABB23B32602FC2C00C8785C /* Menu.m in Sources */,
 				FABB23B42602FC2C00C8785C /* BlogListViewController.m in Sources */,
+				837A53D82AD8C3A400B941A2 /* ReaderFollowButton.swift in Sources */,
 				FABB23B52602FC2C00C8785C /* JetpackScanStatusCell.swift in Sources */,
 				FABB23B62602FC2C00C8785C /* NoteBlockCommentTableViewCell.swift in Sources */,
 				801D951B291AC0B00051993E /* OverlayFrequencyTracker.swift in Sources */,


### PR DESCRIPTION
Closes #21647 

## Description

Updates the Reader's follow buttons in the following locations:

- Site details header
- Tag header
- Post details
- Sites to follow cell
- Manage followed sites

## Screenshots

<details><summary>Click to expand</summary>

|   |   |   |
|--|--|---|
| ![Screenshot 2023-10-12 at 9 29 52 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/6d53511b-182a-4c5f-b539-33c501b0086d) | ![Screenshot 2023-10-12 at 9 30 09 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/e988e773-df28-47ff-9510-a98691c229ac) | ![Screenshot 2023-10-12 at 9 30 23 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/6ef8ef1e-6b54-4795-b64d-83297ed634b5) |
| ![Screenshot 2023-10-12 at 9 30 48 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/a459b955-bd7d-4b83-8cc3-2569e2b68ac7) | ![Screenshot 2023-10-12 at 9 31 12 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/4a38ce80-8f3f-4887-8cf9-368b767a34a0) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-10-12 at 21 31 40](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/27bc58b5-6eae-4e43-87c8-eeef8ec48fc3) |

</details>

## Testing

To test:
- Launch Jetpack and login
- Enable the Reader Improvements v1 feature flag if necessary
- Navigate to the Reader tab
- Tap on a site header
- 🔎 **Verify** the site details screen has the new follow button style
- Navigate back
- Tap on a post
- 🔎 **Verify** the post details screen has the new follow button style
- Navigate back
- Tap on `Discover`
- Tap on a tag under `You might like` section
- 🔎 **Verify** the tag header has the new follow button style
- Navigate back to `Discover`
- Scroll down until you see a `Sites to follow` section
- 🔎 **Verify** it uses the new follow button style
- Tap on the manage icon in the top right
- Tap on the `Followed Sites` filter
- 🔎 **Verify** the sites listed use the new follow button style

## Regression Notes
1. Potential unintended areas of impact
Reader follow buttons when the feature is disabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
