### PR TITLE
Add UI tests of image optimization setting

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -443,7 +443,8 @@ private extension AppSettingsViewController {
         let imageOptimization = SwitchRow(
             title: NSLocalizedString("appSettings.media.imageOptimizationRow", value: "Optimize Images", comment: "Option to enable the optimization of images when uploading."),
             value: imageOptimizationValue,
-            onChange: imageOptimizationChanged()
+            onChange: imageOptimizationChanged(),
+            accessibilityIdentifier: "imageOptimizationSwitch"
         )
 
         let imageSizingRow = ImageSizingRow(

--- a/WordPress/UITests/Tests/AppSettingsTests.swift
+++ b/WordPress/UITests/Tests/AppSettingsTests.swift
@@ -28,16 +28,33 @@ final class AppSettingsTests: XCTestCase {
     }
 
     func testImageOptimizationEnabledByDefault() throws {
-        try TabNavComponent().goToMeScreen().goToAppSettings().verifyImageOptimizationSwitch(enabled: true)
+        try TabNavComponent()
+            .goToMeScreen()
+            .goToAppSettings()
+            .verifyImageOptimizationSwitch(enabled: true)
     }
 
     func testImageOptimizationIsTurnedOnEditor() throws {
-        try TabNavComponent().goToBlockEditorScreen().addImage().chooseOptimizeImages(option: true).closeEditor()
-        try TabNavComponent().goToMeScreen().goToAppSettings().verifyImageOptimizationSwitch(enabled: true)
+        try TabNavComponent()
+            .goToBlockEditorScreen()
+            .addImage()
+            .chooseOptimizeImages(option: true)
+            .closeEditor()
+        try TabNavComponent()
+            .goToMeScreen()
+            .goToAppSettings()
+            .verifyImageOptimizationSwitch(enabled: true)
     }
 
     func testImageOptimizationIsTurnedOffEditor() throws {
-        try TabNavComponent().goToBlockEditorScreen().addImage().chooseOptimizeImages(option: false).closeEditor()
-        try TabNavComponent().goToMeScreen().goToAppSettings().verifyImageOptimizationSwitch(enabled: false)
+        try TabNavComponent()
+            .goToBlockEditorScreen()
+            .addImage()
+            .chooseOptimizeImages(option: false)
+            .closeEditor()
+        try TabNavComponent()
+            .goToMeScreen()
+            .goToAppSettings()
+            .verifyImageOptimizationSwitch(enabled: false)
     }
 }

--- a/WordPress/UITests/Tests/AppSettingsTests.swift
+++ b/WordPress/UITests/Tests/AppSettingsTests.swift
@@ -3,10 +3,20 @@ import XCTest
 
 final class AppSettingsTests: XCTestCase {
 
+    let testsRequiringAppDeletion = [
+        "testImageOptimizationEnabledByDefault",
+        "testImageOptimizationIsTurnedOnEditor",
+        "testImageOptimizationIsTurnedOffEditor"
+    ]
+
     @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
-        setUpTestSuite(removeBeforeLaunching: true)
+
+        let removeBeforeLaunching = testsRequiringAppDeletion.contains { testName in
+            self.name.contains(testName)
+        }
+        setUpTestSuite(removeBeforeLaunching: removeBeforeLaunching)
 
         try LoginFlow
             .login(email: WPUITestCredentials.testWPcomUserEmail)

--- a/WordPress/UITests/Tests/AppSettingsTests.swift
+++ b/WordPress/UITests/Tests/AppSettingsTests.swift
@@ -1,0 +1,31 @@
+import UITestsFoundation
+import XCTest
+
+final class AppSettingsTests: XCTestCase {
+
+    @MainActor
+    override func setUpWithError() throws {
+        setUpTestSuite(removeBeforeLaunching: true)
+
+        try LoginFlow
+            .login(email: WPUITestCredentials.testWPcomUserEmail)
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+    }
+
+    func testImageOptimizationEnabledByDefault() throws {
+        try TabNavComponent().goToMeScreen().goToAppSettings().verifyImageOptimizationSwitch(enabled: true)
+    }
+
+    func testImageOptimizationIsTurnedOnEditor() throws {
+        try TabNavComponent().goToBlockEditorScreen().addImage().chooseOptimizeImages(option: true).closeEditor()
+        try TabNavComponent().goToMeScreen().goToAppSettings().verifyImageOptimizationSwitch(enabled: true)
+    }
+
+    func testImageOptimizationIsTurnedOffEditor() throws {
+        try TabNavComponent().goToBlockEditorScreen().addImage().chooseOptimizeImages(option: false).closeEditor()
+        try TabNavComponent().goToMeScreen().goToAppSettings().verifyImageOptimizationSwitch(enabled: false)
+    }
+}

--- a/WordPress/UITests/Tests/AppSettingsTests.swift
+++ b/WordPress/UITests/Tests/AppSettingsTests.swift
@@ -5,6 +5,7 @@ final class AppSettingsTests: XCTestCase {
 
     @MainActor
     override func setUpWithError() throws {
+        try super.setUpWithError()
         setUpTestSuite(removeBeforeLaunching: true)
 
         try LoginFlow
@@ -12,6 +13,7 @@ final class AppSettingsTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        try super.tearDownWithError()
         takeScreenshotOfFailedTest()
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -96,6 +96,14 @@ public class BlockEditorScreen: ScreenObject {
         $0.staticTexts["You have unsaved changes."]
     }
 
+    private let turnOnImageOptimizationGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Yes, leave on"]
+    }
+
+    private let turnOffImageOptimizationGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["No, turn off"]
+    }
+
     var addBlockButton: XCUIElement { addBlockButtonGetter(app) }
     var chooseFromDeviceButton: XCUIElement { chooseFromDeviceButtonGetter(app) }
     var closeButton: XCUIElement { closeButtonGetter(app) }
@@ -119,6 +127,8 @@ public class BlockEditorScreen: ScreenObject {
     var switchToHTMLModeButton: XCUIElement { switchToHTMLModeButtonGetter(app) }
     var undoButton: XCUIElement { undoButtonGetter(app) }
     var unsavedChangesLabel: XCUIElement { unsavedChangesLabelGetter(app) }
+    var turnOnImageOptimization: XCUIElement { turnOnImageOptimizationGetter(app) }
+    var turnOffImageOptimization: XCUIElement { turnOffImageOptimizationGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         // The block editor has _many_ elements but most are loaded on-demand. To verify the screen
@@ -187,6 +197,20 @@ public class BlockEditorScreen: ScreenObject {
     public func addImageGallery() throws -> BlockEditorScreen {
         addBlock("Gallery block")
         try addMultipleImages(numberOfImages: 3)
+
+        return self
+    }
+
+    /**
+     Chooses the option of Optimize Images popup.
+     */
+    public func chooseOptimizeImages(option: Bool) throws -> BlockEditorScreen {
+        if option {
+            turnOnImageOptimization.tap()
+        }
+        else {
+            turnOffImageOptimization.tap()
+        }
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -96,11 +96,11 @@ public class BlockEditorScreen: ScreenObject {
         $0.staticTexts["You have unsaved changes."]
     }
 
-    private let turnOnImageOptimizationGetter: (XCUIApplication) -> XCUIElement = {
+    private let turnOnImageOptimizationButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Yes, leave on"]
     }
 
-    private let turnOffImageOptimizationGetter: (XCUIApplication) -> XCUIElement = {
+    private let turnOffImageOptimizationButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["No, turn off"]
     }
 
@@ -127,8 +127,8 @@ public class BlockEditorScreen: ScreenObject {
     var switchToHTMLModeButton: XCUIElement { switchToHTMLModeButtonGetter(app) }
     var undoButton: XCUIElement { undoButtonGetter(app) }
     var unsavedChangesLabel: XCUIElement { unsavedChangesLabelGetter(app) }
-    var turnOnImageOptimization: XCUIElement { turnOnImageOptimizationGetter(app) }
-    var turnOffImageOptimization: XCUIElement { turnOffImageOptimizationGetter(app) }
+    var turnOnImageOptimizationButton: XCUIElement { turnOnImageOptimizationButtonGetter(app) }
+    var turnOffImageOptimizationButton: XCUIElement { turnOffImageOptimizationButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         // The block editor has _many_ elements but most are loaded on-demand. To verify the screen
@@ -206,10 +206,10 @@ public class BlockEditorScreen: ScreenObject {
      */
     public func chooseOptimizeImages(option: Bool) throws -> BlockEditorScreen {
         if option {
-            turnOnImageOptimization.tap()
+            turnOnImageOptimizationButton.tap()
         }
         else {
-            turnOffImageOptimization.tap()
+            turnOffImageOptimizationButton.tap()
         }
 
         return self

--- a/WordPress/UITestsFoundation/Screens/Me/AppSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/AppSettingsScreen.swift
@@ -17,7 +17,7 @@ public class AppSettingsScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                backButtonGetter,
+                imageOptimizationSwitchGetter,
             ],
             app: app
         )

--- a/WordPress/UITestsFoundation/Screens/Me/AppSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/AppSettingsScreen.swift
@@ -1,0 +1,45 @@
+import ScreenObject
+import XCTest
+
+public class AppSettingsScreen: ScreenObject {
+
+    private let backButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars.buttons.element(boundBy: 0)
+    }
+
+    private let imageOptimizationSwitchGetter: (XCUIApplication) -> XCUIElement = {
+        $0.switches["imageOptimizationSwitch"]
+    }
+
+    var backButton: XCUIElement { backButtonGetter(app) }
+    var imageOptimizationSwitch: XCUIElement { imageOptimizationSwitchGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                backButtonGetter,
+            ],
+            app: app
+        )
+    }
+
+    public func tapImageOptimizationSwitch() throws -> Self {
+        imageOptimizationSwitch.tap()
+        return self
+    }
+
+    @discardableResult
+    public func verifyImageOptimizationSwitch(enabled: Bool) -> Self {
+        XCTAssertEqual(imageOptimizationSwitch.value as? String, enabled ? "1" : "0")
+        return self
+    }
+
+    public func dismiss() throws -> MeTabScreen {
+        backButton.tap()
+        return try MeTabScreen()
+    }
+
+    static func isLoaded() -> Bool {
+        (try? AppSettingsScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -96,4 +96,10 @@ public class MeTabScreen: ScreenObject {
 
         return try MySiteScreen()
     }
+
+    public func goToAppSettings() throws -> AppSettingsScreen {
+        appSettingsButton.tap()
+
+        return try AppSettingsScreen()
+    }
 }

--- a/WordPress/UITestsFoundation/XCTestCase+Utils.swift
+++ b/WordPress/UITestsFoundation/XCTestCase+Utils.swift
@@ -27,7 +27,7 @@ public extension XCTestCase {
 
         appToRemove.firstMatch.press(forDuration: 1)
         waitAndTap(Apps.springboard.buttons["Remove App"])
-        waitAndTap(Apps.springboard.alerts.buttons["Delete App"])
+        waitForExistenceAndTap(Apps.springboard.alerts.buttons["Delete App"])
         waitAndTap(Apps.springboard.alerts.buttons["Delete"])
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -758,6 +758,9 @@
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
 		1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */; };
 		1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */; };
+		1D0402732B10FA9100888C30 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0402722B10FA9100888C30 /* AppSettingsTests.swift */; };
+		1D0402742B10FA9100888C30 /* AppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0402722B10FA9100888C30 /* AppSettingsTests.swift */; };
+		1D0402762B10FB9E00888C30 /* AppSettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0402752B10FB9E00888C30 /* AppSettingsScreen.swift */; };
 		1D19C56329C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */; };
 		1D19C56429C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */; };
 		1D19C56629C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56529C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift */; };
@@ -6420,6 +6423,8 @@
 		1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApi+Defaults.swift"; sourceTree = "<group>"; };
 		1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressUIBundleTests.swift; sourceTree = "<group>"; };
 		1BC96E982E9B1A6DD86AF491 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		1D0402722B10FA9100888C30 /* AppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsTests.swift; sourceTree = "<group>"; };
+		1D0402752B10FB9E00888C30 /* AppSettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsScreen.swift; sourceTree = "<group>"; };
 		1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergVideoPressUploadProcessor.swift; sourceTree = "<group>"; };
 		1D19C56529C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergVideoPressUploadProcessorTests.swift; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -15863,6 +15868,7 @@
 				CC7CB97222B1510900642EE9 /* SignupTests.swift */,
 				EAD2BF4127594DAB00A847BB /* StatsTests.swift */,
 				6E5BA46826A59D620043A6F2 /* SupportScreenTests.swift */,
+				1D0402722B10FA9100888C30 /* AppSettingsTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -16329,6 +16335,7 @@
 			children = (
 				EA78189327596B2F00554DFA /* ContactUsScreen.swift */,
 				6EC71EC22689A67400ACC0A0 /* SupportScreen.swift */,
+				1D0402752B10FB9E00888C30 /* AppSettingsScreen.swift */,
 			);
 			path = Me;
 			sourceTree = "<group>";
@@ -22963,6 +22970,7 @@
 				EAD08D0E29D45E23001A72F9 /* CommentsScreen.swift in Sources */,
 				3F762E9526784B540088CD45 /* WireMock.swift in Sources */,
 				C7B7CC7328134347007B9807 /* OnboardingQuestionsPromptScreen.swift in Sources */,
+				1D0402762B10FB9E00888C30 /* AppSettingsScreen.swift in Sources */,
 				3FE39A3F26F8384E006E2B3A /* StatsScreen.swift in Sources */,
 				3FE39A3126F836A5006E2B3A /* LoginSiteAddressScreen.swift in Sources */,
 				3F2F855126FAF227000FCDA5 /* WelcomeScreenLoginComponent.swift in Sources */,
@@ -23859,6 +23867,7 @@
 				EA14533229AD874C001F3143 /* SignupTests.swift in Sources */,
 				EA14533329AD874C001F3143 /* EditorFlow.swift in Sources */,
 				01281E9D2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */,
+				1D0402742B10FA9100888C30 /* AppSettingsTests.swift in Sources */,
 				EA14533429AD874C001F3143 /* UIApplication+mainWindow.swift in Sources */,
 				EA14533529AD874C001F3143 /* LoginFlow.swift in Sources */,
 				EA14533629AD874C001F3143 /* XCTest+Extensions.swift in Sources */,
@@ -25817,6 +25826,7 @@
 				CC7CB97322B1510900642EE9 /* SignupTests.swift in Sources */,
 				CC52188C2278C622008998CE /* EditorFlow.swift in Sources */,
 				01281E9C2A051EEA00464F8F /* MenuNavigationTests.swift in Sources */,
+				1D0402732B10FA9100888C30 /* AppSettingsTests.swift in Sources */,
 				8B5FEAF125A746CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */,
 				BED4D8331FF11E3800A11345 /* LoginFlow.swift in Sources */,
 				FF2716A11CABC7D40006E2D4 /* XCTest+Extensions.swift in Sources */,


### PR DESCRIPTION
This PR is a follow-up of https://github.com/wordpress-mobile/WordPress-iOS/pull/21981 and adds UI tests of the new App Setting to optimize images when uploading.

**To test:**
N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
