### PR TITLE
Enable inspection of WKWebView for iOS 16.4 and higher

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -220,6 +220,9 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         webView.customUserAgent = WPUserAgent.wordPress()
         webView.navigationDelegate = self
         webView.uiDelegate = self
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
 
         loadWebViewRequest()
 


### PR DESCRIPTION
Enables `WKWebView`s to be inspected by enabling the [`isInspectable`](https://developer.apple.com/documentation/safari-developer-tools/enabling-inspecting-content-in-your-apps) property.

## Testing
1. Build and run the app on iOS 16.4 or higher.
2. Open a web view via tapping the domain on My Site, tapping the globe in Reader, previewing a post in the editor, or any other place the app presents a web view.
3. Load Safari and make sure the [developer tools](https://support.apple.com/en-uz/guide/safari/sfri20948/mac) are enabled.
4. **Expect:** The ability to inspect the loaded web view.

## Regression Notes
1. Potential unintended areas of impact
    - None identified.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing.

3. What automated tests I added (or what prevented me from doing so)
    - N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
