### PR TITLE
Posts & Pages: Simplify PageListTableViewHandler

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -15,16 +15,6 @@ final class PageListTableViewHandler: WPTableViewHandler {
     private var pages: [Page] = []
     private let blog: Blog
 
-    private lazy var publishedResultController: NSFetchedResultsController<NSFetchRequestResult> = {
-        let publishedFilter = PostListFilter.publishedFilter()
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Page.entityName())
-        let predicate = NSPredicate(format: "\(#keyPath(Page.blog)) = %@ && \(#keyPath(Page.revision)) = nil", blog)
-        let predicates = [predicate, publishedFilter.predicateForFetchRequest]
-        fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-        fetchRequest.sortDescriptors = publishedFilter.sortDescriptors
-        return resultsController(with: fetchRequest, context: managedObjectContext(), performFetch: false)
-    }()
-
     private lazy var _resultsController: NSFetchedResultsController<NSFetchRequestResult> = {
         resultsController(with: fetchRequest(), context: managedObjectContext())
     }()
@@ -68,24 +58,6 @@ final class PageListTableViewHandler: WPTableViewHandler {
     func index(for page: Page) -> Int? {
         return pages.firstIndex(of: page)
     }
-
-    func removePage(from index: Int?) -> [Page] {
-        guard let index = index, status == .published else {
-            do {
-                try publishedResultController.performFetch()
-                if let pages = publishedResultController.fetchedObjects as? [Page] {
-                    return pages.setHomePageFirst().hierarchySort()
-                }
-            } catch {
-                DDLogError("Error fetching pages after refreshing the table: \(error)")
-            }
-
-            return []
-        }
-
-        return pages.remove(from: index)
-    }
-
 
     // MARK: - Override TableView Datasource
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -219,7 +219,7 @@ import Foundation
         return filter
     }
 
-    func predicate(for blog: Blog) -> NSPredicate {
+    func predicate(for blog: Blog, author: PostListFilterSettings.AuthorFilter = .mine) -> NSPredicate {
         var predicates = [NSPredicate]()
 
         // Show all original posts without a revision & revision posts.
@@ -228,7 +228,7 @@ import Foundation
 
         predicates.append(predicateForFetchRequest)
 
-        if let myAuthorID = blog.userID {
+        if author == .mine, let myAuthorID = blog.userID {
             // Brand new local drafts have an authorID of 0.
             let authorPredicate = NSPredicate(format: "authorID = %@ || authorID = 0", myAuthorID)
             predicates.append(authorPredicate)


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21819. This makes removing `WPTableViewHandler` easier. There was no need to handle this in `PageListTableViewHandler` and using `NSFetchedResultsController`.

To test:

Add the following in `didSelctRowAt` to invoke the (deprecated menu):

```swift
let page = pageAtIndexPath(indexPath)
let cell = tableView.cellForRow(at: indexPath)!
handleMenuAction(fromCell: cell, fromButton: UIButton(), forPage: page)
```

Tap "Set Parent" and verify that it displays a list of potential parents pages. The list should contain all parent pages except for the select page and all of its children.

## Regression Notes
1. Potential unintended areas of impact: Pages List
2. What I did to test those areas of impact (or what existing automated tests I relied on): Manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
