### PR TITLE
 Fix an issue with sharing from the context menu not working on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -5,13 +5,13 @@ protocol SiteMediaCollectionViewControllerDelegate: AnyObject {
     func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, didUpdateSelection selection: [Media])
     /// Return a non-nil value to allow adding media using the empty state.
     func makeAddMediaMenu(for viewController: SiteMediaCollectionViewController) -> UIMenu?
-    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media) -> UIMenu?
+    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media, sourceView: UIView) -> UIMenu?
 }
 
 extension SiteMediaCollectionViewControllerDelegate {
     func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, didUpdateSelection: [Media]) {}
     func makeAddMediaMenu(for viewController: SiteMediaCollectionViewController) -> UIMenu? { nil }
-    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media) -> UIMenu? { nil }
+    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media, sourceView: UIView) -> UIMenu? { nil }
 }
 
 /// The internal view controller for managing the media collection view.
@@ -475,7 +475,8 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
             return self.makePreviewViewController(for: media)
         }, actionProvider: { [weak self] _ in
             guard let self else { return nil }
-            return self.delegate?.siteMediaViewController(self, contextMenuFor: media)
+            let cell = collectionView.cellForItem(at: indexPath)
+            return self.delegate?.siteMediaViewController(self, contextMenuFor: media, sourceView: cell ?? self.view)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -99,7 +99,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
 
     // MARK: - SiteMediaCollectionViewControllerDelegate
 
-    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media) -> UIMenu? {
+    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media, sourceView: UIView) -> UIMenu? {
         let title = viewController.isSelected(media) ? Strings.deselect : Strings.select
         return UIMenu(children: [UIAction(title: title, image: UIImage(systemName: "checkmark.circle")) { [weak self] _ in
             self?.collectionViewController.toggleSelection(for: media)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -221,7 +221,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
 
     // MARK: - Actions (Share)
 
-    private func shareSelectedMedia(_ selection: [Media], barButtonItem: UIBarButtonItem? = nil) {
+    private func shareSelectedMedia(_ selection: [Media], barButtonItem: UIBarButtonItem? = nil, sourceView: UIView? = nil) {
         guard !selection.isEmpty else {
             return
         }
@@ -242,7 +242,13 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
                 let fileURLs = try await Media.downloadRemoteData(for: selection, blog: blog)
 
                 let activityViewController = UIActivityViewController(activityItems: fileURLs, applicationActivities: nil)
-                activityViewController.popoverPresentationController?.barButtonItem = barButtonItem
+                if let popover = activityViewController.popoverPresentationController {
+                    if let barButtonItem {
+                        popover.barButtonItem = barButtonItem
+                    } else {
+                        popover.sourceView = sourceView ?? view
+                    }
+                }
                 activityViewController.completionWithItemsHandler = { [weak self] _, isCompleted, _, _ in
                     if isCompleted {
                         self?.setEditing(false)
@@ -267,11 +273,11 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
         buttonAddMediaMenuController.makeMenu(for: self)
     }
 
-    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media) -> UIMenu? {
+    func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media, sourceView: UIView) -> UIMenu? {
         var actions: [UIAction] = []
 
         actions.append(UIAction(title: Strings.buttonShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
-            self?.shareSelectedMedia([media])
+            self?.shareSelectedMedia([media], sourceView: sourceView)
         })
         if blog.supports(.mediaDeletion) {
             actions.append(UIAction(title: Strings.buttonDelete, image: UIImage(systemName: "trash"), attributes: [.destructive]) { [weak self] _ in


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22118

To test:

- Open Site Media on iPad
- Long-press on an asset
- Select "Share"
- Verify that it's working (and not crashing)
- Verify that the sheet is attached to the selected cell

<img width="958" alt="Screenshot 2023-11-29 at 6 56 47 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/8fdd53ee-15af-48c3-a613-c52e1899a416">

## Regression Notes
1. Potential unintended areas of impact: Site Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
