### PR TITLE
Reader: Update toolbar with the new icons

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -34,9 +34,12 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
     weak var delegate: ReaderDetailToolbarDelegate? = nil
 
+    private lazy var readerImprovementsEnabled: Bool = {
+        return RemoteFeatureFlag.readerImprovements.enabled()
+    }()
+
     private var likeButtonTitle: String {
-        guard let post,
-              RemoteFeatureFlag.readerImprovements.enabled() else {
+        guard let post, readerImprovementsEnabled else {
             return likeLabel(count: likeCount)
         }
         return post.isLiked ? Constants.likedButtonTitle : Constants.likeButtonTitle
@@ -163,7 +166,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         WPStyleGuide.applyReaderCardActionButtonStyle(likeButton)
 
         // TODO: Apply changes on the XIB directly once the `readerImprovements` flag is removed.
-        if RemoteFeatureFlag.readerImprovements.enabled() {
+        if readerImprovementsEnabled {
             stackView.distribution = .fillEqually
             stackView.spacing = 16.0
             stackViewLeadingConstraint.constant = 16.0
@@ -226,7 +229,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         /// `imagePlacement` to `.top`.
         ///
         /// TODO: remove unused styles once the `readerImprovements` flag is removed.
-        guard RemoteFeatureFlag.readerImprovements.enabled() else {
+        guard readerImprovementsEnabled else {
             return
         }
 
@@ -269,8 +272,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
         configureActionButton(likeButton,
                               title: likeButtonTitle,
-                              image: Constants.likeImage,
-                              highlightedImage: Constants.likedImage,
+                              image: WPStyleGuide.ReaderDetail.likeToolbarIcon,
+                              highlightedImage: WPStyleGuide.ReaderDetail.likeSelectedToolbarIcon,
                               selected: selected)
 
         if animated {
@@ -296,9 +299,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         }
 
         let animationDuration = 0.3
-        let imageView = UIImageView(image: Constants.likedImage)
+        let imageView = UIImageView(image: WPStyleGuide.ReaderDetail.likeSelectedToolbarIcon)
 
-        if RemoteFeatureFlag.readerImprovements.enabled() {
+        if readerImprovementsEnabled {
             /// When using `UIButton.Configuration`, calling `bringSubviewToFront` somehow does not work.
             /// To work around this, let's add the faux image to the image view instead, so it can be
             /// properly placed in front of the masking view.
@@ -317,7 +320,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             likeImageView.pinSubviewToAllEdges(mask)
             mask.translatesAutoresizingMaskIntoConstraints = false
 
-            if RemoteFeatureFlag.readerImprovements.enabled() {
+            if readerImprovementsEnabled {
                 likeImageView.bringSubviewToFront(imageView)
             } else {
                 likeButton.bringSubviewToFront(imageView)
@@ -371,11 +374,15 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     private func configureCommentActionButton() {
         commentButton.isEnabled = shouldShowCommentActionButton
 
-        commentButton.setImage(Constants.commentImage, for: .normal)
-        commentButton.setImage(Constants.commentSelectedImage, for: .selected)
-        commentButton.setImage(Constants.commentSelectedImage, for: .highlighted)
-        commentButton.setImage(Constants.commentSelectedImage, for: [.highlighted, .selected])
-        commentButton.setImage(Constants.commentImage, for: .disabled)
+        if readerImprovementsEnabled {
+            commentButton.setImage(WPStyleGuide.ReaderDetail.commentToolbarIcon, for: .normal)
+            commentButton.setImage(WPStyleGuide.ReaderDetail.commentHighlightedToolbarIcon, for: .selected)
+            commentButton.setImage(WPStyleGuide.ReaderDetail.commentHighlightedToolbarIcon, for: .highlighted)
+            commentButton.setImage(WPStyleGuide.ReaderDetail.commentHighlightedToolbarIcon, for: [.highlighted, .selected])
+            commentButton.setImage(WPStyleGuide.ReaderDetail.commentToolbarIcon, for: .disabled)
+        } else {
+            WPStyleGuide.applyReaderCardCommentButtonStyle(commentButton, defaultSize: true)
+        }
 
         configureActionButtonStyle(commentButton)
     }
@@ -426,8 +433,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         }
 
         let commentCount = post.commentCount()?.intValue ?? 0
-        let commentTitle = RemoteFeatureFlag.readerImprovements.enabled() ? Constants.commentButtonTitle : commentLabel(count: commentCount)
-        let showTitle: Bool = RemoteFeatureFlag.readerImprovements.enabled() || traitCollection.horizontalSizeClass != .compact
+        let commentTitle = readerImprovementsEnabled ? Constants.commentButtonTitle : commentLabel(count: commentCount)
+        let showTitle: Bool = readerImprovementsEnabled || traitCollection.horizontalSizeClass != .compact
 
         likeButton.setTitle(likeButtonTitle, for: .normal)
         likeButton.setTitle(likeButtonTitle, for: .highlighted)
@@ -492,38 +499,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 private extension ReaderDetailToolbar {
 
     struct Constants {
-        static let buttonContentInsets = NSDirectionalEdgeInsets(top: 2.0, leading: 0, bottom: 0, trailing: 0)
-        static let buttonImagePadding: CGFloat = 4.0
-
-        static var likeImage: UIImage? {
-            if RemoteFeatureFlag.readerImprovements.enabled() {
-                // reduce gridicon images to 20x20 since they don't have intrinsic padding.
-                return UIImage(named: "icon-reader-like")?
-                    .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .default)
-                    .withRenderingMode(.alwaysTemplate)
-            }
-            return UIImage(named: "icon-reader-like")
-        }
-
-        static var likedImage: UIImage? {
-            if RemoteFeatureFlag.readerImprovements.enabled() {
-                // reduce gridicon images to 20x20 since they don't have intrinsic padding.
-                return UIImage(named: "icon-reader-liked")?
-                    .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .default)
-                    .withRenderingMode(.alwaysTemplate)
-            }
-            return UIImage(named: "icon-reader-liked")
-        }
-
-        static let commentImage = UIImage(named: "icon-reader-comment-outline")?
-            .imageFlippedForRightToLeftLayoutDirection()
-            .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .high)
-            .withRenderingMode(.alwaysTemplate)
-
-        static let commentSelectedImage = UIImage(named: "icon-reader-comment-outline-highlighted")?
-            .imageFlippedForRightToLeftLayoutDirection()
-            .resizedImage(WPStyleGuide.Detail.actionBarIconSize, interpolationQuality: .high)
-            .withRenderingMode(.alwaysTemplate)
+        static let buttonContentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        static let buttonImagePadding: CGFloat = 0
 
         // MARK: Strings
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -377,14 +377,12 @@ extension WPStyleGuide {
         button.accessibilityHint = FollowButton.Text.accessibilityHint
     }
 
+    // Reader Detail Toolbar Save button
     @objc public class func applyReaderSaveForLaterButtonStyle(_ button: UIButton) {
-        let icon = UIImage.gridicon(.bookmarkOutline, size: Detail.actionBarIconSize)
-        let selectedIcon = UIImage.gridicon(.bookmark, size: Detail.actionBarIconSize)
-
-        button.setImage(icon, for: .normal)
-        button.setImage(selectedIcon, for: .selected)
-        button.setImage(selectedIcon, for: .highlighted)
-        button.setImage(selectedIcon, for: [.highlighted, .selected])
+        button.setImage(ReaderDetail.saveToolbarIcon, for: .normal)
+        button.setImage(ReaderDetail.saveSelectedToolbarIcon, for: .selected)
+        button.setImage(ReaderDetail.saveSelectedToolbarIcon, for: .highlighted)
+        button.setImage(ReaderDetail.saveSelectedToolbarIcon, for: [.highlighted, .selected])
 
         applyReaderActionButtonStyle(button)
     }
@@ -403,8 +401,10 @@ extension WPStyleGuide {
         applyReaderStreamActionButtonStyle(button)
     }
 
+    // NOTE: this is currently unused in the new designs because of the call to `applyReaderStreamActionButtonStyle`,
+    // which causes the image to be "double-tinted" and results in a different display color.
     @objc public class func applyReaderCardCommentButtonStyle(_ button: UIButton, defaultSize: Bool = false) {
-        let size = defaultSize ? Detail.actionBarIconSize : Cards.actionButtonSize
+        let size = defaultSize ? Gridicon.defaultSize : Cards.actionButtonSize
         let icon = UIImage(named: "icon-reader-comment-outline")?.imageFlippedForRightToLeftLayoutDirection()
         let selectedIcon = UIImage(named: "icon-reader-comment-outline-highlighted")?.imageFlippedForRightToLeftLayoutDirection()
 
@@ -469,9 +469,7 @@ extension WPStyleGuide {
     /// - Parameter button: the button to apply the style to
     /// - Parameter showTitle: if set to true, will show the button label (default: true)
     @objc public class func applyReaderReblogActionButtonStyle(_ button: UIButton, showTitle: Bool = true) {
-        let icon = UIImage.gridicon(.reblog, size: Detail.actionBarIconSize)
-
-        button.setImage(icon, for: .normal)
+        button.setImage(ReaderDetail.reblogToolbarIcon, for: .normal)
 
         WPStyleGuide.applyReaderReblogActionButtonTitle(button, showTitle: showTitle)
         WPStyleGuide.applyReaderActionButtonStyle(button)
@@ -590,9 +588,63 @@ extension WPStyleGuide {
     public struct Detail {
         public static let titleTextStyle: UIFont.TextStyle = .title2
         public static let contentTextStyle: UIFont.TextStyle = .callout
+    }
 
-        public static var actionBarIconSize: CGSize {
-            return RemoteFeatureFlag.readerImprovements.enabled() ? CGSize(width: 20.0, height: 20.0) : Gridicon.defaultSize
+    public struct ReaderDetail {
+        private static var readerImprovements: Bool {
+            return RemoteFeatureFlag.readerImprovements.enabled()
+        }
+
+        public static var reblogToolbarIcon: UIImage? {
+            if readerImprovements {
+                return UIImage(named: "icon-reader-reblog")?.withRenderingMode(.alwaysTemplate)
+            }
+            return UIImage.gridicon(.reblog, size: Gridicon.defaultSize)
+        }
+
+        static var commentToolbarIcon: UIImage? {
+            let imageName = readerImprovements ? "icon-reader-post-comment" : "icon-reader-comment-outline"
+            return UIImage(named: imageName)?
+                .imageFlippedForRightToLeftLayoutDirection()
+                .withRenderingMode(.alwaysTemplate)
+        }
+
+        static var commentHighlightedToolbarIcon: UIImage? {
+            if readerImprovements {
+                // note: we don't have a highlighted variant in the new version.
+                return commentToolbarIcon
+            }
+            return UIImage(named: "icon-reader-comment-outline-highlighted")?
+                .imageFlippedForRightToLeftLayoutDirection()
+                .withRenderingMode(.alwaysTemplate)
+        }
+
+        public static var saveToolbarIcon: UIImage? {
+            if readerImprovements {
+                return UIImage(named: "icon-reader-save-outline")
+            }
+            return UIImage.gridicon(.bookmarkOutline, size: Gridicon.defaultSize)
+        }
+
+        public static var saveSelectedToolbarIcon: UIImage? {
+            if readerImprovements {
+                return UIImage(named: "icon-reader-save-fill")
+            }
+            return UIImage.gridicon(.bookmark, size: Gridicon.defaultSize)
+        }
+
+        static var likeToolbarIcon: UIImage? {
+            if readerImprovements {
+                return UIImage(named: "icon-reader-star-outline")?.withRenderingMode(.alwaysTemplate)
+            }
+            return UIImage(named: "icon-reader-like")
+        }
+
+        static var likeSelectedToolbarIcon: UIImage? {
+            if readerImprovements {
+                return UIImage(named: "icon-reader-star-fill")?.withRenderingMode(.alwaysTemplate)
+            }
+            return UIImage(named: "icon-reader-liked")
         }
     }
 

--- a/WordPress/Resources/AppImages.xcassets/icon-reader-save-fill.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/icon-reader-save-fill.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "icon-reader-save-fill.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/WordPress/Resources/AppImages.xcassets/icon-reader-save-fill.imageset/icon-reader-save-fill.svg
+++ b/WordPress/Resources/AppImages.xcassets/icon-reader-save-fill.imageset/icon-reader-save-fill.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6.25 5.25V18.591L12 13.8473L17.75 18.591V5.25L6.25 5.25Z" fill="black"/>
+</svg>

--- a/WordPress/Resources/AppImages.xcassets/icon-reader-save-outline.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/icon-reader-save-outline.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "icon-reader-save-outline.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/WordPress/Resources/AppImages.xcassets/icon-reader-save-outline.imageset/icon-reader-save-outline.svg
+++ b/WordPress/Resources/AppImages.xcassets/icon-reader-save-outline.imageset/icon-reader-save-outline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6.25 18.591L6.25 5.25L17.75 5.25L17.75 18.591L12 13.8473L6.25 18.591ZM7.75 15.409L12 11.9027L16.25 15.409L16.25 6.75L7.75 6.75L7.75 15.409Z" fill="black"/>
+</svg>


### PR DESCRIPTION
Refs zQnohyMpLzBzQ5jzMMKni3-fi-868:19180#583623585

This updates the toolbar icons in Reader detail. Furthermore, this also fixes some bugs in the implementation that affected the old design when the feature flag is turned off. 

Feature flag enabled | Feature flag disabled
-|-
![toolbar_new](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/a827db8e-1281-4322-8f40-c4f873debbe1) | ![toolbar_old](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/277045ec-af86-468d-8351-c3d8beae33e0)

## To test

- Launch the Jetpack app.
- Go to the Reader tab, and select any post. 
- 🔎 Verify that the new toolbar icons are displayed.
- 🔎 Verify that the toolbar actions work as expected. 
- Go to App Settings, and disable the `readerImprovements` flag.
- Navigate back from the Reader detail page and select the post again (to refresh the toolbar).
- 🔎 Verify that the old toolbar design is displayed correctly.
- 🔎 Verify that the toolbar actions work as expected. 

Bonus: test with posts with comments disabled, likes disabled, reblog disabled, etc.

## Regression Notes
1. Potential unintended areas of impact
This changes impact the Reader detail toolbar when the feature flag is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes with the feature flag on and off.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
