### PR TITLE
Update Aztec to use new media pickers (requires Xcode 15)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+23.9
+----
+* [*] Update the classic editor to use the new Photos and Site Media pickers [#22060]
+
 23.8
 -----
 * [**] Add Optimize Images setting for image uploads and enable it by default [#21981]
@@ -17,7 +21,6 @@
 * [*] Block Editor: Ensure uploaded audio is always visible within Audio block [https://github.com/WordPress/gutenberg/pull/55627]
 * [*] Block Editor: In the deeply nested block warning, only display the ungroup option for blocks that support it [https://github.com/WordPress/gutenberg/pull/56445]
 * [**] Refactor deleting media [#21748]
-* [*] Update the classic editor to use the new Photos and Site Media pickers [#22060]
 
 23.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 * [*] Block Editor: Ensure uploaded audio is always visible within Audio block [https://github.com/WordPress/gutenberg/pull/55627]
 * [*] Block Editor: In the deeply nested block warning, only display the ungroup option for blocks that support it [https://github.com/WordPress/gutenberg/pull/56445]
 * [**] Refactor deleting media [#21748]
+* [*] Update the classic editor to use the new Photos and Site Media pickers [#22060]
 
 23.7
 -----

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1587,7 +1587,7 @@ extension AztecPostViewController {
                 presentDeviceMediaPicker(animated: true)
             case .camera:
                 trackFormatBarAnalytics(stat: .editorMediaPickerTappedCamera)
-                mediaPickerInputViewController?.showCapture()
+                MediaPickerMenu(viewController: self).showCamera(delegate: self)
             case .mediaLibrary:
                 trackFormatBarAnalytics(stat: .editorMediaPickerTappedMediaLibrary)
                 presentSiteMediaPicker()
@@ -3193,6 +3193,37 @@ extension AztecPostViewController: SiteMediaPickerViewControllerDelegate {
         }
     }
 }
+
+// MARK: - AztecPostViewController (ImagePickerControllerDelegate)
+
+extension AztecPostViewController: ImagePickerControllerDelegate {
+    func imagePicker(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        dismiss(animated: true) {
+            guard let mediaType = info[.mediaType] as? String else {
+                return
+            }
+            switch mediaType {
+            case UTType.image.identifier:
+                if let image = info[.originalImage] as? UIImage {
+                    self.insertImage(image: image, source: .camera)
+                }
+            case UTType.movie.identifier:
+                guard let videoURL = info[.mediaURL] as? URL else {
+                    return
+                }
+                guard self.post.blog.canUploadVideo(from: videoURL) else {
+                    self.presentVideoLimitExceededAfterCapture(on: self)
+                    return
+                }
+                self.insert(exportableAsset: videoURL as NSURL, source: .camera)
+            default:
+                break
+            }
+        }
+    }
+}
+
+extension AztecPostViewController: VideoLimitsAlertPresenter {}
 
 // MARK: - MediaPickerViewController (PHPickerViewControllerDelegate)
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1800,6 +1800,7 @@ extension AztecPostViewController {
 
         richTextView.autocorrectionType = .no
 
+#if swift(>=5.9) // Requires Xcode 15
         if #available(iOS 17, *) {
             var configuration = PHPickerConfiguration()
             configuration.filter = .any(of: [.images, .videos])
@@ -1825,6 +1826,7 @@ extension AztecPostViewController {
 
             presentToolbarViewControllerAsInputView(picker)
         }
+#endif
     }
 
     @objc func toggleEditingMode() {


### PR DESCRIPTION
This is one of the remaining prerequisites for fully decommissioning WPMediaPicker.

Note: this PR requires Xcode 15; please test it locally.

## Changes

- Integrate `SiteMediaPickerViewController` for selection from your site media
- Integrate `PHPickerViewController` for selection from Photos
- Use `UIImagePickerController` for camera capture
- Use `PHPickerViewController` to replace the embedded picker. It’s available only on iOS 17, which I think is an acceptable trade-off, considering the extremely low number of Aztec users and people who use this option. The iOS 17 adoption has been lagging behind, but by the time this release I expect at least 50% of users to be on iOS 17. I considered implementing a custom picker using Photos.framework and `PHAsset`, but since the app no longer asks for Photos permissions anywhere else, I don't think it's viable. It also would've required full access to Photos (not "Only Selected")

<img width="320" alt="Screenshot 2023-11-17 at 3 20 00 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/2edc1428-c42e-43fe-8eb1-21280ee35a3b">

<img width="320" alt="Screenshot 2023-11-17 at 3 20 15 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/cf4506c5-c787-4f90-8661-42363a712a3c">

## To test:

**Prerequisite:** In `EditorFactory.swift`, update `EditorFactory `instantiateEditor` to always return Aztec.

### Embedded picker

**Inserting Media**

- Select images, videos from the embedded picker
- Upload the post and verify that the items were displayed
- Upload a GIF image and verify that the editor displayed a "GIF" badge

**Keyboard Toolbar**

- Open embedded picker
- Select a couple of assets
- Verify that the “Insert X” keyboard toolbar button is continuously updated as items are selected
- Press “Cancel” (little “x”)
- Verify that the embedded picker is dismissed
- Open the picker again
- Verify that the keyboard toolbar button for inserting assets no longer shows “Insert X” (selected was cleared)

**iOS 16 and Earlier**

- Verify that inline picker is not displayed on iOS 16 or earlier
- Verify that you can still toggle between "Text" and "Media" modes

### Camera

- Verify that you can capture images and videos using "Camera"

### Photos

- Verify that the new picker is used `PHPickerViewController`
- Verify that images and videos can be selected and added to the post
- Verify that "Cancel" dismissed the picker

### Site Media

- Verify that the new picker is used `PHPickerViewController`
- Verify that images , videos, and **documents** can be selected and added to the post
- Verify that "Cancel" dismissed the picker (**known issue:** https://github.com/wordpress-mobile/WordPress-iOS/pull/22041)

## Regression Notes
1. Potential unintended areas of impact: Aztec (Classic Editor)
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual;
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
