### PR TITLE
Add a gesture for easier debug menu access

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -137,6 +137,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         setupBackgroundRefresh(application)
         setupComponentsAppearance()
         UITestConfigurator.prepareApplicationForUITests(application)
+        DebugMenuViewController.configure(in: window)
 
         // This was necessary to properly load fonts for the Stories editor. I believe external libraries may require this call to access fonts.
         let fonts = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: nil)


### PR DESCRIPTION
To test:

Verify that swiping from the right edge of the screen opens the debug menu. The gesture is available in the simulator as well as on the physical devices. It should work in most of the modally presented screens too.

I'm planning to add some more useful stuff to the menu, so it'll come really handy soon.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/9951f35a-1402-43b5-9476-a7ee591b37fe

I experimented with adding a [custom transition](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/6a334e7a-bd43-406b-9bde-12b140ddec35), but I thought the complexity wasn't worth it.

## Regression Notes
1. Potential unintended areas of impact: Debug Menu
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
