### PR TITLE
Use consistent `init` among `-Builder`s in the unit tests

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -913,6 +913,7 @@
 		3F4EB39228AC561600B8DD86 /* JetpackWordPressLogoAnimation_rtl.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F4EB39128AC561600B8DD86 /* JetpackWordPressLogoAnimation_rtl.json */; };
 		3F50945B2454ECA000C4470B /* ReaderTabItemsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50945A2454ECA000C4470B /* ReaderTabItemsStoreTests.swift */; };
 		3F50945F245537A700C4470B /* ReaderTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50945E245537A700C4470B /* ReaderTabViewModelTests.swift */; };
+		3F56F55C2AEA2F67006BDCEA /* ReaderPostBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F56F55B2AEA2F67006BDCEA /* ReaderPostBuilder.swift */; };
 		3F593FDD2A81DC6D00B29E86 /* NSError+TestInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F593FDC2A81DC6D00B29E86 /* NSError+TestInstance.swift */; };
 		3F5AAC242877791900AEF5DD /* JetpackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFA5ED12876152E00830E28 /* JetpackButton.swift */; };
 		3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */; };
@@ -6582,6 +6583,7 @@
 		3F5689FF25420DE80048A9E4 /* MultiStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiStatsView.swift; sourceTree = "<group>"; };
 		3F568A1E254213B60048A9E4 /* VerticalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCard.swift; sourceTree = "<group>"; };
 		3F568A2E254216550048A9E4 /* FlexibleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleCard.swift; sourceTree = "<group>"; };
+		3F56F55B2AEA2F67006BDCEA /* ReaderPostBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostBuilder.swift; sourceTree = "<group>"; };
 		3F593FDC2A81DC6D00B29E86 /* NSError+TestInstance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSError+TestInstance.swift"; sourceTree = "<group>"; };
 		3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogPresenter.swift; sourceTree = "<group>"; };
 		3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogFormatter.swift; sourceTree = "<group>"; };
@@ -12264,6 +12266,7 @@
 				3F593FDC2A81DC6D00B29E86 /* NSError+TestInstance.swift */,
 				57889AB723589DF100DAE56D /* PageBuilder.swift */,
 				570BFD8F2282418A007859A8 /* PostBuilder.swift */,
+				3F56F55B2AEA2F67006BDCEA /* ReaderPostBuilder.swift */,
 				3F759FBB2A2DB2CF0039A845 /* TestError.swift */,
 			);
 			name = TestUtilities;
@@ -23628,6 +23631,7 @@
 				0147D651294B6EA600AA6410 /* StatsRevampStoreTests.swift in Sources */,
 				57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */,
 				B030FE0A27EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift in Sources */,
+				3F56F55C2AEA2F67006BDCEA /* ReaderPostBuilder.swift in Sources */,
 				D81C2F5C20F872C2002AE1F1 /* ReplyToCommentActionTests.swift in Sources */,
 				08C42C31281807880034720B /* ReaderSubscribeCommentsActionTests.swift in Sources */,
 				D848CC1720FF38EA00A9038F /* FormattableCommentRangeTests.swift in Sources */,

--- a/WordPress/WordPressTest/AbstractPostTest.swift
+++ b/WordPress/WordPressTest/AbstractPostTest.swift
@@ -2,7 +2,7 @@ import XCTest
 import WordPressKit
 @testable import WordPress
 
-class AbstractPostTest: XCTestCase {
+class AbstractPostTest: CoreDataTestCase {
 
     func testTitleForStatus() {
         var status = PostStatusDraft
@@ -31,7 +31,7 @@ class AbstractPostTest: XCTestCase {
     }
 
     func testFeaturedImageURLForDisplay() {
-        let post = PostBuilder().with(pathForDisplayImage: "https://wp.me/awesome.png").build()
+        let post = PostBuilder(mainContext).with(pathForDisplayImage: "https://wp.me/awesome.png").build()
 
         XCTAssertEqual(post.featuredImageURLForDisplay()?.absoluteString, "https://wp.me/awesome.png")
     }

--- a/WordPress/WordPressTest/AccountBuilder.swift
+++ b/WordPress/WordPressTest/AccountBuilder.swift
@@ -8,7 +8,7 @@ import Foundation
 class AccountBuilder: NSObject {
     private var account: WPAccount
 
-    @objc
+    @objc(initWithContext:)
     init(_ context: NSManagedObjectContext) {
         account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
         account.uuid = UUID().uuidString

--- a/WordPress/WordPressTest/AccountBuilder.swift
+++ b/WordPress/WordPressTest/AccountBuilder.swift
@@ -6,14 +6,11 @@ import Foundation
 ///
 @objc
 class AccountBuilder: NSObject {
-    private let coreDataStack: CoreDataStack
     private var account: WPAccount
 
     @objc
-    init(_ coreDataStack: CoreDataStack) {
-        self.coreDataStack = coreDataStack
-
-        account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: coreDataStack.mainContext) as! WPAccount
+    init(_ context: NSManagedObjectContext) {
+        account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
         account.uuid = UUID().uuidString
 
         super.init()

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -174,7 +174,7 @@ class AccountServiceTests: CoreDataTestCase {
     func testMergeDuplicateAccountsKeepingNonDups() throws {
         let context = contextManager.mainContext
 
-        let account1 = AccountBuilder(contextManager)
+        let account1 = AccountBuilder(contextManager.mainContext)
             .with(id: 1)
             .with(username: "username")
             .with(authToken: "authToken")
@@ -182,14 +182,14 @@ class AccountServiceTests: CoreDataTestCase {
             .build()
 
         // account2 is a duplicate of account1
-        let account2 = AccountBuilder(contextManager)
+        let account2 = AccountBuilder(contextManager.mainContext)
             .with(id: 1)
             .with(username: "username")
             .with(authToken: "authToken")
             .with(uuid: UUID().uuidString)
             .build()
 
-        let account3 = AccountBuilder(contextManager)
+        let account3 = AccountBuilder(contextManager.mainContext)
             .with(id: 3)
             .with(username: "username3")
             .with(authToken: "authToken3")

--- a/WordPress/WordPressTest/BasePostTests.swift
+++ b/WordPress/WordPressTest/BasePostTests.swift
@@ -3,7 +3,7 @@ import Nimble
 
 @testable import WordPress
 
-class BasePostTests: XCTestCase {
+class BasePostTests: CoreDataTestCase {
 
     private var localUser: String = {
         let splitedApplicationDirectory = FileManager.default.urls(for: .applicationDirectory, in: .allDomainsMask).first!.absoluteString.split(separator: "/")
@@ -19,7 +19,7 @@ class BasePostTests: XCTestCase {
     }
 
     func testCorrectlyRefreshUUIDForCachedFeaturedImage() {
-        let post = PostBuilder()
+        let post = PostBuilder(mainContext)
             .with(pathForDisplayImage: "file:///Users/\(localUser)/Library/Developer/CoreSimulator/Devices/E690FA1D-AE36-4267-905D-8F6E71F4FA31/data/Containers/Data/Application/79D64D5C-6A83-4290-897E-794B7CC78B9F/Library/Caches/Media/thumbnail-p16-1792x1792.jpeg")
             .build()
 
@@ -28,7 +28,7 @@ class BasePostTests: XCTestCase {
     }
 
     func testCorrectlyRefreshUUIDForFeaturedImageInDocumentsFolder() {
-        let post = PostBuilder()
+        let post = PostBuilder(mainContext)
             .with(pathForDisplayImage: "file:///Users/\(localUser)/Library/Developer/CoreSimulator/Devices/E690FA1D-AE36-4267-905D-8F6E71F4FA31/data/Containers/Data/Application/79D64D5C-6A83-4290-897E-794B7CC78B9F/Documents/Media/p16-1792x1792.jpeg")
             .build()
 
@@ -37,7 +37,7 @@ class BasePostTests: XCTestCase {
     }
 
     func testDoesntChangeRemoteURLs() {
-        let post = PostBuilder()
+        let post = PostBuilder(mainContext)
             .with(pathForDisplayImage: "https://wordpress.com/image.gif")
             .build()
 

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
@@ -67,7 +67,7 @@ final class CompliancePopoverViewModelTests: CoreDataTestCase {
     }
 
     private func account() -> WPAccount {
-        return AccountBuilder(contextManager)
+        return AccountBuilder(contextManager.mainContext)
             .with(id: 1229)
             .with(username: "foobar")
             .with(email: "foo@automattic.com")

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -12,7 +12,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         contextManager.useAsSharedInstance(untilTestFinished: self)
         mockUserDefaults = InMemoryUserDefaults()
         currentDateProvider = MockCurrentDateProvider()
-        let account = AccountBuilder(contextManager).build()
+        let account = AccountBuilder(contextManager.mainContext).build()
         UserSettings.defaultDotComUUID = account.uuid
     }
 

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -21,7 +21,7 @@ final class JetpackBrandingTextProviderTests: CoreDataTestCase {
         remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
         currentDateProvider = MockCurrentDateProvider()
         remoteConfigStore.removalDeadline = "2022-10-10"
-        let account = AccountBuilder(contextManager).build()
+        let account = AccountBuilder(contextManager.mainContext).build()
         UserSettings.defaultDotComUUID = account.uuid
     }
 

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -8,7 +8,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     override func setUp() {
         contextManager.useAsSharedInstance(untilTestFinished: self)
         mockUserDefaults = InMemoryUserDefaults()
-        let account = AccountBuilder(contextManager).build()
+        let account = AccountBuilder(contextManager.mainContext).build()
         UserSettings.defaultDotComUUID = account.uuid
     }
 

--- a/WordPress/WordPressTest/My Site/NoSiteViewModelTests.swift
+++ b/WordPress/WordPressTest/My Site/NoSiteViewModelTests.swift
@@ -37,7 +37,7 @@ final class NoSiteViewModelTests: CoreDataTestCase {
 
     func test_gravatarURLIsNotNil_WhenAccountIsNotNil() {
         // Given
-        let account = AccountBuilder(contextManager)
+        let account = AccountBuilder(contextManager.mainContext)
             .with(email: "account@email.com")
             .build()
         let viewModel = NoSitesViewModel(appUIType: nil, account: account)
@@ -56,7 +56,7 @@ final class NoSiteViewModelTests: CoreDataTestCase {
 
     func test_displayNameIsAccountDisplayName_WhenAccountIsNotNil() {
         // Given
-        let account = AccountBuilder(contextManager)
+        let account = AccountBuilder(contextManager.mainContext)
             .with(email: "account@email.com")
             .with(displayName: "Test")
             .build()

--- a/WordPress/WordPressTest/MySiteViewModelTests.swift
+++ b/WordPress/WordPressTest/MySiteViewModelTests.swift
@@ -97,7 +97,7 @@ class MySiteViewModelTests: CoreDataTestCase {
 
     func makeBlogAccessibleThroughWPCom(file: StaticString = #file, line: UInt = #line) -> Blog {
         let blog = BlogBuilder(contextManager.mainContext).build()
-        let account = AccountBuilder(contextManager)
+        let account = AccountBuilder(contextManager.mainContext)
             // username needs to be set for the token to be registered
             .with(username: "username")
             .with(authToken: "token")

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -22,7 +22,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testPublishedPostOptions() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().withRemote().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().withRemote().build())
 
         postActionSheet.show(for: viewModel, from: view)
 
@@ -31,7 +31,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testLocallyPublishedPostShowsCancelAutoUploadOption() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build())
 
         postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
 
@@ -40,7 +40,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testDraftedPostOptions() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().drafted().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).drafted().build())
 
         postActionSheet.show(for: viewModel, from: view)
 
@@ -49,7 +49,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testScheduledPostOptions() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().scheduled().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).scheduled().build())
 
         postActionSheet.show(for: viewModel, from: view)
 
@@ -58,7 +58,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testTrashedPostOptions() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().trashed().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).trashed().build())
 
         postActionSheet.show(for: viewModel, from: view)
 
@@ -67,7 +67,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testPublishedPostOptionsWithView() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().withRemote().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().withRemote().build())
 
         postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
 
@@ -76,7 +76,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenStatsTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().withRemote().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().withRemote().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Stats", in: viewControllerMock.viewControllerPresented)
@@ -85,7 +85,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenDuplicateTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().withRemote().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().withRemote().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Duplicate", in: viewControllerMock.viewControllerPresented)
@@ -94,7 +94,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenShareTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().withRemote().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().withRemote().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Share", in: viewControllerMock.viewControllerPresented)
@@ -103,7 +103,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenMoveToDraftTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Move to Draft", in: viewControllerMock.viewControllerPresented)
@@ -112,7 +112,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenDeletePermanentlyTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().trashed().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).trashed().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Delete Permanently", in: viewControllerMock.viewControllerPresented)
@@ -121,7 +121,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenCopyLink() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Copy Link", in: viewControllerMock.viewControllerPresented)
@@ -130,7 +130,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenMoveToTrashTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().build())
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Move to Trash", in: viewControllerMock.viewControllerPresented)
@@ -139,7 +139,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallDelegateWhenViewTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().build())
 
         postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
         tap("View", in: viewControllerMock.viewControllerPresented)
@@ -167,7 +167,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallsDelegateWhenCancelAutoUploadIsTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build())
 
         postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
         tap(Titles.cancelAutoUpload, in: viewControllerMock.viewControllerPresented)
@@ -176,7 +176,7 @@ class PostActionSheetTests: CoreDataTestCase {
     }
 
     func testCallsDelegateWhenRetryIsTapped() {
-        let viewModel = PostCardStatusViewModel(post: PostBuilder().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 5).build())
+        let viewModel = PostCardStatusViewModel(post: PostBuilder(mainContext).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 5).build())
 
         postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
         tap(Titles.retry, in: viewControllerMock.viewControllerPresented)

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -8,7 +8,7 @@ import Foundation
 class PostBuilder {
     private let post: Post
 
-    init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext(), blog: Blog? = nil) {
+    init(_ context: NSManagedObjectContext, blog: Blog? = nil) {
         post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
 
         // Non-null Core Data properties
@@ -206,22 +206,5 @@ class PostBuilder {
         // TODO: Enable this assertion once we can ensure that the post's MOC isn't being deallocated after the `PostBuilder` is
         // assert(post.managedObjectContext != nil)
         return post
-    }
-
-    static func setUpInMemoryManagedObjectContext() -> NSManagedObjectContext {
-        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
-
-        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
-
-        do {
-            try persistentStoreCoordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
-        } catch {
-            print("Adding in-memory persistent store failed")
-        }
-
-        let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
-
-        return managedObjectContext
     }
 }

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import WordPress
 
-class PostCompactCellTests: XCTestCase {
+class PostCompactCellTests: CoreDataTestCase {
 
     var postCell: PostCompactCell!
 
@@ -12,7 +12,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testShowImageWhenAvailable() {
-        let post = PostBuilder().withImage().build()
+        let post = PostBuilder(mainContext).withImage().build()
 
         postCell.configure(with: post)
 
@@ -20,7 +20,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testHideImageWhenNotAvailable() {
-        let post = PostBuilder().build()
+        let post = PostBuilder(mainContext).build()
 
         postCell.configure(with: post)
 
@@ -28,7 +28,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testShowPostTitle() {
-        let post = PostBuilder().with(title: "Foo bar").build()
+        let post = PostBuilder(mainContext).with(title: "Foo bar").build()
 
         postCell.configure(with: post)
 
@@ -36,7 +36,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testShowDate() {
-        let post = PostBuilder().with(remoteStatus: .sync)
+        let post = PostBuilder(mainContext).with(remoteStatus: .sync)
             .with(dateCreated: Date()).build()
 
         postCell.configure(with: post)
@@ -46,7 +46,7 @@ class PostCompactCellTests: XCTestCase {
 
     func testMoreAction() {
         let postActionSheetDelegateMock = PostActionSheetDelegateMock()
-        let post = PostBuilder().published().build()
+        let post = PostBuilder(mainContext).published().build()
         postCell.configure(with: post)
         postCell.setActionSheetDelegate(postActionSheetDelegateMock)
 
@@ -57,7 +57,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testStatusAndBadgeLabels() {
-        let post = PostBuilder().with(remoteStatus: .sync)
+        let post = PostBuilder(mainContext).with(remoteStatus: .sync)
             .with(dateCreated: Date()).is(sticked: true).build()
 
         postCell.configure(with: post)
@@ -66,7 +66,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testHideBadgesWhenEmpty() {
-        let post = PostBuilder().build()
+        let post = PostBuilder(mainContext).build()
 
         postCell.configure(with: post)
 
@@ -75,7 +75,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testShowBadgesWhenNotEmpty() {
-        let post = PostBuilder()
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .sync)
             .build()
 
@@ -86,7 +86,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testShowProgressView() {
-        let post = PostBuilder()
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .pushing)
             .published().build()
 
@@ -96,7 +96,7 @@ class PostCompactCellTests: XCTestCase {
     }
 
     func testHideProgressView() {
-        let post = PostBuilder()
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .sync)
             .published().build()
 
@@ -107,7 +107,7 @@ class PostCompactCellTests: XCTestCase {
 
     func testShowsWarningMessageForFailedPublishedPosts() {
         // Given
-        let post = PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         // When
         postCell.configure(with: post)

--- a/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
+++ b/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
@@ -3,7 +3,7 @@ import Nimble
 
 @testable import WordPress
 
-class PrepublishingNudgesViewControllerTests: XCTestCase {
+class PrepublishingNudgesViewControllerTests: CoreDataTestCase {
 
     override class func setUp() {
         super.setUp()
@@ -21,7 +21,7 @@ class PrepublishingNudgesViewControllerTests: XCTestCase {
     /// Call the completion block when the "Publish" button is pressed
     ///
     func testCallCompletionBlockWhenButtonTapped() {
-        var post = PostBuilder().build()
+        var post = PostBuilder(mainContext).build()
         var returnedPost: AbstractPost?
         let prepublishingViewController = PrepublishingViewController(post: post, identifiers: [.schedule, .visibility, .tags, .categories]) { result in
             switch result {

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -3,7 +3,7 @@ import Nimble
 
 @testable import WordPress
 
-class ReaderDetailCoordinatorTests: XCTestCase {
+class ReaderDetailCoordinatorTests: CoreDataTestCase {
 
     /// Given a post ID, site ID and isFeed fetches the post from the service
     ///
@@ -253,7 +253,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     }
 
     func makeReaderPost() -> ReaderPost {
-        ReaderPostBuilder().build()
+        ReaderPostBuilder(mainContext).build()
     }
 }
 

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -36,7 +36,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Inform the view to render a post after it is fetched
     ///
     func testUpdateViewWithRetrievedPost() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         serviceMock.returnPost = post
         let viewMock = ReaderDetailViewMock()
@@ -98,7 +98,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// If a post is given, do not call the servce and render the content right away
     ///
     func testGivenAPostRenderItRightAway() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
@@ -113,7 +113,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Tell the view to show a loading indicator when start is called
     ///
     func testStartCallsTheViewToShowLoader() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
@@ -128,7 +128,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     ///
     func testShowShareSheet() {
         let button = UIView()
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let postSharingControllerMock = PostSharingControllerMock()
@@ -149,7 +149,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Present a site preview in the current view stack
     ///
     func testShowPresentSitePreview() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         post.siteID = 1
         post.isExternal = false
         let serviceMock = ReaderPostServiceMock()
@@ -168,7 +168,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Present a tag in the current view stack
     ///
     func testShowPresentTag() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         post.primaryTagSlug = "tag"
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
@@ -186,7 +186,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Present an image in the view controller
     ///
     func testShowPresentImage() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
@@ -200,7 +200,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Present an URL in a new Reader Detail screen
     ///
     func testShowPresentURL() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
@@ -216,7 +216,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Present an URL in a webview controller
     ///
     func testShowPresentURLInWebViewController() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
@@ -231,7 +231,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     /// Tell the view to scroll when URL is a hash link
     ///
     func testScrollWhenUrlIsHash() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post = makeReaderPost()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
@@ -250,6 +250,10 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         coordinator.postURL = postURL
 
         expect(coordinator.commentID).to(equal(10))
+    }
+
+    func makeReaderPost() -> ReaderPost {
+        ReaderPostBuilder().build()
     }
 }
 

--- a/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
@@ -3,7 +3,7 @@ import Nimble
 
 @testable import WordPress
 
-class ReaderDetailViewControllerTests: XCTestCase {
+class ReaderDetailViewControllerTests: CoreDataTestCase {
 
     /// Given a post URL. returns a ReaderDetailViewController
     ///
@@ -18,7 +18,7 @@ class ReaderDetailViewControllerTests: XCTestCase {
     /// Starts the coordinator with the ReaderPost and call start in viewDidLoad
     ///
     func testControllerWithPostRendersPostContent() {
-        let post: ReaderPost = ReaderPostBuilder().build()
+        let post: ReaderPost = ReaderPostBuilder(mainContext).build()
         let controller = ReaderDetailViewController.controllerWithPost(post)
         let coordinatorMock = ReaderDetailCoordinatorMock(view: controller)
         let originalCoordinator = controller.coordinator
@@ -48,10 +48,10 @@ class ReaderDetailViewControllerTests: XCTestCase {
 
 /// Builds a ReaderPost
 ///
-class ReaderPostBuilder: PostBuilder {
+class ReaderPostBuilder {
     private let post: ReaderPost
 
-    override init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext(), blog: Blog? = nil) {
+    init(_ context: NSManagedObjectContext, blog: Blog? = nil) {
         post = NSEntityDescription.insertNewObject(forEntityName: ReaderPost.entityName(), into: context) as! ReaderPost
     }
 

--- a/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
@@ -46,22 +46,6 @@ class ReaderDetailViewControllerTests: CoreDataTestCase {
 
 }
 
-/// Builds a ReaderPost
-///
-class ReaderPostBuilder {
-    private let post: ReaderPost
-
-    init(_ context: NSManagedObjectContext, blog: Blog? = nil) {
-        post = NSEntityDescription.insertNewObject(forEntityName: ReaderPost.entityName(), into: context) as! ReaderPost
-    }
-
-    func build() -> ReaderPost {
-        post.blogURL = "https://wordpress.com"
-        post.permaLink = "https://wordpress.com"
-        return post
-    }
-}
-
 private class ReaderDetailCoordinatorMock: ReaderDetailCoordinator {
     var didCallStart = false
 

--- a/WordPress/WordPressTest/ReaderPostBuilder.swift
+++ b/WordPress/WordPressTest/ReaderPostBuilder.swift
@@ -1,0 +1,17 @@
+@testable import WordPress
+
+/// Builds a `ReaderPost`
+///
+class ReaderPostBuilder {
+    private let post: ReaderPost
+
+    init(_ context: NSManagedObjectContext, blog: Blog? = nil) {
+        post = NSEntityDescription.insertNewObject(forEntityName: ReaderPost.entityName(), into: context) as! ReaderPost
+    }
+
+    func build() -> ReaderPost {
+        post.blogURL = "https://wordpress.com"
+        post.permaLink = "https://wordpress.com"
+        return post
+    }
+}

--- a/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
@@ -78,7 +78,7 @@ final class ReaderPostCellActionsTests: CoreDataTestCase {
     }
 
     private func makePost() -> ReaderPost {
-        let builder = ReaderPostBuilder()
+        let builder = ReaderPostBuilder(mainContext)
         let post: ReaderPost = builder.build()
         post.isWPCom = true
         return post

--- a/WordPress/WordPressTest/ShareAppContentPresenterTests.swift
+++ b/WordPress/WordPressTest/ShareAppContentPresenterTests.swift
@@ -24,7 +24,7 @@ final class ShareAppContentPresenterTests: CoreDataTestCase {
         super.setUp()
 
         TestAnalyticsTracker.setup()
-        account = AccountBuilder(contextManager).build()
+        account = AccountBuilder(contextManager.mainContext).build()
         mockRemote = MockShareAppContentServiceRemote()
         presenter = ShareAppContentPresenter(remote: mockRemote, account: account)
         viewController = MockViewController()

--- a/WordPress/WordPressTest/SharingServiceTests.swift
+++ b/WordPress/WordPressTest/SharingServiceTests.swift
@@ -10,7 +10,7 @@ class SharingServiceTests: CoreDataTestCase {
     private let blogID = 10
 
     private lazy var account: WPAccount = {
-        AccountBuilder(contextManager)
+        AccountBuilder(contextManager.mainContext)
             .with(id: Int64(userID))
             .with(username: "username")
             .with(authToken: "authToken")

--- a/WordPress/WordPressTest/WPAccount+LookupTests.swift
+++ b/WordPress/WordPressTest/WPAccount+LookupTests.swift
@@ -98,6 +98,6 @@ class WPAccountLookupTests: CoreDataTestCase {
 
     @discardableResult
     func makeAccount(_ additionalSetup: (AccountBuilder) -> (AccountBuilder) = { $0 }) -> WPAccount {
-        additionalSetup(AccountBuilder(contextManager)).build()
+        additionalSetup(AccountBuilder(contextManager.mainContext)).build()
     }
 }

--- a/WordPress/WordPressTest/WPAccount+LookupTests.swift
+++ b/WordPress/WordPressTest/WPAccount+LookupTests.swift
@@ -5,18 +5,18 @@ class WPAccountLookupTests: CoreDataTestCase {
 
     func testIsDefaultWordPressComAccountIsFalseWhenNoAccountIsSet() {
         UserSettings.defaultDotComUUID = nil
-        let account = AccountBuilder(contextManager).build()
+        let account = makeAccount()
         XCTAssertFalse(account.isDefaultWordPressComAccount)
     }
 
     func testIsDefaultWordPressComAccountIsTrueWhenUUIDMatches() {
-        let account = AccountBuilder(contextManager).build()
+        let account = makeAccount()
         UserSettings.defaultDotComUUID = account.uuid
         XCTAssertTrue(account.isDefaultWordPressComAccount)
     }
 
     func testHasBlogsReturnsFalseWhenNoBlogsArePresentForAccount() {
-        let account = AccountBuilder(contextManager).build()
+        let account = makeAccount()
         XCTAssertFalse(account.hasBlogs)
     }
 
@@ -28,12 +28,12 @@ class WPAccountLookupTests: CoreDataTestCase {
     }
 
     func testLookupDefaultWordPressComAccountReturnsNilWhenNoAccountIsSet() throws {
-        let _ = AccountBuilder(contextManager).build()
+        makeAccount()
         try XCTAssertNil(WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext))
     }
 
     func testLookupDefaultWordPressComAccountReturnsAccount() throws {
-        let account = AccountBuilder(contextManager).build()
+        let account = makeAccount()
         UserSettings.defaultDotComUUID = account.uuid
 
         try XCTAssertEqual(WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext)?.uuid, account.uuid)
@@ -47,40 +47,40 @@ class WPAccountLookupTests: CoreDataTestCase {
     }
 
     func testLookupAccountByUUIDReturnsNilForInvalidAccount() throws {
-        AccountBuilder(contextManager).build()
+        makeAccount()
         try XCTAssertNil(WPAccount.lookup(withUUIDString: "", in: contextManager.mainContext))
     }
 
     func testLookupAccountByUUIDReturnsAccount() throws {
         let uuid = UUID().uuidString
-        AccountBuilder(contextManager).with(uuid: uuid).build()
+        makeAccount { $0.with(uuid: uuid) }
         try XCTAssertEqual(WPAccount.lookup(withUUIDString: uuid, in: contextManager.mainContext)?.uuid, uuid)
     }
 
     func testLookupAccountByUsernameReturnsNilIfNotFound() throws {
-        AccountBuilder(contextManager).build()
+        makeAccount()
         try XCTAssertNil(WPAccount.lookup(withUsername: "", in: contextManager.mainContext))
     }
 
     func testLookupAccountByUsernameReturnsAccountForUsername() throws {
         let username = UUID().uuidString
-        AccountBuilder(contextManager).with(username: username).build()
+        makeAccount { $0.with(username: username) }
         try XCTAssertEqual(WPAccount.lookup(withUsername: username, in: contextManager.mainContext)?.username, username)
     }
 
     func testLookupAccountByUsernameReturnsAccountForEmailAddress() throws {
         let email = UUID().uuidString
-        AccountBuilder(contextManager).with(email: email).build()
+        makeAccount { $0.with(email: email) }
         try XCTAssertEqual(WPAccount.lookup(withUsername: email, in: contextManager.mainContext)?.email, email)
     }
 
     func testLookupByUserIdReturnsNilIfNotFound() throws {
-        AccountBuilder(contextManager).with(id: 1).build() // Make a test account that we don't want to match
+        makeAccount { $0.with(id: 1) } // Make a test account that we don't want to match
         try XCTAssertNil(WPAccount.lookup(withUserID: 2, in: contextManager.mainContext))
     }
 
     func testLookupByUserIdReturnsAccount() throws {
-        AccountBuilder(contextManager).with(id: 1).build()
+        makeAccount { $0.with(id: 1) }
         try XCTAssertEqual(WPAccount.lookup(withUserID: 1, in: contextManager.mainContext)?.userID, 1)
     }
 
@@ -89,10 +89,15 @@ class WPAccountLookupTests: CoreDataTestCase {
     }
 
     func testLookupNumberOfAccountsReturnsCorrectValue() throws {
-        let _ = AccountBuilder(contextManager).build()
-        let _ = AccountBuilder(contextManager).build()
-        let _ = AccountBuilder(contextManager).build()
+        makeAccount()
+        makeAccount()
+        makeAccount()
 
         try XCTAssertEqual(WPAccount.lookupNumberOfAccounts(in: contextManager.mainContext), 3)
+    }
+
+    @discardableResult
+    func makeAccount(_ additionalSetup: (AccountBuilder) -> (AccountBuilder) = { $0 }) -> WPAccount {
+        additionalSetup(AccountBuilder(contextManager)).build()
     }
 }

--- a/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
+++ b/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
@@ -15,12 +15,12 @@
 }
 
 - (void) testLookupDefaultWordPressComAccountReturnsNilWhenNoAccountIsSet {
-    [[[AccountBuilder alloc] init: self.contextManager] build];
+    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
     XCTAssertNil([WPAccount lookupDefaultWordPressComAccountInContext: self.contextManager.mainContext]);
 }
 
 - (void) testLookupDefaultWordPressComAccountReturnsAccount {
-    WPAccount *account = [[[AccountBuilder alloc] init: self.contextManager] build];
+    WPAccount *account = [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
     [UserSettings setDefaultDotComUUID: account.uuid];
     XCTAssertEqual([WPAccount lookupDefaultWordPressComAccountInContext:self.contextManager.mainContext].uuid, account.uuid);
 }
@@ -30,27 +30,27 @@
 }
 
 - (void) testLookupNumberOfAccountsReturnsCorrectValue {
-    [[[AccountBuilder alloc] init: self.contextManager] build];
-    [[[AccountBuilder alloc] init: self.contextManager] build];
-    [[[AccountBuilder alloc] init: self.contextManager] build];
+    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
 
     XCTAssertEqual([WPAccount lookupNumberOfAccountsInContext: self.contextManager.mainContext], 3);
 }
 
 - (void) testLookupAccountByUsernameReturnsNilIfNotFound {
-    [[[AccountBuilder alloc] init: self.contextManager] build];
+    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
     XCTAssertNil([WPAccount lookupWithUsername:@"" context:self.contextManager.mainContext]);
 }
 
 - (void) testLookupAccountByUsernameReturnsAccountForUsername {
     NSString *username = [[NSUUID new] UUIDString];
-    [[[[AccountBuilder alloc] init:self.contextManager] withUsername: username] build];
+    [[[[AccountBuilder alloc] init:self.contextManager.mainContext] withUsername: username] build];
     XCTAssertEqual([WPAccount lookupWithUsername:username context:self.contextManager.mainContext].username, username);
 }
 
 - (void) testLookupAccountByUsernameReturnsAccountForEmailAddress {
     NSString *email = [[NSUUID new] UUIDString];
-    [[[[AccountBuilder alloc] init: self.contextManager] withEmail:email] build];
+    [[[[AccountBuilder alloc] init: self.contextManager.mainContext] withEmail:email] build];
     XCTAssertEqual([WPAccount lookupWithUsername:email context:self.contextManager.mainContext].email, email);
 }
 

--- a/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
+++ b/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
@@ -15,12 +15,12 @@
 }
 
 - (void) testLookupDefaultWordPressComAccountReturnsNilWhenNoAccountIsSet {
-    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] build];
     XCTAssertNil([WPAccount lookupDefaultWordPressComAccountInContext: self.contextManager.mainContext]);
 }
 
 - (void) testLookupDefaultWordPressComAccountReturnsAccount {
-    WPAccount *account = [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
+    WPAccount *account = [[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] build];
     [UserSettings setDefaultDotComUUID: account.uuid];
     XCTAssertEqual([WPAccount lookupDefaultWordPressComAccountInContext:self.contextManager.mainContext].uuid, account.uuid);
 }
@@ -30,27 +30,27 @@
 }
 
 - (void) testLookupNumberOfAccountsReturnsCorrectValue {
-    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
-    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
-    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] build];
 
     XCTAssertEqual([WPAccount lookupNumberOfAccountsInContext: self.contextManager.mainContext], 3);
 }
 
 - (void) testLookupAccountByUsernameReturnsNilIfNotFound {
-    [[[AccountBuilder alloc] init: self.contextManager.mainContext] build];
+    [[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] build];
     XCTAssertNil([WPAccount lookupWithUsername:@"" context:self.contextManager.mainContext]);
 }
 
 - (void) testLookupAccountByUsernameReturnsAccountForUsername {
     NSString *username = [[NSUUID new] UUIDString];
-    [[[[AccountBuilder alloc] init:self.contextManager.mainContext] withUsername: username] build];
+    [[[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] withUsername:username] build];
     XCTAssertEqual([WPAccount lookupWithUsername:username context:self.contextManager.mainContext].username, username);
 }
 
 - (void) testLookupAccountByUsernameReturnsAccountForEmailAddress {
     NSString *email = [[NSUUID new] UUIDString];
-    [[[[AccountBuilder alloc] init: self.contextManager.mainContext] withEmail:email] build];
+    [[[[AccountBuilder alloc] initWithContext:self.contextManager.mainContext] withEmail:email] build];
     XCTAssertEqual([WPAccount lookupWithUsername:email context:self.contextManager.mainContext].email, email);
 }
 

--- a/WordPress/WordPressTest/WPCrashLoggingDataProviderTests.swift
+++ b/WordPress/WordPressTest/WPCrashLoggingDataProviderTests.swift
@@ -43,7 +43,7 @@ final class WPCrashLoggingDataProviderTests: XCTestCase {
 
     private func makeCoreDataStack() -> ContextManager {
         let contextManager = ContextManager.forTesting()
-        let account = AccountBuilder(contextManager)
+        let account = AccountBuilder(contextManager.mainContext)
             .with(id: Constants.defaultAccountID)
             .with(email: Constants.defaultAccountEmail)
             .with(username: Constants.defaultAccountUsername)


### PR DESCRIPTION
The aim of this PR is to homogenize the API for the `-Builder` object.
These objects are used to create database objects (`NSManagedObject` sublcasses from the [Core Data](https://developer.apple.com/documentation/coredata/) storage framework we use in the app) in the unit tests.

The value of using a builder object is two-fold.
First, Core Data object are more complex to initialize that the usual `struct` or `class`.
Moving that logic in a dedicated object keeps the unit tests [DRY]() and saves up mental bandwidth to those writing the tests—they can simply call `init` a `Builder`, configure it, and get the Core Data object by calling `build()`.

On top of that, our database objects have certain properties that must be set for them to be valid.
Again, hiding the logic away ensures that a unit tests writer doesn't need to worry about the implementation details of how to create a database object and can focus on the system under test itself.
It also means that we increase the likelihood of having well-formed inputs for our tests.

My hope in making the API consistent is to lower the barrier to entry for using these objects.

## Review tip

I recommend checking out the inline comments in the diff, then reviewing one commit at a time. There's a lot of mechanic changes here, such as an `init` method that had a default value no longer has it, so it went from `init()` to `init(mainContext)`. I tried to [tell the story](https://mokacoding.com/blog/your-git-log-should-tell-a-story/) of this refactor one commit at a time to isolate the noise. (It only occurred to me now that I could have commented in the commits, which would have made that even better, maybe next time).

## Possible next steps

_I'm not committing to these, but I find it useful to track where to go from here to shape the conversation and to connect the dots in the future._

- Audit the unit tests for instances where a `Builder` could be use but isn't yet
- Add static analysis (e.g. a SwiftLint check or a Danger check) to prevent instantiating `NSManagedObject` subclasses in the unit tests (this might be a bit too rigid)

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.