### PR TITLE
Reader: Update `readerImprovements` flag to be remote

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -12,7 +12,6 @@ enum FeatureFlag: Int, CaseIterable {
     case commentModerationUpdate
     case compliancePopover
     case domainFocus
-    case readerImprovements // pcdRpT-3Eb-p2
     case mediaModernization
 
     /// Returns a boolean indicating if the feature is enabled
@@ -42,8 +41,6 @@ enum FeatureFlag: Int, CaseIterable {
             return true
         case .domainFocus:
             return true
-        case .readerImprovements:
-            return false
         case .mediaModernization:
             return false
         }
@@ -88,8 +85,6 @@ extension FeatureFlag {
             return "Compliance Popover"
         case .domainFocus:
             return "Domain Focus"
-        case .readerImprovements:
-            return "Reader Improvements v1"
         case .mediaModernization:
             return "Media Modernization"
         }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -21,6 +21,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case jetpackSocialImprovements
     case domainManagement
     case plansInSiteCreation
+    case readerImprovements // pcdRpT-3Eb-p2
 
     var defaultValue: Bool {
         switch self {
@@ -61,6 +62,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .domainManagement:
             return false
         case .plansInSiteCreation:
+            return false
+        case .readerImprovements:
             return false
         }
     }
@@ -106,6 +109,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "domain_management"
         case .plansInSiteCreation:
             return "plans_in_site_creation"
+        case .readerImprovements:
+            return "reader_improvements"
         }
     }
 
@@ -149,6 +154,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Domain Management"
         case .plansInSiteCreation:
             return "Plans in Site Creation"
+        case .readerImprovements:
+            return "Reader Improvements v1"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -77,7 +77,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// The actual header
     private lazy var header: UIView & ReaderDetailHeader = {
-        guard FeatureFlag.readerImprovements.enabled else {
+        guard RemoteFeatureFlag.readerImprovements.enabled() else {
             return ReaderDetailHeaderView.loadFromNib()
         }
         return ReaderDetailNewHeaderViewHost()
@@ -533,7 +533,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Configure the webview
     private func configureWebView() {
-        webView.usesSansSerifStyle = FeatureFlag.readerImprovements.enabled
+        webView.usesSansSerifStyle = RemoteFeatureFlag.readerImprovements.enabled()
         webView.navigationDelegate = self
     }
 
@@ -606,7 +606,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         headerContainerView.pinSubviewToAllEdges(header)
 
-        if !FeatureFlag.readerImprovements.enabled {
+        if !RemoteFeatureFlag.readerImprovements.enabled() {
             headerContainerView.heightAnchor.constraint(equalTo: header.heightAnchor).isActive = true
         }
     }
@@ -677,7 +677,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         toolbarContainerView.pinSubviewToAllEdges(toolbar)
         toolbarSafeAreaView.backgroundColor = toolbar.backgroundColor
 
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             toolbarHeightConstraint.constant = Constants.preferredToolbarHeight
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -36,7 +36,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
     private var likeButtonTitle: String {
         guard let post,
-              FeatureFlag.readerImprovements.enabled else {
+              RemoteFeatureFlag.readerImprovements.enabled() else {
             return likeLabel(count: likeCount)
         }
         return post.isLiked ? Constants.likedButtonTitle : Constants.likeButtonTitle
@@ -163,7 +163,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         WPStyleGuide.applyReaderCardActionButtonStyle(likeButton)
 
         // TODO: Apply changes on the XIB directly once the `readerImprovements` flag is removed.
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             stackView.distribution = .fillEqually
             stackView.spacing = 16.0
             stackViewLeadingConstraint.constant = 16.0
@@ -226,7 +226,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         /// `imagePlacement` to `.top`.
         ///
         /// TODO: remove unused styles once the `readerImprovements` flag is removed.
-        guard FeatureFlag.readerImprovements.enabled else {
+        guard RemoteFeatureFlag.readerImprovements.enabled() else {
             return
         }
 
@@ -298,7 +298,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         let animationDuration = 0.3
         let imageView = UIImageView(image: Constants.likedImage)
 
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             /// When using `UIButton.Configuration`, calling `bringSubviewToFront` somehow does not work.
             /// To work around this, let's add the faux image to the image view instead, so it can be
             /// properly placed in front of the masking view.
@@ -317,7 +317,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             likeImageView.pinSubviewToAllEdges(mask)
             mask.translatesAutoresizingMaskIntoConstraints = false
 
-            if FeatureFlag.readerImprovements.enabled {
+            if RemoteFeatureFlag.readerImprovements.enabled() {
                 likeImageView.bringSubviewToFront(imageView)
             } else {
                 likeButton.bringSubviewToFront(imageView)
@@ -426,8 +426,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         }
 
         let commentCount = post.commentCount()?.intValue ?? 0
-        let commentTitle = FeatureFlag.readerImprovements.enabled ? Constants.commentButtonTitle : commentLabel(count: commentCount)
-        let showTitle: Bool = FeatureFlag.readerImprovements.enabled || traitCollection.horizontalSizeClass != .compact
+        let commentTitle = RemoteFeatureFlag.readerImprovements.enabled() ? Constants.commentButtonTitle : commentLabel(count: commentCount)
+        let showTitle: Bool = RemoteFeatureFlag.readerImprovements.enabled() || traitCollection.horizontalSizeClass != .compact
 
         likeButton.setTitle(likeButtonTitle, for: .normal)
         likeButton.setTitle(likeButtonTitle, for: .highlighted)
@@ -496,7 +496,7 @@ private extension ReaderDetailToolbar {
         static let buttonImagePadding: CGFloat = 4.0
 
         static var likeImage: UIImage? {
-            if FeatureFlag.readerImprovements.enabled {
+            if RemoteFeatureFlag.readerImprovements.enabled() {
                 // reduce gridicon images to 20x20 since they don't have intrinsic padding.
                 return UIImage(named: "icon-reader-like")?
                     .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .default)
@@ -506,7 +506,7 @@ private extension ReaderDetailToolbar {
         }
 
         static var likedImage: UIImage? {
-            if FeatureFlag.readerImprovements.enabled {
+            if RemoteFeatureFlag.readerImprovements.enabled() {
                 // reduce gridicon images to 20x20 since they don't have intrinsic padding.
                 return UIImage(named: "icon-reader-liked")?
                     .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .default)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -86,7 +86,7 @@ private extension ReaderCrossPostCell {
     // MARK: - Appearance
 
     func applyStyles() {
-        let readerImprovements = FeatureFlag.readerImprovements.enabled
+        let readerImprovements = RemoteFeatureFlag.readerImprovements.enabled()
         backgroundColor = .clear
         contentView.backgroundColor = readerImprovements ? .systemBackground : .listBackground
         borderView?.backgroundColor = readerImprovements ? .systemBackground : .listForeground

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -328,7 +328,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
     }
 
     private func followButton(title: String) -> UIButton {
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             let button = UIButton()
             button.isSelected = true
             WPStyleGuide.applyReaderFollowButtonStyle(button)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
@@ -11,7 +11,7 @@ class ReaderRecommendedSiteCardCell: UITableViewCell {
     weak var delegate: ReaderRecommendedSitesCardCellDelegate?
 
     private var readerImprovements: Bool {
-        FeatureFlag.readerImprovements.enabled
+        RemoteFeatureFlag.readerImprovements.enabled()
     }
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -110,7 +110,7 @@ final class ReaderShowMenuAction {
         }
 
         // Save post
-        if FeatureFlag.readerImprovements.enabled, let vc = vc as? ReaderStreamViewController {
+        if RemoteFeatureFlag.readerImprovements.enabled(), let vc = vc as? ReaderStreamViewController {
             let buttonTitle = post.isSavedForLater ? ReaderPostMenuButtonTitles.removeSavedPost: ReaderPostMenuButtonTitles.savePost
 
             alertController.addActionWithTitle(buttonTitle, style: .default) { _ in

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -39,7 +39,7 @@ extension ReaderStreamViewController {
                 return nil
             }
 
-            return FeatureFlag.readerImprovements.enabled ? nibViews.last : nibViews.first
+            return RemoteFeatureFlag.readerImprovements.enabled() ? nibViews.last : nibViews.first
         }
 
         if ReaderHelpers.isTopicList(topic) {
@@ -47,7 +47,7 @@ extension ReaderStreamViewController {
         }
 
         if ReaderHelpers.isTopicSite(topic) && !isContentFiltered {
-            if FeatureFlag.readerImprovements.enabled {
+            if RemoteFeatureFlag.readerImprovements.enabled() {
                 return ReaderSiteHeaderView()
             } else {
                 return Bundle.main.loadNibNamed("ReaderSiteStreamHeader", owner: nil, options: nil)?.first as? ReaderSiteStreamHeader

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -598,7 +598,7 @@ import Combine
             return
         }
 
-        let isNewSiteHeader = ReaderHelpers.isTopicSite(topic) && !isContentFiltered && FeatureFlag.readerImprovements.enabled
+        let isNewSiteHeader = ReaderHelpers.isTopicSite(topic) && !isContentFiltered && RemoteFeatureFlag.readerImprovements.enabled()
         let headerView = {
             guard isNewSiteHeader else {
                 return header
@@ -719,11 +719,11 @@ import Combine
 
         if ReaderHelpers.isTopicTag(topic) {
             // don't display any title for the tag stream for the new design.
-            if FeatureFlag.readerImprovements.enabled {
+            if RemoteFeatureFlag.readerImprovements.enabled() {
                 return
             }
             title = NSLocalizedString("Topic", comment: "Topic page title")
-        } else if FeatureFlag.readerImprovements.enabled && ReaderHelpers.topicType(topic) == .site {
+        } else if RemoteFeatureFlag.readerImprovements.enabled() && ReaderHelpers.topicType(topic) == .site {
             title = ""
         } else {
             title = topic.title
@@ -1651,7 +1651,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
             return cell
         }
 
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             let cell = tableConfiguration.postCardCell(tableView)
             let viewModel = ReaderPostCardCellViewModel(contentProvider: post,
                                                         isLoggedIn: isLoggedIn,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -26,7 +26,7 @@ class ReaderTopicsTableCardCell: UITableViewCell {
     weak var delegate: ReaderTopicsTableCardCellDelegate?
 
     private var readerImprovements: Bool {
-        FeatureFlag.readerImprovements.enabled
+        RemoteFeatureFlag.readerImprovements.enabled()
     }
 
     // Subclasses should configure these properties
@@ -144,7 +144,7 @@ extension ReaderTopicsTableCardCell: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return FeatureFlag.readerImprovements.enabled ? 16 : 0
+        return RemoteFeatureFlag.readerImprovements.enabled() ? 16 : 0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
@@ -32,7 +32,7 @@ final class ReaderTableConfiguration {
     }
 
     private func setUpCardCell(_ tableView: UITableView) {
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             tableView.register(ReaderPostCardCell.self, forCellReuseIdentifier: readerCardCellReuseIdentifier)
         } else {
             let nib = UINib(nibName: readerCardCellNibName, bundle: nil)
@@ -64,7 +64,7 @@ final class ReaderTableConfiguration {
     }
 
     func estimatedRowHeight() -> CGFloat {
-        return FeatureFlag.readerImprovements.enabled ? rowHeight : oldRowHeight
+        return RemoteFeatureFlag.readerImprovements.enabled() ? rowHeight : oldRowHeight
     }
 
     func crossPostCell(_ tableView: UITableView) -> ReaderCrossPostCell {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -16,7 +16,7 @@ import WordPressShared
     }
 
     @objc func applyStyles() {
-        WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel, usesNewStyle: FeatureFlag.readerImprovements.enabled)
+        WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel, usesNewStyle: RemoteFeatureFlag.readerImprovements.enabled())
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -32,7 +32,7 @@ import WordPressShared
 
     @objc open func configureHeader(_ topic: ReaderAbstractTopic) {
         titleLabel.text = {
-            guard FeatureFlag.readerImprovements.enabled else {
+            guard RemoteFeatureFlag.readerImprovements.enabled() else {
                 return topic.title
             }
             return topic.title.split(separator: "-").map { $0.capitalized }.joined(separator: " ")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -22,7 +22,7 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
     weak var delegate: ReaderTopicsTableCardCellDelegate?
 
     static var defaultNibName: String {
-        FeatureFlag.readerImprovements.enabled ? "ReaderTopicsNewCardCell" : String(describing: self)
+        RemoteFeatureFlag.readerImprovements.enabled() ? "ReaderTopicsNewCardCell" : String(describing: self)
     }
 
     func configure(_ data: [ReaderAbstractTopic]) {
@@ -44,13 +44,13 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
         collectionView.register(ReaderTopicCardCollectionViewCell.self,
                                 forCellWithReuseIdentifier: ReaderTopicCardCollectionViewCell.cellReuseIdentifier())
 
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             configureForNewDesign()
         }
     }
 
     private func applyStyles() {
-        let usesNewDesign = FeatureFlag.readerImprovements.enabled
+        let usesNewDesign = RemoteFeatureFlag.readerImprovements.enabled()
         headerLabel.font = usesNewDesign ? WPStyleGuide.fontForTextStyle(.footnote) : WPStyleGuide.serifFontForTextStyle(.title2)
 
         containerView.backgroundColor = usesNewDesign ? .secondarySystemBackground : .listForeground
@@ -110,7 +110,7 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
 extension ReaderTopicsCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReaderTopicCardCollectionViewCell.cellReuseIdentifier(), for: indexPath) as? ReaderTopicCardCollectionViewCell else {
                 return UICollectionViewCell()
             }
@@ -182,7 +182,7 @@ extension ReaderTopicsCardCell: UICollectionViewDelegateFlowLayout {
 
         var size = title.size(withAttributes: attributes)
         size.height += (CellConstants.marginY * 2)
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             size.height += 2 // to account for the top & bottom border width
         }
 
@@ -190,7 +190,7 @@ extension ReaderTopicsCardCell: UICollectionViewDelegateFlowLayout {
         let maxWidth = collectionView.bounds.width * CellConstants.maxWidthMultiplier
         let width = min(size.width, maxWidth)
         size.width = width + (CellConstants.marginX * 2)
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             size.width += 2 // to account for the leading & trailing border width
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -64,7 +64,7 @@ class ReaderInterestsStyleGuide {
     public class func applyCompactCellLabelStyle(label: UILabel) {
         label.font = Self.compactCellLabelTitleFont
         label.textColor = .text
-        label.backgroundColor = FeatureFlag.readerImprovements.enabled ? .clear : .quaternaryBackground
+        label.backgroundColor = RemoteFeatureFlag.readerImprovements.enabled() ? .clear : .quaternaryBackground
     }
 
     // MARK: - Next Button

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -32,7 +32,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     }
 
     private lazy var metrics: ReaderInterestsStyleGuide.Metrics = {
-        return FeatureFlag.readerImprovements.enabled ? .latest : .legacy
+        return RemoteFeatureFlag.readerImprovements.enabled() ? .latest : .legacy
     }()
 
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
@@ -182,7 +182,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
 
         configure(cell: cell, with: title)
 
-        if layout.isExpanded || FeatureFlag.readerImprovements.enabled {
+        if layout.isExpanded || RemoteFeatureFlag.readerImprovements.enabled() {
             cell.label.backgroundColor = .clear
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -56,7 +56,7 @@ extension WPStyleGuide {
     // MARK: - Card Attributed Text Attributes
 
     @objc public class func readerCrossPostTitleAttributes() -> [NSAttributedString.Key: Any] {
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             let font = UIFont.preferredFont(forTextStyle: .subheadline).semibold()
             return [
                 .font: font,
@@ -77,7 +77,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func readerCrossPostBoldSubtitleAttributes() -> [NSAttributedString.Key: Any] {
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             let font = UIFont.preferredFont(forTextStyle: .footnote).semibold()
             return [
                 .font: font,
@@ -96,7 +96,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func readerCrossPostSubtitleAttributes() -> [NSAttributedString.Key: Any] {
-        if FeatureFlag.readerImprovements.enabled {
+        if RemoteFeatureFlag.readerImprovements.enabled() {
             let font = UIFont.preferredFont(forTextStyle: .footnote)
             return [
                 .font: font,
@@ -293,7 +293,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
-        guard !FeatureFlag.readerImprovements.enabled else {
+        guard !RemoteFeatureFlag.readerImprovements.enabled() else {
             applyNewReaderFollowButtonStyle(button)
             return
         }
@@ -354,7 +354,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderIconFollowButtonStyle(_ button: UIButton) {
-        guard !FeatureFlag.readerImprovements.enabled else {
+        guard !RemoteFeatureFlag.readerImprovements.enabled() else {
             applyNewReaderFollowButtonStyle(button)
             return
         }
@@ -487,7 +487,7 @@ extension WPStyleGuide {
         let likeStr = NSLocalizedString("Like", comment: "Text for the 'like' button. Tapping marks a post in the reader as 'liked'.")
         let likesStr = NSLocalizedString("Likes", comment: "Text for the 'like' button. Tapping removes the 'liked' status from a post.")
 
-        if count == 0 && !FeatureFlag.readerImprovements.enabled {
+        if count == 0 && !RemoteFeatureFlag.readerImprovements.enabled() {
             return likeStr
         } else if count == 1 {
             return "\(count) \(likeStr)"
@@ -500,7 +500,7 @@ extension WPStyleGuide {
         let commentStr = NSLocalizedString("Comment", comment: "Text for the 'comment' when there is 1 or 0 comments")
         let commentsStr = NSLocalizedString("Comments", comment: "Text for the 'comment' button when there are multiple comments")
 
-        if count == 0 && !FeatureFlag.readerImprovements.enabled {
+        if count == 0 && !RemoteFeatureFlag.readerImprovements.enabled() {
             return commentStr
         } else if count == 1 {
             return "\(count) \(commentStr)"
@@ -589,7 +589,7 @@ extension WPStyleGuide {
         public static let contentTextStyle: UIFont.TextStyle = .callout
 
         public static var actionBarIconSize: CGSize {
-            return FeatureFlag.readerImprovements.enabled ? CGSize(width: 20.0, height: 20.0) : Gridicon.defaultSize
+            return RemoteFeatureFlag.readerImprovements.enabled() ? CGSize(width: 20.0, height: 20.0) : Gridicon.defaultSize
         }
     }
 


### PR DESCRIPTION
Part of #21761 

## Description

Updates the local reader improvements feature flag to be a remote feature flag.

## Testing

To test:
- Disable the reader improvements feature flag
- Do a quick smoke test through the old reader UI
- Enable the reader improvements feature flag
- Do a quick smoke test through the new reader UI

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
