### PR TITLE
Posts & Pages: Rename preview action for drafts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -112,7 +112,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
     func title(for post: AbstractPost) -> String {
         switch self {
         case .retry: return Strings.retry
-        case .view: return Strings.view
+        case .view: return post.status == .publish ? Strings.preview : Strings.view
         case .publish: return Strings.publish
         case .stats: return Strings.stats
         case .duplicate: return Strings.duplicate
@@ -181,6 +181,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let delete = NSLocalizedString("posts.delete.actionTitle", value: "Delete permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
         static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to trash", comment: "Label for a option that moves a post to the trash folder")
         static let view = NSLocalizedString("posts.view.actionTitle", value: "View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
+        static let preview = NSLocalizedString("posts.preview.actionTitle", value: "Preview", comment: "Label for the preview post button. Tapping displays the post as it appears on the web.")
         static let retry = NSLocalizedString("posts.retry.actionTitle", value: "Retry", comment: "Retry uploading the post.")
         static let share = NSLocalizedString("posts.share.actionTitle", value: "Share", comment: "Share the post.")
         static let blaze = NSLocalizedString("posts.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the post with Blaze.")


### PR DESCRIPTION
Update the title of the "View" action to align with wp.com. The "View" can leave a wrong impression that the post is already available online.

To test:

- Verify that drafts have "Preview" action instead of "View"

<img width="453" alt="Screenshot 2023-11-07 at 11 27 59 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0c634d3a-0eb8-486d-b488-e7722b06e667">

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): Manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
