### PR TITLE
Reader: Fix like button configuration for Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -483,12 +483,12 @@ private extension ReaderPostCardCell {
         if !viewModel.isReblogEnabled {
             removeFromStackView(controlsStackView, view: reblogButton)
         }
-        if viewModel.isCommentsEnabled {
-            configureLikeButton()
-        } else {
+        if !viewModel.isCommentsEnabled {
             removeFromStackView(controlsStackView, view: commentButton)
         }
-        if !viewModel.isLikesEnabled {
+        if viewModel.isLikesEnabled {
+            configureLikeButton()
+        } else {
             removeFromStackView(controlsStackView, view: likeButton)
         }
     }


### PR DESCRIPTION
## Description

Fixes configuring the like button when the comments are disabled on a post.

## Testing

To test:
- Launch Jetpack and login
- Enable the Reader Improvements v1 feature flag if necessary
- Navigate to the Reader
- Find a post which has comments disabled
- Tap on `Like`
- 🔎 **Verify** the like button properly updates

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
