### PR TITLE
Fix two 2FA controllers being opened when logging in at the same time

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Fix an issue where login with site address is blocked after failing the first attempt. [#21848]
 * [*] Fix an issue with an issue [#16999] with HTML not being stripped from post titles [#21846]
 * [*] Fix an issue that leads to an ambiguous error message when an incorrect SMS 2FA code is submitted. [#21863]
+* [*] Fix an issue where two 2FA controllers were being opened at the same time when logging in. [#21865]
 
 23.5
 -----


### PR DESCRIPTION
Fixes #21864
Related WP-Kit PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/794

Caused by: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/788

## To test:

1. Login with a WP.com account that has 2FA + SMS enabled
2. Confirm that only one controller is opened
3. Confirm that log in can be cone

## Regression Notes
1. Potential unintended areas of impact

I was afraid to break a new functionality recently built but testing and code analysis suggest that this is a bug. It also appeared in the newest WooCommerce-iOS version.

2. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
