### PR TITLE
Posts & Pages: Add swipe actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -28,9 +28,9 @@ extension PageListViewController: InteractivePostViewDelegate {
         publishPost(apost)
     }
 
-    func trash(_ apost: AbstractPost) {
-        guard let page = apost as? Page else { return }
-        trashPage(page)
+    func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
+        guard let page = post as? Page else { return }
+        trashPage(page, completion: completion)
     }
 
     func draft(_ apost: AbstractPost) {
@@ -90,7 +90,7 @@ extension PageListViewController: InteractivePostViewDelegate {
         present(editorViewController, animated: false)
     }
 
-    private func trashPage(_ page: Page) {
+    private func trashPage(_ page: Page, completion: @escaping () -> Void) {
         guard ReachabilityUtils.isInternetReachable() else {
             ReachabilityUtils.showNoInternetConnectionNotice(message: Strings.offlineMessage)
             return
@@ -102,9 +102,12 @@ extension PageListViewController: InteractivePostViewDelegate {
         let messageText = isPageTrashed ? Strings.DeletePermanently.messageText : Strings.Trash.messageText
 
         let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(Strings.cancelText)
-        alertController.addDestructiveActionWithTitle(actionText) { [weak self] action in
+        alertController.addCancelActionWithTitle(Strings.cancelText) { _ in
+            completion()
+        }
+        alertController.addDestructiveActionWithTitle(actionText) { [weak self] _ in
             self?.deletePost(page)
+            completion()
         }
         alertController.presentFromRootViewController()
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -333,16 +333,14 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
-    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        indexPath.section == Section.pages.rawValue
-    }
-
     func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard indexPath.section == Section.pages.rawValue else { return nil }
         let actions = AbstractPostHelper.makeLeadingContextualActions(for: pages[indexPath.row], delegate: self)
         return UISwipeActionsConfiguration(actions: actions)
     }
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard indexPath.section == Section.pages.rawValue else { return nil }
         let actions = AbstractPostHelper.makeTrailingContextualActions(for: pages[indexPath.row], delegate: self)
         return UISwipeActionsConfiguration(actions: actions)
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -255,7 +255,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         refreshResults()
     }
 
-    // MARK: - TableView Handler Delegate Methods
+    // MARK: - Core Data
 
     override func entityName() -> String {
         return String(describing: Page.self)
@@ -331,6 +331,20 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             let cell = self.tableView.cellForRow(at: indexPath)
             return helper.makeMenu(presentingView: cell?.contentView ?? UIView(), delegate: self)
         }
+    }
+
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        indexPath.section == Section.pages.rawValue
+    }
+
+    func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let actions = AbstractPostHelper.makeLeadingContextualActions(for: pages[indexPath.row], delegate: self)
+        return UISwipeActionsConfiguration(actions: actions)
+    }
+
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let actions = AbstractPostHelper.makeTrailingContextualActions(for: pages[indexPath.row], delegate: self)
+        return UISwipeActionsConfiguration(actions: actions)
     }
 
     // MARK: - UITableViewDataSource

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
@@ -1,8 +1,6 @@
 import UIKit
 
 extension AbstractPostHelper {
-    // MARK: - Posts
-
     static func makeLeadingContextualActions(for post: AbstractPost, delegate: InteractivePostViewDelegate) -> [UIContextualAction] {
         var actions: [UIContextualAction] = []
 
@@ -33,7 +31,7 @@ extension AbstractPostHelper {
         trashAction.image = UIImage(systemName: "trash")
         actions.append(trashAction)
 
-        if post.status == .publish && post.hasRemote() {
+        if post is Post, post.status == .publish && post.hasRemote() {
             let shareAction = UIContextualAction(style: .normal, title: Strings.swipeActionShare) { [weak delegate] _, view, completion in
                 delegate?.share(post, fromView: view)
                 completion(true)
@@ -50,5 +48,5 @@ private enum Strings {
     static let swipeActionView = NSLocalizedString("postList.swipeActionView", value: "View", comment: "Swipe action title")
     static let swipeActionShare = NSLocalizedString("postList.swipeActionShare", value: "Share", comment: "Swipe action title")
     static let swipeActionTrash = NSLocalizedString("postList.swipeActionDelete", value: "Trash", comment: "Swipe action title")
-    static let swipeActionDeletePermanently = NSLocalizedString("postList.swipeActionDelete", value: "Delete Permanently", comment: "Swipe action title")
+    static let swipeActionDeletePermanently = NSLocalizedString("postList.swipeActionDelete", value: "Delete", comment: "Swipe action title")
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
@@ -1,0 +1,54 @@
+import UIKit
+
+extension AbstractPostHelper {
+    // MARK: - Posts
+
+    static func makeLeadingContextualActions(for post: AbstractPost, delegate: InteractivePostViewDelegate) -> [UIContextualAction] {
+        var actions: [UIContextualAction] = []
+
+        if post.status != .trash {
+            let viewAction = UIContextualAction(style: .normal, title: Strings.swipeActionView) { [weak delegate] _, _, completion in
+                delegate?.view(post)
+                completion(true)
+            }
+            viewAction.image = UIImage(systemName: "safari")
+            viewAction.backgroundColor = .systemBlue
+            actions.append(viewAction)
+        }
+
+        return actions
+    }
+
+    static func makeTrailingContextualActions(for post: AbstractPost, delegate: InteractivePostViewDelegate) -> [UIContextualAction] {
+        var actions: [UIContextualAction] = []
+
+        let trashAction = UIContextualAction(
+            style: .destructive,
+            title: post.status == .trash ? Strings.swipeActionDeletePermanently : Strings.swipeActionTrash
+        ) { [weak delegate] _, _, completion in
+            delegate?.trash(post) {
+                completion(true)
+            }
+        }
+        trashAction.image = UIImage(systemName: "trash")
+        actions.append(trashAction)
+
+        if post.status == .publish && post.hasRemote() {
+            let shareAction = UIContextualAction(style: .normal, title: Strings.swipeActionShare) { [weak delegate] _, view, completion in
+                delegate?.share(post, fromView: view)
+                completion(true)
+            }
+            shareAction.image = UIImage(systemName: "square.and.arrow.up")
+            actions.append(shareAction)
+        }
+
+        return actions
+    }
+}
+
+private enum Strings {
+    static let swipeActionView = NSLocalizedString("postList.swipeActionView", value: "View", comment: "Swipe action title")
+    static let swipeActionShare = NSLocalizedString("postList.swipeActionShare", value: "Share", comment: "Swipe action title")
+    static let swipeActionTrash = NSLocalizedString("postList.swipeActionDelete", value: "Trash", comment: "Swipe action title")
+    static let swipeActionDeletePermanently = NSLocalizedString("postList.swipeActionDelete", value: "Delete Permanently", comment: "Swipe action title")
+}

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -185,8 +185,9 @@ class AbstractPostListViewController: UIViewController,
     }
 
     private func configureSearchController() {
-        searchResultsViewController.configure(searchController)
-        searchResultsViewController.listViewController = self
+        assert(self is InteractivePostViewDelegate, "The subclass has to implement InteractivePostViewDelegate protocol")
+
+        searchResultsViewController.configure(searchController, self as? InteractivePostViewDelegate)
 
         definesPresentationContext = true
         navigationItem.searchController = searchController

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -6,7 +6,7 @@ protocol InteractivePostViewDelegate: AnyObject {
     func stats(for post: AbstractPost)
     func duplicate(_ post: AbstractPost)
     func publish(_ post: AbstractPost)
-    func trash(_ post: AbstractPost)
+    func trash(_ post: AbstractPost, completion: @escaping () -> Void)
     func draft(_ post: AbstractPost)
     func retry(_ post: AbstractPost)
     func cancelAutoUpload(_ post: AbstractPost)
@@ -22,4 +22,8 @@ extension InteractivePostViewDelegate {
     func setParent(for post: AbstractPost, at indexPath: IndexPath) {}
     func setHomepage(for post: AbstractPost) {}
     func setPostsPage(for post: AbstractPost) {}
+
+    func trash(_ post: AbstractPost) {
+        self.trash(post, completion: {})
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -271,6 +271,20 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        true
+    }
+
+    func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let actions = AbstractPostHelper.makeLeadingContextualActions(for: postAtIndexPath(indexPath), delegate: self)
+        return UISwipeActionsConfiguration(actions: actions)
+    }
+
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let actions = AbstractPostHelper.makeTrailingContextualActions(for: postAtIndexPath(indexPath), delegate: self)
+        return UISwipeActionsConfiguration(actions: actions)
+    }
+
     // MARK: - Post Actions
 
     override func createPost() {
@@ -359,7 +373,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         copyPostLink(post)
     }
 
-    func trash(_ post: AbstractPost) {
+    func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
         guard ReachabilityUtils.isInternetReachable() else {
             let offlineMessage = NSLocalizedString("Unable to trash posts while offline. Please try again later.", comment: "Message that appears when a user tries to trash a post while their device is offline.")
             ReachabilityUtils.showNoInternetConnectionNotice(message: offlineMessage)
@@ -385,9 +399,12 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
 
-        alertController.addCancelActionWithTitle(cancelText)
+        alertController.addCancelActionWithTitle(cancelText) { _ in
+            completion()
+        }
         alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
             self?.deletePost(post)
+            completion()
         }
         alertController.presentFromRootViewController()
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -271,10 +271,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
-    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        true
-    }
-
     func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let actions = AbstractPostHelper.makeLeadingContextualActions(for: postAtIndexPath(indexPath), delegate: self)
         return UISwipeActionsConfiguration(actions: actions)

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -2,8 +2,8 @@ import UIKit
 import Combine
 
 final class PostSearchViewController: UIViewController, UITableViewDelegate, UISearchControllerDelegate, UISearchResultsUpdating {
-    weak var searchController: UISearchController?
-    weak var listViewController: AbstractPostListViewController?
+    private weak var searchController: UISearchController?
+    private weak var delegate: InteractivePostViewDelegate?
 
     private typealias SectionID = PostSearchViewModel.SectionID
     private typealias ItemID = PostSearchViewModel.ItemID
@@ -18,10 +18,6 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
     private var cancellables: [AnyCancellable] = []
 
-    private var postDelegate: InteractivePostViewDelegate {
-        listViewController as! InteractivePostViewDelegate
-    }
-
     init(viewModel: PostSearchViewModel) {
         self.viewModel = viewModel
 
@@ -32,12 +28,13 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(_ searchController: UISearchController) {
+    func configure(_ searchController: UISearchController, _ delegate: InteractivePostViewDelegate?) {
         searchController.delegate = self
         searchController.searchResultsUpdater = self
         searchController.showsSearchResultsController = true
 
         self.searchController = searchController
+        self.delegate = delegate
     }
 
     override func viewDidLoad() {
@@ -111,15 +108,14 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             switch post {
             case let post as Post:
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.postCellID, for: indexPath) as! PostListCell
-                assert(listViewController is InteractivePostViewDelegate)
                 let viewModel = PostListItemViewModel(post: post)
-                cell.configure(with: viewModel, delegate: postDelegate)
+                cell.configure(with: viewModel, delegate: delegate)
                 updateHighlights(for: [cell], searchTerm: self.viewModel.searchTerm)
                 return cell
             case let page as Page:
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell
                 let viewModel = PageListItemViewModel(page: page, indexPath: indexPath)
-                cell.configure(with: viewModel, delegate: postDelegate)
+                cell.configure(with: viewModel, delegate: delegate)
                 updateHighlights(for: [cell], searchTerm: self.viewModel.searchTerm)
                 return cell
             default:
@@ -169,10 +165,10 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             switch viewModel.posts[indexPath.row].latest() {
             case let post as Post:
                 guard post.status != .trash else { return }
-                postDelegate.edit(post)
+                delegate?.edit(post)
             case let page as Page:
                 guard page.status != .trash else { return }
-                postDelegate.edit(page)
+                delegate?.edit(page)
             default:
                 fatalError("Unsupported post")
             }
@@ -186,17 +182,15 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         }
     }
 
-    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        indexPath.section == SectionID.posts.rawValue
-    }
-
     func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let actions = AbstractPostHelper.makeLeadingContextualActions(for: viewModel.posts[indexPath.row], delegate: postDelegate)
+        guard let delegate, indexPath.section == SectionID.posts.rawValue else { return nil }
+        let actions = AbstractPostHelper.makeLeadingContextualActions(for: viewModel.posts[indexPath.row], delegate: delegate)
         return UISwipeActionsConfiguration(actions: actions)
     }
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let actions = AbstractPostHelper.makeTrailingContextualActions(for: viewModel.posts[indexPath.row], delegate: postDelegate)
+        guard let delegate, indexPath.section == SectionID.posts.rawValue else { return nil }
+        let actions = AbstractPostHelper.makeTrailingContextualActions(for: viewModel.posts[indexPath.row], delegate: delegate)
         return UISwipeActionsConfiguration(actions: actions)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -513,6 +513,8 @@
 		0CF0C4232AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
 		0CF0C4242AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
 		0CF7D6C32ABB753A006D1E89 /* MediaImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */; };
+		0CFE9AC62AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
+		0CFE9AC72AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
 		17039225282E6D2800F602E9 /* ViewsVisitorsLineChartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC772B0728201F5300664C02 /* ViewsVisitorsLineChartCell.swift */; };
@@ -6189,6 +6191,7 @@
 		0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostHelper.swift; sourceTree = "<group>"; };
 		0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageServiceTests.swift; sourceTree = "<group>"; };
 		0CFD6C792A73E703003DD0A0 /* WordPress 152.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 152.xcdatamodel"; sourceTree = "<group>"; };
+		0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPostHelper+Actions.swift"; sourceTree = "<group>"; };
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		150B6590614A28DF9AD25491 /* Pods-Apps-Jetpack.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		152F25D5C232985E30F56CAC /* Pods-Apps-Jetpack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.debug.xcconfig"; sourceTree = "<group>"; };
@@ -12576,6 +12579,7 @@
 				FACF66CC2ADD645C008C3E13 /* PostListHeaderView.swift */,
 				FACF66CF2ADD6CD8008C3E13 /* PostListItemViewModel.swift */,
 				0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */,
+				0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */,
 				FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */,
 				FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift */,
 				FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */,
@@ -21875,6 +21879,7 @@
 				85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */,
 				B50C0C5E1EF42A4A00372C65 /* AztecAttachmentViewController.swift in Sources */,
 				43FB3F411EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift in Sources */,
+				0CFE9AC62AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */,
 				57D66B9A234BB206005A2D74 /* PostServiceRemoteFactory.swift in Sources */,
 				3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */,
 				98EB126A20D2DC2500D2D5B5 /* NoResultsViewController+Model.swift in Sources */,
@@ -25348,6 +25353,7 @@
 				FABB25312602FC2C00C8785C /* UIImageView+SiteIcon.swift in Sources */,
 				FABB25322602FC2C00C8785C /* ReaderSiteSearchService.swift in Sources */,
 				FABB25332602FC2C00C8785C /* QuickStartNavigationSettings.swift in Sources */,
+				0CFE9AC72AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */,
 				FABB25342602FC2C00C8785C /* WPImageViewController.m in Sources */,
 				FABB25352602FC2C00C8785C /* ReaderListTopic.swift in Sources */,
 				FABB25362602FC2C00C8785C /* PublicizeService.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21716

To test:

- Verify that non-trashed posts & pages have "View" leading action
- Verify that all posts have "Trash" or "Delete" actions
- Verify that published posts have "Share" trailing actions
- Verify that the same actions are available in search results

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/c9a49ba1-12ee-40f4-9a14-5ca1e6722b73

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
