### PR TITLE
Allow setting the app as JP or WP when testing `DashboardCard`

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -92,7 +92,11 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil) -> Bool {
+    func shouldShow(
+        for blog: Blog,
+        apiResponse: BlogDashboardRemoteEntity? = nil,
+        isJetpack: Bool = AppConfiguration.isJetpack
+    ) -> Bool {
         switch self {
         case .jetpackInstall:
             return JetpackInstallPluginHelper.shouldShowCard(for: blog)
@@ -127,7 +131,7 @@ enum DashboardCard: String, CaseIterable {
         case .jetpackSocial:
             return DashboardJetpackSocialCardCell.shouldShowCard(for: blog)
         case .googleDomains:
-            return FeatureFlag.domainFocus.enabled && AppConfiguration.isJetpack
+            return FeatureFlag.domainFocus.enabled && isJetpack
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -7,12 +7,17 @@ final class BlogDashboardService {
     private let persistence: BlogDashboardPersistence
     private let postsParser: BlogDashboardPostsParser
     private let repository: UserPersistentRepository
+    private let isJetpack: Bool
 
-    init(managedObjectContext: NSManagedObjectContext,
-         remoteService: DashboardServiceRemote? = nil,
-         persistence: BlogDashboardPersistence = BlogDashboardPersistence(),
-         repository: UserPersistentRepository = UserDefaults.standard,
-         postsParser: BlogDashboardPostsParser? = nil) {
+    init(
+        managedObjectContext: NSManagedObjectContext,
+        isJetpack: Bool,
+        remoteService: DashboardServiceRemote? = nil,
+        persistence: BlogDashboardPersistence = BlogDashboardPersistence(),
+        repository: UserPersistentRepository = UserDefaults.standard,
+        postsParser: BlogDashboardPostsParser? = nil
+    ) {
+        self.isJetpack = isJetpack
         self.remoteService = remoteService ?? DashboardServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
         self.persistence = persistence
         self.repository = repository
@@ -88,7 +93,7 @@ private extension BlogDashboardService {
         let personalizationService = BlogDashboardPersonalizationService(repository: repository, siteID: dotComID)
         var cards: [DashboardCardModel] = DashboardCard.allCases.compactMap { card in
             guard personalizationService.isEnabled(card),
-                  card.shouldShow(for: blog, apiResponse: entity) else {
+                  card.shouldShow(for: blog, apiResponse: entity, isJetpack: isJetpack) else {
                 return nil
             }
             return DashboardCardModel(cardType: card, dotComID: dotComID, entity: entity)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -41,7 +41,7 @@ final class BlogDashboardViewModel {
     }()
 
     private lazy var service: BlogDashboardService = {
-        return BlogDashboardService(managedObjectContext: managedObjectContext)
+        return BlogDashboardService(managedObjectContext: managedObjectContext, isJetpack: AppConfiguration.isJetpack)
     }()
 
     private lazy var dataSource: DashboardDataSource? = {

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -63,7 +63,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     func testCallServiceWithCorrectIDAndCards() {
         let expect = expectation(description: "Request the correct ID")
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { _ in
             XCTAssertEqual(self.remoteServiceMock.didCallWithBlogID, self.wpComID)
@@ -135,7 +135,10 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     func testActivityLog() {
         let expect = expectation(description: "Parse activities")
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        // Will fail with logged in user.
+        //
+        // It happens because for some reason the logic that should add activity as one of the type of cards to fetch doesn't do that.
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { cards in
             guard let activityCardItem = cards.first(where: {$0.cardType == .activityLog}) else {
@@ -175,7 +178,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         let expect = expectation(description: "Parse todays stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { cards in
             let todaysStatsItem = cards.first(where: {$0.cardType == .todaysStats})
@@ -242,7 +245,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         let expect = expectation(description: "Parse todays stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { cards in
             // Then it's still disabled for other sites
@@ -408,7 +411,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         return try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
     }
 
-    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true, loggedIn: Bool = false) -> Blog {
+    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true, loggedIn: Bool = true) -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
 
         blog.dotComID = id as NSNumber

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -138,13 +138,32 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         let blog = newTestBlog(id: wpComID, context: mainContext)
 
         service.fetch(blog: blog) { cards in
-            let activityCardItem = cards.first(where: {$0.cardType == .activityLog})
+            guard let activityCardItem = cards.first(where: {$0.cardType == .activityLog}) else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
 
-            // Activity section exists
-            XCTAssertNotNil(activityCardItem)
+            guard let apiResponse = activityCardItem.apiResponse else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let activity = apiResponse.activity else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let value = activity.value else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let current = value.current else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let orderedItems = current.orderedItems else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
 
             // 2 activity items
-            XCTAssertEqual(activityCardItem!.apiResponse!.activity!.value!.current!.orderedItems!.count, 2)
+            XCTAssertEqual(orderedItems.count, 2)
 
             expect.fulfill()
         }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -15,6 +15,17 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
     private let wpComID = 123456
 
+    // FIXME: Accessing WPAccount wordPressComRestApi will crash if WordPressAuthenticationManager has not been initialized!
+    //
+    // This issue doesn't manifest itself when running the whole test suite beceause of the lucky coincidence that a test running before this one sets it up.
+    // But try to comment this class setUp method and run only this test case and you'll get a crash.
+    override class func setUp() {
+        WordPressAuthenticationManager(
+            windowManager: WindowManager(window: UIWindow()),
+            remoteFeaturesStore: RemoteFeatureFlagStore()
+        ).initializeWordPressAuthenticator()
+    }
+
     override func setUp() {
         super.setUp()
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -408,10 +408,20 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         return try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
     }
 
-    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true) -> Blog {
+    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true, loggedIn: Bool = false) -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
+
         blog.dotComID = id as NSNumber
+
+        // Some tests fail when the account associated to the blog is the default account.
+        //
+        // See https://github.com/wordpress-mobile/WordPress-iOS/pull/21796#issuecomment-1767273816
+        if loggedIn {
+            blog.account = try! WPAccount.lookupDefaultWordPressComAccount(in: mainContext)
+        }
+        // FIXME: There is a possible inconsistency here because in production the isAdmin value depends on the account, but here the two can go out of sync
         blog.isAdmin = isAdmin
+
         return blog
     }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -22,7 +22,18 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         persistenceMock = BlogDashboardPersistenceMock()
         repositoryMock = InMemoryUserDefaults()
         postsParserMock = BlogDashboardPostsParserMock(managedObjectContext: mainContext)
-        service = BlogDashboardService(managedObjectContext: mainContext, remoteService: remoteServiceMock, persistence: persistenceMock, repository: repositoryMock, postsParser: postsParserMock)
+        service = BlogDashboardService(
+            managedObjectContext: mainContext,
+            // At the time of writing, tests will fail when the service (DashboardCard under the hood)
+            // is running "as if in Jetpack".
+            //
+            // See https://github.com/wordpress-mobile/WordPress-iOS/pull/21740
+            isJetpack: false,
+            remoteService: remoteServiceMock,
+            persistence: persistenceMock,
+            repository: repositoryMock,
+            postsParser: postsParserMock
+        )
 
         try? featureFlags.override(FeatureFlag.personalizeHomeTab, withValue: true)
         try? featureFlags.override(RemoteFeatureFlag.activityLogDashboardCard, withValue: true)


### PR DESCRIPTION
This is a followup on @crazytonyli 's suggestion from https://github.com/wordpress-mobile/WordPress-iOS/pull/21740#issuecomment-1763511609

It was just a low hanging fruit, that I couldn't resist taking a crack.

I'm not sure where this sits in the broader unit tests conversation that this spun off from. Is it a bandaid or the beginning of a systemic solution? I'm not sure yet, I haven't thought about it long enough.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.