### PR TITLE
Reader: Update avatar spacing if site image is removed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -460,6 +460,7 @@ private extension ReaderPostCardCell {
 
     func configureSiteIcon() {
         guard let viewModel, viewModel.isSiteIconEnabled else {
+            siteStackView.setCustomSpacing(Constants.SiteStackView.iconSpacing, after: avatarContainerView)
             removeFromStackView(siteStackView, view: siteIconContainerView)
             return
         }


### PR DESCRIPTION
Fixes #21857 

## Description

Updates the spacing of the avatar image if there is no site image.

## Testing

To test:
- Follow a P2 which has the site image disabled
- Launch Jetpack and login
- Navigate to the Reader
- Tap on the `Automattic` filter
- Tap on Filter and select the P2 which has the image disabled
- 🔎 **Verify** The avatar image and title are properly spaced apart

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
