### PR TITLE
Posts & Pages: Add comments action

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -255,6 +255,7 @@ import Foundation
 
     // Post List
     case postListShareAction
+    case postListCommentsAction
     case postListSetAsPostsPageAction
     case postListSetHomePageAction
 
@@ -960,6 +961,8 @@ import Foundation
         // Post List
         case .postListShareAction:
             return "post_list_button_pressed"
+        case .postListCommentsAction:
+            return "post_list_button_pressed"
         case .postListSetAsPostsPageAction:
             return "post_list_button_pressed"
         case .postListSetHomePageAction:
@@ -1415,6 +1418,8 @@ import Foundation
             return ["via": "tenor"]
         case .postListShareAction:
             return ["button": "share"]
+        case .postListCommentsAction:
+            return ["button": "comments"]
         case .postListSetAsPostsPageAction:
             return ["button": "set_posts_page"]
         case .postListSetHomePageAction:

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -14,4 +14,5 @@ protocol InteractivePostViewDelegate: AnyObject {
     func share(_ post: AbstractPost, fromView view: UIView)
     func copyLink(_ post: AbstractPost)
     func blaze(_ post: AbstractPost)
+    func comments(_ post: AbstractPost)
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -29,7 +29,7 @@ class PostCardStatusViewModel: NSObject {
     private let autoUploadInteractor = PostAutoUploadInteractor()
 
     private let isInternetReachable: Bool
-
+    private let isJetpackFeaturesEnabled: Bool
     private let isBlazeFlagEnabled: Bool
 
     var progressBlock: ((Float) -> Void)? = nil {
@@ -50,9 +50,11 @@ class PostCardStatusViewModel: NSObject {
 
     init(post: Post,
          isInternetReachable: Bool = ReachabilityUtils.isInternetReachable(),
+         isJetpackFeaturesEnabled: Bool = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
          isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled()) {
         self.post = post
         self.isInternetReachable = isInternetReachable
+        self.isJetpackFeaturesEnabled = isJetpackFeaturesEnabled
         self.isBlazeFlagEnabled = isBlazeFlagEnabled
         super.init()
     }
@@ -205,7 +207,7 @@ class PostCardStatusViewModel: NSObject {
     private func createNavigationSection() -> ButtonSection {
         var buttons = [Button]()
 
-        if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(), post.status == .publish && post.hasRemote() {
+        if isJetpackFeaturesEnabled, post.status == .publish && post.hasRemote() {
             buttons.append(contentsOf: [.stats, .comments])
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -208,7 +208,7 @@ class PostCardStatusViewModel: NSObject {
         if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(), post.status == .publish && post.hasRemote() {
             buttons.append(contentsOf: [.stats, .comments])
         }
-        
+
         return ButtonSection(buttons: buttons)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -19,8 +19,8 @@ class PostCardStatusViewModel: NSObject {
         case trash
         case cancelAutoUpload
         case share
-        case copyLink
         case blaze
+        case comments
     }
 
     let post: Post
@@ -174,10 +174,6 @@ class PostCardStatusViewModel: NSObject {
             buttons.append(.share)
         }
 
-        if post.status != .trash {
-            buttons.append(.copyLink)
-        }
-
         if autoUploadInteractor.canRetryUpload(of: post) ||
             autoUploadInteractor.autoUploadAttemptState(of: post) == .reachedLimit ||
             post.isFailed && isInternetReachable {
@@ -210,11 +206,9 @@ class PostCardStatusViewModel: NSObject {
         var buttons = [Button]()
 
         if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(), post.status == .publish && post.hasRemote() {
-            buttons.append(.stats)
+            buttons.append(contentsOf: [.stats, .comments])
         }
-
-        // TODO: Add reader and comments
-
+        
         return ButtonSection(buttons: buttons)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -103,6 +103,7 @@ final class PostListCell: UITableViewCell, Reusable {
         contentLabel.translatesAutoresizingMaskIntoConstraints = false
         contentLabel.adjustsFontForContentSizeCategory = true
         contentLabel.numberOfLines = 3
+        contentLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 
     private func setupFeaturedImageView() {
@@ -110,6 +111,7 @@ final class PostListCell: UITableViewCell, Reusable {
         featuredImageView.contentMode = .scaleAspectFill
         featuredImageView.layer.masksToBounds = true
         featuredImageView.layer.cornerRadius = 5
+        featuredImageView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
         NSLayoutConstraint.activate([
             featuredImageView.widthAnchor.constraint(equalToConstant: Constants.imageSize.width),

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -494,6 +494,12 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         BlazeFlowCoordinator.presentBlaze(in: self, source: .postsList, blog: blog, post: post)
     }
 
+    func comments(_ post: AbstractPost) {
+        // TODO: track event
+        let contentCoordinator = DefaultContentCoordinator(controller: self, context: ContextManager.sharedInstance().mainContext)
+        try? contentCoordinator.displayCommentsWithPostId(post.postID, siteID: blog.dotComID, commentID: nil, source: .postsList)
+    }
+
     // MARK: - NetworkAwareUI
 
     override func noConnectionMessage() -> String {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -495,7 +495,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func comments(_ post: AbstractPost) {
-        // TODO: track event
+        WPAnalytics.track(.postListCommentsAction, properties: propertiesForAnalytics())
         let contentCoordinator = DefaultContentCoordinator(controller: self, context: ContextManager.sharedInstance().mainContext)
         try? contentCoordinator.displayCommentsWithPostId(post.postID, siteID: blog.dotComID, commentID: nil, source: .postsList)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMenuHelper.swift
@@ -130,8 +130,8 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
 
     private enum Strings {
         static let cancelAutoUpload = NSLocalizedString("posts.cancelUpload.actionTitle", value: "Cancel upload", comment: "Label for the Post List option that cancels automatic uploading of a post.")
-        static let stats = NSLocalizedString("posts.stats.actionTitle", value: "Go to stats", comment: "Label for post stats option. Tapping displays statistics for a post.")
-        static let comments = NSLocalizedString("posts.comments.actionTitle", value: "Go to comments", comment: "Label for post comments option. Tapping comments statistics for a post.")
+        static let stats = NSLocalizedString("posts.stats.actionTitle", value: "Stats", comment: "Label for post stats option. Tapping displays statistics for a post.")
+        static let comments = NSLocalizedString("posts.comments.actionTitle", value: "Comments", comment: "Label for post comments option. Tapping displays comments for a post.")
         static let duplicate = NSLocalizedString("posts.duplicate.actionTitle", value: "Duplicate", comment: "Label for post duplicate option. Tapping creates a copy of the post.")
         static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish now", comment: "Label for an option that moves a publishes a post immediately")
         static let draft = NSLocalizedString("posts.draft.actionTitle", value: "Move to draft", comment: "Label for an option that moves a post to the draft folder")

--- a/WordPress/Classes/ViewRelated/Post/PostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMenuHelper.swift
@@ -62,17 +62,17 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
 
     var icon: UIImage? {
         switch self {
-        case .retry: return UIImage()
+        case .retry: return UIImage() // TODO
         case .view: return UIImage(systemName: "eye")
         case .publish: return UIImage(systemName: "globe")
-        case .stats: return UIImage(systemName: "chart.bar")
+        case .stats: return UIImage(systemName: "chart.bar.xaxis")
         case .duplicate: return UIImage(systemName: "doc.on.doc")
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")
-        case .cancelAutoUpload: return UIImage()
+        case .cancelAutoUpload: return UIImage() // TODO
         case .share: return UIImage(systemName: "square.and.arrow.up")
-        case .copyLink: return UIImage(systemName: "link")
         case .blaze: return UIImage(systemName: "flame")
+        case .comments: return UIImage(systemName: "bubble")
         }
     }
 
@@ -96,8 +96,8 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
         case .trash: return post.status == .trash ? Strings.delete : Strings.trash
         case .cancelAutoUpload: return Strings.cancelAutoUpload
         case .share: return Strings.share
-        case .copyLink: return Strings.copyLink
         case .blaze: return Strings.blaze
+        case .comments: return Strings.comments
         }
     }
 
@@ -121,25 +121,25 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
             delegate.cancelAutoUpload(post)
         case .share:
             delegate.share(post, fromView: view)
-        case .copyLink:
-            delegate.copyLink(post)
         case .blaze:
             delegate.blaze(post)
+        case .comments:
+            delegate.comments(post)
         }
     }
 
     private enum Strings {
-        static let cancelAutoUpload = NSLocalizedString("posts.cancelUpload.actionTitle", value: "Cancel Upload", comment: "Label for the Post List option that cancels automatic uploading of a post.")
-        static let stats = NSLocalizedString("posts.stats.actionTitle", value: "Stats", comment: "Label for post stats option. Tapping displays statistics for a post.")
+        static let cancelAutoUpload = NSLocalizedString("posts.cancelUpload.actionTitle", value: "Cancel upload", comment: "Label for the Post List option that cancels automatic uploading of a post.")
+        static let stats = NSLocalizedString("posts.stats.actionTitle", value: "Go to stats", comment: "Label for post stats option. Tapping displays statistics for a post.")
+        static let comments = NSLocalizedString("posts.comments.actionTitle", value: "Go to comments", comment: "Label for post comments option. Tapping comments statistics for a post.")
         static let duplicate = NSLocalizedString("posts.duplicate.actionTitle", value: "Duplicate", comment: "Label for post duplicate option. Tapping creates a copy of the post.")
-        static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish Now", comment: "Label for an option that moves a publishes a post immediately")
-        static let draft = NSLocalizedString("posts.draft.actionTitle", value: "Move to Draft", comment: "Label for an option that moves a post to the draft folder")
-        static let delete = NSLocalizedString("posts.delete.actionTitle", value: "Delete Permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
-        static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to Trash", comment: "Label for a option that moves a post to the trash folder")
+        static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish now", comment: "Label for an option that moves a publishes a post immediately")
+        static let draft = NSLocalizedString("posts.draft.actionTitle", value: "Move to draft", comment: "Label for an option that moves a post to the draft folder")
+        static let delete = NSLocalizedString("posts.delete.actionTitle", value: "Delete permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
+        static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to trash", comment: "Label for a option that moves a post to the trash folder")
         static let view = NSLocalizedString("posts.view.actionTitle", value: "View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let retry = NSLocalizedString("posts.retry.actionTitle", value: "Retry", comment: "Retry uploading the post.")
         static let share = NSLocalizedString("posts.share.actionTitle", value: "Share", comment: "Share the post.")
         static let blaze = NSLocalizedString("posts.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the post with Blaze.")
-        static let copyLink = NSLocalizedString("posts.copyLink.actionTitle", value: "Copy Link", comment: "Copy the post url and paste anywhere in phone")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -9,7 +9,8 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
     ReaderCommentsSourceCommentNotification,
     ReaderCommentsSourceCommentLikeNotification,
     ReaderCommentsSourceMySiteComment,
-    ReaderCommentsSourceActivityLogDetail
+    ReaderCommentsSourceActivityLogDetail,
+    ReaderCommentsSourcePostsList
 };
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -305,6 +305,8 @@ private extension ReaderCommentsViewController {
             return "my_site_comment"
         case .activityLogDetail:
             return "activity_log_detail"
+        case .postsList:
+            return "posts_list"
         default:
             return "unknown"
         }

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -8,11 +8,15 @@ import Foundation
 class PostBuilder {
     private let post: Post
 
-    init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext(), blog: Blog? = nil) {
+    init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext(), blog: Blog? = nil, canBlaze: Bool = false) {
         post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
 
         // Non-null Core Data properties
-        post.blog = blog ?? BlogBuilder(context).build()
+        if let blog {
+            post.blog = blog
+        } else {
+            post.blog = canBlaze ? BlogBuilder(context).canBlaze().build() : BlogBuilder(context).build()
+        }
     }
 
     private static func buildPost(context: NSManagedObjectContext) -> Post {
@@ -71,7 +75,6 @@ class PostBuilder {
         post.autosaveIdentifier = 1
         return self
     }
-
 
     func withImage() -> PostBuilder {
         post.pathForDisplayImage = "https://localhost/image.png"

--- a/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
@@ -51,7 +51,7 @@ class ReaderDetailViewControllerTests: XCTestCase {
 class ReaderPostBuilder: PostBuilder {
     private let post: ReaderPost
 
-    override init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext(), blog: Blog? = nil) {
+    override init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext(), blog: Blog? = nil, canBlaze: Bool = false) {
         post = NSEntityDescription.insertNewObject(forEntityName: ReaderPost.entityName(), into: context) as! ReaderPost
     }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -1,10 +1,130 @@
 import Nimble
 import XCTest
-
 @testable import WordPress
 
 
 class PostCardStatusViewModelTests: CoreDataTestCase {
+
+    func testPublishedPostButtons() {
+        // Given
+        let post = PostBuilder(mainContext, canBlaze: true)
+            .withRemote()
+            .published()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+            [.view],
+            [.moveToDraft, .duplicate, .share],
+            [.blaze],
+            [.stats, .comments],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testPublishedPostButtonsWithBlazeDisabled() {
+        // Given
+        let post = PostBuilder(mainContext, canBlaze: false)
+            .withRemote()
+            .published()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+            [.view],
+            [.moveToDraft, .duplicate, .share],
+            [.stats, .comments],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testPublishedPostButtonsWithJetpackFeaturesDisabled() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .withRemote()
+            .published()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: false, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+            [.view],
+            [.moveToDraft, .duplicate, .share],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testDraftPostButtons() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .drafted()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+            [.view],
+            [.duplicate, .publish],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testScheduledPostButtons() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .scheduled()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+            [.view],
+            [.moveToDraft],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testTrashedPostButtons() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .trashed()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+            [.view],
+            [.moveToDraft],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
     /// If the post fails to upload and there is internet connectivity, show "Upload failed" message
     ///
     func testReturnFailedMessageIfPostFailedAndThereIsConnectivity() {


### PR DESCRIPTION
Fixes #21718 

## Description
- Add comments action to context menu
- Add tests for PostCardStatusViewModel
- Remove copy link action from context menu (ref: p1698068814743769/1697809073.777199-slack-C04SFL0RP51)

## How to test
- Go to the posts list screen
- Switch to the published tab
  - Tap on the ellipsis button > "Go to comments"
  - ✅ Verify the reader comments screen is shown
  - Post a comment
  - Go back to the posts list screen
  - Tap on the ellipsis button > "Go to comments"
  - ✅ Verify the comment you just posted is displayed
- Switch to the drafts tab, scheduled tab, trashed tab
  - Tap on the ellipsis button
  - ✅ Verify "Go to comments" isn't shown in the context menu
  
  
  

https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/ffbb5edd-ba8b-4b76-8027-4dee15483613



## Regression Notes
1. Potential unintended areas of impact: post list context menu

2. What I did to test those areas of impact (or what existing automated tests I relied on): added tests for PostCardStatusViewModel

3. What automated tests I added (or what prevented me from doing so): added tests for PostCardStatusViewModel

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)