### PR TITLE
Site Media: Integrate media picker in site icon picker and featured image picker flows

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
@@ -34,6 +34,7 @@ class SiteIconView: UIView {
 
     let activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
+        indicatorView.color = .white
         indicatorView.translatesAutoresizingMaskIntoConstraints = false
         return indicatorView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
@@ -33,7 +33,7 @@ class SiteIconView: UIView {
     }()
 
     let activityIndicator: UIActivityIndicatorView = {
-        let indicatorView = UIActivityIndicatorView(style: .large)
+        let indicatorView = UIActivityIndicatorView(style: .medium)
         indicatorView.translatesAutoresizingMaskIntoConstraints = false
         return indicatorView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
@@ -42,7 +42,7 @@ extension SitePickerViewController {
         var actions = [
             mediaMenu.makePhotosAction(delegate: presenter),
             mediaMenu.makeCameraAction(delegate: presenter),
-            mediaMenu.makeMediaAction(blog: blog, delegate: presenter)
+            mediaMenu.makeSiteMediaAction(blog: blog, delegate: presenter)
         ]
         if FeatureFlag.siteIconCreator.enabled {
             actions.append(UIAction(

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
@@ -169,3 +169,24 @@ extension SiteIconPickerPresenter: MediaPickerViewControllerDelegate {
         })
     }
 }
+
+extension SiteIconPickerPresenter: SiteMediaPickerViewControllerDelegate {
+    func siteMediaPickerViewController(_ viewController: SiteMediaPickerViewController, didFinishWithSelection selection: [Media]) {
+        guard let media = selection.first else {
+            onCompletion?(nil, nil)
+            return
+        }
+
+        WPAnalytics.track(.siteSettingsSiteIconGalleryPicked)
+
+        showLoadingMessage()
+        originalMedia = media
+        MediaThumbnailCoordinator.shared.thumbnail(for: media, with: CGSize.zero, onCompletion: { [weak self] (image, error) in
+            guard let image = image else {
+                self?.showErrorLoadingImageMessage()
+                return
+            }
+            self?.showImageCropViewController(image, presentingViewController: viewController)
+        })
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -144,22 +144,22 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     private func setSelect(_ isSelected: Bool, for media: Media) {
+        guard collectionView.allowsMultipleSelection else {
+            delegate?.siteMediaViewController(self, didUpdateSelection: [media])
+            return
+        }
         if isSelected {
             selection.add(media)
         } else {
             selection.remove(media)
             getViewModel(for: media).badge = nil
         }
-        if collectionView.allowsMultipleSelection {
-            for (index, media) in selection.enumerated() {
-                if let media = media as? Media {
-                    getViewModel(for: media).badge = isSelectionOrdered ? .ordered(index: index) : .unordered
-                } else {
-                    assertionFailure("Invalid selection")
-                }
+        for (index, media) in selection.enumerated() {
+            if let media = media as? Media {
+                getViewModel(for: media).badge = isSelectionOrdered ? .ordered(index: index) : .unordered
+            } else {
+                assertionFailure("Invalid selection")
             }
-        } else {
-            // Don't display a badge
         }
         delegate?.siteMediaViewController(self, didUpdateSelection: selectedMedia)
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -31,6 +31,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
 
         title = Strings.title
         extendedLayoutIncludesOpaqueBars = true
+        modalPresentationStyle = .formSheet
     }
 
     required init?(coder: NSCoder) {
@@ -43,20 +44,12 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
         collectionViewController.embed(in: self)
         collectionViewController.delegate = self
 
-        configureNavigationBarAppearance()
+        configureDefaultNavigationBarAppearance()
         configurationNavigationItems()
         startSelection()
     }
 
     // MARK: - Configuration
-
-    private func configureNavigationBarAppearance() {
-        let appearance = UINavigationBarAppearance()
-        navigationItem.standardAppearance = appearance
-        navigationItem.compactAppearance = appearance
-        navigationItem.scrollEdgeAppearance = appearance
-        navigationItem.compactScrollEdgeAppearance = appearance
-    }
 
     private func configurationNavigationItems() {
         let buttonCancel = UIBarButtonItem(systemItem: .cancel, primaryAction: UIAction { [weak self] _ in

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -32,7 +32,7 @@ extension PostSettingsViewController: PHPickerViewControllerDelegate, ImagePicke
         return UIMenu(children: [
             menu.makePhotosAction(delegate: self),
             menu.makeCameraAction(delegate: self),
-            menu.makeMediaAction(blog: self.apost.blog, delegate: self)
+            menu.makeSiteMediaAction(blog: self.apost.blog, delegate: self)
         ])
     }
 
@@ -71,6 +71,18 @@ extension PostSettingsViewController: MediaPickerViewControllerDelegate {
 
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         dismiss(animated: true)
+    }
+}
+
+extension PostSettingsViewController: SiteMediaPickerViewControllerDelegate {
+    func siteMediaPickerViewController(_ viewController: SiteMediaPickerViewController, didFinishWithSelection selection: [Media]) {
+        dismiss(animated: true)
+
+        guard let media = selection.first else { return }
+
+        WPAnalytics.track(.editorPostFeaturedImageChanged, properties: ["via": "settings", "action": "added"])
+        setFeaturedImage(media: media)
+        reloadFeaturedImageCell()
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

This is the initial PR with integration of the new Site Media picker in just two places of the app. More will follow.

To test:

> [!IMPORTANT]
> - Enable the "Modernize Media" feature flag before testing

- Follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/pull/21370 but use the "Choose from Media" option
- Follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/pull/21391 but use the "Choose from Media" option


## Regression Notes
1. Potential unintended areas of impact: Site Icon Picker and Featured Image Picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x]  I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
