### PR TITLE
Posts & Pages: Integrate context menus, selection in search

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import Combine
 
-final class PageListCell: UITableViewCell, Reusable {
+final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
 
     // MARK: - Views
 
@@ -18,6 +18,13 @@ final class PageListCell: UITableViewCell, Reusable {
     // MARK: - Properties
 
     private lazy var imageLoader = ImageLoader(imageView: featuredImageView, loadingIndicator: SolidColorActivityIndicator())
+
+    // MARK: - PostSearchResultCell
+
+    var attributedText: NSAttributedString? {
+        get { titleLabel.attributedText }
+        set { titleLabel.attributedText = newValue }
+    }
 
     // MARK: - Initializers
 
@@ -35,14 +42,11 @@ final class PageListCell: UITableViewCell, Reusable {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        cancellables = []
         imageLoader.prepareForReuse()
     }
 
     func configure(with viewModel: PageListItemViewModel, indentation: Int = 0, isFirstSubdirectory: Bool = false) {
-        viewModel.$title.sink { [titleLabel] in
-            titleLabel.attributedText = $0
-        }.store(in: &cancellables)
+        titleLabel.attributedText = viewModel.title
 
         badgeIconView.image = viewModel.badgeIcon
         badgeIconView.isHidden = viewModel.badgeIcon == nil

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -52,7 +52,6 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         badgeIconView.isHidden = viewModel.badgeIcon == nil
         badgesLabel.text = viewModel.badges
 
-        imageLoader.prepareForReuse()
         featuredImageView.isHidden = viewModel.imageURL == nil
         if let imageURL = viewModel.imageURL {
             let host = MediaHost(with: viewModel.page) { error in

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 final class PageListItemViewModel {
     let page: Page
-    @Published var title: NSAttributedString
+    let title: NSAttributedString
     let badgeIcon: UIImage?
     let badges: String
     let imageURL: URL?

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -422,7 +422,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         BlazeFlowCoordinator.presentBlaze(in: self, source: .pagesList, blog: blog, post: page)
     }
 
-    fileprivate func editPage(_ page: Page) {
+    func editPage(_ page: Page) {
         let didOpenEditor = PageEditorPresenter.handle(page: page, in: self, entryPoint: .pagesList)
 
         if didOpenEditor {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -207,6 +207,7 @@ class AbstractPostListViewController: UIViewController,
         searchController.searchResultsUpdater = searchResultsViewController
         searchController.showsSearchResultsController = true
         searchResultsViewController.searchController = searchController
+        searchResultsViewController.listViewController = self
 
         definesPresentationContext = true
 

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -1,8 +1,7 @@
 import Foundation
 import UIKit
-import Combine
 
-final class PostListCell: UITableViewCell, Reusable {
+final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
 
     // MARK: - Views
 
@@ -22,11 +21,17 @@ final class PostListCell: UITableViewCell, Reusable {
     private let contentLabel = UILabel()
     private let featuredImageView = CachedAnimatedImageView()
     private let statusLabel = UILabel()
-    private var cancellables: [AnyCancellable] = []
 
     // MARK: - Properties
 
     private lazy var imageLoader = ImageLoader(imageView: featuredImageView, loadingIndicator: SolidColorActivityIndicator())
+
+    // MARK: - PostSearchResultCell
+
+    var attributedText: NSAttributedString? {
+        get { contentLabel.attributedText }
+        set { contentLabel.attributedText = newValue }
+    }
 
     // MARK: - Initializers
 
@@ -44,17 +49,13 @@ final class PostListCell: UITableViewCell, Reusable {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        cancellables = []
+        imageLoader.prepareForReuse()
     }
 
     func configure(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate? = nil) {
         headerView.configure(with: viewModel, delegate: delegate)
+        contentLabel.attributedText = viewModel.content
 
-        viewModel.$content.sink { [contentLabel] in
-            contentLabel.attributedText = $0
-        }.store(in: &cancellables)
-
-        imageLoader.prepareForReuse()
         featuredImageView.isHidden = viewModel.imageURL == nil
         if let imageURL = viewModel.imageURL {
             let host = MediaHost(with: viewModel.post) { error in

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 final class PostListItemViewModel {
     let post: Post
-    @Published var content: NSAttributedString
+    let content: NSAttributedString
     let imageURL: URL?
     let date: String?
     let accessibilityIdentifier: String?

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -59,7 +59,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             if self?.searchController?.searchBar.text != $0 {
                 self?.searchController?.searchBar.text = $0
             }
-            self?.updateHighlighsForVisibleCells(searchTerm: $0)
+            self?.updateHighlightsForVisibleCells(searchTerm: $0)
         }.store(in: &cancellables)
 
         viewModel.$selectedTokens
@@ -102,12 +102,12 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
                 assert(listViewController is InteractivePostViewDelegate)
                 let viewModel = PostListItemViewModel(post: post)
                 cell.configure(with: viewModel, delegate: listViewController as? InteractivePostViewDelegate)
-                updateHighlighs(for: [cell], searchTerm: self.viewModel.searchTerm)
+                updateHighlights(for: [cell], searchTerm: self.viewModel.searchTerm)
                 return cell
             case let page as Page:
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell
                 cell.configure(with: PageListItemViewModel(page: page))
-                updateHighlighs(for: [cell], searchTerm: viewModel.searchTerm)
+                updateHighlights(for: [cell], searchTerm: viewModel.searchTerm)
                 return cell
             default:
                 fatalError("Unsupported item: \(type(of: post))")
@@ -187,13 +187,13 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
     // MARK: - Highlighter
 
-    private func updateHighlighsForVisibleCells(searchTerm: String) {
+    private func updateHighlightsForVisibleCells(searchTerm: String) {
         let cells = (tableView.indexPathsForVisibleRows ?? [])
             .compactMap(tableView.cellForRow)
-        updateHighlighs(for: cells, searchTerm: searchTerm)
+        updateHighlights(for: cells, searchTerm: searchTerm)
     }
 
-    private func updateHighlighs(for cells: [UITableViewCell], searchTerm: String) {
+    private func updateHighlights(for cells: [UITableViewCell], searchTerm: String) {
         let terms = searchTerm
             .trimmingCharacters(in: .whitespaces)
             .components(separatedBy: .whitespaces)

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -118,7 +118,8 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             switch viewModel.results[indexPath.row] {
             case .post(let post):
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath) as! PostListCell
-                cell.configure(with: post)
+                assert(listViewController is InteractivePostViewDelegate)
+                cell.configure(with: post, delegate: listViewController as? InteractivePostViewDelegate)
                 return cell
             case .page(let page):
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -3,6 +3,7 @@ import Combine
 
 final class PostSearchViewController: UIViewController, UITableViewDelegate, UISearchResultsUpdating {
     weak var searchController: UISearchController?
+    weak var listViewController: AbstractPostListViewController?
 
     enum SectionID: Int, CaseIterable {
         case tokens = 0
@@ -162,6 +163,19 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         case .tokens:
             viewModel.didSelectToken(at: indexPath.row)
         case .posts:
+            // TODO: Move to viewWillAppear (the way editor is displayed doesn't allow)
+            tableView.deselectRow(at: indexPath, animated: true)
+
+            switch viewModel.results[indexPath.row] {
+            case .post(let viewModel):
+                guard viewModel.post.status != .trash else { return }
+                (listViewController as! PostListViewController)
+                    .edit(viewModel.post)
+            case .page(let viewModel):
+                guard viewModel.page.status != .trash else { return }
+                (listViewController as! PageListViewController)
+                    .editPage(viewModel.page)
+            }
             break // TODO: Show post
         }
     }


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21720

To test:

- Verify that the context menus are available for search results
- Verify that you can tap on a search result
- Verify that search results automatically update when the remote posts do (no support for displaying status; not sure it's feasible given how the revisions are managed)
- Verify that highlighter still works

_Note on highlighter_: I remove `cachedItems` to make it easier to reload cells. The highlights are now purely presentation layer concern. And the Post/Page list item ViewModels are now again immutable, which is great. It's also now a bit more efficient because the highlights now get updated only for the visible cells.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/445ec284-6814-4f0f-a997-279816892cd1


## Regression Notes
1. Potential unintended areas of impact: Posts search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
