### PR TITLE
Reader: Constrain reader card to `readableContentGuide`

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -351,8 +351,8 @@ private extension ReaderPostCardCell {
     func contentViewConstraints() -> [NSLayoutConstraint] {
         let margins = Constants.ContentStackView.margins
         return [
-            contentStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: margins),
-            contentStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -margins),
+            contentStackView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            contentStackView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
             contentStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: margins),
             contentStackView.bottomAnchor.constraint(equalTo: controlsStackView.topAnchor,
                                                      constant: Constants.ContentStackView.bottomAnchor)


### PR DESCRIPTION
Closes #21645

## Description

- Fixes the safe area issue I mentioned in previous PRs: The very first time the reader was opened, if the device was rotated, the card wouldn't respect the safe area. These changes resolve that issue.
- Fixes the width of the cards for iPad

## Screenshots

| Before | After |
|-------|-------|
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-10-13 at 22 43 31](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/1f9e647d-16ba-4cc8-b251-d4f3da58ffa4) | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-10-13 at 22 41 44](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/4ffabdb8-736e-46c1-92ff-32845cc25dfa) |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-10-13 at 22 43 35](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/8b14283e-c055-449b-ab77-b2883563bb77) | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2023-10-13 at 22 41 50](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/92fa1f4d-2664-4fbe-aa09-bf18b97eebaa) |

## Testing

### Safe area fix
> **Note**
> This only happened the first time the reader was opened. Due to that, these steps need to be followed on a fresh launch.
- Use an iPhone with a notch/island
- Start the device in portrait
- Launch Jetpack and login
- Enable the Reader Improvements v1 feature flag
- Tap on Reader
- Rotate to landscape
- 🔎 **Verify** the safe area is respected by the card

### iPad
- Launch Jetpack and login
- Enable the Reader Improvements v1 feature flag
- Tap on Reader
- 🔎 **Verify** the card uses the readable content guide and does not go to the edge of the screen
- Rotate the device
- 🔎 **Verify** the card uses the readable content guide and does not go to the edge of the screen 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
