### PR TITLE
Posts & Pages: Native search (Part 2)

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -93,7 +93,7 @@ class AbstractPostListViewController: UIViewController,
 
     let filterTabBar = FilterTabBar()
 
-    private lazy var searchResultsViewController = PostSearchViewController(viewModel: PostSearchViewModel(blog: blog, postType: postTypeToSync()))
+    private lazy var searchResultsViewController = PostSearchViewController(viewModel: PostSearchViewModel(blog: blog, filters: filterSettings))
 
     private lazy var searchController = UISearchController(searchResultsController: searchResultsViewController)
 

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -1,12 +1,8 @@
 import UIKit
 import Combine
 
-// TODO: Add loading and empty states
 final class PostSearchViewController: UITableViewController, UISearchResultsUpdating, NSFetchedResultsControllerDelegate {
     private let viewModel: PostSearchViewModel
-    private var fetchResultsViewController: NSFetchedResultsController<BasePost> {
-        viewModel.fetchResultsController
-    }
 
     init(viewModel: PostSearchViewModel) {
         self.viewModel = viewModel
@@ -23,18 +19,20 @@ final class PostSearchViewController: UITableViewController, UISearchResultsUpda
 
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cellID")
 
-        fetchResultsViewController.delegate = self
+        viewModel.objectDidChange = { [weak self] in
+            self?.tableView.reloadData()
+        }
     }
+
+    // MARK: - UITableViewController
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        fetchResultsViewController.fetchedObjects?.count ?? 0
+        viewModel.numberOfPosts
     }
 
-    // TODO: Update new cells and display in sections
-    // TODO: Add context menus and navigation (reuse with the plain list)
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cellID", for: indexPath)
-        let post = fetchResultsViewController.object(at: indexPath)
+        let post = viewModel.posts(at: indexPath)
         cell.textLabel?.text = post.titleForDisplay()
         return cell
     }
@@ -42,12 +40,6 @@ final class PostSearchViewController: UITableViewController, UISearchResultsUpda
     // MARK: - UISearchResultsUpdating
 
     func updateSearchResults(for searchController: UISearchController) {
-        viewModel.searchText = searchController.searchBar.text ?? ""
-    }
-
-    // MARK: - NSFetchedResultsControllerDelegate
-
-    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        tableView.reloadData()
+        viewModel.searchTerm = searchController.searchBar.text ?? ""
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -74,8 +74,7 @@ final class PostSearchViewModel: NSObject, NSFetchedResultsControllerDelegate {
     private func makeFetchRequest(searchTerm: String) -> NSFetchRequest<BasePost> {
         let request = NSFetchRequest<BasePost>(entityName: makeEntityName())
         request.predicate = makePredicate(searchTerm: searchTerm)
-        // TODO: Update sort descriptors
-        request.sortDescriptors = [NSSortDescriptor(key: "date_created_gmt", ascending: true)]
+        request.sortDescriptors = [NSSortDescriptor(keyPath: \AbstractPost.date_created_gmt, ascending: false)]
         request.fetchBatchSize = 40
         return request
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21719

Migrate the remaining search code to the new screen:

- Pass authorID
- Fix sort descriptors
- Fix an issue with search not reloading
- Make VC a bit more dumb

The next step would be to update the design of the cells and potentially add state views (not sure we need any, really). But that's in the scope of https://github.com/wordpress-mobile/WordPress-iOS/issues/21720.

Heads-up, I'm planning to use the same approach as on Android to show posts types: badge on each cell instead of sections.

To test:

- Verify that the "Me"/"Everyone" filter applies to search
- Verify that posts are sorted by their creation date (most recent first)

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): no, but made it testable

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
