### PR TITLE
Fix an issue with WordPress → Jetpack migration not working for new accounts with no sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Fix the media item details screen layout on iPad [#22042]
 * [*] Integrate native photos picker (`PHPickerViewControlle`) in Story Editor [#22059]
+* [*] Fix an issue [#https://github.com/wordpress-mobile/WordPress-iOS/issues/21959] where WordPress → Jetpack migration was not working for newly created accounts with no sites. The new users are now presented with a shortened migration flow. [#22064]
 * [*] [internal] Fix an issue with scheduling of posts not working on iOS 17 with Xcode 15 [#22012]
 * [*] [internal] Remove SDWebImage dependency from the app and improve cache cost calculation for GIFs [#21285]
 * [*] Stats: Fix an issue where sites for clicked URLs do not open [#22061]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,8 @@
 23.8
 -----
 * [*] Fix the media item details screen layout on iPad [#22042]
-* [*] Integrate native photos picker (`PHPickerViewControlle`) in Story Editor [#22059]
-* [*] Fix an issue [#https://github.com/wordpress-mobile/WordPress-iOS/issues/21959] where WordPress → Jetpack migration was not working for newly created accounts with no sites. The new users are now presented with a shortened migration flow. [#22064]
+* [*] Integrate native photos picker (`PHPickerViewController`) in Story Editor [#22059]
+* [*] Fix an issue [#21959] where WordPress → Jetpack migration was not working for accounts with no sites. These users are now presented with a shortened migration flow. The "Uninstall WordPress" prompt will now also appear only as a card on the Dashboard. [#22064]
 * [*] [internal] Fix an issue with scheduling of posts not working on iOS 17 with Xcode 15 [#22012]
 * [*] [internal] Remove SDWebImage dependency from the app and improve cache cost calculation for GIFs [#21285]
 * [*] Stats: Fix an issue where sites for clicked URLs do not open [#22061]

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -187,7 +187,7 @@ protocol ContentMigrationEligibilityProvider {
 
 extension AppConfiguration: ContentMigrationEligibilityProvider {
     var isEligibleForMigration: Bool {
-        Self.isWordPress && AccountHelper.isLoggedIn && AccountHelper.hasBlogs
+        Self.isWordPress && AccountHelper.isLoggedIn
     }
 }
 

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -76,9 +76,11 @@
             return
         }
 
+        let hasBlogs = AccountHelper.hasBlogs
+
         guard isLocalPostsSynced() else {
             let error = MigrationError.localDraftsNotSynced
-            tracker.trackContentExportFailed(reason: error.localizedDescription)
+            tracker.trackContentExportFailed(reason: error.localizedDescription, hasBlogs: hasBlogs)
             processResult(.failure(error), completion: completion)
             return
         }
@@ -86,12 +88,12 @@
         dataMigrator.exportData { [weak self] result in
             switch result {
             case .success:
-                self?.tracker.trackContentExportSucceeded()
+                self?.tracker.trackContentExportSucceeded(hasBlogs: hasBlogs)
                 self?.processResult(.success(()), completion: completion)
 
             case .failure(let error):
                 DDLogError("[Jetpack Migration] Error exporting data: \(error)")
-                self?.tracker.trackContentExportFailed(reason: error.localizedDescription)
+                self?.tracker.trackContentExportFailed(reason: error.localizedDescription, hasBlogs: hasBlogs)
                 self?.processResult(.failure(.exportFailure), completion: completion)
             }
         }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/All done/MigrationDoneViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/All done/MigrationDoneViewController.swift
@@ -35,6 +35,11 @@ class MigrationDoneViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.tracker.track(.thanksScreenShown)
+
+        var properties: [String: String] = [:]
+        if BlogListDataSource().visibleBlogsCount == 0 {
+            properties["no_sites"] = "true"
+        }
+        tracker.track(.thanksScreenShown, properties: properties)
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/All done/MigrationDoneViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/All done/MigrationDoneViewController.swift
@@ -19,8 +19,7 @@ class MigrationDoneViewController: UIViewController {
     override func loadView() {
         self.view = MigrationStepView(
             headerView: MigrationHeaderView(configuration: viewModel.configuration.headerConfiguration),
-            actionsView: MigrationActionsView(configuration: viewModel.configuration.actionsConfiguration),
-            centerView: MigrationCenterView.deleteWordPress(with: viewModel.configuration.centerViewConfiguration)
+            actionsView: MigrationActionsView(configuration: viewModel.configuration.actionsConfiguration)
         )
     }
 

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 struct MigrationAnalyticsTracker {
-
     // MARK: - Track Method
 
     func track(_ event: MigrationEvent, properties: Properties = [:]) {
@@ -16,12 +15,19 @@ struct MigrationAnalyticsTracker {
         self.track(.contentExportEligibility, properties: properties)
     }
 
-    func trackContentExportSucceeded() {
-        self.track(.contentExportSucceeded)
+    func trackContentExportSucceeded(hasBlogs: Bool) {
+        var properties: [String: String] = [:]
+        if !hasBlogs {
+            properties["no_sites"] = "true"
+        }
+        self.track(.contentExportSucceeded, properties: properties)
     }
 
-    func trackContentExportFailed(reason: String) {
-        let properties = ["error_type": reason]
+    func trackContentExportFailed(reason: String, hasBlogs: Bool) {
+        var properties = ["error_type": reason]
+        if !hasBlogs {
+            properties["no_sites"] = "true"
+        }
         self.track(.contentExportFailed, properties: properties)
     }
 

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationDependencyContainer.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationDependencyContainer.swift
@@ -1,6 +1,6 @@
 struct MigrationDependencyContainer {
 
-    let migrationCoordinator = MigrationFlowCoordinator()
+    let migrationCoordinator = MigrationFlowCoordinator(account: makeAccount())
 
     func makeInitialViewController() -> UIViewController {
         MigrationNavigationController(coordinator: migrationCoordinator,
@@ -31,17 +31,6 @@ struct MigrationViewControllerFactory {
 
     func initialViewController() -> UIViewController? {
         viewController(for: coordinator.currentStep)
-    }
-
-    private func makeAccount() -> WPAccount? {
-
-        let context = ContextManager.shared.mainContext
-        do {
-            return try WPAccount.lookupDefaultWordPressComAccount(in: context)
-        } catch {
-            DDLogError("Account lookup failed with error: \(error)")
-            return nil
-        }
     }
 
     // MARK: - View Controllers
@@ -100,5 +89,15 @@ struct MigrationViewControllerFactory {
     private class ActionHandlers {
         var primary: (() -> Void)?
         var secondary: (() -> Void)?
+    }
+}
+
+private func makeAccount() -> WPAccount? {
+    let context = ContextManager.shared.mainContext
+    do {
+        return try WPAccount.lookupDefaultWordPressComAccount(in: context)
+    } catch {
+        DDLogError("Account lookup failed with error: \(error)")
+        return nil
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationDependencyContainer.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationDependencyContainer.swift
@@ -1,6 +1,6 @@
 struct MigrationDependencyContainer {
 
-    let migrationCoordinator = MigrationFlowCoordinator(account: makeAccount())
+    let migrationCoordinator = MigrationFlowCoordinator()
 
     func makeInitialViewController() -> UIViewController {
         MigrationNavigationController(coordinator: migrationCoordinator,
@@ -31,6 +31,16 @@ struct MigrationViewControllerFactory {
 
     func initialViewController() -> UIViewController? {
         viewController(for: coordinator.currentStep)
+    }
+
+    private func makeAccount() -> WPAccount? {
+        let context = ContextManager.shared.mainContext
+        do {
+            return try WPAccount.lookupDefaultWordPressComAccount(in: context)
+        } catch {
+            DDLogError("Account lookup failed with error: \(error)")
+            return nil
+        }
     }
 
     // MARK: - View Controllers
@@ -89,15 +99,5 @@ struct MigrationViewControllerFactory {
     private class ActionHandlers {
         var primary: (() -> Void)?
         var secondary: (() -> Void)?
-    }
-}
-
-private func makeAccount() -> WPAccount? {
-    let context = ContextManager.shared.mainContext
-    do {
-        return try WPAccount.lookupDefaultWordPressComAccount(in: context)
-    } catch {
-        DDLogError("Account lookup failed with error: \(error)")
-        return nil
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Navigation/MigrationFlowCoordinator.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Navigation/MigrationFlowCoordinator.swift
@@ -19,10 +19,18 @@ final class MigrationFlowCoordinator: ObservableObject {
     // MARK: - Init
 
     init(migrationEmailService: MigrationEmailService? = try? .init(),
-         userPersistentRepository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+         userPersistentRepository: UserPersistentRepository = UserPersistentStoreFactory.instance(),
+         account: WPAccount?) {
         self.migrationEmailService = migrationEmailService
         self.userPersistentRepository = userPersistentRepository
         self.userPersistentRepository.jetpackContentMigrationState = .inProgress
+
+        // Skip the migration if the user just created an account and haven't
+        // created any site yet.
+        if BlogListDataSource().visibleBlogsCount == 0 {
+            self.currentStep = MigrationStep.done
+            self.userPersistentRepository.jetpackContentMigrationState = .completed
+        }
     }
 
     deinit {

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Navigation/MigrationFlowCoordinator.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Navigation/MigrationFlowCoordinator.swift
@@ -19,8 +19,7 @@ final class MigrationFlowCoordinator: ObservableObject {
     // MARK: - Init
 
     init(migrationEmailService: MigrationEmailService? = try? .init(),
-         userPersistentRepository: UserPersistentRepository = UserPersistentStoreFactory.instance(),
-         account: WPAccount?) {
+         userPersistentRepository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.migrationEmailService = migrationEmailService
         self.userPersistentRepository = userPersistentRepository
         self.userPersistentRepository.jetpackContentMigrationState = .inProgress

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationActionsConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationActionsConfiguration.swift
@@ -46,8 +46,8 @@ private extension MigrationActionsViewConfiguration {
                                                            value: "Continue",
                                                            comment: "The primary button title in the migration welcome and notifications screens.")
 
-        static let donePrimaryTitle = NSLocalizedString("migration.done.actions.primary.title",
-                                                        value: "Finish",
+        static let donePrimaryTitle = NSLocalizedString("migrationDone.actions.primaryTitle",
+                                                        value: "Let's go",
                                                         comment: "Primary button title in the migration done screen.")
 
         static let welcomeSecondaryTitle = NSLocalizedString("Need help?",

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationHeaderConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationHeaderConfiguration.swift
@@ -52,7 +52,7 @@ private extension MigrationHeaderConfiguration {
             case .notifications:
                 return notificationsPrimaryDescription
             case .done:
-                return donePrimaryDescription
+                return donePrimaryDescription + "\n\n" + doneSecondaryDescription
             case .dismiss:
                 return nil
             }
@@ -94,6 +94,8 @@ private extension MigrationHeaderConfiguration {
         static let donePrimaryDescription = NSLocalizedString("migration.done.primaryDescription",
                                                               value: "We’ve transferred all your data and settings. Everything is right where you left it.",
                                                               comment: "Primary description in the migration done screen.")
+
+        static let doneSecondaryDescription = NSLocalizedString("migration.done.secondaryDescription", value: "It's time to continue your WordPress journey on the Jetpack app!", comment: "Secondary description (second paragraph) in the migration done screen.")
 
         static let notificationsSecondaryDescription = NSLocalizedString("migration.notifications.secondaryDescription",
                                                                          value: "We’ll disable notifications for the WordPress app.",

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/MigrationStepView.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/MigrationStepView.swift
@@ -14,11 +14,11 @@ class MigrationStepView: UIView {
     // MARK: - Views
 
     private let headerView: MigrationHeaderView
-    private let centerView: UIView
+    private let centerView: UIView?
     private let actionsView: MigrationActionsView
 
     private lazy var mainStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [headerView, centerView, UIView()])
+        let stackView = UIStackView(arrangedSubviews: [headerView, centerView, UIView()].compactMap { $0 })
         stackView.axis = .vertical
         stackView.distribution = .equalSpacing
         stackView.directionalLayoutMargins = Constants.mainStackViewMargins
@@ -50,10 +50,9 @@ class MigrationStepView: UIView {
 
     init(headerView: MigrationHeaderView,
          actionsView: MigrationActionsView,
-         centerView: UIView) {
+         centerView: UIView? = nil) {
         self.headerView = headerView
         self.centerView = centerView
-        centerView.translatesAutoresizingMaskIntoConstraints = false
         self.actionsView = actionsView
         headerView.directionalLayoutMargins = .zero
         actionsView.translatesAutoresizingMaskIntoConstraints = false
@@ -141,6 +140,6 @@ class MigrationStepView: UIView {
         static let stackViewSpacing: CGFloat = 20
 
         // Adds margins to the main sack view.
-        static let mainStackViewMargins = NSDirectionalEdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 30)
+        static let mainStackViewMargins = NSDirectionalEdgeInsets(top: 0, leading: 24, bottom: 0, trailing: 24)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21959 and shortens the ~~darkness~~ migration flow for the new users with no sites.

To test:

(Can be fully tested in a simulator)

**Scenario 1**

Recording: https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/77affad8-74ce-46c3-be2d-620f0ac8befb 

1. Install the WordPress app and create a new account (don’t create any sites!) or log in using an account with no sites
2. Tap “Create a new site” and when presented with the “Welcome to WordPress” screen
3. A “Give WordPress a boost with Jetpack” screen appears
4. Tap “Switch to the Jetpack app”
5. Install the Jetpack app (from Xcode or a one-off build)
6. Verify that it shows the “Migration Done” confirmation screen 
7. Tap “Finish”
8. Verify that you land on the home page with a “Create Site” CTA
9. Verify that you are logged in and can create a site now
10. Verify that you got no “Migration Done” emails from WordPress (we don’t want to spam you, assuming you _just_ created an account anyway)

**Scenario 2**

Recording: https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/4b2d22bc-8fd0-4db0-b7af-09a9cf3d2c69

1. Install the WordPress app and create a new account (don’t create any sites!) or log in using an account with no sites
2. Tap “Skip” and when presented with the “Welcome to WordPress” screen. Don't accept any prompts to install Jetpack
3. Install the Jetpack app (from Xcode or a one-off build)
4. Verify that it prompts you to migrate your account from the WordPress app
5. Tap "Open WordPress"
6. Verify that the systems briefly opens the WordPress app and returns you to the Jetpack app
7. Verify that it shows the “Migration Done” confirmation screen 
8. Tap “Finish”
9. Verify that you land on the home page with a “Create Site” CTA
10. Verify that you are logged in and can create a site now
11. Verify that you got no “Migration Done” emails from WordPress (we don’t want to spam you, assuming you _just_ created an account anyway)

## Regression Notes
1. Potential unintended areas of impact: Migration to Jetpack
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
