### PR TITLE
Integrate gutenberg-mobile release v1.109.0

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  tag: v1.108.0
+  commit: 728536dc80e7f2333003a7451345cf3e322f337f
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 728536dc80e7f2333003a7451345cf3e322f337f
+  commit: d1a9005a549a82b99d90cff58a249e71a3700f84
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: fd29fcf88de16da3e5c5d8cee98ce1756876cd23
+  tag: v1.109.0
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: d1a9005a549a82b99d90cff58a249e71a3700f84
+  commit: fd29fcf88de16da3e5c5d8cee98ce1756876cd23
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -108,7 +108,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-728536dc80e7f2333003a7451345cf3e322f337f.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-d1a9005a549a82b99d90cff58a249e71a3700f84.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-728536dc80e7f2333003a7451345cf3e322f337f.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-d1a9005a549a82b99d90cff58a249e71a3700f84.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: c23bcfe39a38768d4bd6e8e6fd5756462a92fb6a
+  Gutenberg: 78b43416ada29c95e9ddb7e842463d719477d5df
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -108,7 +108,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-d1a9005a549a82b99d90cff58a249e71a3700f84.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-fd29fcf88de16da3e5c5d8cee98ce1756876cd23.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-d1a9005a549a82b99d90cff58a249e71a3700f84.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-fd29fcf88de16da3e5c5d8cee98ce1756876cd23.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 78b43416ada29c95e9ddb7e842463d719477d5df
+  Gutenberg: 8154b166fcafed619580d9adf3130dc5829b636a
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -108,7 +108,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-fd29fcf88de16da3e5c5d8cee98ce1756876cd23.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.109.0.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-fd29fcf88de16da3e5c5d8cee98ce1756876cd23.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.109.0.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 8154b166fcafed619580d9adf3130dc5829b636a
+  Gutenberg: 34ff6e6e1897936e5695176cb7615596d1c4ca42
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,7 +26,7 @@ PODS:
   - FSInteractiveMap (0.1.0)
   - Gifu (3.3.1)
   - Gridicons (1.2.0)
-  - Gutenberg (1.108.0)
+  - Gutenberg (1.109.0)
   - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.9):
     - CropViewController
@@ -108,7 +108,7 @@ DEPENDENCIES:
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.108.0.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-728536dc80e7f2333003a7451345cf3e322f337f.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.108.0.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-728536dc80e7f2333003a7451345cf3e322f337f.podspec
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: dc1c9450b90706bb127f991330c8551acd5f4343
+  Gutenberg: c23bcfe39a38768d4bd6e8e6fd5756462a92fb6a
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,9 @@
 * [*] Stats: Fix an issue where sites for clicked URLs do not open [#22061]
 * [*] [internal] Make Reader web views inspectable on iOS 16.4 and higher [#22077]
 * [*] [internal] Add workarounds for large emoji on P2. [#22080]
+* [*] [Jetpack-only] Block Editor: Ensure text is always visible within Contact Info block [https://github.com/Automattic/jetpack/pull/33873]
+* [*] Block Editor: Ensure uploaded audio is always visible within Audio block [https://github.com/WordPress/gutenberg/pull/55627]
+* [*] Block Editor: In the deeply nested block warning, only display the ungroup option for blocks that support it [https://github.com/WordPress/gutenberg/pull/56445]
 
 23.7
 -----


### PR DESCRIPTION
## Description
This PR incorporates the 1.109.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6398

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.