### PR TITLE
Fix release notes for the Plans in Site Creation project

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 23.6
 -----
-* [***] [internal][Jetpack-only] [***] Added paid domain selection, plan selection, and checkout screens in site creation flow [#21688]
+* [***] [Jetpack-only] Added paid domain selection, plan selection, and checkout screens in site creation flow [#21688]
 * [**] When moving a post to trash, show a toast message with undo action instead of an inline undo row. [#21724]
 * [*] Site Domains: Fixed an issue where the message shared while adding a domain was inaccurate. [#21827]
 * [*] Fix an issue where login with site address is blocked after failing the first attempt. [#21848]


### PR DESCRIPTION
Plans in Site Creation project will be publicly available in version `23.6`. This PR removes the incorrect `[internal]` tag and extra `[***]` from the release note.