### PR TITLE
Posts & Pages: Fix view action title for published posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -121,7 +121,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
     func title(for post: AbstractPost) -> String {
         switch self {
         case .retry: return Strings.retry
-        case .view: return post.status == .publish ? Strings.preview : Strings.view
+        case .view: return post.status == .publish ? Strings.view : Strings.preview
         case .publish: return Strings.publish
         case .stats: return Strings.stats
         case .duplicate: return Strings.duplicate


### PR DESCRIPTION
## Description
- Follow-on for https://github.com/wordpress-mobile/WordPress-iOS/pull/21991#discussion_r1385623433
- Fixes view action title - "view" for published posts, "preview" for draft / scheduled posts

## How to test
- Go to posts screen and tap on a the context menu for a post
- Verify the view action is "view" for published posts, "preview" for draft / scheduled posts

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
