### PR TITLE
Posts & Pages: Page hierarchy

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -12,6 +12,7 @@ final class PageListCell: UITableViewCell, Reusable {
     private let featuredImageView = CachedAnimatedImageView()
     private let ellipsisButton = UIButton(type: .custom)
     private let contentStackView = UIStackView()
+    private var indentionIconView = UIImageView()
     private var cancellables: [AnyCancellable] = []
 
     // MARK: - Properties
@@ -38,7 +39,7 @@ final class PageListCell: UITableViewCell, Reusable {
         imageLoader.prepareForReuse()
     }
 
-    func configure(with viewModel: PageListItemViewModel, indentation: Int) {
+    func configure(with viewModel: PageListItemViewModel, indentation: Int = 0, isFirstSubdirectory: Bool = false) {
         viewModel.$title.sink { [titleLabel] in
             titleLabel.attributedText = $0
         }.store(in: &cancellables)
@@ -56,9 +57,15 @@ final class PageListCell: UITableViewCell, Reusable {
             imageLoader.loadImage(with: imageURL, from: host, preferredSize: Constants.imageSize)
         }
 
-        let leading = 16 + CGFloat(indentation) * 16
-        separatorInset = UIEdgeInsets(top: 0, left: leading, bottom: 0, right: 0)
-        contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 12, leading: leading, bottom: 12, trailing: 16)
+        separatorInset = UIEdgeInsets(top: 0, left: 16 + CGFloat(indentation) * 32, bottom: 0, right: 0)
+        contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: 12,
+            leading: 16 + CGFloat(max(0, indentation - 1)) * 32,
+            bottom: 12,
+            trailing: 16
+        )
+        indentionIconView.isHidden = indentation == 0
+        indentionIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
     }
 
     // MARK: - Setup
@@ -67,6 +74,10 @@ final class PageListCell: UITableViewCell, Reusable {
         setupLabels()
         setupFeaturedImageView()
         setupEllipsisButton()
+
+        indentionIconView.image = UIImage(named: "subdirectory")
+        indentionIconView.setContentHuggingPriority(.required, for: .horizontal)
+        indentionIconView.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         let badgesStackView = UIStackView(arrangedSubviews: [
             badgeIconView, badgesLabel, UIView()
@@ -81,7 +92,7 @@ final class PageListCell: UITableViewCell, Reusable {
         labelsStackView.axis = .vertical
 
         contentStackView.addArrangedSubviews([
-            labelsStackView, featuredImageView, ellipsisButton
+            indentionIconView, labelsStackView, featuredImageView, ellipsisButton
         ])
         contentStackView.spacing = 8
         contentStackView.alignment = .center

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -11,6 +11,7 @@ final class PageListCell: UITableViewCell, Reusable {
     private let badgesLabel = UILabel()
     private let featuredImageView = CachedAnimatedImageView()
     private let ellipsisButton = UIButton(type: .custom)
+    private let contentStackView = UIStackView()
     private var cancellables: [AnyCancellable] = []
 
     // MARK: - Properties
@@ -37,7 +38,7 @@ final class PageListCell: UITableViewCell, Reusable {
         imageLoader.prepareForReuse()
     }
 
-    func configure(with viewModel: PageListItemViewModel) {
+    func configure(with viewModel: PageListItemViewModel, indentation: Int) {
         viewModel.$title.sink { [titleLabel] in
             titleLabel.attributedText = $0
         }.store(in: &cancellables)
@@ -54,13 +55,15 @@ final class PageListCell: UITableViewCell, Reusable {
             }
             imageLoader.loadImage(with: imageURL, from: host, preferredSize: Constants.imageSize)
         }
+
+        let leading = 16 + CGFloat(indentation) * 16
+        separatorInset = UIEdgeInsets(top: 0, left: leading, bottom: 0, right: 0)
+        contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 12, leading: leading, bottom: 12, trailing: 16)
     }
 
     // MARK: - Setup
 
     private func setupViews() {
-        separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
-
         setupLabels()
         setupFeaturedImageView()
         setupEllipsisButton()
@@ -77,13 +80,12 @@ final class PageListCell: UITableViewCell, Reusable {
         labelsStackView.spacing = 4
         labelsStackView.axis = .vertical
 
-        let contentStackView = UIStackView(arrangedSubviews: [
+        contentStackView.addArrangedSubviews([
             labelsStackView, featuredImageView, ellipsisButton
         ])
         contentStackView.spacing = 8
         contentStackView.alignment = .center
         contentStackView.isLayoutMarginsRelativeArrangement = true
-        contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
 
         NSLayoutConstraint.activate([
             badgeIconView.heightAnchor.constraint(equalToConstant: 18),

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -12,7 +12,7 @@ final class PageListCell: UITableViewCell, Reusable {
     private let featuredImageView = CachedAnimatedImageView()
     private let ellipsisButton = UIButton(type: .custom)
     private let contentStackView = UIStackView()
-    private var indentionIconView = UIImageView()
+    private var indentationIconView = UIImageView()
     private var cancellables: [AnyCancellable] = []
 
     // MARK: - Properties
@@ -64,8 +64,8 @@ final class PageListCell: UITableViewCell, Reusable {
             bottom: 12,
             trailing: 16
         )
-        indentionIconView.isHidden = indentation == 0
-        indentionIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
+        indentationIconView.isHidden = indentation == 0
+        indentationIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
     }
 
     // MARK: - Setup
@@ -75,9 +75,9 @@ final class PageListCell: UITableViewCell, Reusable {
         setupFeaturedImageView()
         setupEllipsisButton()
 
-        indentionIconView.image = UIImage(named: "subdirectory")
-        indentionIconView.setContentHuggingPriority(.required, for: .horizontal)
-        indentionIconView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        indentationIconView.image = UIImage(named: "subdirectory")
+        indentationIconView.setContentHuggingPriority(.required, for: .horizontal)
+        indentationIconView.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         let badgesStackView = UIStackView(arrangedSubviews: [
             badgeIconView, badgesLabel, UIView()
@@ -92,7 +92,7 @@ final class PageListCell: UITableViewCell, Reusable {
         labelsStackView.axis = .vertical
 
         contentStackView.addArrangedSubviews([
-            indentionIconView, labelsStackView, featuredImageView, ellipsisButton
+            indentationIconView, labelsStackView, featuredImageView, ellipsisButton
         ])
         contentStackView.spacing = 8
         contentStackView.alignment = .center

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -75,6 +75,7 @@ final class PageListCell: UITableViewCell, Reusable {
         setupFeaturedImageView()
         setupEllipsisButton()
 
+        indentationIconView.tintColor = .secondaryLabel
         indentationIconView.image = UIImage(named: "subdirectory")
         indentationIconView.setContentHuggingPriority(.required, for: .horizontal)
         indentationIconView.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -374,19 +374,18 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let identifier = cellIdentifierForPage(page)
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
 
-        configureCell(cell, at: indexPath)
         if let cell = cell as? PageListCell {
-            cell.configure(with: PageListItemViewModel(page: page))
+            let filterType = filterSettings.currentPostListFilter().filterType
+            let indentation = filterType == .published ? page.hierarchyIndex : 0
+            cell.configure(with: PageListItemViewModel(page: page), indentation: indentation)
         }
+
         return cell
     }
 
     override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
-        // TODO: Implement indenting for child pages (#21818)
         // TODO: Implement cntext menus (#21717)
 //        if cell.reuseIdentifier == Constant.Identifiers.pageCellIdentifier {
-//            cell.indentationWidth = Constant.Size.pageListTableViewCellLeading
-//            cell.indentationLevel = filterType != .published ? 0 : page.hierarchyIndex
 //            cell.onAction = { [weak self] cell, button, page in
 //                self?.handleMenuAction(fromCell: cell, fromButton: button, forPage: page)
 //            }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -375,12 +375,23 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
 
         if let cell = cell as? PageListCell {
-            let filterType = filterSettings.currentPostListFilter().filterType
-            let indentation = filterType == .published ? page.hierarchyIndex : 0
-            cell.configure(with: PageListItemViewModel(page: page), indentation: indentation)
+            let indentation = getIndentationLevel(at: indexPath)
+            let isFirstSubdirectory = getIndentationLevel(at: IndexPath(row: indexPath.row - 1, section: indexPath.section)) == (indentation - 1)
+            cell.configure(with: PageListItemViewModel(page: page), indentation: indentation, isFirstSubdirectory: isFirstSubdirectory)
         }
 
         return cell
+    }
+
+    private func getIndentationLevel(at indexPath: IndexPath) -> Int {
+        guard filterSettings.currentPostListFilter().filterType == .published else {
+            return 0
+        }
+        let lowerBound = _tableViewHandler.showEditorHomepage ? 1 : 0
+        guard indexPath.row > lowerBound else {
+            return 0
+        }
+        return pageAtIndexPath(indexPath).hierarchyIndex
     }
 
     override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -121,7 +121,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
                 return cell
             case .page(let page):
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell
-                cell.configure(with: page, indentation: 0)
+                cell.configure(with: page)
                 return cell
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -121,7 +121,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
                 return cell
             case .page(let page):
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell
-                cell.configure(with: page)
+                cell.configure(with: page, indentation: 0)
                 return cell
             }
         }

--- a/WordPress/Resources/AppImages.xcassets/subdirectory.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/subdirectory.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/AppImages.xcassets/subdirectory.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/subdirectory.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "subdirectory.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WordPress/Resources/AppImages.xcassets/subdirectory.imageset/subdirectory.pdf
+++ b/WordPress/Resources/AppImages.xcassets/subdirectory.imageset/subdirectory.pdf
@@ -1,0 +1,147 @@
+%PDF-1.7
+
+1 0 obj
+  << /Type /XObject
+     /Length 2 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Subtype /Form
+     /Resources << >>
+     /BBox [ 0.000000 0.000000 24.000000 24.000000 ]
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
+0.313726 0.341176 0.368627 scn
+0.000000 24.000000 m
+24.000000 24.000000 l
+24.000000 0.000000 l
+0.000000 0.000000 l
+0.000000 24.000000 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+2 0 obj
+  232
+endobj
+
+3 0 obj
+  << /Type /XObject
+     /Length 4 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Subtype /Form
+     /Resources << >>
+     /BBox [ 0.000000 0.000000 24.000000 24.000000 ]
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 4.500000 3.500000 cm
+0.000000 0.000000 0.000000 scn
+15.000000 6.000000 m
+9.000000 0.000000 l
+7.580000 1.420000 l
+11.170000 5.000000 l
+0.000000 5.000000 l
+0.000000 17.000000 l
+2.000000 17.000000 l
+2.000000 7.000000 l
+11.170000 7.000000 l
+7.580000 10.580000 l
+9.000000 12.000000 l
+15.000000 6.000000 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+4 0 obj
+  375
+endobj
+
+5 0 obj
+  << /XObject << /X1 1 0 R >>
+     /ExtGState << /E1 << /SMask << /Type /Mask
+                                    /G 3 0 R
+                                    /S /Alpha
+                                 >>
+                          /Type /ExtGState
+                       >> >>
+  >>
+endobj
+
+6 0 obj
+  << /Length 7 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+/E1 gs
+/X1 Do
+Q
+
+endstream
+endobj
+
+7 0 obj
+  46
+endobj
+
+8 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 24.000000 24.000000 ]
+     /Resources 5 0 R
+     /Contents 6 0 R
+     /Parent 9 0 R
+  >>
+endobj
+
+9 0 obj
+  << /Kids [ 8 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+10 0 obj
+  << /Pages 9 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000010 00000 n
+0000000490 00000 n
+0000000512 00000 n
+0000001135 00000 n
+0000001157 00000 n
+0000001455 00000 n
+0000001557 00000 n
+0000001578 00000 n
+0000001751 00000 n
+0000001825 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 10 0 R
+   /Size 11
+>>
+startxref
+1885
+%%EOF


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/21818

To test:

- Verify that pages with parents are rendered with indentation

Known issues:

- Order doesn't match https://github.com/wordpress-mobile/WordPress-iOS/issues/21856

<img width="360" alt="Screenshot 2023-10-23 at 5 21 12 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/44b67bf8-489c-41e1-851b-c12a793597fb">

## Regression Notes
1. Potential unintended areas of impact: Pages List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
