### PR TITLE
Site Media: Add aspect mode on iPad (Experimental)

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -17,6 +17,7 @@ private enum UPRUConstants {
     static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
     static let isJPContentImportCompleteKey = "jetpackContentImportComplete"
     static let jetpackContentMigrationStateKey = "jetpackContentMigrationState"
+    static let mediaAspectRatioModeEnabledKey = "mediaAspectRatioModeEnabled"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -183,6 +184,19 @@ extension UserPersistentRepositoryUtility {
             }
         } set {
             UserPersistentStoreFactory.instance().set(newValue.rawValue, forKey: UPRUConstants.jetpackContentMigrationStateKey)
+        }
+    }
+
+    var isMediaAspectRatioModeEnabled: Bool {
+        get {
+            let repository = UserPersistentStoreFactory.instance()
+            if let value = repository.object(forKey: UPRUConstants.mediaAspectRatioModeEnabledKey) as? Bool {
+                return value
+            }
+            return UIDevice.current.userInterfaceIdiom == .pad
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.mediaAspectRatioModeEnabledKey)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -216,7 +216,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
                   let panGestureInitialIndexPath,
                   let panGesturePeviousSelection else { return }
 
-            var isDeselecting = panGesturePeviousSelection.contains(fetchController.object(at: panGestureInitialIndexPath))
+            let isDeselecting = panGesturePeviousSelection.contains(fetchController.object(at: panGestureInitialIndexPath))
 
             updateSelection {
                 selection = NSMutableOrderedSet(orderedSet: panGesturePeviousSelection)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -157,12 +157,21 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
             actions.append(UIAction(
                 title: isAspect ? Strings.squareGrid : Strings.aspectRatioGrid,
                 image: UIImage(systemName: isAspect ? "rectangle.arrowtriangle.2.outward" : "rectangle.arrowtriangle.2.inward")) { [weak self] _ in
-                    UserDefaults.standard.isMediaAspectRatioModeEnabled.toggle()
-                    self?.updateFlowLayoutItemSize()
-                    self?.collectionView.reloadData()
+                    self?.toggleAspectRatioMode()
                 })
         }
         return actions
+    }
+
+    private func toggleAspectRatioMode() {
+        UserDefaults.standard.isMediaAspectRatioModeEnabled.toggle()
+        UIView.animate(withDuration: 0.33) {
+            self.updateFlowLayoutItemSize()
+            for cell in self.collectionView.visibleCells {
+                guard let cell = cell as? SiteMediaCollectionCell else { continue }
+                cell.configure(isAspectRatioModeEnabled: UserDefaults.standard.isMediaAspectRatioModeEnabled)
+            }
+        }
     }
 
     // MARK: - Editing (Selection)
@@ -422,7 +431,8 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         let cell = collectionView.dequeue(cell: SiteMediaCollectionCell.self, for: indexPath)!
         let media = fetchController.object(at: indexPath)
         let viewModel = getViewModel(for: media)
-        cell.configure(viewModel: viewModel, isAspectRatioModeEnabled: UserDefaults.standard.isMediaAspectRatioModeEnabled)
+        cell.configure(viewModel: viewModel)
+        cell.configure(isAspectRatioModeEnabled: UserDefaults.standard.isMediaAspectRatioModeEnabled)
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -21,7 +21,9 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
         super.init(nibName: nil, bundle: nil)
 
         hidesBottomBarWhenPushed = true
-        title = Strings.title
+        if !UIDevice.isPad() {
+            title = Strings.title
+        }
         extendedLayoutIncludesOpaqueBars = true
     }
 
@@ -80,21 +82,39 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
         navigationItem.rightBarButtonItems = {
             var rightBarButtonItems: [UIBarButtonItem] = []
 
-            if !isEditing, blog.userCanUploadMedia {
-                configureAddMediaButton()
-                rightBarButtonItems.append(UIBarButtonItem(customView: buttonAddMedia))
+            func addEditingButtons() {
+                if isEditing {
+                    let doneButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonDoneTapped))
+                    rightBarButtonItems.append(doneButton)
+                } else {
+                    let selectButton = UIBarButtonItem(title: Strings.select, style: .plain, target: self, action: #selector(buttonSelectTapped))
+                    rightBarButtonItems.append(selectButton)
+                }
             }
 
-            if isEditing {
-                let doneButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonDoneTapped))
-                rightBarButtonItems.append(doneButton)
-            } else {
+            func addMoreButton() {
                 if let menu = collectionViewController.makeMoreMenu() {
                     rightBarButtonItems.append(UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: menu))
                 }
-                let selectButton = UIBarButtonItem(title: Strings.select, style: .plain, target: self, action: #selector(buttonSelectTapped))
-                rightBarButtonItems.append(selectButton)
             }
+
+            func addUploadButton() {
+                if !isEditing, blog.userCanUploadMedia {
+                    configureAddMediaButton()
+                    rightBarButtonItems.append(UIBarButtonItem(customView: buttonAddMedia))
+                }
+            }
+
+            if UIDevice.isPad() {
+                addEditingButtons()
+                addMoreButton()
+                addUploadButton()
+
+            } else {
+                addUploadButton()
+                addEditingButtons()
+            }
+
             return rightBarButtonItems
         }()
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -89,6 +89,9 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
                 let doneButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonDoneTapped))
                 rightBarButtonItems.append(doneButton)
             } else {
+                if let menu = collectionViewController.makeMoreMenu() {
+                    rightBarButtonItems.append(UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), menu: menu))
+                }
                 let selectButton = UIBarButtonItem(title: Strings.select, style: .plain, target: self, action: #selector(buttonSelectTapped))
                 rightBarButtonItems.append(selectButton)
             }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -13,7 +13,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
 
     private var viewModel: SiteMediaCollectionCellViewModel?
     private var cancellables: [AnyCancellable] = []
-    private lazy var aspectRatioConstraint = imageContainerView.widthAnchor.constraint(equalTo: imageContainerView.heightAnchor, multiplier: 1)
+    private var aspectRatioConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -30,12 +30,16 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         NSLayoutConstraint.activate([
             imageContainerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             imageContainerView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            imageContainerView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor),
-            imageContainerView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor),
-            imageContainerView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
-            imageContainerView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor),
-            aspectRatioConstraint
         ])
+        NSLayoutConstraint.activate([
+            imageContainerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageContainerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            imageContainerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor)
+        ].map {
+            $0.priority = .init(rawValue: 900)
+            return $0
+        })
 
         overlayView.backgroundColor = .neutral(.shade70).withAlphaComponent(0.5)
 
@@ -73,8 +77,17 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         documentInfoView?.isHidden = true
     }
 
-    func configure(viewModel: SiteMediaCollectionCellViewModel) {
+    func configure(viewModel: SiteMediaCollectionCellViewModel, isAspectRatioModeEnabled: Bool) {
         self.viewModel = viewModel
+
+        aspectRatioConstraint?.isActive = false
+        aspectRatioConstraint = nil
+
+        if isAspectRatioModeEnabled, let aspectRatio = viewModel.aspectRatio {
+            let aspectRatioConstraint = imageContainerView.widthAnchor.constraint(equalTo: imageContainerView.heightAnchor, multiplier: aspectRatio)
+            aspectRatioConstraint.isActive = true
+            self.aspectRatioConstraint = aspectRatioConstraint
+        }
 
         if let image = viewModel.getCachedThubmnail() {
             // Display with no animations. It should happen often thanks to prefetching.

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -77,17 +77,8 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         documentInfoView?.isHidden = true
     }
 
-    func configure(viewModel: SiteMediaCollectionCellViewModel, isAspectRatioModeEnabled: Bool) {
+    func configure(viewModel: SiteMediaCollectionCellViewModel) {
         self.viewModel = viewModel
-
-        aspectRatioConstraint?.isActive = false
-        aspectRatioConstraint = nil
-
-        if isAspectRatioModeEnabled, let aspectRatio = viewModel.aspectRatio {
-            let aspectRatioConstraint = imageContainerView.widthAnchor.constraint(equalTo: imageContainerView.heightAnchor, multiplier: aspectRatio)
-            aspectRatioConstraint.isActive = true
-            self.aspectRatioConstraint = aspectRatioConstraint
-        }
 
         if let image = viewModel.getCachedThubmnail() {
             // Display with no animations. It should happen often thanks to prefetching.
@@ -114,6 +105,17 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         configureAccessibility(viewModel)
 
         viewModel.onAppear()
+    }
+
+    func configure(isAspectRatioModeEnabled: Bool) {
+        aspectRatioConstraint?.isActive = false
+        aspectRatioConstraint = nil
+
+        if isAspectRatioModeEnabled, let aspectRatio = viewModel?.aspectRatio {
+            let aspectRatioConstraint = imageContainerView.widthAnchor.constraint(equalTo: imageContainerView.heightAnchor, multiplier: aspectRatio)
+            aspectRatioConstraint.isActive = true
+            self.aspectRatioConstraint = aspectRatioConstraint
+        }
     }
 
     // MARK: - Refresh

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -225,7 +225,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         let selectionView = SiteMediaCollectionCellSelectionOverlayView()
         imageContainerView.addSubview(selectionView)
         selectionView.translatesAutoresizingMaskIntoConstraints = false
-        pinSubviewToAllEdges(selectionView)
+        imageContainerView.pinSubviewToAllEdges(selectionView)
         self.selectionView = selectionView
         return selectionView
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -3,6 +3,7 @@ import Combine
 import Gifu
 
 final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
+    private let imageContainerView = UIView()
     private let imageView = GIFImageView()
     private let overlayView = CircularProgressView()
     private let placeholderView = UIView()
@@ -12,6 +13,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
 
     private var viewModel: SiteMediaCollectionCellViewModel?
     private var cancellables: [AnyCancellable] = []
+    private lazy var aspectRatioConstraint = imageContainerView.widthAnchor.constraint(equalTo: imageContainerView.heightAnchor, multiplier: 1)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -22,19 +24,32 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         imageView.contentMode = .scaleAspectFill
         imageView.accessibilityIgnoresInvertColors = true
 
+        contentView.addSubview(imageContainerView)
+        imageContainerView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            imageContainerView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            imageContainerView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            imageContainerView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor),
+            imageContainerView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor),
+            imageContainerView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
+            imageContainerView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor),
+            aspectRatioConstraint
+        ])
+
         overlayView.backgroundColor = .neutral(.shade70).withAlphaComponent(0.5)
 
-        contentView.addSubview(placeholderView)
+        imageContainerView.addSubview(placeholderView)
         placeholderView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(placeholderView)
+        imageContainerView.pinSubviewToAllEdges(placeholderView)
 
-        contentView.addSubview(imageView)
+        imageContainerView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(imageView)
+        imageContainerView.pinSubviewToAllEdges(imageView)
 
-        contentView.addSubview(overlayView)
+        imageContainerView.addSubview(overlayView)
         overlayView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(overlayView)
+        imageContainerView.pinSubviewToAllEdges(overlayView)
     }
 
     required init?(coder: NSCoder) {
@@ -51,6 +66,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         imageView.prepareForReuse()
         imageView.image = nil
         imageView.alpha = 0
+
         placeholderView.alpha = 1
         selectionView?.isHidden = true
         durationView?.isHidden = true
@@ -160,13 +176,13 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
             return documentInfoView
         }
         let documentInfoView = SiteMediaDocumentInfoView()
-        contentView.addSubview(documentInfoView)
+        imageContainerView.addSubview(documentInfoView)
         documentInfoView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            documentInfoView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor, constant: 0),
-            documentInfoView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 0),
-            documentInfoView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 4),
-            documentInfoView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -4)
+            documentInfoView.centerXAnchor.constraint(equalTo: imageContainerView.centerXAnchor, constant: 0),
+            documentInfoView.centerYAnchor.constraint(equalTo: imageContainerView.centerYAnchor, constant: 0),
+            documentInfoView.leadingAnchor.constraint(greaterThanOrEqualTo: imageContainerView.leadingAnchor, constant: 4),
+            documentInfoView.trailingAnchor.constraint(lessThanOrEqualTo: imageContainerView.trailingAnchor, constant: -4)
         ])
         self.documentInfoView = documentInfoView
         return documentInfoView
@@ -177,11 +193,11 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
             return durationView
         }
         let durationView = SiteMediaVideoDurationView()
-        contentView.addSubview(durationView)
+        imageContainerView.addSubview(durationView)
         durationView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            durationView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: 0),
-            durationView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 0)
+            durationView.trailingAnchor.constraint(equalTo: imageContainerView.trailingAnchor, constant: 0),
+            durationView.bottomAnchor.constraint(equalTo: imageContainerView.bottomAnchor, constant: 0)
         ])
         self.durationView = durationView
         return durationView
@@ -192,7 +208,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
             return selectionView
         }
         let selectionView = SiteMediaCollectionCellSelectionOverlayView()
-        contentView.addSubview(selectionView)
+        imageContainerView.addSubview(selectionView)
         selectionView.translatesAutoresizingMaskIntoConstraints = false
         pinSubviewToAllEdges(selectionView)
         self.selectionView = selectionView

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift
@@ -23,6 +23,14 @@ final class SiteMediaCollectionCellViewModel {
     private var progressObserver: NSKeyValueObservation?
     private var observations: [NSKeyValueObservation] = []
 
+    var aspectRatio: CGFloat? {
+        guard let width = media.width?.floatValue, width > 0,
+              let height = media.height?.floatValue, height > 0 else {
+            return nil
+        }
+        return CGFloat(width / height)
+    }
+
     enum BadgeType {
         case unordered
         case ordered(index: Int)


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

To test:

Make sure to enable FF!

- Verify that on iPhone, the display mode is still square and there is no way to toggle it
- Verify that iPad defaults to the new aspect ratio display mode
- Verify that you can toggle the mode by using the new more menu
- Verify that the search bar now appears under the navigation bar
- Verify that after toggling the mode, the display mode is updated automatically
- Verify that the existing features of collection view cells: selection badges, duration labels work correctly


https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/9007c45d-eca6-4861-80a4-e7e5f2936670



## Regression Notes
1. Potential unintended areas of impact: Media (FF disabled)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
