### PR TITLE
[Domain Management] Pull to Refresh All Domains

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift
@@ -98,7 +98,9 @@ class AllDomainsListViewModel {
     // MARK: - Load Domains
 
     func loadData() {
-        self.state = .loading
+        if domains.isEmpty {
+            self.state = .loading
+        }
         self.fetchAllDomains { [weak self] result in
             guard let self else {
                 return

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListTableViewCell.swift
@@ -10,6 +10,7 @@ final class AllDomainsListTableViewCell: UITableViewCell {
 
         if let hostingController {
             hostingController.rootView = content
+            hostingController.view.invalidateIntrinsicContentSize()
         } else {
             let hostingController = UIHostingController(rootView: content)
             hostingController.view.backgroundColor = .clear
@@ -21,8 +22,6 @@ final class AllDomainsListTableViewCell: UITableViewCell {
             hostingController.didMove(toParent: parent)
             self.hostingController = hostingController
         }
-
-        self.hostingController?.view.layoutIfNeeded()
     }
 
     typealias ViewModel = AllDomainsListCardView.ViewModel

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -184,12 +184,12 @@ final class AllDomainsListViewController: UIViewController {
 extension AllDomainsListViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        // Workaround to accurately control section height using `tableView.sectionHeaderHeight`.
+        // Workaround to change the section height using `tableView.sectionHeaderHeight`.
         return UIView()
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        // Workaround to accurately control footer height using `tableView.sectionFooterHeight`.
+        // Workaround to change the footer height using `tableView.sectionFooterHeight`.
         return UIView()
     }
 

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -69,7 +69,7 @@ final class AllDomainsListViewController: UIViewController {
         self.setupBarButtonItems()
         self.setupSearchBar()
         self.setupTableView()
-        self.setupRefreshContro()
+        self.setupRefreshControl()
         self.setupEmptyView()
         self.setupNavigationBarAppearance()
     }
@@ -127,7 +127,7 @@ final class AllDomainsListViewController: UIViewController {
         self.navigationItem.compactScrollEdgeAppearance = appearance
     }
 
-    private func setupRefreshContro() {
+    private func setupRefreshControl() {
         let action = UIAction { [weak self] action in
             guard let self, let refreshControl = action.sender as? UIRefreshControl else {
                 return
@@ -139,7 +139,7 @@ final class AllDomainsListViewController: UIViewController {
         self.tableView.addSubview(refreshControl)
     }
 
-    // MARK: - UI Updates
+    // MARK: - Reacting to State Changes
 
     private func observeState() {
         self.viewModel.$state.sink { [weak self] state in

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -70,6 +70,7 @@ final class AllDomainsListViewController: UIViewController {
         self.setupSearchBar()
         self.setupTableView()
         self.setupEmptyView()
+        self.setupNavigationBarAppearance()
     }
 
     private func setupBarButtonItems() {
@@ -116,6 +117,13 @@ final class AllDomainsListViewController: UIViewController {
             self.emptyView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor, constant: Length.Padding.double),
             self.emptyView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor, constant: -Length.Padding.double)
         ])
+    }
+
+    /// Force the navigation bar separator to be always visible.
+    private func setupNavigationBarAppearance() {
+        let appearance = self.navigationController?.navigationBar.standardAppearance
+        self.navigationItem.scrollEdgeAppearance = appearance
+        self.navigationItem.compactScrollEdgeAppearance = appearance
     }
 
     // MARK: - UI Updates

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -26,7 +26,7 @@ final class AllDomainsListViewController: UIViewController {
     // MARK: - Views
 
     private let tableView = UITableView(frame: .zero, style: .insetGrouped)
-
+    private let refreshControl = UIRefreshControl()
     private let emptyView = AllDomainsListEmptyView()
 
     // MARK: - Properties
@@ -69,6 +69,7 @@ final class AllDomainsListViewController: UIViewController {
         self.setupBarButtonItems()
         self.setupSearchBar()
         self.setupTableView()
+        self.setupRefreshContro()
         self.setupEmptyView()
         self.setupNavigationBarAppearance()
     }
@@ -126,6 +127,18 @@ final class AllDomainsListViewController: UIViewController {
         self.navigationItem.compactScrollEdgeAppearance = appearance
     }
 
+    private func setupRefreshContro() {
+        let action = UIAction { [weak self] action in
+            guard let self, let refreshControl = action.sender as? UIRefreshControl else {
+                return
+            }
+            self.tableView.sendSubviewToBack(refreshControl)
+            self.viewModel.loadData()
+        }
+        self.refreshControl.addAction(action, for: .valueChanged)
+        self.tableView.addSubview(refreshControl)
+    }
+
     // MARK: - UI Updates
 
     private func observeState() {
@@ -136,6 +149,7 @@ final class AllDomainsListViewController: UIViewController {
             self.state = state
             switch state {
             case .normal, .loading:
+                self.refreshControl.endRefreshing()
                 self.tableView.isHidden = false
                 self.tableView.reloadData()
             case .message(let viewModel):


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/21860#pullrequestreview-1707485211

## Description

This PR implements the following:
- Ability to pull-to-refresh All Domains list.
- Shows the default navigation bar shadow, to visually separate between the navigation bar and the list.

| Search Inactive | Search Active |
| --------------- | -------------- |
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/4d2c8540-563f-4783-a2d1-f81c7056317a) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/42e708f1-67c2-4283-a9d5-7c6ee54d3937) |

## Test Instructions

#### Prerequisites
Enable `Domain Management` feature flag.

#### Case 1: Search Inactive
1. Install Jetpack and login.
2. Head to Me > All Domains.
3. Wait for the domains to load then pull-to-refresh the list.
4. **Expect** the refresh control to disappear and the list to reload.

#### Case 2: Search Active
1. Install Jetpack and login.
2. Head to Me > All Domains.
3. Search for an existing domain.
4. **Verify** the pull-to-refresh is working and it maintains the search result.

_N.B. For Automattic developers, enable / disable the proxy, then refresh the domains list to see the difference._

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
