### PR TITLE
Fix broken widget routing

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -894,7 +894,12 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
                 blogDetailsViewController?.showDetailViewController(viewController, sender: blogDetailsViewController)
             }
         } else {
-            blogDetailsViewController?.show(viewController, sender: nil)
+            switch currentSection {
+            case .dashboard:
+                blogDashboardViewController?.show(viewController, sender: blogDashboardViewController)
+            case .siteMenu:
+                blogDetailsViewController?.show(viewController, sender: blogDetailsViewController)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -884,6 +884,8 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
         blogDetailsViewController?.showDetailView(for: subsection)
     }
 
+    // TODO: Refactor presentation from routes
+    // More context: https://github.com/wordpress-mobile/WordPress-iOS/issues/21759
     func presentBlogDetailsViewController(_ viewController: UIViewController) {
         viewController.loadViewIfNeeded()
         if MySitesCoordinator.isSplitViewEnabled {


### PR DESCRIPTION
Fixes #21759 (more context there as well)

## Solution

If the split view controller is not presented, still present the view controller based on the current section.

## To test:

- Confirm cases described in https://github.com/wordpress-mobile/WordPress-iOS/pull/21588 are still working
- Confirm tapping widget opens Stats on both iPhone and iPad

## Regression Notes
1. Potential unintended areas of impact

Breaking https://github.com/wordpress-mobile/WordPress-iOS/pull/21588

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
