### PR TITLE
Posts & Pages: Pages context menu part 1

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -45,7 +45,11 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         imageLoader.prepareForReuse()
     }
 
-    func configure(with viewModel: PageListItemViewModel, indentation: Int = 0, isFirstSubdirectory: Bool = false) {
+    func configure(with viewModel: PageListItemViewModel, indentation: Int = 0, isFirstSubdirectory: Bool = false, delegate: InteractivePostViewDelegate? = nil) {
+        if let delegate {
+            configureEllipsisButton(with: viewModel.page, viewModel: viewModel.pageMenuViewModel, delegate: delegate)
+        }
+
         titleLabel.attributedText = viewModel.title
 
         badgeIconView.image = viewModel.badgeIcon
@@ -69,6 +73,12 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         )
         indentationIconView.isHidden = indentation == 0
         indentationIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
+    }
+
+    private func configureEllipsisButton(with page: Page, viewModel: PageMenuViewModel, delegate: InteractivePostViewDelegate) {
+        let menuHelper = AbstractPostMenuHelper(page, viewModel: viewModel)
+        ellipsisButton.showsMenuAsPrimaryAction = true
+        ellipsisButton.menu = menuHelper.makeMenu(presentingView: ellipsisButton, delegate: delegate)
     }
 
     // MARK: - Setup

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -7,6 +7,7 @@ final class PageListItemViewModel {
     let badges: NSAttributedString
     let imageURL: URL?
     let accessibilityIdentifier: String?
+    let pageMenuViewModel: PageMenuViewModel
 
     init(page: Page) {
         self.page = page
@@ -15,6 +16,7 @@ final class PageListItemViewModel {
         self.badges = makeBadgesString(for: page)
         self.imageURL = page.featuredImageURL
         self.accessibilityIdentifier = page.slugForDisplay()
+        self.pageMenuViewModel = PageMenuViewModel(page: page)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -52,10 +52,6 @@ extension PageListViewController: InteractivePostViewDelegate {
         // Not available for pages
     }
 
-    func copyLink(_ apost: AbstractPost) {
-        // TODO: Remove
-    }
-
     func blaze(_ apost: AbstractPost) {
         BlazeEventsTracker.trackEntryPointTapped(for: .pagesList)
         BlazeFlowCoordinator.presentBlaze(in: self, source: .pagesList, blog: blog, post: apost)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -2,59 +2,113 @@ import Foundation
 
 extension PageListViewController: InteractivePostViewDelegate {
 
-    func edit(_ post: AbstractPost) {
+    func edit(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+
+        let didOpenEditor = PageEditorPresenter.handle(page: page, in: self, entryPoint: .pagesList)
+        if didOpenEditor {
+            WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: page)
+        }
+    }
+
+    func view(_ apost: AbstractPost) {
+        viewPost(apost)
+    }
+
+    func stats(for apost: AbstractPost) {
+        // Not available for pages
+    }
+
+    func duplicate(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        copyPage(page)
+    }
+
+    func publish(_ apost: AbstractPost) {
+        publishPost(apost)
+    }
+
+    func trash(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        trashPage(page)
+    }
+
+    func draft(_ apost: AbstractPost) {
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            moveToDraft(apost)
+        }
+    }
+
+    func retry(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        retryPage(page)
+    }
+
+    func cancelAutoUpload(_ apost: AbstractPost) {
+        // Not available for pages
+    }
+
+    func share(_ apost: AbstractPost, fromView view: UIView) {
+        // Not available for pages
+    }
+
+    func copyLink(_ apost: AbstractPost) {
         // TODO: Remove
     }
 
-    func view(_ post: AbstractPost) {
-        // TODO
+    func blaze(_ apost: AbstractPost) {
+        BlazeEventsTracker.trackEntryPointTapped(for: .pagesList)
+        BlazeFlowCoordinator.presentBlaze(in: self, source: .pagesList, blog: blog, post: apost)
     }
 
-    func stats(for post: AbstractPost) {
-        // TODO
+    func comments(_ apost: AbstractPost) {
+        // Not available for pages
     }
 
-    func duplicate(_ post: AbstractPost) {
-        // TODO
+    private func copyPage(_ page: Page) {
+        // Analytics
+        WPAnalytics.track(.postListDuplicateAction, withProperties: propertiesForAnalytics())
+        // Copy Page
+        let newPage = page.blog.createDraftPage()
+        newPage.postTitle = page.postTitle
+        newPage.content = page.content
+        // Open Editor
+        let editorViewController = EditPageViewController(page: newPage)
+        present(editorViewController, animated: false)
     }
 
-    func publish(_ post: AbstractPost) {
-        // TODO
+    private func retryPage(_ page: Page) {
+        PostCoordinator.shared.save(page)
     }
 
-    func trash(_ post: AbstractPost) {
-        // TODO
-    }
+    private func trashPage(_ page: Page) {
+        guard ReachabilityUtils.isInternetReachable() else {
+            let offlineMessage = NSLocalizedString("pagesList.trash.offline", value: "Unable to trash pages while offline. Please try again later.", comment: "Message that appears when a user tries to trash a page while their device is offline.")
+            ReachabilityUtils.showNoInternetConnectionNotice(message: offlineMessage)
+            return
+        }
 
-    func restore(_ post: AbstractPost) {
-        // TODO
-    }
+        let cancelText = NSLocalizedString("pagesList.trash.cancel", value: "Cancel", comment: "Cancels an Action")
+        let deleteText: String
+        let messageText: String
+        let titleText: String
 
-    func draft(_ post: AbstractPost) {
-        // TODO
-    }
+        if page.status == .trash {
+            deleteText = NSLocalizedString("pagesList.deletePermanently.actionTitle", value: "Delete Permanently", comment: "Delete option in the confirmation alert when deleting a page from the trash.")
+            titleText = NSLocalizedString("pagesList.deletePermanently.alertTitle", value: "Delete Permanently?", comment: "Title of the confirmation alert when deleting a page from the trash.")
+            messageText = NSLocalizedString("pagesList.deletePermanently.alertMessage", value: "Are you sure you want to permanently delete this page?", comment: "Message of the confirmation alert when deleting a page from the trash.")
+        } else {
+            deleteText = NSLocalizedString("pagesList.trash.actionTitle", value: "Move to Trash", comment: "Trash option in the trash page confirmation alert.")
+            titleText = NSLocalizedString("pagesList.trash.alertTitle", value: "Trash this page?", comment: "Title of the trash page confirmation alert.")
+            messageText = NSLocalizedString("pagesList.trash.alertMessage", value: "Are you sure you want to trash this page?", comment: "Message of the trash page confirmation alert.")
+        }
 
-    func retry(_ post: AbstractPost) {
-        // TODO
-    }
+        let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
 
-    func cancelAutoUpload(_ post: AbstractPost) {
-        // TODO
-    }
-
-    func share(_ post: AbstractPost, fromView view: UIView) {
-        // TODO
-    }
-
-    func copyLink(_ post: AbstractPost) {
-        // TODO: Remove
-    }
-
-    func blaze(_ post: AbstractPost) {
-        // TODO
-    }
-
-    func comments(_ post: AbstractPost) {
-        // TODO
+        alertController.addCancelActionWithTitle(cancelText)
+        alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
+            Task { await self?.deletePost(page) }
+        }
+        alertController.presentFromRootViewController()
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension PageListViewController: InteractivePostViewDelegate {
+
+    func edit(_ post: AbstractPost) {
+        // TODO: Remove
+    }
+
+    func view(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func stats(for post: AbstractPost) {
+        // TODO
+    }
+
+    func duplicate(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func publish(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func trash(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func restore(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func draft(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func retry(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func cancelAutoUpload(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func share(_ post: AbstractPost, fromView view: UIView) {
+        // TODO
+    }
+
+    func copyLink(_ post: AbstractPost) {
+        // TODO: Remove
+    }
+
+    func blaze(_ post: AbstractPost) {
+        // TODO
+    }
+
+    func comments(_ post: AbstractPost) {
+        // TODO
+    }
+}

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -351,7 +351,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let page = pageAtIndexPath(indexPath)
         let indentation = getIndentationLevel(at: indexPath)
         let isFirstSubdirectory = getIndentationLevel(at: IndexPath(row: indexPath.row - 1, section: indexPath.section)) == (indentation - 1)
-        cell.configure(with: PageListItemViewModel(page: page), indentation: indentation, isFirstSubdirectory: isFirstSubdirectory)
+        cell.configure(with: PageListItemViewModel(page: page), indentation: indentation, isFirstSubdirectory: isFirstSubdirectory, delegate: self)
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -336,7 +336,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             present(navigationController, animated: true)
         } else {
             let page = pageAtIndexPath(indexPath)
-            editPage(page)
+            edit(page)
         }
     }
 
@@ -386,14 +386,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     private func blazePage(_ page: AbstractPost) {
         BlazeEventsTracker.trackEntryPointTapped(for: .pagesList)
         BlazeFlowCoordinator.presentBlaze(in: self, source: .pagesList, blog: blog, post: page)
-    }
-
-    func editPage(_ page: Page) {
-        let didOpenEditor = PageEditorPresenter.handle(page: page, in: self, entryPoint: .pagesList)
-
-        if didOpenEditor {
-            WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: page)
-        }
     }
 
     fileprivate func copyPage(_ page: Page) {
@@ -629,7 +621,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let buttonTitle = NSLocalizedString("Edit", comment: "Label for a button that opens the Edit Page view controller")
         controller.addActionWithTitle(buttonTitle, style: .default, handler: { [weak self] _ in
             if let page = self?.pageForObjectID(page.objectID) {
-                self?.editPage(page)
+                self?.edit(page)
             }
         })
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -1,0 +1,124 @@
+import Nimble
+import XCTest
+@testable import WordPress
+
+class PageMenuViewModelTests: CoreDataTestCase {
+
+    func testPublishedPageButtons() {
+        // Given
+        let page = PageBuilder(mainContext, canBlaze: true)
+            .withRemote()
+            .with(status: .publish)
+            .build()
+        let viewModel = PageMenuViewModel(page: page, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.moveToDraft, .duplicate],
+            [.blaze],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testPublishedPageButtonsWithBlazeDisabled() {
+        // Given
+        let page = PageBuilder(mainContext, canBlaze: false)
+            .withRemote()
+            .with(status: .publish)
+            .build()
+        let viewModel = PageMenuViewModel(page: page, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: false)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.moveToDraft, .duplicate],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testPublishedPageButtonsWithJetpackFeaturesDisabled() {
+        // Given
+        let page = PageBuilder(mainContext)
+            .withRemote()
+            .with(status: .publish)
+            .build()
+
+        let viewModel = PageMenuViewModel(page: page, isJetpackFeaturesEnabled: false, isBlazeFlagEnabled: false)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.moveToDraft, .duplicate],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testDraftPageButtons() {
+        // Given
+        let page = PageBuilder(mainContext)
+            .with(status: .draft)
+            .build()
+        let viewModel = PageMenuViewModel(page: page, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.duplicate, .publish],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testScheduledPostButtons() {
+        // Given
+        let page = PageBuilder(mainContext)
+            .with(status: .scheduled)
+            .build()
+        let viewModel = PageMenuViewModel(page: page, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.moveToDraft, .publish],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
+    func testTrashedPageButtons() {
+        // Given
+        let page = PageBuilder(mainContext)
+            .with(status: .trash)
+            .build()
+        let viewModel = PageMenuViewModel(page: page, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.moveToDraft],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenu.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+protocol AbstractPostMenu {
+    var buttonSections: [AbstractPostButtonSection] { get }
+}
+
+struct AbstractPostButtonSection {
+    let buttons: [AbstractPostButton]
+}
+
+enum AbstractPostButton {
+    case retry
+    case view
+    case publish
+    case stats
+    case duplicate
+    case moveToDraft
+    case trash
+    case cancelAutoUpload
+    case share
+    case blaze
+    case comments
+}

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -4,7 +4,12 @@ import UIKit
 struct AbstractPostMenuHelper {
 
     let post: AbstractPost
-    let menu: AbstractPostMenu
+    let viewModel: AbstractPostMenuViewModel
+
+    init(_ post: AbstractPost, viewModel: AbstractPostMenuViewModel) {
+        self.post = post
+        self.viewModel = viewModel
+    }
 
     /// Creates a menu for post actions
     ///
@@ -22,7 +27,7 @@ struct AbstractPostMenuHelper {
     ///   - presentingView: The view presenting the menu
     ///   - delegate: The delegate that performs post actions
     private func makeSections(presentingView: UIView, delegate: InteractivePostViewDelegate) -> [UIMenu] {
-        return menu.buttonSections
+        return viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { section in
                 let actions = makeActions(for: section.buttons, presentingView: presentingView, delegate: delegate)

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -1,9 +1,10 @@
 import Foundation
 import UIKit
 
-struct PostMenuHelper {
+struct AbstractPostMenuHelper {
 
-    let statusViewModel: PostCardStatusViewModel
+    let post: AbstractPost
+    let menu: AbstractPostMenu
 
     /// Creates a menu for post actions
     ///
@@ -21,7 +22,7 @@ struct PostMenuHelper {
     ///   - presentingView: The view presenting the menu
     ///   - delegate: The delegate that performs post actions
     private func makeSections(presentingView: UIView, delegate: InteractivePostViewDelegate) -> [UIMenu] {
-        return statusViewModel.buttonSections
+        return menu.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { section in
                 let actions = makeActions(for: section.buttons, presentingView: presentingView, delegate: delegate)
@@ -36,12 +37,10 @@ struct PostMenuHelper {
     ///   - presentingView: The view presenting the menu
     ///   - delegate: The delegate that performs post actions
     private func makeActions(
-        for buttons: [PostCardStatusViewModel.Button],
+        for buttons: [AbstractPostButton],
         presentingView: UIView,
         delegate: InteractivePostViewDelegate
     ) -> [UIAction] {
-        let post = statusViewModel.post
-
         return buttons.map { button in
             UIAction(title: button.title(for: post), image: button.icon, attributes: button.attributes ?? [], handler: { [weak delegate] _ in
                 guard let delegate else { return }
@@ -51,14 +50,14 @@ struct PostMenuHelper {
     }
 }
 
-protocol PostMenuAction {
+protocol AbstractPostMenuAction {
     var icon: UIImage? { get }
     var attributes: UIMenuElement.Attributes? { get }
-    func title(for post: Post) -> String
-    func performAction(for post: Post, view: UIView, delegate: InteractivePostViewDelegate)
+    func title(for post: AbstractPost) -> String
+    func performAction(for post: AbstractPost, view: UIView, delegate: InteractivePostViewDelegate)
 }
 
-extension PostCardStatusViewModel.Button: PostMenuAction {
+extension AbstractPostButton: AbstractPostMenuAction {
 
     var icon: UIImage? {
         switch self {
@@ -85,7 +84,7 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
         }
     }
 
-    func title(for post: Post) -> String {
+    func title(for post: AbstractPost) -> String {
         switch self {
         case .retry: return Strings.retry
         case .view: return Strings.view
@@ -101,7 +100,7 @@ extension PostCardStatusViewModel.Button: PostMenuAction {
         }
     }
 
-    func performAction(for post: Post, view: UIView, delegate: InteractivePostViewDelegate) {
+    func performAction(for post: AbstractPost, view: UIView, delegate: InteractivePostViewDelegate) {
         switch self {
         case .retry:
             delegate.retry(post)

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol AbstractPostMenu {
+protocol AbstractPostMenuViewModel {
     var buttonSections: [AbstractPostButtonSection] { get }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -11,7 +11,6 @@ protocol InteractivePostViewDelegate: AnyObject {
     func retry(_ post: AbstractPost)
     func cancelAutoUpload(_ post: AbstractPost)
     func share(_ post: AbstractPost, fromView view: UIView)
-    func copyLink(_ post: AbstractPost)
     func blaze(_ post: AbstractPost)
     func comments(_ post: AbstractPost)
 }

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+final class PageMenuViewModel: AbstractPostMenuViewModel {
+
+    private let page: Page
+    private let isJetpackFeaturesEnabled: Bool
+    private let isBlazeFlagEnabled: Bool
+
+    var buttonSections: [AbstractPostButtonSection] {
+        [
+            createPrimarySection(),
+            createSecondarySection(),
+            createBlazeSection(),
+            createTrashSection()
+        ]
+    }
+
+    init(
+        page: Page,
+        isJetpackFeaturesEnabled: Bool = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
+        isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled()
+    ) {
+        self.page = page
+        self.isJetpackFeaturesEnabled = isJetpackFeaturesEnabled
+        self.isBlazeFlagEnabled = isBlazeFlagEnabled
+    }
+
+    private func createPrimarySection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
+
+        if !page.isFailed {
+            buttons.append(.view)
+        }
+
+        return AbstractPostButtonSection(buttons: buttons)
+    }
+
+    private func createSecondarySection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
+
+        if page.status != .draft {
+            buttons.append(.moveToDraft)
+        }
+
+        if page.status == .publish || page.status == .draft {
+            buttons.append(.duplicate)
+        }
+
+        if page.status != .trash && page.isFailed {
+            buttons.append(.retry)
+        }
+
+        if !page.isFailed, page.status != .publish && page.status != .trash {
+            buttons.append(.publish)
+        }
+
+        return AbstractPostButtonSection(buttons: buttons)
+    }
+
+    private func createBlazeSection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
+
+        if isBlazeFlagEnabled && page.canBlaze {
+            buttons.append(.blaze)
+        }
+
+        return AbstractPostButtonSection(buttons: buttons)
+    }
+
+    private func createTrashSection() -> AbstractPostButtonSection {
+        return AbstractPostButtonSection(buttons: [.trash])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -61,6 +61,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         var buttons = [AbstractPostButton]()
 
         if isBlazeFlagEnabled && page.canBlaze {
+            BlazeEventsTracker.trackEntryPointDisplayed(for: .pagesList)
             buttons.append(.blaze)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -3,7 +3,7 @@ import Gridicons
 
 /// Encapsulates status display logic for PostCardTableViewCells.
 ///
-class PostCardStatusViewModel: NSObject, AbstractPostMenu {
+class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
 
     let post: Post
     private var progressObserverUUID: UUID? = nil

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -3,25 +3,7 @@ import Gridicons
 
 /// Encapsulates status display logic for PostCardTableViewCells.
 ///
-class PostCardStatusViewModel: NSObject {
-
-    struct ButtonSection {
-        let buttons: [Button]
-    }
-
-    enum Button {
-        case retry
-        case view
-        case publish
-        case stats
-        case duplicate
-        case moveToDraft
-        case trash
-        case cancelAutoUpload
-        case share
-        case blaze
-        case comments
-    }
+class PostCardStatusViewModel: NSObject, AbstractPostMenu {
 
     let post: Post
     private var progressObserverUUID: UUID? = nil
@@ -141,7 +123,7 @@ class PostCardStatusViewModel: NSObject {
     }
 
     /// Returns what buttons are visible
-    var buttonSections: [ButtonSection] {
+    var buttonSections: [AbstractPostButtonSection] {
         return [
             createPrimarySection(),
             createSecondarySection(),
@@ -151,18 +133,18 @@ class PostCardStatusViewModel: NSObject {
         ]
     }
 
-    private func createPrimarySection() -> ButtonSection {
-        var buttons = [Button]()
+    private func createPrimarySection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
 
         if !post.isFailed {
             buttons.append(.view)
         }
 
-        return ButtonSection(buttons: buttons)
+        return AbstractPostButtonSection(buttons: buttons)
     }
 
-    private func createSecondarySection() -> ButtonSection {
-        var buttons = [Button]()
+    private func createSecondarySection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
 
         if post.status != .draft {
             buttons.append(.moveToDraft)
@@ -190,33 +172,33 @@ class PostCardStatusViewModel: NSObject {
             buttons.append(.publish)
         }
 
-        return ButtonSection(buttons: buttons)
+        return AbstractPostButtonSection(buttons: buttons)
     }
 
-    private func createBlazeSection() -> ButtonSection {
-        var buttons = [Button]()
+    private func createBlazeSection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
 
         if isBlazeFlagEnabled && post.canBlaze {
             buttons.append(.blaze)
         }
 
-        return ButtonSection(buttons: buttons)
+        return AbstractPostButtonSection(buttons: buttons)
     }
 
 
-    private func createNavigationSection() -> ButtonSection {
-        var buttons = [Button]()
+    private func createNavigationSection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
 
         if isJetpackFeaturesEnabled, post.status == .publish && post.hasRemote() {
             buttons.append(contentsOf: [.stats, .comments])
         }
 
-        return ButtonSection(buttons: buttons)
+        return AbstractPostButtonSection(buttons: buttons)
     }
 
 
-    private func createTrashSection() -> ButtonSection {
-        return ButtonSection(buttons: [.trash])
+    private func createTrashSection() -> AbstractPostButtonSection {
+        return AbstractPostButtonSection(buttons: [.trash])
     }
 
     private var canCancelAutoUpload: Bool {

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -33,7 +33,7 @@ final class PostListHeaderView: UIView {
     }
 
     private func configureEllipsisButton(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate) {
-        let menuHelper = PostMenuHelper(statusViewModel: viewModel.statusViewModel)
+        let menuHelper = AbstractPostMenuHelper(post: viewModel.post, menu: viewModel.statusViewModel)
         ellipsisButton.showsMenuAsPrimaryAction = true
         ellipsisButton.menu = menuHelper.makeMenu(presentingView: ellipsisButton, delegate: delegate)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -27,13 +27,13 @@ final class PostListHeaderView: UIView {
 
     func configure(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate? = nil) {
         if let delegate {
-            configureEllipsisButton(with: viewModel, delegate: delegate)
+            configureEllipsisButton(with: viewModel.post, viewModel: viewModel.statusViewModel, delegate: delegate)
         }
         textLabel.attributedText = viewModel.badges
     }
 
-    private func configureEllipsisButton(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate) {
-        let menuHelper = AbstractPostMenuHelper(post: viewModel.post, menu: viewModel.statusViewModel)
+    private func configureEllipsisButton(with post: Post, viewModel: PostCardStatusViewModel, delegate: InteractivePostViewDelegate) {
+        let menuHelper = AbstractPostMenuHelper(post, viewModel: viewModel)
         ellipsisButton.showsMenuAsPrimaryAction = true
         ellipsisButton.menu = menuHelper.makeMenu(presentingView: ellipsisButton, delegate: delegate)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -142,8 +142,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.separatorStyle = .singleLine
         tableView.rowHeight = UITableView.automaticDimension
 
-        let bundle = Bundle.main
-
         // Register the cells
         tableView.register(PostListCell.self, forCellReuseIdentifier: PostListCell.defaultReuseID)
 

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -161,7 +161,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             case let page as Page:
                 guard page.status != .trash else { return }
                 (listViewController as! PageListViewController)
-                    .editPage(page)
+                    .edit(page)
             default:
                 fatalError("Unsupported post")
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5432,8 +5432,8 @@
 		FAD256B82611B01B00EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
 		FAD257132611B04D00EDAF88 /* UIColor+JetpackColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD257112611B04D00EDAF88 /* UIColor+JetpackColors.swift */; };
 		FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
-		FAD3DE812AE2965A00A3B031 /* PostMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD3DE802AE2965A00A3B031 /* PostMenuHelper.swift */; };
-		FAD3DE822AE2965A00A3B031 /* PostMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD3DE802AE2965A00A3B031 /* PostMenuHelper.swift */; };
+		FAD3DE812AE2965A00A3B031 /* AbstractPostMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */; };
+		FAD3DE822AE2965A00A3B031 /* AbstractPostMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */; };
 		FAD7625B29ED780B00C09583 /* JSONDecoderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD7625A29ED780B00C09583 /* JSONDecoderExtension.swift */; };
 		FAD7625C29ED780B00C09583 /* JSONDecoderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD7625A29ED780B00C09583 /* JSONDecoderExtension.swift */; };
 		FAD7626429F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD7626329F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift */; };
@@ -5464,6 +5464,8 @@
 		FAE8EE99273AC06F00A65307 /* QuickStartSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE8EE98273AC06F00A65307 /* QuickStartSettings.swift */; };
 		FAE8EE9A273AC06F00A65307 /* QuickStartSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE8EE98273AC06F00A65307 /* QuickStartSettings.swift */; };
 		FAE8EE9C273AD0A800A65307 /* QuickStartSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE8EE9B273AD0A800A65307 /* QuickStartSettingsTests.swift */; };
+		FAEC116E2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */; };
+		FAEC116F2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */; };
 		FAF0FAAC2AA094C0004C3228 /* NoSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF0FAAB2AA094C0004C3228 /* NoSiteViewModelTests.swift */; };
 		FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */; };
 		FAF13E3025A59240003EE470 /* JetpackRestoreStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13E2F25A59240003EE470 /* JetpackRestoreStatusViewController.swift */; };
@@ -9313,7 +9315,7 @@
 		FAD2544126116CEA00EDAF88 /* AppStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyleGuide.swift; sourceTree = "<group>"; };
 		FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+WordPressColors.swift"; sourceTree = "<group>"; };
 		FAD257112611B04D00EDAF88 /* UIColor+JetpackColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+JetpackColors.swift"; sourceTree = "<group>"; };
-		FAD3DE802AE2965A00A3B031 /* PostMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMenuHelper.swift; sourceTree = "<group>"; };
+		FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostMenuHelper.swift; sourceTree = "<group>"; };
 		FAD7625A29ED780B00C09583 /* JSONDecoderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoderExtension.swift; sourceTree = "<group>"; };
 		FAD7626329F1480E00C09583 /* DashboardActivityLogCardCell+ActivityPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardActivityLogCardCell+ActivityPresenter.swift"; sourceTree = "<group>"; };
 		FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupOptionsCoordinator.swift; sourceTree = "<group>"; };
@@ -9333,6 +9335,7 @@
 		FAE4CA672732C094003BFDFE /* QuickStartPromptViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuickStartPromptViewController.xib; sourceTree = "<group>"; };
 		FAE8EE98273AC06F00A65307 /* QuickStartSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartSettings.swift; sourceTree = "<group>"; };
 		FAE8EE9B273AD0A800A65307 /* QuickStartSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartSettingsTests.swift; sourceTree = "<group>"; };
+		FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostMenu.swift; sourceTree = "<group>"; };
 		FAF0FAAB2AA094C0004C3228 /* NoSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSiteViewModelTests.swift; sourceTree = "<group>"; };
 		FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningViewController.swift; sourceTree = "<group>"; };
 		FAF13E2F25A59240003EE470 /* JetpackRestoreStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreStatusViewController.swift; sourceTree = "<group>"; };
@@ -12569,8 +12572,9 @@
 				FACF66C92ADD4703008C3E13 /* PostListCell.swift */,
 				FACF66CC2ADD645C008C3E13 /* PostListHeaderView.swift */,
 				FACF66CF2ADD6CD8008C3E13 /* PostListItemViewModel.swift */,
-				FAD3DE802AE2965A00A3B031 /* PostMenuHelper.swift */,
 				0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */,
+				FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */,
+				FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -21108,6 +21112,7 @@
 				0C7E09202A4286A00052324C /* PostMetaButton.m in Sources */,
 				9826AE8221B5C6A700C851FA /* LatestPostSummaryCell.swift in Sources */,
 				F47E154A29E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift in Sources */,
+				FAEC116E2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */,
 				433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */,
 				0C7E09242A4286F40052324C /* PostMetaButton+Swift.swift in Sources */,
 				4395A1592106389800844E8E /* QuickStartTours.swift in Sources */,
@@ -22247,7 +22252,7 @@
 				57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,
 				E14694071F3459E2004052C8 /* PluginListViewController.swift in Sources */,
-				FAD3DE812AE2965A00A3B031 /* PostMenuHelper.swift in Sources */,
+				FAD3DE812AE2965A00A3B031 /* AbstractPostMenuHelper.swift in Sources */,
 				FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */,
 				B0B89DC02A1E882F003D5295 /* DomainResultView.swift in Sources */,
 				7EA30DB621ADA20F0092F894 /* AztecAttachmentDelegate.swift in Sources */,
@@ -24196,6 +24201,7 @@
 				FABB22072602FC2C00C8785C /* BlogSettings+DateAndTimeFormat.swift in Sources */,
 				FABB22082602FC2C00C8785C /* PostSearchHeader.swift in Sources */,
 				018635882A8109F900915532 /* SupportChatBotViewModel.swift in Sources */,
+				FAEC116F2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */,
 				FABB22092602FC2C00C8785C /* ReaderPostCardContentLabel.swift in Sources */,
 				FA90EFF0262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */,
 				80A2153E29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */,
@@ -24655,7 +24661,7 @@
 				FABB23512602FC2C00C8785C /* NoResultsStockPhotosConfiguration.swift in Sources */,
 				FABB23532602FC2C00C8785C /* UIImage+Export.swift in Sources */,
 				FABB23542602FC2C00C8785C /* NotificationName+Names.swift in Sources */,
-				FAD3DE822AE2965A00A3B031 /* PostMenuHelper.swift in Sources */,
+				FAD3DE822AE2965A00A3B031 /* AbstractPostMenuHelper.swift in Sources */,
 				FABB23552602FC2C00C8785C /* NSFetchedResultsController+Helpers.swift in Sources */,
 				FABB23562602FC2C00C8785C /* BlogSettings+Discussion.swift in Sources */,
 				0C8FC9A22A8BC8630059DCE4 /* PHPickerController+Extensions.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3847,6 +3847,10 @@
 		FA00863D24EB68B100C863F2 /* FollowCommentsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */; };
 		FA111E382A2F38FC00896FCE /* BlazeCampaignsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */; };
 		FA111E392A2F474600896FCE /* BlazeCampaignsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */; };
+		FA141F272AEC1D9E00C9A653 /* PageMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */; };
+		FA141F282AEC1D9E00C9A653 /* PageMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */; };
+		FA141F2A2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */; };
+		FA141F2B2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */; };
 		FA1A543E25A6E2F60033967D /* RestoreWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */; };
 		FA1A544025A6E3080033967D /* RestoreWarningView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1A543F25A6E3080033967D /* RestoreWarningView.xib */; };
 		FA1A55EF25A6F0740033967D /* RestoreStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */; };
@@ -5464,8 +5468,8 @@
 		FAE8EE99273AC06F00A65307 /* QuickStartSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE8EE98273AC06F00A65307 /* QuickStartSettings.swift */; };
 		FAE8EE9A273AC06F00A65307 /* QuickStartSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE8EE98273AC06F00A65307 /* QuickStartSettings.swift */; };
 		FAE8EE9C273AD0A800A65307 /* QuickStartSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE8EE9B273AD0A800A65307 /* QuickStartSettingsTests.swift */; };
-		FAEC116E2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */; };
-		FAEC116F2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */; };
+		FAEC116E2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift */; };
+		FAEC116F2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift */; };
 		FAF0FAAC2AA094C0004C3228 /* NoSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF0FAAB2AA094C0004C3228 /* NoSiteViewModelTests.swift */; };
 		FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */; };
 		FAF13E3025A59240003EE470 /* JetpackRestoreStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13E2F25A59240003EE470 /* JetpackRestoreStatusViewController.swift */; };
@@ -9209,6 +9213,8 @@
 		F9C47A8E238C9D6400AAD9ED /* StatsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsScreen.swift; sourceTree = "<group>"; };
 		FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsService.swift; sourceTree = "<group>"; };
 		FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsViewController.swift; sourceTree = "<group>"; };
+		FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageMenuViewModel.swift; sourceTree = "<group>"; };
+		FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PageListViewController+Menu.swift"; sourceTree = "<group>"; };
 		FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWarningView.swift; sourceTree = "<group>"; };
 		FA1A543F25A6E3080033967D /* RestoreWarningView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreWarningView.xib; sourceTree = "<group>"; };
 		FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreStatusView.swift; sourceTree = "<group>"; };
@@ -9335,7 +9341,7 @@
 		FAE4CA672732C094003BFDFE /* QuickStartPromptViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuickStartPromptViewController.xib; sourceTree = "<group>"; };
 		FAE8EE98273AC06F00A65307 /* QuickStartSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartSettings.swift; sourceTree = "<group>"; };
 		FAE8EE9B273AD0A800A65307 /* QuickStartSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartSettingsTests.swift; sourceTree = "<group>"; };
-		FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostMenu.swift; sourceTree = "<group>"; };
+		FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostMenuViewModel.swift; sourceTree = "<group>"; };
 		FAF0FAAB2AA094C0004C3228 /* NoSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSiteViewModelTests.swift; sourceTree = "<group>"; };
 		FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningViewController.swift; sourceTree = "<group>"; };
 		FAF13E2F25A59240003EE470 /* JetpackRestoreStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreStatusViewController.swift; sourceTree = "<group>"; };
@@ -12574,7 +12580,8 @@
 				FACF66CF2ADD6CD8008C3E13 /* PostListItemViewModel.swift */,
 				0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */,
 				FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */,
-				FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenu.swift */,
+				FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift */,
+				FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -12602,6 +12609,7 @@
 				59DCA5201CC68AF3000F245F /* PageListViewController.swift */,
 				9AF724EE2146813C00F63A61 /* ParentPageSettingsViewController.swift */,
 				7D21280C251CF0850086DD2C /* EditPageViewController.swift */,
+				FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -21112,7 +21120,7 @@
 				0C7E09202A4286A00052324C /* PostMetaButton.m in Sources */,
 				9826AE8221B5C6A700C851FA /* LatestPostSummaryCell.swift in Sources */,
 				F47E154A29E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift in Sources */,
-				FAEC116E2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */,
+				FAEC116E2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift in Sources */,
 				433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */,
 				0C7E09242A4286F40052324C /* PostMetaButton+Swift.swift in Sources */,
 				4395A1592106389800844E8E /* QuickStartTours.swift in Sources */,
@@ -21792,6 +21800,7 @@
 				02D75D9922793EA2003FF09A /* BlogDetailsSectionFooterView.swift in Sources */,
 				08E39B4528A3DEB200874CB8 /* UserPersistentStoreFactory.swift in Sources */,
 				C81CCD67243AECA200A83E27 /* TenorGIFCollection.swift in Sources */,
+				FA141F2A2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */,
 				4AD5656C28E3D0670054C676 /* ReaderPost+Helper.swift in Sources */,
 				E137B1661F8B77D4006AC7FC /* WebNavigationDelegate.swift in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
@@ -22202,6 +22211,7 @@
 				E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */,
 				F41E3301287B5FE500F89082 /* SuggestionViewModel.swift in Sources */,
+				FA141F272AEC1D9E00C9A653 /* PageMenuViewModel.swift in Sources */,
 				1762B6DC2845510400F270A5 /* StatsReferrersChartViewModel.swift in Sources */,
 				3F851428260D1EA300A4B938 /* CircledIcon.swift in Sources */,
 				3101866B1A373B01008F7DF6 /* WPTabBarController.m in Sources */,
@@ -24201,7 +24211,7 @@
 				FABB22072602FC2C00C8785C /* BlogSettings+DateAndTimeFormat.swift in Sources */,
 				FABB22082602FC2C00C8785C /* PostSearchHeader.swift in Sources */,
 				018635882A8109F900915532 /* SupportChatBotViewModel.swift in Sources */,
-				FAEC116F2AEBEEA600F9DA54 /* AbstractPostMenu.swift in Sources */,
+				FAEC116F2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift in Sources */,
 				FABB22092602FC2C00C8785C /* ReaderPostCardContentLabel.swift in Sources */,
 				FA90EFF0262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */,
 				80A2153E29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */,
@@ -25389,6 +25399,7 @@
 				FA6402D229C325C1007A235C /* MovedToJetpackEventsTracker.swift in Sources */,
 				FABB256B2602FC2C00C8785C /* InteractivePostView.swift in Sources */,
 				FABB256C2602FC2C00C8785C /* LinearGradientView.swift in Sources */,
+				FA141F282AEC1D9E00C9A653 /* PageMenuViewModel.swift in Sources */,
 				FABB256D2602FC2C00C8785C /* WizardStep.swift in Sources */,
 				0C35FFF229CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */,
 				C395FB242821FE4B00AE7C11 /* SiteDesignSection.swift in Sources */,
@@ -25577,6 +25588,7 @@
 				FABB25EF2602FC2C00C8785C /* ReaderWebView.swift in Sources */,
 				FABB25F02602FC2C00C8785C /* PostVisibilitySelectorViewController.swift in Sources */,
 				FABB25F12602FC2C00C8785C /* UIApplication+Helpers.m in Sources */,
+				FA141F2B2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */,
 				3F3DD0B026FCDA3100F5F121 /* PresentationButton.swift in Sources */,
 				FABB25F22602FC2C00C8785C /* ErrorStateView.swift in Sources */,
 				FABB25F32602FC2C00C8785C /* MenusSelectionDetailView.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3851,6 +3851,7 @@
 		FA141F282AEC1D9E00C9A653 /* PageMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */; };
 		FA141F2A2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */; };
 		FA141F2B2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */; };
+		FA141F322AF139A200C9A653 /* PageMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA141F312AF139A200C9A653 /* PageMenuViewModelTests.swift */; };
 		FA1A543E25A6E2F60033967D /* RestoreWarningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */; };
 		FA1A544025A6E3080033967D /* RestoreWarningView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1A543F25A6E3080033967D /* RestoreWarningView.xib */; };
 		FA1A55EF25A6F0740033967D /* RestoreStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */; };
@@ -9215,6 +9216,7 @@
 		FA111E372A2F38FC00896FCE /* BlazeCampaignsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsViewController.swift; sourceTree = "<group>"; };
 		FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageMenuViewModel.swift; sourceTree = "<group>"; };
 		FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PageListViewController+Menu.swift"; sourceTree = "<group>"; };
+		FA141F312AF139A200C9A653 /* PageMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageMenuViewModelTests.swift; path = Classes/ViewRelated/Pages/PageMenuViewModelTests.swift; sourceTree = SOURCE_ROOT; };
 		FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreWarningView.swift; sourceTree = "<group>"; };
 		FA1A543F25A6E3080033967D /* RestoreWarningView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreWarningView.xib; sourceTree = "<group>"; };
 		FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreStatusView.swift; sourceTree = "<group>"; };
@@ -13899,16 +13901,9 @@
 		8B7623352384372200AB3EE7 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
-				8B7623362384372F00AB3EE7 /* Controllers */,
+				FA141F312AF139A200C9A653 /* PageMenuViewModelTests.swift */,
 			);
 			path = Pages;
-			sourceTree = "<group>";
-		};
-		8B7623362384372F00AB3EE7 /* Controllers */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Controllers;
 			sourceTree = "<group>";
 		};
 		8B7F51C724EED488008CF5B5 /* Analytics */ = {
@@ -23499,6 +23494,7 @@
 				FF8032661EE9E22200861F28 /* MediaProgressCoordinatorTests.swift in Sources */,
 				173D82E7238EE2A7008432DA /* FeatureFlagTests.swift in Sources */,
 				3F4A4C212AD39CB100DE5DF8 /* TruthTable.swift in Sources */,
+				FA141F322AF139A200C9A653 /* PageMenuViewModelTests.swift in Sources */,
 				E63C897C1CB9A0D700649C8F /* UITextFieldTextHelperTests.swift in Sources */,
 				FF2EC3C22209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift in Sources */,
 				D81C2F5A20F86E94002AE1F1 /* LikeCommentActionTests.swift in Sources */,

--- a/WordPress/WordPressTest/TestUtilities/PageBuilder.swift
+++ b/WordPress/WordPressTest/TestUtilities/PageBuilder.swift
@@ -6,11 +6,11 @@ import Foundation
 class PageBuilder {
     private let page: Page
 
-    init(_ context: NSManagedObjectContext) {
+    init(_ context: NSManagedObjectContext, canBlaze: Bool = false) {
         page = NSEntityDescription.insertNewObject(forEntityName: Page.entityName(), into: context) as! Page
 
         // Non-null Core Data properties
-        page.blog = BlogBuilder(context).build()
+        page.blog = canBlaze ? BlogBuilder(context).canBlaze().build() : BlogBuilder(context).build()
     }
 
     func with(status: BasePost.Status) -> Self {

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -2,7 +2,6 @@ import Nimble
 import XCTest
 @testable import WordPress
 
-
 class PostCardStatusViewModelTests: CoreDataTestCase {
 
     func testPublishedPostButtons() {
@@ -17,7 +16,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
-        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+        let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.blaze],
@@ -39,7 +38,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
-        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+        let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.stats, .comments],
@@ -54,13 +53,13 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
             .withRemote()
             .published()
             .build()
-        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: false, isBlazeFlagEnabled: true)
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: false, isBlazeFlagEnabled: false)
 
         // When & Then
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
-        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+        let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.trash]
@@ -79,7 +78,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
-        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+        let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.duplicate, .publish],
             [.trash]
@@ -98,7 +97,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
-        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+        let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft],
             [.trash]
@@ -117,7 +116,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
-        let expectedButtons: [[PostCardStatusViewModel.Button]] = [
+        let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft],
             [.trash]


### PR DESCRIPTION
Part of #21873

## Description
- Adds a context menu to the pages cell
- The set parent, set as homepage, and set as post page actions will be handled in the next PR

## Notes
- For now, I've copied over the actions logic as to avoid introducing regressions. We've discussed the unreliability of ReachabilityUtils, but I'd prefer to address any enhancements in a future PR

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/96644a74-22ac-4da7-ab54-facc0a370561" width=200>

## How to test
- Go to the pages list screen
- Tap on the ellipsis button
- ✅ Verify a context menu appears
- Tap on actions
- ✅ Verify the selected action work as expected

## Regression Notes
1. Potential unintended areas of impact: pages actions

2. What I did to test those areas of impact (or what existing automated tests I relied on): added tests for PagesMenuViewModel

3. What automated tests I added (or what prevented me from doing so): PagesMenuViewModel

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
