### PR TITLE
Only call `prepareForReuse` if image is a GIF

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -52,6 +52,10 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
 
     private var customLoadingIndicator: ActivityIndicatorType?
 
+    private var isImageAnimated: Bool {
+        animatedGifData != nil
+    }
+
     private lazy var defaultLoadingIndicator: UIActivityIndicatorView = {
         let loadingIndicator = UIActivityIndicatorView(style: .medium)
         layoutViewCentered(loadingIndicator, size: nil)
@@ -143,7 +147,9 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
     }
 
     @objc public func prepForReuse() {
-        self.prepareForReuse()
+        if isImageAnimated {
+            self.prepareForReuse()
+        }
     }
 
     @objc public func startLoadingAnimation() {


### PR DESCRIPTION
Part of #21929 

## Description

This updates `CachedAnimatedImageView` to only call `prepareForReuse` on its protocol, `GIFAnimatable`, when the image is a GIF. The `prepareForReuse` call was causing some animation hitches when scrolling in the Reader. I believe what was happening was the downstream call to the `Animator` class was setting a property on a `CADisplayLink` variable that was causing the commits to be expensive.

## Instruments Comparisons

> **Note**
> Obviously, these two runs won't be perfectly identical but I tried to perform the same steps between the two measurements:
> - Launch and wait until 10 seconds
> - Tap on Reader
> - Scroll down to a specific post
> - Scroll back up

<details><summary>Before</summary>
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/b6bb692f-4281-4db6-968f-afa654f2747a">
</details>

<details><summary>After</summary>
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/b5f28aea-def3-4c1a-bb0f-8ba1240ba645">
</details>

## Testing

### General Reader test
- Launch Jetpack and login
- Navigate to the Reader
- Scroll through various posts
- 🔎 **Verify** the featured images display correctly

### Confirm GIFs don't break
- Launch Jetpack and login
- Navigate to a view which uses this view and has GIFs (I did: Media > `+` in top right > Free GIF Library)
- 🔎 **Verify** the image views still animate and display properly

## Regression Notes
1. Potential unintended areas of impact
Views which use `CachedAnimatedImageView`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
