### PR TITLE
Add missing purging to the fetchAllPages function

### DIFF
--- a/WordPress/WordPressTest/PostRepositoryTests.swift
+++ b/WordPress/WordPressTest/PostRepositoryTests.swift
@@ -312,6 +312,123 @@ class PostRepositoryTests: CoreDataTestCase {
         await fulfillment(of: [cancelled], timeout: 0.3)
     }
 
+    func testFetchTwoFullPages() async throws {
+        // 300 pages of API result
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = try (1...2).map { pageNo in
+            try (1...100).map {
+                let post = try XCTUnwrap(RemotePost(siteID: NSNumber(value: pageNo * 1000 + $0), status: "publish", title: "Post: Test", content: "This is a test post"))
+                post.type = "page"
+                return post
+            }
+        } + [[]]
+
+        let allPages = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        XCTAssertEqual(allPages.count, 15_000)
+    }
+
+    func testFetchManyManyPages() async throws {
+        // 90 pages of API result
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = try (1...99).map { pageNo in
+            try (1...100).map {
+                let post = try XCTUnwrap(RemotePost(siteID: NSNumber(value: pageNo * 1000 + $0), status: "publish", title: "Post: Test", content: "This is a test post"))
+                post.type = "page"
+                return post
+            }
+        } + [[]]
+
+        let allPages = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        XCTAssertEqual(allPages.count, 9_900)
+    }
+
+    func testFetchAllPagesPurgesDeletedPages() async throws {
+        let postToBeKept = try XCTUnwrap(RemotePost(siteID: 1, status: "publish", title: "Post: Kept", content: "This is a test post"))
+        postToBeKept.postID = 100
+        postToBeKept.type = "page"
+        let postToBeDeleted = try XCTUnwrap(RemotePost(siteID: 1, status: "publish", title: "Post: Deleted", content: "This is a test post"))
+        postToBeDeleted.postID = 200
+        postToBeDeleted.type = "page"
+
+        // The first fetch returns both page instances.
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = [
+            [postToBeKept, postToBeDeleted],
+        ]
+        let firstFetch = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        XCTAssertEqual(firstFetch.count, 2)
+        try await contextManager.performQuery { context in
+            let first = try context.existingObject(with: XCTUnwrap(firstFetch.first))
+            let second = try context.existingObject(with: XCTUnwrap(firstFetch.last))
+            XCTAssertEqual(first.postID, 100)
+            XCTAssertEqual(second.postID, 200)
+        }
+
+        // The second fetch only returns one of them, to simulate an situation where the other page has been deleted from the site.
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = [
+            [postToBeKept],
+        ]
+        let secondFetch = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        XCTAssertEqual(secondFetch.count, 1)
+        try await contextManager.performQuery { context in
+            let page = try context.existingObject(with: XCTUnwrap(firstFetch.first))
+            XCTAssertEqual(page.postID, postToBeKept.postID)
+        }
+    }
+
+    func testFetchAllPagesKeepPagesWithOtherStatus() async throws {
+        let remotePage = try XCTUnwrap(RemotePost(siteID: 1, status: "publish", title: "Post: Kept", content: "This is a test post"))
+        remotePage.postID = 100
+        remotePage.type = "page"
+
+        // The first fetch returns a published post
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = [[remotePage]]
+        let firstFetch = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        try await contextManager.performQuery { context in
+            let page = try context.existingObject(with: XCTUnwrap(firstFetch.first))
+            XCTAssertEqual(page.postID, remotePage.postID)
+        }
+
+        // The second fetch returns empty result, because there is no draft on the site
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = [[]]
+        let secondFetch = try await repository.fetchAllPages(statuses: [.draft], in: blogID).value
+        XCTAssertTrue(secondFetch.isEmpty)
+
+        let pageExists = await contextManager.performQuery { context in
+            (try? context.existingObject(with: XCTUnwrap(firstFetch.first))) != nil
+        }
+        XCTAssertTrue(pageExists, "The previously fetched published pages is not deleted by the draft pages fetching request")
+    }
+
+    func testFetchAllPagesKeepLocalEdits() async throws {
+        let remotePage = try XCTUnwrap(RemotePost(siteID: 1, status: "publish", title: "Post: Kept", content: "This is a test post"))
+        remotePage.postID = 100
+        remotePage.type = "page"
+        remoteMock.remotePostsToReturnOnSyncPostsOfType = [[remotePage], [remotePage]]
+
+        // The first fetch returns a published post
+        let firstFetch = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        try await contextManager.performQuery { context in
+            let page = try context.existingObject(with: XCTUnwrap(firstFetch.first))
+            XCTAssertEqual(page.postID, remotePage.postID)
+        }
+
+        // Edit the fetched page.
+        let localEditID = try await contextManager.performAndSave { context in
+            let page = try context.existingObject(with: XCTUnwrap(firstFetch.first))
+            let localEdit = page.createRevision()
+            localEdit.postTitle = "Changes changes and changes"
+            return TaggedManagedObjectID(localEdit)
+        }
+
+        // The second fetch returns the same result as the previous one.
+        let secondFetch = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
+        XCTAssertEqual(firstFetch, secondFetch)
+
+        try await contextManager.performQuery { context in
+            let localEdit = try context.existingObject(with: localEditID)
+            XCTAssertNotNil(localEdit.original)
+            try XCTAssertEqual(XCTUnwrap(localEdit.original).objectID, XCTUnwrap(secondFetch.first).objectID)
+        }
+    }
+
 }
 
 // These mock classes are copied from PostServiceWPComTests. We can't simply remove the `private` in the original class

--- a/WordPress/WordPressTest/PostRepositoryTests.swift
+++ b/WordPress/WordPressTest/PostRepositoryTests.swift
@@ -313,7 +313,7 @@ class PostRepositoryTests: CoreDataTestCase {
     }
 
     func testFetchTwoFullPages() async throws {
-        // 300 pages of API result
+        // `fetchAllPages` fetchs 100 page instances at at time. Here we simulate two full pages result.
         remoteMock.remotePostsToReturnOnSyncPostsOfType = try (1...2).map { pageNo in
             try (1...100).map {
                 let post = try XCTUnwrap(RemotePost(siteID: NSNumber(value: pageNo * 1000 + $0), status: "publish", title: "Post: Test", content: "This is a test post"))
@@ -323,11 +323,11 @@ class PostRepositoryTests: CoreDataTestCase {
         } + [[]]
 
         let allPages = try await repository.fetchAllPages(statuses: [.publish], in: blogID).value
-        XCTAssertEqual(allPages.count, 15_000)
+        XCTAssertEqual(allPages.count, 200)
     }
 
     func testFetchManyManyPages() async throws {
-        // 90 pages of API result
+        // Here we simulate a site that has a super large number of pages.
         remoteMock.remotePostsToReturnOnSyncPostsOfType = try (1...99).map { pageNo in
             try (1...100).map {
                 let post = try XCTUnwrap(RemotePost(siteID: NSNumber(value: pageNo * 1000 + $0), status: "publish", title: "Post: Test", content: "This is a test post"))

--- a/WordPress/WordPressTest/PostRepositoryTests.swift
+++ b/WordPress/WordPressTest/PostRepositoryTests.swift
@@ -361,7 +361,7 @@ class PostRepositoryTests: CoreDataTestCase {
             XCTAssertEqual(second.postID, 200)
         }
 
-        // The second fetch only returns one of them, to simulate an situation where the other page has been deleted from the site.
+        // The second fetch only returns one of them, to simulate a situation where the other page has been deleted from the site.
         remoteMock.remotePostsToReturnOnSyncPostsOfType = [
             [postToBeKept],
         ]

--- a/WordPress/WordPressTest/PostRepositoryTests.swift
+++ b/WordPress/WordPressTest/PostRepositoryTests.swift
@@ -326,7 +326,9 @@ class PostRepositoryTests: CoreDataTestCase {
         XCTAssertEqual(allPages.count, 200)
     }
 
-    func testFetchManyManyPages() async throws {
+    // This test takes one minute to complete on CI. We'll disable it for now and potentially re-enable
+    // it after CI is migrated to Apple Silicon agents.
+    func _testFetchManyManyPages() async throws {
         // Here we simulate a site that has a super large number of pages.
         remoteMock.remotePostsToReturnOnSyncPostsOfType = try (1...99).map { pageNo in
             try (1...100).map {


### PR DESCRIPTION
## Issue

I forgot to implement purging existing pages in the new `PostRepository.fetchAllPages` function, which existed in the `PostService.syncPosts` function.

Here is an issue that caused by the missing feature:
1. Check out https://github.com/wordpress-mobile/WordPress-iOS/pull/21974 or the trunk branch if the PR is merged.
2. From your browser, create two top level pages on a test site.
3. Launch the app, and go to Site Settings -> Homepage Settings -> Static Homepage -> Homepage
4. On the "Choose Homepage" screen, you should see the two pages you just created.
5. Go back to the Homepage Settings screen.
6. From your browser, delete one of the page and update the other page's title.
7. Go back to the app, tap "Homepage" on the "Homepage Settings" screen.
8. Check out the pages displayed on the "Choose Homepage" screen.

Expected behaviour:
The deleted page should not be there. And the updated page title should be displayed on the screen.

Actual behaviour:
We can the updated page, but also the deleted page.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verify the issue is fixed.

3. What automated tests I added (or what prevented me from doing so)
Many in this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A