### PR TITLE
Fix missing Comments context menu icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -99,7 +99,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .cancelAutoUpload: return UIImage(systemName: "xmark.icloud")
         case .share: return UIImage(systemName: "square.and.arrow.up")
         case .blaze: return UIImage(systemName: "flame")
-        case .comments: return UIImage(systemName: "bubble")
+        case .comments: return UIImage(systemName: "bubble.right")
         case .settings: return UIImage(systemName: "gearshape")
         case .setParent: return UIImage(systemName: "text.append")
         case .setHomepage: return UIImage(systemName: "house")


### PR DESCRIPTION
(issue in new change added in 23.7)

To test:

<img width="320" alt="Screenshot 2023-11-15 at 6 02 47 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/201a1240-9aa0-4de9-9a9c-f620586eddd0">

## Regression Notes
1. Potential unintended areas of impact: Posts
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
