### PR TITLE
[Domain Management] Display transfer domains webview from domains search screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardCell.swift
@@ -86,7 +86,7 @@ final class DashboardGoogleDomainsCardCell: DashboardCollectionViewCell {
 
 extension DashboardGoogleDomainsCardCell: DashboardGoogleDomainsCardCellProtocol {
     func presentGoogleDomainsWebView(with url: URL) {
-
+        // TODO: Use `TransferDomainsWebViewController` instead.
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(
             url: url,
             source: "domain_focus_card"

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -4,7 +4,7 @@ import WordPressAuthenticator
 
 
 protocol DomainSuggestionsTableViewControllerDelegate: AnyObject {
-    func domainSelected(_ domain: FullyQuotedDomainSuggestion)
+    func domainSelected(_ domain: FullyQuotedDomainSuggestion?)
     func newSearchStarted()
 }
 
@@ -52,8 +52,10 @@ class DomainSuggestionsTableViewController: UITableViewController {
             tableView.reloadSections(IndexSet(integer: Sections.suggestions.rawValue), with: .automatic)
         }
     }
+
     private var isSearching: Bool = false
     private var selectedCell: UITableViewCell?
+    private var selectedDomain: FullyQuotedDomainSuggestion?
 
     // API returned no domain suggestions.
     private var noSuggestions: Bool = false
@@ -486,29 +488,34 @@ private extension DomainSuggestionsTableViewController {
 
 extension DomainSuggestionsTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let selectedDomain: FullyQuotedDomainSuggestion
-
-        switch indexPath.section {
-        case Sections.suggestions.rawValue:
-            selectedDomain = searchSuggestions[indexPath.row]
-        default:
+        guard indexPath.section == Sections.suggestions.rawValue else {
             return
         }
 
-        delegate?.domainSelected(selectedDomain)
-
         tableView.deselectSelectedRowWithAnimation(true)
+
+        let domain = searchSuggestions[indexPath.row]
+
+        let selectedDomain: FullyQuotedDomainSuggestion? = {
+            let isSameDomain = self.selectedDomain?.domainName == domain.domainName
+            return isSameDomain ? nil : domain
+        }()
+
+        self.delegate?.domainSelected(selectedDomain)
 
         // Uncheck the previously selected cell.
         if let selectedCell = selectedCell {
             selectedCell.accessoryType = .none
+            self.selectedCell = nil
         }
 
         // Check the currently selected cell.
-        if let cell = self.tableView.cellForRow(at: indexPath) {
+        if selectedDomain != nil, let cell = self.tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .checkmark
             selectedCell = cell
         }
+
+        self.selectedDomain = selectedDomain
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -41,7 +41,13 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         return buttonViewController
     }()
 
-    private lazy var transferFooterView = RegisterDomainTransferFooterView()
+    private lazy var transferFooterView: RegisterDomainTransferFooterView = {
+        let configuration = RegisterDomainTransferFooterView.Configuration { [weak self] in
+            let destination = TransferDomainsWebViewController(source: "register_domain")
+            self?.present(UINavigationController(rootViewController: destination), animated: true)
+        }
+        return .init(configuration: configuration)
+    }()
 
     /// Represents the layout constraints for the transfer footer view in its visible and hidden states.
     private lazy var transferFooterViewConstraints: (visible: [NSLayoutConstraint], hidden: [NSLayoutConstraint]) = {
@@ -119,13 +125,8 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         guard domainSelectionType == .purchaseFromDomainManagement else {
             return
         }
-        let configuration = RegisterDomainTransferFooterView.Configuration { [weak self] in
-            let destination = TransferDomainsWebViewController(source: "register_domain")
-            self?.present(UINavigationController(rootViewController: destination), animated: true)
-        }
         self.view.addSubview(transferFooterView)
         self.transferFooterView.translatesAutoresizingMaskIntoConstraints = false
-        self.transferFooterView.setup(with: configuration, parent: self)
         NSLayoutConstraint.activate(transferFooterViewConstraints.visible)
 #endif
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -167,6 +167,9 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         NSLayoutConstraint.deactivate(hidden ? constraints.visible : constraints.hidden)
         NSLayoutConstraint.activate(hidden ? constraints.hidden : constraints.visible)
 
+        if !hidden {
+            self.transferFooterView.isHidden = false
+        }
         UIView.animate(withDuration: duration) {
             self.view.layoutIfNeeded()
         } completion: { _ in

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -41,12 +41,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         return buttonViewController
     }()
 
-    private let transferFooterView: UIView = {
-        let view = UIView()
-        view.backgroundColor = UIColor(light: .systemBackground, dark: .secondarySystemBackground)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
+    private lazy var transferFooterView = RegisterDomainTransferFooterView()
 
     static func instance(coordinator: RegisterDomainCoordinator,
                          domainSelectionType: DomainSelectionType = .registerWithPaidPlan,
@@ -113,33 +108,17 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         guard domainSelectionType == .purchaseFromDomainManagement else {
             return
         }
-
         let configuration = RegisterDomainTransferFooterView.Configuration {
 
         }
-
-        let hostingController = UIHostingController(rootView: RegisterDomainTransferFooterView(configuration: configuration))
-        hostingController.willMove(toParent: self)
-        hostingController.view.backgroundColor = .clear
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-
-        self.transferFooterView.addTopBorder(withColor: .divider)
-        self.transferFooterView.addSubview(hostingController.view)
         self.view.addSubview(transferFooterView)
-
-        self.addChild(hostingController)
-
+        self.transferFooterView.translatesAutoresizingMaskIntoConstraints = false
+        self.transferFooterView.setup(with: configuration, parent: self)
         NSLayoutConstraint.activate([
-            hostingController.view.leadingAnchor.constraint(equalTo: transferFooterView.readableContentGuide.leadingAnchor, constant: Length.Padding.double),
-            hostingController.view.trailingAnchor.constraint(equalTo: transferFooterView.readableContentGuide.trailingAnchor, constant: -Length.Padding.double),
-            hostingController.view.topAnchor.constraint(equalTo: transferFooterView.topAnchor, constant: Length.Padding.double),
-            hostingController.view.bottomAnchor.constraint(equalTo: transferFooterView.safeAreaLayoutGuide.bottomAnchor, constant: -Length.Padding.double),
             transferFooterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             transferFooterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            transferFooterView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            transferFooterView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
-
-        hostingController.didMove(toParent: self)
 #endif
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -119,8 +119,9 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         guard domainSelectionType == .purchaseFromDomainManagement else {
             return
         }
-        let configuration = RegisterDomainTransferFooterView.Configuration {
-
+        let configuration = RegisterDomainTransferFooterView.Configuration { [weak self] in
+            let destination = TransferDomainsWebViewController()
+            self?.present(UINavigationController(rootViewController: destination), animated: true)
         }
         self.view.addSubview(transferFooterView)
         self.transferFooterView.translatesAutoresizingMaskIntoConstraints = false
@@ -159,15 +160,16 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         guard transferFooterView.superview != nil else {
             return
         }
-        let constraintsToDeactivate = hidden ? transferFooterViewConstraints.visible : transferFooterViewConstraints.hidden
-        let constraintsToActivate = hidden ? transferFooterViewConstraints.hidden : transferFooterViewConstraints.visible
-        let animations: () -> Void = {
-            NSLayoutConstraint.deactivate(constraintsToDeactivate)
-            NSLayoutConstraint.activate(constraintsToActivate)
-            self.view.layoutIfNeeded()
-        }
+
+        let constraints = transferFooterViewConstraints
         let duration = animated ? WPAnimationDurationDefault : 0
-        UIView.animate(withDuration: duration, animations: animations) { _ in
+
+        NSLayoutConstraint.deactivate(hidden ? constraints.visible : constraints.hidden)
+        NSLayoutConstraint.activate(hidden ? constraints.hidden : constraints.visible)
+
+        UIView.animate(withDuration: duration) {
+            self.view.layoutIfNeeded()
+        } completion: { _ in
             self.transferFooterView.isHidden = hidden
             self.view.setNeedsLayout()
         }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -282,11 +282,17 @@ class RegisterDomainSuggestionsViewController: UIViewController {
 // MARK: - DomainSuggestionsTableViewControllerDelegate
 
 extension RegisterDomainSuggestionsViewController: DomainSuggestionsTableViewControllerDelegate {
-    func domainSelected(_ domain: FullyQuotedDomainSuggestion) {
-        WPAnalytics.track(.automatedTransferCustomDomainSuggestionSelected)
-        coordinator?.domain = domain
-        showButton(animated: true)
-        hideTransferFooterView(animated: true)
+    func domainSelected(_ domain: FullyQuotedDomainSuggestion?) {
+        self.coordinator?.domain = domain
+
+        if domain != nil {
+            WPAnalytics.track(.automatedTransferCustomDomainSuggestionSelected)
+            showButton(animated: true)
+            hideTransferFooterView(animated: true)
+        } else {
+            hideButton(animated: true)
+            showTransferFooterView(animated: true)
+        }
     }
 
     func newSearchStarted() {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -202,7 +202,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
 
     /// Shows the domain picking button
     ///
-    /// - Parameters:
+    /// - Parameters:r
     ///     - animated: whether the transition is animated.
     ///
     private func showButton(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -126,14 +126,12 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     // MARK: - Setup subviews
 
     private func setupTransferFooterView() {
-#if JETPACK
         guard domainSelectionType == .purchaseFromDomainManagement else {
             return
         }
         self.view.addSubview(transferFooterView)
         self.transferFooterView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate(transferFooterViewConstraints.visible)
-#endif
     }
 
     private func configure() {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -200,7 +200,9 @@ class RegisterDomainSuggestionsViewController: UIViewController {
 
     /// Shows the domain picking button
     ///
-    /// - Parameters:r
+    /// - Parameters:
+    ///
+    /// g
     ///     - animated: whether the transition is animated.
     ///
     private func showButton(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -25,12 +25,6 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     private var includeSupportButton: Bool = true
     private var navBarTitle: String = TextContent.title
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        configure()
-        hideButton()
-    }
-
     @IBOutlet private var buttonViewContainer: UIView! {
         didSet {
             buttonViewController.move(to: self, into: buttonViewContainer)
@@ -45,6 +39,13 @@ class RegisterDomainSuggestionsViewController: UIViewController {
             primary: TextContent.primaryButtonTitle
         )
         return buttonViewController
+    }()
+
+    private let transferFooterView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(light: .systemBackground, dark: .secondarySystemBackground)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     static func instance(coordinator: RegisterDomainCoordinator,
@@ -79,6 +80,67 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         }
 
         return nil
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+        hideButton()
+        setupTransferFooterView()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if let domainsTableViewController {
+            let insets = UIEdgeInsets(
+                top: 0,
+                left: 0,
+                bottom: transferFooterView.bounds.height,
+                right: 0
+            )
+            if insets != domainsTableViewController.additionalSafeAreaInsets {
+                domainsTableViewController.additionalSafeAreaInsets = insets
+            }
+        }
+    }
+
+    // MARK: - Setup subviews
+
+    private func setupTransferFooterView() {
+#if JETPACK
+        guard domainSelectionType == .purchaseFromDomainManagement else {
+            return
+        }
+
+        let configuration = RegisterDomainTransferFooterView.Configuration {
+
+        }
+
+        let hostingController = UIHostingController(rootView: RegisterDomainTransferFooterView(configuration: configuration))
+        hostingController.willMove(toParent: self)
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        self.transferFooterView.addTopBorder(withColor: .divider)
+        self.transferFooterView.addSubview(hostingController.view)
+        self.view.addSubview(transferFooterView)
+
+        self.addChild(hostingController)
+
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: transferFooterView.readableContentGuide.leadingAnchor, constant: Length.Padding.double),
+            hostingController.view.trailingAnchor.constraint(equalTo: transferFooterView.readableContentGuide.trailingAnchor, constant: -Length.Padding.double),
+            hostingController.view.topAnchor.constraint(equalTo: transferFooterView.topAnchor, constant: Length.Padding.double),
+            hostingController.view.bottomAnchor.constraint(equalTo: transferFooterView.safeAreaLayoutGuide.bottomAnchor, constant: -Length.Padding.double),
+            transferFooterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            transferFooterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            transferFooterView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        hostingController.didMove(toParent: self)
+#endif
     }
 
     private func configure() {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -120,7 +120,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
             return
         }
         let configuration = RegisterDomainTransferFooterView.Configuration { [weak self] in
-            let destination = TransferDomainsWebViewController()
+            let destination = TransferDomainsWebViewController(source: "register_domain")
             self?.present(UINavigationController(rootViewController: destination), animated: true)
         }
         self.view.addSubview(transferFooterView)

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -27,7 +27,12 @@ class RegisterDomainSuggestionsViewController: UIViewController {
 
     @IBOutlet private var buttonViewContainer: UIView! {
         didSet {
-            buttonViewController.move(to: self, into: buttonViewContainer)
+            guard let view = buttonViewContainer else {
+                return
+            }
+            view.addTopBorder(withColor: .divider)
+            view.backgroundColor = UIColor(light: .systemBackground, dark: .secondarySystemBackground)
+            buttonViewController.move(to: self, into: view)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -50,6 +50,7 @@ struct RegisterDomainTransferFooterView: View {
             .buttonStyle(PrimaryButtonStyle())
         }
         .frame(maxWidth: .infinity)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct RegisterDomainTransferFooterView: View {
+
+    // MARK: - Types
+
+    struct Configuration {
+
+        let title: String
+        let buttonTitle: String
+        let buttonAction: () -> Void
+
+        init(
+            title: String = Strings.title,
+            buttonTitle: String = Strings.buttonTitle,
+            buttonAction: @escaping () -> Void
+        ) {
+            self.title = title
+            self.buttonTitle = buttonTitle
+            self.buttonAction = buttonAction
+        }
+    }
+
+    struct Strings {
+        static let title = NSLocalizedString(
+            "register.domain.transfer.title",
+            value: "Looking to transfer a domain you already own?",
+            comment: "The title for the transfer footer view in Register Domain screen"
+        )
+        static let buttonTitle = NSLocalizedString(
+            "register.domain.transfer.button.title",
+            value: "Transfer domain",
+            comment: "The button title for the transfer footer view in Register Domain screen"
+        )
+    }
+
+    // MARK: - Properties
+
+    let configuration: Configuration
+
+    // MARK: - Views
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Length.Padding.double) {
+            Text(configuration.title)
+                .font(.body)
+            Button(action: configuration.buttonAction) {
+                Text(configuration.buttonTitle)
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Previews
+
+struct RegisterDomainTransferFooterView_Reviews: PreviewProvider {
+    static var previews: some View {
+        RegisterDomainTransferFooterView(configuration: .init(buttonAction: {}))
+            .padding(Length.Padding.double)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -78,7 +78,7 @@ final class RegisterDomainTransferFooterView: UIView {
         stackView.distribution = .fill
 
         self.addSubview(stackView)
-        
+
         self.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: Length.Padding.double,
             leading: Length.Padding.double,

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
+import UIKit
 
-struct RegisterDomainTransferFooterView: View {
+final class RegisterDomainTransferFooterView: UIView {
 
     // MARK: - Types
 
@@ -22,6 +23,7 @@ struct RegisterDomainTransferFooterView: View {
     }
 
     struct Strings {
+
         static let title = NSLocalizedString(
             "register.domain.transfer.title",
             value: "Looking to transfer a domain you already own?",
@@ -34,11 +36,72 @@ struct RegisterDomainTransferFooterView: View {
         )
     }
 
-    // MARK: - Properties
+    // MARK: - Views
+
+    private var hostingController: UIHostingController<Content>?
+
+    // MARK: - Init
+
+    init() {
+        super.init(frame: .zero)
+        self.backgroundColor = UIColor(light: .systemBackground, dark: .secondarySystemBackground)
+        self.addTopBorder(withColor: .divider)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    func setup(with configuration: Configuration, parent: UIViewController) {
+        self.setup(with: Content(configuration: configuration), parent: parent)
+    }
+
+    private func setup(with content: Content, parent: UIViewController) {
+        if let hostingController {
+            hostingController.rootView = content
+            hostingController.view.invalidateIntrinsicContentSize()
+        } else {
+            let hostingController = UIHostingController<Content>(rootView: content)
+            self.add(hostingController: hostingController, parent: parent)
+            self.constraint(hostingController: hostingController)
+            self.hostingController = hostingController
+        }
+    }
+
+    private func add(hostingController: UIHostingController<Content>, parent: UIViewController) {
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        hostingController.view.backgroundColor = .clear
+        hostingController.willMove(toParent: parent)
+        self.addSubview(hostingController.view)
+        parent.add(hostingController)
+        hostingController.didMove(toParent: parent)
+    }
+
+    private func constraint(hostingController: UIHostingController<Content>) {
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: Length.Padding.double),
+            hostingController.view.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor, constant: -Length.Padding.double),
+            hostingController.view.topAnchor.constraint(equalTo: topAnchor, constant: Length.Padding.double),
+            hostingController.view.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Length.Padding.double),
+        ])
+    }
+
+    // MARK: - Trait Collection
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        self.hostingController?.view.invalidateIntrinsicContentSize()
+    }
+
+}
+
+// MARK: - SwiftUI
+
+fileprivate struct Content: View {
 
     let configuration: Configuration
-
-    // MARK: - Views
 
     var body: some View {
         VStack(alignment: .leading, spacing: Length.Padding.double) {
@@ -52,13 +115,14 @@ struct RegisterDomainTransferFooterView: View {
         .frame(maxWidth: .infinity)
         .fixedSize(horizontal: false, vertical: true)
     }
-}
 
-// MARK: - Previews
+    typealias Configuration = RegisterDomainTransferFooterView.Configuration
+
+}
 
 struct RegisterDomainTransferFooterView_Reviews: PreviewProvider {
     static var previews: some View {
-        RegisterDomainTransferFooterView(configuration: .init(buttonAction: {}))
+        Content(configuration: .init(buttonAction: {}))
             .padding(Length.Padding.double)
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -90,7 +90,7 @@ final class RegisterDomainTransferFooterView: UIView {
             stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
             readableContentGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
-            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
+            layoutMarginsGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
         ])
 
         let action = UIAction { _ in

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -77,7 +77,7 @@ final class RegisterDomainTransferFooterView: UIView {
         stackView.spacing = Length.Padding.double
         stackView.distribution = .fill
 
-        addSubview(stackView)
+        self.addSubview(stackView)
 
         let insets = NSDirectionalEdgeInsets(
             top: Length.Padding.double,

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -78,8 +78,8 @@ final class RegisterDomainTransferFooterView: UIView {
         stackView.distribution = .fill
 
         self.addSubview(stackView)
-
-        let insets = NSDirectionalEdgeInsets(
+        
+        self.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: Length.Padding.double,
             leading: Length.Padding.double,
             bottom: Length.Padding.double,
@@ -87,10 +87,10 @@ final class RegisterDomainTransferFooterView: UIView {
         )
 
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor, constant: insets.top),
-            stackView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: insets.leading),
-            readableContentGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: insets.trailing),
-            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: insets.bottom)
+            stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            readableContentGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
         ])
 
         let action = UIAction { _ in

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import WordPressUI
 
 final class RegisterDomainTransferFooterView: UIView {
 
@@ -38,14 +39,29 @@ final class RegisterDomainTransferFooterView: UIView {
 
     // MARK: - Views
 
-    private var hostingController: UIHostingController<Content>?
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        label.textColor = UIColor.DS.Foreground.primary
+        label.numberOfLines = 2
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private let primaryButton: UIButton = {
+        let button = FancyButton()
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .regular)
+        button.isPrimary = true
+        return button
+    }()
 
     // MARK: - Init
 
-    init() {
+    init(configuration: Configuration) {
         super.init(frame: .zero)
         self.backgroundColor = UIColor(light: .systemBackground, dark: .secondarySystemBackground)
         self.addTopBorder(withColor: .divider)
+        self.setup(with: configuration)
     }
 
     required init?(coder: NSCoder) {
@@ -54,75 +70,35 @@ final class RegisterDomainTransferFooterView: UIView {
 
     // MARK: - Setup
 
-    func setup(with configuration: Configuration, parent: UIViewController) {
-        self.setup(with: Content(configuration: configuration), parent: parent)
-    }
+    private func setup(with configuration: Configuration) {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, primaryButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = Length.Padding.double
+        stackView.distribution = .fill
 
-    private func setup(with content: Content, parent: UIViewController) {
-        if let hostingController {
-            hostingController.rootView = content
-            hostingController.view.invalidateIntrinsicContentSize()
-        } else {
-            let hostingController = UIHostingController<Content>(rootView: content)
-            self.add(hostingController: hostingController, parent: parent)
-            self.constraint(hostingController: hostingController)
-            self.hostingController = hostingController
-        }
-    }
+        addSubview(stackView)
 
-    private func add(hostingController: UIHostingController<Content>, parent: UIViewController) {
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-        hostingController.view.backgroundColor = .clear
-        hostingController.willMove(toParent: parent)
-        self.addSubview(hostingController.view)
-        parent.add(hostingController)
-        hostingController.didMove(toParent: parent)
-    }
+        let insets = NSDirectionalEdgeInsets(
+            top: Length.Padding.double,
+            leading: Length.Padding.double,
+            bottom: Length.Padding.double,
+            trailing: Length.Padding.double
+        )
 
-    private func constraint(hostingController: UIHostingController<Content>) {
         NSLayoutConstraint.activate([
-            hostingController.view.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: Length.Padding.double),
-            hostingController.view.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor, constant: -Length.Padding.double),
-            hostingController.view.topAnchor.constraint(equalTo: topAnchor, constant: Length.Padding.double),
-            hostingController.view.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Length.Padding.double),
+            stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor, constant: insets.top),
+            stackView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: insets.leading),
+            readableContentGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: insets.trailing),
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: insets.bottom)
         ])
-    }
 
-    // MARK: - Trait Collection
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        self.hostingController?.view.invalidateIntrinsicContentSize()
-    }
-
-}
-
-// MARK: - SwiftUI
-
-fileprivate struct Content: View {
-
-    let configuration: Configuration
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Length.Padding.double) {
-            Text(configuration.title)
-                .font(.body)
-            Button(action: configuration.buttonAction) {
-                Text(configuration.buttonTitle)
-            }
-            .buttonStyle(PrimaryButtonStyle())
+        let action = UIAction { _ in
+            configuration.buttonAction()
         }
-        .frame(maxWidth: .infinity)
-        .fixedSize(horizontal: false, vertical: true)
+        self.titleLabel.text = configuration.title
+        self.primaryButton.setTitle(configuration.buttonTitle, for: .normal)
+        self.primaryButton.addAction(action, for: .touchUpInside)
     }
 
-    typealias Configuration = RegisterDomainTransferFooterView.Configuration
-
-}
-
-struct RegisterDomainTransferFooterView_Reviews: PreviewProvider {
-    static var previews: some View {
-        Content(configuration: .init(buttonAction: {}))
-            .padding(Length.Padding.double)
-    }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Transfer Domains/TransferDomainsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Transfer Domains/TransferDomainsWebViewController.swift
@@ -3,7 +3,7 @@ import Foundation
 final class TransferDomainsWebViewController: WebKitViewController {
 
     private enum Constants {
-        static let url = URL(string: "https://wordpress.com/transfer-google-domains/")!
+        static let url = URL(string: "https://wordpress.com/setup/domain-transfer/intro")!
     }
 
     init(source: String? = nil) {

--- a/WordPress/Classes/ViewRelated/Domains/Transfer Domains/TransferDomainsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Transfer Domains/TransferDomainsWebViewController.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+final class TransferDomainsWebViewController: WebKitViewController {
+    
+    private enum Constants {
+        static let url = URL(string: "https://wordpress.com/transfer-google-domains/")!
+    }
+
+    init(source: String? = nil) {
+        let configuration = WebViewControllerConfiguration(url: Constants.url)
+        configuration.analyticsSource = source
+        configuration.authenticateWithDefaultAccount()
+        super.init(configuration: configuration)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Domains/Transfer Domains/TransferDomainsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Transfer Domains/TransferDomainsWebViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class TransferDomainsWebViewController: WebKitViewController {
-    
+
     private enum Constants {
         static let url = URL(string: "https://wordpress.com/transfer-google-domains/")!
     }
@@ -12,7 +12,7 @@ final class TransferDomainsWebViewController: WebKitViewController {
         configuration.authenticateWithDefaultAccount()
         super.init(configuration: configuration)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/WordPress/Classes/ViewRelated/Reusable SwiftUI Views/ButtonStyles.swift
+++ b/WordPress/Classes/ViewRelated/Reusable SwiftUI Views/ButtonStyles.swift
@@ -1,14 +1,19 @@
 import SwiftUI
 
-struct PrimaryButtonStyle: ButtonStyle {
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 44.0)
+struct PrimaryButtonStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
             .font(.headline)
-            .background(Color.DS.Background.brand)
-            .foregroundColor(Color.white)
-            .clipShape(RoundedRectangle(cornerRadius: Length.Radius.minHeightButton))
-            .opacity(configuration.isPressed ? 0.5 : 1)
+            .padding()
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 44.0, maxHeight: 44.0)
+            .background(Color(.primary))
+            .foregroundColor(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 8.0))
+    }
+}
+
+extension View {
+    func primaryButtonStyle() -> some View {
+        self.modifier(PrimaryButtonStyle())
     }
 }

--- a/WordPress/Classes/ViewRelated/Reusable SwiftUI Views/ButtonStyles.swift
+++ b/WordPress/Classes/ViewRelated/Reusable SwiftUI Views/ButtonStyles.swift
@@ -1,19 +1,14 @@
 import SwiftUI
 
-struct PrimaryButtonStyle: ViewModifier {
-    func body(content: Content) -> some View {
-        content
-            .font(.headline)
-            .padding()
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 44.0, maxHeight: 44.0)
-            .background(Color(.primary))
-            .foregroundColor(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 8.0))
-    }
-}
+struct PrimaryButtonStyle: ButtonStyle {
 
-extension View {
-    func primaryButtonStyle() -> some View {
-        self.modifier(PrimaryButtonStyle())
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 44.0)
+            .font(.headline)
+            .background(Color.DS.Background.brand)
+            .foregroundColor(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: Length.Radius.minHeightButton))
+            .opacity(configuration.isPressed ? 0.5 : 1)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3754,6 +3754,8 @@
 		F4CBE3D7292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */; };
 		F4CBE3D929265BC8004FFBB6 /* LogOutActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */; };
 		F4CBE3DA29265BC8004FFBB6 /* LogOutActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */; };
+		F4D140202AFD9B9700961797 /* TransferDomainsWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D1401F2AFD9B9700961797 /* TransferDomainsWebViewController.swift */; };
+		F4D140212AFD9D5300961797 /* TransferDomainsWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D1401F2AFD9B9700961797 /* TransferDomainsWebViewController.swift */; };
 		F4D36AD5298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */; };
 		F4D36AD6298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */; };
 		F4D7FD6C2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */; };
@@ -9146,6 +9148,7 @@
 		F4CBE3D329258AD6004FFBB6 /* MeHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeHeaderView.h; sourceTree = "<group>"; };
 		F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewControllerConfiguration.swift; sourceTree = "<group>"; };
 		F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutActionHandler.swift; sourceTree = "<group>"; };
+		F4D1401F2AFD9B9700961797 /* TransferDomainsWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferDomainsWebViewController.swift; sourceTree = "<group>"; };
 		F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostBlockingController.swift; sourceTree = "<group>"; };
 		F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompliancePopoverViewControllerTests.swift; sourceTree = "<group>"; };
 		F4D829612930E9F300038726 /* MigrationDeleteWordPressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationDeleteWordPressViewController.swift; sourceTree = "<group>"; };
@@ -10518,6 +10521,7 @@
 		173BCE711CEB365400AE8817 /* Domains */ = {
 			isa = PBXGroup;
 			children = (
+				F4D1401E2AFD9B8200961797 /* Transfer Domains */,
 				02BF30512271D76F00616558 /* Domain credit */,
 				437EF0C820F79C0C0086129B /* Domain registration */,
 				3F3DD0B426FD18D400F5F121 /* Utility */,
@@ -17780,6 +17784,14 @@
 			path = "Privacy Settings";
 			sourceTree = "<group>";
 		};
+		F4D1401E2AFD9B8200961797 /* Transfer Domains */ = {
+			isa = PBXGroup;
+			children = (
+				F4D1401F2AFD9B9700961797 /* TransferDomainsWebViewController.swift */,
+			);
+			path = "Transfer Domains";
+			sourceTree = "<group>";
+		};
 		F4D829602930E9DD00038726 /* Delete WordPress */ = {
 			isa = PBXGroup;
 			children = (
@@ -21460,6 +21472,7 @@
 				F5B9D7F0245BA938002BB2C7 /* FancyAlertViewController+CreateButtonAnnouncement.swift in Sources */,
 				FF54D4641D6F3FA900A0DC4D /* GutenbergSettings.swift in Sources */,
 				3FAF9CC526D03C7400268EA2 /* DomainSuggestionViewControllerWrapper.swift in Sources */,
+				F4D140202AFD9B9700961797 /* TransferDomainsWebViewController.swift in Sources */,
 				FE4DC5A7293A79F1008F322F /* WordPressExportRoute.swift in Sources */,
 				D80BC79E20746B4100614A59 /* MediaPickingContext.swift in Sources */,
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
@@ -25382,6 +25395,7 @@
 				010459E729153FFF000C7778 /* JetpackNotificationMigrationService.swift in Sources */,
 				FABB24FE2602FC2C00C8785C /* ReaderTopicToReaderTagTopic37to38.swift in Sources */,
 				084777962AEFFCBE00EC9F85 /* PrimaryButton.swift in Sources */,
+				F4D140212AFD9D5300961797 /* TransferDomainsWebViewController.swift in Sources */,
 				FABB24FF2602FC2C00C8785C /* ChangeUsernameViewModel.swift in Sources */,
 				C31852A329673BFC00A78BE9 /* MenusViewController+JetpackBannerViewController.swift in Sources */,
 				FABB25002602FC2C00C8785C /* PlansLoadingIndicatorView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3756,6 +3756,7 @@
 		F4CBE3DA29265BC8004FFBB6 /* LogOutActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */; };
 		F4D140202AFD9B9700961797 /* TransferDomainsWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D1401F2AFD9B9700961797 /* TransferDomainsWebViewController.swift */; };
 		F4D140212AFD9D5300961797 /* TransferDomainsWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D1401F2AFD9B9700961797 /* TransferDomainsWebViewController.swift */; };
+		F4D140222AFE794300961797 /* RegisterDomainTransferFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F479995D2AFD241E0023F4FB /* RegisterDomainTransferFooterView.swift */; };
 		F4D36AD5298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */; };
 		F4D36AD6298498E600E6B84C /* ReaderPostBlockingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D36AD4298498E600E6B84C /* ReaderPostBlockingController.swift */; };
 		F4D7FD6C2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */; };
@@ -22626,6 +22627,7 @@
 				FEA1123C29944896008097B0 /* SelfHostedJetpackRemoteInstallViewModel.swift in Sources */,
 				FAD7625B29ED780B00C09583 /* JSONDecoderExtension.swift in Sources */,
 				C81CCD83243BF7A600A83E27 /* TenorDataLoader.swift in Sources */,
+				F4D140222AFE794300961797 /* RegisterDomainTransferFooterView.swift in Sources */,
 				98797DBC222F434500128C21 /* OverviewCell.swift in Sources */,
 				F484D4ED2A32C4520050BE15 /* CATransaction+Extension.swift in Sources */,
 				C3BC86F629528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3720,6 +3720,7 @@
 		F465980B28E66A5B00D5F49A /* white-on-blue-icon-app-60@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465980628E66A5A00D5F49A /* white-on-blue-icon-app-60@2x.png */; };
 		F465980C28E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465980728E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png */; };
 		F478B152292FC1BC00AA8645 /* MigrationAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = F478B151292FC1BC00AA8645 /* MigrationAppearance.swift */; };
+		F479995F2AFD241E0023F4FB /* RegisterDomainTransferFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F479995D2AFD241E0023F4FB /* RegisterDomainTransferFooterView.swift */; };
 		F47E154A29E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47E154929E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift */; };
 		F47E154B29E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47E154929E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift */; };
 		F484D4EA2A32B51C0050BE15 /* RootViewPresenter+AppSettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F484D4E92A32B51C0050BE15 /* RootViewPresenter+AppSettingsNavigation.swift */; };
@@ -9127,6 +9128,7 @@
 		F465980628E66A5A00D5F49A /* white-on-blue-icon-app-60@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "white-on-blue-icon-app-60@2x.png"; sourceTree = "<group>"; };
 		F465980728E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "white-on-blue-icon-app-83.5@2x.png"; sourceTree = "<group>"; };
 		F478B151292FC1BC00AA8645 /* MigrationAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAppearance.swift; sourceTree = "<group>"; };
+		F479995D2AFD241E0023F4FB /* RegisterDomainTransferFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDomainTransferFooterView.swift; sourceTree = "<group>"; };
 		F47E154929E84A9300B6E426 /* SiteCreationPurchasingWebFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationPurchasingWebFlowController.swift; sourceTree = "<group>"; };
 		F484D4E92A32B51C0050BE15 /* RootViewPresenter+AppSettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RootViewPresenter+AppSettingsNavigation.swift"; sourceTree = "<group>"; };
 		F484D4EC2A32C4520050BE15 /* CATransaction+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CATransaction+Extension.swift"; sourceTree = "<group>"; };
@@ -12080,6 +12082,7 @@
 				171096CA270F01EA001BCDD6 /* DomainSuggestionsTableViewController.swift */,
 				436D560C2117312600CEAA33 /* RegisterDomainSuggestionsViewController.swift */,
 				80DB57912AF8B59B00C728FF /* RegisterDomainCoordinator.swift */,
+				F479995D2AFD241E0023F4FB /* RegisterDomainTransferFooterView.swift */,
 			);
 			path = RegisterDomainSuggestions;
 			sourceTree = "<group>";
@@ -25535,6 +25538,7 @@
 				FABB256E2602FC2C00C8785C /* PostPostViewController.swift in Sources */,
 				FABB256F2602FC2C00C8785C /* QuickStartSpotlightView.swift in Sources */,
 				FABB25702602FC2C00C8785C /* ReaderReblogAction.swift in Sources */,
+				F479995F2AFD241E0023F4FB /* RegisterDomainTransferFooterView.swift in Sources */,
 				FABB25712602FC2C00C8785C /* SiteAssemblyWizardContent.swift in Sources */,
 				08A4E12A289D202F001D9EC7 /* UserPersistentStore.swift in Sources */,
 				FEDDD47026A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */,


### PR DESCRIPTION
Fixes #21782

## Description

This adds a button in "Register Domain" screen that navigates to "Transfer Domains" web view when tapped.

| Light Mode | Dark Mode |
| ----------- | ----------- |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/c55be6dd-4db5-4ca6-bbb9-85b1de58549e"></video> | <img width=350 src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/31180183-8df4-4e17-87db-58a6144aaad9" /> |

## Test Instructions

1. Install Jetpack and Login.
2. Enable `Domain Management` feature flag.
3. Head to Me > All Domains > Tap "+"
4. **Expect** the "Register Domain" to be presented modally with **Transfer Domain** view at the bottom.
5. Tap "Transfer Domain".
6. **Expect** the "Transfer Domain" web view to be presented modally.
7. Dismiss the web view.
8. Search for a domain then select a row.
9. **Expect** the "Transfer Domain" footer view to disappear and "Select Domain" to appear.
10. Start a new search.
11. **Expect** the "Transfer Domain" footer view to appear again.

## Regression Notes

1. Potential unintended areas of impact
Smoke test "Register Domain" screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

# PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

# UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
