### PR TITLE
Reader: Fix Reader detail toolbar action labels wrapping on overflow

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -248,6 +248,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             return outgoing
         }
 
+        // Don't allow the button title to wrap.
+        configuration.titleLineBreakMode = .byTruncatingTail
+
         button.configuration = configuration
 
         /// Remove default background styles. The `.plain()` configuration adds a gray background to selected state.


### PR DESCRIPTION
Fixes #21835

> **Note**
> This targets the release branch, which is in code freeze. There are no new strings added in this PR.

Addresses an issue where the action buttons' title would wrap into a new line on overflow. It should now be truncated and kept in one line, like so:

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b4051f3f-d99d-41a3-8ccc-9f5660ccf958" width=375>

## To test

- Turn on accessibility size.
- Launch the Jetpack app.
- Go to any post from the Reader tab.
- 🔎  Verify that the action labels are displayed in one line.
- Rotate the device to landscape orientation.
- 🔎  Verify that the text is now fully displayed if the space fits.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
