### PR TITLE
Site Domains: Fix an issue where the message when searching for a new domain was misleading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 
 * [***] [internal][Jetpack-only] [***] Added paid domain selection, plan selection, and checkout screens in site creation flow [#21688]
+* [*] Site Domains: Fixed an issue where the message shared while adding a domain was inaccurate. [#21827]
 
 23.5
 -----

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -33,7 +33,7 @@ class DomainSuggestionsTableViewController: UITableViewController {
     weak var delegate: DomainSuggestionsTableViewControllerDelegate?
     var domainSuggestionType: DomainsServiceRemote.DomainSuggestionType = .noWordpressDotCom
     var domainSelectionType: DomainSelectionType?
-    var freeSiteAddress: String = ""
+    var primaryDomainAddress: String = ""
 
     var useFadedColorForParentDomains: Bool {
         return false
@@ -299,10 +299,10 @@ extension DomainSuggestionsTableViewController {
         textLabel.minimumScaleFactor = 0.5
 
         let template = NSLocalizedString("Domains purchased on this site will redirect to %@", comment: "Description for the first domain purchased with a free plan.")
-        let formatted = String(format: template, freeSiteAddress)
+        let formatted = String(format: template, primaryDomainAddress)
         let attributed = NSMutableAttributedString(string: formatted, attributes: [:])
 
-        if let range = formatted.range(of: freeSiteAddress) {
+        if let range = formatted.range(of: primaryDomainAddress) {
             attributed.addAttributes([.font: textLabel.font.bold()], range: NSRange(range, in: formatted))
         }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -175,7 +175,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
             vc.siteName = siteName
             vc.blog = site
             vc.domainSelectionType = domainSelectionType
-            vc.freeSiteAddress = site.freeSiteAddress
+            vc.primaryDomainAddress = site.primaryDomainAddress
 
             if site.hasBloggerPlan {
                 vc.domainSuggestionType = .allowlistedTopLevelDomains(["blog"])

--- a/WordPress/Classes/ViewRelated/Domains/Utility/Blog+DomainsDashboardView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Utility/Blog+DomainsDashboardView.swift
@@ -44,4 +44,16 @@ extension Blog {
     var freeDomainIsPrimary: Bool {
         freeDomain?.isPrimaryDomain ?? false
     }
+
+    var primaryDomain: Domain? {
+        guard let domainsSet = domains as? Set<ManagedDomain>,
+              let freeDomain = (domainsSet.first { $0.isPrimary == true }) else {
+            return nil
+        }
+        return Domain(managedDomain: freeDomain)
+    }
+
+    var primaryDomainAddress: String {
+        primaryDomain?.domainName ?? ""
+    }
 }


### PR DESCRIPTION
Fixes #21826
Ref: p1697601465683189-slack-C0180B5PRJ4

## Description
This PR fixes an issue where the message shared while adding a domain was inaccurate. It always states that new domains will redirect to the dotcom domain even if the user has a custom primary domain.

## Testing Instructions
1. Setup a site with a paid plan and a custom domain set as the primary domain
2. Navigate to My Site -> More -> Domains
3. Notice that the custom domain is marked correctly as the primary domain
4. Tap "Add a domain"
5. ✅ Make sure that the header displayed reads "Domains purchased on this site redirects to {Your Primary Custom Domain}"

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.