### PR TITLE
Update Reader detail toolbar

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,14 +18,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9JA-VQ-zzw">
-                                <rect key="frame" x="0.0" y="44" width="414" height="768"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="764"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xyq-y6-zPR">
-                                        <rect key="frame" x="0.0" y="0.0" width="446" height="222.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="446" height="218.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iSu-TI-yew" customClass="ReaderWebView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <rect key="frame" x="16" y="234.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="414" placeholder="YES" id="akw-kl-dl7"/>
@@ -38,13 +38,13 @@
                                         </wkWebViewConfiguration>
                                     </wkWebView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qXQ-id-Ffz" userLabel="Likes Container View">
-                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <rect key="frame" x="16" y="234.5" width="414" height="0.0"/>
                                         <constraints>
                                             <constraint firstAttribute="height" placeholder="YES" id="C8J-Hu-daf"/>
                                         </constraints>
                                     </view>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6yS-ZE-nbR" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <rect key="frame" x="16" y="234.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" placeholder="YES" id="hNK-J4-GC2"/>
@@ -52,14 +52,14 @@
                                         <sections/>
                                     </tableView>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CpT-U7-bfv" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <rect key="frame" x="16" y="234.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" placeholder="YES" id="tci-Li-Egi"/>
                                         </constraints>
                                     </tableView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O4e-BA-8jp">
-                                        <rect key="frame" x="16" y="238.5" width="414" height="20.5"/>
+                                        <rect key="frame" x="16" y="234.5" width="414" height="20.5"/>
                                         <subviews>
                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ewc-f7-89P" customClass="ReaderCardDiscoverAttributionView" customModule="WordPress">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
@@ -140,7 +140,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="vGc-hu-x5V">
-                                        <rect key="frame" x="0.0" y="44" width="414" height="131"/>
+                                        <rect key="frame" x="0.0" y="48" width="414" height="135"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jeJ-N0-e8Q">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="66"/>
@@ -171,14 +171,14 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Post Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="urB-nS-vfS">
-                                                <rect key="frame" x="0.0" y="70" width="414" height="37"/>
+                                                <rect key="frame" x="0.0" y="70" width="414" height="41"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xdF-0Y-F5a">
-                                                <rect key="frame" x="0.0" y="111" width="414" height="20"/>
+                                                <rect key="frame" x="0.0" y="115" width="414" height="20"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="PpC-lI-LMW" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -248,28 +248,28 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EKd-IB-Upn">
-                                        <rect key="frame" x="0.0" y="207" width="414" height="203"/>
+                                        <rect key="frame" x="0.0" y="215" width="414" height="213.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i7W-OY-6MY">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="17"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbt-ra-94i">
-                                                <rect key="frame" x="0.0" y="25" width="414" height="17"/>
+                                                <rect key="frame" x="0.0" y="28.5" width="414" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdQ-G5-Hl2">
-                                                <rect key="frame" x="0.0" y="50" width="414" height="17"/>
+                                                <rect key="frame" x="0.0" y="57" width="414" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xrm-JQ-hpv">
-                                                <rect key="frame" x="0.0" y="75" width="414" height="128"/>
+                                                <rect key="frame" x="0.0" y="85.5" width="414" height="128"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jvg-nM-lV9">
                                                         <rect key="frame" x="0.0" y="0.0" width="345" height="128"/>
@@ -331,6 +331,7 @@
                         <outlet property="relatedPostsTableView" destination="CpT-U7-bfv" id="Ndh-H4-FlR"/>
                         <outlet property="scrollView" destination="9JA-VQ-zzw" id="lCO-o1-bLB"/>
                         <outlet property="toolbarContainerView" destination="Qzd-gm-oIu" id="Esk-Iq-Wbd"/>
+                        <outlet property="toolbarHeightConstraint" destination="jvh-iQ-g9a" id="y6Q-1h-IBP"/>
                         <outlet property="toolbarSafeAreaView" destination="ERb-e0-U8L" id="sVN-sI-9e5"/>
                         <outlet property="webView" destination="iSu-TI-yew" id="DQy-Fd-C3y"/>
                         <outlet property="webViewHeight" destination="ywz-kG-xyW" id="q3p-wI-yeb"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -70,6 +70,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Attribution view for Discovery posts
     @IBOutlet weak var attributionView: ReaderCardDiscoverAttributionView!
 
+    @IBOutlet weak var toolbarHeightConstraint: NSLayoutConstraint!
+
     /// The actual header
     private let featuredImage: ReaderDetailFeaturedImageView = .loadFromNib()
 
@@ -674,6 +676,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         toolbarContainerView.pinSubviewToAllEdges(toolbar)
         toolbarSafeAreaView.backgroundColor = toolbar.backgroundColor
+
+        if FeatureFlag.readerImprovements.enabled {
+            toolbarHeightConstraint.constant = Constants.preferredToolbarHeight
+        }
     }
 
     private func configureDiscoverAttribution(_ post: ReaderPost) {
@@ -803,6 +809,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         static let bottomMargin: CGFloat = 16
         static let toolbarHeight: CGFloat = 50
         static let delay: Double = 50
+        static let preferredToolbarHeight: CGFloat = 58.0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -535,7 +535,7 @@ private extension ReaderDetailToolbar {
 
         static let savedButtonHint = NSLocalizedString(
             "reader.detail.toolbar.saved.button.a11y.hint",
-            value: "Unsave this post.",
+            value: "Unsaves this post.",
             comment: "Accessibility hint for the 'Save Post' button when a post is already saved."
         )
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -475,6 +475,11 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         let isSavedForLater = post?.isSavedForLater ?? false
         saveForLaterButton.accessibilityLabel = isSavedForLater ? NSLocalizedString("Saved Post", comment: "Accessibility label for the 'Save Post' button when a post has been saved.") : NSLocalizedString("Save post", comment: "Accessibility label for the 'Save Post' button.")
         saveForLaterButton.accessibilityHint = isSavedForLater ? NSLocalizedString("Remove this post from my saved posts.", comment: "Accessibility hint for the 'Save Post' button when a post is already saved.") : NSLocalizedString("Saves this post for later.", comment: "Accessibility hint for the 'Save Post' button.")
+
+        let isLiked = post?.isLiked ?? false
+        likeButton.accessibilityHint = isLiked ? Constants.likedButtonHint : Constants.likeButtonHint
+
+        commentButton.accessibilityHint = Constants.commentButtonHint
     }
 
     private func prepareReblogForVoiceOver() {
@@ -568,6 +573,15 @@ private extension ReaderDetailToolbar {
             comment: """
                 Title for the Comment button on the Reader Detail toolbar.
                 Note: Since the display space is limited, a short or concise translation is preferred.
+                """
+        )
+
+        static let commentButtonHint = NSLocalizedString(
+            "reader.detail.toolbar.comment.button.a11y.hint",
+            value: "Tap to view comments for this post",
+            comment: """
+                Accessibility hint for the Comment button.
+                Tapping on the button takes the user to the comment threads for the post.
                 """
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -535,7 +535,7 @@ private extension ReaderDetailToolbar {
 
         static let savedButtonHint = NSLocalizedString(
             "reader.detail.toolbar.saved.button.a11y.hint",
-            value: "Remove this post from my saved posts.",
+            value: "Unsave this post.",
             comment: "Accessibility hint for the 'Save Post' button when a post is already saved."
         )
 
@@ -563,7 +563,7 @@ private extension ReaderDetailToolbar {
 
         static let likeButtonHint = NSLocalizedString(
             "reader.detail.toolbar.like.button.a11y.hint",
-            value: "Tap to like this post",
+            value: "Likes this post.",
             comment: """
                 Accessibility hint for the Like button state. The button shows that the user has not liked the post,
                 but tapping on this button will add a Like to the post.
@@ -582,7 +582,7 @@ private extension ReaderDetailToolbar {
 
         static let likedButtonHint = NSLocalizedString(
             "reader.detail.toolbar.liked.button.a11y.hint",
-            value: "Tap to unlike this post",
+            value: "Unlikes this post.",
             comment: """
                 Accessibility hint for the Liked button state. The button shows that the user has liked the post,
                 but tapping on this button will remove their like from the post.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -11,6 +11,12 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     @IBOutlet weak var commentButton: PostMetaButton!
     @IBOutlet weak var likeButton: PostMetaButton!
 
+    /// These are added to dynamically apply changes based on the `readerImprovements` feature flag.
+    /// Once the flag is removed, we should remove these and apply the changes directly on the XIB file.
+    @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet weak var stackViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var stackViewTrailingConstraint: NSLayoutConstraint!
+
     /// The reader post that the toolbar interacts with
     private var post: ReaderPost?
 
@@ -27,6 +33,18 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     var shouldHideComments = false
 
     weak var delegate: ReaderDetailToolbarDelegate? = nil
+
+    private var likeButtonTitle: String {
+        guard let post,
+              FeatureFlag.readerImprovements.enabled else {
+            return likeLabel(count: likeCount)
+        }
+        return post.isLiked ? Constants.likedButtonTitle : Constants.likeButtonTitle
+    }
+
+    private var likeCount: Int {
+        post?.likeCount.intValue ?? 0
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -50,12 +68,26 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         self.post = post
         self.viewController = viewController
 
-        likeCountObserver = post.observe(\.likeCount, options: .new) { [weak self] updatedPost, _ in
+        likeCountObserver = post.observe(\.likeCount, options: [.old, .new]) { [weak self] updatedPost, change in
+            // ensure that we only update the like button when there's actual change.
+            let oldValue = change.oldValue??.intValue ?? 0
+            let newValue = change.newValue??.intValue ?? 0
+            guard oldValue != newValue else {
+                return
+            }
+
             self?.configureLikeActionButton(true)
             self?.delegate?.didTapLikeButton(isLiked: updatedPost.isLiked)
         }
 
-        commentCountObserver = post.observe(\.commentCount, options: .new) { [weak self] _, _ in
+        commentCountObserver = post.observe(\.commentCount, options: [.old, .new]) { [weak self] _, change in
+            // ensure that we only update the like button when there's actual change.
+            let oldValue = change.oldValue??.intValue ?? 0
+            let newValue = change.newValue??.intValue ?? 0
+            guard oldValue != newValue else {
+                return
+            }
+
             self?.configureCommentActionButton()
         }
 
@@ -129,6 +161,14 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
         WPStyleGuide.applyReaderCardActionButtonStyle(commentButton)
         WPStyleGuide.applyReaderCardActionButtonStyle(likeButton)
+
+        // TODO: Apply changes on the XIB directly once the `readerImprovements` flag is removed.
+        if FeatureFlag.readerImprovements.enabled {
+            stackView.distribution = .fillEqually
+            stackView.spacing = 16.0
+            stackViewLeadingConstraint.constant = 16.0
+            stackViewTrailingConstraint.constant = 16.0
+        }
     }
 
     // MARK: - Configuration
@@ -173,12 +213,49 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
     private func configureActionButtonStyle(_ button: UIButton) {
         let disabledColor = UIColor(light: .muriel(color: .gray, .shade10),
-                                    dark: .textSubtle)
+                                    dark: .textQuaternary)
 
         WPStyleGuide.applyReaderActionButtonStyle(button,
                                                   titleColor: .textSubtle,
                                                   imageColor: .textSubtle,
                                                   disabledColor: disabledColor)
+
+        /// Configure the UIButton so it displays the button image on top of the title label.
+        /// Previously, this would be achieved through titleEdgeInsets and imageEdgeInsets, but these
+        /// will be deprecated soon. The new way to do this is through `UIButton.Configuration`, by setting
+        /// `imagePlacement` to `.top`.
+        ///
+        /// TODO: remove unused styles once the `readerImprovements` flag is removed.
+        guard FeatureFlag.readerImprovements.enabled else {
+            return
+        }
+
+        var configuration = UIButton.Configuration.plain()
+
+        // Vertically stack the button's image and title.
+        configuration.imagePlacement = .top
+        configuration.contentInsets = Constants.buttonContentInsets
+        configuration.imagePadding = Constants.buttonImagePadding
+
+        /// Override the button's title label font.
+        /// When the button's configuration exists, updating the font via `titleLabel` no longer works somehow.
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = WPStyleGuide.fontForTextStyle(.footnote)
+            return outgoing
+        }
+
+        button.configuration = configuration
+
+        /// Remove default background styles. The `.plain()` configuration adds a gray background to selected state.
+        button.configurationUpdateHandler = { button in
+            switch button.state {
+            case .selected:
+                button.configuration?.background.backgroundColor = .clear
+            default:
+                return
+            }
+        }
     }
 
     private func configureLikeActionButton(_ animated: Bool = false) {
@@ -186,16 +263,14 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             return
         }
 
-        let likeCount = post.likeCount?.intValue ?? 0
-        likeButton.isEnabled = (ReaderHelpers.isLoggedIn() || likeCount > 0) && !post.isExternal
-        // as by design spec, only display like counts
-        let title = likeLabel(count: likeCount)
-
         let selected = post.isLiked
-        let likeImage = UIImage(named: "icon-reader-like")
-        let likedImage = UIImage(named: "icon-reader-liked")
+        likeButton.isEnabled = (ReaderHelpers.isLoggedIn() || likeCount > 0) && !post.isExternal
 
-        configureActionButton(likeButton, title: title, image: likeImage, highlightedImage: likedImage, selected: selected)
+        configureActionButton(likeButton,
+                              title: likeButtonTitle,
+                              image: Constants.likeImage,
+                              highlightedImage: Constants.likedImage,
+                              selected: selected)
 
         if animated {
             playLikeButtonAnimation()
@@ -215,21 +290,37 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func playLikeButtonAnimation() {
-        let likeImageView = likeButton.imageView!
-
-        let imageView = UIImageView(image: UIImage(named: "icon-reader-liked"))
-        likeButton.addSubview(imageView)
+        guard let likeImageView = likeButton.imageView else {
+            return
+        }
 
         let animationDuration = 0.3
+        let imageView = UIImageView(image: Constants.likedImage)
+
+        if FeatureFlag.readerImprovements.enabled {
+            /// When using `UIButton.Configuration`, calling `bringSubviewToFront` somehow does not work.
+            /// To work around this, let's add the faux image to the image view instead, so it can be
+            /// properly placed in front of the masking view.
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            likeImageView.addSubview(imageView)
+            likeImageView.pinSubviewAtCenter(imageView)
+        } else {
+            likeButton.addSubview(imageView)
+        }
 
         if likeButton.isSelected {
-            // Prep a mask to hide the likeButton's image, since changes to visiblility and alpha are ignored
+            // Prep a mask to hide the likeButton's image, since changes to visibility and alpha are ignored
             let mask = UIView(frame: frame)
             mask.backgroundColor = backgroundColor
             likeImageView.addSubview(mask)
             likeImageView.pinSubviewToAllEdges(mask)
             mask.translatesAutoresizingMaskIntoConstraints = false
-            likeButton.bringSubviewToFront(imageView)
+
+            if FeatureFlag.readerImprovements.enabled {
+                likeImageView.bringSubviewToFront(imageView)
+            } else {
+                likeButton.bringSubviewToFront(imageView)
+            }
 
             // Configure starting state
             imageView.alpha = 0.0
@@ -277,8 +368,13 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func configureCommentActionButton() {
-        WPStyleGuide.applyReaderCardCommentButtonStyle(commentButton, defaultSize: true)
         commentButton.isEnabled = shouldShowCommentActionButton
+
+        commentButton.setImage(Constants.commentImage, for: .normal)
+        commentButton.setImage(Constants.commentSelectedImage, for: .selected)
+        commentButton.setImage(Constants.commentSelectedImage, for: .highlighted)
+        commentButton.setImage(Constants.commentSelectedImage, for: [.highlighted, .selected])
+        commentButton.setImage(Constants.commentImage, for: .disabled)
 
         configureActionButtonStyle(commentButton)
     }
@@ -326,15 +422,12 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             return
         }
 
-        let likeCount = post.likeCount()?.intValue ?? 0
         let commentCount = post.commentCount()?.intValue ?? 0
+        let commentTitle = FeatureFlag.readerImprovements.enabled ? Constants.commentButtonTitle : commentLabel(count: commentCount)
+        let showTitle: Bool = FeatureFlag.readerImprovements.enabled || traitCollection.horizontalSizeClass != .compact
 
-        let likeTitle = likeLabel(count: likeCount)
-        let commentTitle: String = commentLabel(count: commentCount)
-        let showTitle: Bool = traitCollection.horizontalSizeClass != .compact
-
-        likeButton.setTitle(likeTitle, for: .normal)
-        likeButton.setTitle(likeTitle, for: .highlighted)
+        likeButton.setTitle(likeButtonTitle, for: .normal)
+        likeButton.setTitle(likeButtonTitle, for: .highlighted)
 
         commentButton.setTitle(commentTitle, for: .normal)
         commentButton.setTitle(commentTitle, for: .highlighted)
@@ -388,5 +481,94 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         reblogButton.accessibilityLabel = NSLocalizedString("Reblog post", comment: "Accessibility label for the reblog button.")
         reblogButton.accessibilityHint = NSLocalizedString("Reblog this post", comment: "Accessibility hint for the reblog button.")
         reblogButton.accessibilityTraits = UIAccessibilityTraits.button
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension ReaderDetailToolbar {
+
+    struct Constants {
+        static let buttonContentInsets = NSDirectionalEdgeInsets(top: 2.0, leading: 0, bottom: 0, trailing: 0)
+        static let buttonImagePadding: CGFloat = 4.0
+
+        static var likeImage: UIImage? {
+            if FeatureFlag.readerImprovements.enabled {
+                // reduce gridicon images to 20x20 since they don't have intrinsic padding.
+                return UIImage(named: "icon-reader-like")?
+                    .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .default)
+                    .withRenderingMode(.alwaysTemplate)
+            }
+            return UIImage(named: "icon-reader-like")
+        }
+
+        static var likedImage: UIImage? {
+            if FeatureFlag.readerImprovements.enabled {
+                // reduce gridicon images to 20x20 since they don't have intrinsic padding.
+                return UIImage(named: "icon-reader-liked")?
+                    .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .default)
+                    .withRenderingMode(.alwaysTemplate)
+            }
+            return UIImage(named: "icon-reader-liked")
+        }
+
+        static let commentImage = UIImage(named: "icon-reader-comment-outline")?
+            .imageFlippedForRightToLeftLayoutDirection()
+            .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .high)
+            .withRenderingMode(.alwaysTemplate)
+
+        static let commentSelectedImage = UIImage(named: "icon-reader-comment-outline-highlighted")?
+            .imageFlippedForRightToLeftLayoutDirection()
+            .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .high)
+            .withRenderingMode(.alwaysTemplate)
+
+        // MARK: Strings
+
+        static let likeButtonTitle = NSLocalizedString(
+            "reader.detail.toolbar.like.button",
+            value: "Like",
+            comment: """
+                Title for the Like button in the Reader Detail toolbar.
+                This is shown when the user has not liked the post yet.
+                Note: Since the display space is limited, a short or concise translation is preferred.
+                """
+        )
+
+        static let likeButtonHint = NSLocalizedString(
+            "reader.detail.toolbar.like.button.a11y.hint",
+            value: "Tap to like this post",
+            comment: """
+                Accessibility hint for the Like button state. The button shows that the user has not liked the post,
+                but tapping on this button will add a Like to the post.
+                """
+        )
+
+        static let likedButtonTitle = NSLocalizedString(
+            "reader.detail.toolbar.liked.button",
+            value: "Liked",
+            comment: """
+                Title for the Like button in the Reader Detail toolbar.
+                This is shown when the user has already liked the post.
+                Note: Since the display space is limited, a short or concise translation is preferred.
+                """
+        )
+
+        static let likedButtonHint = NSLocalizedString(
+            "reader.detail.toolbar.liked.button.a11y.hint",
+            value: "Tap to unlike this post",
+            comment: """
+                Accessibility hint for the Liked button state. The button shows that the user has liked the post,
+                but tapping on this button will remove their like from the post.
+                """
+        )
+
+        static let commentButtonTitle = NSLocalizedString(
+            "reader.detail.toolbar.comment.button",
+            value: "Comment",
+            comment: """
+                Title for the Comment button on the Reader Detail toolbar.
+                Note: Since the display space is limited, a short or concise translation is preferred.
+                """
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -265,6 +265,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
         let selected = post.isLiked
         likeButton.isEnabled = (ReaderHelpers.isLoggedIn() || likeCount > 0) && !post.isExternal
+        likeButton.accessibilityHint = selected ? Constants.likedButtonHint : Constants.likeButtonHint
 
         configureActionButton(likeButton,
                               title: likeButtonTitle,
@@ -401,7 +402,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         WPStyleGuide.applyReaderSaveForLaterButtonStyle(saveForLaterButton)
         WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: false)
 
-        saveForLaterButton.isSelected = post?.isSavedForLater ?? false
+        let isSaved = post?.isSavedForLater ?? false
+        saveForLaterButton.isSelected = isSaved
+        prepareActionButtonsForVoiceOver()
 
         configureActionButtonStyle(saveForLaterButton)
     }
@@ -472,14 +475,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     // MARK: - Voice Over
 
     private func prepareActionButtonsForVoiceOver() {
-        let isSavedForLater = post?.isSavedForLater ?? false
-        saveForLaterButton.accessibilityLabel = isSavedForLater ? NSLocalizedString("Saved Post", comment: "Accessibility label for the 'Save Post' button when a post has been saved.") : NSLocalizedString("Save post", comment: "Accessibility label for the 'Save Post' button.")
-        saveForLaterButton.accessibilityHint = isSavedForLater ? NSLocalizedString("Remove this post from my saved posts.", comment: "Accessibility hint for the 'Save Post' button when a post is already saved.") : NSLocalizedString("Saves this post for later.", comment: "Accessibility hint for the 'Save Post' button.")
-
-        let isLiked = post?.isLiked ?? false
-        likeButton.accessibilityHint = isLiked ? Constants.likedButtonHint : Constants.likeButtonHint
-
-        commentButton.accessibilityHint = Constants.commentButtonHint
+        let isSaved = post?.isSavedForLater ?? false
+        saveForLaterButton.accessibilityLabel = isSaved ? Constants.savedButtonAccessibilityLabel : Constants.saveButtonAccessibilityLabel
+        saveForLaterButton.accessibilityHint = isSaved ? Constants.savedButtonHint : Constants.saveButtonHint
     }
 
     private func prepareReblogForVoiceOver() {
@@ -529,6 +527,30 @@ private extension ReaderDetailToolbar {
 
         // MARK: Strings
 
+        static let savedButtonAccessibilityLabel = NSLocalizedString(
+            "reader.detail.toolbar.saved.button.a11y.label",
+            value: "Saved Post",
+            comment: "Accessibility label for the 'Save Post' button when a post has been saved."
+        )
+
+        static let savedButtonHint = NSLocalizedString(
+            "reader.detail.toolbar.saved.button.a11y.hint",
+            value: "Remove this post from my saved posts.",
+            comment: "Accessibility hint for the 'Save Post' button when a post is already saved."
+        )
+
+        static let saveButtonAccessibilityLabel = NSLocalizedString(
+            "reader.detail.toolbar.save.button.a11y.label",
+            value: "Save post",
+            comment: "Accessibility label for the 'Save Post' button."
+        )
+
+        static let saveButtonHint = NSLocalizedString(
+            "reader.detail.toolbar.save.button.a11y.hint",
+            value: "Saves this post for later.",
+            comment: "Accessibility hint for the 'Save Post' button."
+        )
+
         static let likeButtonTitle = NSLocalizedString(
             "reader.detail.toolbar.like.button",
             value: "Like",
@@ -573,15 +595,6 @@ private extension ReaderDetailToolbar {
             comment: """
                 Title for the Comment button on the Reader Detail toolbar.
                 Note: Since the display space is limited, a short or concise translation is preferred.
-                """
-        )
-
-        static let commentButtonHint = NSLocalizedString(
-            "reader.detail.toolbar.comment.button.a11y.hint",
-            value: "Tap to view comments for this post",
-            comment: """
-                Accessibility hint for the Comment button.
-                Tapping on the button takes the user to the comment threads for the post.
                 """
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="opk-iy-IwF" customClass="ReaderDetailToolbar" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="99"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RGe-0W-AQZ">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
@@ -20,7 +20,7 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
-                    <rect key="frame" x="28" y="426" width="358" height="44"/>
+                    <rect key="frame" x="28" y="27.5" width="358" height="44"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
                             <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
@@ -101,8 +101,11 @@
                 <outlet property="likeButton" destination="1Ht-4U-b7J" id="cZs-ZL-BT4"/>
                 <outlet property="reblogButton" destination="TVh-aP-o67" id="iyb-fz-V0I"/>
                 <outlet property="saveForLaterButton" destination="kYk-HZ-8zf" id="YaG-nx-qsB"/>
+                <outlet property="stackView" destination="TSN-68-1mv" id="6DM-P6-cng"/>
+                <outlet property="stackViewLeadingConstraint" destination="sW1-Ik-cCa" id="lds-dr-DNC"/>
+                <outlet property="stackViewTrailingConstraint" destination="ibp-zt-iup" id="ggo-IN-DhM"/>
             </connections>
-            <point key="canvasLocation" x="167" y="-132"/>
+            <point key="canvasLocation" x="166.66666666666669" y="134.26339285714286"/>
         </view>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -326,9 +326,8 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderSaveForLaterButtonStyle(_ button: UIButton) {
-        let size = Gridicon.defaultSize
-        let icon = UIImage.gridicon(.bookmarkOutline, size: size)
-        let selectedIcon = UIImage.gridicon(.bookmark, size: size)
+        let icon = UIImage.gridicon(.bookmarkOutline, size: Detail.actionBarIconSize)
+        let selectedIcon = UIImage.gridicon(.bookmark, size: Detail.actionBarIconSize)
 
         button.setImage(icon, for: .normal)
         button.setImage(selectedIcon, for: .selected)
@@ -353,7 +352,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderCardCommentButtonStyle(_ button: UIButton, defaultSize: Bool = false) {
-        let size = defaultSize ? Gridicon.defaultSize : Cards.actionButtonSize
+        let size = defaultSize ? Detail.actionBarIconSize : Cards.actionButtonSize
         let icon = UIImage(named: "icon-reader-comment-outline")?.imageFlippedForRightToLeftLayoutDirection()
         let selectedIcon = UIImage(named: "icon-reader-comment-outline-highlighted")?.imageFlippedForRightToLeftLayoutDirection()
 
@@ -418,8 +417,7 @@ extension WPStyleGuide {
     /// - Parameter button: the button to apply the style to
     /// - Parameter showTitle: if set to true, will show the button label (default: true)
     @objc public class func applyReaderReblogActionButtonStyle(_ button: UIButton, showTitle: Bool = true) {
-        let size = Gridicon.defaultSize
-        let icon = UIImage.gridicon(.reblog, size: size)
+        let icon = UIImage.gridicon(.reblog, size: Detail.actionBarIconSize)
 
         button.setImage(icon, for: .normal)
 
@@ -540,6 +538,10 @@ extension WPStyleGuide {
     public struct Detail {
         public static let titleTextStyle: UIFont.TextStyle = .title2
         public static let contentTextStyle: UIFont.TextStyle = .callout
+
+        public static var actionBarIconSize: CGSize {
+            return FeatureFlag.readerImprovements.enabled ? CGSize(width: 20.0, height: 20.0) : Gridicon.defaultSize
+        }
     }
 
     public struct FollowButton {


### PR DESCRIPTION
Refs #21644
Designs zQnohyMpLzBzQ5jzMMKni3-fi-868_19180

This updates the Reader detail toolbar component, as per the new design. 

• | Light | Dark
-|-|-
Default state | ![Simulator Screenshot - iPhone 15 - 2023-10-14 at 00 23 34](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/28cc5e3b-a576-4df3-a6ab-0c766890499f) | ![Simulator Screenshot - iPhone 15 - 2023-10-14 at 00 21 26](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/fc3304cd-64b2-447b-ba6c-6c463b622162)
Various states | ![Simulator Screenshot - iPhone 15 - 2023-10-14 at 00 23 47](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/3f3c6346-651e-4c1f-8835-5beef070711b) | ![Simulator Screenshot - iPhone 15 - 2023-10-14 at 00 24 05](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/0653f40f-e9ec-40e0-a700-178bad25d8c4)

To apply the new design, I tried to modify the existing toolbar implementation since it looks close enough to the new design. To achieve the vertical arrangement between the button's image and title, I used `UIButton.Configuration`'s `imagePlacement` (which is pretty convenient!).

This PR also fixes some legacy issues:

- Like button animation being triggered when saving a post.
- The disabled comment button appeared way darker than the rest of the disabled icons.
- Disabled comment icon sometimes appears enabled.
- Disabled Like button sometimes appears enabled.

Some notes: 

- I'm still using the previous icons. Using half-new and half-old icons causes misalignments in the toolbar, and they need to be manually aligned with insets, padding, etc.. I'll use the previous icons for now to reduce the complexity. 
- The toolbar height is hardcoded. Perhaps this was intended, so to have fewer "surprises", I'm simply updating the hardcoded value (from previously 50px to now 58px as per design.)

## To test

- Launch Jetpack.
- Ensure that the `readerImprovements` flag is enabled.
- Navigate to the Reader and select any tab.
- Tap one of the posts.
- 🔎  Verify that the new toolbar is displayed.
- Tap on the Like icon.
- 🔎  Verify that the animation works correctly, and that the post is now liked.
- Go back to the stream, and select one post that you've liked before.
- 🔎 Verify that the Like button is in a selected state. 
- Go back to the stream, and select one post that you've saved.
- 🔎 Verify that the Save button is in a selected state.
- 🔎 Verify that tapping Reblog opens a Site selector sheet.
- 🔎 Verify that tapping Comment opens the comment thread.

Additional tests:
- Test in iPad
- Test VoiceOver

## Regression Notes
1. Potential unintended areas of impact
Toolbar buttons when the feature flag is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)