### PR TITLE
Posts & Pages: Remove dead code and grouping for scheduled pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -2,9 +2,6 @@ import Foundation
 
 final class PageListTableViewHandler: WPTableViewHandler {
     var status: PostListFilter.Status = .published
-    var groupResults: Bool {
-        status == .scheduled
-    }
 
     var showEditorHomepage: Bool {
         guard RemoteFeatureFlag.siteEditorMVP.enabled() else {
@@ -12,7 +9,7 @@ final class PageListTableViewHandler: WPTableViewHandler {
         }
 
         let isFSETheme = blog.blockEditorSettings?.isFSETheme ?? false
-        return isFSETheme && status == .published && !groupResults
+        return isFSETheme && status == .published
     }
 
     private var pages: [Page] = []
@@ -28,14 +25,9 @@ final class PageListTableViewHandler: WPTableViewHandler {
         return resultsController(with: fetchRequest, context: managedObjectContext(), performFetch: false)
     }()
 
-    private lazy var groupedResultsController: NSFetchedResultsController<NSFetchRequestResult> = {
-        return resultsController(with: fetchRequest(), context: managedObjectContext(), keyPath: sectionNameKeyPath())
+    private lazy var _resultsController: NSFetchedResultsController<NSFetchRequestResult> = {
+        resultsController(with: fetchRequest(), context: managedObjectContext())
     }()
-
-    private lazy var flatResultsController: NSFetchedResultsController<NSFetchRequestResult> = {
-        return resultsController(with: fetchRequest(), context: managedObjectContext())
-    }()
-
 
     init(tableView: UITableView, blog: Blog) {
         self.blog = blog
@@ -43,7 +35,7 @@ final class PageListTableViewHandler: WPTableViewHandler {
     }
 
     override var resultsController: NSFetchedResultsController<NSFetchRequestResult> {
-        groupResults ? groupedResultsController : flatResultsController
+        _resultsController
     }
 
     override func refreshTableView() {
@@ -70,21 +62,7 @@ final class PageListTableViewHandler: WPTableViewHandler {
     // MARK: - Public methods
 
     func page(at indexPath: IndexPath) -> Page {
-        guard groupResults else {
-            return pages[indexPath.row]
-        }
-
-        guard let page = resultsController.object(at: indexPath) as? Page else {
-            // Retrieveing anything other than a post object means we have an app with an invalid
-            // state.  Ignoring this error would be counter productive as we have no idea how this
-            // can affect the App.  This controlled interruption is intentional.
-            //
-            // - Diego Rey Mendez, May 18 2016
-            //
-            fatalError("Expected a Page object.")
-        }
-
-        return page
+        pages[indexPath.row]
     }
 
     func index(for page: Page) -> Int? {
@@ -112,12 +90,11 @@ final class PageListTableViewHandler: WPTableViewHandler {
     // MARK: - Override TableView Datasource
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return groupResults ? super.numberOfSections(in: tableView) : 1
+        1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let additionalPage = showEditorHomepage ? 1 : 0
-        return groupResults ? super.tableView(tableView, numberOfRowsInSection: section) : pages.count + additionalPage
+        pages.count + (showEditorHomepage ? 1 : 0)
     }
 
 
@@ -151,15 +128,10 @@ final class PageListTableViewHandler: WPTableViewHandler {
         return delegate?.managedObjectContext()
     }
 
-    private func sectionNameKeyPath() -> String? {
-        return delegate?.sectionNameKeyPath!()
-    }
-
     private func setupPages() -> [Page] {
-        guard !groupResults, let pages = resultsController.fetchedObjects as? [Page] else {
+        guard let pages = _resultsController.fetchedObjects as? [Page] else {
             return []
         }
-
         return status == .published ? pages.setHomePageFirst().hierarchySort() : pages
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -1,15 +1,9 @@
 import Foundation
 
-
 final class PageListTableViewHandler: WPTableViewHandler {
-    var isSearching: Bool = false
     var status: PostListFilter.Status = .published
     var groupResults: Bool {
-        if isSearching {
-            return true
-        }
-
-        return status == .scheduled
+        status == .scheduled
     }
 
     var showEditorHomepage: Bool {
@@ -34,10 +28,6 @@ final class PageListTableViewHandler: WPTableViewHandler {
         return resultsController(with: fetchRequest, context: managedObjectContext(), performFetch: false)
     }()
 
-    private lazy var searchResultsController: NSFetchedResultsController<NSFetchRequestResult> = {
-        return resultsController(with: fetchRequest(), context: managedObjectContext(), keyPath: BasePost.statusKeyPath, performFetch: false)
-    }()
-
     private lazy var groupedResultsController: NSFetchedResultsController<NSFetchRequestResult> = {
         return resultsController(with: fetchRequest(), context: managedObjectContext(), keyPath: sectionNameKeyPath())
     }()
@@ -53,11 +43,7 @@ final class PageListTableViewHandler: WPTableViewHandler {
     }
 
     override var resultsController: NSFetchedResultsController<NSFetchRequestResult> {
-        if isSearching {
-            return searchResultsController
-        }
-
-        return groupResults ? groupedResultsController : flatResultsController
+        groupResults ? groupedResultsController : flatResultsController
     }
 
     override func refreshTableView() {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -333,11 +333,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     // MARK: - Table View Handling
 
-    func sectionNameKeyPath() -> String {
-        let sortField = filterSettings.currentPostListFilter().sortField
-        return Page.sectionIdentifier(dateKeyPath: sortField.keyPath)
-    }
-
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 


### PR DESCRIPTION
To test:

- Verify that the app doesn't crash (on all tabs in Pages)
- Verify that the scheduled pages are now displayed with no grouping (approved here p1698158290975579-slack-C04SFL0RP51)

Here's before and after:

<img width="320" alt="Screenshot 2023-10-24 at 9 20 12 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/aee6ee3f-bb87-4d97-8057-a2b61ba5ccd3"> <img width="320" alt="Screenshot 2023-10-24 at 10 46 49 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/e64cd808-510b-4eda-94ed-dcf669d8cb3c">

## Regression Notes
1. Potential unintended areas of impact: Pages (scheduled)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
