### PR TITLE
Reader: Follow button fixes

### DIFF
--- a/WordPress/Classes/Extensions/Font/UIConfigurationTextAttributesTransformer+Font.swift
+++ b/WordPress/Classes/Extensions/Font/UIConfigurationTextAttributesTransformer+Font.swift
@@ -1,0 +1,13 @@
+
+extension UIConfigurationTextAttributesTransformer {
+
+    /// Instance method that sets the font on the ``AttributeContainer``
+    static func transformer(with font: UIFont) -> UIConfigurationTextAttributesTransformer {
+        return UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = font
+            return outgoing
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -237,7 +237,8 @@ struct ReaderDetailNewHeaderView: View {
             authorStack
             Spacer()
             ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
-                               isEnabled: viewModel.isFollowButtonInteractive) {
+                               isEnabled: viewModel.isFollowButtonInteractive,
+                               size: .compact) {
                 viewModel.didTapFollowButton()
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
@@ -4,7 +4,13 @@ struct ReaderFollowButton: View {
 
     let isFollowing: Bool
     let isEnabled: Bool
+    let size: ButtonSize
     let action: () -> Void
+
+    enum ButtonSize {
+        case compact
+        case regular
+    }
 
     var body: some View {
         if isFollowing {
@@ -29,7 +35,7 @@ struct ReaderFollowButton: View {
                 .font(.subheadline)
         }
         .disabled(!isEnabled)
-        .padding(.horizontal, 24.0)
+        .padding(.horizontal, size == .compact ? 16.0 : 24.0)
         .padding(.vertical, 8.0)
         .background(backgroundColor)
         .cornerRadius(5.0)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -330,8 +330,9 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
     private func followButton(title: String) -> UIButton {
         if RemoteFeatureFlag.readerImprovements.enabled() {
             let button = UIButton()
+            let contentInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 16.0, bottom: 8.0, trailing: 16.0)
             button.isSelected = true
-            WPStyleGuide.applyReaderFollowButtonStyle(button)
+            WPStyleGuide.applyNewReaderFollowButtonStyle(button, contentInsets: contentInsets)
             button.tintColor = .clear
             button.sizeToFit()
             return button

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.swift
@@ -96,11 +96,20 @@ class ReaderRecommendedSiteCardCell: UITableViewCell {
     }
 
     private func applyFollowButtonStyles() {
+        guard !RemoteFeatureFlag.readerImprovements.enabled() else {
+            applyNewFollowButtonStyles()
+            return
+        }
         if UIDevice.current.userInterfaceIdiom == .pad {
             WPStyleGuide.applyReaderFollowButtonStyle(followButton)
         } else {
             WPStyleGuide.applyReaderIconFollowButtonStyle(followButton)
         }
+    }
+
+    private func applyNewFollowButtonStyles() {
+        let contentInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 16.0, bottom: 8.0, trailing: 16.0)
+        WPStyleGuide.applyNewReaderFollowButtonStyle(followButton, contentInsets: contentInsets)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -88,7 +88,8 @@ struct ReaderSiteHeader: View {
             countsDisplay
             if !viewModel.isFollowHidden {
                 ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
-                                   isEnabled: viewModel.isFollowEnabled) {
+                                   isEnabled: viewModel.isFollowEnabled,
+                                   size: .regular) {
                     viewModel.updateFollowStatus()
                 }
             }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -329,7 +329,8 @@ extension WPStyleGuide {
         applyCommonReaderFollowButtonStyles(button)
     }
 
-    public class func applyNewReaderFollowButtonStyle(_ button: UIButton) {
+    public class func applyNewReaderFollowButtonStyle(_ button: UIButton,
+                                                      contentInsets: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 24.0, bottom: 8.0, trailing: 24.0)) {
         let font: UIFont = .preferredFont(forTextStyle: .subheadline)
         button.setTitleColor(.invertedLabel, for: .normal)
         button.setTitleColor(.secondaryLabel, for: .selected)
@@ -340,7 +341,7 @@ extension WPStyleGuide {
         button.tintColor = .clear
 
         button.configuration = .plain()
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 24.0, bottom: 8.0, trailing: 24.0)
+        button.configuration?.contentInsets = contentInsets
         button.configuration?.titleTextAttributesTransformer = .transformer(with: font)
         applyCommonReaderFollowButtonStyles(button)
     }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -330,16 +330,18 @@ extension WPStyleGuide {
     }
 
     public class func applyNewReaderFollowButtonStyle(_ button: UIButton) {
+        let font: UIFont = .preferredFont(forTextStyle: .subheadline)
         button.setTitleColor(.invertedLabel, for: .normal)
         button.setTitleColor(.secondaryLabel, for: .selected)
         button.backgroundColor = button.isSelected ? .clear : .label
         button.layer.borderColor = UIColor.separator.cgColor
         button.layer.cornerRadius = 5.0
-        button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
+        button.titleLabel?.font = font
         button.tintColor = .clear
 
         button.configuration = .plain()
         button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 24.0, bottom: 8.0, trailing: 24.0)
+        button.configuration?.titleTextAttributesTransformer = .transformer(with: font)
         applyCommonReaderFollowButtonStyles(button)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2056,6 +2056,8 @@
 		8320BDE5283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8320BDE6283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8323789928526E6E003F4443 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
+		8332D7452ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */; };
+		8332D7462ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */; };
 		8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
 		8332DD2529259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
 		8332DD2829259BEB00802F7D /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2729259BEB00802F7D /* DataMigratorTests.swift */; };
@@ -7424,6 +7426,7 @@
 		8313B9F92995A03C000AF26E /* JetpackRemoteInstallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRemoteInstallCardView.swift; sourceTree = "<group>"; };
 		83204EDB2ACE098B000C3229 /* ReaderPostCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellViewModel.swift; sourceTree = "<group>"; };
 		8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogService+BloggingPrompts.swift"; sourceTree = "<group>"; };
+		8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfigurationTextAttributesTransformer+Font.swift"; sourceTree = "<group>"; };
 		8332DD2329259AE300802F7D /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		8332DD2729259BEB00802F7D /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
@@ -17232,8 +17235,9 @@
 		F407AF1529BA835B008BA5B9 /* Font */ = {
 			isa = PBXGroup;
 			children = (
-				17C3FA6E25E591D200EFFE12 /* UIFont+Weight.swift */,
+				8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */,
 				17C1D6902670E4A2006C8970 /* UIFont+Fitting.swift */,
+				17C3FA6E25E591D200EFFE12 /* UIFont+Weight.swift */,
 			);
 			path = Font;
 			sourceTree = "<group>";
@@ -21240,6 +21244,7 @@
 				C3E2462926277B7700B99EA6 /* PostAuthorSelectorViewController.swift in Sources */,
 				F5E032E62408D537003AF350 /* ActionSheetViewController.swift in Sources */,
 				9A4F8F56218B88E000EEDCCC /* PostService+Revisions.swift in Sources */,
+				8332D7452ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */,
 				3F73388226C1CE9B0075D1DD /* TimeSelectionButton.swift in Sources */,
 				5DED0E181B432E0400431FCD /* SourcePostAttribution.m in Sources */,
 				1715179420F4B5CD002C4A38 /* MySitesCoordinator.swift in Sources */,
@@ -24787,6 +24792,7 @@
 				FABB23E52602FC2C00C8785C /* EditorMediaUtility.swift in Sources */,
 				FABB23E62602FC2C00C8785C /* ShareMediaFileManager.swift in Sources */,
 				FABB23E82602FC2C00C8785C /* ReaderCoordinator.swift in Sources */,
+				8332D7462ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */,
 				FABB23E92602FC2C00C8785C /* RestoreCompleteView.swift in Sources */,
 				FABB23EA2602FC2C00C8785C /* NoteBlockImageTableViewCell.swift in Sources */,
 				FABB23EB2602FC2C00C8785C /* PostCategoryService.m in Sources */,


### PR DESCRIPTION
Fixes #21809

## Description

- Fixes the font not being set on the follow buttons
- Reduces the content inset of the follow button on the followed sites list

## Testing

To test:
- Launch Jetpack and login
- Tap on Reader
- Tap on `Discover`
- Scroll down until you see a `Sites to follow` cell
- 🔎 **Verify** the `Follow` text is using the 15pt font size
- Tap on the manage icon in the top right
- Tap on `Followed Sites`
- 🔎 **Verify** the leading and trailing content insets are reduced to 16pt each

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
