### PR TITLE
Make Reader web view inspectable on iOS 16.4 and higher

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] [internal] Fix an issue with scheduling of posts not working on iOS 17 with Xcode 15 [#22012]
 * [*] [internal] Remove SDWebImage dependency from the app and improve cache cost calculation for GIFs [#21285]
 * [*] Stats: Fix an issue where sites for clicked URLs do not open [#22061]
+* [*] [internal] Make Reader web views inspectable on iOS 16.4 and higher [#22077]
 
 23.7
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -21,6 +21,9 @@ class ReaderWebView: WKWebView {
 
         isOpaque = false
         backgroundColor = .clear
+        if #available(iOS 16.4, *) {
+            isInspectable = true
+        }
     }
 
     /// Loads a HTML content into the webview and apply styles


### PR DESCRIPTION
Related: https://github.com/wordpress-mobile/WordPress-iOS/pull/22022

Adds inspectability of Reader web views on iOS 16.4.

## Testing
1. Build and run the app on iOS 16.4 or higher with the Simulator or device connected to a Mac.
2. Open a post in Reader
3. Load Safari and make sure the [developer tools](https://support.apple.com/en-uz/guide/safari/sfri20948/mac) are enabled.
4. Expect: The ability to inspect the loaded web view.

## Regression Notes
1. Potential unintended areas of impact
    - None

3. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested inspecting with Safari

4. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
