### PR TITLE
Reader: Update reader share tracks property to a valid key

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
@@ -10,7 +10,7 @@ final class ReaderShareAction {
             let sharingController = PostSharingController()
 
             sharingController.shareReaderPost(post, fromAnchor: anchor, inViewController: vc)
-            WPAnalytics.trackReader(.itemSharedReader, properties: ["blogId": post.siteID as Any])
+            WPAnalytics.trackReader(.itemSharedReader, properties: ["blog_id": post.siteID as Any])
         }
     }
 }


### PR DESCRIPTION
Fixes #22110

## Description

Currently, the `item_shared_reader` event gets rejected before even being sent. This fixes the property which is causing it to be rejected.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Open the `More` menu (`...`) on any post
- Tap on `Share`
- 🔎 **Verify** `🔵 Tracked: item_shared_reader <blog_id: xxxx, subscription_count: xxxx>` is sent with no error

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
