### PR TITLE
Widget: Fix potential tracks crash by calling uniqueKeysWithValues with unique array

### DIFF
--- a/WordPress/JetpackStatsWidgets/Tracks/WidgetAnalytics.swift
+++ b/WordPress/JetpackStatsWidgets/Tracks/WidgetAnalytics.swift
@@ -11,7 +11,7 @@ import WidgetKit
         }
     }
 
-    private static func properties(from widgetInfo: Result<[WidgetInfo], Error>) -> [String: String] {
+    private static func properties(from widgetInfo: Result<[WidgetInfo], Error>) -> [String: Int] {
         guard let installedWidgets = try? widgetInfo.get() else {
             return [:]
         }
@@ -24,9 +24,9 @@ import WidgetKit
             return "\(Events.eventPrefix(for: eventKind).rawValue)_\(widgetInfo.family.description.lowercased())"
         }
 
-        let dict = Dictionary(uniqueKeysWithValues: Set(widgetAnalyticNames).map { name in
-            return (name, "true")
-        })
+        let dict = widgetAnalyticNames.reduce(into: [String: Int]()) { partialResult, name in
+            partialResult[name, default: 0] += 1
+        }
 
         return dict
     }

--- a/WordPress/JetpackStatsWidgets/Tracks/WidgetAnalytics.swift
+++ b/WordPress/JetpackStatsWidgets/Tracks/WidgetAnalytics.swift
@@ -24,7 +24,7 @@ import WidgetKit
             return "\(Events.eventPrefix(for: eventKind).rawValue)_\(widgetInfo.family.description.lowercased())"
         }
 
-        let dict = Dictionary(uniqueKeysWithValues: widgetAnalyticNames.map { name in
+        let dict = Dictionary(uniqueKeysWithValues: Set(widgetAnalyticNames).map { name in
             return (name, "true")
         })
 


### PR DESCRIPTION
When jumping between branches I jumped on a case where `Dictionary(uniqueKeysWithValues...)` call crashed due to `widgetAnalyticNames` having duplicate widget analytic names. I couldn't reproduce it any more time. However, just to defend against such cases passing `Set` instead of `Array` to `Dictionary(uniqueKeysWithValues...)`

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
