### PR TITLE
Reader: Minor improvements to detail header accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -144,7 +144,7 @@ class ReaderDetailHeaderViewModel: ObservableObject {
 
             // hide the author name if it exactly matches the site name.
             // context: https://github.com/wordpress-mobile/WordPress-iOS/pull/21674#issuecomment-1747202728
-            self.showsAuthorName = self.authorName != self.siteName
+            self.showsAuthorName = self.authorName != self.siteName && !self.authorName.isEmpty
 
             self.postTitle = post.titleForDisplay() ?? nil
             self.tags = post.tagsForDisplay() ?? []
@@ -258,6 +258,9 @@ struct ReaderDetailNewHeaderView: View {
                 authorAndTimestampView
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits([.isButton])
+        .accessibilityHint(Constants.authorStackAccessibilityHint)
         .onTapGesture {
             viewModel.didTapAuthorSection()
         }
@@ -316,7 +319,7 @@ struct ReaderDetailNewHeaderView: View {
 
     var authorAndTimestampView: some View {
         HStack(spacing: 0) {
-            if viewModel.showsAuthorName, !viewModel.authorName.isEmpty {
+            if viewModel.showsAuthorName {
                 Text(viewModel.authorName)
                     .font(.footnote)
                     .foregroundColor(Color(.text))
@@ -335,6 +338,8 @@ struct ReaderDetailNewHeaderView: View {
 
             Spacer()
         }
+        .accessibilityElement()
+        .accessibilityLabel(authorAccessibilityLabel)
     }
 
     var timestampText: Text {
@@ -351,8 +356,23 @@ fileprivate extension ReaderDetailNewHeaderView {
     struct Constants {
         static let siteIconLength: CGFloat = 40.0
         static let authorImageLength: CGFloat = 20.0
+
+        static let authorStackAccessibilityHint = NSLocalizedString(
+            "reader.detail.header.authorInfo.a11y.hint",
+            value: "Views posts from the site",
+            comment: "Accessibility hint to inform that the author section can be tapped to see posts from the site."
+        )
     }
 
+    var authorAccessibilityLabel: String {
+        var labels = [viewModel.relativePostTime]
+
+        if viewModel.showsAuthorName {
+            labels.insert(viewModel.authorName, at: .zero)
+        }
+
+        return labels.joined(separator: ", ")
+    }
 }
 
 // MARK: - TopicCollectionView UIViewRepresentable Wrapper


### PR DESCRIPTION
Refs #21644 

This adds a small improvement to VoiceOver structure, particularly the author stack. When running VoiceOver, the author stack should group the site, author, and timestamp as a single button.

To test:

- Launch Jetpack.
- Enable `readerImprovements` feature flag.
- Navigate to Reader > select any post.
- Run VoiceOver or use Accessibility Inspector.
- 🔎 Verify that the header section of the post has a good structure: Interactable elements are spelled out as a button, and the VoiceOver navigation structure is correct.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
