### PR TITLE
Use PostRepository to fetch all pages in homepage settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Bug fix: Reader now scrolls to the top when tapping the status bar. [#21914]
 * [*] Fix an issue in Menu screen where it fails to create default menu items. [#21949]
+* [*] [internal] Refactor how site's pages are loaded in Site Settings -> Homepage Settings. [#21974]
 
 23.6
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -68,23 +68,21 @@ import WordPressShared
         ImmuTable.registerRows([CheckmarkRow.self, NavigationItemRow.self, ActivityIndicatorRow.self], tableView: tableView)
         reloadViewModel()
 
-        fetchAllPages()
-    }
-
-    private func fetchAllPages() {
-        let options = PostServiceSyncOptions()
-        options.number = 20
-
-        postService.syncPosts(ofType: .page, with: options, for: blog, success: { [weak self] posts in
-            self?.reloadViewModel()
-        }, failure: { _ in
-
-        })
+        fetchAllPagesTask = postRepository.fetchAllPages(statuses: [], in: TaggedManagedObjectID(blog))
     }
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         animateDeselectionInteractively()
+    }
+
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        if self.navigationController == nil {
+            fetchAllPagesTask?.cancel()
+            fetchAllPagesTask = nil
+        }
     }
 
     // MARK: - Model


### PR DESCRIPTION
There are a few issues in the "sync posts" function in `PostServices`, which I have described in https://github.com/wordpress-mobile/WordPress-iOS/pull/21814. This PR replaces the "sync posts" function used in the Homepage Settings screen with the new fetch all pages function.

There is also a potential bug in the original implementations, where it fetches 20 pages from the site. Since there is no way to load other pages, user may not be able to find the page they are looking for.

## Test Instructions

Verify you can change site's homepage from the Homepage screen. If you can't see the screen from Site Settings -> Homepage Settings, try disabling this permission check.

https://github.com/wordpress-mobile/WordPress-iOS/blob/1938f12a70020e748cf88d05674534cac707b4a1/WordPress/Classes/ViewRelated/Blog/Site%20Settings/SiteSettingsViewController.m#L169-L171

> **Note**
> The diff looks a bit messy, but it becomes fairly straight forward when reviewed commit by commit.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the Test Instructions section.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A