### PR TITLE
Posts & Pages: Integrate new cells in search

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,102 @@
   "object": {
     "pins": [
       {
+        "package": "AutomatticAbout",
+        "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
+        "state": {
+          "branch": null,
+          "revision": "0f784591b324e5d3ddc5771808ef8eca923e3de2",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "package": "Charts",
+        "repositoryURL": "https://github.com/danielgindi/Charts",
+        "state": {
+          "branch": null,
+          "revision": "07b23476ad52b926be772f317d8f1d4511ee8d02",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Lottie",
+        "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "4ca8023b820b7d5d5ae1e2637c046e3dab0f45d0",
+          "version": "3.4.2"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble",
+        "state": {
+          "branch": null,
+          "revision": "1f3bde57bde12f5e7b07909848c071e9b73d6edc",
+          "version": "10.0.0"
+        }
+      },
+      {
+        "package": "ScreenObject",
+        "repositoryURL": "https://github.com/Automattic/ScreenObject",
+        "state": {
+          "branch": null,
+          "revision": "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+          "version": "0.2.3"
+        }
+      },
+      {
+        "package": "swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "state": {
+          "branch": null,
+          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "state": {
+          "branch": null,
+          "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",
+          "version": "1.0.2"
+        }
+      },
+      {
         "package": "BuildkiteTestCollector",
         "repositoryURL": "https://github.com/buildkite/test-collector-swift",
         "state": {
           "branch": null,
           "revision": "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
           "version": "0.3.0"
+        }
+      },
+      {
+        "package": "XCUITestHelpers",
+        "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
+        "state": {
+          "branch": null,
+          "revision": "5179cb69d58b90761cc713bdee7740c4889d3295",
+          "version": "0.4.0"
         }
       }
     ]

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Combine
 
 final class PostListCell: UITableViewCell, Reusable {
 
@@ -21,6 +22,7 @@ final class PostListCell: UITableViewCell, Reusable {
     private let titleAndSnippetLabel = UILabel()
     private let featuredImageView = CachedAnimatedImageView()
     private let statusLabel = UILabel()
+    private var cancellables: [AnyCancellable] = []
 
     // MARK: - Properties
 
@@ -39,10 +41,18 @@ final class PostListCell: UITableViewCell, Reusable {
 
     // MARK: - Public
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        cancellables = []
+    }
+
     func configure(with viewModel: PostListItemViewModel) {
         headerView.configure(with: viewModel)
 
-        configureTitleAndSnippet(with: viewModel)
+        viewModel.$title.sink { [titleAndSnippetLabel] in
+            titleAndSnippetLabel.attributedText = $0
+        }.store(in: &cancellables)
 
         imageLoader.prepareForReuse()
         featuredImageView.isHidden = viewModel.imageURL == nil
@@ -56,30 +66,6 @@ final class PostListCell: UITableViewCell, Reusable {
         statusLabel.text = viewModel.status
         statusLabel.textColor = viewModel.statusColor
         statusLabel.isHidden = viewModel.status.isEmpty
-    }
-
-    private func configureTitleAndSnippet(with viewModel: PostListItemViewModel) {
-        var titleAndSnippetString = NSMutableAttributedString()
-
-        if let title = viewModel.title, !title.isEmpty {
-            let attributes: [NSAttributedString.Key: Any] = [
-                .font: WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold),
-                .foregroundColor: UIColor.text
-            ]
-            let titleAttributedString = NSAttributedString(string: "\(title)\n", attributes: attributes)
-            titleAndSnippetString.append(titleAttributedString)
-        }
-
-        if let snippet = viewModel.snippet, !snippet.isEmpty {
-            let attributes: [NSAttributedString.Key: Any] = [
-                .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular),
-                .foregroundColor: UIColor.textSubtle
-            ]
-            let snippetAttributedString = NSAttributedString(string: snippet, attributes: attributes)
-            titleAndSnippetString.append(snippetAttributedString)
-        }
-
-        titleAndSnippetLabel.attributedText = titleAndSnippetString
     }
 
     // MARK: - Setup

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -19,7 +19,7 @@ final class PostListCell: UITableViewCell, Reusable {
     }()
 
     private let headerView = PostListHeaderView()
-    private let titleAndSnippetLabel = UILabel()
+    private let contentLabel = UILabel()
     private let featuredImageView = CachedAnimatedImageView()
     private let statusLabel = UILabel()
     private var cancellables: [AnyCancellable] = []
@@ -50,8 +50,8 @@ final class PostListCell: UITableViewCell, Reusable {
     func configure(with viewModel: PostListItemViewModel) {
         headerView.configure(with: viewModel)
 
-        viewModel.$title.sink { [titleAndSnippetLabel] in
-            titleAndSnippetLabel.attributedText = $0
+        viewModel.$content.sink { [contentLabel] in
+            contentLabel.attributedText = $0
         }.store(in: &cancellables)
 
         imageLoader.prepareForReuse()
@@ -71,13 +71,13 @@ final class PostListCell: UITableViewCell, Reusable {
     // MARK: - Setup
 
     private func setupViews() {
-        setupTitleAndSnippetLabel()
+        setupcontentLabel()
         setupFeaturedImageView()
         setupStatusLabel()
 
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.addArrangedSubviews([
-            titleAndSnippetLabel,
+            contentLabel,
             featuredImageView
         ])
         contentStackView.spacing = 16
@@ -98,10 +98,10 @@ final class PostListCell: UITableViewCell, Reusable {
         contentView.backgroundColor = .systemBackground
     }
 
-    private func setupTitleAndSnippetLabel() {
-        titleAndSnippetLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleAndSnippetLabel.adjustsFontForContentSizeCategory = true
-        titleAndSnippetLabel.numberOfLines = 3
+    private func setupcontentLabel() {
+        contentLabel.translatesAutoresizingMaskIntoConstraints = false
+        contentLabel.adjustsFontForContentSizeCategory = true
+        contentLabel.numberOfLines = 3
     }
 
     private func setupFeaturedImageView() {

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -2,8 +2,7 @@ import Foundation
 
 final class PostListItemViewModel {
     let post: Post
-    let title: String?
-    let snippet: String?
+    @Published var title: NSAttributedString
     let imageURL: URL?
     let date: String?
     let accessibilityIdentifier: String?
@@ -16,13 +15,40 @@ final class PostListItemViewModel {
 
     init(post: Post) {
         self.post = post
-        self.title = post.titleForDisplay()
-        self.snippet = post.contentPreviewForDisplay()
+        self.title = makeContentAttributedString(for: post)
         self.imageURL = post.featuredImageURL
         self.date = post.displayDate()?.capitalizeFirstWord
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.accessibilityIdentifier = post.slugForDisplay()
     }
+}
+
+private func makeContentAttributedString(for post: Post) -> NSAttributedString {
+    let title = post.titleForDisplay()
+    let snippet = post.contentPreviewForDisplay()
+
+    let string = NSMutableAttributedString()
+    if !title.isEmpty {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold),
+            .foregroundColor: UIColor.text
+        ]
+        let titleAttributedString = NSAttributedString(string: title, attributes: attributes)
+        string.append(titleAttributedString)
+    }
+    if !snippet.isEmpty {
+        if string.length > 0 {
+            string.append(NSAttributedString(string: "\n"))
+        }
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular),
+            .foregroundColor: UIColor.textSubtle
+        ]
+        let snippetAttributedString = NSAttributedString(string: snippet, attributes: attributes)
+        string.append(snippetAttributedString)
+    }
+
+    return string
 }
 
 private extension String {

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct PostListItemViewModel {
+final class PostListItemViewModel {
     let post: Post
     let title: String?
     let snippet: String?
@@ -8,11 +8,11 @@ struct PostListItemViewModel {
     let date: String?
     let accessibilityIdentifier: String?
 
-    private var statusViewModel: PostCardStatusViewModel { .init(post: post) }
-
     var status: String { statusViewModel.statusAndBadges(separatedBy: " · ")}
     var statusColor: UIColor { statusViewModel.statusColor }
     var author: String { statusViewModel.author }
+
+    private let statusViewModel: PostCardStatusViewModel
 
     init(post: Post) {
         self.post = post
@@ -20,6 +20,7 @@ struct PostListItemViewModel {
         self.snippet = post.contentPreviewForDisplay()
         self.imageURL = post.featuredImageURL
         self.date = post.displayDate()?.capitalizeFirstWord
+        self.statusViewModel = PostCardStatusViewModel(post: post)
         self.accessibilityIdentifier = post.slugForDisplay()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 final class PostListItemViewModel {
     let post: Post
-    @Published var title: NSAttributedString
+    @Published var content: NSAttributedString
     let imageURL: URL?
     let date: String?
     let accessibilityIdentifier: String?
@@ -15,7 +15,7 @@ final class PostListItemViewModel {
 
     init(post: Post) {
         self.post = post
-        self.title = makeContentAttributedString(for: post)
+        self.content = makeContentAttributedString(for: post)
         self.imageURL = post.featuredImageURL
         self.date = post.displayDate()?.capitalizeFirstWord
         self.statusViewModel = PostCardStatusViewModel(post: post)

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchService.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchService.swift
@@ -13,9 +13,9 @@ final class PostSearchService {
 
     weak var delegate: PostSearchServiceDelegate?
 
+    let criteria: PostSearchCriteria
     private let blog: Blog
     private let settings: PostListFilterSettings
-    private let criteria: PostSearchCriteria
     private let coreDataStack: CoreDataStack
 
     private var postIDs: Set<NSManagedObjectID> = []

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -11,7 +11,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
     enum ItemID: Hashable {
         case token(AnyHashable)
-        case post(NSManagedObjectID)
+        case result(NSManagedObjectID)
     }
 
     private let tableView = UITableView(frame: .zero, style: .plain)
@@ -95,7 +95,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         snapshot.appendItems(tokenIDs, toSection: SectionID.tokens)
 
         snapshot.appendSections([SectionID.posts])
-        let postIDs = viewModel.posts.map { ItemID.post($0.objectID) }
+        let postIDs = viewModel.results.map { ItemID.result($0.objectID) }
         snapshot.appendItems(postIDs, toSection: SectionID.posts)
 
         dataSource.apply(snapshot, animatingDifferences: false)
@@ -113,12 +113,12 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             cell.separatorInset = UIEdgeInsets(top: 0, left: view.bounds.size.width, bottom: 0, right: 0) // Hide the native separator
             return cell
         case .posts:
-            let item = viewModel.posts[indexPath.row]
-            if let post = item as? Post {
+            switch viewModel.results[indexPath.row] {
+            case .post(let post):
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath) as! PostListCell
-                cell.configure(with: .init(post: post))
+                cell.configure(with: post)
                 return cell
-            } else if let page = item as? Page {
+            case .page(let page):
                 // TODO: Update the cell design
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath)
                 var configuration = cell.defaultContentConfiguration()
@@ -127,8 +127,6 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
                 configuration.secondaryTextProperties.color = .secondaryLabel
                 cell.contentConfiguration = configuration
                 return cell
-            } else {
-                fatalError("Unsupported item: \(type(of: item))")
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -75,6 +75,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
         tableView.dataSource = dataSource
         tableView.delegate = self
+        tableView.sectionHeaderTopPadding = 0
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -70,7 +70,8 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         view.pinSubviewToAllEdges(tableView)
 
         tableView.register(PostSearchTokenTableCell.self, forCellReuseIdentifier: Constants.tokenCellID)
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.postCellID)
+        tableView.register(PostListCell.self, forCellReuseIdentifier: Constants.postCellID)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.pageCellID)
 
         tableView.dataSource = dataSource
         tableView.delegate = self
@@ -112,15 +113,23 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             cell.separatorInset = UIEdgeInsets(top: 0, left: view.bounds.size.width, bottom: 0, right: 0) // Hide the native separator
             return cell
         case .posts:
-            // TODO: Update the cell design
-            let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath)
-            let post = viewModel.posts[indexPath.row]
-            var configuration = cell.defaultContentConfiguration()
-            configuration.text = post.titleForDisplay()
-            configuration.secondaryText = post.latest().dateStringForDisplay()
-            configuration.secondaryTextProperties.color = .secondaryLabel
-            cell.contentConfiguration = configuration
-            return cell
+            let item = viewModel.posts[indexPath.row]
+            if let post = item as? Post {
+                let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath) as! PostListCell
+                cell.configure(with: .init(post: post))
+                return cell
+            } else if let page = item as? Page {
+                // TODO: Update the cell design
+                let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath)
+                var configuration = cell.defaultContentConfiguration()
+                configuration.text = page.titleForDisplay()
+                configuration.secondaryText = page.latest().dateStringForDisplay()
+                configuration.secondaryTextProperties.color = .secondaryLabel
+                cell.contentConfiguration = configuration
+                return cell
+            } else {
+                fatalError("Unsupported item: \(type(of: item))")
+            }
         }
     }
 
@@ -182,5 +191,6 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
 private enum Constants {
     static let postCellID = "postCellID"
+    static let pageCellID = "pageCellID"
     static let tokenCellID = "suggestedTokenCellID"
 }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -11,7 +11,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
     enum ItemID: Hashable {
         case token(AnyHashable)
-        case post(PostSearchResult.ID)
+        case post(NSManagedObjectID)
     }
 
     private let tableView = UITableView(frame: .zero, style: .plain)
@@ -94,7 +94,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         snapshot.appendItems(tokenIDs, toSection: SectionID.tokens)
 
         snapshot.appendSections([SectionID.posts])
-        let postIDs = viewModel.posts.map { ItemID.post($0.id) }
+        let postIDs = viewModel.posts.map { ItemID.post($0.objectID) }
         snapshot.appendItems(postIDs, toSection: SectionID.posts)
 
         dataSource.apply(snapshot, animatingDifferences: false)
@@ -114,10 +114,10 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         case .posts:
             // TODO: Update the cell design
             let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath)
-            let result = viewModel.posts[indexPath.row]
+            let post = viewModel.posts[indexPath.row]
             var configuration = cell.defaultContentConfiguration()
-            configuration.attributedText = result.title
-            configuration.secondaryText = result.post.latest().dateStringForDisplay()
+            configuration.text = post.titleForDisplay()
+            configuration.secondaryText = post.latest().dateStringForDisplay()
             configuration.secondaryTextProperties.color = .secondaryLabel
             cell.contentConfiguration = configuration
             return cell

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel+Highlighter.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel+Highlighter.swift
@@ -1,6 +1,22 @@
 import UIKit
 
 extension PostSearchViewModel {
+    static func highlight(terms: [String], in attributedString: NSMutableAttributedString) {
+        attributedString.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: attributedString.length))
+
+        let string = attributedString.string
+
+        let ranges = terms.flatMap {
+            string.ranges(of: $0, options: [.caseInsensitive, .diacriticInsensitive])
+        }.sorted { $0.lowerBound < $1.lowerBound }
+
+        for range in collapseAdjacentRanges(ranges, in: string) {
+            attributedString.addAttributes([
+                .backgroundColor: UIColor.systemYellow.withAlphaComponent(0.25)
+            ], range: NSRange(range, in: string))
+        }
+    }
+
     // Both decoding & searching are expensive, so the service performs these
     // operations in the background.
     static func higlight(_ title: String, terms: [String]) -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel+Highlighter.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel+Highlighter.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+extension PostSearchViewModel {
+    // Both decoding & searching are expensive, so the service performs these
+    // operations in the background.
+    static func higlight(_ title: String, terms: [String]) -> NSAttributedString {
+        let title = title
+            .trimmingCharacters(in: .whitespaces)
+            .stringByDecodingXMLCharacters()
+
+        let ranges = terms.flatMap {
+            title.ranges(of: $0, options: [.caseInsensitive, .diacriticInsensitive])
+        }.sorted { $0.lowerBound < $1.lowerBound }
+
+        let string = NSMutableAttributedString(string: title, attributes: [
+            .font: WPStyleGuide.fontForTextStyle(.body)
+        ])
+        for range in collapseAdjacentRanges(ranges, in: title) {
+            string.setAttributes([
+                .backgroundColor: UIColor.systemYellow.withAlphaComponent(0.25)
+            ], range: NSRange(range, in: title))
+        }
+        return string
+    }
+
+    private static func collapseAdjacentRanges(_ ranges: [Range<String.Index>], in string: String) -> [Range<String.Index>] {
+        var output: [Range<String.Index>] = []
+        var ranges = ranges
+        while let rhs = ranges.popLast() {
+            if let lhs = ranges.last,
+               rhs.lowerBound > string.startIndex,
+               lhs.upperBound == string.index(before: rhs.lowerBound),
+               string[string.index(before: rhs.lowerBound)].isWhitespace {
+                ranges.removeLast()
+                ranges.append(lhs.lowerBound..<rhs.upperBound)
+            } else {
+                output.append(rhs)
+            }
+        }
+        return output
+    }
+}
+
+private extension String {
+    func ranges(of string: String, options: String.CompareOptions) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var startIndex = self.startIndex
+        while startIndex < endIndex,
+              let range = range(of: string, options: options, range: startIndex..<endIndex) {
+            ranges.append(range)
+            startIndex = range.upperBound
+        }
+        return ranges
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -190,9 +190,9 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
         for item in results {
             switch item {
             case .post(let viewModel):
-                let string = NSMutableAttributedString(attributedString: viewModel.title)
+                let string = NSMutableAttributedString(attributedString: viewModel.content)
                 PostSearchViewModel.highlight(terms: terms, in: string)
-                viewModel.title = string
+                viewModel.content = string
             case .page:
                 break // TODO: Implement highlighting
             }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -10,7 +10,7 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
         didSet { didUpdateData?() }
     }
 
-    private(set) var posts: [PostSearchResult] = [] {
+    private(set) var posts: [AbstractPost] = [] {
         didSet { didUpdateData?() }
     }
 
@@ -122,7 +122,7 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
 
     // MARK: - PostSearchServiceDelegate
 
-    func service(_ service: PostSearchService, didAppendPosts posts: [PostSearchResult]) {
+    func service(_ service: PostSearchService, didAppendPosts posts: [AbstractPost]) {
         assert(Thread.isMainThread)
 
         if isRefreshing {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -397,6 +397,8 @@
 		0C0AE75A2A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C0D3B0E2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
+		0C1531FE2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */; };
+		0C1531FF2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */; };
 		0C23F3362AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */; };
 		0C23F3372AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */; };
 		0C23F33E2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23F33D2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift */; };
@@ -479,13 +481,13 @@
 		0CB4057A29C8DDEE008EED0A /* BlogDashboardPersonalizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */; };
 		0CB4057D29C8DF83008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
 		0CB4057E29C8DF84008EED0A /* BlogDashboardPersonalizeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */; };
-		0CB424F62AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
-		0CB424F72AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
 		0CB424EE2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424ED2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift */; };
 		0CB424EF2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424ED2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift */; };
 		0CB424F12ADEE52A0080B807 /* PostSearchToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F02ADEE52A0080B807 /* PostSearchToken.swift */; };
 		0CB424F22ADEE52A0080B807 /* PostSearchToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F02ADEE52A0080B807 /* PostSearchToken.swift */; };
-		0CB424F42ADF3CBE0080B807 /* PostSearchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F32ADF3CBE0080B807 /* PostSearchServiceTests.swift */; };
+		0CB424F42ADF3CBE0080B807 /* PostSearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F32ADF3CBE0080B807 /* PostSearchViewModelTests.swift */; };
+		0CB424F62AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
+		0CB424F72AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
 		0CD223DF2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */; };
 		0CD223E02AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */; };
 		0CD382832A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */; };
@@ -6116,6 +6118,7 @@
 		0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaDocumentInfoView.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
+		0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSearchViewModel+Highlighter.swift"; sourceTree = "<group>"; };
 		0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaSelectionTitleView.swift; sourceTree = "<group>"; };
 		0C23F33D2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPickerViewController.swift; sourceTree = "<group>"; };
 		0C2518AD2ABE1EA000381D31 /* iphone-photo.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iphone-photo.heic"; sourceTree = "<group>"; };
@@ -6165,10 +6168,10 @@
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
 		0CB4057229C8DD01008EED0A /* BlogDashboardPersonalizationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationView.swift; sourceTree = "<group>"; };
 		0CB4057B29C8DEE1008EED0A /* BlogDashboardPersonalizeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizeCardCell.swift; sourceTree = "<group>"; };
-		0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidColorActivityIndicator.swift; sourceTree = "<group>"; };
 		0CB424ED2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchTokenTableCell.swift; sourceTree = "<group>"; };
 		0CB424F02ADEE52A0080B807 /* PostSearchToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchToken.swift; sourceTree = "<group>"; };
-		0CB424F32ADF3CBE0080B807 /* PostSearchServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchServiceTests.swift; sourceTree = "<group>"; };
+		0CB424F32ADF3CBE0080B807 /* PostSearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchViewModelTests.swift; sourceTree = "<group>"; };
+		0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidColorActivityIndicator.swift; sourceTree = "<group>"; };
 		0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionsViewModel.swift; sourceTree = "<group>"; };
 		0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModel.swift; sourceTree = "<group>"; };
 		0CD382852A4B6FCE00612173 /* DashboardBlazeCardCellViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModelTest.swift; sourceTree = "<group>"; };
@@ -10276,6 +10279,7 @@
 			children = (
 				0CD9CC9E2AD73A560044A33C /* PostSearchViewController.swift */,
 				0CD9CCA22AD831590044A33C /* PostSearchViewModel.swift */,
+				0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */,
 				0CB424ED2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift */,
 				0CB424F02ADEE52A0080B807 /* PostSearchToken.swift */,
 				0CA10F6C2ADAE86D00CE75AC /* PostSearchSuggestionsService.swift */,
@@ -12314,7 +12318,7 @@
 				59ECF87A1CB7061D00E68F25 /* PostSharingControllerTests.swift */,
 				F18B43771F849F580089B817 /* PostAttachmentTests.swift */,
 				8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */,
-				0CB424F32ADF3CBE0080B807 /* PostSearchServiceTests.swift */,
+				0CB424F32ADF3CBE0080B807 /* PostSearchViewModelTests.swift */,
 			);
 			name = Posts;
 			sourceTree = "<group>";
@@ -21246,6 +21250,7 @@
 				F5B9151F244653C100179876 /* TabbedViewController.swift in Sources */,
 				FF00889B204DF3ED007CCE66 /* Blog+Quota.swift in Sources */,
 				C533CF350E6D3ADA000C3DE8 /* CommentsViewController.m in Sources */,
+				0C1531FE2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift in Sources */,
 				FAFF153D1C98962E007D1C90 /* SiteSettingsViewController+SiteManagement.swift in Sources */,
 				D816C1EE20E0892200C4D82F /* Follow.swift in Sources */,
 				0C896DE22A3A767200D7D4E7 /* SiteVisibility+Extensions.swift in Sources */,
@@ -23555,7 +23560,7 @@
 				D88A649C208D7D81008AE9BC /* StockPhotosDataSourceTests.swift in Sources */,
 				F4DD58362A168229009A772D /* ReaderPostCellActionsTests.swift in Sources */,
 				3236F7A124B61B950088E8F3 /* ReaderInterestsDataSourceTests.swift in Sources */,
-				0CB424F42ADF3CBE0080B807 /* PostSearchServiceTests.swift in Sources */,
+				0CB424F42ADF3CBE0080B807 /* PostSearchViewModelTests.swift in Sources */,
 				8BDA5A74247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift in Sources */,
 				74585B991F0D58F300E7E667 /* DomainsServiceTests.swift in Sources */,
 				8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */,
@@ -24768,6 +24773,7 @@
 				FABB23A02602FC2C00C8785C /* PluginDirectoryViewController.swift in Sources */,
 				FABB23A12602FC2C00C8785C /* RoleService.swift in Sources */,
 				FABB23A22602FC2C00C8785C /* AccountHelper.swift in Sources */,
+				0C1531FF2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift in Sources */,
 				FABB23A32602FC2C00C8785C /* Sites.intentdefinition in Sources */,
 				FABB23A42602FC2C00C8785C /* MenuItemSourceTextBar.m in Sources */,
 				FABB23A52602FC2C00C8785C /* PluginDirectoryViewModel.swift in Sources */,

--- a/WordPress/WordPressTest/PostSearchViewModelTests.swift
+++ b/WordPress/WordPressTest/PostSearchViewModelTests.swift
@@ -5,10 +5,10 @@ import XCTest
 class PostSearchViewModelTests: XCTestCase {
     func testThatAdjacentRangesAreCollapsed() throws {
         // GIVEN
-        let title = "one two xxxxx one"
+        let string = NSMutableAttributedString(string: "one two xxxxx one")
 
         // WHEN
-        let string = PostSearchViewModel.higlight(title, terms: ["one", "two"])
+        PostSearchViewModel.highlight(terms: ["one", "two"], in: string)
 
         // THEN
         XCTAssertTrue(string.hasAttribute(.backgroundColor, in: NSRange(location: 0, length: 7)))
@@ -18,10 +18,10 @@ class PostSearchViewModelTests: XCTestCase {
 
     func testThatCaseIsIgnored() {
         // GIVEN
-        let title = "One xxxxx óne"
+        let string = NSMutableAttributedString(string: "One xxxxx óne")
 
         // WHEN
-        let string = PostSearchViewModel.higlight(title, terms: ["one"])
+        PostSearchViewModel.highlight(terms: ["one"], in: string)
 
         // THEN
         XCTAssertTrue(string.hasAttribute(.backgroundColor, in: NSRange(location: 0, length: 3)))

--- a/WordPress/WordPressTest/PostSearchViewModelTests.swift
+++ b/WordPress/WordPressTest/PostSearchViewModelTests.swift
@@ -2,13 +2,13 @@ import XCTest
 
 @testable import WordPress
 
-class PostSearchServiceTests: XCTestCase {
+class PostSearchViewModelTests: XCTestCase {
     func testThatAdjacentRangesAreCollapsed() throws {
         // GIVEN
         let title = "one two xxxxx one"
 
         // WHEN
-        let string = PostSearchService.makeTitle(for: title, terms: ["one", "two"])
+        let string = PostSearchViewModel.higlight(title, terms: ["one", "two"])
 
         // THEN
         XCTAssertTrue(string.hasAttribute(.backgroundColor, in: NSRange(location: 0, length: 7)))
@@ -21,7 +21,7 @@ class PostSearchServiceTests: XCTestCase {
         let title = "One xxxxx óne"
 
         // WHEN
-        let string = PostSearchService.makeTitle(for: title, terms: ["one"])
+        let string = PostSearchViewModel.higlight(title, terms: ["one"])
 
         // THEN
         XCTAssertTrue(string.hasAttribute(.backgroundColor, in: NSRange(location: 0, length: 3)))


### PR DESCRIPTION
This PR integrates new cells in search and adds live highlighting I tested the performance and there is no need to move the highlighting to the background.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/ceb2ad53-f341-4e01-bee7-728346e459b5

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual & test
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
