### PR TITLE
Fix invalid hidden privacy description

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 * [*] Site Media: Fix rare crashes in the Site Media screen and media picker [#21572]
 * [*] Site Media: Fix an issue with sharing PDF and other documents [#22021]
 * [*] Bug fix: Reader now scrolls to the top when tapping the status bar. [#21914]
+* [*] Fix an issue with incorrect description for "Hidden" post privacy status [#21955]
 * [*] [internal] Refactor sending the API requests for searching posts and pages. [#21976]
 * [*] Fix an issue in Menu screen where it fails to create default menu items. [#21949]
 * [*] [internal] Refactor how site's pages are loaded in Site Settings -> Homepage Settings. [#21974]

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteVisibility+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteVisibility+Extensions.swift
@@ -35,7 +35,7 @@ extension SiteVisibility {
         case .private:
             return NSLocalizedString("siteVisibility.private.hint", value: "Your site is only visible to you and users you approve.", comment: "Hint for users when private privacy setting is set")
         case .hidden:
-            return NSLocalizedString("siteVisibility.hidden.hint", value: "Your site is visible to everyone, but asks search engines not to index your site.", comment: "Hint for users when hidden privacy setting is set")
+            return NSLocalizedString("siteVisibility.hidden.hint", value: "Your site is hidden from visitors behind a \"Coming Soon\" notice until it is ready for viewing.", comment: "Hint for users when hidden privacy setting is set")
         case .public:
             return NSLocalizedString("siteVisibility.public.hint", value: "Your site is visible to everyone, and it may be indexed by search engines.", comment: "Hint for users when public privacy setting is set")
         case .unknown:

--- a/WordPress/Resources/ar.lproj/Localizable.strings
+++ b/WordPress/Resources/ar.lproj/Localizable.strings
@@ -10950,9 +10950,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "الخصوصية";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "إن موقعك مرئي للجميع، ولكنه يطلب من محركات البحث عدم فهرسة موقعك.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "مخفي";
 

--- a/WordPress/Resources/de.lproj/Localizable.strings
+++ b/WordPress/Resources/de.lproj/Localizable.strings
@@ -11008,9 +11008,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Datenschutz";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Deine Website ist für alle sichtbar. Suchmaschinen werden aufgefordert, sie nicht zu indexieren.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Verborgen";
 

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -8460,9 +8460,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Label for the blogging reminders setting */
 "sitesettings.reminders.title" = "Reminders";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Your site is visible to everyone, but asks search engines not to index your site.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Hidden";
 

--- a/WordPress/Resources/es.lproj/Localizable.strings
+++ b/WordPress/Resources/es.lproj/Localizable.strings
@@ -11049,9 +11049,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacidad";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Tu sitio es visible por todos pero pide a los motores de búsqueda que no lo indexen.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Oculto";
 

--- a/WordPress/Resources/fr.lproj/Localizable.strings
+++ b/WordPress/Resources/fr.lproj/Localizable.strings
@@ -11006,9 +11006,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Confidentialité";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Votre site est visible de tous, mais demande aux moteurs de recherche de ne pas l’indexer.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Masqué";
 

--- a/WordPress/Resources/he.lproj/Localizable.strings
+++ b/WordPress/Resources/he.lproj/Localizable.strings
@@ -11015,9 +11015,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "פרטיות";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "האתר זמין לכולם, אבל מנועי חיפוש מתבקשים לא לאנדקס אותו.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "מוסתר";
 

--- a/WordPress/Resources/id.lproj/Localizable.strings
+++ b/WordPress/Resources/id.lproj/Localizable.strings
@@ -11012,9 +11012,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privasi";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Situs Anda dapat dilihat oleh semua orang, tetapi Anda meminta mesin pencari untuk tidak mengindeks situs Anda.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Tersembunyi";
 

--- a/WordPress/Resources/it.lproj/Localizable.strings
+++ b/WordPress/Resources/it.lproj/Localizable.strings
@@ -11015,9 +11015,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacy";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Il tuo sito è visibile a chiunque, ma chiede ai motori di ricerca di non indicizzarlo.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Nascosto";
 

--- a/WordPress/Resources/ja.lproj/Localizable.strings
+++ b/WordPress/Resources/ja.lproj/Localizable.strings
@@ -11015,9 +11015,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "プライバシー";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "誰でもサイトを閲覧可能にし、検索エンジンにはインデックスしないよう要求します。";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "非表示";
 

--- a/WordPress/Resources/ko.lproj/Localizable.strings
+++ b/WordPress/Resources/ko.lproj/Localizable.strings
@@ -11021,9 +11021,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "개인정보";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "사이트가 모든 사람에게 공개되지만 검색 엔진에서 사이트가 검색되지 않도록 지정하세요.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "숨김";
 

--- a/WordPress/Resources/nl.lproj/Localizable.strings
+++ b/WordPress/Resources/nl.lproj/Localizable.strings
@@ -10804,9 +10804,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacy";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Je site is zichtbaar voor iedereen, maar vraagt de zoekmachines om je site niet te indexeren.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Verborgen";
 

--- a/WordPress/Resources/ro.lproj/Localizable.strings
+++ b/WordPress/Resources/ro.lproj/Localizable.strings
@@ -11049,9 +11049,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Confidențialitate";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Site-ul tău este vizibil pentru toată lumea, dar cere motoarelor de căutare să nu-ți indexeze site-ul.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Ascuns";
 

--- a/WordPress/Resources/ru.lproj/Localizable.strings
+++ b/WordPress/Resources/ru.lproj/Localizable.strings
@@ -11049,9 +11049,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Конфиденциальность";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Ваш сайт доступен всем посетителям, но для него настроен запрет на индексацию поисковыми системами.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Скрытый";
 

--- a/WordPress/Resources/sq.lproj/Localizable.strings
+++ b/WordPress/Resources/sq.lproj/Localizable.strings
@@ -10894,9 +10894,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privatësi";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Sajti juaj është i dukshëm për këdo, por u kërkon motorëve të kërkimeve të mos e indeksojnë.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "I fshehur";
 

--- a/WordPress/Resources/sv.lproj/Localizable.strings
+++ b/WordPress/Resources/sv.lproj/Localizable.strings
@@ -11046,9 +11046,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Integritet";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Din webbplats är synlig för alla, men begär av sökmotorer att inte indexera den.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Dold";
 

--- a/WordPress/Resources/tr.lproj/Localizable.strings
+++ b/WordPress/Resources/tr.lproj/Localizable.strings
@@ -11018,9 +11018,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Gizlilik";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "Siteniz herkes tarafından görüntülenebilir, ancak arama motorlarından kendisini indekslememelerini ister.";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "Gizli";
 

--- a/WordPress/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WordPress/Resources/zh-Hans.lproj/Localizable.strings
@@ -11018,9 +11018,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "隐私";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "您的站点对所有人均可见，但要求搜索引擎不要对您的站点进行索引。";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "已隐藏";
 

--- a/WordPress/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WordPress/Resources/zh-Hant.lproj/Localizable.strings
@@ -11009,9 +11009,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "隱私權";
 
-/* Hint for users when hidden privacy setting is set */
-"siteVisibility.hidden.hint" = "所有人都能看見你的網站，但系統會要求搜尋引擎不要將你的網站加入索引。";
-
 /* Text for privacy settings: Hidden */
 "siteVisibility.hidden.title" = "已隱藏";
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21942

To test:

- Open Site Settings / Privacy
- Verify that the description of the "Hidden" privacy type now matches wp.com

P.S. I'm not sure if it's the right way to trigger a refresh of the strings.

## Regression Notes
1. Potential unintended areas of impact: Site Settings
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
