### PR TITLE
Reader improvements design fixes

### DIFF
--- a/WordPress/Classes/Models/ReaderCard+CoreDataClass.swift
+++ b/WordPress/Classes/Models/ReaderCard+CoreDataClass.swift
@@ -25,6 +25,15 @@ public class ReaderCard: NSManagedObject {
         return .unknown
     }
 
+    var isRecommendationCard: Bool {
+        switch type {
+        case .topics, .sites:
+            return true
+        default:
+            return false
+        }
+    }
+
     var topicsArray: [ReaderTagTopic] {
         topics?.array as? [ReaderTagTopic] ?? []
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -253,7 +253,7 @@ struct ReaderDetailNewHeaderView: View {
                let avatarURL = viewModel.authorAvatarURL {
                 avatarView(with: siteIconURL, avatarURL: avatarURL)
             }
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 4.0) {
                 Text(viewModel.siteName)
                     .font(.callout)
                     .fontWeight(.semibold)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -71,7 +71,16 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
             guard let post = card.post else {
                 return UITableViewCell()
             }
-            return cell(for: post, at: indexPath)
+
+            let shouldShowSeparator: Bool = {
+                guard let cards,
+                      let nextCard = cards[safe: indexPath.row + 1] else {
+                    return true
+                }
+                return !nextCard.isRecommendationCard
+            }()
+            return cell(for: post, at: indexPath, showsSeparator: shouldShowSeparator)
+
         case .topics:
             return cell(for: card.topicsArray)
         case .sites:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -56,6 +56,10 @@ class ReaderPostCardCell: UITableViewCell {
         addViewConstraints()
     }
 
+    func prepareForDisplay() {
+        updateSeparatorState()
+    }
+
     func configure(with viewModel: ReaderPostCardCellViewModel) {
         self.viewModel = viewModel
     }
@@ -150,6 +154,10 @@ private extension ReaderPostCardCell {
 
     var usesAccessibilitySize: Bool {
         traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+    }
+
+    var showsSeparator: Bool {
+        viewModel?.showsSeparator ?? true
     }
 
     func commonInit() {
@@ -345,8 +353,12 @@ private extension ReaderPostCardCell {
 
     func setupSeparatorView() {
         separatorView.translatesAutoresizingMaskIntoConstraints = false
-        separatorView.backgroundColor = .separator
+        updateSeparatorState()
         contentView.addSubview(separatorView)
+    }
+
+    func updateSeparatorState() {
+        separatorView.backgroundColor = showsSeparator ? .separator : .clear
     }
 
     // MARK: - View constraints

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCellViewModel.swift
@@ -123,11 +123,15 @@ struct ReaderPostCardCellViewModel {
 
     private var followCommentsService: FollowCommentsService?
 
+    private(set) var showsSeparator: Bool
+
     init(contentProvider: ReaderPostContentProvider,
          isLoggedIn: Bool,
+         showsSeparator: Bool = true,
          parentViewController: ReaderStreamViewController) {
         self.contentProvider = contentProvider
         self.actionVisibility = .visible(enabled: isLoggedIn)
+        self.showsSeparator = showsSeparator
         self.parentViewController = parentViewController
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1644,7 +1644,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         return cell(for: post, at: indexPath)
     }
 
-    func cell(for post: ReaderPost, at indexPath: IndexPath) -> UITableViewCell {
+    func cell(for post: ReaderPost, at indexPath: IndexPath, showsSeparator: Bool = true) -> UITableViewCell {
         if post.isKind(of: ReaderGapMarker.self) {
             let cell = tableConfiguration.gapMarkerCell(tableView)
             cellConfiguration.configureGapMarker(cell, filling: syncIsFillingGap)
@@ -1677,6 +1677,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
             let cell = tableConfiguration.postCardCell(tableView)
             let viewModel = ReaderPostCardCellViewModel(contentProvider: post,
                                                         isLoggedIn: isLoggedIn,
+                                                        showsSeparator: showsSeparator,
                                                         parentViewController: self)
             cell.configure(with: viewModel)
             return cell
@@ -1704,6 +1705,10 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
 
         // Check to see if we need to load more.
         syncMoreContentIfNeeded(for: tableView, indexPathForVisibleRow: indexPath)
+
+        if let cell = cell as? ReaderPostCardCell {
+            cell.prepareForDisplay()
+        }
 
         guard cell.isKind(of: OldReaderPostCardCell.self) || cell.isKind(of: ReaderCrossPostCell.self) else {
             return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -56,24 +56,15 @@ class ReaderTopicsTableCardCell: UITableViewCell {
     }
 
     func setupTableView() {
-        let separatorView = UIView()
-        separatorView.translatesAutoresizingMaskIntoConstraints = false
-        separatorView.backgroundColor = .separator
-
         addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         pinSubviewToSafeArea(containerView, insets: readerImprovements ? Constants.newContainerInsets : Constants.containerInsets)
         containerView.addSubview(tableView)
-        containerView.addSubview(separatorView)
         tableView.translatesAutoresizingMaskIntoConstraints = false
         let tableViewMargin = readerImprovements ? 16.0 : 0.0
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: tableViewMargin),
-            tableView.bottomAnchor.constraint(equalTo: separatorView.topAnchor, constant: -tableViewMargin),
-            separatorView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            separatorView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            separatorView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-            separatorView.heightAnchor.constraint(equalToConstant: readerImprovements ? 0.5 : 0.0),
+            tableView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -tableViewMargin)
         ])
 
         // Constraints for regular horizontal size class

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -77,19 +77,6 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
 
         backgroundColor = .systemBackground
         contentView.backgroundColor = .systemBackground
-
-        // add manual separator view
-        let separatorView = UIView()
-        separatorView.backgroundColor = .separator
-        separatorView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.addSubview(separatorView)
-
-        NSLayoutConstraint.activate([
-            separatorView.heightAnchor.constraint(equalToConstant: 0.5),
-            separatorView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-        ])
     }
 
     private func refreshData() {


### PR DESCRIPTION
Refs p5T066-47C-p2#comment-15044

This introduces two changes:
- Added a 4px padding between the Site title and author name in the Reader Detail.
- Removed dividers around recommendation cards in the Reader stream.


<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8830eda4-1d04-4383-bff8-7f6e474d317b" width=375>

#### Site icon fix is not included in this PR

I need to look into the site icon issue a bit more and will open a separate PR to fix it. 

~~Also, @osullivanchris, we are using 20x20 everywhere right now, but in Figma I noticed that the site icon is sized 24x24 for the post cards, but we also use 20x20 for cross-posts/internal card layouts. Can you confirm if you'd prefer to use 24x24 for the site icon in the post cards?~~ Confirmed via https://github.com/wordpress-mobile/WordPress-iOS/pull/21923#pullrequestreview-1706598946.

#### Technical note about the separator

For the separator, I tried updating the separator color in `prepareForReuse` but it is inconsistent; sometimes, it would still display the separator despite being next to a recommendation card. So I let the cell update itself during `tableView(_:willDisplay:forRowAt:)`.

## To test

- Launch the Jetpack app
- Go to the Reader tab, and open any post.
- 🔎  Verify that there is an extra padding between the Site title and the author name.
- Go back to the Reader stream and select the Discover tab.
- 🔎  Scroll down and verify that no separator is displayed around recommendation cards.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn't complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)