### PR TITLE
Reader: Update scroll-to-top behavior

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -804,13 +804,18 @@ import Combine
         tableView.tableHeaderView = headerView
     }
 
-
     /// Scrolls to the top of the list of posts.
-    ///
     @objc func scrollViewToTop() {
-        tableView.setContentOffset(.zero, animated: true)
-    }
+        guard RemoteFeatureFlag.readerImprovements.enabled(),
+              tableView.numberOfRows(inSection: .zero) > 0 else {
+            tableView.setContentOffset(.zero, animated: true)
+            return
+        }
 
+        /// `scrollToRow` somehow works better when the first cell has dynamic height. With `setContentOffset`,
+        /// sometimes it doesn't perfectly scroll to the top, thus making the top cell appear clipped.
+        tableView.scrollToRow(at: IndexPath(row: .zero, section: .zero), at: .top, animated: true)
+    }
 
     /// Returns the analytics property dictionary for the current topic.
     private func topicPropertyForStats() -> [AnyHashable: Any]? {


### PR DESCRIPTION
Fixes #21800
Depends on #21815

I've found a way to reproduce #21800 consistently. 

- You need to start with a tag list that only occupies one line. Keep refreshing the Discover tab until you get one that's configured as such. 
- Then, keep scrolling down until you find another tag list recommendation that wraps into a new line (thus increasing the cell height).
- Once you have the new tag list in view, press the Reader tab to trigger scroll to top.
- Observe that it doesn't fully scroll to top, thus making the first tag list cell appear clipped.

This fixes the issue by updating the `scrollViewToTop` method in `ReaderStreamViewController`. I found that somehow `tableView.scrollToRow` works as intended compared to `setContentOffset` when dealing with dynamic height cells.

In the previous implementation, the tag recommendation card flows horizontally with a horizontal scroll, so the height is static regardless of its contents. This likely explains why `setContentOffset` works well for that case.

## To test

- Follow the reproduction steps above.
- 🔎 Verify that the scroll-to-top behaves correctly: the tag recommendation cell at the top does not appear clipped.
- 🔎 Test the scroll-to-top behavior in other Reader tabs: Following, Likes, Saved, etc., and make sure nothing is wrong.

## Regression Notes
1. Potential unintended areas of impact
There could be some unexpected "scroll to top" behavior since I changed the method. However, the method is wrapped with a remote feature flag, so we can disable it remotely if anything goes terribly wrong

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes in all the other Reader tabs.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
