### PR TITLE
Remove unneeded env vars from Fastfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,13 +53,8 @@ Dotenv.load(USER_ENV_FILE_PATH)
 Dotenv.load(PROJECT_ENV_FILE_PATH)
 GITHUB_REPO = 'wordpress-mobile/wordpress-iOS'
 DEFAULT_BRANCH = 'trunk'
-ENV['PROJECT_NAME'] = 'WordPress'
 PUBLIC_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.Public.xcconfig')
-ENV['PUBLIC_CONFIG_FILE'] = PUBLIC_CONFIG_FILE
 INTERNAL_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.internal.xcconfig')
-ENV['INTERNAL_CONFIG_FILE'] = INTERNAL_CONFIG_FILE
-ENV['PROJECT_ROOT_FOLDER'] = "#{PROJECT_ROOT_FOLDER}/"
-ENV['APP_STORE_STRINGS_FILE_NAME'] = 'AppStoreStrings.po'
 ENV['FASTLANE_WWDR_USE_HTTP1_AND_RETRIES'] = 'true'
 
 # Instanstiate versioning classes

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -88,7 +88,10 @@ platform :ios do
       release_notes_file_path: release_notes_source_path,
       extracted_notes_file_path: extracted_release_notes_file_path(app: :jetpack)
     )
-    ios_update_release_notes(new_version:)
+    ios_update_release_notes(
+      new_version:,
+      release_notes_file_path: release_notes_source_path
+    )
 
     if prompt_for_confirmation(
       message: 'Ready to push changes to remote to let the automation configure it on GitHub?',


### PR DESCRIPTION
## Summary of changes:

This PR removes several unneeded environment variables:
- `PROJECT_ROOT_FOLDER` - The only action used by WP/JP that uses this one is[`ios_update_release_notes`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_update_release_notes.rb) Release Toolkit action. I passed the `release_notes_source_path` variable to the method so that it doesn't rely on the default value of the action, which does use the env var.
- `PROJECT_NAME` - This env var is used by Android apps in a path like `PROJECT_ROOT_FOLDER/PROJECT_NAME/build.gradle`, but it's not currently used by any iOS actions. I don't know if that was different in the past, but it's not needed at all now. 
- `PUBLIC_CONFIG_FILE` - This is used by [`ios_get_build_version.rb`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_get_build_version.rb), and the `update_xc_configs` method in [`ios_version_helper`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_version_helper.rb) but none of those actions are used by WP/JPiOS anymore after the recent versioning changes: https://github.com/Automattic/pocket-casts-ios/pull/1137
- `INTERNAL_CONFIG_FILE` - Used by the `ios_bump_version_beta.rb`, `ios_bump_version_hotfix.rb`, `ios_hotfix_version_release.rb`, `ios_get_build_version.rb`, and the `update_xc_configs` method in `ios_version_helper.rb`. Like the public file, none of those actions are used anymore after the recent versioning changes. It is also used by the `ios_tag_build.rb` action, but WP/JPiOS doesn't use it.  
- `APP_STORE_STRINGS_FILE_NAME` - This env var isn't used by any actions in the Release Toolkit anymore ([See Migration.md when updating to `9.0.0`](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/MIGRATION.md#from-800-to-900))