### PR TITLE
Custom analyticsSource for the checkout web view when presented from All Domains flow

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -2,23 +2,38 @@ import Foundation
 
 extension WPAnalytics {
 
-    /// Checks if the Domain Purchasing Feature Flag and AB Experiment are enabled
+    /// Checks if the Domain Purchasing Feature Flag is enabled.
     private static var domainPurchasingEnabled: Bool {
         RemoteFeatureFlag.plansInSiteCreation.enabled()
     }
 
-    static func domainsProperties(for blog: Blog, origin: SiteCreationWebViewViewOrigin? = .menu) -> [AnyHashable: Any] {
-        domainsProperties(usingCredit: blog.canRegisterDomainWithPaidPlan, origin: origin)
+    /// Checks if the Domain Management Feature Flag is enabled.
+    private static var domainManagementEnabled: Bool {
+        return RemoteFeatureFlag.domainManagement.enabled()
+    }
+
+    static func domainsProperties(
+        for blog: Blog,
+        origin: SiteCreationWebViewViewOrigin? = .menu
+    ) -> [AnyHashable: Any] {
+        domainsProperties(
+            usingCredit: blog.canRegisterDomainWithPaidPlan,
+            origin: origin,
+            domainOnly: false
+        )
     }
 
     static func domainsProperties(
         usingCredit: Bool,
-        origin: SiteCreationWebViewViewOrigin?
+        origin: SiteCreationWebViewViewOrigin? = nil,
+        domainOnly: Bool = false
     ) -> [AnyHashable: Any] {
         var dict: [AnyHashable: Any] = ["using_credit": usingCredit.stringLiteral]
-        if Self.domainPurchasingEnabled,
-           let origin = origin {
+        if Self.domainPurchasingEnabled, let origin = origin {
             dict["origin"] = origin.rawValue
+        }
+        if Self.domainManagementEnabled {
+            dict["domain_only"] = domainOnly.stringLiteral
         }
         return dict
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -46,6 +46,7 @@ import SwiftUI
     ///   - customTitle: Title of of the presented view. If nil the title displays the title of the webview..
     ///   - purchaseCallback: closure to be called when user completes a plan purchase.
     static func plansFlowAfterDomainAddedToCartBlock(customTitle: String?,
+                                                     analyticsSource: String? = nil,
                                                      purchaseCallback: @escaping PurchaseCallback) -> RegisterDomainCoordinator.DomainAddedToCartCallback {
         let planSelected = { (planSelectionViewController: PlanSelectionViewController, domainName: String, checkoutURL: URL) in
             let viewModel = CheckoutViewModel(url: checkoutURL)
@@ -59,7 +60,11 @@ import SwiftUI
 
         let domainAddedToCart = { (domainViewController: UIViewController, domainName: String, blog: Blog) in
             guard let viewModel = PlanSelectionViewModel(blog: blog) else { return }
-            let planSelectionViewController = PlanSelectionViewController(viewModel: viewModel, customTitle: customTitle)
+            let planSelectionViewController = PlanSelectionViewController(
+                viewModel: viewModel,
+                customTitle: customTitle,
+                analyticsSource: analyticsSource
+            )
             planSelectionViewController.planSelectedCallback = { planSelectionViewController, checkoutURL in
                 planSelected(planSelectionViewController, domainName, checkoutURL)
             }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/PlanSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/PlanSelectionViewController.swift
@@ -44,13 +44,14 @@ final class PlanSelectionViewController: WebKitViewController {
 
     private var webViewURLChangeObservation: NSKeyValueObservation?
 
-    init(viewModel: PlanSelectionViewModel, customTitle: String?) {
+    init(viewModel: PlanSelectionViewModel, customTitle: String?, analyticsSource: String? = nil) {
         self.viewModel = viewModel
 
         let configuration = WebViewControllerConfiguration(url: viewModel.url)
         configuration.authenticateWithDefaultAccount()
         configuration.secureInteraction = true
         configuration.customTitle = customTitle
+        configuration.analyticsSource = analyticsSource ?? ""
         super.init(configuration: configuration)
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -192,9 +192,11 @@ class RegisterDomainCoordinator {
         }
 
         if let site {
-            WPAnalytics.track(.domainsPurchaseWebviewViewed, properties: WPAnalytics.domainsProperties(for: site), blog: site)
+            let properties = WPAnalytics.domainsProperties(for: site)
+            WPAnalytics.track(.domainsPurchaseWebviewViewed, properties: properties, blog: site)
         } else {
-            // TODO: Track showing no site checkout
+            let properties = WPAnalytics.domainsProperties(usingCredit: false, domainOnly: true)
+            WPAnalytics.track(.domainsPurchaseWebviewViewed, properties: properties)
         }
 
         webViewController.configureSandboxStore {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -15,6 +15,7 @@ class RegisterDomainCoordinator {
     // MARK: Variables
 
     private let crashLogger: CrashLogging
+    private let analyticsSource: String?
 
     var site: Blog?
     var domainPurchasedCallback: DomainPurchasedCallback?
@@ -23,12 +24,21 @@ class RegisterDomainCoordinator {
 
     private var webViewURLChangeObservation: NSKeyValueObservation?
 
+    /// Initializes a `RegisterDomainCoordinator` with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - site: An optional `Blog` object representing the blog associated with the domain registration.
+    ///   - domainPurchasedCallback: An optional closure to be called when a domain is successfully purchased.
+    ///   - analyticsSource: A string representing the source for analytics tracking. Defaults to `domains_register` if not provided.
+    ///   - crashLogger: An instance of `CrashLogging` to handle crash logging. Defaults to `.main` if not provided.
     init(site: Blog?,
          domainPurchasedCallback: RegisterDomainCoordinator.DomainPurchasedCallback? = nil,
+         analyticsSource: String? = "domains_register",
          crashLogger: CrashLogging = .main) {
         self.site = site
         self.domainPurchasedCallback = domainPurchasedCallback
         self.crashLogger = crashLogger
+        self.analyticsSource = analyticsSource
     }
 
     // MARK: Public Functions
@@ -153,8 +163,9 @@ class RegisterDomainCoordinator {
 
         let webViewController = WebViewControllerFactory.controllerWithDefaultAccountAndSecureInteraction(
             url: url,
-            source: "domains_register", // TODO: Update source
-            title: title)
+            source: analyticsSource ?? "",
+            title: title
+        )
         let navController = LightNavigationController(rootViewController: webViewController)
 
         // WORKAROUND: The reason why we have to use this mechanism to detect success and failure conditions

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
@@ -2,7 +2,8 @@ import Foundation
 
 @objc final class AllDomainsAddDomainCoordinator: NSObject {
     static func presentAddDomainFlow(in allDomainsViewController: AllDomainsListViewController) {
-        let coordinator = RegisterDomainCoordinator(site: nil, analyticsSource: "all_domains")
+        let analyticsSource = AllDomainsListViewController.Constants.analyticsSource
+        let coordinator = RegisterDomainCoordinator(site: nil, analyticsSource: analyticsSource)
         let domainSuggestionsViewController = RegisterDomainSuggestionsViewController.instance(
             coordinator: coordinator,
             domainSelectionType: .purchaseFromDomainManagement,
@@ -18,7 +19,9 @@ import Foundation
 
         let domainAddedToCart = FreeToPaidPlansCoordinator.plansFlowAfterDomainAddedToCartBlock(
             customTitle: RegisterDomainCoordinator.TextContent.checkoutTitle,
-            purchaseCallback: domainPurchasedCallback)
+            analyticsSource: analyticsSource,
+            purchaseCallback: domainPurchasedCallback
+        )
 
         coordinator.domainPurchasedCallback = domainPurchasedCallback // For no site flow (domain only)
         coordinator.domainAddedToCartAndLinkedToSiteCallback = domainAddedToCart // For existing site flow (plans)

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc final class AllDomainsAddDomainCoordinator: NSObject {
     static func presentAddDomainFlow(in allDomainsViewController: AllDomainsListViewController) {
-        let coordinator = RegisterDomainCoordinator(site: nil)
+        let coordinator = RegisterDomainCoordinator(site: nil, analyticsSource: "all_domains")
         let domainSuggestionsViewController = RegisterDomainSuggestionsViewController.instance(
             coordinator: coordinator,
             domainSelectionType: .purchaseFromDomainManagement,

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -6,6 +6,10 @@ final class AllDomainsListViewController: UIViewController {
 
     // MARK: - Types
 
+    enum Constants {
+        static let analyticsSource = "all_domains"
+    }
+
     private enum Layout {
         static let interRowSpacing = Length.Padding.double
     }


### PR DESCRIPTION
Closes #21996

## Description

This PR changes the `analyticsSource` value for the checkout web view when presented from the All Domains flow.

## Test Instructions

#### Domain Only
1. Navigate to `Me > All Domains` then tap + button.
2. Search for a domain then select it.
3. Tap "Just buy a domain"
4. **Expect** the event `webkitview_displayed <source: all_domains>` to be logged in the console.

#### Existing Site
1. Navigate to `Me > All Domains` then tap + button.
2. Search for a domain then select it.
3. Tap "Existing wordpress.com site"
4. Select a site.
5. **Expect** the event `webkitview_displayed <source: all_domains>` to be logged in the console.

#### Regression
1. Navigate to `My Site > Domains`.
2. Search for a domain then select it.
3. **Expect** the event `webkitview_displayed <source: domains_register>` to be logged in the console.


## Regression Notes
1. Potential unintended areas of impact
The value of `analyticsSource` should be `domains_register` when presented from the `My Site > Domains` flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.