### PR TITLE
Reader: Fix stream header margins and separator

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -95,7 +95,7 @@ struct ReaderSiteHeader: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .padding(EdgeInsets(top: 8, leading: 16, bottom: 16, trailing: 16))
+        .padding(EdgeInsets(top: 8, leading: 0, bottom: 16, trailing: 0))
         .background(Color(UIColor.listForeground))
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -598,13 +598,15 @@ import Combine
             return
         }
 
-        let isNewSiteHeader = ReaderHelpers.isTopicSite(topic) && !isContentFiltered && RemoteFeatureFlag.readerImprovements.enabled()
+        let isNewHeader = RemoteFeatureFlag.readerImprovements.enabled() && !isContentFiltered
+        let isNewSiteHeader = isNewHeader && ReaderHelpers.isTopicSite(topic)
+
         let headerView = {
             guard isNewSiteHeader else {
                 return header
             }
 
-            // The container view is so that the header respects the safe area boundaries and expands
+            // The container view is added so that the header respects the safe area boundaries and expands
             // the header's background color to the screen's edges.
             let containerView = UIView()
             containerView.translatesAutoresizingMaskIntoConstraints = false
@@ -637,8 +639,23 @@ import Combine
             constraints.append(contentsOf: [
                 header.topAnchor.constraint(equalTo: headerView.topAnchor),
                 header.bottomAnchor.constraint(equalTo: headerView.bottomAnchor),
-                header.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-                header.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                header.trailingAnchor.constraint(equalTo: tableView.readableContentGuide.trailingAnchor),
+                header.leadingAnchor.constraint(equalTo: tableView.readableContentGuide.leadingAnchor),
+            ])
+        }
+
+        // manually add a separator for the new header views.
+        if isNewHeader {
+            let borderView = UIView()
+            borderView.backgroundColor = .separator
+            borderView.translatesAutoresizingMaskIntoConstraints = false
+            headerView.addSubview(borderView)
+
+            constraints.append(contentsOf: [
+                borderView.bottomAnchor.constraint(equalTo: headerView.bottomAnchor),
+                borderView.heightAnchor.constraint(equalToConstant: 0.5),
+                borderView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                borderView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
             ])
         }
 


### PR DESCRIPTION
Fixes #21851 

This fixes a case where the header is misaligned with the content on iPad. Additionally, this also adds a separator for the stream header, as it was missing as per the design specs.

### iPhone

• | Sites | Tags
-|-|-
Portrait | ![iphone_sites_portrait](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/a52ffbd5-22d6-474a-b2d0-9369575235a4) | ![iphone_tags_portrait](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/fa97b589-dbc0-4a0b-a426-e96777f4ed89)
Landscape | ![iphone_sites_landscape](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/2ca74d3d-3a11-40f7-9513-e1bb5aa231aa) | ![iphone_tags_landscape](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/ee38833a-4da1-4e38-85d3-d2dedbfc683d)

### iPad

• | Sites | Tags
-|-|-
Portrait | ![ipad_sites_portrait](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/938fac74-8990-48b1-aea7-c16749224e81) | ![ipad_tags_portrait](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/7e9201aa-12c2-4a5d-b3f6-d47e3a8c6676)
Landscape | ![ipad_sites_landscape](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/137418a6-e1ec-4d5c-8136-f974e0d4861e) | ![ipad_tags_landscape](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/3e18a6aa-e899-49ac-be01-cb2adc5fef19)

## To test

- Launch Jetpack app on iPhone.
- Go to Reader > Discover, and tap one of the tags.
- 🔎 Verify that the header aligns with the content.
- Rotate the device to landscape. 
- 🔎 Verify that the header aligns with the content.
- Go back to Discover, and tap the site name of any post.
- 🔎 Verify that the header aligns with the content.
- Rotate the device to landscape. 
- 🔎 Verify that the header aligns with the content.
- Repeat the above steps on iPad.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes are gated behind the flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
