### PR TITLE
Enable scroll edge appearance for Me screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -12,7 +12,6 @@ class MeViewController: UITableViewController {
 
     override init(style: UITableView.Style) {
         super.init(style: style)
-        navigationItem.title = NSLocalizedString("Me", comment: "Me page title")
         clearsSelectionOnViewWillAppear = false
     }
 
@@ -29,6 +28,8 @@ class MeViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        configureDefaultNavigationBarAppearance()
 
         // Preventing MultiTouch Scenarios
         view.isExclusiveTouch = true


### PR DESCRIPTION
Before and After

<img width="320" alt="Screenshot 2023-11-21 at 11 31 56 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/4ab1aef5-68a7-499c-a3be-4d2aa8544262"> <img width="320" alt="Screenshot 2023-11-21 at 11 32 46 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/69d20177-0223-48f4-89c5-517714f54a48">

Here's iPad: [screenshot](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/de39161f-a9de-4319-aad8-f3086e567a65).

## Regression Notes
1. Potential unintended areas of impact: Me tab
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
