### PR TITLE
Posts & Pages: Update image placeholder to use solid color

### DIFF
--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -32,7 +32,7 @@ import AutomatticTracks
     // MARK: Private Fields
 
     private unowned let imageView: CachedAnimatedImageView
-    private let loadingIndicator: CircularProgressView
+    private let loadingIndicator: ActivityIndicatorType
 
     private var successHandler: ImageLoaderSuccessBlock?
     private var errorHandler: ImageLoaderFailureBlock?
@@ -47,16 +47,27 @@ import AutomatticTracks
         return requestOptions
     }()
 
-    @objc init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs) {
+    @objc convenience init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs) {
+        self.init(imageView: imageView, gifStrategy: gifStrategy, loadingIndicator: nil)
+    }
+
+    init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs, loadingIndicator: ActivityIndicatorType?) {
         self.imageView = imageView
         imageView.gifStrategy = gifStrategy
-        loadingIndicator = CircularProgressView(style: .primary)
+
+        if let loadingIndicator {
+            self.loadingIndicator = loadingIndicator
+        } else {
+            let loadingIndicator = CircularProgressView(style: .primary)
+            WPStyleGuide.styleProgressViewWhite(loadingIndicator)
+            self.loadingIndicator = loadingIndicator
+        }
 
         super.init()
 
-        WPStyleGuide.styleProgressViewWhite(loadingIndicator)
-        imageView.addLoadingIndicator(loadingIndicator, style: .fullView)
+        imageView.addLoadingIndicator(self.loadingIndicator, style: .fullView)
     }
+
 
     /// Removes the gif animation and prevents it from animate again.
     /// Call this in a table/collection cell's `prepareForReuse()`.
@@ -298,7 +309,7 @@ import AutomatticTracks
             }
 
             if self.imageView.shouldShowLoadingIndicator {
-                self.loadingIndicator.state = .error
+                (self.loadingIndicator as? CircularProgressView)?.state = .error
             }
 
             self.errorHandler?(error)

--- a/WordPress/Classes/ViewRelated/Media/SolidColorActivityIndicator.swift
+++ b/WordPress/Classes/ViewRelated/Media/SolidColorActivityIndicator.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+final class SolidColorActivityIndicator: UIView, ActivityIndicatorType {
+    init(color: UIColor = .secondarySystemBackground) {
+        super.init(frame: .zero)
+        backgroundColor = color
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func startAnimating() {
+        isHidden = false
+    }
+
+    func stopAnimating() {
+        isHidden = true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -24,7 +24,7 @@ final class PostListCell: UITableViewCell, Reusable {
 
     // MARK: - Properties
 
-    private lazy var imageLoader = ImageLoader(imageView: featuredImageView)
+    private lazy var imageLoader = ImageLoader(imageView: featuredImageView, loadingIndicator: SolidColorActivityIndicator())
 
     // MARK: - Initializers
 
@@ -50,8 +50,7 @@ final class PostListCell: UITableViewCell, Reusable {
             let host = MediaHost(with: viewModel.post) { error in
                 WordPressAppDelegate.crashLogging?.logError(error)
             }
-            let preferredSize = CGSize(width: 44, height: 44)
-            imageLoader.loadImage(with: imageURL, from: host, preferredSize: preferredSize)
+            imageLoader.loadImage(with: imageURL, from: host, preferredSize: Constants.imageSize)
         }
 
         statusLabel.text = viewModel.status
@@ -126,8 +125,8 @@ final class PostListCell: UITableViewCell, Reusable {
         featuredImageView.layer.cornerRadius = 5
 
         NSLayoutConstraint.activate([
-            featuredImageView.widthAnchor.constraint(equalToConstant: 64),
-            featuredImageView.heightAnchor.constraint(equalToConstant: 64),
+            featuredImageView.widthAnchor.constraint(equalToConstant: Constants.imageSize.width),
+            featuredImageView.heightAnchor.constraint(equalToConstant: Constants.imageSize.height),
         ])
     }
 
@@ -137,4 +136,8 @@ final class PostListCell: UITableViewCell, Reusable {
         statusLabel.numberOfLines = 1
         statusLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
     }
+}
+
+private enum Constants {
+    static let imageSize = CGSize(width: 64, height: 64)
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -472,6 +472,8 @@
 		0CB4057A29C8DDEE008EED0A /* BlogDashboardPersonalizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */; };
 		0CB4057D29C8DF83008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
 		0CB4057E29C8DF84008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
+		0CB424F62AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
+		0CB424F72AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
 		0CD223DF2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */; };
 		0CD223E02AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */; };
 		0CD382832A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */; };
@@ -6146,6 +6148,7 @@
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
 		0CB4057229C8DD01008EED0A /* BlogDashboardPersonalizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationView.swift; sourceTree = "<group>"; };
 		0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizeCardCell.swift; sourceTree = "<group>"; };
+		0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidColorActivityIndicator.swift; sourceTree = "<group>"; };
 		0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionsViewModel.swift; sourceTree = "<group>"; };
 		0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModel.swift; sourceTree = "<group>"; };
 		0CD382852A4B6FCE00612173 /* DashboardBlazeCardCellViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModelTest.swift; sourceTree = "<group>"; };
@@ -12479,6 +12482,7 @@
 				D8A3A5AD206A059100992576 /* StockPhotos */,
 				FF8A04DF1D9BFE7400523BC4 /* CachedAnimatedImageView.swift */,
 				7435CE7220A4B9170075A1B9 /* AnimatedImageCache.swift */,
+				0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */,
 				0C7073942A65CB2E00F325CE /* MemoryCache.swift */,
 				B5FF3BE61CAD881100C1D597 /* ImageCropOverlayView.swift */,
 				B5A05AD81CA48601002EC787 /* ImageCropViewController.swift */,
@@ -22666,6 +22670,7 @@
 				FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */,
 				5D1181E71B4D6DEB003F3084 /* WPStyleGuide+Reader.swift in Sources */,
 				3250490724F988220036B47F /* Interpolation.swift in Sources */,
+				0CB424F62AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */,
 				0C8FC9A12A8BC8630059DCE4 /* PHPickerController+Extensions.swift in Sources */,
 				E17FEAD8221490F7006E1D2D /* PostEditorAnalyticsSession.swift in Sources */,
 				738B9A5221B85CF20005062B /* SiteCreationWizardLauncher.swift in Sources */,
@@ -25193,6 +25198,7 @@
 				FABB24FC2602FC2C00C8785C /* NoResultsViewController+MediaLibrary.swift in Sources */,
 				FA4B203929A8C48F0089FE68 /* AbstractPost+Blaze.swift in Sources */,
 				083ED8CD2A4322CB007F89B3 /* ComplianceLocationService.swift in Sources */,
+				0CB424F72AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */,
 				FABB24FD2602FC2C00C8785C /* StockPhotosDataLoader.swift in Sources */,
 				010459E729153FFF000C7778 /* JetpackNotificationMigrationService.swift in Sources */,
 				FABB24FE2602FC2C00C8785C /* ReaderTopicToReaderTagTopic37to38.swift in Sources */,


### PR DESCRIPTION
Part of #21712 

Update image placeholder to use solid color

To test:

- Instead of a green spinner, the images now use solid gray placeholders
- Fix the size of the downloaded thumbnails

<img width="360" alt="Screenshot 2023-10-18 at 12 48 56 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/ac505e77-7a0d-49c9-a6e6-43da1d143e8b">

## Regression Notes
1. Potential unintended areas of impact: Posts List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
