### PR TITLE
Test how `BlogDashboardService` behaves for Jetpack

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -92,7 +92,11 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil) -> Bool {
+    func shouldShow(
+        for blog: Blog,
+        apiResponse: BlogDashboardRemoteEntity? = nil,
+        isJetpack: Bool = AppConfiguration.isJetpack
+    ) -> Bool {
         switch self {
         case .jetpackInstall:
             return JetpackInstallPluginHelper.shouldShowCard(for: blog)
@@ -127,7 +131,7 @@ enum DashboardCard: String, CaseIterable {
         case .jetpackSocial:
             return DashboardJetpackSocialCardCell.shouldShowCard(for: blog)
         case .googleDomains:
-            return FeatureFlag.domainFocus.enabled && AppConfiguration.isJetpack
+            return FeatureFlag.domainFocus.enabled && isJetpack
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -7,12 +7,17 @@ final class BlogDashboardService {
     private let persistence: BlogDashboardPersistence
     private let postsParser: BlogDashboardPostsParser
     private let repository: UserPersistentRepository
+    private let isJetpack: Bool
 
-    init(managedObjectContext: NSManagedObjectContext,
-         remoteService: DashboardServiceRemote? = nil,
-         persistence: BlogDashboardPersistence = BlogDashboardPersistence(),
-         repository: UserPersistentRepository = UserDefaults.standard,
-         postsParser: BlogDashboardPostsParser? = nil) {
+    init(
+        managedObjectContext: NSManagedObjectContext,
+        isJetpack: Bool,
+        remoteService: DashboardServiceRemote? = nil,
+        persistence: BlogDashboardPersistence = BlogDashboardPersistence(),
+        repository: UserPersistentRepository = UserDefaults.standard,
+        postsParser: BlogDashboardPostsParser? = nil
+    ) {
+        self.isJetpack = isJetpack
         self.remoteService = remoteService ?? DashboardServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
         self.persistence = persistence
         self.repository = repository
@@ -88,7 +93,7 @@ private extension BlogDashboardService {
         let personalizationService = BlogDashboardPersonalizationService(repository: repository, siteID: dotComID)
         var cards: [DashboardCardModel] = DashboardCard.allCases.compactMap { card in
             guard personalizationService.isEnabled(card),
-                  card.shouldShow(for: blog, apiResponse: entity) else {
+                  card.shouldShow(for: blog, apiResponse: entity, isJetpack: isJetpack) else {
                 return nil
             }
             return DashboardCardModel(cardType: card, dotComID: dotComID, entity: entity)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -8,16 +8,22 @@ final class BlogDashboardService {
     private let postsParser: BlogDashboardPostsParser
     private let repository: UserPersistentRepository
     private let isJetpack: Bool
+    private let isDotComAvailable: Bool
+    private let shouldShowJetpackFeatures: Bool
 
     init(
         managedObjectContext: NSManagedObjectContext,
         isJetpack: Bool,
+        isDotComAvailable: Bool,
+        shouldShowJetpackFeatures: Bool,
         remoteService: DashboardServiceRemote? = nil,
         persistence: BlogDashboardPersistence = BlogDashboardPersistence(),
         repository: UserPersistentRepository = UserDefaults.standard,
         postsParser: BlogDashboardPostsParser? = nil
     ) {
         self.isJetpack = isJetpack
+        self.isDotComAvailable = isDotComAvailable
+        self.shouldShowJetpackFeatures = shouldShowJetpackFeatures
         self.remoteService = remoteService ?? DashboardServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
         self.persistence = persistence
         self.repository = repository
@@ -92,10 +98,20 @@ private extension BlogDashboardService {
     func parse(_ entity: BlogDashboardRemoteEntity?, blog: Blog, dotComID: Int) -> [DashboardCardModel] {
         let personalizationService = BlogDashboardPersonalizationService(repository: repository, siteID: dotComID)
         var cards: [DashboardCardModel] = DashboardCard.allCases.compactMap { card in
-            guard personalizationService.isEnabled(card),
-                  card.shouldShow(for: blog, apiResponse: entity, isJetpack: isJetpack) else {
+            guard personalizationService.isEnabled(card) else {
                 return nil
             }
+
+            guard card.shouldShow(
+                for: blog,
+                apiResponse: entity,
+                isJetpack: isJetpack,
+                isDotComAvailable: isDotComAvailable,
+                shouldShowJetpackFeatures: shouldShowJetpackFeatures
+            ) else {
+                return nil
+            }
+
             return DashboardCardModel(cardType: card, dotComID: dotComID, entity: entity)
         }
         if cards.isEmpty || cards.map(\.cardType) == [.personalize] {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -41,7 +41,12 @@ final class BlogDashboardViewModel {
     }()
 
     private lazy var service: BlogDashboardService = {
-        return BlogDashboardService(managedObjectContext: managedObjectContext, isJetpack: AppConfiguration.isJetpack)
+        return BlogDashboardService(
+            managedObjectContext: managedObjectContext,
+            isJetpack: AppConfiguration.isJetpack,
+            isDotComAvailable: AccountHelper.isDotcomAvailable(),
+            shouldShowJetpackFeatures: JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
+        )
     }()
 
     private lazy var dataSource: DashboardDataSource? = {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -41,7 +41,7 @@ final class BlogDashboardViewModel {
     }()
 
     private lazy var service: BlogDashboardService = {
-        return BlogDashboardService(managedObjectContext: managedObjectContext)
+        return BlogDashboardService(managedObjectContext: managedObjectContext, isJetpack: AppConfiguration.isJetpack)
     }()
 
     private lazy var dataSource: DashboardDataSource? = {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
@@ -5,7 +5,6 @@ import Foundation
 enum JetpackBrandingVisibility {
 
     case all
-    case dotcomAccountsOnWpApp // useful if we want to release in phases and exclude the feature flag in some cases
     case featureFlagBased
 
     var enabled: Bool {
@@ -14,9 +13,6 @@ enum JetpackBrandingVisibility {
             return AppConfiguration.isWordPress &&
             AccountHelper.isDotcomAvailable() &&
             JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
-        case .dotcomAccountsOnWpApp:
-            return AppConfiguration.isWordPress &&
-            AccountHelper.isDotcomAvailable()
         case .featureFlagBased:
             return true
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
@@ -5,7 +5,6 @@ import Foundation
 enum JetpackBrandingVisibility {
 
     case all
-    case wordPressApp
     case dotcomAccounts
     case dotcomAccountsOnWpApp // useful if we want to release in phases and exclude the feature flag in some cases
     case featureFlagBased
@@ -16,8 +15,6 @@ enum JetpackBrandingVisibility {
             return AppConfiguration.isWordPress &&
             AccountHelper.isDotcomAvailable() &&
             JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
-        case .wordPressApp:
-            return AppConfiguration.isWordPress
         case .dotcomAccounts:
             return AccountHelper.isDotcomAvailable()
         case .dotcomAccountsOnWpApp:

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
@@ -5,7 +5,6 @@ import Foundation
 enum JetpackBrandingVisibility {
 
     case all
-    case dotcomAccounts
     case dotcomAccountsOnWpApp // useful if we want to release in phases and exclude the feature flag in some cases
     case featureFlagBased
 
@@ -15,8 +14,6 @@ enum JetpackBrandingVisibility {
             return AppConfiguration.isWordPress &&
             AccountHelper.isDotcomAvailable() &&
             JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
-        case .dotcomAccounts:
-            return AccountHelper.isDotcomAvailable()
         case .dotcomAccountsOnWpApp:
             return AppConfiguration.isWordPress &&
             AccountHelper.isDotcomAvailable()

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
@@ -1,17 +1,28 @@
-
-import Foundation
-
 /// An enum that unifies the checks to limit the visibility of the Jetpack branding elements (banners and badges)
+///
+/// This thing was born as an enum but at the time of writing had only one case in use.
+/// There is no reason to have that case linger around, it's been left merely to avoid changing its 15 usages.
 enum JetpackBrandingVisibility {
 
     case all
 
-    var enabled: Bool {
+    func isEnabled(
+        isWordPress: Bool,
+        isDotComAvailable: Bool,
+        shouldShowJetpackFeatures: Bool
+    ) -> Bool {
         switch self {
         case .all:
-            return AppConfiguration.isWordPress &&
-            AccountHelper.isDotcomAvailable() &&
-            JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
+            return isWordPress && isDotComAvailable && shouldShowJetpackFeatures
         }
+    }
+
+    @available(*, deprecated, message: "Use the isEnabled function to allow injecting the configuration.")
+    var enabled: Bool {
+        return isEnabled(
+            isWordPress: AppConfiguration.isWordPress,
+            isDotComAvailable: AccountHelper.isDotcomAvailable(),
+            shouldShowJetpackFeatures: JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
@@ -5,7 +5,6 @@ import Foundation
 enum JetpackBrandingVisibility {
 
     case all
-    case featureFlagBased
 
     var enabled: Bool {
         switch self {
@@ -13,8 +12,6 @@ enum JetpackBrandingVisibility {
             return AppConfiguration.isWordPress &&
             AccountHelper.isDotcomAvailable() &&
             JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
-        case .featureFlagBased:
-            return true
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 		3FE3D1FD26A6F34900F3CD10 /* WPStyleGuide+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */; };
 		3FE3D1FE26A6F4AC00F3CD10 /* ListTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088002696E7F600193358 /* ListTableHeaderView.swift */; };
 		3FE3D1FF26A6F56700F3CD10 /* Comment+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02F95E269DC14A00752A44 /* Comment+Interface.swift */; };
+		3FE6D31E2B0705D400D14923 /* JetpackBrandingVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6D31D2B0705D400D14923 /* JetpackBrandingVisibilityTests.swift */; };
 		3FEC241525D73E8B007AFE63 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC241425D73E8B007AFE63 /* ConfettiView.swift */; };
 		3FF15A56291B4EEA00E1B4E5 /* MigrationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF15A55291B4EEA00E1B4E5 /* MigrationCenterView.swift */; };
 		3FF15A5C291ED21100E1B4E5 /* MigrationNotificationsCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF15A5B291ED21100E1B4E5 /* MigrationNotificationsCenterView.swift */; };
@@ -6718,6 +6719,7 @@
 		3FDDFE9527C8178C00606933 /* SiteStatsInformationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsInformationTests.swift; sourceTree = "<group>"; };
 		3FE20C1425CF165700A15525 /* GroupedViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedViewData.swift; sourceTree = "<group>"; };
 		3FE20C3625CF211F00A15525 /* ListViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewData.swift; sourceTree = "<group>"; };
+		3FE6D31D2B0705D400D14923 /* JetpackBrandingVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingVisibilityTests.swift; sourceTree = "<group>"; };
 		3FE77C8225B0CA89007DE9E5 /* LocalizableStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizableStrings.swift; sourceTree = "<group>"; };
 		3FEC241425D73E8B007AFE63 /* ConfettiView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
 		3FF15A55291B4EEA00E1B4E5 /* MigrationCenterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationCenterView.swift; sourceTree = "<group>"; };
@@ -15930,6 +15932,7 @@
 			isa = PBXGroup;
 			children = (
 				C3C2F84528AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift */,
+				3FE6D31D2B0705D400D14923 /* JetpackBrandingVisibilityTests.swift */,
 			);
 			path = Jetpack;
 			sourceTree = "<group>";
@@ -23700,6 +23703,7 @@
 				C995C22629D30AB000ACEF43 /* WidgetUrlSourceTests.swift in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */,
+				3FE6D31E2B0705D400D14923 /* JetpackBrandingVisibilityTests.swift in Sources */,
 				027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */,
 				F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */,
 				2481B1E8260D4EAC00AE59DB /* WPAccount+LookupTests.swift in Sources */,

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -31,10 +31,6 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
         contextManager.useAsSharedInstance(untilTestFinished: self)
 
-        // Simulate the app is signed in with a WP.com account
-        let accountService = AccountService(coreDataStack: contextManager)
-        _ = accountService.createOrUpdateAccount(withUsername: "username", authToken: "token")
-
         remoteServiceMock = DashboardServiceRemoteMock()
         persistenceMock = BlogDashboardPersistenceMock()
         repositoryMock = InMemoryUserDefaults()
@@ -426,6 +422,9 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         //
         // See https://github.com/wordpress-mobile/WordPress-iOS/pull/21796#issuecomment-1767273816
         if loggedIn {
+            let accountService = AccountService(coreDataStack: contextManager)
+            _ = accountService.createOrUpdateAccount(withUsername: "username", authToken: "token")
+
             blog.account = try! WPAccount.lookupDefaultWordPressComAccount(in: mainContext)
         }
         // FIXME: There is a possible inconsistency here because in production the isAdmin value depends on the account, but here the two can go out of sync

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -37,11 +37,15 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         postsParserMock = BlogDashboardPostsParserMock(managedObjectContext: mainContext)
         service = BlogDashboardService(
             managedObjectContext: mainContext,
-            // At the time of writing, tests will fail when the service (DashboardCard under the hood)
-            // is running "as if in Jetpack".
+            // Notice these three boolean make the test run as if the app was Jetpack.
             //
-            // See https://github.com/wordpress-mobile/WordPress-iOS/pull/21740
-            isJetpack: false,
+            // What would be the additional effor to test the remaining 5 configurations?
+            // Is there something we can do to reduce the combinatorial space?
+            //
+            // See also https://github.com/wordpress-mobile/WordPress-iOS/pull/21740
+            isJetpack: true,
+            isDotComAvailable: true,
+            shouldShowJetpackFeatures: true,
             remoteService: remoteServiceMock,
             persistence: persistenceMock,
             repository: repositoryMock,

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -29,6 +29,12 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     override func setUp() {
         super.setUp()
 
+        contextManager.useAsSharedInstance(untilTestFinished: self)
+
+        // Simulate the app is signed in with a WP.com account
+        let accountService = AccountService(coreDataStack: contextManager)
+        _ = accountService.createOrUpdateAccount(withUsername: "username", authToken: "token")
+
         remoteServiceMock = DashboardServiceRemoteMock()
         persistenceMock = BlogDashboardPersistenceMock()
         repositoryMock = InMemoryUserDefaults()

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -63,7 +63,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     func testCallServiceWithCorrectIDAndCards() {
         let expect = expectation(description: "Request the correct ID")
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { _ in
             XCTAssertEqual(self.remoteServiceMock.didCallWithBlogID, self.wpComID)
@@ -135,7 +135,10 @@ class BlogDashboardServiceTests: CoreDataTestCase {
     func testActivityLog() {
         let expect = expectation(description: "Parse activities")
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        // Will fail with logged in user.
+        //
+        // It happens because for some reason the logic that should add activity as one of the type of cards to fetch doesn't do that.
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { cards in
             guard let activityCardItem = cards.first(where: {$0.cardType == .activityLog}) else {
@@ -175,7 +178,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         let expect = expectation(description: "Parse todays stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { cards in
             let todaysStatsItem = cards.first(where: {$0.cardType == .todaysStats})
@@ -242,7 +245,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         let expect = expectation(description: "Parse todays stats")
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
-        let blog = newTestBlog(id: wpComID, context: mainContext)
+        let blog = newTestBlog(id: wpComID, context: mainContext, loggedIn: false)
 
         service.fetch(blog: blog) { cards in
             // Then it's still disabled for other sites
@@ -408,7 +411,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         return try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
     }
 
-    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true, loggedIn: Bool = false) -> Blog {
+    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true, loggedIn: Bool = true) -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
 
         blog.dotComID = id as NSNumber

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -138,13 +138,32 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         let blog = newTestBlog(id: wpComID, context: mainContext)
 
         service.fetch(blog: blog) { cards in
-            let activityCardItem = cards.first(where: {$0.cardType == .activityLog})
+            guard let activityCardItem = cards.first(where: {$0.cardType == .activityLog}) else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
 
-            // Activity section exists
-            XCTAssertNotNil(activityCardItem)
+            guard let apiResponse = activityCardItem.apiResponse else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let activity = apiResponse.activity else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let value = activity.value else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let current = value.current else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
+
+            guard let orderedItems = current.orderedItems else {
+                return XCTFail("Unexpectedly found nil Optional")
+            }
 
             // 2 activity items
-            XCTAssertEqual(activityCardItem!.apiResponse!.activity!.value!.current!.orderedItems!.count, 2)
+            XCTAssertEqual(orderedItems.count, 2)
 
             expect.fulfill()
         }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -55,9 +55,18 @@ class BlogDashboardServiceTests: CoreDataTestCase {
             postsParser: postsParserMock
         )
 
+        // The state of the world these tests assume relies on certain feature flags.
+        //
+        // Similarly to the isJetpack, isDotComAvailable, etc above, it would be ideal to inject these at call site to:
+        // 1. Make the dependency on that bit of information explicit
+        // 2. Allow for testing all combinations
+        //
+        // At the time of writing, the priority was getting some tests for new code to pass under the important Jetpac user path.
+        // As such, here are a bunch of global-state feature flags overrides.
         try? featureFlags.override(FeatureFlag.personalizeHomeTab, withValue: true)
         try? featureFlags.override(RemoteFeatureFlag.activityLogDashboardCard, withValue: true)
         try? featureFlags.override(RemoteFeatureFlag.pagesDashboardCard, withValue: true)
+        try? featureFlags.override(FeatureFlag.domainFocus, withValue: false)
     }
 
     override func tearDown() {
@@ -67,6 +76,7 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         try? featureFlags.override(FeatureFlag.personalizeHomeTab, withValue: FeatureFlag.personalizeHomeTab.originalValue)
         try? featureFlags.override(RemoteFeatureFlag.activityLogDashboardCard, withValue: RemoteFeatureFlag.activityLogDashboardCard.originalValue)
         try? featureFlags.override(RemoteFeatureFlag.pagesDashboardCard, withValue: RemoteFeatureFlag.pagesDashboardCard.originalValue)
+        try? featureFlags.override(FeatureFlag.domainFocus, withValue: FeatureFlag.domainFocus.originalValue)
     }
 
     func testCallServiceWithCorrectIDAndCards() {

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -15,6 +15,17 @@ class BlogDashboardServiceTests: CoreDataTestCase {
 
     private let wpComID = 123456
 
+    // FIXME: Accessing WPAccount wordPressComRestApi will crash if WordPressAuthenticationManager has not been initialized!
+    //
+    // This issue doesn't manifest itself when running the whole test suite beceause of the lucky coincidence that a test running before this one sets it up.
+    // But try to comment this class setUp method and run only this test case and you'll get a crash.
+    override class func setUp() {
+        WordPressAuthenticationManager(
+            windowManager: WindowManager(window: UIWindow()),
+            remoteFeaturesStore: RemoteFeatureFlagStore()
+        ).initializeWordPressAuthenticator()
+    }
+
     override func setUp() {
         super.setUp()
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -408,10 +408,20 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         return try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
     }
 
-    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true) -> Blog {
+    private func newTestBlog(id: Int, context: NSManagedObjectContext, isAdmin: Bool = true, loggedIn: Bool = false) -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
+
         blog.dotComID = id as NSNumber
+
+        // Some tests fail when the account associated to the blog is the default account.
+        //
+        // See https://github.com/wordpress-mobile/WordPress-iOS/pull/21796#issuecomment-1767273816
+        if loggedIn {
+            blog.account = try! WPAccount.lookupDefaultWordPressComAccount(in: mainContext)
+        }
+        // FIXME: There is a possible inconsistency here because in production the isAdmin value depends on the account, but here the two can go out of sync
         blog.isAdmin = isAdmin
+
         return blog
     }
 }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -22,7 +22,18 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         persistenceMock = BlogDashboardPersistenceMock()
         repositoryMock = InMemoryUserDefaults()
         postsParserMock = BlogDashboardPostsParserMock(managedObjectContext: mainContext)
-        service = BlogDashboardService(managedObjectContext: mainContext, remoteService: remoteServiceMock, persistence: persistenceMock, repository: repositoryMock, postsParser: postsParserMock)
+        service = BlogDashboardService(
+            managedObjectContext: mainContext,
+            // At the time of writing, tests will fail when the service (DashboardCard under the hood)
+            // is running "as if in Jetpack".
+            //
+            // See https://github.com/wordpress-mobile/WordPress-iOS/pull/21740
+            isJetpack: false,
+            remoteService: remoteServiceMock,
+            persistence: persistenceMock,
+            repository: repositoryMock,
+            postsParser: postsParserMock
+        )
 
         try? featureFlags.override(FeatureFlag.personalizeHomeTab, withValue: true)
         try? featureFlags.override(RemoteFeatureFlag.activityLogDashboardCard, withValue: true)

--- a/WordPress/WordPressTest/Jetpack/JetpackBrandingVisibilityTests.swift
+++ b/WordPress/WordPressTest/Jetpack/JetpackBrandingVisibilityTests.swift
@@ -1,0 +1,28 @@
+@testable import WordPress
+import XCTest
+
+class JetpackBrandingVisibilityTests: XCTestCase {
+
+    func testEnabledCaseAll() {
+        let visibility = JetpackBrandingVisibility.all
+
+        TruthTable.threeValues.forEach {
+            let isEnabled = visibility.isEnabled(
+                isWordPress: $0,
+                isDotComAvailable: $1,
+                shouldShowJetpackFeatures: $2
+            )
+
+            // Only visible if:
+            // - the app is WordPress,
+            // - there is a DotCom account,
+            // - shouldShowJetpackFeatures is true
+            let expected = $0 && $1 && $2
+            XCTAssertEqual(
+                isEnabled,
+                expected,
+                "isEnabled for WordPress \($0), DotCom \($1), and Jetpack features \($2) was not \(expected)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Following @momo-ozawa's suggestion https://github.com/wordpress-mobile/WordPress-iOS/pull/21796#issuecomment-1774984777 this PR, which builds on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/21796 and https://github.com/wordpress-mobile/WordPress-iOS/pull/21740 and makes `JetpackBrandingVisibility` expect the configuration flags instead of reading them from shared instances under the hood.

In the comment linked above @momo-ozawa also mentioned that "we'll also need to somehow hide the google domains card." I run into that once during my work here and used `featureFlags.override` in the test to disable it (I think). However, I when I removed that line after figuring out how to inject the configuration that drive the `DashboardCard` the tests still passed. Waiting for CI to see if that had something to do with other settings in my local state or not...

Update: Clearly, it had to do with my local state:

<img width="1186" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/8c374762-6a51-470d-bc74-c52d83a50ace">

With those seams available, the `BlogDashboardService` tests can now run as if the app was Jetpack and pass.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.