### PR TITLE
Blogging Prompts: Migrate to v3 logic

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/Shared/wpcom_sites_blogging_prompts.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/Shared/wpcom_sites_blogging_prompts.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPathPattern": "/wpcom/v2/sites/([0-9]+)/blogging-prompts",
+    "urlPathPattern": "/wpcom/v3/sites/([0-9]+)/blogging-prompts",
     "queryParameters": {
       "number": {
         "matches": "(.*)"

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/Shared/wpcom_sites_blogging_prompts.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/Shared/wpcom_sites_blogging_prompts.json
@@ -3,10 +3,13 @@
     "method": "GET",
     "urlPathPattern": "/wpcom/v3/sites/([0-9]+)/blogging-prompts",
     "queryParameters": {
-      "number": {
+      "per_page": {
         "matches": "(.*)"
       },
-      "from": {
+      "after": {
+        "matches": "(.*)"
+      },
+      "force_year": {
         "matches": "(.*)"
       },
       "_locale": {
@@ -16,239 +19,237 @@
   },
   "response": {
     "status": 200,
-    "jsonBody": {
-      "prompts": [
-        {
-          "id": 2003,
-          "text": "What foods would you like to make?",
-          "attribution": "dayone",
-          "date": "2022-07-20",
-          "answered": false,
-          "answered_users_count": 3,
-          "answered_users_sample": [
-            {
-              "avatar": "https://2.gravatar.com/avatar/5dffa9e5d426449127114fe04f4820ba?s=96&d=identicon&r=G"
-            },
-            {
-              "avatar": "https://0.gravatar.com/avatar/9cd92ae622fc905b4908503cf9fbd489?s=96&d=identicon&r=G"
-            },
-            {
-              "avatar": "https://2.gravatar.com/avatar/e2526cb456f69198425ebeaff0a9225f?s=96&d=identicon&r=G"
-            }
-          ],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2003",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2004,
-          "text": "What&#039;s your favorite game (card, board, video, etc.)? Why?",
-          "attribution": "",
-          "date": "2022-07-21",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2004",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2005,
-          "text": "What’s your go-to comfort food?",
-          "attribution": "dayone",
-          "date": "2022-07-22",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2005",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2006,
-          "text": "What do you listen to while you work?",
-          "attribution": "dayone",
-          "date": "2022-07-23",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2006",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2007,
-          "text": "What would you change about modern society?",
-          "attribution": "dayone",
-          "date": "2022-07-24",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2007",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2008,
-          "text": "What are your future travel plans?",
-          "attribution": "dayone",
-          "date": "2022-07-25",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2008",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2009,
-          "text": "What&#039;s the sickest you&#039;ve ever been?",
-          "attribution": "dayone",
-          "date": "2022-07-26",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2009",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2010,
-          "text": "What&#039;s the story behind your nickname?",
-          "attribution": "dayone",
-          "date": "2022-07-27",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2010",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2011,
-          "text": "If you won two free plane tickets, where would you go?",
-          "attribution": "",
-          "date": "2022-07-28",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2011",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2012,
-          "text": "If you could bring back one dinosaur, which one would it be?",
-          "attribution": "dayone",
-          "date": "2022-07-29",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2012",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2013,
-          "text": "How would you describe yourself to someone?",
-          "attribution": "dayone",
-          "date": "2022-07-30",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2013",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2014,
-          "text": "Was today typical?",
-          "attribution": "dayone",
-          "date": "2022-07-31",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2014",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2015,
-          "text": "What traditions have you not kept that your parents had?",
-          "attribution": "dayone",
-          "date": "2022-08-01",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2015",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2016,
-          "text": "How would you describe yourself to someone who can&#039;t see you?",
-          "attribution": "dayone",
-          "date": "2022-08-02",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2016",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2017,
-          "text": "Write about a random act of kindness you&#039;ve done for someone.",
-          "attribution": "dayone",
-          "date": "2022-08-03",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2017",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2018,
-          "text": "What are you curious about?",
-          "attribution": "dayone",
-          "date": "2022-08-04",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2018",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2019,
-          "text": "Do you have any habits you&#039;re currently trying to break?",
-          "attribution": "dayone",
-          "date": "2022-08-05",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2019",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2020,
-          "text": "List 30 things that make you happy.",
-          "attribution": "dayone",
-          "date": "2022-08-06",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2020",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2021,
-          "text": "Scour the news for an entirely uninteresting story. Consider how it connects to your life. Write about that.",
-          "attribution": "",
-          "date": "2022-08-07",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2021",
-          "answered_link_text": "View all responses"
-        },
-        {
-          "id": 2022,
-          "text": "What&#039;s the most money you&#039;ve ever spent on a meal? Was it worth it?",
-          "attribution": "",
-          "date": "{{now format='yyyy-MM-dd'}}",
-          "answered": false,
-          "answered_users_count": 0,
-          "answered_users_sample": [],
-          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2022",
-          "answered_link_text": "View all responses"
-        }
-      ]
-    }
+    "jsonBody": [
+      {
+        "id": 2003,
+        "text": "What foods would you like to make?",
+        "attribution": "dayone",
+        "date": "2022-07-20",
+        "answered": false,
+        "answered_users_count": 3,
+        "answered_users_sample": [
+          {
+            "avatar": "https://2.gravatar.com/avatar/5dffa9e5d426449127114fe04f4820ba?s=96&d=identicon&r=G"
+          },
+          {
+            "avatar": "https://0.gravatar.com/avatar/9cd92ae622fc905b4908503cf9fbd489?s=96&d=identicon&r=G"
+          },
+          {
+            "avatar": "https://2.gravatar.com/avatar/e2526cb456f69198425ebeaff0a9225f?s=96&d=identicon&r=G"
+          }
+        ],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2003",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2004,
+        "text": "What&#039;s your favorite game (card, board, video, etc.)? Why?",
+        "attribution": "",
+        "date": "2022-07-21",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2004",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2005,
+        "text": "What’s your go-to comfort food?",
+        "attribution": "dayone",
+        "date": "2022-07-22",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2005",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2006,
+        "text": "What do you listen to while you work?",
+        "attribution": "dayone",
+        "date": "2022-07-23",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2006",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2007,
+        "text": "What would you change about modern society?",
+        "attribution": "dayone",
+        "date": "2022-07-24",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2007",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2008,
+        "text": "What are your future travel plans?",
+        "attribution": "dayone",
+        "date": "2022-07-25",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2008",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2009,
+        "text": "What&#039;s the sickest you&#039;ve ever been?",
+        "attribution": "dayone",
+        "date": "2022-07-26",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2009",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2010,
+        "text": "What&#039;s the story behind your nickname?",
+        "attribution": "dayone",
+        "date": "2022-07-27",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2010",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2011,
+        "text": "If you won two free plane tickets, where would you go?",
+        "attribution": "",
+        "date": "2022-07-28",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2011",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2012,
+        "text": "If you could bring back one dinosaur, which one would it be?",
+        "attribution": "dayone",
+        "date": "2022-07-29",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2012",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2013,
+        "text": "How would you describe yourself to someone?",
+        "attribution": "dayone",
+        "date": "2022-07-30",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2013",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2014,
+        "text": "Was today typical?",
+        "attribution": "dayone",
+        "date": "2022-07-31",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2014",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2015,
+        "text": "What traditions have you not kept that your parents had?",
+        "attribution": "dayone",
+        "date": "2022-08-01",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2015",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2016,
+        "text": "How would you describe yourself to someone who can&#039;t see you?",
+        "attribution": "dayone",
+        "date": "2022-08-02",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2016",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2017,
+        "text": "Write about a random act of kindness you&#039;ve done for someone.",
+        "attribution": "dayone",
+        "date": "2022-08-03",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2017",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2018,
+        "text": "What are you curious about?",
+        "attribution": "dayone",
+        "date": "2022-08-04",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2018",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2019,
+        "text": "Do you have any habits you&#039;re currently trying to break?",
+        "attribution": "dayone",
+        "date": "2022-08-05",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2019",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2020,
+        "text": "List 30 things that make you happy.",
+        "attribution": "dayone",
+        "date": "2022-08-06",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2020",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2021,
+        "text": "Scour the news for an entirely uninteresting story. Consider how it connects to your life. Write about that.",
+        "attribution": "",
+        "date": "2022-08-07",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2021",
+        "answered_link_text": "View all responses"
+      },
+      {
+        "id": 2022,
+        "text": "What&#039;s the most money you&#039;ve ever spent on a meal? Was it worth it?",
+        "attribution": "",
+        "date": "{{now format='yyyy-MM-dd'}}",
+        "answered": false,
+        "answered_users_count": 0,
+        "answered_users_sample": [],
+        "answered_link": "https://wordpress.com/tag/dailyprompt-2022",
+        "answered_link_text": "View all responses"
+      }
+    ]
   }
 }

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/Shared/wpcom_sites_blogging_prompts.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/Shared/wpcom_sites_blogging_prompts.json
@@ -21,8 +21,6 @@
         {
           "id": 2003,
           "text": "What foods would you like to make?",
-          "title": "Prompt number 200",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What foods would you like to make?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-20",
           "answered": false,
@@ -37,216 +35,218 @@
             {
               "avatar": "https://2.gravatar.com/avatar/e2526cb456f69198425ebeaff0a9225f?s=96&d=identicon&r=G"
             }
-          ]
+          ],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2003",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2004,
           "text": "What&#039;s your favorite game (card, board, video, etc.)? Why?",
-          "title": "Prompt number 201",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What's your favorite game (card, board, video, etc.)? Why?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "",
           "date": "2022-07-21",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2004",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2005,
           "text": "What’s your go-to comfort food?",
-          "title": "Prompt number 202",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What’s your go-to comfort food?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-22",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2005",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2006,
           "text": "What do you listen to while you work?",
-          "title": "Prompt number 203",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What do you listen to while you work?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-23",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2006",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2007,
           "text": "What would you change about modern society?",
-          "title": "Prompt number 204",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What would you change about modern society?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-24",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2007",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2008,
           "text": "What are your future travel plans?",
-          "title": "Prompt number 205",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What are your future travel plans?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-25",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2008",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2009,
           "text": "What&#039;s the sickest you&#039;ve ever been?",
-          "title": "Prompt number 206",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What's the sickest you've ever been?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-26",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2009",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2010,
           "text": "What&#039;s the story behind your nickname?",
-          "title": "Prompt number 207",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What's the story behind your nickname?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-27",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2010",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2011,
           "text": "If you won two free plane tickets, where would you go?",
-          "title": "Prompt number 208",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>If you won two free plane tickets, where would you go?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "",
           "date": "2022-07-28",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2011",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2012,
           "text": "If you could bring back one dinosaur, which one would it be?",
-          "title": "Prompt number 209",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>If you could bring back one dinosaur, which one would it be?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-29",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2012",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2013,
           "text": "How would you describe yourself to someone?",
-          "title": "Prompt number 210",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>How would you describe yourself to someone?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-30",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2013",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2014,
           "text": "Was today typical?",
-          "title": "Prompt number 211",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was today typical?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-07-31",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2014",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2015,
           "text": "What traditions have you not kept that your parents had?",
-          "title": "Prompt number 212",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What traditions have you not kept that your parents had?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-08-01",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2015",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2016,
           "text": "How would you describe yourself to someone who can&#039;t see you?",
-          "title": "Prompt number 213",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>How would you describe yourself to someone who can't see you?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-08-02",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2016",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2017,
           "text": "Write about a random act of kindness you&#039;ve done for someone.",
-          "title": "Prompt number 214",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Write about a random act of kindness you've done for someone.</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-08-03",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2017",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2018,
           "text": "What are you curious about?",
-          "title": "Prompt number 215",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What are you curious about?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-08-04",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2018",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2019,
           "text": "Do you have any habits you&#039;re currently trying to break?",
-          "title": "Prompt number 216",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Do you have any habits you're currently trying to break?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-08-05",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2019",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2020,
           "text": "List 30 things that make you happy.",
-          "title": "Prompt number 217",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>List 30 things that make you happy.</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "dayone",
           "date": "2022-08-06",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2020",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2021,
           "text": "Scour the news for an entirely uninteresting story. Consider how it connects to your life. Write about that.",
-          "title": "Prompt number 218",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Scour the news for an entirely uninteresting story. Consider how it connects to your life. Write about that.</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "",
           "date": "2022-08-07",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2021",
+          "answered_link_text": "View all responses"
         },
         {
           "id": 2022,
           "text": "What&#039;s the most money you&#039;ve ever spent on a meal? Was it worth it?",
-          "title": "Prompt number 219",
-          "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What's the most money you've ever spent on a meal? Was it worth it?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "",
           "date": "{{now format='yyyy-MM-dd'}}",
           "answered": false,
           "answered_users_count": 0,
-          "answered_users_sample": []
+          "answered_users_sample": [],
+          "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-2022",
+          "answered_link_text": "View all responses"
         }
       ]
     }

--- a/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
@@ -21,17 +21,17 @@ public class BloggingPrompt: NSManagedObject {
         BloggingPromptsAttribution(rawValue: attribution.lowercased())
     }
 
-    /// Convenience method to map properties from `RemoteBloggingPrompt`.
+    /// Convenience method to map properties from `BloggingPromptRemoteObject`.
     ///
     /// - Parameters:
     ///   - remotePrompt: The remote prompt model to convert
     ///   - siteID: The ID of the site that the prompt is intended for
-    func configure(with remotePrompt: RemoteBloggingPrompt, for siteID: Int32) {
+    func configure(with remotePrompt: BloggingPromptRemoteObject, for siteID: Int32) {
         self.promptID = Int32(remotePrompt.promptID)
         self.siteID = siteID
         self.text = remotePrompt.text
-        self.title = remotePrompt.title
-        self.content = remotePrompt.content
+        self.title = String() // TODO: Remove
+        self.content = String() // TODO: Remove
         self.attribution = remotePrompt.attribution
         self.date = remotePrompt.date
         self.answered = remotePrompt.answered

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
@@ -1,13 +1,3 @@
-/// A model representing the response object for blogging prompts v3 requests.
-struct RemoteBloggingPromptsResponse: Decodable {
-    let prompts: [BloggingPromptRemoteObject]
-
-    init(from decoder: Decoder) throws {
-        var container = try decoder.unkeyedContainer()
-        self.prompts = try container.decode([BloggingPromptRemoteObject].self)
-    }
-}
-
 /// Encapsulates a single blogging prompt object from the v3 API.
 struct BloggingPromptRemoteObject {
     var promptID: Int

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
@@ -1,14 +1,14 @@
 /// Encapsulates a single blogging prompt object from the v3 API.
 struct BloggingPromptRemoteObject {
-    var promptID: Int
-    var text: String
-    var attribution: String
-    var date: Date
-    var answered: Bool
-    var answeredUsersCount: Int
-    var answeredUserAvatarURLs: [URL]
-    var answeredLink: URL?
-    var answeredLinkText: String
+    let promptID: Int
+    let text: String
+    let attribution: String
+    let date: Date
+    let answered: Bool
+    let answeredUsersCount: Int
+    let answeredUserAvatarURLs: [URL]
+    let answeredLink: URL?
+    let answeredLinkText: String
 }
 
 // MARK: - Decodable
@@ -57,6 +57,8 @@ extension BloggingPromptRemoteObject: Decodable {
         if let linkURLString = try? container.decode(String.self, forKey: .answeredLink),
            let answeredLinkURL = URL(string: linkURLString) {
             self.answeredLink = answeredLinkURL
+        } else {
+            self.answeredLink = nil
         }
 
         self.answeredLinkText = try container.decode(String.self, forKey: .answeredLinkText)

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -29,6 +29,14 @@ class BloggingPromptsService {
         return formatter
     }()
 
+    /// A JSON decoder that can parse date strings that matches `JSONDecoder.DateDecodingStrategy.DateFormat` into `Date`.
+    private static var jsonDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = JSONDecoder.DateDecodingStrategy.supportMultipleDateFormats
+
+        return decoder
+    }()
+
     /// Convenience computed variable that returns today's prompt from local store.
     ///
     var localTodaysPrompt: BloggingPrompt? {
@@ -320,11 +328,7 @@ private extension BloggingPromptsService {
             case .success(let responseObject):
                 do {
                     let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
-                    let decoder = JSONDecoder()
-                    decoder.dateDecodingStrategy = JSONDecoder.DateDecodingStrategy.supportMultipleDateFormats
-                    decoder.keyDecodingStrategy = .useDefaultKeys
-
-                    let remotePrompts = try decoder.decode([BloggingPromptRemoteObject].self, from: data)
+                    let remotePrompts = try Self.jsonDecoder.decode([BloggingPromptRemoteObject].self, from: data)
                     completion(.success(remotePrompts))
                 } catch {
                     completion(.failure(error))

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -184,6 +184,8 @@ class BloggingPromptsService {
     ///     Otherwise, a remote service with the default account's credentials will be used.
     ///   - blog: When supplied, the service will perform blogging prompts requests for this specified blog.
     ///     Otherwise, this falls back to the default account's primary blog.
+    ///   - api: When supplied, the WordPressComRestApi instance to use to fetch the prompts.
+    ///     Otherwise, an default or anonymous instance will be computed based on whether there is an account available.
     required init?(contextManager: CoreDataStackSwift = ContextManager.shared,
                    api: WordPressComRestApi? = nil,
                    remote: BloggingPromptsServiceRemote? = nil,

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -305,8 +305,8 @@ private extension BloggingPromptsService {
             }
 
             if let fromDate {
-                // convert to yyyy-MM-dd format in UTC timezone so users would get the same prompts everywhere.
-                var dateString = Self.utcDateFormatter.string(from: fromDate)
+                // convert to yyyy-MM-dd format in local timezone so users would see the same prompt throughout their day.
+                var dateString = Self.localDateFormatter.string(from: fromDate)
 
                 // when the year needs to be ignored, we'll transform the dateString to match the "--mm-dd" format.
                 if ignoresYear, !dateString.isEmpty {

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -5,7 +5,7 @@ class BloggingPromptsService {
     let siteID: NSNumber
 
     private let contextManager: CoreDataStackSwift
-    private let remote: BloggingPromptsServiceRemote // TODO: replace with api.
+    private let remote: BloggingPromptsServiceRemote // TODO: Remove once the settings logic is ported.
     private let api: WordPressComRestApi
     private let calendar: Calendar = .autoupdatingCurrent
     private let maxListPrompts = 11

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -295,8 +295,7 @@ private extension BloggingPromptsService {
             }
 
             if let fromDate {
-                // convert to yyyy-MM-dd format, excluding the timezone information.
-                // the date parameter doesn't need to be timezone-accurate since prompts are grouped by date.
+                // convert to yyyy-MM-dd format in UTC timezone so users would get the same prompts everywhere.
                 var dateString = Self.utcDateFormatter.string(from: fromDate)
 
                 // when the year needs to be ignored, we'll transform the dateString to match the "--mm-dd" format.

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -385,7 +385,7 @@ private extension BloggingPromptsService {
         fetchRequest.predicate = predicate
 
         contextManager.performAndSave({ derivedContext in
-            /// try to overwrite prompts that have the same dates.
+            /// Try to overwrite prompts that have the same dates.
             ///
             /// Perf. notes: since we're at most updating 25 entries, it should be acceptable to update them one by one.
             /// However, if requirements change and we need to work through a larger data set, consider switching to

--- a/WordPress/Classes/Services/BloggingPrompts/RemoteBloggingPromptsResponse.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/RemoteBloggingPromptsResponse.swift
@@ -1,0 +1,74 @@
+/// A model representing the response object for blogging prompts v3 requests.
+struct RemoteBloggingPromptsResponse: Decodable {
+    let prompts: [BloggingPromptRemoteObject]
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.prompts = try container.decode([BloggingPromptRemoteObject].self)
+    }
+}
+
+/// Encapsulates a single blogging prompt object from the v3 API.
+struct BloggingPromptRemoteObject {
+    var promptID: Int
+    var text: String
+    var attribution: String
+    var date: Date
+    var answered: Bool
+    var answeredUsersCount: Int
+    var answeredUserAvatarURLs: [URL]
+    var answeredLink: URL?
+    var answeredLinkText: String
+}
+
+// MARK: - Decodable
+
+extension BloggingPromptRemoteObject: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case text
+        case attribution
+        case date
+        case answered
+        case answeredUsersCount = "answered_users_count"
+        case answeredUserAvatarURLs = "answered_users_sample"
+        case answeredLink = "answered_link"
+        case answeredLinkText = "answered_link_text"
+    }
+
+    /// meta structure to simplify decoding logic for user avatar objects.
+    /// this is intended to be private.
+    private struct UserAvatar: Codable {
+        var avatar: String
+    }
+
+    /// Used to format the fetched object's date string to a date.
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.timeZone = .init(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.promptID = try container.decode(Int.self, forKey: .id)
+        self.text = try container.decode(String.self, forKey: .text)
+        self.attribution = try container.decode(String.self, forKey: .attribution)
+        self.answered = try container.decode(Bool.self, forKey: .answered)
+        self.date = Self.dateFormatter.date(from: try container.decode(String.self, forKey: .date)) ?? Date()
+        self.answeredUsersCount = try container.decode(Int.self, forKey: .answeredUsersCount)
+
+        let userAvatars = try container.decode([UserAvatar].self, forKey: .answeredUserAvatarURLs)
+        self.answeredUserAvatarURLs = userAvatars.compactMap { URL(string: $0.avatar) }
+
+        if let linkURLString = try? container.decode(String.self, forKey: .answeredLink),
+           let answeredLinkURL = URL(string: linkURLString) {
+            self.answeredLink = answeredLinkURL
+        }
+
+        self.answeredLinkText = try container.decode(String.self, forKey: .answeredLinkText)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5580,8 +5580,8 @@
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFF2A4C9855008A48E0 /* Blog+PublicizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */; };
-		FEF207F42AF2903E0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */; };
-		FEF207F52AF2904D0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */; };
+		FEF207F42AF2903E0025CB2C /* BloggingPromptRemoteObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */; };
+		FEF207F52AF2904D0025CB2C /* BloggingPromptRemoteObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */; };
 		FEF28E822ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
 		FEF28E832ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
 		FEF4DC5528439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
@@ -9405,7 +9405,7 @@
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
-		FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBloggingPromptsResponse.swift; sourceTree = "<group>"; };
+		FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptRemoteObject.swift; sourceTree = "<group>"; };
 		FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailNewHeaderView.swift; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
@@ -18376,7 +18376,7 @@
 		FEF207F02AF287860025CB2C /* BloggingPrompts */ = {
 			isa = PBXGroup;
 			children = (
-				FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */,
+				FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */,
 				FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */,
 			);
 			path = BloggingPrompts;
@@ -21188,7 +21188,7 @@
 				8B074A5027AC3A64003A2EB8 /* BlogDashboardViewModel.swift in Sources */,
 				F5A34A9925DEF47D00C9654B /* WPMediaPicker+MediaPicker.swift in Sources */,
 				9A8ECE132254A3260043C8DA /* JetpackInstallError+Blocking.swift in Sources */,
-				FEF207F52AF2904D0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */,
+				FEF207F52AF2904D0025CB2C /* BloggingPromptRemoteObject.swift in Sources */,
 				43AF2F972107D3810069C012 /* QuickStartTourState.swift in Sources */,
 				FA4B202F29A619130089FE68 /* BlazeFlowCoordinator.swift in Sources */,
 				5D5A6E931B613CA400DAF819 /* OldReaderPostCardCell.swift in Sources */,
@@ -25101,7 +25101,7 @@
 				46F583AC2624CE790010A723 /* BlockEditorSettings+CoreDataProperties.swift in Sources */,
 				FABB24AA2602FC2C00C8785C /* ActivityListRow.swift in Sources */,
 				FABB24AB2602FC2C00C8785C /* UIColor+MurielColorsObjC.swift in Sources */,
-				FEF207F42AF2903E0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */,
+				FEF207F42AF2903E0025CB2C /* BloggingPromptRemoteObject.swift in Sources */,
 				FABB24AC2602FC2C00C8785C /* InteractiveNotificationsManager.swift in Sources */,
 				FABB24AD2602FC2C00C8785C /* PageTemplateLayout+CoreDataProperties.swift in Sources */,
 				F195C42D26DFBE3A000EC884 /* WordPressBackgroundTaskEventHandler.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5580,6 +5580,8 @@
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFF2A4C9855008A48E0 /* Blog+PublicizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */; };
+		FEF207F42AF2903E0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */; };
+		FEF207F52AF2904D0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */; };
 		FEF28E822ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
 		FEF28E832ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
 		FEF4DC5528439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
@@ -9403,6 +9405,7 @@
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
+		FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBloggingPromptsResponse.swift; sourceTree = "<group>"; };
 		FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailNewHeaderView.swift; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
@@ -14103,6 +14106,7 @@
 		93FA59DA18D88BDB001446BC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				FEF207F02AF287860025CB2C /* BloggingPrompts */,
 				F4B0F4812ADED999003ABC61 /* Domains */,
 				F4EDAA4F29A66DA900622D3D /* Reader Post */,
 				5D44EB361986D8BA008B7175 /* ReaderSiteService.h */,
@@ -14121,7 +14125,6 @@
 				F12FA5D82428FA8F0054DA21 /* AuthenticationService.swift */,
 				FA4BC0CF2996A589005EB077 /* BlazeService.swift */,
 				46F584812624DCC80010A723 /* BlockEditorSettingsService.swift */,
-				FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */,
 				822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */,
 				93C1148318EDF6E100DAC95C /* BlogService.h */,
 				93C1148418EDF6E100DAC95C /* BlogService.m */,
@@ -18370,6 +18373,15 @@
 			path = "Blogging Prompts";
 			sourceTree = "<group>";
 		};
+		FEF207F02AF287860025CB2C /* BloggingPrompts */ = {
+			isa = PBXGroup;
+			children = (
+				FEF207F22AF2882A0025CB2C /* RemoteBloggingPromptsResponse.swift */,
+				FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */,
+			);
+			path = BloggingPrompts;
+			sourceTree = "<group>";
+		};
 		FF2716901CAAC87B0006E2D4 /* UITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -21176,6 +21188,7 @@
 				8B074A5027AC3A64003A2EB8 /* BlogDashboardViewModel.swift in Sources */,
 				F5A34A9925DEF47D00C9654B /* WPMediaPicker+MediaPicker.swift in Sources */,
 				9A8ECE132254A3260043C8DA /* JetpackInstallError+Blocking.swift in Sources */,
+				FEF207F52AF2904D0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */,
 				43AF2F972107D3810069C012 /* QuickStartTourState.swift in Sources */,
 				FA4B202F29A619130089FE68 /* BlazeFlowCoordinator.swift in Sources */,
 				5D5A6E931B613CA400DAF819 /* OldReaderPostCardCell.swift in Sources */,
@@ -25088,6 +25101,7 @@
 				46F583AC2624CE790010A723 /* BlockEditorSettings+CoreDataProperties.swift in Sources */,
 				FABB24AA2602FC2C00C8785C /* ActivityListRow.swift in Sources */,
 				FABB24AB2602FC2C00C8785C /* UIColor+MurielColorsObjC.swift in Sources */,
+				FEF207F42AF2903E0025CB2C /* RemoteBloggingPromptsResponse.swift in Sources */,
 				FABB24AC2602FC2C00C8785C /* InteractiveNotificationsManager.swift in Sources */,
 				FABB24AD2602FC2C00C8785C /* PageTemplateLayout+CoreDataProperties.swift in Sources */,
 				F195C42D26DFBE3A000EC884 /* WordPressBackgroundTaskEventHandler.swift in Sources */,

--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -375,7 +375,7 @@ private extension BloggingPromptsServiceTests {
         let month = try XCTUnwrap(Int(components.first ?? ""))
         let day = try XCTUnwrap(Int(components.last ?? ""))
 
-        var dateComponents = Self.calendar.dateComponents(in: Self.utcTimeZone, from: Date())
+        var dateComponents = Self.calendar.dateComponents(in: .current, from: Date())
         dateComponents.year = forcedYear
         dateComponents.month = month
         dateComponents.day = day

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -119,6 +119,7 @@ class PromptRemindersSchedulerTests: XCTestCase {
         scheduler.schedule(schedule, for: blog, time: makeTime(hour: expectedHour, minute: expectedMinute)) { result in
             guard case .success = result else {
                 XCTFail("Expected a success result, but got error: \(result)")
+                expectation.fulfill()
                 return
             }
 
@@ -405,17 +406,17 @@ private extension PromptRemindersSchedulerTests {
             objects.append([
                 "id": 100 + i,
                 "text": "Prompt text \(i)",
-                "title": "Prompt title \(i)",
-                "content": "Prompt content \(i)",
                 "attribution": "",
                 "date": Self.dateFormatter.string(from: date),
                 "answered": false,
                 "answered_users_count": 0,
-                "answered_users_sample": [[String: Any]]()
+                "answered_users_sample": [[String: Any]](),
+                "answered_link": "",
+                "answered_link_text": "View all responses"
             ] as [String: Any])
         }
 
-        return ["prompts": objects]
+        return objects
     }
 
     func makeBlog() -> Blog {

--- a/WordPress/WordPressTest/Test Data/blogging-prompts-fetch-success.json
+++ b/WordPress/WordPressTest/Test Data/blogging-prompts-fetch-success.json
@@ -1,30 +1,30 @@
-{
-  "prompts": [
+[
     {
       "id": 239,
-      "text": "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.",
-      "title": "Prompt number 1",
-      "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
-      "attribution": "dayone",
       "date": "2022-05-03",
+      "label": "Daily writing prompt",
+      "text": "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.",
+      "attribution": "dayone",
       "answered": false,
       "answered_users_count": 0,
-      "answered_users_sample": []
+      "answered_users_sample": [],
+      "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-239",
+      "answered_link_text": "View all responses"
     },
     {
       "id": 248,
-      "text": "Tell us about a time when you felt out of place.",
-      "title": "Prompt number 10",
-      "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Tell us about a time when you felt out of place.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
-      "attribution": "",
       "date": "2021-09-12",
+      "label": "Daily writing prompt",
+      "text": "Tell us about a time when you felt out of place.",
+      "attribution": "",
       "answered": true,
       "answered_users_count": 1,
       "answered_users_sample": [
         {
           "avatar": "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
         }
-      ]
+      ],
+      "answered_link": "https:\/\/wordpress.com\/tag\/dailyprompt-248",
+      "answered_link_text": "View all responses"
     }
-  ]
-}
+]


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/20496

> **Note**
> Originally, this was meant to be done partially in WordPressKit (see https://github.com/wordpress-mobile/WordPressKit-iOS/pull/592), but I've decided to port the logic here since the Jetpack app is only the sole consumer of Blogging Prompts. 
> 
> See https://github.com/wordpress-mobile/WordPressKit-iOS/pull/592#issuecomment-1788042166 for more context. 

This PR migrates the Blogging Prompts fetching mechanism to the v3 version. Just so you know, the new endpoint version **will return a different set of prompts** when compared to v2, despite having the same date range. Some other notes:

- With the fetching logic now ported to `WordPress-iOS`, we now use `BloggingPromptRemoteObject` to represent a blogging prompt object from the v3 API.
  - I didn't port the Blogging Prompt Settings logic just yet to keep things manageable. It's a low priority, but once it's ported, we can remove the dependency on `BloggingPromptServiceRemote`.
- The `upsert` method is updated to overwrite based on `date` instead of `promptID`. Furthermore, the method ensures that there will only be one prompt per date. When processing new prompts, the first matching existing prompt will be overwritten, and the remaining "duplicates" will be deleted.
- Adjusted the unit tests and added new ones for various upsert scenarios.
- For locally scheduled prompts, any pending prompt reminders should be rescheduled and updated on app launch. See: [BloggingPromptCoordinator#updatePromptsIfNeeded](https://github.com/wordpress-mobile/WordPress-iOS/blob/901e6bf5ec58e043ee02e4529a88f45e2b5f61c8/WordPress/Classes/ViewRelated/Blog/Blogging%20Prompts/BloggingPromptCoordinator.swift#L82) and [PromptRemindersScheduler#processSchedule](https://github.com/wordpress-mobile/WordPress-iOS/blob/901e6bf5ec58e043ee02e4529a88f45e2b5f61c8/WordPress/Classes/Utility/Blogging%20Prompts/PromptRemindersScheduler.swift#L148)
- With this update, the `title` and `content` properties in `BloggingPrompt` are now unused. I'll make a separate PR that cleans up the property from the Core Data model to keep this PR manageable.

## To test

> **Important**
Before testing this PR, launch a previous version of the Jetpack app to locally save some prompts from the v2 API. You can do this by going to the prompts card > ellipsis menu > "View more prompts" to load v2 prompts about 10 days back.

- Launch the Jetpack app.
- Log in to a WP.com account.
- 🔎 Verify that the blogging prompt card appears on the home dashboard.
- Tap "View all responses".
- 🔎 Verify that the Reader stream shows the posts related to the prompt.
- Go back and tap "Answer prompt".
- 🔎 Verify that the draft post is opened and shows the prompt content in quotes.
- Go back, tap the ellipsis menu, and select "View more prompts".
- 🔎 Verify that the lists are loaded correctly, and no duplicated dates are shown.

#### Prompt scheduling

- Install the app store version of Jetpack.
- Schedule a prompt.
- Update the Jetpack with this version and launch the app.
- Wait for the reminder to be fired.
- 🔎 Verify that the reminder shows the contents of the new v3 prompts.

## Regression Notes
1. Potential unintended areas of impact
Prompts may be incorrectly loaded, or there could be other unexpected behavior with the Blogging Prompt features.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes, as described in the testing steps.

3. What automated tests I added (or what prevented me from doing so)
Adjusted the unit tests and added some new ones.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn't complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)