### PR TITLE
[UI Tests] - Fix top flaky tests

### DIFF
--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -62,10 +62,10 @@ public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 20) {
     }
 }
 
-public func tap(element: XCUIElement, untilAppears elementToAppear: XCUIElement, maxRetries: Int = 10) {
+public func tapUntilCondition(element: XCUIElement, condition: Bool, description: String, maxRetries: Int = 10) {
     var retries = 0
     while retries < maxRetries {
-        if !elementToAppear.exists {
+        if !condition {
             element.tap()
             break
         }
@@ -75,7 +75,7 @@ public func tap(element: XCUIElement, untilAppears elementToAppear: XCUIElement,
     }
 
     if retries == maxRetries {
-        XCTFail("Expected element (\(elementToAppear)) still does not exist after \(maxRetries) tries.")
+        XCTFail("Condition \(description) still not met after \(maxRetries) tries.")
     }
 }
 

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -45,7 +45,7 @@ public func waitForExistenceAndTap(_ element: XCUIElement, timeout: TimeInterval
     element.tap()
 }
 
-public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10) {
+public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 20) {
     var retries = 0
     while retries < maxRetries {
         if element.isHittable {
@@ -53,7 +53,7 @@ public func waitAndTap( _ element: XCUIElement, maxRetries: Int = 10) {
             break
         }
 
-        usleep(500000) // a 0.5 second delay before retrying
+        usleep(250000) // a 0.25 second delay before retrying
         retries += 1
     }
 

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -12,8 +12,11 @@ public class ActivityLogScreen: ScreenObject {
         $0.buttons["Activity Type"].firstMatch
     }
 
-    var dateRangeButton: XCUIElement { dateRangeButtonGetter(app) }
     var activityTypeButton: XCUIElement { activityTypeButtonGetter(app) }
+    var dateRangeButton: XCUIElement { dateRangeButtonGetter(app) }
+
+    // Timeout duration to overwrite value defined in XCUITestHelpers
+    var duration: TimeInterval = 10.0
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         tabBar = try TabNavComponent()
@@ -31,7 +34,7 @@ public class ActivityLogScreen: ScreenObject {
     @discardableResult
     public func verifyActivityLogScreen(hasActivityPartial activityTitle: String) -> Self {
         XCTAssertTrue(
-            app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", activityTitle)).firstMatch.waitForIsHittable(),
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", activityTitle)).firstMatch.waitForIsHittable(timeout: duration),
             "Activity Log Screen: \"\(activityTitle)\" activity not displayed.")
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -142,7 +142,7 @@ public class EditorPostSettings: ScreenObject {
 
         // Selects the first day of the next month
         nextMonthButton.tap()
-        firstCalendarDayButton.tap()
+        tapUntilCondition(element: firstCalendarDayButton, condition: firstCalendarDayButton.isSelected, description: "First Day button selected")
 
         doneButton.tap()
         return self

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -124,7 +124,7 @@ public class MySiteScreen: ScreenObject {
     var switchSiteButton: XCUIElement { switchSiteButtonGetter(app) }
 
     // Timeout duration to overwrite value defined in XCUITestHelpers
-    var duration: TimeInterval = 5.0
+    var duration: TimeInterval = 10.0
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -84,7 +84,8 @@ public class NotificationsScreen: ScreenObject {
     }
 
     public func replyToComment(withText text: String) -> Self {
-        tap(element: replyCommentButton, untilAppears: replyTextView)
+        tapUntilCondition(element: replyCommentButton, condition: replyTextView.exists, description: "Reply Text View exists")
+
         replyTextView.typeText(text)
         replyButton.tap()
 


### PR DESCRIPTION
### Description
The UI Tests reliability seems to be going down again, and these are the top offenders: `DashboardTests testActivityLogCardHeaderNavigation`, `PostTests testCreateScheduledPost` and `EditorGutenbergTests testBasicPostPublishWithCategoryAndTag`. The changes in this PR attempts to fix the flakiness by:
1. Increase timeout from default value of 3 seconds to 10 (if the element appears earlier, test should still continue and won't wait for the whole 10 seconds) in an attempt to fix flakiness in `testActivityLogCardHeaderNavigation`
2. Updated tap on the Calendar for `testCreateScheduledPost` as it seems like sometimes a future date is not properly tapped, causing the button to not change from `Publish` to `Scheduled` 
3. Reduced the time taken for the test to find the View button (a notice that can disappear) in `testBasicPostPublishWithCategoryAndTag` from every 0.5 seconds to every 0.25 seconds. If this continues to be really flaky we might need to rethink the implementation.


### Testing
CI should be 🟢 