### PR TITLE
Assert tests with localized values

### DIFF
--- a/WordPress/WordPressTest/Dashboard/BlazeCampaignViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlazeCampaignViewModelTests.swift
@@ -12,7 +12,7 @@ final class BlazeCampaignViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.imageURL, URL(string: "https://i0.wp.com/public-api.wordpress.com/wpcom/v2/wordads/dsp/api/v1/dsp/creatives/56259/image?w=600&zoom=2"))
 
         // Then stats are displayed
-        XCTAssertEqual(viewModel.impressions, "1,000")
+        XCTAssertEqual(viewModel.impressions, 1_000.abbreviatedString())
         XCTAssertEqual(viewModel.clicks, "235")
         XCTAssertTrue(viewModel.isShowingStats)
     }

--- a/WordPress/WordPressTest/Dashboard/DashboardStatsViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardStatsViewModelTests.swift
@@ -24,9 +24,9 @@ class DashboardStatsViewModelTests: XCTestCase {
         let viewModel = DashboardStatsViewModel(apiResponse: apiResponse)
 
         // When & Then
-        XCTAssertEqual(viewModel.todaysViews, "10,000")
-        XCTAssertEqual(viewModel.todaysVisitors, "200.0K")
-        XCTAssertEqual(viewModel.todaysLikes, "3.0M")
+        XCTAssertEqual(viewModel.todaysViews, 10_000.abbreviatedString(forHeroNumber: true))
+        XCTAssertEqual(viewModel.todaysVisitors, 200_000.abbreviatedString(forHeroNumber: true))
+        XCTAssertEqual(viewModel.todaysLikes, 3_000_000.abbreviatedString(forHeroNumber: true))
     }
 
     func testReturnZeroIfAPIResponseIsEmpty() {


### PR DESCRIPTION
Hi @momo-ozawa and @hassaanelgarem 👋🏼 , I'm assigning y'all as reviewers based on GitHub recommendations.

Some of the unit test cases failed locally because the assertions expected the code to use `,` as the thousands separator and `.` as the decimal separator. However, in my locale `en_ID`, it is the other way around (e.g. `10.000`, `1,25M`).

This PR addresses the issue by using the `abbreviatedString(forHeroNumber:)` for the expected value so it adjusts properly in different locales.

Alternatively, we can also force all local test runs to run in the UTC timezone and use `en_US` locale, but I'm not sure if this is the best way. 🤔 cc-ing @mokagio in case you have thoughts on this.

## To test

- Go to WordPressUnitTests.xctestplan > Configuration.
- In the Localization > Application Region field, select `Indonesia`.
- 🔎  Run `DashboardStatsViewModelTests.testReturnedDataIsFormattedCorrectly()` and `BlazeCampaignViewModelTests.testViewModel()` and verify that they are passing.
- 🔎  Re-run the tests in your local region, and ensure that they are also passing.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran the tests in both local and US locale.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

Not applicable.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
