### PR TITLE
Add a few test for the hierarchySort function

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1280,6 +1280,7 @@
 		4A526BE0296BE9A50007B5BA /* CoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A526BDD296BE9A50007B5BA /* CoreDataService.m */; };
 		4A535E142AF3368B008B87B9 /* MenusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A535E132AF3368B008B87B9 /* MenusViewController.swift */; };
 		4A535E152AF3368B008B87B9 /* MenusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A535E132AF3368B008B87B9 /* MenusViewController.swift */; };
+		4A5598852B05AC180083C220 /* PagesListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5598842B05AC180083C220 /* PagesListTests.swift */; };
 		4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */; };
 		4A76A4BD29D43BFD00AABF4B /* CommentService+MorderationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */; };
 		4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */; };
@@ -6916,6 +6917,7 @@
 		4A526BDD296BE9A50007B5BA /* CoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataService.m; sourceTree = "<group>"; };
 		4A526BDE296BE9A50007B5BA /* CoreDataService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreDataService.h; sourceTree = "<group>"; };
 		4A535E132AF3368B008B87B9 /* MenusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenusViewController.swift; sourceTree = "<group>"; };
+		4A5598842B05AC180083C220 /* PagesListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesListTests.swift; sourceTree = "<group>"; };
 		4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+LikesTests.swift"; sourceTree = "<group>"; };
 		4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+MorderationTests.swift"; sourceTree = "<group>"; };
 		4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-success.json"; sourceTree = "<group>"; };
@@ -13649,6 +13651,7 @@
 				0C896DE62A3A832B00D7D4E7 /* SiteVisibilityTests.swift */,
 				0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */,
 				4AD862E42AFAEF1700A07557 /* PostsListAPIStub.swift */,
+				4A5598842B05AC180083C220 /* PagesListTests.swift */,
 				93B853211B44165B0064FE72 /* Analytics */,
 				DC06DFF727BD52A100969974 /* BackgroundTasks */,
 				FE32E7EF284496F500744D80 /* Blogging Prompts */,
@@ -23632,6 +23635,7 @@
 				C373D6EA280452F6008F8C26 /* SiteIntentDataTests.swift in Sources */,
 				8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */,
 				B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */,
+				4A5598852B05AC180083C220 /* PagesListTests.swift in Sources */,
 				575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */,
 				2481B20C260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m in Sources */,
 				FEFA6AC82A88D5FC004EE5E6 /* Post+JetpackSocialTests.swift in Sources */,

--- a/WordPress/WordPressTest/PagesListTests.swift
+++ b/WordPress/WordPressTest/PagesListTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import XCTest
+
+@testable import WordPress
+
+class PagesListTests: CoreDataTestCase {
+
+    var algorithm: ([Page]) -> [Page] = { $0.hierarchySort() }
+
+    func testFlatList() throws {
+        let total = 1000
+        let pages = (1...total).map { id in
+            let page = PageBuilder(mainContext).build()
+            page.postID = NSNumber(value: id)
+            return page
+        }
+        let pagesList = algorithm(pages)
+        try XCTAssertEqual(pagesList.map { try XCTUnwrap($0.postID).intValue }, (1...total).map { $0 })
+    }
+
+    func testOneNestedList() throws {
+        let total = 1000
+        var pages = [Page]()
+        for index in (0..<total) {
+            let page = PageBuilder(mainContext).build()
+            page.postID = NSNumber(value: index + 1)
+            pages.append(page)
+
+            if index > 0 {
+                let previous = pages[index - 1]
+                page.parentID = previous.postID
+            }
+        }
+
+        let pagesList = algorithm(pages)
+        try XCTAssertEqual(pagesList.map { try XCTUnwrap($0.postID).intValue }, (1...total).map { $0 })
+    }
+
+    func testManyNestedLists() throws {
+        var pages = [Page]()
+        pages.append(contentsOf: parentPage(postID: 10, childrenCount: 1))
+        pages.append(contentsOf: parentPage(postID: 20, childrenCount: 2))
+        pages.append(contentsOf: parentPage(postID: 30, childrenCount: 3))
+
+        let pagesList = algorithm(pages)
+        try XCTAssertEqual(pagesList.map { try XCTUnwrap($0.postID).intValue }, [10, 11, 20, 21, 22, 30, 31, 32, 33])
+    }
+
+    private func parentPage(postID: Int, childrenCount: Int) -> [Page] {
+        let parent = PageBuilder(mainContext).build()
+        parent.postID = NSNumber(value: postID)
+
+        let children = (0..<childrenCount).map { index in
+            let child = PageBuilder(mainContext).build()
+            child.postID = NSNumber(value: postID + index + 1)
+            child.parentID = parent.postID
+            return child
+        }
+
+        return [parent] + children
+    }
+}


### PR DESCRIPTION
## Issue

The `hierarchySort` function is extremely slow. It only contains three statements, but every single one of them are O(n^2) functions.

https://github.com/wordpress-mobile/WordPress-iOS/blob/6d6f1cac01da5c73aadcd890a308ca9b10e9e63d/WordPress/Classes/Extensions/Array%2BPage.swift#L82-L89

### Test in the app

The issue can be observed on Pages List. Due to an existing bug https://github.com/wordpress-mobile/WordPress-iOS/issues/21813, Pages List on a site that has lots of pages can't be displayed. If you want to see this issue in a real app, check out [this branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/tonyli-pages-list-performance), launch the app from Xcode to an iOS device, choose Field Guide (or any site that have 500+ pages), go to pages list, and scroll through the pages.

From my test, the issue is so bad that it's miserable to scroll though Field Guide pages. For a site with 600 pages, scrolling through the list would still gets jerky during fetching the pages.

## This PR is not a fix

I'm planning to fix this issue, but this PR is not it. This PR adds some basic unit tests for this function and I'll work on addressing the issue separately.

## Regression Notes
N/A