### PR TITLE
Posts & Pages: Normalize newlines

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -72,8 +72,8 @@ private func makeContentString(for post: Post) -> NSAttributedString {
         string.append(titleAttributedString)
     }
     if !snippet.isEmpty {
-        // Normalize newlines for list items
-        let adjustedSnippet = snippet.replacingOccurrences(of: "\n\n\n\n", with: "\n")
+        // Normalize newlines by collapsing multiple occurrences of newlines to a single newline
+        let adjustedSnippet = snippet.replacingOccurrences(of: "[\n]{2,}", with: "\n", options: .regularExpression)
         if string.length > 0 {
             string.append(NSAttributedString(string: "\n"))
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -72,6 +72,8 @@ private func makeContentString(for post: Post) -> NSAttributedString {
         string.append(titleAttributedString)
     }
     if !snippet.isEmpty {
+        // Normalize newlines for list items
+        let adjustedSnippet = snippet.replacingOccurrences(of: "\n\n\n\n", with: "\n")
         if string.length > 0 {
             string.append(NSAttributedString(string: "\n"))
         }
@@ -79,7 +81,7 @@ private func makeContentString(for post: Post) -> NSAttributedString {
             .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular),
             .foregroundColor: UIColor.textSubtle
         ]
-        let snippetAttributedString = NSAttributedString(string: snippet, attributes: attributes)
+        let snippetAttributedString = NSAttributedString(string: adjustedSnippet, attributes: attributes)
         string.append(snippetAttributedString)
     }
 


### PR DESCRIPTION
Fixes an issue where empty lines were being rendered in the posts cell

To test:
- Publish a post with a title and a single list item block, with 2+ items in the list
- Verify the post cell displays three lines: the title and the the first two items of the list block

Before | After
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/016c2454-13cc-4070-a762-16e743d35094" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/e1ac707e-fd90-4c8b-8e55-57e84257eaeb" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

