### PR TITLE
Fix an issue with pan gesture breaking Site Media picker in single selection mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -240,7 +240,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     }
 
     @objc private func didRecognizePanGesture(_ gesture: UIPanGestureRecognizer) {
-        guard isEditing else { return }
+        guard isEditing, allowsMultipleSelection else { return }
 
         switch gesture.state {
         case .began:


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/56598

To test: follow the ticket

## Regression Notes
1. Potential unintended areas of impact: Editor and Site Media picker
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
