### PR TITLE
Site Media: Integrate the new site media picker in Gutenberg

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -77,8 +77,8 @@ class GutenbergMediaPickerHelper: NSObject {
     }
 
     private func presentLegacySiteMediaPicker(filter: WPMediaType,
-                                     allowMultipleSelection: Bool,
-                                     callback: @escaping GutenbergMediaPickerHelperCallback) {
+                                              allowMultipleSelection: Bool,
+                                              callback: @escaping GutenbergMediaPickerHelperCallback) {
         didPickMediaCallback = callback
 
         let mediaPickerOptions = WPMediaPickerOptions.withDefaults(filter: filter, allowMultipleSelection: allowMultipleSelection)

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -15,13 +15,6 @@ struct MediaPickerMenu {
     enum MediaFilter {
         case images
         case videos
-
-        var mediaType: MediaType {
-            switch self {
-            case .images: return .image
-            case .videos: return .video
-            }
-        }
     }
 
     /// Initializes the options.
@@ -326,6 +319,13 @@ extension MediaPickerMenu.MediaFilter {
         case .image: self = .images
         case .video: self = .videos
         default: return nil
+        }
+    }
+
+    var mediaType: MediaType {
+        switch self {
+        case .images: return .image
+        case .videos: return .video
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

To test:

- ❗ Enable "Media Modernization" feature flag
- Verify that when you add an Image block and select your Media as a source, it shows a new picker filtered to displayed only images and with single selection enabled
- Verify that when you add a Gallery block and select your Media as a source, it shows a new picker filtered to displayed only images and with multiple selection enabled
- Verify that when you add a Video block and select your Media as a source, it shows a new picker filtered to displayed only video and with single selection enabled

## Regression Notes
1. Potential unintended areas of impact: Post Editor (only Gutenberg)
2. What I did to test those areas of impact (or what existing automated tests I relied on: manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x]  I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
