### PR TITLE
Remove dead code which was used to preload all posts and pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1740,70 +1740,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     // only preload on wifi
     if (isOnWifi) {
-        [self preloadPosts];
-        [self preloadPages];
         [self preloadComments];
         [self preloadMetadata];
         [self preloadDomains];
-    }
-}
-
-- (void)preloadPosts
-{
-    [self preloadPostsOfType:PostServiceTypePost];
-}
-
-- (void)preloadPages
-{
-    [self preloadPostsOfType:PostServiceTypePage];
-}
-
-// preloads posts or pages.
-- (void)preloadPostsOfType:(PostServiceType)postType
-{
-    // Temporarily disable posts preloading until we can properly resolve the issues on:
-    // https://github.com/wordpress-mobile/WordPress-iOS/issues/6151
-    // Brent C. Nov 3/2016
-    BOOL preloadingPostsDisabled = YES;
-    if (preloadingPostsDisabled) {
-        return;
-    }
-
-    NSDate *lastSyncDate;
-    if ([postType isEqual:PostServiceTypePage]) {
-        lastSyncDate = self.blog.lastPagesSync;
-    } else {
-        lastSyncDate = self.blog.lastPostsSync;
-    }
-    NSTimeInterval now = [[NSDate date] timeIntervalSinceReferenceDate];
-    NSTimeInterval lastSync = lastSyncDate.timeIntervalSinceReferenceDate;
-    if (now - lastSync > PreloadingCacheTimeout) {
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
-        PostListFilterSettings *filterSettings = [[PostListFilterSettings alloc] initWithBlog:self.blog postType:postType];
-        PostListFilter *filter = [filterSettings currentPostListFilter];
-
-        PostServiceSyncOptions *options = [PostServiceSyncOptions new];
-        options.statuses = filter.statuses;
-        options.authorID = [filterSettings authorIDFilter];
-        options.purgesLocalSync = YES;
-
-        if ([postType isEqual:PostServiceTypePage]) {
-            self.blog.lastPagesSync = [NSDate date];
-        } else {
-            self.blog.lastPostsSync = [NSDate date];
-        }
-        NSError *error = nil;
-        [self.blog.managedObjectContext save:&error];
-
-        [postService syncPostsOfType:postType withOptions:options forBlog:self.blog success:nil failure:^(NSError * __unused error) {
-            NSDate *invalidatedDate = [NSDate dateWithTimeIntervalSince1970:0.0];
-            if ([postType isEqual:PostServiceTypePage]) {
-                self.blog.lastPagesSync = invalidatedDate;
-            } else {
-                self.blog.lastPostsSync = invalidatedDate;
-            }
-        }];
     }
 }
 


### PR DESCRIPTION
Relates to
- https://github.com/wordpress-mobile/WordPress-iOS/issues/6151
- https://github.com/wordpress-mobile/WordPress-iOS/issues/12161

I don't think it's a good idea to resurrect the preloading code that has been disabled for 6 years, despite the two issues above.

The main reason is, the preloading code fetches and saves every single posts and pages of the site. However, the posts and pages list [re-fetches the same data](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.4/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift#L634), and even [deleted all previously saved posts](https://github.com/wordpress-mobile/WordPress-iOS/blob/23.4/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift#L649). All the syncing work would be wasted for nothing.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A