### PR TITLE
Posts & Pages: Minor fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -276,17 +276,13 @@ class AbstractPostListViewController: UIViewController,
     // MARK: - GUI: No results view logic
 
     func hideNoResultsView() {
-        setFooterHidden(false)
         noResultsViewController.removeFromView()
     }
 
     func showNoResultsView() {
-
         guard refreshNoResultsViewController != nil, atLeastSyncedOnce else {
             return
         }
-
-        setFooterHidden(true)
         refreshNoResultsViewController(noResultsViewController)
 
         // Only add no results view if it isn't already in the table view

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -170,7 +170,6 @@ class AbstractPostListViewController: UIViewController,
 
     func configureFilterBar() {
         WPStyleGuide.configureFilterTabBar(filterTabBar)
-        filterTabBar.isLayoutMarginsRelativeArrangement = false
         filterTabBar.backgroundColor = .clear
         filterTabBar.items = filterSettings.availablePostListFilters()
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -35,7 +35,7 @@ class AbstractPostListViewController: UIViewController,
     /// to the subclass to define this property.
     ///
     var refreshNoResultsViewController: ((NoResultsViewController) -> ())!
-    let tableViewController = UITableViewController(style: .grouped)
+    let tableViewController = UITableViewController(style: .plain)
     private var reloadTableViewBeforeAppearing = false
 
     @objc var tableView: UITableView {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -397,6 +397,14 @@ class AbstractPostListViewController: UIViewController,
         nil
     }
 
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        0
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        nil
+    }
+
     func tableViewDidChangeContent(_ tableView: UITableView) {
         refreshResults()
     }

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -66,11 +66,6 @@ class FilterTabBar: UIControl {
         }
     }
 
-    var isLayoutMarginsRelativeArrangement: Bool {
-        get { stackView.isLayoutMarginsRelativeArrangement }
-        set { stackView.isLayoutMarginsRelativeArrangement = newValue }
-    }
-
     private var tabBarHeightConstraint: NSLayoutConstraint! {
         didSet {
             if let oldValue = oldValue {


### PR DESCRIPTION
- Fix issue reported here https://github.com/wordpress-mobile/WordPress-iOS/pull/21907#pullrequestreview-1703849162
- Fix extra spacing before the footer view
- Fix filter bar layout in landscape
- Fix cell background in dark mode

To test:

- Open Posts
- Scroll to the bottom
- Verify that the spinner is displayed when loading more content

There is a scenario in which it won't be displayed immediately. It happens when the DB already has cached posts and by the time you reach the bottom, the initial sync is still not finished. I'm not sure if it's worth addressing it.

## Regression Notes
1. Potential unintended areas of impact: Posts list
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
