### PR TITLE
Centralize build code bump logic – Fixes incorrect beta bump

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -172,18 +172,7 @@ platform :ios do
     download_localized_strings_and_metadata(options)
     lint_localizations
 
-    # Bump the build code
-    UI.message 'Bumping build code...'
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
-    PUBLIC_VERSION_FILE.write(version_long: build_code_next)
-    UI.success "Done! New Build Code: #{build_code_current}"
-
-    # Bump the internal build code
-    UI.message 'Bumping internal build code...'
-    PUBLIC_VERSION_FILE.write(version_long: build_code_next_internal)
-    UI.success "Done! New Internal Build Code: #{build_code_current_internal}"
-
+    bump_build_codes
     commit_version_bump
 
     if prompt_for_confirmation(
@@ -312,16 +301,8 @@ platform :ios do
     download_localized_strings_and_metadata(options)
     lint_localizations
 
-    # Bump the build code
-    UI.message 'Bumping build code...'
-    PUBLIC_VERSION_FILE.write(version_long: build_code_next)
-    UI.success "Done! New Build Code: #{build_code_current}"
-
-    # Bump the internal build code
-    UI.message 'Bumping internal build code...'
-    INTERNAL_VERSION_FILE.write(version_long: build_code_next_internal)
+    bump_build_codes
     commit_version_bump
-    UI.success "Done! New Internal Build Code: #{build_code_current_internal}"
 
     # Wrap up
     version = release_version_current
@@ -464,6 +445,23 @@ end
 
 def release_branch_name
   "release/#{release_version_current}"
+end
+
+def bump_build_codes
+  bump_production_build_code
+  bump_internal_build_code
+end
+
+def bump_production_build_code
+  UI.message 'Bumping build code...'
+  PUBLIC_VERSION_FILE.write(version_long: build_code_next)
+  UI.success "Done. New Build Code: #{build_code_current}"
+end
+
+def bump_internal_build_code
+  UI.message 'Bumping internal build code...'
+  INTERNAL_VERSION_FILE.write(version_long: build_code_next_internal)
+  UI.success "Done. New Internal Build Code: #{build_code_current_internal}"
 end
 
 def commit_version_bump

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -173,7 +173,6 @@ platform :ios do
     lint_localizations
 
     bump_build_codes
-    commit_version_and_build_files
 
     if prompt_for_confirmation(
       message: 'Ready to push changes to remote and trigger the beta build?',
@@ -302,7 +301,6 @@ platform :ios do
     lint_localizations
 
     bump_build_codes
-    commit_version_and_build_files
 
     # Wrap up
     version = release_version_current
@@ -450,6 +448,7 @@ end
 def bump_build_codes
   bump_production_build_code
   bump_internal_build_code
+  commit_version_and_build_files
 end
 
 def bump_production_build_code

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -61,7 +61,7 @@ platform :ios do
     )
     UI.success "Done! New Internal Release Version: #{release_version_current_internal}. New Internal Build Code: #{build_code_current_internal}"
 
-    commit_version_bump
+    commit_version_and_build_files
 
     new_version = release_version_current
 
@@ -173,7 +173,7 @@ platform :ios do
     lint_localizations
 
     bump_build_codes
-    commit_version_bump
+    commit_version_and_build_files
 
     if prompt_for_confirmation(
       message: 'Ready to push changes to remote and trigger the beta build?',
@@ -248,7 +248,7 @@ platform :ios do
     )
     UI.success "Done! New Internal Release Version: #{release_version_current_internal}. New Internal Build Code: #{build_code_current_internal}"
 
-    commit_version_bump
+    commit_version_and_build_files
   end
 
   # Finalizes a hotfix, by triggering a release build on CI
@@ -302,7 +302,7 @@ platform :ios do
     lint_localizations
 
     bump_build_codes
-    commit_version_bump
+    commit_version_and_build_files
 
     # Wrap up
     version = release_version_current
@@ -464,7 +464,7 @@ def bump_internal_build_code
   UI.success "Done. New Internal Build Code: #{build_code_current_internal}"
 end
 
-def commit_version_bump
+def commit_version_and_build_files
   git_commit(
     path: [PUBLIC_CONFIG_FILE, INTERNAL_CONFIG_FILE],
     message: 'Bump version number',


### PR DESCRIPTION
After creating the first beta, I missed an error in the version bump logic: Only `Version.Public.xcconfig` changed and the `VERSION_LONG` value was the one that the internal build should have had. I only noticed the issue today, when submitting the finalized 23.7 build for App Store review.

The source of the issue was the beta lane writing the new internal build code into `Version.Public.xcconfig`. Once the value changed there every subsequent bump, even if using the correct logic, would have ended up being wrong. Case in point, the final binary has build code `23.7.0.20231116` which is correctly computed as `23.7.0.20231115 + 1` but nevertheless not the one we'd want.

This PR fixes the issue and also centralizes the build code bump logic, previously duplicated between beta and finalization lanes.

I tested this by:

1. Restoring the build code format in `Version.Public.xcconfig` to be `23.7.0.0`
2. Adding a lane to wrap the `bump_build_codes` method
3. Verifying the resulting commit has the values I expected

<img width="1719" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/0fdd7019-47be-4612-a8a7-8242a5cd75dd">

<img width="1728" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/83125f7a-4323-48ae-b798-119e4b8c8c09">


## Regression Notes

1. Potential unintended areas of impact – N.A.
5. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
6. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.