### PR TITLE
Integrate gutenberg-mobile release 1.107.0

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 5d8a4f3d8194be4313ee9520fa0c4f057ae2e38
+  commit: e5d8a4f3d8194be4313ee9520fa0c4f057ae2e38
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  tag: v1.106.0
+  commit: 5d8a4f3d8194be4313ee9520fa0c4f057ae2e38
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - FSInteractiveMap (0.1.0)
   - Gifu (3.3.1)
   - Gridicons (1.2.0)
-  - Gutenberg (1.106.0)
+  - Gutenberg (1.107.0)
   - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.9):
     - CropViewController
@@ -111,7 +111,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-e5d8a4f3d8194be4313ee9520fa0c4f057ae2e38.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -183,7 +183,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.106.0.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-e5d8a4f3d8194be4313ee9520fa0c4f057ae2e38.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -206,7 +206,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 46edef6239e4fa8c032aee57f67c9a258edf0cc1
+  Gutenberg: e266663261fdf27bc5655089913f6f5b47d624d7
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae


### PR DESCRIPTION
## Description
This PR incorporates the 1.107.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6328

Release Submission Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.