### PR TITLE
Posts & Pages: Fix empty state position

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -292,14 +292,8 @@ class AbstractPostListViewController: UIViewController,
         // Only add no results view if it isn't already in the table view
         if noResultsViewController.view.isDescendant(of: tableView) == false {
             tableViewController.addChild(noResultsViewController)
-            tableView.addSubview(withFadeAnimation: noResultsViewController.view)
-            noResultsViewController.view.frame = tableView.frame
-
-            // Adjust the NRV to accommodate for the search bar.
-            if let tableHeaderView = tableView.tableHeaderView {
-                noResultsViewController.view.frame.origin.y = tableHeaderView.frame.origin.y
-            }
-
+            tableView.addSubview(noResultsViewController.view)
+            noResultsViewController.view.frame = tableView.frame.offsetBy(dx: 0, dy: -view.safeAreaInsets.top + 40)
             noResultsViewController.didMove(toParent: tableViewController)
         }
 


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21900

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages list
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x  I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
