### PR TITLE
Posts & Pages: Make the page attributes section collapsible

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -35,7 +35,17 @@ struct AbstractPostMenuHelper {
             .filter { !$0.buttons.isEmpty }
             .map { section in
                 let actions = makeActions(for: section.buttons, presentingView: presentingView, delegate: delegate)
-                return UIMenu(title: "", options: .displayInline, children: actions)
+                let menu = UIMenu(title: "", options: .displayInline, children: actions)
+
+                if let submenuButton = section.submenuButton {
+                    return UIMenu(
+                        title: submenuButton.title(for: post),
+                        image: submenuButton.icon,
+                        children: [menu]
+                    )
+                } else {
+                    return menu
+                }
             }
     }
 
@@ -84,6 +94,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .setParent: return UIImage(systemName: "text.append")
         case .setHomepage: return UIImage(systemName: "house")
         case .setPostsPage: return UIImage(systemName: "text.word.spacing")
+        case .pageAttributes: return UIImage(systemName: "doc")
         }
     }
 
@@ -112,6 +123,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .setParent: return Strings.setParent
         case .setHomepage: return Strings.setHomepage
         case .setPostsPage: return Strings.setPostsPage
+        case .pageAttributes: return Strings.pageAttributes
         }
     }
 
@@ -145,6 +157,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
             delegate.setHomepage(for: post)
         case .setPostsPage:
             delegate.setPostsPage(for: post)
+        case .pageAttributes:
+            break
         }
     }
 
@@ -164,5 +178,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let setParent = NSLocalizedString("posts.setParent.actionTitle", value: "Set parent", comment: "Set the parent page for the selected page.")
         static let setHomepage = NSLocalizedString("posts.setHomepage.actionTitle", value: "Set as homepage", comment: "Set the selected page as the homepage.")
         static let setPostsPage = NSLocalizedString("posts.setPostsPage.actionTitle", value: "Set as posts page", comment: "Set the selected page as a posts page.")
+        static let pageAttributes = NSLocalizedString("posts.pageAttributes.actionTitle", value: "Page attributes", comment: "Opens a submenu for page attributes.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -80,14 +80,14 @@ extension AbstractPostButton: AbstractPostMenuAction {
 
     var icon: UIImage? {
         switch self {
-        case .retry: return UIImage() // TODO
+        case .retry: return UIImage(systemName: "arrow.clockwise")
         case .view: return UIImage(systemName: "safari")
         case .publish: return UIImage(systemName: "globe")
         case .stats: return UIImage(systemName: "chart.bar.xaxis")
         case .duplicate: return UIImage(systemName: "doc.on.doc")
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")
-        case .cancelAutoUpload: return UIImage() // TODO
+        case .cancelAutoUpload: return UIImage(systemName: "xmark.icloud")
         case .share: return UIImage(systemName: "square.and.arrow.up")
         case .blaze: return UIImage(systemName: "flame")
         case .comments: return UIImage(systemName: "bubble")

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -6,6 +6,12 @@ protocol AbstractPostMenuViewModel {
 
 struct AbstractPostButtonSection {
     let buttons: [AbstractPostButton]
+    let submenuButton: AbstractPostButton?
+
+    init(buttons: [AbstractPostButton], submenuButton: AbstractPostButton? = nil) {
+        self.buttons = buttons
+        self.submenuButton = submenuButton
+    }
 }
 
 enum AbstractPostButton: Equatable {
@@ -22,6 +28,7 @@ enum AbstractPostButton: Equatable {
     case comments
 
     /// Specific to pages
+    case pageAttributes
     case setParent(IndexPath)
     case setHomepage
     case setPostsPage

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -14,7 +14,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             createPrimarySection(),
             createSecondarySection(),
             createBlazeSection(),
-            createSetPageSection(),
+            createSetPageAttributesSection(),
             createTrashSection()
         ]
     }
@@ -82,7 +82,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         return AbstractPostButtonSection(buttons: buttons)
     }
 
-    private func createSetPageSection() -> AbstractPostButtonSection {
+    private func createSetPageAttributesSection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
         guard page.status != .trash else {
@@ -99,7 +99,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             buttons.append(.setPostsPage)
         }
 
-        return AbstractPostButtonSection(buttons: buttons)
+        return AbstractPostButtonSection(buttons: buttons, submenuButton: .pageAttributes)
     }
 
     private func createTrashSection() -> AbstractPostButtonSection {


### PR DESCRIPTION
## Description
- Displays the pages attributes section as a submenu

https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/b6131ffa-3af9-4bfa-b257-4bce3ddbc130

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
