### PR TITLE
Jetpack Focus: Handle Jetpack app installation notification on the WordPress app

### DIFF
--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -206,7 +206,8 @@ final public class PushNotificationsManager: NSObject {
                         handleAuthenticationNotification,
                         handleInactiveNotification,
                         handleBackgroundNotification,
-                        handleQuickStartLocalNotification]
+                        handleQuickStartLocalNotification,
+                        handleJetpackAppInstallNotification]
 
         for handler in handlers {
             if handler(userInfo, userInteraction, completionHandler) {
@@ -363,7 +364,7 @@ extension PushNotificationsManager {
         }
 
         RootViewCoordinator.sharedPresenter.showNotificationsTabForNote(withID: notificationId)
-        completionHandler?(.newData)
+        completionHandler?(.noData)
 
         return true
     }
@@ -425,6 +426,7 @@ extension PushNotificationsManager {
         static let badgeResetValue = "badge-reset"
         static let local = "qs-local-notification"
         static let bloggingPrompts = "blogging-prompts-notification"
+        static let jetpackAppInstall = "jetpack-app-install"
     }
 
     enum Tracking {
@@ -518,5 +520,31 @@ private extension Date {
     var components: DateComponents {
         return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
                                                from: self)
+    }
+}
+
+// MARK: - Jetpack App Installation Notifications
+
+extension PushNotificationsManager {
+
+    /// Handles a Jetpack App Install Notification
+    ///
+    /// - Parameters:
+    ///     - userInfo: The Notification's Payload
+    ///     - completionHandler: A callback, to be executed on completion
+    ///
+    /// - Returns: True when handled. False otherwise
+    @objc private func handleJetpackAppInstallNotification(_ userInfo: NSDictionary, userInteraction: Bool, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+        guard let type = userInfo.string(forKey: Notification.typeKey),
+              type == Notification.jetpackAppInstall else {
+            return false
+        }
+
+        let topmostViewController = RootViewCoordinator.sharedPresenter.rootViewController.topmostPresentedViewController
+        JetpackBrandingCoordinator.presentOverlay(from: topmostViewController)
+
+        completionHandler?(.newData)
+
+        return true
     }
 }


### PR DESCRIPTION
Fixes: #22073

Handle Jetpack app installation notification by installing Jetpack app

## To test:

1. Install WordPress app
2. Disable Jetpack focus feature flags to enable notifications
3. Drag and drop `apns` file
4. Tap on it
5. Confirm that Jetpack focus overlay appears

#### Test file

jetpack_app_installation.apns

```
{
    "Simulator Target Bundle": "org.wordpress",
	"aps": {
		"alert": "Switch to Jetpack by WordPress.com: Publish, Monitor Stats, Get Notified!",
		"badge": 1,
		"content-available": 1,
		"mutable-content": 1,
		"sound": "n.caf"
	},
	"type": "jetpack-app-install"
}
```

### Video: Simple case

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/6fd7a0d3-bd90-4787-b292-9f9d3791a608

### Video 2: Case when WordPress app has something opened and in the foreground

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/031e40f7-d07a-4814-b8ea-c9dcde7ba9d1

## Regression Notes
1. Potential unintended areas of impact

None, this change is completely isolated.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)