### PR TITLE
Configure UI tests to always store screenshots

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -16,7 +16,8 @@
       "identifier" : "FABB1F8F2602FC2C00C8785C",
       "name" : "Jetpack"
     },
-    "testRepetitionMode" : "retryOnFailure"
+    "testRepetitionMode" : "retryOnFailure",
+    "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [
     {

--- a/WordPress/UITests/WordPressUITests.xctestplan
+++ b/WordPress/UITests/WordPressUITests.xctestplan
@@ -16,7 +16,8 @@
       "identifier" : "1D6058900D05DD3D006BFB54",
       "name" : "WordPress"
     },
-    "testRepetitionMode" : "retryOnFailure"
+    "testRepetitionMode" : "retryOnFailure",
+    "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [
     {


### PR DESCRIPTION
Previously, the UI tests would deleted the screenshots in case of a successful run. I feel that's a reasonable default because it does not waste space. However, storage is cheap and we can build tooling to garbage collect if necessary and I just run an investigation in which it would have been useful to observe the recording for a successful test. It's conceivable to imagine we'll run in similar situations in the future and I believe we won't regret storing these assets.

Case in point: I implemented this in WooCommerce, see https://github.com/woocommerce/woocommerce-ios/pull/10931 and meant to add it here, too. I obviously didn't till now—right when I run into a test that passed on the second run for which I wanted to see what happened!

## Testing

If the UI tests are green, we're good.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.