### PR TITLE
Posts & Pages: Minor fixes and improvements

### DIFF
--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -12,6 +12,8 @@ extension ReachabilityUtils {
     /// Performs the action when an internet connection is available
     /// If no internet connection is available an error message is displayed
     ///
+    /// - warning: Do not use as it can't reliable identify as the connection
+    /// is reachable or not. Always send the request.
     @objc class func onAvailableInternetConnectionDo(_ action: () -> Void) {
         guard ReachabilityUtils.isInternetReachable() else {
             WPError.showAlert(withTitle: DefaultNoConnectionMessage.title, message: DefaultNoConnectionMessage.message)

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -13,7 +13,8 @@ extension ReachabilityUtils {
     /// If no internet connection is available an error message is displayed
     ///
     /// - warning: Do not use as it can't reliable identify as the connection
-    /// is reachable or not. Always send the request.
+    /// is reachable or not and can significantly lag behind the actual
+    /// connectivity status.
     @objc class func onAvailableInternetConnectionDo(_ action: () -> Void) {
         guard ReachabilityUtils.isInternetReachable() else {
             WPError.showAlert(withTitle: DefaultNoConnectionMessage.title, message: DefaultNoConnectionMessage.message)

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -12,7 +12,7 @@ extension ReachabilityUtils {
     /// Performs the action when an internet connection is available
     /// If no internet connection is available an error message is displayed
     ///
-    /// - warning: Do not use as it can't reliable identify as the connection
+    /// - warning: Do not use it as it can't reliably identify as the connection
     /// is reachable or not and can significantly lag behind the actual
     /// connectivity status.
     @objc class func onAvailableInternetConnectionDo(_ action: () -> Void) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -2,7 +2,6 @@ import Foundation
 
 final class PageListItemViewModel {
     let page: Page
-    let indexPath: IndexPath
     let title: NSAttributedString
     let badgeIcon: UIImage?
     let badges: NSAttributedString
@@ -10,15 +9,14 @@ final class PageListItemViewModel {
     let accessibilityIdentifier: String?
     let pageMenuViewModel: PageMenuViewModel
 
-    init(page: Page, indexPath: IndexPath) {
+    init(page: Page) {
         self.page = page
-        self.indexPath = indexPath
         self.title = makeContentAttributedString(for: page)
         self.badgeIcon = makeBadgeIcon(for: page)
         self.badges = makeBadgesString(for: page)
         self.imageURL = page.featuredImageURL
         self.accessibilityIdentifier = page.slugForDisplay()
-        self.pageMenuViewModel = PageMenuViewModel(page: page, indexPath: indexPath)
+        self.pageMenuViewModel = PageMenuViewModel(page: page)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -59,9 +59,9 @@ extension PageListViewController: InteractivePostViewDelegate {
         // Not available for pages
     }
 
-    func setParent(for apost: AbstractPost, at indexPath: IndexPath) {
+    func setParent(for apost: AbstractPost) {
         guard let page = apost as? Page else { return }
-        setParentPage(for: page, at: indexPath)
+        setParentPage(for: page)
     }
 
     func setHomepage(for apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -89,11 +89,6 @@ extension PageListViewController: InteractivePostViewDelegate {
     }
 
     private func trashPage(_ page: Page, completion: @escaping () -> Void) {
-        guard ReachabilityUtils.isInternetReachable() else {
-            ReachabilityUtils.showNoInternetConnectionNotice(message: Strings.offlineMessage)
-            return
-        }
-
         let isPageTrashed = page.status == .trash
         let actionText = isPageTrashed ? Strings.DeletePermanently.actionText : Strings.Trash.actionText
         let titleText = isPageTrashed ? Strings.DeletePermanently.titleText : Strings.Trash.titleText

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -34,9 +34,7 @@ extension PageListViewController: InteractivePostViewDelegate {
     }
 
     func draft(_ apost: AbstractPost) {
-        ReachabilityUtils.onAvailableInternetConnectionDo {
-            moveToDraft(apost)
-        }
+        moveToDraft(apost)
     }
 
     func retry(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -108,7 +108,6 @@ extension PageListViewController: InteractivePostViewDelegate {
 
 private enum Strings {
 
-    static let offlineMessage = NSLocalizedString("pagesList.trash.offline", value: "Unable to trash pages while offline. Please try again later.", comment: "Message that appears when a user tries to trash a page while their device is offline.")
     static let cancelText = NSLocalizedString("pagesList.trash.cancel", value: "Cancel", comment: "Cancels an Action")
 
     enum DeletePermanently {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -322,7 +322,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             guard let self else { return nil }
             let page = self.pages[indexPath.row]
-            let viewModel = PageMenuViewModel(page: page, indexPath: indexPath)
+            let viewModel = PageMenuViewModel(page: page)
             let helper = AbstractPostMenuHelper(page, viewModel: viewModel)
             let cell = self.tableView.cellForRow(at: indexPath)
             return helper.makeMenu(presentingView: cell?.contentView ?? UIView(), delegate: self)
@@ -367,7 +367,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             let page = pages[indexPath.row]
             let indentation = getIndentationLevel(at: indexPath)
             let isFirstSubdirectory = getIndentationLevel(at: IndexPath(row: indexPath.row - 1, section: indexPath.section)) == (indentation - 1)
-            let viewModel = PageListItemViewModel(page: page, indexPath: indexPath)
+            let viewModel = PageListItemViewModel(page: page)
             cell.configure(with: viewModel, indentation: indentation, isFirstSubdirectory: isFirstSubdirectory, delegate: self)
             return cell
         }
@@ -400,7 +400,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     // MARK: - Cell Action Handling
 
-    func setParentPage(for page: Page, at index: IndexPath?) {
+    func setParentPage(for page: Page) {
         let request = NSFetchRequest<Page>(entityName: Page.entityName())
         let filter = PostListFilter.publishedFilter()
         request.predicate = filter.predicate(for: blog, author: .everyone)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -473,31 +473,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         ActionDispatcher.global.dispatch(NoticeAction.post(notice))
     }
 
-    private func handleTrashPage(_ post: AbstractPost) {
-        let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-        let deleteText: String
-        let messageText: String
-        let titleText: String
-
-        if post.status == .trash {
-            deleteText = NSLocalizedString("Delete Permanently", comment: "Delete option in the confirmation alert when deleting a page from the trash.")
-            titleText = NSLocalizedString("Delete Permanently?", comment: "Title of the confirmation alert when deleting a page from the trash.")
-            messageText = NSLocalizedString("Are you sure you want to permanently delete this page?", comment: "Message of the confirmation alert when deleting a page from the trash.")
-        } else {
-            deleteText = NSLocalizedString("Move to Trash", comment: "Trash option in the trash page confirmation alert.")
-            titleText = NSLocalizedString("Trash this page?", comment: "Title of the trash page confirmation alert.")
-            messageText = NSLocalizedString("Are you sure you want to trash this page?", comment: "Message of the trash page confirmation alert.")
-        }
-
-        let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
-
-        alertController.addCancelActionWithTitle(cancelText)
-        alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
-            self?.deletePost(post)
-        }
-        alertController.presentFromRootViewController()
-    }
-
     // MARK: - NetworkAwareUI
 
     override func noConnectionMessage() -> String {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -474,12 +474,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func handleTrashPage(_ post: AbstractPost) {
-        guard ReachabilityUtils.isInternetReachable() else {
-            let offlineMessage = NSLocalizedString("Unable to trash pages while offline. Please try again later.", comment: "Message that appears when a user tries to trash a page while their device is offline.")
-            ReachabilityUtils.showNoInternetConnectionNotice(message: offlineMessage)
-            return
-        }
-
         let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
         let deleteText: String
         let messageText: String

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -212,10 +212,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         return (success: wrappedSuccess, failure: wrappedFailure)
     }
 
-    override internal func lastSyncDate() -> Date? {
-        return blog?.lastPagesSync
-    }
-
     override func updateAndPerformFetchRequest() {
         super.updateAndPerformFetchRequest()
 

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -193,7 +193,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
-            [.view],
             [.moveToDraft],
             [.trash]
         ]

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -4,8 +4,6 @@ import XCTest
 
 final class PageMenuViewModelTests: CoreDataTestCase {
 
-    private let indexPath = IndexPath()
-
     func testPublishedPageButtonsWithBlazeEnabled() {
         // Given
         let page = PageBuilder(mainContext, canBlaze: true)
@@ -14,7 +12,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .build()
         let viewModel = PageMenuViewModel(
             page: page,
-            indexPath: indexPath,
             isSiteHomepage: false,
             isSitePostsPage: false,
             isJetpackFeaturesEnabled: true,
@@ -29,7 +26,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate],
             [.blaze],
-            [.setParent(indexPath), .setHomepage, .setPostsPage],
+            [.setParent, .setHomepage, .setPostsPage],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -43,7 +40,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .build()
         let viewModel = PageMenuViewModel(
             page: page,
-            indexPath: indexPath,
             isSiteHomepage: false,
             isSitePostsPage: false,
             isJetpackFeaturesEnabled: true,
@@ -57,7 +53,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate],
-            [.setParent(indexPath), .setHomepage, .setPostsPage],
+            [.setParent, .setHomepage, .setPostsPage],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -71,7 +67,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .build()
         let viewModel = PageMenuViewModel(
             page: page,
-            indexPath: indexPath,
             isSiteHomepage: false,
             isSitePostsPage: false,
             isJetpackFeaturesEnabled: false,
@@ -85,7 +80,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate],
-            [.setParent(indexPath), .setHomepage, .setPostsPage],
+            [.setParent, .setHomepage, .setPostsPage],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -99,7 +94,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .build()
         let viewModel = PageMenuViewModel(
             page: page,
-            indexPath: indexPath,
             isSiteHomepage: true,
             isSitePostsPage: false,
             isJetpackFeaturesEnabled: true,
@@ -114,7 +108,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate],
             [.blaze],
-            [.setParent(indexPath), .setPostsPage],
+            [.setParent, .setPostsPage],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -128,7 +122,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .build()
         let viewModel = PageMenuViewModel(
             page: page,
-            indexPath: indexPath,
             isSiteHomepage: false,
             isSitePostsPage: true,
             isJetpackFeaturesEnabled: true,
@@ -143,7 +136,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate],
             [.blaze],
-            [.setParent(indexPath), .setHomepage],
+            [.setParent, .setHomepage],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -154,7 +147,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let page = PageBuilder(mainContext)
             .with(status: .draft)
             .build()
-        let viewModel = PageMenuViewModel(page: page, indexPath: indexPath)
+        let viewModel = PageMenuViewModel(page: page)
 
         // When & Then
         let buttons = viewModel.buttonSections
@@ -163,7 +156,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.duplicate, .publish],
-            [.setParent(indexPath)],
+            [.setParent],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -174,7 +167,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let page = PageBuilder(mainContext)
             .with(status: .scheduled)
             .build()
-        let viewModel = PageMenuViewModel(page: page, indexPath: indexPath)
+        let viewModel = PageMenuViewModel(page: page)
 
         // When & Then
         let buttons = viewModel.buttonSections
@@ -183,7 +176,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .publish],
-            [.setParent(indexPath)],
+            [.setParent],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -194,7 +187,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let page = PageBuilder(mainContext)
             .with(status: .trash)
             .build()
-        let viewModel = PageMenuViewModel(page: page, indexPath: indexPath)
+        let viewModel = PageMenuViewModel(page: page)
         // When & Then
         let buttons = viewModel.buttonSections
             .filter { !$0.buttons.isEmpty }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -446,13 +446,8 @@ class AbstractPostListViewController: UIViewController,
             return
         }
 
-        if let lastSynced = lastSyncDate(), abs(lastSynced.timeIntervalSinceNow) <= type(of: self).postsControllerRefreshInterval {
-
-            refreshResults()
-        } else {
-            // Update in the background
-            syncItemsWithUserInteraction(false)
-        }
+        // Update in the background
+        syncItemsWithUserInteraction(false)
     }
 
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
@@ -484,10 +479,6 @@ class AbstractPostListViewController: UIViewController,
     @objc internal func postTypeToSync() -> PostServiceType {
         // Subclasses should override.
         return .any
-    }
-
-    @objc func lastSyncDate() -> Date? {
-        return blog.lastPostsSync
     }
 
     func syncHelper(_ syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((_ hasMore: Bool) -> ())?, failure: ((_ error: NSError) -> ())?) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -139,8 +139,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
             delegate.blaze(post)
         case .comments:
             delegate.comments(post)
-        case .setParent(let indexPath):
-            delegate.setParent(for: post, at: indexPath)
+        case .setParent:
+            delegate.setParent(for: post)
         case .setHomepage:
             delegate.setHomepage(for: post)
         case .setPostsPage:

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -22,7 +22,7 @@ enum AbstractPostButton: Equatable {
     case comments
 
     /// Specific to pages
-    case setParent(IndexPath)
+    case setParent
     case setHomepage
     case setPostsPage
 }

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -13,13 +13,13 @@ protocol InteractivePostViewDelegate: AnyObject {
     func share(_ post: AbstractPost, fromView view: UIView)
     func blaze(_ post: AbstractPost)
     func comments(_ post: AbstractPost)
-    func setParent(for post: AbstractPost, at indexPath: IndexPath)
+    func setParent(for post: AbstractPost)
     func setHomepage(for post: AbstractPost)
     func setPostsPage(for post: AbstractPost)
 }
 
 extension InteractivePostViewDelegate {
-    func setParent(for post: AbstractPost, at indexPath: IndexPath) {}
+    func setParent(for post: AbstractPost) {}
     func setHomepage(for post: AbstractPost) {}
     func setPostsPage(for post: AbstractPost) {}
 

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -42,7 +42,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
     private func createPrimarySection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        if !page.isFailed {
+        if !page.isFailed && page.status != .trash {
             buttons.append(.view)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -3,7 +3,6 @@ import Foundation
 final class PageMenuViewModel: AbstractPostMenuViewModel {
 
     private let page: Page
-    private let indexPath: IndexPath
     private let isSiteHomepage: Bool
     private let isSitePostsPage: Bool
     private let isJetpackFeaturesEnabled: Bool
@@ -19,20 +18,18 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         ]
     }
 
-    convenience init(page: Page, indexPath: IndexPath) {
-        self.init(page: page, indexPath: indexPath, isSiteHomepage: page.isSiteHomepage, isSitePostsPage: page.isSitePostsPage)
+    convenience init(page: Page) {
+        self.init(page: page, isSiteHomepage: page.isSiteHomepage, isSitePostsPage: page.isSitePostsPage)
     }
 
     init(
         page: Page,
-        indexPath: IndexPath,
         isSiteHomepage: Bool,
         isSitePostsPage: Bool,
         isJetpackFeaturesEnabled: Bool = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
         isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled()
     ) {
         self.page = page
-        self.indexPath = indexPath
         self.isSiteHomepage = isSiteHomepage
         self.isSitePostsPage = isSitePostsPage
         self.isJetpackFeaturesEnabled = isJetpackFeaturesEnabled
@@ -89,7 +86,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             return AbstractPostButtonSection(buttons: buttons)
         }
 
-        buttons.append(.setParent(indexPath))
+        buttons.append(.setParent)
 
         if page.status == .publish, !isSiteHomepage {
             buttons.append(.setHomepage)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -142,7 +142,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     private func createPrimarySection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        if !post.isFailed {
+        if !post.isFailed && post.status != .trash {
             buttons.append(.view)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -364,12 +364,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
-        guard ReachabilityUtils.isInternetReachable() else {
-            let offlineMessage = NSLocalizedString("Unable to trash posts while offline. Please try again later.", comment: "Message that appears when a user tries to trash a post while their device is offline.")
-            ReachabilityUtils.showNoInternetConnectionNotice(message: offlineMessage)
-            return
-        }
-
         let cancelText: String
         let deleteText: String
         let messageText: String

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -342,9 +342,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func stats(for post: AbstractPost) {
-        ReachabilityUtils.onAvailableInternetConnectionDo {
-            viewStatsForPost(post)
-        }
+        viewStatsForPost(post)
     }
 
     func duplicate(_ post: AbstractPost) {
@@ -402,9 +400,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func draft(_ post: AbstractPost) {
-        ReachabilityUtils.onAvailableInternetConnectionDo {
-            moveToDraft(post)
-        }
+        moveToDraft(post)
     }
 
     func retry(_ post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -178,10 +178,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         return .post
     }
 
-    override func lastSyncDate() -> Date? {
-        return blog?.lastPostsSync
-    }
-
     // MARK: - Data Model Interaction
 
     /// Retrieves the post object at the specified index path.

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchTokenTableCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchTokenTableCell.swift
@@ -11,6 +11,8 @@ final class PostSearchTokenTableCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+        selectionStyle = .none
+
         iconView.tintColor = .secondaryLabel
 
         separator.backgroundColor = .separator
@@ -18,7 +20,7 @@ final class PostSearchTokenTableCell: UITableViewCell {
         stackView.spacing = 8
         stackView.alignment = .center
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.layoutMargins = UIEdgeInsets(top: 4, left: 16, bottom: 14, right: 16)
+        stackView.layoutMargins = UIEdgeInsets(top: 4, left: 16, bottom: 12, right: 16)
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
         contentView.addSubview(stackView)

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -114,7 +114,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
                 return cell
             case let page as Page:
                 let cell = tableView.dequeueReusableCell(withIdentifier: Constants.pageCellID, for: indexPath) as! PageListCell
-                let viewModel = PageListItemViewModel(page: page, indexPath: indexPath)
+                let viewModel = PageListItemViewModel(page: page)
                 cell.configure(with: viewModel, delegate: delegate)
                 updateHighlights(for: [cell], searchTerm: self.viewModel.searchTerm)
                 return cell

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -117,7 +117,6 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
             .filter { !$0.buttons.isEmpty }
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
-            [.view],
             [.moveToDraft],
             [.trash]
         ]


### PR DESCRIPTION
- Remove indexPath parameter from setParentPage action
- Remove .view action from trashed post fixing https://github.com/wordpress-mobile/WordPress-iOS/issues/14428 (I checked there is no way to preview it)
- Fix selection style for search tokens and slightly adjust the layout
- Remove isInternetReachable checks
- Remove onAvailableInternetConnectionDo usage
- Remove unused lastSyncDate (it never worked and was removed in https://github.com/wordpress-mobile/WordPress-iOS/pull/21861)


## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
