### PR TITLE
Strip HTML from post titles

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -364,7 +364,9 @@ class Post: AbstractPost {
 
     override func titleForDisplay() -> String {
         var title = postTitle?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
-        title = title.stringByDecodingXMLCharacters()
+        title = title
+            .stringByDecodingXMLCharacters()
+            .strippingHTML()
 
         if title.count == 0 && contentPreviewForDisplay().count == 0 && !hasRemote() {
             title = NSLocalizedString("(no title)", comment: "Lets a user know that a local draft does not have a title.")

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -254,6 +254,9 @@ class PostTests: CoreDataTestCase {
         post.postTitle = "hello world"
         XCTAssertEqual(post.titleForDisplay(), "hello world")
 
+        post.postTitle = "hello <i>world</i>"
+        XCTAssertEqual(post.titleForDisplay(), "hello world")
+
         post.postTitle = "    "
         XCTAssertEqual(post.titleForDisplay(), NSLocalizedString("(no title)", comment: "(no title)"))
     }


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/16999 (targeting `trunk`)
 
To test: see the linked defect

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/f1fba226-321d-43f3-83c9-869e9dd3cf6f



## Regression Notes
1. Potential unintended areas of impact: Posts List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual & unit tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
