### PR TITLE
Fix an issue with GIF upload progress

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -21,6 +21,7 @@
 * [*] Bug fix: Reader now scrolls to the top when tapping the status bar. [#21914]
 * [*] [internal] Refactor sending the API requests for searching posts and pages. [#21976]
 * [*] Fix an issue in Menu screen where it fails to create default menu items. [#21949]
+* [*] Fix an issue with GIF uploads [#22025]
 * [*] [internal] Refactor how site's pages are loaded in Site Settings -> Homepage Settings. [#21974]
 
 23.6

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -38,6 +38,9 @@ final class ItemProviderMediaExporter: MediaExporter {
         func processGIF(at url: URL) throws {
             let pixelSize = url.pixelSize
             let media = MediaExport(url: url, fileSize: url.fileSize, width: pixelSize.width, height: pixelSize.height, duration: nil)
+            let exportProgress = Progress(totalUnitCount: 1)
+            exportProgress.completedUnitCount = 1
+            progress.addChild(exportProgress, withPendingUnitCount: MediaExportProgressUnits.halfDone)
             onCompletion(media)
         }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6366

**RCA**

- `ItemProviderMediaExporter` has a special handling for GIF uploads and it fails to report its progress to the subsystem that manages the upload
- The app uses `MediaProgressCoordinator.isRunning` and the progress percentage as a way to track wether there are any pending uploads. 

Tech debt: the app should not use progress percentage to check if there are pending uploads. It should be a simple yes/no started/ended.

To test:

## Regression Notes
1. Potential unintended areas of impact: GIF uploads
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
