### PR TITLE
Posts & Pages: Fix notice message for deleting a trashed post / page

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -507,10 +507,13 @@ class PostCoordinator: NSObject {
             SearchManager.shared.deleteSearchableItem(post)
 
             let message: String
-            if post is Post {
-                message = NSLocalizedString("postsList.movePostToTrash.message", value: "Post moved to trash", comment: "A short message explaining that a post was moved to the trash bin.")
-            } else {
-                message = NSLocalizedString("postsList.movePageToTrash.message", value: "Page moved to trash", comment: "A short message explaining that a page was moved to the trash bin.")
+            switch post {
+            case _ as Post:
+                message = trashed ? Strings.deletePost : Strings.movePostToTrash
+            case _ as Page:
+                message = trashed ? Strings.deletePage : Strings.movePageToTrash
+            default:
+                fatalError("Unsupported item: \(type(of: post))")
             }
 
             let notice = Notice(title: message)
@@ -618,4 +621,11 @@ extension PostCoordinator {
             }
         }
     }
+}
+
+private enum Strings {
+    static let movePostToTrash = NSLocalizedString("postsList.movePostToTrash.message", value: "Post moved to trash", comment: "A short message explaining that a post was moved to the trash bin.")
+    static let deletePost = NSLocalizedString("postsList.deletePost.message", value: "Post deleted permanently", comment: "A short message explaining that a post was deleted permanently.")
+    static let movePageToTrash = NSLocalizedString("postsList.movePageToTrash.message", value: "Page moved to trash", comment: "A short message explaining that a page was moved to the trash bin.")
+    static let deletePage = NSLocalizedString("postsList.deletePage.message", value: "Page deleted permanently", comment: "A short message explaining that a page was deleted permanently.")
 }


### PR DESCRIPTION
Fixes the notice message for deleting a trashed post / page

## How to test
- Go to Posts
- Switch to drafts
- Trash a post, verify the notice message is "Post moved to trash"
- Switch to pages
- Delete a post, verify the notice message is "Post deleted permanently"
- Repeat the same steps for Pages


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/42a4b964-dc0d-4da4-ab07-c75e5a4b6b5e


## Regression Notes
1. Potential unintended areas of impact: deleting posts / pages


2. What I did to test those areas of impact (or what existing automated tests I relied on): tested manually


3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
