### PR TITLE
Remove old Gutenberg reference

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -189,10 +189,6 @@ CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
-  Gutenberg:
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
-    :submodules: true
-    :tag: v1.100.2
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844


### PR DESCRIPTION
This is brings the changes of https://github.com/wordpress-mobile/WordPress-iOS/pull/21925 again.

They were introduced back in https://github.com/wordpress-mobile/WordPress-iOS/pull/22023

Removes old reference of Gutenberg when we didn't have the XCFramework setup.

To test CI checks should pass.

## Regression Notes
1. Potential unintended areas of impact
No impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Make sure CI checks pass

3. What automated tests I added (or what prevented me from doing so)
None, no new functionality added.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
