### PR TITLE
Remove explicit Alamofire dependency from `Podfile`

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -71,7 +71,6 @@ def shared_with_all_pods
 end
 
 def shared_with_networking_pods
-  pod 'Alamofire', '4.8.0'
   pod 'Reachability', '3.2'
 
   wordpress_kit

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (4.8.0)
+  - Alamofire (4.8.2)
   - AlamofireImage (3.5.2):
     - Alamofire (~> 4.8)
   - AlamofireNetworkActivityIndicator (2.4.0):
@@ -95,7 +95,6 @@ PODS:
   - ZIPFoundation (0.9.16)
 
 DEPENDENCIES:
-  - Alamofire (= 4.8.0)
   - AlamofireImage (= 3.5.2)
   - AlamofireNetworkActivityIndicator (~> 2.4)
   - AppCenter (~> 5.0)
@@ -189,7 +188,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
-  Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
+  Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   AlamofireImage: 63cfe3baf1370be6c498149687cf6db3e3b00999
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AppCenter: a4070ec3d4418b5539067a51f57155012e486ebd
@@ -232,6 +231,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 8638d2a485a756411d904506c5cce8c10652cd3f
+PODFILE CHECKSUM: 9ed23c1a12abf7621d4b831f7aebac740c8fab7d
 
 COCOAPODS: 1.14.2

--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -1,5 +1,4 @@
 import AlamofireImage
-import Alamofire
 import AutomatticTracks
 import Foundation
 import Gridicons

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsCell.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Alamofire
 import Gridicons
 import WordPressKit
 


### PR DESCRIPTION
What it says on the title. The library already comes via transitive dependency on AlamofireImage
and AlamofireActivityIndicator.

@crazytonyli I started working on this a while back to cleanup the `Podfile` but it fell in the low priority bucket. Your work on #22398 reminded me of it and I think it might be a nice incremental cleanup on the way to removal. What do you think?

Feel free to discard if it doesn't fit your plan.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.