### PR TITLE
Reader: Scroll to top when status bar is tapped

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 23.7
 -----
-
+* [*] Bug fix: Reader now scrolls to the top when tapping the status bar. [#21914]
 
 23.6
 -----

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -33,6 +33,7 @@ class FilterTabBar: UIControl {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.showsVerticalScrollIndicator = false
+        scrollView.scrollsToTop = false
 
         return scrollView
     }()


### PR DESCRIPTION
Fixes #20625

## Description

This PR disables the `scrollsToTop` property of Reader's `FilterTabBar` as it was conflicting with the main scroll view's gesture. See `UIScrollView` [special considerations](https://developer.apple.com/documentation/uikit/uiscrollview/1619421-scrollstotop#1681700).

| Before | After |
| - | - |
| Tapping the status bar has no effect | Tapping the status bar scrolls to the top |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/53097893-aecd-4a8a-a1d0-46568812514f" /> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/be0525e3-80f9-432d-be17-07c8b7503178" /> |

## Testing

### iPhone
1. Open Reader and load enough posts to scroll in the portrait orientation
2. Scroll down
3. Tap the status bar
4. **Expect:** Reader scrolls to the top
5. **Expect:** In landscape orientation there is no change in behavior (tapping the top of the screen has no effect)

### iPad
1. Open Reader and load enough posts to scroll
2. Scroll down
3. Tap the status bar (test in both portrait and landscape)
4. **Expect:** Reader scrolls to the top

## Regression Notes
1. Potential unintended areas of impact
- None identified. The `FilterTabBar` scrolls horizontally so it shouldn't respond to this gesture.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing above.

3. What automated tests I added (or what prevented me from doing so)
- None, as this is implemented by the system.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
