### PR TITLE
Reader: Stream post card accessibility improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -308,10 +308,12 @@ private extension ReaderPostCardCell {
     }
 
     func setupControlButtons() {
-        setupControlButton(reblogButton,
-                           image: Constants.reblogButtonImage,
-                           text: Constants.reblogButtonText,
-                           action: #selector(didTapReblog))
+        if !usesAccessibilitySize {
+            setupControlButton(reblogButton,
+                               image: Constants.reblogButtonImage,
+                               text: Constants.reblogButtonText,
+                               action: #selector(didTapReblog))
+        }
         setupControlButton(commentButton,
                            image: Constants.commentButtonImage,
                            text: Constants.commentButtonText,
@@ -536,7 +538,7 @@ private extension ReaderPostCardCell {
         accessibilityElements = [
             siteStackView, postTitleLabel, postSummaryLabel, postCountsLabel,
             reblogButton, commentButton, likeButton, menuButton
-        ]
+        ].filter { $0 != reblogButton || !self.usesAccessibilitySize } // skip reblog button if a11y size is active.
     }
 
     // MARK: - Cell reuse
@@ -544,7 +546,10 @@ private extension ReaderPostCardCell {
     func addMissingViews() {
         let siteHeaderViews = [avatarContainerView, siteIconContainerView, siteTitleLabel, postDateLabel]
         let contentViews = [siteStackView, postTitleLabel, postSummaryLabel, featuredImageView, postCountsLabel]
-        let controlViews = [reblogButton, commentButton, likeButton]
+        let controlViews = [reblogButton, commentButton, likeButton].filter {
+            // skip reblog button if a11y size is active.
+            $0 != reblogButton || !self.usesAccessibilitySize
+        }
 
         siteHeaderViews.enumerated().forEach { (index, view) in
             addToStackView(siteStackView, view: view, index: index)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -148,6 +148,10 @@ class ReaderPostCardCell: UITableViewCell {
 
 private extension ReaderPostCardCell {
 
+    var usesAccessibilitySize: Bool {
+        traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+    }
+
     func commonInit() {
         setupViews()
         addViewConstraints()
@@ -237,7 +241,11 @@ private extension ReaderPostCardCell {
         postDateLabel.font = .preferredFont(forTextStyle: .footnote)
         postDateLabel.numberOfLines = 1
         postDateLabel.textColor = .secondaryLabel
-        siteStackView.addArrangedSubview(postDateLabel)
+
+        // if accessibility size
+        if !usesAccessibilitySize {
+            siteStackView.addArrangedSubview(postDateLabel)
+        }
     }
 
     func setupSiteStackView() {
@@ -250,6 +258,10 @@ private extension ReaderPostCardCell {
         siteStackView.addGestureRecognizer(tapGesture)
 
         contentStackView.addArrangedSubview(siteStackView)
+
+        if usesAccessibilitySize {
+            contentStackView.addArrangedSubview(postDateLabel)
+        }
     }
 
     func setupPostTitle() {
@@ -430,7 +442,7 @@ private extension ReaderPostCardCell {
 
     func configureLabels() {
         configureLabel(siteTitleLabel, text: viewModel?.siteTitle)
-        configureLabel(postDateLabel, text: viewModel?.postDate)
+        configureLabel(postDateLabel, text: usesAccessibilitySize ? viewModel?.shortPostDate : viewModel?.postDate)
         configureLabel(postTitleLabel, text: viewModel?.postTitle)
         configureLabel(postSummaryLabel, text: viewModel?.postSummary)
         configureLabel(postCountsLabel, text: viewModel?.postCounts)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -3,6 +3,10 @@ import UIKit
 final class ReaderShowMenuAction {
     private let isLoggedIn: Bool
 
+    private lazy var readerImprovementsEnabled: Bool = {
+        RemoteFeatureFlag.readerImprovements.enabled()
+    }()
+
     init(loggedIn: Bool) {
         isLoggedIn = loggedIn
     }
@@ -109,8 +113,26 @@ final class ReaderShowMenuAction {
                                                })
         }
 
+        // Reblog
+        //
+        // Only show the Reblog menu when:
+        // - The site is not private,
+        // - The user is logged in,
+        // - and the user uses accessibility content size.
+        if readerImprovementsEnabled,
+           !post.isPrivate(),
+           isLoggedIn,
+           let vc = vc as? ReaderStreamViewController,
+           vc.traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            let buttonTitle = ReaderPostCardCell.Constants.reblogButtonText
+
+            alertController.addActionWithTitle(buttonTitle, style: .default) { _ in
+                ReaderReblogAction().execute(readerPost: post, origin: vc, reblogSource: .list)
+            }
+        }
+
         // Save post
-        if RemoteFeatureFlag.readerImprovements.enabled(), let vc = vc as? ReaderStreamViewController {
+        if readerImprovementsEnabled, let vc = vc as? ReaderStreamViewController {
             let buttonTitle = post.isSavedForLater ? ReaderPostMenuButtonTitles.removeSavedPost: ReaderPostMenuButtonTitles.savePost
 
             alertController.addActionWithTitle(buttonTitle, style: .default) { _ in


### PR DESCRIPTION
Refs p5T066-47C-p2#comment-14999

This improves the Reader post card visuals when accessibility content size is active. Here are the changes included in the PR:

- The post date now wraps into a new line.
- The reblog button is moved to the context menu.

Note that the above changes only apply when the accessibility content size is active (AX1 - AX5). For smaller text size, it should default to the original card design. Here are some previews:

• | Normal size | A11y size
-|-|-
Card | ![normal_card](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/d7008d09-af9d-4fbb-81f9-bb1343ffc2af) | ![a11y_card](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/39317bb2-a9ce-4f2e-ba5c-03cff33a8fed)
Context menu | ![normal_contextmenu](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/4ae7f913-3f2b-4589-9701-b88d12a7ea28) | ![a11y_menu](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/63c82e9f-bbd4-4b89-bea1-2a37aee3e3e5)

## To test

### Using Accessibility size

- Launch Jetpack app
- Go to Reader and view any post card.
- 🔎  The Reblog button should **not** visible.
- Tap the ellipsis menu.
- 🔎  The Reblog menu should be visible.
- 🔎  Tapping the Reblog menu item shows a site picker.
- Run VoiceOver.
- 🔎 VoiceOver should not describe the Reblog button.

### Using normal size

- Launch Jetpack app
- Go to Reader and view any post card.
- 🔎  The Reblog button should be visible.
- 🔎  Tapping the Reblog button shows a site picker.
- Tap the ellipsis menu.
- 🔎  The Reblog menu should **not** be visible.
- Run VoiceOver.
- 🔎 The Reblog button should be described/visited by the VoiceOver. 

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes take place on a different file when the feature flag is active. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes, both in accessibility size and normal size.

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)