### PR TITLE
Check if the uploaded post is made on top of the latest revision

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,9 +50,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  # pod 'WordPressKit', '~> 8.7', '>= 8.7.1'
+  pod 'WordPressKit', '~> 8.9'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'get-post-latest-revision-id'
+  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -50,9 +50,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 8.7', '>= 8.7.1'
+  # pod 'WordPressKit', '~> 8.7', '>= 8.7.1'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'get-post-latest-revision-id'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 8.9'
+  # Anything compatible with 8.9, starting from 8.9.1 which has a breaking change fix
+  pod 'WordPressKit', '~> 8.9', '>= 8.9.1'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - WordPressKit (~> 8.7-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.7.1):
+  - WordPressKit (8.9.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 7.2.1-beta.2)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `get-post-latest-revision-id`)
+  - WordPressKit (~> 8.9)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
   - WPMediaPicker (>= 1.8.10, ~> 1.8)
@@ -164,6 +164,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -183,9 +184,6 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec
-  WordPressKit:
-    :branch: get-post-latest-revision-id
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -195,9 +193,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
-  WordPressKit:
-    :commit: ec7ff3e2b34a8b0e5a197afdf56686a538363200
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -231,7 +226,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: 1d73abee8fdd87032e987c40f140423a6aa0e577
-  WordPressKit: 33a0571389da6b40c765398a8c84da72f5514a6f
+  WordPressKit: a472d5ff906efb4cddef9097bf822d875a0ce1f8
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   WPMediaPicker: 332812329cbdc672cdb385b8ac3a389f668d3012
@@ -245,6 +240,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 7782dcbd630cb8b6bfedd2f5cfb8949919b1ee34
+PODFILE CHECKSUM: c9c5dde12c2fd2fa48a2cdf1ac8bbab8f19d24f4
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - WordPressKit (~> 8.7-beta)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (8.9.0):
+  - WordPressKit (8.9.1):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 7.2.1-beta.2)
-  - WordPressKit (~> 8.9)
+  - WordPressKit (>= 8.9.1, ~> 8.9)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
   - WPMediaPicker (>= 1.8.10, ~> 1.8)
@@ -226,7 +226,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: 1d73abee8fdd87032e987c40f140423a6aa0e577
-  WordPressKit: a472d5ff906efb4cddef9097bf822d875a0ce1f8
+  WordPressKit: e774ca87068b8ea02bbb0bd0b75b98aa5d722cb9
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   WPMediaPicker: 332812329cbdc672cdb385b8ac3a389f668d3012
@@ -240,6 +240,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: c9c5dde12c2fd2fa48a2cdf1ac8bbab8f19d24f4
+PODFILE CHECKSUM: e5c5369947a1f32a1c03bb35d92c86ee8c39833a
 
 COCOAPODS: 1.12.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -126,7 +126,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 7.2.1-beta.2)
-  - WordPressKit (>= 8.7.1, ~> 8.7)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `get-post-latest-revision-id`)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
   - WPMediaPicker (>= 1.8.10, ~> 1.8)
@@ -164,7 +164,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -184,6 +183,9 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec
+  WordPressKit:
+    :branch: get-post-latest-revision-id
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -193,6 +195,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
+  WordPressKit:
+    :commit: ec7ff3e2b34a8b0e5a197afdf56686a538363200
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -240,6 +245,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: fe27477bb386333975be481e9f9718ea47ec4e29
+PODFILE CHECKSUM: 7782dcbd630cb8b6bfedd2f5cfb8949919b1ee34
 
 COCOAPODS: 1.12.1

--- a/WordPress/Classes/Services/PostService+Revisions.swift
+++ b/WordPress/Classes/Services/PostService+Revisions.swift
@@ -42,7 +42,7 @@ extension PostService {
 
         restApi.getPostLatestRevisionID(for: postID) { latestRemoteRevision in
             if let latestRemoteRevision, latestRemoteRevision != localRevision {
-                DDLogError("The latest revision (\(latestRemoteRevision)) of the post (id: \(postID) is about to be overwriten by an edit that's based on revision \(localRevision)")
+                DDLogError("The latest revision (\(latestRemoteRevision)) of the post (id: \(postID)) is about to be overwritten by an edit that's based on revision \(localRevision)")
                 WordPressAppDelegate.logError(NSError(domain: "PostEditor.OverwritePost", code: 1))
             }
         } failure: { _ in

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -197,6 +197,30 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
            failure:(nullable void (^)(NSError * _Nullable error))failure
 {
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
+
+    // It's possible that the post has been updated while the user is making changes to the post in the app.
+    // In that case, this function here will overwrite the latest revision on the server.
+    //
+    // See also: https://github.com/wordpress-mobile/WordPress-iOS/issues/8111
+    //
+    // Here we check (only for WP.com posts for now) and log events for such scenario to get a sense of how
+    // often it occurs.
+    //
+    // The updating post API is made in parallel with this get revision API request–we don't want to delay
+    // saving post. In theory, it's possible that the updating post API finishes before the server handles
+    // the get revision API request, which means we'll receive an incorrect revision. But that should be
+    // extremely rare and we'll ignore it for now.
+    [self checkLatestRevisionForPost:post usingRemote:remote];
+
+    [self uploadPost:post forceDraftIfCreating:forceDraftIfCreating usingRemote:remote success:success failure:failure];
+}
+
+- (void)uploadPost:(AbstractPost *)post
+forceDraftIfCreating:(BOOL)forceDraftIfCreating
+        usingRemote:(id<PostServiceRemote>)remote
+           success:(nullable void (^)(AbstractPost * _Nullable post))success
+           failure:(nullable void (^)(NSError * _Nullable error))failure
+{
     RemotePost *remotePost = [PostHelper remotePostWithPost:post];
 
     post.remoteStatus = AbstractPostRemoteStatusPushing;


### PR DESCRIPTION
Relates to https://github.com/wordpress-mobile/WordPress-iOS/issues/8111.

The issue is a basic version control issue.

When user edits a post, the app creates a copy of the post and presents the copy for user to edit. When saving the local edits, the `uploadPost` function sends the content of the local copy to the server, and the server accepts it and uses it as the latest revision. That means, all changes that are made after the copy is created will disappear from the latest revision.

The `uploadPost` now checks if the local copy is made on top of the latest revision, and logs an error if it's not.

This new check only applies to WP.com sites. Because currently the posts returned from XML-RPC don't have revisions in it. We can look into adding the check to self-hosted sites if we see value in it after getting stats from WP.com sites.

See the WordPressKit changes here: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/637

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A