### PR TITLE
Reader: Add a stretchable image container in recommended sites card

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRecommendedSiteCardCell.xib
@@ -21,21 +21,33 @@
                         <rect key="frame" x="0.0" y="0.0" width="454" height="130"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YSm-00-vyn">
-                                <rect key="frame" x="16" y="12" width="422" height="40"/>
+                                <rect key="frame" x="16" y="12" width="422" height="75.666666666666671"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="750" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mms-yI-nd4" userLabel="Header Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="384" height="40"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="384" height="75.666666666666671"/>
                                         <subviews>
-                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="FEv-sY-BYI" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
-                                                <gestureRecognizers/>
+                                            <view contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vYe-Ee-b18" userLabel="Image Container">
+                                                <rect key="frame" x="0.0" y="0.0" width="40" height="75.666666666666671"/>
+                                                <subviews>
+                                                    <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="FEv-sY-BYI" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="18" width="40" height="40"/>
+                                                        <gestureRecognizers/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="40" id="BAX-Rs-vVo"/>
+                                                            <constraint firstAttribute="width" constant="40" id="C9q-wn-fc4"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="BAX-Rs-vVo"/>
-                                                    <constraint firstAttribute="width" constant="40" id="C9q-wn-fc4"/>
+                                                    <constraint firstAttribute="trailing" secondItem="FEv-sY-BYI" secondAttribute="trailing" id="ayO-Pi-bOJ"/>
+                                                    <constraint firstItem="FEv-sY-BYI" firstAttribute="leading" secondItem="vYe-Ee-b18" secondAttribute="leading" id="ceN-Dx-fYb"/>
+                                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="FEv-sY-BYI" secondAttribute="bottom" id="iMu-vn-0yX"/>
+                                                    <constraint firstItem="FEv-sY-BYI" firstAttribute="centerY" secondItem="vYe-Ee-b18" secondAttribute="centerY" id="oCj-Sk-Miw"/>
+                                                    <constraint firstItem="FEv-sY-BYI" firstAttribute="top" relation="greaterThanOrEqual" secondItem="vYe-Ee-b18" secondAttribute="top" id="vyz-lq-2WR"/>
                                                 </constraints>
-                                            </imageView>
+                                            </view>
                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="L7q-C1-xba">
-                                                <rect key="frame" x="48" y="0.0" width="336" height="40"/>
+                                                <rect key="frame" x="48" y="0.0" width="336" height="75.666666666666671"/>
                                                 <subviews>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" horizontalCompressionResistancePriority="740" text="Blog Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kEs-BA-Qeh">
                                                         <rect key="frame" x="0.0" y="0.0" width="336" height="17"/>
@@ -44,8 +56,8 @@
                                                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="740" text="blog.host.name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RNB-9V-A6a" userLabel="Blog Host Name">
-                                                        <rect key="frame" x="0.0" y="18" width="336" height="22"/>
+                                                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="250" text="blog.host.name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RNB-9V-A6a" userLabel="Blog Host Name">
+                                                        <rect key="frame" x="0.0" y="17.999999999999996" width="336" height="57.666666666666657"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -56,7 +68,7 @@
                                         </subviews>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="epE-Yr-j1l" userLabel="Follow Button">
-                                        <rect key="frame" x="392" y="3" width="30" height="34"/>
+                                        <rect key="frame" x="392" y="21" width="30" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="ai0-Bv-Ahu"/>
                                         </constraints>
@@ -76,7 +88,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site Description / Tag Line" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="guM-Ci-dh4">
-                                <rect key="frame" x="16" y="62" width="422" height="56"/>
+                                <rect key="frame" x="16" y="97.666666666666671" width="422" height="20.333333333333329"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -102,7 +114,7 @@
                 <outlet property="hostNameLabel" destination="RNB-9V-A6a" id="EQr-pT-p1q"/>
                 <outlet property="iconImageView" destination="FEv-sY-BYI" id="zxN-JN-Jgs"/>
             </connections>
-            <point key="canvasLocation" x="-601.171875" y="-58.857979502196187"/>
+            <point key="canvasLocation" x="-601.39534883720933" y="-59.227467811158803"/>
         </tableViewCell>
     </objects>
     <resources>


### PR DESCRIPTION
Fixes #21836

The text in the recommended sites card gets _vertically_ clipped when using a11y size because it is forced to have 40px height, matching the image. This PR fixes the issue by adding a stretchable container for the image to accommodate for the text size growth, while keeping the image at 40x40. Here's a screenshot:

![Simulator Screenshot - iPhone 15 - 2023-10-25 at 23 47 41](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/720c7746-af02-4a2e-80f0-8230c74023ca)


## To test

- Turn on the a11y size
- Launch the Jetpack app
- Navigate to Reader > Discover and scroll down until you find the 'You might like' card.
- 🔎 Verify that the text is not vertically clipped. 
  - Note that the truncation is intended.
- Launch the Jetpack app using normal text size, and redo the steps above.
- 🔎 Verify that the 'You might like' card appears correctly and does not show any extra padding.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
