### PR TITLE
Site Media: Add long-press support with a preview and a context menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -435,7 +435,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     private func makePreviewViewController(for media: Media) -> UIViewController? {
-        let viewModel = self.getViewModel(for: media)
+        let viewModel = getViewModel(for: media)
         guard let image = viewModel.getCachedThubmnail() else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -237,6 +237,17 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     func makeAddMediaMenu(for viewController: SiteMediaCollectionViewController) -> UIMenu? {
         buttonAddMediaMenuController.makeMenu(for: self)
     }
+
+    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media) -> UIMenu? {
+        UIMenu(children: [
+            UIAction(title: Strings.buttonShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+                self?.shareSelectedMedia([media])
+            },
+            UIAction(title: Strings.buttonDelete, image: UIImage(systemName: "trash"), attributes: [.destructive]) { [weak self] _ in
+                self?.deleteSelectedMedia([media])
+            }
+        ])
+    }
 }
 
 private enum Strings {
@@ -252,4 +263,6 @@ private enum Strings {
     static let deletionSuccessMessage = NSLocalizedString("mediaLibrary.deletionSuccessMessage", value: "Deleted!", comment: "Text displayed in HUD after successfully deleting a media item")
     static let deletionFailureMessage = NSLocalizedString("mediaLibrary.deletionFailureMessage", value: "Unable to delete all media items.", comment: "Text displayed in HUD if there was an error attempting to delete a group of media items.")
     static let sharingFailureMessage = NSLocalizedString("mediaLibrary.sharingFailureMessage", value: "Unable to share the selected items.", comment: "Text displayed in HUD if there was an error attempting to share a group of media items.")
+    static let buttonShare = NSLocalizedString("mediaLibrary.buttonShare", value: "Share", comment: "Context menu button")
+    static let buttonDelete = NSLocalizedString("mediaLibrary.buttonDelete", value: "Delete", comment: "Context menu button")
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -239,14 +239,17 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     }
 
     func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media) -> UIMenu? {
-        UIMenu(children: [
-            UIAction(title: Strings.buttonShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
-                self?.shareSelectedMedia([media])
-            },
-            UIAction(title: Strings.buttonDelete, image: UIImage(systemName: "trash"), attributes: [.destructive]) { [weak self] _ in
+        var actions: [UIAction] = []
+
+        actions.append(UIAction(title: Strings.buttonShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+            self?.shareSelectedMedia([media])
+        })
+        if blog.supports(.mediaDeletion) {
+            actions.append(UIAction(title: Strings.buttonDelete, image: UIImage(systemName: "trash"), attributes: [.destructive]) { [weak self] _ in
                 self?.deleteSelectedMedia([media])
-            }
-        ])
+            })
+        }
+        return UIMenu(children: actions)
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

To test:

- Verify that when you long-press media item in Media, it shows a large preview and context actions: “Share” and “Delete” (when you have access to delete)
- Verify that when you long-press a media item in Picker, it shows only a preview
- 
<img width="453" alt="Screenshot 2023-11-07 at 2 01 14 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0a1bd5dd-4d68-4031-848f-0da161c89f64">

## Regression Notes
1. Potential unintended areas of impact: Site Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
