### PR TITLE
Posts & Pages: Remove Create Story action

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -144,15 +144,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                     self?.createPost()
             }, source: Constants.source)
         ]
-        if blog.supports(.stories) {
-            actions.insert(StoryAction(handler: { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                let presenter = RootViewCoordinator.sharedPresenter
-                presenter.showStoryEditor(blog: self.blog, title: nil, content: nil)
-            }, source: Constants.source), at: 0)
-        }
         return CreateButtonCoordinator(self, actions: actions, source: Constants.source, blog: blog)
     }()
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21714

To test:

- Verify that the "Create" FAB on the Posts screen open a new post on tap (and not an action sheet with options)

Note: I kept the coordinator because it managed the entire presentation.

## Regression Notes
1. Potential unintended areas of impact: Posts List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
