### PR TITLE
Clearly inform user of delay till domain becomes active

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainResultView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainResultView.swift
@@ -55,22 +55,7 @@ struct DomainResultView: View {
 
                         Spacer().frame(height: Metrics.subtitleToNoticeBoxSpacing)
 
-                        HStack() {
-                            Image(uiImage: .gridicon(.infoOutline))
-                                .frame(height: Metrics.iconHeight)
-                                .foregroundColor(Color(UIColor.muriel(color: .gray)))
-                                .accessibility(hidden: true)
-
-                            Spacer().frame(width: Metrics.iconToNoticeSpacing)
-
-                            Text(TextContent.notice)
-                                .font(.footnote)
-                                .foregroundColor(Color(UIColor.muriel(color: .textSubtle)))
-                        }
-                        .padding(Metrics.noticeBoxPadding)
-                        .frame(maxWidth: .infinity)
-                        .background(Color(UIColor.tertiaryFill))
-                        .cornerRadius(Metrics.noticeBoxCornerRadius)
+                        DomainSetupNoticeView(noticeText: TextContent.notice)
                     }
                     .frame(width: geometry.size.width)
                     .frame(minHeight: geometry.size.height)
@@ -119,10 +104,6 @@ private extension DomainResultView {
         static let logoHeight = 65.0
         static let logoToTitleSpacing = 33.0
         static let titleToSubtitleSpacing = 16.0
-        static let noticeBoxCornerRadius = 8.0
-        static let noticeBoxPadding = EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
-        static let iconHeight = 24.0
-        static let iconToNoticeSpacing = 16.0
         static let subtitleToNoticeBoxSpacing = 32.0
         static let primaryButtonCornerRadius = 7.0
     }

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
@@ -17,6 +17,7 @@ struct DomainSetupNoticeView: View {
 
             Text(noticeText)
                 .font(.footnote)
+                .dynamicTypeSize(.large)
                 .foregroundColor(Color(UIColor.muriel(color: .textSubtle)))
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
@@ -36,8 +36,3 @@ private extension DomainSetupNoticeView {
         static let iconToNoticeSpacing = 16.0
     }
 }
-
-
-#Preview {
-    DomainSetupNoticeView(noticeText: "Hello, world!")
-}

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import Foundation
+
+struct DomainSetupNoticeView: View {
+
+    let noticeText: String
+
+    var body: some View {
+
+        HStack() {
+            Image(uiImage: .gridicon(.infoOutline))
+                .frame(height: Metrics.iconHeight)
+                .foregroundColor(Color(UIColor.muriel(color: .gray)))
+                .accessibility(hidden: true)
+
+            Spacer().frame(width: Metrics.iconToNoticeSpacing)
+
+            Text(noticeText)
+                .font(.footnote)
+                .foregroundColor(Color(UIColor.muriel(color: .textSubtle)))
+        }
+        .padding(Metrics.noticeBoxPadding)
+        .frame(maxWidth: .infinity)
+        .background(Color(UIColor.tertiaryFill))
+        .cornerRadius(Metrics.noticeBoxCornerRadius)
+    }
+}
+
+// MARK: - Constants
+private extension DomainSetupNoticeView {
+
+    private enum Metrics {
+        static let noticeBoxCornerRadius = 8.0
+        static let noticeBoxPadding = EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let iconHeight = 24.0
+        static let iconToNoticeSpacing = 16.0
+    }
+}
+
+
+#Preview {
+    DomainSetupNoticeView(noticeText: "Hello, world!")
+}

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainSetupNoticeView.swift
@@ -18,6 +18,7 @@ struct DomainSetupNoticeView: View {
             Text(noticeText)
                 .font(.footnote)
                 .foregroundColor(Color(UIColor.muriel(color: .textSubtle)))
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(Metrics.noticeBoxPadding)
         .frame(maxWidth: .infinity)

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -332,8 +332,6 @@ final class SiteAssemblyContentView: UIView {
             prevailingLayoutGuide.trailingAnchor.constraint(equalTo: statusStackView.trailingAnchor, constant: Parameters.horizontalMargin),
             statusStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             statusStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            noticeView.leadingAnchor.constraint(equalTo: completionLabelsStack.leadingAnchor),
-            completionLabelsStack.trailingAnchor.constraint(equalTo: noticeView.trailingAnchor)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyContentView.swift
@@ -36,27 +36,25 @@ final class SiteAssemblyContentView: UIView {
         return $0
     }(UILabel())
 
+    private let noticeView: UIView = {
+        let noticeText = NSLocalizedString(
+            "domain.purchase.preview.footer",
+            value: "It may take up to 30 minutes for your custom domain to start working.",
+            comment: "Domain Purchase Completion footer"
+        )
+        let noticeView = DomainSetupNoticeView(noticeText: noticeText)
+        let embeddedView = UIView.embedSwiftUIView(noticeView)
+        embeddedView.translatesAutoresizingMaskIntoConstraints = false
+        return embeddedView
+    }()
+
     private lazy var completionLabelsStack: UIStackView = {
-        $0.addArrangedSubviews([completionLabel, completionDescription])
+        $0.addArrangedSubviews([completionLabel, completionDescription, noticeView])
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.axis = .vertical
         $0.spacing = 24
         return $0
     }(UIStackView())
-
-    private let footnoteLabel: UILabel = {
-        $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.numberOfLines = 0
-        $0.font = WPStyleGuide.fontForTextStyle(.footnote)
-        $0.textColor = .text
-        let footerText = NSLocalizedString(
-            "domain.purchase.preview.footer",
-            value: "It may take up to 30 minutes for your custom domain to start working.",
-            comment: "Domain Purchase Completion footer"
-        )
-        $0.text = footerText
-        return $0
-    }(UILabel())
 
     /// This provides the user with some playful words while their site is being assembled
     private let statusTitleLabel: UILabel
@@ -315,7 +313,7 @@ final class SiteAssemblyContentView: UIView {
         backgroundColor = .listBackground
 
         statusStackView.addArrangedSubviews([ statusTitleLabel, statusSubtitleLabel, statusImageView, statusMessageRotatingView, activityIndicator ])
-        addSubviews([completionLabelsStack, statusStackView, footnoteLabel])
+        addSubviews([completionLabelsStack, statusStackView])
 
         // Increase the spacing around the illustration
         statusStackView.setCustomSpacing(Parameters.verticalSpacing, after: statusSubtitleLabel)
@@ -334,8 +332,8 @@ final class SiteAssemblyContentView: UIView {
             prevailingLayoutGuide.trailingAnchor.constraint(equalTo: statusStackView.trailingAnchor, constant: Parameters.horizontalMargin),
             statusStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             statusStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            footnoteLabel.leadingAnchor.constraint(equalTo: completionLabelsStack.leadingAnchor),
-            completionLabelsStack.trailingAnchor.constraint(equalTo: footnoteLabel.trailingAnchor)
+            noticeView.leadingAnchor.constraint(equalTo: completionLabelsStack.leadingAnchor),
+            completionLabelsStack.trailingAnchor.constraint(equalTo: noticeView.trailingAnchor)
         ])
     }
 
@@ -369,7 +367,7 @@ final class SiteAssemblyContentView: UIView {
         if shouldShowDomainPurchase() {
             assembledSiteView.layer.cornerRadius = 12
             assembledSiteView.layer.masksToBounds = true
-            assembledSiteViewBottomConstraint = footnoteLabel.topAnchor.constraint(
+            assembledSiteViewBottomConstraint = (buttonContainerView?.topAnchor ?? bottomAnchor).constraint(
                 equalTo: assembledSiteView.bottomAnchor,
                 constant: 24
             )
@@ -390,7 +388,7 @@ final class SiteAssemblyContentView: UIView {
             assembledSiteViewBottomConstraint,
             assembledSiteView.centerXAnchor.constraint(equalTo: centerXAnchor),
             assembledSiteWidthConstraint,
-            (buttonContainerView?.topAnchor ?? bottomAnchor).constraint(equalTo: footnoteLabel.bottomAnchor, constant: 15)
+            (buttonContainerView?.topAnchor ?? bottomAnchor).constraint(equalTo: assembledSiteView.bottomAnchor, constant: 15)
         ])
 
         self.assembledSiteView = assembledSiteView
@@ -446,7 +444,7 @@ final class SiteAssemblyContentView: UIView {
     private func layoutIdle() {
         completionLabel.isHidden = true
         completionDescription.isHidden = true
-        footnoteLabel.isHidden = true
+        noticeView.isHidden = true
         statusStackView.alpha = 0
         errorStateView?.alpha = 0
     }
@@ -512,7 +510,7 @@ final class SiteAssemblyContentView: UIView {
                     self.completionDescription.isHidden = false
                     self.completionLabel.text = self.shouldShowDomainPurchase() ? Strings.Paid.completionTitle : Strings.Free.completionTitle
                     self.completionDescription.text = self.shouldShowDomainPurchase() ? Strings.Paid.description : Strings.Free.description
-                    self.footnoteLabel.isHidden = !self.shouldShowDomainPurchase()
+                    self.noticeView.isHidden = !self.shouldShowDomainPurchase()
 
 
                     if let buttonView = self.buttonContainerView {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2723,6 +2723,8 @@
 		B0B89DC12A1E882F003D5295 /* DomainResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B89DBF2A1E882F003D5295 /* DomainResultView.swift */; };
 		B0CD27CF286F8858009500BF /* JetpackBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CD27CE286F8858009500BF /* JetpackBannerView.swift */; };
 		B0CD27D0286F8858009500BF /* JetpackBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CD27CE286F8858009500BF /* JetpackBannerView.swift */; };
+		B0DE91B52AF9778200D51A02 /* DomainSetupNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DE91B42AF9778200D51A02 /* DomainSetupNoticeView.swift */; };
+		B0DE91B62AF9778200D51A02 /* DomainSetupNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DE91B42AF9778200D51A02 /* DomainSetupNoticeView.swift */; };
 		B0F2EFBF259378E600C7EB6D /* SiteSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F2EFBE259378E600C7EB6D /* SiteSuggestionService.swift */; };
 		B5015C581D4FDBB300C9449E /* NotificationActionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5015C571D4FDBB300C9449E /* NotificationActionsService.swift */; };
 		B50248AF1C96FF6200AFBDED /* WPStyleGuide+Share.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50248AE1C96FF6200AFBDED /* WPStyleGuide+Share.swift */; };
@@ -8053,6 +8055,7 @@
 		B0B89DBF2A1E882F003D5295 /* DomainResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainResultView.swift; sourceTree = "<group>"; };
 		B0CD27CE286F8858009500BF /* JetpackBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerView.swift; sourceTree = "<group>"; };
 		B0DDC2EB252F7C4F002BAFB3 /* WordPress 100.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 100.xcdatamodel"; sourceTree = "<group>"; };
+		B0DE91B42AF9778200D51A02 /* DomainSetupNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSetupNoticeView.swift; sourceTree = "<group>"; };
 		B0F2EFBE259378E600C7EB6D /* SiteSuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSuggestionService.swift; sourceTree = "<group>"; };
 		B124AFFFB3F0204107FD33D0 /* Pods-JetpackIntents.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JetpackIntents.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-JetpackIntents/Pods-JetpackIntents.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		B3694C30079615C927D26E9F /* Pods-JetpackStatsWidgets.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JetpackStatsWidgets.release.xcconfig"; path = "../Pods/Target Support Files/Pods-JetpackStatsWidgets/Pods-JetpackStatsWidgets.release.xcconfig"; sourceTree = "<group>"; };
@@ -11692,6 +11695,7 @@
 				3FA62FD226FE2E4B0020793A /* ShapeWithTextView.swift */,
 				011896A429D5B72500D34BA9 /* DomainsDashboardCoordinator.swift */,
 				011896A729D5BBB400D34BA9 /* DomainsDashboardFactory.swift */,
+				B0DE91B42AF9778200D51A02 /* DomainSetupNoticeView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -22223,6 +22227,7 @@
 				E14200781C117A2E00B3B115 /* ManagedAccountSettings.swift in Sources */,
 				0C23F3362AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift in Sources */,
 				401AC82722DD2387006D78D4 /* Blog+Plans.swift in Sources */,
+				B0DE91B52AF9778200D51A02 /* DomainSetupNoticeView.swift in Sources */,
 				08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */,
 				FE06AC8526C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift in Sources */,
 				59A9AB351B4C33A500A433DC /* ThemeService.m in Sources */,
@@ -24686,6 +24691,7 @@
 				3F46EEC728BC4935004F02B2 /* JetpackPrompt.swift in Sources */,
 				175CC1712720548700622FB4 /* DomainExpiryDateFormatter.swift in Sources */,
 				FABB22F42602FC2C00C8785C /* ReaderStreamViewController+Sharing.swift in Sources */,
+				B0DE91B62AF9778200D51A02 /* DomainSetupNoticeView.swift in Sources */,
 				FABB22F52602FC2C00C8785C /* FilterTabBar.swift in Sources */,
 				FABB22F72602FC2C00C8785C /* EditComment.swift in Sources */,
 				FABB22F82602FC2C00C8785C /* UnknownEditorViewController.swift in Sources */,


### PR DESCRIPTION
Fixes a UX issue where a customer who buys a domain might not see the notice saying their domain would take up to 30 minutes to activate.

- See design discussion: p1698419259984079/1698270714.971209-slack-C05SY592UG4
- See rationale to include this as a beta-fix: p1699041111187389/1699038644.934359-slack-C05SY592UG4

How this looks (the notice used to be at the bottom of the screen so less visible:
| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/62a86854-b43e-4ecd-bf0f-c61d6c0b154c" width="300" /> |
| - |


### To test

#### Paid site creation
1. Log in to an existing WP.com account
2. Begin the new site creation flow using a paid domain and a paid plan
3. Expect the "It may take up to 30 minutes..." notice to appear **near the top of the screen** once the purchase has been made

#### Free site creation (check for regressions)
1. Log in to an existing WP.com account
2. Begin the new site creation flow using a free subdomain and a Free plan
3. Expect no changes on the "Your site has been created!" screen

## Regression Notes
1. Potential unintended areas of impact

The screen that's shown after a user creates a site (a.k.a. the site assembly screen) is the place most likely to have regressions

5. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing as described above

6. What automated tests I added (or what prevented me from doing so)

This is a UI change, and I think automated tests are best for functional changes (unless for critical flows). It doesn't look like we have a UI test for site creation despite it being IMO a critical flow, but this seems out of scope here.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)