### PR TITLE
Me tab: Update me tab icon when default account changes

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -353,6 +353,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         WPAccount *account = [context existingObjectWithID:objectID error:nil];
         [self updateDefaultBlogIfNeeded:account inContext:context];
+        [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountEmailAndDefaultBlogUpdatedNotification object:nil];
     }];
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -8,10 +8,13 @@ extension WPTabBarController {
 
     @objc func observeGravatarImageUpdate() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateGravatarImage(_:)), name: .GravatarImageUpdateNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountChanged), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
     }
 
     @objc func configureMeTabImage(placeholderImage: UIImage) {
         meNavigationController?.tabBarItem.image = placeholderImage
+        meNavigationController?.tabBarItem.selectedImage = placeholderImage
 
         guard let account = defaultAccount(),
               let email = account.email else {
@@ -37,6 +40,10 @@ extension WPTabBarController {
 
         ImageCache.shared.setImage(image, forKey: url.absoluteString)
         meNavigationController?.tabBarItem.configureGravatarImage(image)
+    }
+
+    @objc private func defaultAccountChanged() {
+        configureMeTabImage(placeholderImage: UIImage(named: "icon-tab-me") ?? UIImage())
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -9,7 +9,9 @@ extension WPTabBarController {
     @objc func observeGravatarImageUpdate() {
         NotificationCenter.default.addObserver(self, selector: #selector(updateGravatarImage(_:)), name: .GravatarImageUpdateNotification, object: nil)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountChanged), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(accountDidChange), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(accountDidChange), name: .WPAccountEmailAndDefaultBlogUpdated, object: nil)
     }
 
     @objc func configureMeTabImage(placeholderImage: UIImage) {
@@ -42,7 +44,7 @@ extension WPTabBarController {
         meNavigationController?.tabBarItem.configureGravatarImage(image)
     }
 
-    @objc private func defaultAccountChanged() {
+    @objc private func accountDidChange() {
         configureMeTabImage(placeholderImage: UIImage(named: "icon-tab-me") ?? UIImage())
     }
 }


### PR DESCRIPTION
Fixes #21680

## Description
This fixes an issue where the Me tab gravatar image wasn’t being removed when logging out of an account with self-hosted sites.

## How to test
- Login using wp.com account
- Add a self-hosted site
- Switch to the Me tab and logout
- Verify: gravatar image is removed from the Me tab
- Login again using a a wp.com account
- Verify: Me tab shows profile image associated with account


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/030b82aa-b019-4396-a594-f73d699bee26


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

