### PR TITLE
Fix sharing of PDFs and other documents

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 * [*] Site Media: Fix an issue with 'you have no media' appears just before the media does [#9922] [#21457]
 * [*] Site Media: Fix an issue with media occasionally flashing white on the Site Media screen
 * [*] Site Media: Fix rare crashes in the Site Media screen and media picker [#21572]
+* [*] Site Media: Fix an issue with sharing PDF and other documents [#22021]
 * [*] Bug fix: Reader now scrolls to the top when tapping the status bar. [#21914]
 * [*] [internal] Refactor sending the API requests for searching posts and pages. [#21976]
 * [*] Fix an issue in Menu screen where it fails to create default menu items. [#21949]

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -282,6 +282,10 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     }
 }
 
+extension SiteMediaViewController {
+    static var sharingFailureMessage: String { Strings.sharingFailureMessage }
+}
+
 private enum Strings {
     static let title = NSLocalizedString("mediaLibrary.title", value: "Media", comment: "Media screen navigation title")
     static let select = NSLocalizedString("mediaLibrary.buttonSelect", value: "Select", comment: "Media screen navigation bar button Select title")


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/18917

This change also benefits from other improvements made to sharing in SiteMediaViewController. It also removes one of the last soft-deprecated `imageWithSize:` usages. It also add a spinner.

To test:

- Verify that when sharing on iPad, the shore sheet is presented as a popover
- Verify that sharing PDF (or other documents) works
- Verify that sharing images and video also still works
- Verify that the bar button item now displays an indicator when preparing for sharing


https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/abb0c7df-9d88-471a-9d03-d2a25749c9a7


## Regression Notes
1. Potential unintended areas of impact: Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
