### PR TITLE
[Notifications Navigation] Display navigation stack when long pressing navigation back button

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -378,13 +378,11 @@ extension NotificationDetailsViewController: UITableViewDelegate, UITableViewDat
 //
 extension NotificationDetailsViewController {
     func setupNavigationBar() {
-        // Don't show the notification title in the next-view's back button
-        let backButton = UIBarButtonItem(title: String(),
-                                         style: .plain,
-                                         target: nil,
-                                         action: nil)
-
-        navigationItem.backBarButtonItem = backButton
+        navigationItem.backButtonTitle = NSLocalizedString(
+            "notificationDetails.backButton.title",
+            value: "Notification Details",
+            comment: "Title displayed in the navigation stack when long pressing navigation back button")
+        navigationItem.backButtonDisplayMode = .minimal
 
         let next = UIButton(type: .custom)
         next.setImage(.gridicon(.arrowUp), for: .normal)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -535,11 +535,8 @@ private extension NotificationsViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
 
-        // Don't show 'Notifications' in the next-view back button
-        // we are using a space character because we need a non-empty string to ensure a smooth
-        // transition back, with large titles enabled.
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
         navigationItem.title = NSLocalizedString("Notifications", comment: "Notifications View Controller title")
+        navigationItem.backButtonDisplayMode = .minimal
     }
 
     func updateNavigationItems() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1005,24 +1005,12 @@ private extension ReaderDetailViewController {
             safariButtonItem()
         ]
 
-        if !isModal() {
-            navigationItem.leftBarButtonItem = backButtonItem()
-        } else {
+        if isModal() {
             navigationItem.leftBarButtonItem = dismissButtonItem()
         }
+
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
-    }
-
-    func backButtonItem() -> UIBarButtonItem {
-        let button = barButtonItem(with: .gridicon(.chevronLeft), action: #selector(didTapBackButton(_:)))
-        button.accessibilityLabel = Strings.backButtonAccessibilityLabel
-
-        return button
-    }
-
-    @objc func didTapBackButton(_ sender: UIButton) {
-        navigationController?.popViewController(animated: true)
     }
 
     func dismissButtonItem() -> UIBarButtonItem {
@@ -1113,11 +1101,6 @@ extension ReaderDetailViewController: UIViewControllerRestoration {
 // MARK: - Strings
 extension ReaderDetailViewController {
     private struct Strings {
-        static let backButtonAccessibilityLabel = NSLocalizedString(
-            "readerDetail.backButton.accessibilityLabel",
-            value: "Back",
-            comment: "Spoken accessibility label"
-        )
         static let dismissButtonAccessibilityLabel = NSLocalizedString(
             "readerDetail.dismissButton.accessibilityLabel",
             value: "Dismiss",


### PR DESCRIPTION
Fixes #21769 

## Description
The navigation stack is not being shown when long pressing the navigation back button:
![simulator_screenshot_57629DD8-28CF-46F5-B45C-1E5E0AD4125E](https://github.com/wordpress-mobile/WordPress-iOS/assets/96448621/4f1b24e6-a303-4543-9e3f-8dfba183cd03)

It should display information about the previous navigation ("Notification Details" and "Notifications" in this case): 
![simulator_screenshot_947EFE4C-F089-4AE3-94C9-51D35621E143](https://github.com/wordpress-mobile/WordPress-iOS/assets/96448621/cb397681-9a4a-4b72-9200-98cea1c7692a)

To test:
- Login Jetpack
- Navigate to "Notifications" tab
- Tap on "Likes"
- Tap on a like notification
- Long press the navigation back button on the top left corner
- Verify the navigation stack contains "Notifications"
- Tap on the liked item
- Long press the navigation back button again
- Verify the navigation stack contains "Notification Details" and "Notifications"

Test flow: 
![Simulator Screen Recording - iPhone 15 Pro Max - 2023-11-01 at 19 03 14](https://github.com/wordpress-mobile/WordPress-iOS/assets/96448621/216fd4e1-35eb-4821-ad3b-68b3bf72bbc2)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
