### PR TITLE
Reader: Enable the Reader Improvements v1 feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Block Editor: Split formatted text on triple Enter [https://github.com/WordPress/gutenberg/pull/53354]
 * [*] Block Editor: Quote block: Ensure border is visible with block-based themes in dark [https://github.com/WordPress/gutenberg/pull/54964]
 * [*] (Internal) Remove .nativePhotoPicker feature flag and the disabled code [#21681](https://github.com/wordpress-mobile/WordPress-iOS/pull/21681)
+* [**] Reader: Improvement of core UI elements, including feed cards, tag and site headers, buttons and recommendation sections. [#]
 
 23.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [*] Block Editor: Split formatted text on triple Enter [https://github.com/WordPress/gutenberg/pull/53354]
 * [*] Block Editor: Quote block: Ensure border is visible with block-based themes in dark [https://github.com/WordPress/gutenberg/pull/54964]
 * [*] (Internal) Remove .nativePhotoPicker feature flag and the disabled code [#21681](https://github.com/wordpress-mobile/WordPress-iOS/pull/21681)
-* [**] Reader: Improvement of core UI elements, including feed cards, tag and site headers, buttons and recommendation sections. [#21772]
+* [**] [Jetpack-only] Reader: Improvement of core UI elements, including feed cards, tag and site headers, buttons and recommendation sections. [#21772]
 
 23.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [*] Block Editor: Split formatted text on triple Enter [https://github.com/WordPress/gutenberg/pull/53354]
 * [*] Block Editor: Quote block: Ensure border is visible with block-based themes in dark [https://github.com/WordPress/gutenberg/pull/54964]
 * [*] (Internal) Remove .nativePhotoPicker feature flag and the disabled code [#21681](https://github.com/wordpress-mobile/WordPress-iOS/pull/21681)
-* [**] Reader: Improvement of core UI elements, including feed cards, tag and site headers, buttons and recommendation sections. [#]
+* [**] Reader: Improvement of core UI elements, including feed cards, tag and site headers, buttons and recommendation sections. [#21772]
 
 23.4
 -----

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -64,7 +64,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .plansInSiteCreation:
             return false
         case .readerImprovements:
-            return false
+            return true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -139,6 +139,7 @@ class ReaderPostCardCell: UITableViewCell {
         static let borderWidth: CGFloat = 0.5
         static let imageSeparatorBorderWidth: CGFloat = 1.0
         static let separatorHeight: CGFloat = 0.5
+        static let likeButtonIdentifier = "reader-like-button"
     }
 
 }
@@ -516,6 +517,7 @@ private extension ReaderPostCardCell {
         reblogButton.accessibilityHint = Constants.Accessibility.reblogButtonHint
         commentButton.accessibilityHint = Constants.Accessibility.commentButtonHint
         likeButton.accessibilityHint = viewModel?.isPostLiked == true ? Constants.Accessibility.likedButtonHint : Constants.Accessibility.likeButtonHint
+        likeButton.accessibilityIdentifier = Constants.likeButtonIdentifier
         menuButton.accessibilityLabel = Constants.Accessibility.menuButtonLabel
         menuButton.accessibilityHint = Constants.Accessibility.menuButtonHint
         accessibilityElements = [

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -117,6 +117,8 @@ extension ReaderTopicsCardCell: UICollectionViewDelegate, UICollectionViewDataSo
 
             let title = data[indexPath.row].title
             cell.titleLabel.text = title
+            cell.titleLabel.accessibilityIdentifier = .topicsCardCellIdentifier
+            cell.titleLabel.accessibilityTraits = .button
 
             return cell
         }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -55,8 +55,12 @@ public class ReaderScreen: ScreenObject {
         $0.staticTexts["no-results-label-stack-view"]
     }
 
+    private let moreButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["More"]
+    }
+
     private let savePostButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Save post"]
+        $0.buttons["Save"]
     }
 
     var backButton: XCUIElement { backButtonGetter(app) }
@@ -69,6 +73,7 @@ public class ReaderScreen: ScreenObject {
     var noResultsView: XCUIElement { noResultsViewGetter(app) }
     var readerButton: XCUIElement { readerButtonGetter(app) }
     var readerTable: XCUIElement { readerTableGetter(app) }
+    var moreButton: XCUIElement { moreButtonGetter(app) }
     var savePostButton: XCUIElement { savePostButtonGetter(app) }
     var savedButton: XCUIElement { savedButtonGetter(app) }
     var topicCellButton: XCUIElement { topicCellButtonGetter(app) }
@@ -96,7 +101,7 @@ public class ReaderScreen: ScreenObject {
     }
 
     public func openLastPostComments() throws -> CommentsScreen {
-        let commentButton = getLastPost().buttons["0 comment"]
+        let commentButton = getLastPost().buttons["Comment"]
         guard commentButton.waitForIsHittable() else { fatalError("ReaderScreen.Post: Comments button not loaded") }
         commentButton.tap()
         return try CommentsScreen()
@@ -177,6 +182,7 @@ public class ReaderScreen: ScreenObject {
     }
 
     public func followTopic() -> Self {
+        _ = followButton.waitForExistence(timeout: 3)
         followButton.tap()
 
         return self
@@ -193,6 +199,7 @@ public class ReaderScreen: ScreenObject {
     public func saveFirstPost() throws -> (ReaderScreen, String) {
         XCTAssertTrue(readerTable.waitForExistence(timeout: 3))
         let postLabel = readerTable.cells.firstMatch.label
+        moreButton.firstMatch.tap()
         savePostButton.firstMatch.tap()
 
         // An alert about saved post is displayed the first time a post is saved
@@ -260,11 +267,11 @@ public class ReaderScreen: ScreenObject {
 
 private extension String {
     static let emptyListLabel = "Empty list"
-    static let postLiked = "This post is in My Likes"
+    static let postLiked = "Liked"
     static let postNotEqualOneError = "There should only be 1 post!"
     static let postNotEqualSavedPostError = "Post displayed does not match saved post!"
     static let postNotGreaterThanOneError = "There shouldn't only be 1 post!"
-    static let postNotLiked = "This post is not in My Likes"
+    static let postNotLiked = "Like"
     static let withoutPosts = "without posts"
     static let withPosts = "with posts"
 }


### PR DESCRIPTION
Closes #21761 
Relies on: #21771
Ref: pcdRpT-3Eb-p2

## Description

- Enables the Reader Improvements v1 feature flag
- Fixes the Reader UI tests after enabling the new changes

## Testing

To test:
- Perform a fresh installation of Jetpack to prevent any overridden feature flags
- Login
- Tap on Reader
- Go through the various screens and cards
- 🔎 **Verify** all the screens and cards from the PT (pcdRpT-3Eb-p2) are now enabled

## Regression Notes
1. Potential unintended areas of impact
Reader

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)