### PR TITLE
Reader: Hide like/comment label when at zero

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCellViewModel.swift
@@ -55,18 +55,20 @@ struct ReaderPostCardCellViewModel {
     }
 
     var commentCount: String? {
-        guard isCommentsEnabled else {
+        guard isCommentsEnabled,
+              let count = contentProvider.commentCount()?.intValue,
+              count > 0 else {
             return nil
         }
-        let count = contentProvider.commentCount()?.intValue ?? 0
         return WPStyleGuide.commentCountForDisplay(count)
     }
 
     var likeCount: String? {
-        guard isLikesEnabled else {
+        guard isLikesEnabled,
+              let count = contentProvider.likeCount()?.intValue,
+              count > 0 else {
             return nil
         }
-        let count = contentProvider.likeCount()?.intValue ?? 0
         return WPStyleGuide.likeCountForDisplay(count)
     }
 


### PR DESCRIPTION
Fixes #21807 

## Description

Hides the like and comment labels when they're at zero, respectively.

## Testing

To test:
- Launch Jetpack and login
- Tap on Reader
- Scroll through any of the feeds and 🔎 **verify** no cards contain either `0 Likes` or `0 Comments`
- Like and/or comment on a post without any likes/comments
- 🔎 **Verify** the card properly updates and shows either `1 Like`/`1 Comment`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
