### PR TITLE
Posts & Pages: Enable context menus in search

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -106,7 +106,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
                 return cell
             case let page as Page:
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell
-                cell.configure(with: PageListItemViewModel(page: page))
+                cell.configure(with: PageListItemViewModel(page: page), delegate: listViewController as? InteractivePostViewDelegate)
                 updateHighlights(for: [cell], searchTerm: viewModel.searchTerm)
                 return cell
             default:


### PR DESCRIPTION
<img width="320" alt="Screenshot 2023-10-31 at 3 00 47 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/7170f636-c56c-4ac5-9a45-167b9d14bfbe">

To test:

## Regression Notes
1. Potential unintended areas of impact: Pages Search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
