### PR TITLE
Reader Detail: Dispatch header layoutIfNeeded on main queue

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -60,8 +60,11 @@ class ReaderDetailNewHeaderViewHost: UIView {
         guard let swiftUIView = subviews.first else {
             return
         }
-        swiftUIView.invalidateIntrinsicContentSize()
-        layoutIfNeeded()
+
+        DispatchQueue.main.async {
+            swiftUIView.invalidateIntrinsicContentSize()
+            self.layoutIfNeeded()
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #21797 

This (hopefully) fixes an intermittent issue where the header can appear to overlap with the contents sometimes. See #21797 for more details. I'm guessing that some sort of race might be happening here. Even though the GeometryReader has triggered its `onChange` closure, the view might not be done updating its content size yet, and the host view calls `layoutIfNeeded` before the changes are fully applied.

<img width="332" alt="Screenshot 2023-10-17 at 18 07 00" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/7c3d5820-9fa4-4e59-8d33-23be77a8ff12">


The view highlighted in blue is the swiftUI's host view. As you can see, the SwiftUI view (right in front of the highlighted view) already has its content size updated, but the host view is still using the "old" size somehow.

To fix this, I simply dispatched the `layoutIfNeeded` call to the main queue. I no longer see this issue after retrying it 10-20 times.

## To test

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
