### PR TITLE
Fix: Submitting wrong code for SMS 2FA can result in a vague error message

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -147,8 +147,8 @@ abstract_target 'Apps' do
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
-  # pod 'WordPressAuthenticator', '~> 7.2.1-beta.1'
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'fix/submitting-wrong-sms-2fa-results-in-vague-error-message'
+  pod 'WordPressAuthenticator', '~> 7.2.1-beta.2'
+  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -147,8 +147,8 @@ abstract_target 'Apps' do
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
-  pod 'WordPressAuthenticator', '~> 7.2.1-beta.1'
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
+  # pod 'WordPressAuthenticator', '~> 7.2.1-beta.1'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'fix/submitting-wrong-sms-2fa-results-in-vague-error-message'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
     - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (7.2.1-beta.1):
+  - WordPressAuthenticator (7.2.1-beta.2):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -125,7 +125,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (~> 7.2.1-beta.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/submitting-wrong-sms-2fa-results-in-vague-error-message`)
   - WordPressKit (>= 8.7.1, ~> 8.7)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
@@ -134,8 +134,6 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AlamofireImage
@@ -185,6 +183,9 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec
+  WordPressAuthenticator:
+    :branch: fix/submitting-wrong-sms-2fa-results-in-vague-error-message
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -194,6 +195,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
+  WordPressAuthenticator:
+    :commit: 6c9d9b0aeaaec6565a4624bedbe67756c9b9d132
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -226,7 +230,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: c0971120d2dc761e8ac161ffce521b8a2368578e
+  WordPressAuthenticator: 1d73abee8fdd87032e987c40f140423a6aa0e577
   WordPressKit: 33a0571389da6b40c765398a8c84da72f5514a6f
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
@@ -241,6 +245,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 38cfc60545d07a448c12d5765a8b676cb4c22f8d
+PODFILE CHECKSUM: 0eaa9256303831c61784f6625bb9d4170e318af0
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -125,7 +125,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/submitting-wrong-sms-2fa-results-in-vague-error-message`)
+  - WordPressAuthenticator (~> 7.2.1-beta.2)
   - WordPressKit (>= 8.7.1, ~> 8.7)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
@@ -163,6 +163,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -183,9 +184,6 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec
-  WordPressAuthenticator:
-    :branch: fix/submitting-wrong-sms-2fa-results-in-vague-error-message
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -195,9 +193,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
-  WordPressAuthenticator:
-    :commit: 6c9d9b0aeaaec6565a4624bedbe67756c9b9d132
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -245,6 +240,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 0eaa9256303831c61784f6625bb9d4170e318af0
+PODFILE CHECKSUM: fe27477bb386333975be481e9f9718ea47ec4e29
 
 COCOAPODS: 1.12.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Site Domains: Fixed an issue where the message shared while adding a domain was inaccurate. [#21827]
 * [*] Fix an issue where login with site address is blocked after failing the first attempt. [#21848]
 * [*] Fix an issue with an issue [#16999] with HTML not being stripped from post titles [#21846]
+* [*] Fix an issue that leads to an ambiguous error message when an incorrect SMS 2FA code is submitted. [#21863]
 
 23.5
 -----


### PR DESCRIPTION
Fixes #20983
WP-Kit PR with more details: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/793

## To test:

1. Start the login flow for a WordPress.com account through Google, that has 2FA+SMS enabled on the WordPress.com side.
2. When prompted for the 2FA code, type an incorrect code with 6 digits
3. Confirm that error message is descriptive
4. Enter incorrect code with 7 digits
5. Confirm that the error message is descriptive
6. Enter the correct code
7. Confirm the login is successful 

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/ac6e1899-f5fd-4d22-8247-1144d42c0dc3


## Regression Notes
1. Potential unintended areas of impact

There's a chance of breaking something unintentionally. However, the current behavior on WP-Authenticator simply tries to validate login fields using parent view controller `LoginViewController` when 2fa code is wrong, always resulting in vague and wrong error messages. I think that this chance is safe. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Testing different 2fa flows.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
