### PR TITLE
Posts & Pages: Add tags sync

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -7,7 +7,6 @@ import WordPressFlux
 
 class AbstractPostListViewController: UIViewController,
                                       WPContentSyncHelperDelegate,
-                                      UISearchControllerDelegate,
                                       WPTableViewHandlerDelegate,
                                       NetworkAwareUI // This protocol is not in an extension so that subclasses can override noConnectionMessage()
 {
@@ -201,14 +200,10 @@ class AbstractPostListViewController: UIViewController,
     }
 
     private func configureSearchController() {
-        searchController.delegate = self
-        searchController.searchResultsUpdater = searchResultsViewController
-        searchController.showsSearchResultsController = true
-        searchResultsViewController.searchController = searchController
+        searchResultsViewController.configure(searchController)
         searchResultsViewController.listViewController = self
 
         definesPresentationContext = true
-
         navigationItem.searchController = searchController
     }
 
@@ -849,12 +844,6 @@ class AbstractPostListViewController: UIViewController,
         syncItemsWithUserInteraction(false)
 
         WPAnalytics.track(.postListStatusFilterChanged, withProperties: propertiesForAnalytics())
-    }
-
-    // MARK: - UISearchControllerDelegate
-
-    func willPresentSearchController(_ searchController: UISearchController) {
-        WPAnalytics.track(.postListSearchOpened, withProperties: propertiesForAnalytics())
     }
 
     // MARK: - NetworkAwareUI

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchTokenTableCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchTokenTableCell.swift
@@ -6,7 +6,7 @@ final class PostSearchTokenTableCell: UITableViewCell {
     private lazy var stackView = UIStackView(arrangedSubviews: [
         iconView, titleLabel, UIView()
     ])
-    let separator = UIView()
+    private let separator = UIView()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -18,7 +18,7 @@ final class PostSearchTokenTableCell: UITableViewCell {
         stackView.spacing = 8
         stackView.alignment = .center
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.layoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+        stackView.layoutMargins = UIEdgeInsets(top: 4, left: 16, bottom: 14, right: 16)
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
         contentView.addSubview(stackView)
@@ -42,7 +42,10 @@ final class PostSearchTokenTableCell: UITableViewCell {
     func configure(with token: any PostSearchToken, isLast: Bool) {
         iconView.image = token.icon
         titleLabel.text = token.value
-        stackView.layoutMargins.bottom = isLast ? 14 : 8
+        configure(isLast: isLast)
+    }
+
+    func configure(isLast: Bool) {
         separator.isHidden = !isLast
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -128,7 +128,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         for indexPath in tableView.indexPathsForVisibleRows ?? [] {
             if let cell = tableView.cellForRow(at: indexPath) as? PostSearchTokenTableCell {
                 let isLast = indexPath.row == viewModel.suggestedTokens.count - 1
-                cell.separator.isHidden = !isLast
+                cell.configure(isLast: isLast)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Combine
 
-final class PostSearchViewController: UIViewController, UITableViewDelegate, UISearchResultsUpdating {
+final class PostSearchViewController: UIViewController, UITableViewDelegate, UISearchControllerDelegate, UISearchResultsUpdating {
     weak var searchController: UISearchController?
     weak var listViewController: AbstractPostListViewController?
 
@@ -26,6 +26,14 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(_ searchController: UISearchController) {
+        searchController.delegate = self
+        searchController.searchResultsUpdater = self
+        searchController.showsSearchResultsController = true
+
+        self.searchController = searchController
     }
 
     override func viewDidLoad() {
@@ -173,6 +181,12 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         if scrollView.contentOffset.y + scrollView.frame.size.height > scrollView.contentSize.height - 500 {
             viewModel.didReachBottom()
         }
+    }
+
+    // MARK: - UISearchControllerDelegate
+
+    func willPresentSearchController(_ searchController: UISearchController) {
+        viewModel.willStartSearching()
     }
 
     // MARK: - UISearchResultsUpdating

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -52,6 +52,12 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
 
         $searchTerm
             .dropFirst()
+            .first()
+            .sink { [weak self] _ in self?.syncTags() }
+            .store(in: &cancellables)
+
+        $searchTerm
+            .dropFirst()
             .removeDuplicates()
             .sink { [weak self] in self?.updateSuggestedTokens(for: $0) }
             .store(in: &cancellables)
@@ -222,5 +228,10 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
             self.suggestedTokens = tokens
             self.reload()
         }
+    }
+
+    private func syncTags() {
+        let tagsService = PostTagService(managedObjectContext: coreData.mainContext)
+        tagsService.syncTags(for: blog, success: { _ in }, failure: { _ in })
     }
 }


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21900

- Fix an issue with tags not loaded on fresh launch
- Fix layout issue with tokens (it was updating the constraints without reloading the cells)

To test:

- Fresh install
- Go to Posts / Search
- Verify that tag suggestions work

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
