### PR TITLE
Investigate flaky `testThatCampaignIsCached`

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -14,7 +14,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.0.1
+    IMAGE_ID: xcode-14.3.1
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,29 +12,6 @@ common_params:
 steps:
 
   #################
-  # Create Prototype Builds for WP and JP
-  #################
-  - group: "🛠 Prototype Builds"
-    steps:
-      - label: "🛠 WordPress Prototype Build"
-        command: ".buildkite/commands/prototype-build-wordpress.sh"
-        env: *common_env
-        plugins: *common_plugins
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "WordPress Prototype Build"
-
-      - label: "🛠 Jetpack Prototype Build"
-        command: ".buildkite/commands/prototype-build-jetpack.sh"
-        env: *common_env
-        plugins: *common_plugins
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "Jetpack Prototype Build"
-
-  #################
   # Create Builds for Testing
   #################
   - group: "🛠 Builds for Testing"
@@ -47,15 +24,6 @@ steps:
         notify:
           - github_commit_status:
               context: "WordPress Build for Testing"
-
-      - label: "🛠 :jetpack: Build for Testing"
-        key: "build_jetpack"
-        command: ".buildkite/commands/build-for-testing.sh jetpack"
-        env: *common_env
-        plugins: *common_plugins
-        notify:
-          - github_commit_status:
-              context: "Jetpack Build for Testing"
 
   #################
   # Run Unit Tests
@@ -70,66 +38,3 @@ steps:
     notify:
       - github_commit_status:
           context: "Unit Tests"
-
-  #################
-  # UI Tests
-  #################
-  - group: "🔬 UI Tests"
-    steps:
-      - label: "🔬 :jetpack: UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh 'iPhone 15'
-        depends_on: "build_jetpack"
-        env: *common_env
-        plugins: *common_plugins
-        artifact_paths:
-          - "build/results/*"
-          - "build/results/crashes/*"
-        notify:
-          - github_commit_status:
-              context: "UI Tests (iPhone)"
-
-      - label: "🔬 :jetpack: UI Tests (iPad)"
-        command: .buildkite/commands/run-ui-tests.sh 'iPad Pro (12.9-inch) (6th generation)'
-        depends_on: "build_jetpack"
-        env: *common_env
-        plugins: *common_plugins
-        artifact_paths:
-          - "build/results/*"
-          - "build/results/crashes/*"
-        notify:
-          - github_commit_status:
-              context: "UI Tests (iPad)"
-
-  #################
-  # Linters
-  #################
-  - group: "Linters"
-    steps:
-      - label: "☢️ Danger - PR Check"
-        command: .buildkite/commands/danger-pr-check.sh
-        plugins:
-          - docker#v5.8.0:
-              image: "public.ecr.aws/docker/library/ruby:3.2.2"
-              propagate-environment: true
-              environment:
-                - "DANGER_GITHUB_API_TOKEN"
-        if: "build.pull_request.id != null"
-        agents:
-          queue: "default"
-        retry:
-          manual:
-            permit_on_passed: true
-      - label: "🧹 Lint Translations"
-        command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
-        plugins:
-          - docker#v3.8.0:
-              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-        agents:
-          queue: "default"
-        notify:
-          - github_commit_status:
-              context: "Lint Translations"
-      - label: ":sleuth_or_spy: Lint Localized Strings Format"
-        command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: *common_plugins
-        env: *common_env

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.0.1
+    IMAGE_ID: xcode-14.3.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -11,7 +11,7 @@ common_params:
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.0.1
+    IMAGE_ID: xcode-14.3.1
 
 steps:
 

--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -16,7 +16,8 @@
       "identifier" : "FABB1F8F2602FC2C00C8785C",
       "name" : "Jetpack"
     },
-    "testRepetitionMode" : "retryOnFailure"
+    "testRepetitionMode" : "retryOnFailure",
+    "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [
     {

--- a/WordPress/WordPressTest/Dashboard/DashboardBlazeCardCellViewModelTest.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardBlazeCardCellViewModelTest.swift
@@ -17,15 +17,29 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
         blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.dotComID = 1
 
-        createSUT()
+        sut = createSUT(service: service, store: store, blog: blog)
     }
 
-    private func createSUT() {
-        sut = DashboardBlazeCardCellViewModel(
+    private func createSUT(blazeCampaignsEnabled: Bool = true) -> DashboardBlazeCardCellViewModel {
+        createSUT(
+            service: service,
+            store: store,
+            blog: blog,
+            blazeCampaignsEnabled: blazeCampaignsEnabled
+        )
+    }
+
+    private func createSUT(
+        service: MockBlazeService,
+        store: MockDashboardBlazeStore,
+        blog: Blog,
+        blazeCampaignsEnabled: Bool = true
+    ) -> DashboardBlazeCardCellViewModel {
+        DashboardBlazeCardCellViewModel(
             blog: blog,
             service: service,
             store: store,
-            isBlazeCampaignsFlagEnabled: { [unowned self] in self.isBlazeCampaignsFlagEnabled }
+            isBlazeCampaignsFlagEnabled: { blazeCampaignsEnabled }
         )
     }
 
@@ -66,7 +80,7 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
         wait(for: [expectation], timeout: 1)
 
         // When the ViewModel is re-created
-        createSUT()
+        let newSUT = createSUT()
 
         // Then it shows the cached campaign
         switch sut.state {
@@ -80,8 +94,7 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
     // FIXME: This test is testing the default state of the service and exercises async behavior synchronousely.
     func testThatNoRequestsAreMadeWhenFlagDisabled() {
         // Given
-        isBlazeCampaignsFlagEnabled = false
-        createSUT()
+        let sut = createSUT(blazeCampaignsEnabled: false)
 
         // When
         sut.refresh()

--- a/WordPress/WordPressTest/Dashboard/DashboardBlazeCardCellViewModelTest.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardBlazeCardCellViewModelTest.swift
@@ -3,8 +3,8 @@ import XCTest
 @testable import WordPress
 
 final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
-    private let service = MockBlazeService()
-    private let store = MockDashboardBlazeStore()
+    private var service: MockBlazeService!
+    private var store: MockDashboardBlazeStore!
     private var blog: Blog!
     private var sut: DashboardBlazeCardCellViewModel!
     private var isBlazeCampaignsFlagEnabled = true
@@ -12,6 +12,8 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
     override func setUp() {
         super.setUp()
 
+        service = MockBlazeService()
+        store = MockDashboardBlazeStore()
         blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.dotComID = 1
 
@@ -75,6 +77,7 @@ final class DashboardBlazeCardCellViewModelTest: CoreDataTestCase {
         }
     }
 
+    // FIXME: This test is testing the default state of the service and exercises async behavior synchronousely.
     func testThatNoRequestsAreMadeWhenFlagDisabled() {
         // Given
         isBlazeCampaignsFlagEnabled = false

--- a/WordPress/WordPressTest/WordPressUnitTests.xctestplan
+++ b/WordPress/WordPressTest/WordPressUnitTests.xctestplan
@@ -25,8 +25,7 @@
       "containerPath" : "container:WordPress.xcodeproj",
       "identifier" : "1D6058900D05DD3D006BFB54",
       "name" : "WordPress"
-    },
-    "testRepetitionMode" : "retryOnFailure"
+    }
   },
   "testTargets" : [
     {


### PR DESCRIPTION
The test 100% fails on the first run in CI, then passes. 

It has been like that for at least the last 28 days:

<img width="1032" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/b320b57d-1aea-455d-8020-3f0499dcc945">

I cannot reproduce locally. I tried the same Simulator and iOS version.

Ideas to try:

- I haven't tried running the tests via Fastlane, only Xcode. Maybe there's something different ther.
- I'm using 15.0.1, CI uses 14.3.1. We are due for to update anyways, but haven't done it yet because of some failing tests. Maybe this is a good time to do it, just so we homogenize the testing environment further.
- I doubt this has to do with Intel + VM performance, given the test is not hitting the network or doing anything CPU heavy. Still, I could try on my Intel machine to see how it goes.

---


Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
