### PR TITLE
Update `DashboardPostsSyncManagerListener` function signature

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
@@ -271,7 +271,6 @@ extension PagesCardViewModel: DashboardPostsSyncManagerListener {
     func postsSynced(success: Bool,
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
-                     posts: [AbstractPost]?,
                      for statuses: [BasePost.Status]) {
         guard postType == .page,
               self.blog == blog else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
@@ -232,7 +232,7 @@ private extension PagesCardViewModel {
     func sync() {
         isSyncing = true
         let filter = filter
-        DashboardPostsSyncManager.shared.syncPosts(blog: blog, postType: .page, statuses: filter.statuses.strings)
+        DashboardPostsSyncManager.shared.syncPosts(blog: blog, postType: .page, statuses: filter.statuses)
     }
 
     func hideLoading() {
@@ -272,7 +272,7 @@ extension PagesCardViewModel: DashboardPostsSyncManagerListener {
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
                      posts: [AbstractPost]?,
-                     for statuses: [String]) {
+                     for statuses: [BasePost.Status]) {
         guard postType == .page,
               self.blog == blog else {
             return

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -286,7 +286,6 @@ extension PostsCardViewModel: DashboardPostsSyncManagerListener {
     func postsSynced(success: Bool,
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
-                     posts: [AbstractPost]?,
                      for statuses: [BasePost.Status]) {
         let currentStatuses = postListFilter.statuses
         guard postType == .post,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -198,7 +198,7 @@ private extension PostsCardViewModel {
     func sync() {
         isSyncing = true
         let filter = postListFilter
-        DashboardPostsSyncManager.shared.syncPosts(blog: blog, postType: .post, statuses: filter.statuses.strings)
+        DashboardPostsSyncManager.shared.syncPosts(blog: blog, postType: .post, statuses: filter.statuses)
     }
 
     func updateFilter() {
@@ -287,8 +287,8 @@ extension PostsCardViewModel: DashboardPostsSyncManagerListener {
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
                      posts: [AbstractPost]?,
-                     for statuses: [String]) {
-        let currentStatuses = postListFilter.statuses.strings
+                     for statuses: [BasePost.Status]) {
+        let currentStatuses = postListFilter.statuses
         guard postType == .post,
               self.blog == blog,
               currentStatuses.allSatisfy(statuses.contains) else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardState.swift
@@ -28,8 +28,8 @@ class BlogDashboardState {
         !hasCachedData && failedToLoad
     }
 
-    @Atomic var postsSyncingStatuses: [String] = []
-    @Atomic var pagesSyncingStatuses: [String] = []
+    @Atomic var postsSyncingStatuses: [BasePost.Status] = []
+    @Atomic var pagesSyncingStatuses: [BasePost.Status] = []
 
     private init() { }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/DashboardPostsSyncManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/DashboardPostsSyncManager.swift
@@ -4,7 +4,6 @@ protocol DashboardPostsSyncManagerListener: AnyObject {
     func postsSynced(success: Bool,
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
-                     posts: [AbstractPost]?,
                      for statuses: [BasePost.Status])
 }
 
@@ -74,17 +73,17 @@ class DashboardPostsSyncManager {
                 self?.syncPosts(blog: blog, postType: postType, statuses: toBeSynced)
             }, failure: { [weak self] error in
                 postType.stopSyncingStatuses(toBeSynced, for: blog)
-                self?.notifyListenersOfPostsSync(success: false, blog: blog, postType: postType, posts: nil, for: toBeSynced)
+                self?.notifyListenersOfPostsSync(success: false, blog: blog, postType: postType, for: toBeSynced)
             })
             return
         }
 
         postService.syncPosts(ofType: postType.postServiceType, with: options, for: blog) { [weak self] posts in
             postType.stopSyncingStatuses(toBeSynced, for: blog)
-            self?.notifyListenersOfPostsSync(success: true, blog: blog, postType: postType, posts: posts, for: toBeSynced)
+            self?.notifyListenersOfPostsSync(success: true, blog: blog, postType: postType, for: toBeSynced)
         } failure: { [weak self] error in
             postType.stopSyncingStatuses(toBeSynced, for: blog)
-            self?.notifyListenersOfPostsSync(success: false, blog: blog, postType: postType, posts: nil, for: toBeSynced)
+            self?.notifyListenersOfPostsSync(success: false, blog: blog, postType: postType, for: toBeSynced)
         }
     }
 
@@ -97,10 +96,9 @@ class DashboardPostsSyncManager {
     private func notifyListenersOfPostsSync(success: Bool,
                                             blog: Blog,
                                             postType: PostType,
-                                            posts: [AbstractPost]?,
                                             for statuses: [BasePost.Status]) {
         for aListener in listeners {
-            aListener.postsSynced(success: success, blog: blog, postType: postType, posts: posts, for: statuses)
+            aListener.postsSynced(success: success, blog: blog, postType: postType, for: statuses)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/DashboardPostsSyncManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/DashboardPostsSyncManager.swift
@@ -5,7 +5,7 @@ protocol DashboardPostsSyncManagerListener: AnyObject {
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
                      posts: [AbstractPost]?,
-                     for statuses: [String])
+                     for statuses: [BasePost.Status])
 }
 
 class DashboardPostsSyncManager {
@@ -50,7 +50,7 @@ class DashboardPostsSyncManager {
         }
     }
 
-    func syncPosts(blog: Blog, postType: PostType, statuses: [String]) {
+    func syncPosts(blog: Blog, postType: PostType, statuses: [BasePost.Status]) {
         let toBeSynced = postType.statusesNotBeingSynced(statuses, for: blog)
         guard toBeSynced.isEmpty == false else {
             return
@@ -59,7 +59,7 @@ class DashboardPostsSyncManager {
         postType.markStatusesAsBeingSynced(toBeSynced, for: blog)
 
         let options = PostServiceSyncOptions()
-        options.statuses = toBeSynced
+        options.statuses = toBeSynced.strings
         options.authorID = blog.userID
         options.number = Constants.numberOfPostsToSync
         options.order = .descending
@@ -98,7 +98,7 @@ class DashboardPostsSyncManager {
                                             blog: Blog,
                                             postType: PostType,
                                             posts: [AbstractPost]?,
-                                            for statuses: [String]) {
+                                            for statuses: [BasePost.Status]) {
         for aListener in listeners {
             aListener.postsSynced(success: success, blog: blog, postType: postType, posts: posts, for: statuses)
         }
@@ -119,8 +119,8 @@ private extension DashboardPostsSyncManager.PostType {
         }
     }
 
-    func statusesNotBeingSynced(_ statuses: [String], for blog: Blog) -> [String] {
-        var currentlySyncing: [String]
+    func statusesNotBeingSynced(_ statuses: [BasePost.Status], for blog: Blog) -> [BasePost.Status] {
+        var currentlySyncing: [BasePost.Status]
         switch self {
         case .post:
             currentlySyncing = blog.dashboardState.postsSyncingStatuses
@@ -131,7 +131,7 @@ private extension DashboardPostsSyncManager.PostType {
         return notCurrentlySyncing
     }
 
-    func markStatusesAsBeingSynced(_ toBeSynced: [String], for blog: Blog) {
+    func markStatusesAsBeingSynced(_ toBeSynced: [BasePost.Status], for blog: Blog) {
         switch self {
         case .post:
             blog.dashboardState.postsSyncingStatuses.append(contentsOf: toBeSynced)
@@ -140,7 +140,7 @@ private extension DashboardPostsSyncManager.PostType {
         }
     }
 
-    func stopSyncingStatuses(_ statuses: [String], for blog: Blog) {
+    func stopSyncingStatuses(_ statuses: [BasePost.Status], for blog: Blog) {
         switch self {
         case .post:
             blog.dashboardState.postsSyncingStatuses = blog.dashboardState.postsSyncingStatuses.filter({ !statuses.contains($0) })

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -28,16 +28,16 @@ final class BlogDashboardViewModel {
 
     private var currentCards: [DashboardCardModel] = []
 
-    private lazy var draftStatusesToSync: [String] = {
-        return PostListFilter.draftFilter().statuses.strings
+    private lazy var draftStatusesToSync: [BasePost.Status] = {
+        return PostListFilter.draftFilter().statuses
     }()
 
-    private lazy var scheduledStatusesToSync: [String] = {
-        return PostListFilter.scheduledFilter().statuses.strings
+    private lazy var scheduledStatusesToSync: [BasePost.Status] = {
+        return PostListFilter.scheduledFilter().statuses
     }()
 
-    private lazy var pageStatusesToSync: [String] = {
-        return PostListFilter.allNonTrashedFilter().statuses.strings
+    private lazy var pageStatusesToSync: [BasePost.Status] = {
+        return PostListFilter.allNonTrashedFilter().statuses
     }()
 
     private lazy var service: BlogDashboardService = {

--- a/WordPress/WordPressTest/Dashboard/DashboardPostsSyncManagerTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardPostsSyncManagerTests.swift
@@ -35,14 +35,13 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
         manager.addListener(listener)
 
         // When
-        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses.strings)
+        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses)
 
         // Then
         XCTAssertTrue(listener.postsSyncedCalled)
         XCTAssertTrue(listener.postsSyncSuccess ?? false)
         XCTAssertEqual(listener.postsSyncBlog, blog)
         XCTAssertEqual(listener.postsSyncType, .post)
-        XCTAssertEqual(listener.postsSynced, postsToReturn)
         XCTAssertEqual(blog.dashboardState.postsSyncingStatuses, [])
         XCTAssertTrue(postService.syncPostsCalled)
         XCTAssertFalse(blogService.syncAuthorsCalled)
@@ -59,14 +58,13 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
         manager.addListener(listener)
 
         // When
-        manager.syncPosts(blog: blog, postType: .page, statuses: draftStatuses.strings)
+        manager.syncPosts(blog: blog, postType: .page, statuses: draftStatuses)
 
         // Then
         XCTAssertTrue(listener.postsSyncedCalled)
         XCTAssertTrue(listener.postsSyncSuccess ?? false)
         XCTAssertEqual(listener.postsSyncBlog, blog)
         XCTAssertEqual(listener.postsSyncType, .page)
-        XCTAssertEqual(listener.postsSynced, postsToReturn)
         XCTAssertEqual(blog.dashboardState.pagesSyncingStatuses, [])
         XCTAssertTrue(postService.syncPostsCalled)
         XCTAssertFalse(blogService.syncAuthorsCalled)
@@ -81,7 +79,7 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
         manager.addListener(listener)
 
         // When
-        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses.strings)
+        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses)
 
         // Then
         XCTAssertTrue(listener.postsSyncedCalled)
@@ -96,14 +94,14 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
     func testNotSyncingIfAnotherSyncinProgress() {
         // Given
         postService.syncShouldSucceed = false
-        blog.dashboardState.postsSyncingStatuses = draftStatuses.strings
+        blog.dashboardState.postsSyncingStatuses = draftStatuses
 
         let manager = DashboardPostsSyncManager(postService: postService, blogService: blogService)
         let listener = SyncManagerListenerMock()
         manager.addListener(listener)
 
         // When
-        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses.strings)
+        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses)
 
         // Then
         XCTAssertFalse(listener.postsSyncedCalled)
@@ -114,14 +112,14 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
     func testSyncingPostsIfSomeStatusesAreNotBeingSynced() {
         // Given
         postService.syncShouldSucceed = false
-        blog.dashboardState.postsSyncingStatuses = draftStatuses.strings
+        blog.dashboardState.postsSyncingStatuses = draftStatuses
 
         let manager = DashboardPostsSyncManager(postService: postService, blogService: blogService)
         let listener = SyncManagerListenerMock()
         manager.addListener(listener)
 
         // When
-        let toBeSynced = draftStatuses.strings + scheduledStatuses.strings
+        let toBeSynced = draftStatuses + scheduledStatuses
         manager.syncPosts(blog: blog, postType: .post, statuses: toBeSynced)
 
         // Then
@@ -129,8 +127,8 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
         XCTAssertFalse(listener.postsSyncSuccess ?? false)
         XCTAssertEqual(listener.postsSyncBlog, blog)
         XCTAssertEqual(listener.postsSyncType, .post)
-        XCTAssertEqual(listener.statusesSynced, scheduledStatuses.strings)
-        XCTAssertEqual(blog.dashboardState.postsSyncingStatuses, draftStatuses.strings)
+        XCTAssertEqual(listener.statusesSynced, scheduledStatuses)
+        XCTAssertEqual(blog.dashboardState.postsSyncingStatuses, draftStatuses)
         XCTAssertTrue(postService.syncPostsCalled)
         XCTAssertFalse(blogService.syncAuthorsCalled)
     }
@@ -148,7 +146,7 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
 
 
         // When
-        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses.strings)
+        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses)
 
         // Then
         XCTAssertTrue(listener.postsSyncedCalled)
@@ -172,7 +170,7 @@ class DashboardPostsSyncManagerTests: CoreDataTestCase {
         manager.addListener(listener)
 
         // When
-        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses.strings)
+        manager.syncPosts(blog: blog, postType: .post, statuses: draftStatuses)
 
         // Then
         XCTAssertTrue(listener.postsSyncedCalled)
@@ -192,19 +190,16 @@ class SyncManagerListenerMock: DashboardPostsSyncManagerListener {
     var postsSyncSuccess: Bool?
     var postsSyncBlog: Blog?
     var postsSyncType: DashboardPostsSyncManager.PostType?
-    var postsSynced: [AbstractPost]?
-    var statusesSynced: [String]?
+    var statusesSynced: [BasePost.Status]?
 
     func postsSynced(success: Bool,
                      blog: Blog,
                      postType: DashboardPostsSyncManager.PostType,
-                     posts: [AbstractPost]?,
-                     for statuses: [String]) {
+                     for statuses: [BasePost.Status]) {
         self.postsSyncedCalled = true
         self.postsSyncSuccess = success
         self.postsSyncBlog = blog
         self.postsSyncType = postType
-        self.postsSynced = posts
         self.statusesSynced = statuses
     }
 }


### PR DESCRIPTION
## Description

There are two `DashboardPostsSyncManagerListener` changes in this PR:
1. Declare the status properties (and the call sites) as `BasePost.Status`, instead of `String`. In general, I think it's better to use specialized type instead of a generic string type which can be any random text.
2. Remove the `posts` argument—which isn't used anywhere—from the listener function.

The motivation of these changes is: I'm refactoring loading posts/pages list, and these two changes could avoid some unnecessary code in my refactor.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A