### PR TITLE
Site Media: Improve media details screen

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -75,7 +75,7 @@
       },
       {
         "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics.git",
+        "repositoryURL": "https://github.com/apple/swift-numerics",
         "state": {
           "branch": null,
           "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -75,7 +75,7 @@
       },
       {
         "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics.git",
         "state": {
           "branch": null,
           "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -43,11 +43,11 @@ class MediaItemImageTableViewCell: WPTableViewCell {
     private func setupImageView() {
         contentView.addSubview(customImageView)
         customImageView.translatesAutoresizingMaskIntoConstraints = false
-        customImageView.contentMode = .scaleAspectFit
+        customImageView.contentMode = .scaleAspectFill
 
         NSLayoutConstraint.activate([
-            customImageView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
-            customImageView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
+            customImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            customImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             customImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             customImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
             ])

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -30,7 +30,7 @@ class MediaItemViewController: UITableViewController {
 
         self.mediaMetadata = MediaMetadata(media: media)
 
-        super.init(style: .grouped)
+        super.init(style: .insetGrouped)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -40,9 +40,9 @@ class MediaItemViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        WPStyleGuide.configureColors(view: view, tableView: tableView)
-        ImmuTable.registerRows([TextRow.self, EditableTextRow.self, MediaImageRow.self, MediaDocumentRow.self],
-                               tableView: tableView)
+        tableView.showsVerticalScrollIndicator = false
+
+        ImmuTable.registerRows([TextRow.self, EditableTextRow.self, MediaImageRow.self, MediaDocumentRow.self], tableView: tableView)
 
         updateViewModel()
         updateNavigationItem()
@@ -436,7 +436,6 @@ extension MediaItemViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = viewModel.rowAtIndexPath(indexPath)
         let cell = tableView.dequeueReusableCell(withIdentifier: row.reusableIdentifier, for: indexPath)
-
         row.configureCell(cell)
 
         return cell

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -160,13 +160,13 @@ class MediaItemViewController: UITableViewController {
     private func updateNavigationItem() {
         if mediaMetadata.matches(media) {
             navigationItem.leftBarButtonItem = nil
-            let shareItem = UIBarButtonItem(image: .gridicon(.shareiOS),
+            let shareItem = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"),
                                             style: .plain,
                                             target: self,
                                             action: #selector(shareTapped(_:)))
             shareItem.accessibilityLabel = NSLocalizedString("Share", comment: "Accessibility label for share buttons in nav bars")
 
-            let trashItem = UIBarButtonItem(image: .gridicon(.trash),
+            let trashItem = UIBarButtonItem(image: UIImage(systemName: "trash"),
                                             style: .plain,
                                             target: self,
                                             action: #selector(trashTapped(_:)))

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -479,7 +479,7 @@ private struct MediaMetadataPresenter {
         let width = media.width ?? 0
         let height = media.height ?? 0
 
-        return "\(width) ✕ \(height)"
+        return "\(width) × \(height)"
     }
 
     /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -15,15 +15,7 @@ extension SiteMediaCollectionViewControllerDelegate {
 }
 
 /// The internal view controller for managing the media collection view.
-final class SiteMediaCollectionViewController:
-    UIViewController,
-    NSFetchedResultsControllerDelegate,
-    UICollectionViewDataSource,
-    UICollectionViewDelegate,
-    UICollectionViewDataSourcePrefetching,
-    UISearchResultsUpdating,
-    UIGestureRecognizerDelegate,
-    SiteMediaPageViewControllerDelegate {
+final class SiteMediaCollectionViewController: UIViewController, NSFetchedResultsControllerDelegate, UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDataSourcePrefetching, UISearchResultsUpdating, UIGestureRecognizerDelegate, SiteMediaPageViewControllerDelegate {
     weak var delegate: SiteMediaCollectionViewControllerDelegate?
 
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -352,13 +352,7 @@ final class SiteMediaCollectionViewController:
             pendingChanges.append({ $0.deleteItems(at: [indexPath]) })
             if let media = anObject as? Media {
                 setSelected(false, for: media)
-
-                if let viewController = navigationController?.topViewController,
-                   viewController !== self,
-                    let detailsViewController = viewController as? MediaItemViewController,
-                   detailsViewController.media.objectID == media.objectID {
-                    navigationController?.popViewController(animated: true)
-                }
+                didDeleteMedia(media, at: indexPath)
             } else {
                 assertionFailure("Invalid object: \(anObject)")
             }
@@ -371,6 +365,16 @@ final class SiteMediaCollectionViewController:
             pendingChanges.append({ $0.moveItem(at: indexPath, to: newIndexPath) })
         @unknown default:
             break
+        }
+    }
+
+    private func didDeleteMedia(_ media: Media, at indexPath: IndexPath) {
+        if let viewController = navigationController?.topViewController,
+           let detailsViewController = viewController as? SiteMediaPageViewController {
+            let before = indexPath.item > 0 ? fetchController.object(at: IndexPath(item: indexPath.item - 1, section: 0)) : nil
+            let after = indexPath.item < (fetchController.fetchedObjects?.count ?? 0) ? fetchController.object(at: IndexPath(item: indexPath.item + 1, section: 0)) : nil
+
+            detailsViewController.didDeleteItem(media, before: before, after: after)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -423,8 +423,7 @@ final class SiteMediaCollectionViewController:
                 WPAppAnalytics.track(.mediaLibraryPreviewedItem, with: blog)
 
                 let viewController = SiteMediaPageViewController(media: media, delegate: self)
-                let navigationController = UINavigationController(rootViewController: viewController)
-                present(navigationController, animated: true)
+                self.navigationController?.pushViewController(viewController, animated: true)
             default: break
             }
         }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
@@ -47,11 +47,11 @@ final class SiteMediaPageViewController: UIPageViewController, UIPageViewControl
             }
         }
         if let cell = viewController.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) {
-            UIView.animate(withDuration: 0.5) {
+            UIView.animate(withDuration: 0.4) {
                 cell.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
                 cell.alpha = 0.0
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(350)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
                 showAdjacentPage()
             }
         } else {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
@@ -51,7 +51,7 @@ final class SiteMediaPageViewController: UIPageViewController, UIPageViewControl
                 cell.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
                 cell.alpha = 0.0
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(350)) {
                 showAdjacentPage()
             }
         } else {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
@@ -1,0 +1,66 @@
+import UIKit
+
+protocol SiteMediaPageViewControllerDelegate: AnyObject {
+    func siteMediaPageViewController(_ viewController: SiteMediaPageViewController, getMediaBeforeMedia media: Media) -> Media?
+    func siteMediaPageViewController(_ viewController: SiteMediaPageViewController, getMediaAfterMedia media: Media) -> Media?
+}
+
+final class SiteMediaPageViewController: UIPageViewController, UIPageViewControllerDataSource, UIPageViewControllerDelegate {
+    private weak var siteMediaDelegate: SiteMediaPageViewControllerDelegate?
+
+    init(media: Media, delegate: SiteMediaPageViewControllerDelegate) {
+        super.init(transitionStyle: .scroll, navigationOrientation: .horizontal)
+        siteMediaDelegate = delegate
+
+        dataSource = self
+        self.delegate = self
+
+        let page = makePageViewController(with: media)
+        setViewControllers([page], direction: .forward, animated: false)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        updateNavigationForCurrentViewController()
+    }
+
+    private func makePageViewController(with media: Media) -> MediaItemViewController {
+        MediaItemViewController(media: media)
+    }
+
+    // MARK: - UIPageViewControllerDataSource
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        let current = (viewController as! MediaItemViewController).media
+        guard let media = siteMediaDelegate?.siteMediaPageViewController(self, getMediaBeforeMedia: current) else {
+            return nil
+        }
+        return makePageViewController(with: media)
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        let current = (viewController as! MediaItemViewController).media
+        guard let media = siteMediaDelegate?.siteMediaPageViewController(self, getMediaAfterMedia: current) else {
+            return nil
+        }
+        return makePageViewController(with: media)
+    }
+
+    // MARK: - UIPageViewControllerDelegate
+
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        updateNavigationForCurrentViewController()
+    }
+
+    private func updateNavigationForCurrentViewController() {
+        if let viewController = viewControllers?.first {
+            navigationItem.title = viewController.title
+            navigationItem.rightBarButtonItems = viewController.navigationItem.rightBarButtonItems
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
@@ -26,7 +26,37 @@ final class SiteMediaPageViewController: UIPageViewController, UIPageViewControl
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.backgroundColor = .systemBackground
         updateNavigationForCurrentViewController()
+    }
+
+    func didDeleteItem(_ media: Media, before: Media?, after: Media?) {
+        guard let viewController = viewControllers?.first as? MediaItemViewController,
+              viewController.media == media else {
+            return
+        }
+        func showAdjacentPage() {
+            if let before {
+                setViewControllers([makePageViewController(with: before)], direction: .reverse, animated: true, completion: nil)
+                updateNavigationForCurrentViewController()
+            } else if let after {
+                setViewControllers([makePageViewController(with: after)], direction: .forward, animated: true, completion: nil)
+                updateNavigationForCurrentViewController()
+            } else {
+                navigationController?.popViewController(animated: true)
+            }
+        }
+        if let cell = viewController.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) {
+            UIView.animate(withDuration: 0.5) {
+                cell.transform = CGAffineTransform(scaleX: 0.1, y: 0.1)
+                cell.alpha = 0.0
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) {
+                showAdjacentPage()
+            }
+        } else {
+            showAdjacentPage()
+        }
     }
 
     private func makePageViewController(with media: Media) -> MediaItemViewController {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -15,6 +15,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     private lazy var toolbarItemShare = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(buttonShareTapped))
 
     private var isPreparingToShare = false
+    private var isFirstAppearance = true
 
     @objc init(blog: Blog) {
         self.blog = blog
@@ -45,14 +46,19 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        navigationItem.hidesSearchBarWhenScrolling = false
+        if isFirstAppearance {
+            navigationItem.hidesSearchBarWhenScrolling = false
+        }
         buttonAddMedia.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.mediaUpload)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        navigationItem.hidesSearchBarWhenScrolling = true
+        if isFirstAppearance {
+            navigationItem.hidesSearchBarWhenScrolling = true
+            isFirstAppearance = false
+        }
     }
 
     // MARK: - Configuration

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10757,7 +10757,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+		29B97314FDCFA39411CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -19104,14 +19104,14 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			mainGroup = 29B97314FDCFA39411CA2CEA;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				17A8858B2757B97F0071FCA3 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */,
 				3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
 				3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
@@ -20717,11 +20717,11 @@
 			files = (
 			);
 			inputPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
 			);
 			outputPaths = (
 				"",
@@ -20892,13 +20892,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
 			);
 			outputPaths = (
 			);
@@ -30322,7 +30322,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
+		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -30403,12 +30403,12 @@
 		};
 		3F411B6E28987E3F002513AE /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
 			productName = Lottie;
 		};
 		3F44DD57289C379C006334CD /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
 			productName = Lottie;
 		};
 		3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */ = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -509,6 +509,8 @@
 		0CD9CCA42AD831590044A33C /* PostSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9CCA22AD831590044A33C /* PostSearchViewModel.swift */; };
 		0CD9FB7E2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB7D2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift */; };
 		0CD9FB7F2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB7D2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift */; };
+		0CD9FB8B2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */; };
+		0CD9FB8C2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CED95602A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
@@ -6196,6 +6198,7 @@
 		0CD9CC9E2AD73A560044A33C /* PostSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchViewController.swift; sourceTree = "<group>"; };
 		0CD9CCA22AD831590044A33C /* PostSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchViewModel.swift; sourceTree = "<group>"; };
 		0CD9FB7D2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Extensions.swift"; sourceTree = "<group>"; };
+		0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPageViewController.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFeatureFlagsView.swift; sourceTree = "<group>"; };
 		0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostHelper.swift; sourceTree = "<group>"; };
@@ -10304,6 +10307,7 @@
 			children = (
 				0C8E2F2C2AC4722F0023F9D6 /* SiteMediaViewController.swift */,
 				0C23F33D2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift */,
+				0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */,
 				0C23F33C2AC4AED900EE6117 /* Controllers */,
 				0C23F3332AC49C1000EE6117 /* Views */,
 			);
@@ -22516,6 +22520,7 @@
 				98BC522427F6245700D6E8C2 /* BloggingPromptsFeatureIntroduction.swift in Sources */,
 				8BF1C81A27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
+				0CD9FB8B2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */,
 				0CD9CC9F2AD73A560044A33C /* PostSearchViewController.swift in Sources */,
 				984B139421F66B2D0004B6A2 /* StatsPeriodStore.swift in Sources */,
 				DC772AF1282009BA00664C02 /* InsightsLineChart.swift in Sources */,
@@ -24659,6 +24664,7 @@
 				FABB23162602FC2C00C8785C /* WPWebViewController.m in Sources */,
 				FABB23172602FC2C00C8785C /* ShadowView.swift in Sources */,
 				FABB23182602FC2C00C8785C /* Wizard.swift in Sources */,
+				0CD9FB8C2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */,
 				98E14A3D27C9712D007B0896 /* NotificationCommentDetailViewController.swift in Sources */,
 				FABB23192602FC2C00C8785C /* Media+WPMediaAsset.m in Sources */,
 				FABB231A2602FC2C00C8785C /* GutenbergImgUploadProcessor.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10757,7 +10757,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -19104,14 +19104,14 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				17A8858B2757B97F0071FCA3 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */,
 				3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
+				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
@@ -20717,11 +20717,11 @@
 			files = (
 			);
 			inputPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 				"",
@@ -20892,13 +20892,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 			);
@@ -30322,7 +30322,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
+		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -30403,12 +30403,12 @@
 		};
 		3F411B6E28987E3F002513AE /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3F44DD57289C379C006334CD /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */ = {


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457.

I've discussed with Chris which changes to prioritize for the 23.7 release the it comes to the Media details view. This is the best bank for a buck:

- Allow swiping between media items left and right
- Update navigation bar icons
- Update table view style
- Use optimistic UI for savings metadata changes
- When you delete an item and there are more item in the media library, switch to the adjacent one
- Use “correct” multiplication sign in dimensions: ×
- Remove vertical scroll indicator

To test:

- Verify based on the "acceptance criteria",
- Verify that the metadata does get saved on the server and the when you updated the title, it updated the navigation bar title
- Verify the edge cases: deleting first and last item

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/926f57a6-bd07-410e-a270-bd59e6f22eb8


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
