### PR TITLE
Fix an issue with posts reloading when nothing changes

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -637,7 +637,9 @@
     // First lets check the post content for a suitable image
     NSString *result = [DisplayableImageHelper searchPostContentForImageToDisplay:self.content];
     if (result.length > 0) {
-        self.pathForDisplayImage = result;
+        if (self.pathForDisplayImage != result) {
+            self.pathForDisplayImage = result;
+        }
     }
     // If none found let's see if some galleries are available
     NSSet *mediaIDs = [DisplayableImageHelper searchPostContentForAttachmentIdsInGalleries:self.content];
@@ -647,7 +649,16 @@
             result = media.remoteURL;
         }
     }
-    self.pathForDisplayImage = result;    
+    if (result.length > 0) { // Can return @""
+        if (self.pathForDisplayImage != result) {
+            self.pathForDisplayImage = result;
+        }
+    } else {
+        if (self.pathForDisplayImage != nil) {
+            self.pathForDisplayImage = nil;
+        }
+    }
+
 }
 
 @end

--- a/WordPress/Classes/Services/PostHelper+Swift.swift
+++ b/WordPress/Classes/Services/PostHelper+Swift.swift
@@ -1,0 +1,85 @@
+import Foundation
+import WordPressKit
+import CoreData
+
+extension PostHelper {
+    @objc(updatePost:withRemotePost:inContext:)
+    static func update(_ post: AbstractPost, with remotePost: RemotePost, in context: NSManagedObjectContext) {
+        let previousPostID = post.postID
+        updateIfNeeded(post, \.postID, remotePost.postID)
+
+        // Used to populate author information for self-hosted sites.
+        let author = post.blog.getAuthorWith(id: remotePost.authorID)
+        updateIfNeeded(post, \.author, remotePost.authorDisplayName ?? author?.displayName)
+        updateIfNeeded(post, \.authorID, remotePost.authorID)
+        updateIfNeeded(post, \.date_created_gmt, remotePost.date)
+        updateIfNeeded(post, \.dateModified, remotePost.dateModified)
+
+
+        updateIfNeeded(post, \.postTitle, remotePost.title)
+        updateIfNeeded(post, \.permaLink, remotePost.url.absoluteString)
+        updateIfNeeded(post, \.content, remotePost.content)
+        updateIfNeeded(post, \.statusString, remotePost.status)
+        updateIfNeeded(post, \.password, remotePost.password)
+
+        if let postThumbnailID = remotePost.postThumbnailID {
+            let media = Media.existingOrStubMediaWith(mediaID: postThumbnailID, inBlog: post.blog)
+            updateIfNeeded(post, \.featuredImage, media)
+        } else {
+            updateIfNeeded(post, \.featuredImage, nil)
+        }
+        updateIfNeeded(post, \.pathForDisplayImage, remotePost.pathForDisplayImage)
+        if post.pathForDisplayImage?.isEmpty ?? true {
+            post.updatePathForDisplayImageBasedOnContent()
+        }
+
+        updateIfNeeded(post, \.authorAvatarURL, remotePost.authorAvatarURL ?? author?.avatarURL)
+        updateIfNeeded(post, \.mt_excerpt, remotePost.excerpt)
+        updateIfNeeded(post, \.wp_slug, remotePost.slug)
+        updateIfNeeded(post, \.suggested_slug, remotePost.suggestedSlug)
+
+        let currentRevisions = post.revisions as? [NSNumber]
+        let newRevisions = remotePost.revisions as? [NSNumber]
+        if newRevisions != currentRevisions {
+            post.revisions = newRevisions
+        }
+        if remotePost.postID != previousPostID {
+            PostHelper.updateComments(for: post)
+        }
+
+        let autosave = remotePost.autosave
+        updateIfNeeded(post, \.autosaveTitle, autosave?.title)
+        updateIfNeeded(post, \.autosaveExcerpt, autosave?.excerpt)
+        updateIfNeeded(post, \.autosaveContent, autosave?.content)
+        updateIfNeeded(post, \.autosaveModifiedDate, autosave?.modifiedDate)
+        updateIfNeeded(post, \.autosaveIdentifier, autosave?.identifier)
+
+        switch post {
+        case let page as Page:
+            updateIfNeeded(page, \.parentID, remotePost.parentID)
+        case let post as Post:
+            updateIfNeeded(post, \.statusAfterSyncString, remotePost.status)
+            updateIfNeeded(post, \.commentCount, remotePost.commentCount)
+            updateIfNeeded(post, \.likeCount, remotePost.likeCount)
+            updateIfNeeded(post, \.postFormat, remotePost.format)
+            updateIfNeeded(post, \.tags, (remotePost.tags as? [String])?.joined(separator: ","))
+            updateIfNeeded(post, \.postType, remotePost.type)
+            updateIfNeeded(post, \.isStickyPost, (remotePost.isStickyPost != nil ? remotePost.isStickyPost.boolValue : false))
+            PostHelper.update(post, withRemoteCategories: remotePost.categories, in: context)
+
+            let publicizeInfo = PostHelper.makePublicizeInfo(with: post, remotePost: remotePost)
+            updateIfNeeded(post, \.publicID, publicizeInfo.publicID)
+            updateIfNeeded(post, \.publicizeMessage, publicizeInfo.publicizeMessage)
+            updateIfNeeded(post, \.publicizeMessageID, publicizeInfo.publicizeMessageID)
+            updateIfNeeded(post, \.disabledPublicizeConnections, publicizeInfo.disabledPublicizeConnections)
+        default:
+            break
+        }
+    }
+}
+
+private func updateIfNeeded<T, U: Equatable>(_ object: T, _ path: ReferenceWritableKeyPath<T, U>, _ newValue: U) {
+    if object[keyPath: path] != newValue {
+        object[keyPath: path] = newValue
+    }
+}

--- a/WordPress/Classes/Services/PostHelper.h
+++ b/WordPress/Classes/Services/PostHelper.h
@@ -6,9 +6,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PostHelper: NSObject
+@interface PostPublicizeInfo: NSObject
+@property (nonatomic, nullable) NSString *publicID;
+@property (nonatomic, nullable) NSString *publicizeMessage;
+@property (nonatomic, nullable) NSString *publicizeMessageID;
+@property (nonatomic, nullable) NSDictionary<NSNumber *, NSDictionary<NSString *, NSString *> *> *disabledPublicizeConnections;
+@end
 
-+ (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext;
+@interface PostHelper: NSObject
 
 /**
  Creates a RemotePost from an AbstractPost to be used for API calls.
@@ -25,6 +30,13 @@ NS_ASSUME_NONNULL_BEGIN
           purgeExisting:(BOOL)purge
               inContext:(NSManagedObjectContext *)context;
 
+// For internal use (needs rewrite to Swift)
++ (void)updateCommentsForPost:(AbstractPost *)post;
++ (void)updatePost:(Post *)post withRemoteCategories:(NSArray *)remoteCategories inContext:(NSManagedObjectContext *)managedObjectContext;
++ (PostPublicizeInfo *)makePublicizeInfoWithPost:(AbstractPost *)post remotePost:(RemotePost *)remotePost;
+
 @end
+
+
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -515,6 +515,8 @@
 		0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		0CF0C4232AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
 		0CF0C4242AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
+		0CF691232AF597BB003DF075 /* PostHelper+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF691222AF597BB003DF075 /* PostHelper+Swift.swift */; };
+		0CF691242AF597BB003DF075 /* PostHelper+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF691222AF597BB003DF075 /* PostHelper+Swift.swift */; };
 		0CF7D6C32ABB753A006D1E89 /* MediaImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */; };
 		0CFE9AC62AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
 		0CFE9AC72AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
@@ -6203,6 +6205,7 @@
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFeatureFlagsView.swift; sourceTree = "<group>"; };
 		0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostHelper.swift; sourceTree = "<group>"; };
+		0CF691222AF597BB003DF075 /* PostHelper+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHelper+Swift.swift"; sourceTree = "<group>"; };
 		0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageServiceTests.swift; sourceTree = "<group>"; };
 		0CFD6C792A73E703003DD0A0 /* WordPress 152.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 152.xcdatamodel"; sourceTree = "<group>"; };
 		0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPostHelper+Actions.swift"; sourceTree = "<group>"; };
@@ -14271,6 +14274,7 @@
 				2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */,
 				4A2C73ED2A9577C000ACE79E /* PostHelper.h */,
 				4A2C73EC2A9577C000ACE79E /* PostHelper.m */,
+				0CF691222AF597BB003DF075 /* PostHelper+Swift.swift */,
 				FEFA6AC22A83F4BE004EE5E6 /* PostHelper+JetpackSocial.swift */,
 				08472A1E1C7273FA0040769D /* PostServiceOptions.h */,
 				08472A1F1C727E020040769D /* PostServiceOptions.m */,
@@ -22626,6 +22630,7 @@
 				98E58A2F2360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				F5E1577F25DE04E200EEEDFB /* GutenbergMediaFilesUploadProcessor.swift in Sources */,
 				80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */,
+				0CF691232AF597BB003DF075 /* PostHelper+Swift.swift in Sources */,
 				805CC0BC29668986002941DC /* JetpackBrandedScreen.swift in Sources */,
 				4A2C73EE2A9577C000ACE79E /* PostHelper.m in Sources */,
 				5DF7F7741B22337C003A05C8 /* WordPress-30-31.xcmappingmodel in Sources */,
@@ -24278,6 +24283,7 @@
 				C72A4F68264088E4009CA633 /* JetpackNotFoundErrorViewModel.swift in Sources */,
 				FE1E201B2A473E0800CE7C90 /* JetpackSocialService.swift in Sources */,
 				FABB21F82602FC2C00C8785C /* AdaptiveNavigationController.swift in Sources */,
+				0CF691242AF597BB003DF075 /* PostHelper+Swift.swift in Sources */,
 				FABB21F92602FC2C00C8785C /* RemotePostCategory+Extensions.swift in Sources */,
 				FABB21FA2602FC2C00C8785C /* PostAutoUploadMessages.swift in Sources */,
 				FABB21FB2602FC2C00C8785C /* WPError+Swift.swift in Sources */,


### PR DESCRIPTION
This PR addresses an issue where when you open Posts, quickly open a context menu for a post, it gets dismissed when the background refresh completes.

I followed the [same approach](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/Services/MediaHelper.swift) as in Media that ensures that the database does not get updated if nothing changes.

**Problematic aspects:**

- Performance. Currently, mergePosts gets called on the main thread (should it be moved to the background?). I measured it, and comparison **don't** add significant overhead. The main problematic part in terms of performance is the existing [updatePathForDisplayImageBasedOnContent](https://github.com/wordpress-mobile/WordPress-iOS/blob/b65aad696ae635d38ae5619272d9f6f68bbc5d9d/WordPress/Classes/Models/AbstractPost.m#L635) method that iterates over all your media for each post ([measurement](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/3d716123-604c-4f34-bc1f-17644d0da79d)).
- A non-UI property can still trigger a reload when it's not even needed

**Alternatives considered:**

- Compare ViewModels and prevent the reload on the UI level. This can be an additional change. Rewriting the PostHelper in Swift and preventing unnecessary reload has value on its own.

To test:

- Add breakpoint to `controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?)` and verify that `reloadRows` is not called when you open the screen.
- Review the code carefully

## Regression Notes
1. Potential unintended areas of impact: Posts & Pages
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
