### PR TITLE
Reader: Reduce amount requested for followed sites

### DIFF
--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -13,7 +13,7 @@
 @import WordPressKit;
 @import WordPressShared;
 
-NSUInteger const ReaderPostServiceNumberToSync = 40;
+NSUInteger const ReaderPostServiceNumberToSync = 7;
 // NOTE: The search endpoint is currently capped to max results of 20 and returns
 // a 500 error if more are requested.
 // For performance reasons, request fewer results. EJ 2016-05-13


### PR DESCRIPTION
Closes #21854 

## Description

Reduces the amount of followed sites requested to `7`. This matches what the web is currently doing and decreases the time it takes to load the `Following` tab.

## Testing

To test:
- Select your preferred method for observing the request (breakpoint, Charles, etc)
- Launch Jetpack and login
- Navigate to the Reader tab
- Tap on the `Following` filter if necessary
- Observe the API call and 🔎 **verify** the amount parameter is set to `7`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
