### PR TITLE
Passkeys Out, Universal Links In

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -148,9 +148,9 @@ abstract_target 'Apps' do
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
-  pod 'WordPressAuthenticator', '~> 7.3'
+  # pod 'WordPressAuthenticator', '~> 7.3'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'task/add-option-disable-webauthn'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   pod 'MediaEditor', '~> 1.2', '>= 1.2.2'

--- a/Podfile
+++ b/Podfile
@@ -148,9 +148,9 @@ abstract_target 'Apps' do
   # pod 'WPMediaPicker', git: 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', branch: ''
   # pod 'WPMediaPicker', path: '../MediaPicker-iOS'
 
-  # pod 'WordPressAuthenticator', '~> 7.3'
+  pod 'WordPressAuthenticator', '~> 7.3', '>= 7.3.1'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'task/add-option-disable-webauthn'
+  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   pod 'MediaEditor', '~> 1.2', '>= 1.2.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
     - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (7.3.0):
+  - WordPressAuthenticator (7.3.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -125,7 +125,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `task/add-option-disable-webauthn`)
+  - WordPressAuthenticator (>= 7.3.1, ~> 7.3)
   - WordPressKit (~> 8.11)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
@@ -163,6 +163,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -183,9 +184,6 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.108.0.podspec
-  WordPressAuthenticator:
-    :branch: task/add-option-disable-webauthn
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -195,9 +193,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
-  WordPressAuthenticator:
-    :commit: 0e58dede2cb9f30979fff190d7a0081e703e9fec
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -230,7 +225,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: 16f6560a06008cc502b92c85e76eaaa90248c12b
+  WordPressAuthenticator: 503a174d8ccc0781a0f5769e5e284e07cb294dc0
   WordPressKit: 13e01ed70f6ab2397c228959bc47cb2073521f63
   WordPressShared: 87f3ee89b0a3e83106106f13a8b71605fb8eb6d2
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
@@ -245,6 +240,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 6525f5eafbd12a89a0425cca6d323c8cb31fb235
+PODFILE CHECKSUM: 4ee417f4ebc199aa8408da42f5e590f2d9ac75b3
 
 COCOAPODS: 1.14.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -125,7 +125,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (~> 7.3)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `task/add-option-disable-webauthn`)
   - WordPressKit (~> 8.11)
   - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
@@ -163,7 +163,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -184,6 +183,9 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.108.0.podspec
+  WordPressAuthenticator:
+    :branch: task/add-option-disable-webauthn
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -193,6 +195,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.100.2
+  WordPressAuthenticator:
+    :commit: 0e58dede2cb9f30979fff190d7a0081e703e9fec
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -240,6 +245,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 111cf685318a6ee88f6f6c75c044570fc8bf84f7
+PODFILE CHECKSUM: 6525f5eafbd12a89a0425cca6d323c8cb31fb235
 
 COCOAPODS: 1.14.2

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -79,6 +79,7 @@ extension WordPressAuthenticationManager {
                                                    enableSignupWithGoogle: AppConfiguration.allowSignUp,
                                                    enableUnifiedAuth: true,
                                                    enableUnifiedCarousel: true,
+                                                   enablePasskeys: false,
                                                    enableSocialLogin: true)
     }
 

--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -14,6 +14,7 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -10,6 +10,7 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -10,6 +10,7 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -14,6 +14,7 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>

--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -6,6 +6,7 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -12,6 +12,7 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:wordpress.com</string>
+		<string>applinks:*.wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>


### PR DESCRIPTION
This PR disables Passkeys support and re-enables the universal links for all wordpress.com subdomains.

Technical details:
1. I branched out from WordPressAuthenticator [7.3.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/7.3.0) and [added](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/809) a configuration option that simply hides the Passkey option from the interface.
2. I reverted the Associated Domains change

**TODO**: Set the target branch to the hotfix branch

To test:

- Verify that the universal links for subdomains now open the app again
- Verify that the users with Passkeys (WebAuthN / Security Key) enabled can still log in into the app using other 2FA methods

## Regression Notes
1. Potential unintended areas of impact: Login, Universal Links
4. What I did to test those areas of impact (or what existing automated tests I relied on): manual
5. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
