### PR TITLE
Test Danger setup preventing merging PR with pods referenced by via branch

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -35,3 +35,6 @@ pr_size_checker.check_diff_size
 milestone_checker.check_milestone_due_date(days_before_due: 4) unless github.pr_draft? || (wip_feature? && !(release_branch? || main_branch?))
 
 rubocop.lint(inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
+
+podfile_checks.check_podfile_does_not_have_branch_references
+podfile_checks.check_podfile_diff_does_not_have_branch_references

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.14'
 gem 'commonmarker'
-gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic'
+gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic', branch: 'mokagio/podfile-branch-check'
 gem 'dotenv'
 gem 'fastlane', '~> 2.216'
 gem 'fastlane-plugin-appcenter', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/Automattic/dangermattic
-  revision: 06a54db4f546d20c0465e4d144049d061a2a1e20
+  revision: ba1b3fb8581a21a3862aba1876812147fc439a62
+  branch: mokagio/podfile-branch-check
   specs:
     danger-dangermattic (0.0.1)
       danger (~> 9.3)

--- a/Podfile
+++ b/Podfile
@@ -51,9 +51,9 @@ end
 
 def wordpress_kit
   # Anything compatible with 8.9, starting from 8.9.1 which has a breaking change fix
-  pod 'WordPressKit', '~> 8.11'
+  # pod 'WordPressKit', '~> 8.11'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'trunk'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'trunk'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
 end
@@ -147,8 +147,8 @@ abstract_target 'Apps' do
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
-  pod 'WordPressAuthenticator', '~> 7.3'
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
+  # pod 'WordPressAuthenticator', '~> 7.3'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: 'eba0445e0942ce8cad6fcb9323d26e8799b6e3d5'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,8 +121,8 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (~> 7.3)
-  - WordPressKit (~> 8.11)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `eba0445e0942ce8cad6fcb9323d26e8799b6e3d5`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `trunk`)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
   - WPMediaPicker (>= 1.8.10, ~> 1.8)
@@ -158,8 +158,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -179,11 +177,23 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.108.0.podspec
+  WordPressAuthenticator:
+    :commit: eba0445e0942ce8cad6fcb9323d26e8799b6e3d5
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :branch: trunk
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressAuthenticator:
+    :commit: eba0445e0942ce8cad6fcb9323d26e8799b6e3d5
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :commit: 791df1f29c2356fb948c0ffb15fb3a6b43e3c91a
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -230,6 +240,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: beaa30560a95fe4f9e8153c20fa4b4ae54be1fd5
+PODFILE CHECKSUM: 0152f2c07604ff85cfcf607f17d366e5b36c109f
 
 COCOAPODS: 1.14.2


### PR DESCRIPTION
See https://github.com/Automattic/dangermattic/pull/30

If all goes well, we should see a Danger error about WordPressKit being referenced by branch.

---

Update. [CI logs](https://buildkite.com/automattic/wordpress-ios/builds/18612#018bfb23-613c-40a4-ab20-cc8e01144611):

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/5d69fa26-351d-460d-b51d-1067ffa5c729)

And the comment in the PR below:

<img width="907" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/6a77f040-2c54-456d-83f5-fbb519baf29a">

We might want to iterate on whether to use both checks and how to format the message, but as far as the check working, this is proof 👍 
