### PR TITLE
Attempt to fix P2 emoji size bug.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] [internal] Remove SDWebImage dependency from the app and improve cache cost calculation for GIFs [#21285]
 * [*] Stats: Fix an issue where sites for clicked URLs do not open [#22061]
 * [*] [internal] Make Reader web views inspectable on iOS 16.4 and higher [#22077]
+* [*] [internal] Add workarounds for large emoji on P2. [#22080]
 
 23.7
 -----

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -108,6 +108,10 @@ extension URL {
         return components.count == 4 && isHostedAtWPCom
     }
 
+    var isA8CEmoji: Bool {
+        absoluteString.contains(".wp.com/i/emojis")
+    }
+
 
     /// Handle the common link protocols.
     /// - tel: open a prompt to call the phone number

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -108,7 +108,7 @@ extension URL {
         return components.count == 4 && isHostedAtWPCom
     }
 
-    var isA8CEmoji: Bool {
+    var isWPComEmoji: Bool {
         absoluteString.contains(".wp.com/i/emojis")
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -253,6 +253,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             webView.postURL = postURL
         }
 
+        webView.isP2 = post.isP2Type()
+
         coordinator?.storeAuthenticationCookies(in: webView) { [weak self] in
             self?.webView.loadHTMLString(post.contentForDisplay())
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -12,6 +12,8 @@ class ReaderWebView: WKWebView {
 
     var postURL: URL? = nil
 
+    var isP2 = false
+
     var usesSansSerifStyle = false
 
     /// Make the webview transparent
@@ -50,6 +52,7 @@ class ReaderWebView: WKWebView {
         <style>
         \(cssColors())
         \(cssStyles())
+        \(p2Styles())
         \(overrideStyles())
         </style>
         </head><body class="reader-full-post reader-full-post__story-content">
@@ -162,6 +165,19 @@ class ReaderWebView: WKWebView {
 
         let cssContent = try? String(contentsOf: cssURL)
         return cssContent ?? ""
+    }
+
+    /// Enforce a width for emojis on P2
+    private func p2Styles() -> String {
+        guard isP2 else {
+            return ""
+        }
+
+        return """
+        img.emoji {
+            width: 1em;
+        }
+        """
     }
 
     private func overrideStyles() -> String {

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -255,7 +255,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
     /// - Parameter size: The proposed size for the gif image.
     /// - Returns: The most efficient size with good quality.
     fileprivate func efficientImageSize(with url: URL, proposedSize size: CGSize) -> CGSize {
-        guard url.isGif else {
+        guard url.isGif, !url.isA8CEmoji else {
             return size
         }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -255,7 +255,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
     /// - Parameter size: The proposed size for the gif image.
     /// - Returns: The most efficient size with good quality.
     fileprivate func efficientImageSize(with url: URL, proposedSize size: CGSize) -> CGSize {
-        guard url.isGif, !url.isA8CEmoji else {
+        guard url.isGif, !url.isWPComEmoji else {
             return size
         }
 


### PR DESCRIPTION
Fixes #16868

## Description

This is an attempt to work around the large P2 emoji bug by:
- Injecting a CSS style to limit the emoji width to `1 em` if it's on P2
- Detecting P2 emojis when rendering comments and returning their default size

| Before | After |
| - | - |
| <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/2ddafb45-e0f5-4e0e-8fc2-5c54808df5a1" /> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/2bb6d593-c1fd-41ef-86e1-5650b3b43e4d" /> |

**Note:** Gutenberg commenting may be coming soon, which would hopefully overhaul how these are rendered and allow us to remove these workarounds.

## Testing
1. Load this internal P2 in Reader: pdQkYd-1b-p2
2. Expect the output to match the "After" video (emojis are small and similar to web)
3. Tap "View all comments"
4. Expect the output to match the "After" video (emojis are small and similar to web)

- Test on other P2s
- Test loading from Notifications
- Test that the CSS isn't injected on non-P2s (use Safari to observe the web view)

## Regression Notes
1. Potential unintended areas of impact
    - None identified.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested various P2s.

3. What automated tests I added (or what prevented me from doing so)
    - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text. **Note:** Emojis in the post will scale, but emojis in comments will not.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)