### PR TITLE
Add support for GIF thumbnail resizing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] [internal] Fix an issue with scheduling of posts not working on iOS 17 with Xcode 15 [#22012]
 * [*] [internal] Remove SDWebImage dependency from the app and improve cache cost calculation for GIFs [#21285]
 * [*] Stats: Fix an issue where sites for clicked URLs do not open [#22061]
+* [*] Fix an issue with local thumbnails for GIFs inserted to Site Media not being animated [#22083]
 * [*] [internal] Make Reader web views inspectable on iOS 16.4 and higher [#22077]
 * [*] [internal] Add workarounds for large emoji on P2. [#22080]
 

--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -105,6 +105,9 @@ final class MediaImageService: NSObject {
         }
 
         let exporter = makeThumbnailExporter(for: media, size: size)
+        if sourceURL.isGif {
+            exporter.options.thumbnailImageType = UTType.gif.identifier
+        }
         guard exporter.supportsThumbnailExport(forFile: sourceURL),
               let (_, export) = try? await exporter.exportThumbnail(forFileURL: sourceURL),
               let image = try? await makeImage(from: export.url)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22076. I added GIF resizing support to `MediaImageExporter` but it only kicks in when the output type is set to `gif`, which currently only happens in the new `MediaImageService`, so it will only affect the screens I updated.

To test:

Follow the steps from the issue.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b4e38add-182d-4242-beb8-87739eb767ee


## Regression Notes
1. Potential unintended areas of impact: Site Media import GIFs
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
