### PR TITLE
Add Swift library search path to fix local Gutenberg builds

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26491,7 +26491,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "$(VERSION_SHORT)";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -26558,7 +26561,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "$(VERSION_SHORT)";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -28384,7 +28390,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "$(VERSION_SHORT)";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -28822,7 +28831,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "$(VERSION_SHORT)";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -29328,7 +29340,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "${VERSION_SHORT}";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -29397,7 +29412,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "${VERSION_SHORT}";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -29465,7 +29483,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "${VERSION_SHORT}";
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -29532,7 +29553,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
+					"$(inherited)",
+				);
 				MARKETING_VERSION = "${VERSION_SHORT}";
 				OTHER_CFLAGS = (
 					"$(inherited)",


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/pull/21504#issuecomment-1789466523.

### The problem this PR solves:

1. As part of the "post install" step of local Gutenberg builds (`LOCAL_GUTENBERG=true bundle exec pod install`), [we run the scripts that come with React Native](https://github.com/wordpress-mobile/WordPress-iOS/blob/15b16539475e52b5257031efbb41c182d5c0956d/Gutenberg/cocoapods_helpers.rb#L126).
2. In the script for the RN version we're currently using ([0.71.11](https://github.com/WordPress/gutenberg/blob/c2717e157278f45638e22f01a74866ab9f3865a2/packages/react-native-editor/package.json#L60C20-L60C27)) [it checks to see](https://github.com/facebook/react-native/blob/7ea7d946c643f076c29bcf11b927f7569e3c516f/scripts/cocoapods/utils.rb#L165) if `$(SDKROOT)/usr/lib/swift` is in the library search paths.
3. If it isn't, it inserts the string into `lib_search_paths` which is `LIBRARY_SEARCH_PATHS` in the Xcode project file. 

**This is where things go wrong:** It may be an array in the Ruby script, but eventually it turns into a concatenated malformed string which breaks our builds:

```
LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift$(inherited)";
```

rather than what we needed:

```
LIBRARY_SEARCH_PATHS = (
    "$(SDKROOT)/usr/lib/swift",
    "$(inherited)",
);
```

Since the RN script only adds the string if it doesn't exist, this PR goes ahead and puts it there in array form. A potential downside, though, is that `"$(SDKROOT)/usr/lib/swift"` is now included in standard builds that don't build Gutenberg locally.


To test:
- Can build with and without `LOCAL_GUTENBERG=true bundle exec pod install`
- `LIBRARY_SEARCH_PATHS` are updated on all targets

## Regression Notes
1. Potential unintended areas of impact


6. What I did to test those areas of impact (or what existing automated tests I relied on)


7. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
