### PR TITLE
UI Tests: Disable compliance popover for UI Tests

### DIFF
--- a/WordPress/Classes/System/UITestConfigurator.swift
+++ b/WordPress/Classes/System/UITestConfigurator.swift
@@ -4,6 +4,7 @@ struct UITestConfigurator {
     static func prepareApplicationForUITests(_ application: UIApplication) {
         disableAnimations(application)
         logoutAtLaunch()
+        disableCompliancePopover()
     }
 
     /// This method will disable animations and speed-up keyboad input if command-line arguments includes "NoAnimations"
@@ -22,6 +23,12 @@ struct UITestConfigurator {
     private static func logoutAtLaunch() {
         if CommandLine.arguments.contains("-logout-at-launch") {
             AccountHelper.logOutDefaultWordPressComAccount()
+        }
+    }
+
+    private static func disableCompliancePopover() {
+        if CommandLine.arguments.contains("-ui-testing") {
+            UserDefaults.standard.didShowCompliancePopup = true
         }
     }
 }

--- a/WordPress/Classes/System/UITestConfigurator.swift
+++ b/WordPress/Classes/System/UITestConfigurator.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct UITestConfigurator {
+    static func prepareApplicationForUITests(_ application: UIApplication) {
+        disableAnimations(application)
+        logoutAtLaunch()
+    }
+
+    /// This method will disable animations and speed-up keyboad input if command-line arguments includes "NoAnimations"
+    /// It was designed to be used in UI test suites. To enable it just pass a launch argument into XCUIApplicaton:
+    ///
+    /// XCUIApplication().launchArguments = ["-no-animations"]
+    ///
+    private static func disableAnimations(_ application: UIApplication) {
+        if CommandLine.arguments.contains("-no-animations") {
+            UIView.setAnimationsEnabled(false)
+            application.windows.first?.layer.speed = MAXFLOAT
+            application.mainWindow?.layer.speed = MAXFLOAT
+        }
+    }
+
+    private static func logoutAtLaunch() {
+        if CommandLine.arguments.contains("-logout-at-launch") {
+            AccountHelper.logOutDefaultWordPressComAccount()
+        }
+    }
+}

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -135,7 +135,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         setupPingHub()
         setupBackgroundRefresh(application)
         setupComponentsAppearance()
-        prepareApplicationForUITests(application)
+        UITestConfigurator.prepareApplicationForUITests(application)
 
         // This was necessary to properly load fonts for the Stories editor. I believe external libraries may require this call to access fonts.
         let fonts = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: nil)

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -135,8 +135,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         setupPingHub()
         setupBackgroundRefresh(application)
         setupComponentsAppearance()
-        disableAnimationsForUITests(application)
-        logoutAtLaunchForUITests(application)
+        prepareApplicationForUITests(application)
 
         // This was necessary to properly load fonts for the Stories editor. I believe external libraries may require this call to access fonts.
         let fonts = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: nil)
@@ -359,25 +358,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // MARK: - Helpers
-
-    /// This method will disable animations and speed-up keyboad input if command-line arguments includes "NoAnimations"
-    /// It was designed to be used in UI test suites. To enable it just pass a launch argument into XCUIApplicaton:
-    ///
-    /// XCUIApplication().launchArguments = ["-no-animations"]
-    ///
-    private func disableAnimationsForUITests(_ application: UIApplication) {
-        if CommandLine.arguments.contains("-no-animations") {
-            UIView.setAnimationsEnabled(false)
-            application.windows.first?.layer.speed = MAXFLOAT
-            application.mainWindow?.layer.speed = MAXFLOAT
-        }
-    }
-
-    private func logoutAtLaunchForUITests(_ application: UIApplication) {
-        if CommandLine.arguments.contains("-logout-at-launch") {
-            AccountHelper.logOutDefaultWordPressComAccount()
-        }
-    }
 
     var runningInBackground: Bool {
         return UIApplication.shared.applicationState == .background

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		01A8508C2A8A126400BD8A97 /* support_chat_widget.css in Resources */ = {isa = PBXBuildFile; fileRef = 01A8508A2A8A126400BD8A97 /* support_chat_widget.css */; };
 		01ABF1702AD578B3004331BD /* WidgetAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ABF16F2AD578B3004331BD /* WidgetAnalytics.swift */; };
 		01ABF1712AD578B3004331BD /* WidgetAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ABF16F2AD578B3004331BD /* WidgetAnalytics.swift */; };
+		01B5C3C72AE7FC61007055BB /* UITestConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B5C3C62AE7FC61007055BB /* UITestConfigurator.swift */; };
+		01B5C3C82AE7FC61007055BB /* UITestConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B5C3C62AE7FC61007055BB /* UITestConfigurator.swift */; };
 		01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
 		01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
 		01CE500E290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
@@ -5867,6 +5869,7 @@
 		019D699F2A5EBF47003B676D /* WordPressAuthenticatorProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorProtocol.swift; sourceTree = "<group>"; };
 		01A8508A2A8A126400BD8A97 /* support_chat_widget.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = support_chat_widget.css; sourceTree = "<group>"; };
 		01ABF16F2AD578B3004331BD /* WidgetAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetAnalytics.swift; sourceTree = "<group>"; };
+		01B5C3C62AE7FC61007055BB /* UITestConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestConfigurator.swift; sourceTree = "<group>"; };
 		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenFieldView.swift; sourceTree = "<group>"; };
@@ -9863,6 +9866,14 @@
 			name = Coordinators;
 			sourceTree = "<group>";
 		};
+		01B5C3C52AE7FC3B007055BB /* UITesting */ = {
+			isa = PBXGroup;
+			children = (
+				01B5C3C62AE7FC61007055BB /* UITestConfigurator.swift */,
+			);
+			name = UITesting;
+			sourceTree = "<group>";
+		};
 		01E258002ACC36DC00F09666 /* Plan */ = {
 			isa = PBXGroup;
 			children = (
@@ -13707,6 +13718,7 @@
 		8584FDB719243E550019C02E /* System */ = {
 			isa = PBXGroup;
 			children = (
+				01B5C3C52AE7FC3B007055BB /* UITesting */,
 				0107E0F128FD6A3100DE87DB /* Constants */,
 				803BB97E295957A200B3F6D6 /* Root View */,
 				BE87E19E1BD4052F0075D45B /* 3DTouch */,
@@ -22488,6 +22500,7 @@
 				D82253DC2199411F0014D0E2 /* SiteAddressService.swift in Sources */,
 				83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */,
 				B5B56D3319AFB68800B4E29B /* WPStyleGuide+Notifications.swift in Sources */,
+				01B5C3C72AE7FC61007055BB /* UITestConfigurator.swift in Sources */,
 				FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */,
 				9A3BDA0E22944F3500FBF510 /* CountriesMapView.swift in Sources */,
 				17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */,
@@ -24743,6 +24756,7 @@
 				FABB23B22602FC2C00C8785C /* StatsChildRowsView.swift in Sources */,
 				FABB23B32602FC2C00C8785C /* Menu.m in Sources */,
 				FABB23B42602FC2C00C8785C /* BlogListViewController.m in Sources */,
+				01B5C3C82AE7FC61007055BB /* UITestConfigurator.swift in Sources */,
 				837A53D82AD8C3A400B941A2 /* ReaderFollowButton.swift in Sources */,
 				FABB23B52602FC2C00C8785C /* JetpackScanStatusCell.swift in Sources */,
 				FABB23B62602FC2C00C8785C /* NoteBlockCommentTableViewCell.swift in Sources */,


### PR DESCRIPTION
During a UI testing pairing with @tiagomar we got blocked by a compliance popover constantly showing up locally when running UI tests.

### Solution

Set compliance popover as already shown if the app is launch with `ui-testing` arguments. Additionally, I grouped UITestConfiguration related code into a single file. 

## To test:

It could be tested locally in the EU, by confirming that the compliance popover is not displayed after the login epilogue is dismissed. Or by confirming that `disableCompliancePopover` gets called and value set.

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/12b57919-9e1e-4008-92f5-8523f958c194


## Regression Notes
1. Potential unintended areas of impact

None


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
