### PR TITLE
Posts & Pages: Search for all posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -202,9 +202,6 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
         if let token = selectedTokens.lazy.compactMap({ $0 as? PostSearchAuthorToken }).first {
             return token.authorID
         }
-        if settings.shouldShowOnlyMyPosts(), let userID = blog.userID {
-            return userID
-        }
         return nil
     }
 


### PR DESCRIPTION
Fixes the comment https://github.com/wordpress-mobile/WordPress-iOS/pull/21953#issuecomment-1791064936 by searching posts from everyone by default.

To test:

- Login on a site with multiple users
- Open Posts
- Select filter "Me"
- Open Search
- Verify that search doesn't apply the filter and search all posts

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
