### PR TITLE
Posts & Pages: Enable long press in search results

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -47,7 +47,7 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
 
     func configure(with viewModel: PageListItemViewModel, indentation: Int = 0, isFirstSubdirectory: Bool = false, delegate: InteractivePostViewDelegate? = nil) {
         if let delegate {
-            configureEllipsisButton(with: viewModel.page, viewModel: viewModel.pageMenuViewModel, delegate: delegate)
+            configureEllipsisButton(with: viewModel.page, delegate: delegate)
         }
 
         titleLabel.attributedText = viewModel.title
@@ -75,10 +75,9 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         indentationIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
     }
 
-    private func configureEllipsisButton(with page: Page, viewModel: PageMenuViewModel, delegate: InteractivePostViewDelegate) {
-        let menuHelper = AbstractPostMenuHelper(page, viewModel: viewModel)
+    private func configureEllipsisButton(with page: Page, delegate: InteractivePostViewDelegate) {
         ellipsisButton.showsMenuAsPrimaryAction = true
-        ellipsisButton.menu = menuHelper.makeMenu(presentingView: ellipsisButton, delegate: delegate)
+        ellipsisButton.menu = AbstractPostMenuHelper(page).makeMenu(presentingView: ellipsisButton, delegate: delegate)
     }
 
     // MARK: - Setup

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -7,7 +7,6 @@ final class PageListItemViewModel {
     let badges: NSAttributedString
     let imageURL: URL?
     let accessibilityIdentifier: String?
-    let pageMenuViewModel: PageMenuViewModel
 
     init(page: Page) {
         self.page = page
@@ -16,7 +15,6 @@ final class PageListItemViewModel {
         self.badges = makeBadgesString(for: page)
         self.imageURL = page.featuredImageURL
         self.accessibilityIdentifier = page.slugForDisplay()
-        self.pageMenuViewModel = PageMenuViewModel(page: page)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -319,7 +319,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
-        UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+        guard indexPath.section == Section.pages.rawValue else { return nil }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             guard let self else { return nil }
             let page = self.pages[indexPath.row]
             let cell = self.tableView.cellForRow(at: indexPath)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -324,7 +324,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             guard let self else { return nil }
             let page = self.pages[indexPath.row]
             let cell = self.tableView.cellForRow(at: indexPath)
-            return AbstractPostHelper.makeContextMenu(for: page, presentingView: cell, delegate: self)
+            return AbstractPostMenuHelper(page).makeMenu(presentingView: cell ?? UIView(), delegate: self)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -322,10 +322,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             guard let self else { return nil }
             let page = self.pages[indexPath.row]
-            let viewModel = PageMenuViewModel(page: page)
-            let helper = AbstractPostMenuHelper(page, viewModel: viewModel)
             let cell = self.tableView.cellForRow(at: indexPath)
-            return helper.makeMenu(presentingView: cell?.contentView ?? UIView(), delegate: self)
+            return AbstractPostHelper.makeContextMenu(for: page, presentingView: cell, delegate: self)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 extension AbstractPostHelper {
+    // MARK: - Swipe Actions
+
     static func makeLeadingContextualActions(for post: AbstractPost, delegate: InteractivePostViewDelegate) -> [UIContextualAction] {
         var actions: [UIContextualAction] = []
 
@@ -41,6 +43,23 @@ extension AbstractPostHelper {
         }
 
         return actions
+    }
+
+    // MARK: - Context Menu
+
+    static func makeContextMenu(for post: AbstractPost, presentingView: UIView?, delegate: InteractivePostViewDelegate) -> UIMenu {
+        switch post {
+        case let post as Post:
+            let viewModel = PostListItemViewModel(post: post).statusViewModel
+            let helper = AbstractPostMenuHelper(post, viewModel: viewModel)
+            return helper.makeMenu(presentingView: presentingView ?? UIView(), delegate: delegate)
+        case let page as Page:
+            let viewModel = PageMenuViewModel(page: page)
+            let helper = AbstractPostMenuHelper(page, viewModel: viewModel)
+            return helper.makeMenu(presentingView: presentingView ?? UIView(), delegate: delegate)
+        default:
+            fatalError("Unsupported post type: \(type(of: post))")
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
@@ -44,23 +44,6 @@ extension AbstractPostHelper {
 
         return actions
     }
-
-    // MARK: - Context Menu
-
-    static func makeContextMenu(for post: AbstractPost, presentingView: UIView?, delegate: InteractivePostViewDelegate) -> UIMenu {
-        switch post {
-        case let post as Post:
-            let viewModel = PostListItemViewModel(post: post).statusViewModel
-            let helper = AbstractPostMenuHelper(post, viewModel: viewModel)
-            return helper.makeMenu(presentingView: presentingView ?? UIView(), delegate: delegate)
-        case let page as Page:
-            let viewModel = PageMenuViewModel(page: page)
-            let helper = AbstractPostMenuHelper(page, viewModel: viewModel)
-            return helper.makeMenu(presentingView: presentingView ?? UIView(), delegate: delegate)
-        default:
-            fatalError("Unsupported post type: \(type(of: post))")
-        }
-    }
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -2,13 +2,10 @@ import Foundation
 import UIKit
 
 struct AbstractPostMenuHelper {
-
     let post: AbstractPost
-    let viewModel: AbstractPostMenuViewModel
 
-    init(_ post: AbstractPost, viewModel: AbstractPostMenuViewModel) {
+    init(_ post: AbstractPost) {
         self.post = post
-        self.viewModel = viewModel
     }
 
     /// Creates a menu for post actions
@@ -25,13 +22,25 @@ struct AbstractPostMenuHelper {
         ])
     }
 
+    private func makeSections() -> [AbstractPostButtonSection] {
+        switch post {
+        case let post as Post:
+            return PostCardStatusViewModel(post: post).buttonSections
+        case let page as Page:
+            return PageMenuViewModel(page: page).buttonSections
+        default:
+            assertionFailure("Unsupported entity: \(post)")
+            return []
+        }
+    }
+
     /// Creates post actions grouped into sections
     ///
     /// - parameters:
     ///   - presentingView: The view presenting the menu
     ///   - delegate: The delegate that performs post actions
     private func makeSections(presentingView: UIView, delegate: InteractivePostViewDelegate) -> [UIMenu] {
-        return viewModel.buttonSections
+        return makeSections()
             .filter { !$0.buttons.isEmpty }
             .map { section in
                 let actions = makeActions(for: section.buttons, presentingView: presentingView, delegate: delegate)

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -27,13 +27,13 @@ final class PostListHeaderView: UIView {
 
     func configure(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate? = nil) {
         if let delegate {
-            configureEllipsisButton(with: viewModel.post, viewModel: viewModel.statusViewModel, delegate: delegate)
+            configureEllipsisButton(with: viewModel.post, delegate: delegate)
         }
         textLabel.attributedText = viewModel.badges
     }
 
-    private func configureEllipsisButton(with post: Post, viewModel: PostCardStatusViewModel, delegate: InteractivePostViewDelegate) {
-        let menuHelper = AbstractPostMenuHelper(post, viewModel: viewModel)
+    private func configureEllipsisButton(with post: Post, delegate: InteractivePostViewDelegate) {
+        let menuHelper = AbstractPostMenuHelper(post)
         ellipsisButton.showsMenuAsPrimaryAction = true
         ellipsisButton.menu = menuHelper.makeMenu(presentingView: ellipsisButton, delegate: delegate)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -6,7 +6,7 @@ final class PostListItemViewModel {
     let imageURL: URL?
     let badges: NSAttributedString
     let isEnabled: Bool
-    let statusViewModel: PostCardStatusViewModel
+    private let statusViewModel: PostCardStatusViewModel
 
     var status: String { statusViewModel.statusAndBadges(separatedBy: " · ")}
     var statusColor: UIColor { statusViewModel.statusColor }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -258,10 +258,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
             guard let self else { return nil }
             let post = self.postAtIndexPath(indexPath)
-            let viewModel = PostListItemViewModel(post: post).statusViewModel
-            let helper = AbstractPostMenuHelper(post, viewModel: viewModel)
             let cell = self.tableView.cellForRow(at: indexPath)
-            return helper.makeMenu(presentingView: cell?.contentView ?? UIView(), delegate: self)
+            return AbstractPostHelper.makeContextMenu(for: post, presentingView: cell, delegate: self)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -259,7 +259,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             guard let self else { return nil }
             let post = self.postAtIndexPath(indexPath)
             let cell = self.tableView.cellForRow(at: indexPath)
-            return AbstractPostHelper.makeContextMenu(for: post, presentingView: cell, delegate: self)
+            return AbstractPostMenuHelper(post).makeMenu(presentingView: cell ?? UIView(), delegate: self)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -188,7 +188,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             guard let self, let delegate = self.delegate else { return nil }
             let post = self.viewModel.posts[indexPath.row]
             let cell = self.tableView.cellForRow(at: indexPath)
-            return AbstractPostHelper.makeContextMenu(for: post, presentingView: cell, delegate: delegate)
+            return AbstractPostMenuHelper(post).makeMenu(presentingView: cell ?? UIView(), delegate: delegate)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -172,7 +172,6 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
             default:
                 fatalError("Unsupported post")
             }
-            break // TODO: Show post
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -182,6 +182,16 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         }
     }
 
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        guard indexPath.section == SectionID.posts.rawValue else { return nil }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self, let delegate = self.delegate else { return nil }
+            let post = self.viewModel.posts[indexPath.row]
+            let cell = self.tableView.cellForRow(at: indexPath)
+            return AbstractPostHelper.makeContextMenu(for: post, presentingView: cell, delegate: delegate)
+        }
+    }
+
     func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let delegate, indexPath.section == SectionID.posts.rawValue else { return nil }
         let actions = AbstractPostHelper.makeLeadingContextualActions(for: viewModel.posts[indexPath.row], delegate: delegate)


### PR DESCRIPTION
To test:

- Open Posts/Pages
- Verify that context menus open and test some of the actions (if one works, so should the others)
- Open search
- Verify that the same content menus open on long press

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x]  I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
