### PR TITLE
Posts & Pages: Remove cell switcher from Posts List screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -167,12 +167,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: ActivityListSectionHeaderView.identifier)
     }
 
-    override func configureGhostableTableView() {
-        super.configureGhostableTableView()
-
-        ghostingEnabled = true
-    }
-
     private func configureInitialFilterIfNeeded() {
         guard let initialFilterWithPostStatus = initialFilterWithPostStatus else {
             return

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -158,6 +158,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         let bundle = Bundle.main
 
         // Register the cells
+        tableView.register(PostListCell.self, forCellReuseIdentifier: PostListCell.defaultReuseID)
 
         let postCardRestoreCellNib = UINib(nibName: postCardRestoreCellNibName, bundle: bundle)
         tableView.register(postCardRestoreCellNib, forCellReuseIdentifier: postCardRestoreCellIdentifier)
@@ -306,18 +307,22 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let post = postAtIndexPath(indexPath)
 
-        guard let interactivePostView = cell as? InteractivePostView,
-            let configurablePostView = cell as? ConfigurablePostView else {
-                fatalError("Cell does not implement the required protocols")
+//        TODO: Remove later
+//        guard let interactivePostView = cell as? InteractivePostView,
+//            let configurablePostView = cell as? ConfigurablePostView else {
+//                fatalError("Cell does not implement the required protocols")
+//        }
+//
+//        interactivePostView.setInteractionDelegate(self)
+//        interactivePostView.setActionSheetDelegate(self)
+//
+//        configurablePostView.configure(with: post)
+
+        // TODO: Hide author if only showing my posts?
+        guard let cell = cell as? PostListCell else {
+            return
         }
-
-        interactivePostView.setInteractionDelegate(self)
-        interactivePostView.setActionSheetDelegate(self)
-
-        configurablePostView.configure(with: post)
-
-        configurePostCell(cell)
-        configureRestoreCell(cell)
+        cell.configure(with: PostListItemViewModel(post: post))
     }
 
     fileprivate func cellIdentifierForPost(_ post: Post) -> String {
@@ -326,26 +331,10 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         if recentlyTrashedPostObjectIDs.contains(post.objectID) == true && filterSettings.currentPostListFilter().filterType != .trashed {
             identifier = postCardRestoreCellIdentifier
         } else {
-            identifier = postCellIdentifier
+            identifier = PostListCell.defaultReuseID
         }
 
         return identifier
-    }
-
-    private func configurePostCell(_ cell: UITableViewCell) {
-        guard let cell = cell as? PostCardCell else {
-            return
-        }
-
-        cell.shouldHideAuthor = showingJustMyPosts
-    }
-
-    private func configureRestoreCell(_ cell: UITableViewCell) {
-        guard let cell = cell as? RestorePostTableViewCell else {
-            return
-        }
-
-        cell.isCompact = isCompact
     }
 
     // MARK: - Post Actions

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
@@ -13,11 +13,6 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
 
     private weak var delegate: InteractivePostViewDelegate?
 
-    var isCompact: Bool = false {
-        didSet {
-            isCompact ? configureCompact() : configureDefault()
-        }
-    }
     var post: Post?
 
     func configure(with post: Post) {
@@ -45,14 +40,7 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
         restoreButton.setTitle(buttonTitle, for: .normal)
         restoreButton.setImage(.gridicon(.undo, size: CGSize(width: Constants.imageSize,
                                                              height: Constants.imageSize)), for: .normal)
-    }
 
-    private func configureCompact() {
-        topMargin.constant = Constants.compactMargin
-        postContentView.layer.borderWidth = 0
-    }
-
-    private func configureDefault() {
         topMargin.constant = Constants.defaultMargin
         postContentView.layer.borderColor = WPStyleGuide.postCardBorderColor.cgColor
         postContentView.layer.borderWidth = .hairlineBorderWidth
@@ -82,7 +70,6 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
 
     private enum Constants {
         static let defaultMargin: CGFloat = 16
-        static let compactMargin: CGFloat = 0
         static let imageSize: CGFloat = 18.0
     }
 }

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PostListViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PostListViewControllerTests.swift
@@ -6,36 +6,6 @@ import Nimble
 
 class PostListViewControllerTests: CoreDataTestCase {
 
-    func testShowsGhostableTableView() {
-        let blog = BlogBuilder(mainContext).build()
-        let postListViewController = PostListViewController.controllerWithBlog(blog)
-        let _ = postListViewController.view
-
-        postListViewController.startGhost()
-
-        expect(postListViewController.ghostableTableView.isHidden).to(beFalse())
-    }
-
-    func testHidesGhostableTableView() {
-        let blog = BlogBuilder(mainContext).build()
-        let postListViewController = PostListViewController.controllerWithBlog(blog)
-        let _ = postListViewController.view
-
-        postListViewController.stopGhost()
-
-        expect(postListViewController.ghostableTableView.isHidden).to(beTrue())
-    }
-
-    func testShowTenMockedItemsInGhostableTableView() {
-        let blog = BlogBuilder(mainContext).build()
-        let postListViewController = PostListViewController.controllerWithBlog(blog)
-        let _ = postListViewController.view
-
-        postListViewController.startGhost()
-
-        expect(postListViewController.ghostableTableView.numberOfRows(inSection: 0)).to(equal(50))
-    }
-
     func testItCanHandleNewPostUpdatesEvenIfTheGhostViewIsStillVisible() throws {
         // This test simulates and proves that the app will no longer crash on these conditions:
         //


### PR DESCRIPTION
Part of #21712 

## Description
- Removes cell switcher
- Removes ghost table view
- Registers and displays new cell design

## How to test
- Go to the posts lists screen
- Verify the cell switcher isn't displayed

## Regression Notes
1. Potential unintended areas of impact
Post list screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
