### PR TITLE
Fix crash when deleting media from details from the end of the list

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -399,7 +399,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         if let viewController = navigationController?.topViewController,
            let detailsViewController = viewController as? SiteMediaPageViewController {
             let before = indexPath.item > 0 ? fetchController.object(at: IndexPath(item: indexPath.item - 1, section: 0)) : nil
-            let after = indexPath.item < (fetchController.fetchedObjects?.count ?? 0) ? fetchController.object(at: IndexPath(item: indexPath.item + 1, section: 0)) : nil
+            let after = indexPath.item < (fetchController.fetchedObjects?.count ?? 0) ? fetchController.object(at: IndexPath(item: indexPath.item, section: 0)) : nil
 
             detailsViewController.didDeleteItem(media, before: before, after: after)
         }


### PR DESCRIPTION
🍒 cherry-pick of https://github.com/wordpress-mobile/WordPress-iOS/pull/22098
