### PR TITLE
Posts & Pages: Replace the eye

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMenuHelper.swift
@@ -63,7 +63,7 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
     var icon: UIImage? {
         switch self {
         case .retry: return UIImage()
-        case .view: return UIImage(systemName: "eye")
+        case .view: return UIImage(systemName: "safari")
         case .publish: return UIImage(systemName: "globe")
         case .stats: return UIImage(systemName: "chart.bar")
         case .duplicate: return UIImage(systemName: "doc.on.doc")


### PR DESCRIPTION
Replaces the eye, which is commonly used for show/hide password, with a Safari icon.

<img width="447" alt="Screenshot 2023-10-26 at 10 08 13 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0f40975f-ca42-48f4-bfc6-02f688f5e3d3">


## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
