### PR TITLE
Reader Detail: Update link color to blue

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -210,8 +210,8 @@ class ReaderWebView: WKWebView {
               dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString() ?? "");
               --color-neutral-50: #\(UIColor.textSubtle.color(for: trait).hexString() ?? "");
               --color-neutral-70: #\(UIColor.text.color(for: trait).hexString() ?? "");
-              --main-link-color: #\(UIColor.primary.color(for: trait).hexString() ?? "");
-              --main-link-active-color: #\(UIColor.primaryDark.color(for: trait).hexString() ?? "");
+              --main-link-color: #\(UIColor.muriel(color: .init(name: .blue)).color(for: trait).hexString() ?? "");
+              --main-link-active-color: #\(UIColor.muriel(name: .blue, .shade30).color(for: trait).hexString() ?? "");
             }
         """
     }


### PR DESCRIPTION
Refs p1698224643398909-slack-C05N140C8H5

This updates the link color to blue. Here's a preview:

Light | Dark
-|-
![light_link](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/75642043-d044-423d-a7e4-73d3bb8254eb) | ![dark_link](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/fb0b720b-3dc4-44bd-8102-e621a8593b6c)

## To test

- Launch the Jetpack app.
- Go to Reader and open any post with a link in the body.
- 🔎 Verify that the link color is blue.
- Turn on dark mode from settings.
- Go back to the post.
- 🔎 Verify that the link color is blue.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The link color is updated to be the actual value of the link color used in the WordPress app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)