### PR TITLE
Reader: Add new `Sites to follow` reader UI styles

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.xib
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_72" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" shouldIndentWhileEditing="NO" id="KGk-i7-Jjw" customClass="ReaderRecommendedSiteCardCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="454" height="119"/>
+        <tableViewCell contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" shouldIndentWhileEditing="NO" rowHeight="130" id="KGk-i7-Jjw" customClass="ReaderRecommendedSiteCardCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="454" height="130"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="454" height="119"/>
+                <rect key="frame" x="0.0" y="0.0" width="454" height="130"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="72T-vk-e3M">
-                        <rect key="frame" x="0.0" y="0.0" width="454" height="119"/>
+                        <rect key="frame" x="0.0" y="0.0" width="454" height="130"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YSm-00-vyn">
                                 <rect key="frame" x="16" y="12" width="422" height="40"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mms-yI-nd4" userLabel="Header Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="378" height="40"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="750" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mms-yI-nd4" userLabel="Header Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="384" height="40"/>
                                         <subviews>
                                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="FEv-sY-BYI" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -35,18 +34,18 @@
                                                     <constraint firstAttribute="width" constant="40" id="C9q-wn-fc4"/>
                                                 </constraints>
                                             </imageView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="L7q-C1-xba">
-                                                <rect key="frame" x="48" y="4" width="330" height="32.5"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="L7q-C1-xba">
+                                                <rect key="frame" x="48" y="0.0" width="336" height="40"/>
                                                 <subviews>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" horizontalCompressionResistancePriority="740" text="Blog Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kEs-BA-Qeh">
-                                                        <rect key="frame" x="0.0" y="0.0" width="330" height="17"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="336" height="17"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="740" text="blog.host.name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RNB-9V-A6a" userLabel="Blog Host Name">
-                                                        <rect key="frame" x="0.0" y="18" width="330" height="14.5"/>
+                                                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="740" text="blog.host.name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RNB-9V-A6a" userLabel="Blog Host Name">
+                                                        <rect key="frame" x="0.0" y="18" width="336" height="22"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -55,25 +54,11 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="40" id="oB4-oo-Iej"/>
-                                        </constraints>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F8n-bs-L9T" userLabel="Follow Button">
-                                        <rect key="frame" x="398" y="8" width="24" height="24"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" priority="999" constant="24" id="CFi-vR-xRD"/>
-                                            <constraint firstAttribute="height" constant="24" id="RoQ-H3-RLD"/>
-                                        </constraints>
-                                        <color key="tintColor" systemColor="systemBackgroundColor"/>
-                                        <connections>
-                                            <action selector="didTapFollowButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="lEX-zT-byw"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="epE-Yr-j1l">
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="epE-Yr-j1l" userLabel="Follow Button">
                                         <rect key="frame" x="392" y="3" width="30" height="34"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="ai0-Bv-Ahu"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="ai0-Bv-Ahu"/>
                                         </constraints>
                                         <connections>
                                             <action selector="didTapFollowButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="NxD-2g-dfT"/>
@@ -83,17 +68,15 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="mms-yI-nd4" firstAttribute="top" secondItem="YSm-00-vyn" secondAttribute="top" id="A3P-rP-4cw"/>
-                                    <constraint firstAttribute="trailing" secondItem="F8n-bs-L9T" secondAttribute="trailing" id="KAa-40-7Fp"/>
                                     <constraint firstAttribute="trailing" secondItem="epE-Yr-j1l" secondAttribute="trailing" id="TFj-oJ-K1g"/>
-                                    <constraint firstItem="F8n-bs-L9T" firstAttribute="centerY" secondItem="YSm-00-vyn" secondAttribute="centerY" id="dyH-Hy-hqz"/>
+                                    <constraint firstItem="epE-Yr-j1l" firstAttribute="leading" secondItem="mms-yI-nd4" secondAttribute="trailing" constant="8" id="TcR-aT-ZhD"/>
                                     <constraint firstItem="epE-Yr-j1l" firstAttribute="centerY" secondItem="YSm-00-vyn" secondAttribute="centerY" id="l5y-Ki-ps8"/>
-                                    <constraint firstAttribute="trailing" secondItem="mms-yI-nd4" secondAttribute="trailing" constant="44" id="sFg-8b-VnL"/>
                                     <constraint firstItem="mms-yI-nd4" firstAttribute="leading" secondItem="YSm-00-vyn" secondAttribute="leading" id="sgI-z5-n7U"/>
                                     <constraint firstAttribute="bottom" secondItem="mms-yI-nd4" secondAttribute="bottom" id="zzn-Us-jOT"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site Description / Tag Line" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="guM-Ci-dh4">
-                                <rect key="frame" x="16" y="62" width="422" height="45"/>
+                                <rect key="frame" x="16" y="62" width="422" height="56"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -114,19 +97,15 @@
             <connections>
                 <outlet property="blogNameLabel" destination="kEs-BA-Qeh" id="ynz-iR-VpE"/>
                 <outlet property="descriptionLabel" destination="guM-Ci-dh4" id="64l-1G-VYB"/>
-                <outlet property="followButton" destination="F8n-bs-L9T" id="dAG-Qb-3Ym"/>
+                <outlet property="followButton" destination="epE-Yr-j1l" id="ts5-8g-DQp"/>
+                <outlet property="headerStackView" destination="mms-yI-nd4" id="qxS-2d-0xQ"/>
                 <outlet property="hostNameLabel" destination="RNB-9V-A6a" id="EQr-pT-p1q"/>
-                <outlet property="iPadFollowButton" destination="epE-Yr-j1l" id="wvy-Iv-wVy"/>
                 <outlet property="iconImageView" destination="FEv-sY-BYI" id="zxN-JN-Jgs"/>
-                <outlet property="infoTrailingConstraint" destination="sFg-8b-VnL" id="VMA-B5-96d"/>
             </connections>
-            <point key="canvasLocation" x="-601" y="-61"/>
+            <point key="canvasLocation" x="-601.171875" y="-58.857979502196187"/>
         </tableViewCell>
     </objects>
     <resources>
         <image name="post-blavatar-placeholder" width="32" height="32"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -25,9 +25,12 @@ class ReaderTopicsTableCardCell: UITableViewCell {
 
     weak var delegate: ReaderTopicsTableCardCellDelegate?
 
+    private var readerImprovements: Bool {
+        FeatureFlag.readerImprovements.enabled
+    }
+
     // Subclasses should configure these properties
     var headerTitle: String?
-    var headerContentInsets: UIEdgeInsets = UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 0)
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -53,26 +56,36 @@ class ReaderTopicsTableCardCell: UITableViewCell {
     }
 
     func setupTableView() {
+        let separatorView = UIView()
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        separatorView.backgroundColor = .separator
+
         addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
-        pinSubviewToSafeArea(containerView, insets: Constants.containerInsets)
+        pinSubviewToSafeArea(containerView, insets: readerImprovements ? Constants.newContainerInsets : Constants.containerInsets)
         containerView.addSubview(tableView)
+        containerView.addSubview(separatorView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
+        let tableViewMargin = readerImprovements ? 16.0 : 0.0
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+            tableView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: tableViewMargin),
+            tableView.bottomAnchor.constraint(equalTo: separatorView.topAnchor, constant: -tableViewMargin),
+            separatorView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            separatorView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            separatorView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: readerImprovements ? 0.5 : 0.0),
         ])
 
         // Constraints for regular horizontal size class
         regularConstraints = [
-            tableView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
+            tableView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: tableViewMargin),
+            tableView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor, constant: -tableViewMargin)
         ]
 
         // Constraints for compact horizontal size class
         compactConstraints = [
-            tableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+            tableView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: tableViewMargin),
+            tableView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -tableViewMargin)
         ]
 
         tableView.isScrollEnabled = false
@@ -82,8 +95,9 @@ class ReaderTopicsTableCardCell: UITableViewCell {
 
     private func applyStyles() {
         containerView.backgroundColor = .listForeground
-        tableView.backgroundColor = .listForeground
-        tableView.separatorColor = .placeholderElement
+        tableView.backgroundColor = readerImprovements ? .secondarySystemBackground : .listForeground
+        tableView.layer.cornerRadius = readerImprovements ? 10.0 : 0.0
+        tableView.separatorColor = readerImprovements ? .clear : .placeholderElement
 
         backgroundColor = .clear
         contentView.backgroundColor = .clear
@@ -105,6 +119,9 @@ class ReaderTopicsTableCardCell: UITableViewCell {
 
     private enum Constants {
         static let containerInsets = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
+        static let newContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        static let headerInsets = UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 0)
+        static let newHeaderInsets = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 0)
     }
 }
 
@@ -127,7 +144,7 @@ extension ReaderTopicsTableCardCell: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 1
+        return FeatureFlag.readerImprovements.enabled ? 16 : 0
     }
 }
 
@@ -141,8 +158,10 @@ extension ReaderTopicsTableCardCell: UITableViewDelegate {
         headerTitle.text = title
         header.addSubview(headerTitle)
         headerTitle.translatesAutoresizingMaskIntoConstraints = false
-        header.pinSubviewToAllEdges(headerTitle, insets: headerContentInsets)
-        headerTitle.font = WPStyleGuide.serifFontForTextStyle(.title2)
+        header.pinSubviewToAllEdges(headerTitle,
+                                    insets: readerImprovements ? Constants.newHeaderInsets : Constants.headerInsets)
+        headerTitle.font = readerImprovements ? WPStyleGuide.fontForTextStyle(.footnote) : WPStyleGuide.serifFontForTextStyle(.title2)
+        headerTitle.textColor = readerImprovements ? .secondaryLabel : .label
         return header
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -336,6 +336,7 @@ extension WPStyleGuide {
         button.layer.borderColor = UIColor.separator.cgColor
         button.layer.cornerRadius = 5.0
         button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
+        button.tintColor = .clear
 
         button.configuration = .plain()
         button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 24.0, bottom: 8.0, trailing: 24.0)


### PR DESCRIPTION
Part of #21646 

## Description

Updates the `Sites to follow` cell with the new reader styles.

## Screenshots

| Light | Dark |
|------|------|
| ![Light](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/ff47736d-eaae-4d51-9c04-e2b9e6adf730) | ![Screenshot 2023-10-13 at 9 32 24 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/6a02a61c-485b-485e-aeb5-4fa9102a419c) |

## Testing

To test:
- Launch Jetpack and login
- Enable the Reader Improvements v1 feature flag
- Navigate to the Reader tab
- Tap on `Discover`
- Scroll until you see the `Sites to follow` cell
- 🔎 **Verify** the styles match zQnohyMpLzBzQ5jzMMKni3-fi-937%3A37051
- Tap on `Follow`
- 🔎 **Verify** the button updates to `Following` and the site title/URL are properly truncated if needed

## Regression Notes
1. Potential unintended areas of impact
Previous `Sites to follow` card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)