### PR TITLE
Posts & Pages: Show latest posts in search

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -95,7 +95,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             cell.separatorInset = UIEdgeInsets(top: 0, left: view.bounds.size.width, bottom: 0, right: 0) // Hide the native separator
             return cell
         case .posts:
-            let post = viewModel.posts[indexPath.row]
+            let post = viewModel.posts[indexPath.row].latest()
             switch post {
             case let post as Post:
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath) as! PostListCell
@@ -153,7 +153,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             // TODO: Move to viewWillAppear (the way editor is displayed doesn't allow)
             tableView.deselectRow(at: indexPath, animated: true)
 
-            switch viewModel.posts[indexPath.row] {
+            switch viewModel.posts[indexPath.row].latest() {
             case let post as Post:
                 guard post.status != .trash else { return }
                 (listViewController as! PostListViewController)

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -86,27 +86,42 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
     private func reload(with notification: Foundation.Notification) {
         guard let userInfo = notification.userInfo else { return }
 
-        let existingObjects = Set(posts)
-        var updated = (userInfo[NSUpdatedObjectsKey] as? Set<NSManagedObject>) ?? []
-        var deleted = (userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? []
+        // The list displays the latest versions of a post when available,
+        // but it uses the original posts as identifiers (because they are stable).
+        // This method ensures that the list updates whenever either the
+        // original version or the latest version changes.
+        let existingOriginalPosts = Set(posts)
+        var existingLatestPosts: [NSManagedObject: NSManagedObject] = [:]
+        for object in posts {
+            existingLatestPosts[object] = object.latest()
+        }
 
-        updated.formIntersection(existingObjects)
-        deleted.formIntersection(existingObjects)
+        let updatedObjects = (userInfo[NSUpdatedObjectsKey] as? Set<NSManagedObject>) ?? []
+        var updatedPosts = updatedObjects.intersection(existingOriginalPosts)
+        for (original, latest) in existingLatestPosts {
+            if updatedObjects.contains(latest) {
+                updatedPosts.insert(original)
+            }
+        }
 
-        guard !updated.isEmpty || !deleted.isEmpty else {
+        let deletedPosts = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
+            .intersection(existingOriginalPosts)
+
+        guard !updatedPosts.isEmpty || !deletedPosts.isEmpty else {
             return
         }
 
         var snapshot = makeSnapshot()
-        snapshot.reloadItems(updated.map({ ItemID.post($0.objectID) }))
 
-        for object in deleted {
+        snapshot.reloadItems(updatedPosts.map({ ItemID.post($0.objectID) }))
+
+        for object in deletedPosts {
             if let post = object as? AbstractPost,
                let index = posts.firstIndex(of: post) {
                 posts.remove(at: index)
             }
-            snapshot.deleteItems(deleted.map({ ItemID.post($0.objectID) }))
         }
+        snapshot.deleteItems(deletedPosts.map({ ItemID.post($0.objectID) }))
 
         self.snapshot = snapshot
     }


### PR DESCRIPTION
To test:

- Find a post in search
- Update the post
- Verify that the search list updates and shows the latest revision

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/e90f394b-776d-4c31-920b-44a9f41a4107

## Regression Notes
1. Potential unintended areas of impact: Posts search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
