### PR TITLE
Reader: Recommendation card design fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -121,7 +121,8 @@ class ReaderTopicsTableCardCell: UITableViewCell {
         static let containerInsets = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
         static let newContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         static let headerInsets = UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 0)
-        static let newHeaderInsets = UIEdgeInsets(top: 16, left: 16, bottom: 0, right: 0)
+        static let newHeaderInsets = UIEdgeInsets(top: 8, left: 16, bottom: 0, right: 0)
+        static let tableFooterHeight: CGFloat = 8.0
     }
 }
 
@@ -144,7 +145,7 @@ extension ReaderTopicsTableCardCell: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return RemoteFeatureFlag.readerImprovements.enabled() ? 16 : 0
+        return readerImprovements ? Constants.tableFooterHeight : 0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -233,11 +233,18 @@ class ReaderTopicCardCollectionViewCell: UICollectionViewCell, ReusableCell {
         contentView.backgroundColor = .clear
         contentView.layer.cornerRadius = 5.0
         contentView.layer.borderWidth = 1.0
-        contentView.layer.borderColor = UIColor.separator.cgColor
+        contentView.layer.borderColor = UIColor(light: .separator, dark: Constants.darkModeSeparatorColor).cgColor
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private struct Constants {
+        // This is a customized `.separator` color with the alpha updated to 1.0.
+        // With the default color on top of the gray background, the border appears almost invisible on certain devices.
+        // More context: p1697541472738849-slack-C05N140C8H5
+        static let darkModeSeparatorColor = UIColor(red: 0.33, green: 0.33, blue: 0.35, alpha: 1.0)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -61,7 +61,6 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
         contentView.backgroundColor = usesNewDesign ? .systemBackground : .listForeground
     }
 
-
     /// Configures the cell and the collection view for the new design.
     private func configureForNewDesign() {
         // set up custom collection view flow layout
@@ -230,14 +229,27 @@ class ReaderTopicCardCollectionViewCell: UICollectionViewCell, ReusableCell {
         contentView.addSubview(titleLabel)
         contentView.pinSubviewToAllEdges(titleLabel, insets: .init(top: 8.0, left: 16.0, bottom: 8.0, right: 16.0))
 
-        contentView.backgroundColor = .clear
         contentView.layer.cornerRadius = 5.0
         contentView.layer.borderWidth = 1.0
-        contentView.layer.borderColor = UIColor(light: .separator, dark: Constants.darkModeSeparatorColor).cgColor
+        updateColors()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if let previousTraitCollection,
+           traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            updateColors()
+        }
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func updateColors() {
+        contentView.backgroundColor = .clear
+        contentView.layer.borderColor = UIColor(light: .separator, dark: Constants.darkModeSeparatorColor).cgColor
     }
 
     private struct Constants {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsNewCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsNewCardCell.xib
@@ -24,13 +24,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="428" height="118"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Header Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="452-xW-WjN">
-                                        <rect key="frame" x="12" y="8" width="404" height="32"/>
+                                        <rect key="frame" x="16" y="8" width="396" height="32"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="251" scrollEnabled="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="3Vw-yu-3oz" customClass="DynamicHeightCollectionView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="12" y="52" width="404" height="50"/>
+                                        <rect key="frame" x="16" y="52" width="396" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="tDm-cO-RQC"/>
@@ -47,7 +47,7 @@
                                         </connections>
                                     </collectionView>
                                 </subviews>
-                                <edgeInsets key="layoutMargins" top="8" left="12" bottom="16" right="12"/>
+                                <edgeInsets key="layoutMargins" top="8" left="16" bottom="16" right="16"/>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsNewCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsNewCardCell.xib
@@ -10,30 +10,30 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="168" id="IA3-Z8-bh4" userLabel="Reader Topics New Card Cell" customClass="ReaderTopicsCardCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="460" height="168"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="150" id="IA3-Z8-bh4" userLabel="Reader Topics New Card Cell" customClass="ReaderTopicsCardCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="460" height="150"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IA3-Z8-bh4" id="W1C-lC-x4W">
-                <rect key="frame" x="0.0" y="0.0" width="460" height="168"/>
+                <rect key="frame" x="0.0" y="0.0" width="460" height="150"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" verticalHuggingPriority="750" verticalCompressionResistancePriority="751" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QtT-ep-Eo1">
-                        <rect key="frame" x="16" y="16" width="428" height="136"/>
+                        <rect key="frame" x="16" y="16" width="428" height="118"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="BFW-y7-Haz">
-                                <rect key="frame" x="0.0" y="0.0" width="428" height="136"/>
+                                <rect key="frame" x="0.0" y="0.0" width="428" height="118"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Header Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="452-xW-WjN">
-                                        <rect key="frame" x="12" y="8" width="404" height="50"/>
+                                        <rect key="frame" x="12" y="8" width="404" height="32"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="251" scrollEnabled="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="3Vw-yu-3oz" customClass="DynamicHeightCollectionView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="12" y="70" width="404" height="50"/>
+                                        <rect key="frame" x="12" y="52" width="404" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="tDm-cO-RQC"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="tDm-cO-RQC"/>
                                         </constraints>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="nXm-pz-kEj">
                                             <size key="itemSize" width="128" height="128"/>
@@ -71,7 +71,7 @@
                 <outlet property="containerView" destination="QtT-ep-Eo1" id="hAl-Pg-yra"/>
                 <outlet property="headerLabel" destination="452-xW-WjN" id="fnu-nh-fsg"/>
             </connections>
-            <point key="canvasLocation" x="-720.61068702290072" y="-148.59154929577466"/>
+            <point key="canvasLocation" x="-720.61068702290072" y="-154.92957746478874"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsNewCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsNewCardCell.xib
@@ -33,7 +33,7 @@
                                         <rect key="frame" x="16" y="52" width="396" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="30" id="tDm-cO-RQC"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="tDm-cO-RQC"/>
                                         </constraints>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="nXm-pz-kEj">
                                             <size key="itemSize" width="128" height="128"/>


### PR DESCRIPTION
Refs p1697541472738849-slack-C05N140C8H5

- Updated the tags' border color to #545458 with 1.0 alpha. The hex value practically matches `UIColor.separator`, but the alpha component is updated to 1.0.
- Removed extra bottom padding when the tags are just occupying one line.
- Updated the horizontal content padding of the card from 12pt to 16pt.

Previews:

Tags | Sites
-|-
<img width="462" alt="Screenshot 2023-10-18 at 16 50 24" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f46dd991-91ca-4c9d-bd40-12a9cd05018f"> | <img width="382" alt="Screenshot 2023-10-18 at 17 07 09" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/500a9ce7-2dc4-423b-928f-8a54f733b717">

Note: the Follow button fixes are being done separately in #21810.

## To test

- Launch the Jetpack app.
- Navigate to Reader > Discover.
- 🔎 Verify that the tags' border color is visible.
- Try to look for a tag recommendation card where the tags are only occupying one line.
- 🔎 Verify that the extra bottom padding is removed.
- Look for a site recommendation card.
- 🔎 Verify that the card's padding is updated.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)