### PR TITLE
Fix a crash when deleting media from the details screen close to the end

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -403,7 +403,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         if let viewController = navigationController?.topViewController,
            let detailsViewController = viewController as? SiteMediaPageViewController {
             let before = indexPath.item > 0 ? fetchController.object(at: IndexPath(item: indexPath.item - 1, section: 0)) : nil
-            let after = indexPath.item < (fetchController.fetchedObjects?.count ?? 0) ? fetchController.object(at: IndexPath(item: indexPath.item + 1, section: 0)) : nil
+            let after = indexPath.item < (fetchController.fetchedObjects?.count ?? 0) ? fetchController.object(at: IndexPath(item: indexPath.item, section: 0)) : nil
 
             detailsViewController.didDeleteItem(media, before: before, after: after)
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22097

To test:

## Crash

- Add two images to the media
- Open Site Media
- Tap on the first (left) one to open the Media Details page
- Delete it
- Verify that the details page scrolls to the remaining item (to the right) and doesn't crash

## Incorrect Scroll

- Add a few images to the media
- Open Site Media
- Tap on the first (left) one to open the Media Details page
- Delete it
- Verify that the details page scrolls to the adjacent item to the right (and not the next one after it: +2 index)

## Regression Notes
1. Potential unintended areas of impact: Site Media details page
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
