### PR TITLE
Site Media: Display storage quota when adding content

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
@@ -13,7 +13,7 @@ final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDel
 
     func makeMenu(for viewController: UIViewController) -> UIMenu {
         let menu = MediaPickerMenu(viewController: viewController, isMultipleSelectionEnabled: true)
-        return UIMenu(options: [.displayInline], children: [
+        var children: [UIMenuElement] = [
             UIMenu(options: [.displayInline], children: [
                 menu.makePhotosAction(delegate: self),
             ]),
@@ -25,7 +25,13 @@ final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDel
                 menu.makeStockPhotos(blog: blog, delegate: self),
                 menu.makeFreeGIFAction(blog: blog, delegate: self)
             ])
-        ])
+        ]
+        if let quotaUsageDescription = blog.quotaUsageDescription {
+            children += [
+                UIAction(subtitle: quotaUsageDescription, handler: { _ in })
+            ]
+        }
+        return UIMenu(options: [.displayInline], children: children)
     }
 
     // MARK: - PHPickerViewControllerDelegate


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21457

<img width="320" alt="Screenshot 2023-11-09 at 8 27 26 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/55b7a296-23b6-44ec-841f-7eb0310b479a">

To test:

- Verify that for sites with a storage quota, it gets displayed in the add photo context menu

## Regression Notes
1. Potential unintended areas of impact: Site Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
