### PR TITLE
Fix an issue with cancel not working correctly in site media picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -45,15 +45,15 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
         collectionViewController.delegate = self
 
         configureDefaultNavigationBarAppearance()
-        configurationNavigationItems()
+        configureNavigationItems()
         startSelection()
     }
 
     // MARK: - Configuration
 
-    private func configurationNavigationItems() {
+    private func configureNavigationItems() {
         let buttonCancel = UIBarButtonItem(systemItem: .cancel, primaryAction: UIAction { [weak self] _ in
-            self?.buttonDoneTapped()
+            self?.buttonCancelTapped()
         })
 
         navigationItem.leftBarButtonItem = buttonCancel


### PR DESCRIPTION
Fixes a regression introduced in 23.7.

To test:

- Follow steps reported here https://github.com/wordpress-mobile/WordPress-iOS/pull/22040#issuecomment-1811488219

## Regression Notes
1. Potential unintended areas of impact: Site Media Picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
