### PR TITLE
Posts & Pages: Invoke context menus on long press

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -322,6 +322,17 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self else { return nil }
+            let page = self.pages[indexPath.row]
+            let viewModel = PageMenuViewModel(page: page, indexPath: indexPath)
+            let helper = AbstractPostMenuHelper(page, viewModel: viewModel)
+            let cell = self.tableView.cellForRow(at: indexPath)
+            return helper.makeMenu(presentingView: cell?.contentView ?? UIView(), delegate: self)
+        }
+    }
+
     // MARK: - UITableViewDataSource
 
     func numberOfSections(in tableView: UITableView) -> Int {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -260,6 +260,17 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         editPost(apost: post)
     }
 
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self else { return nil }
+            let post = self.postAtIndexPath(indexPath)
+            let viewModel = PostListItemViewModel(post: post).statusViewModel
+            let helper = AbstractPostMenuHelper(post, viewModel: viewModel)
+            let cell = self.tableView.cellForRow(at: indexPath)
+            return helper.makeMenu(presentingView: cell?.contentView ?? UIView(), delegate: self)
+        }
+    }
+
     // MARK: - Post Actions
 
     override func createPost() {


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21717

To test:

- Verify that the context menus can be invoked on long press
- Smoke test that the actions work

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/54c03949-34eb-4d3a-bd4e-4c6e5a469f16


## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
