### PR TITLE
Don't require user to have blogs in order to migrate

### DIFF
--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -187,7 +187,7 @@ protocol ContentMigrationEligibilityProvider {
 
 extension AppConfiguration: ContentMigrationEligibilityProvider {
     var isEligibleForMigration: Bool {
-        Self.isWordPress && AccountHelper.isLoggedIn && AccountHelper.hasBlogs
+        Self.isWordPress && AccountHelper.isLoggedIn
     }
 }
 


### PR DESCRIPTION
Fixes #21959

## Description

This PR drops the requirement for the user to have at least one blog in order to be eligible to transfer data (including their logged-in session) to the Jetpack app after download.

Potential issues:
- Jetpack welcome view says "We found your site" (the user doesn't have any sites)
- Sending an email may be noisy, since these users most likely just signed up

It would also be nice if the user landed back on the site creation screen in the Jetpack app so they can resume the flow as quickly as possible.

| Before | After |
| - | - |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/a969a7b3-b1f7-48e6-b08d-10279735927d" /> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/fc420b63-0a96-44d7-aad2-a9a09e643718" /> |

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
