### PR TITLE
Enable feature flag for the Bloganuary nudge

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -21,6 +21,7 @@
 * [*] Block Editor: Ensure uploaded audio is always visible within Audio block [https://github.com/WordPress/gutenberg/pull/55627]
 * [*] Block Editor: In the deeply nested block warning, only display the ungroup option for blocks that support it [https://github.com/WordPress/gutenberg/pull/56445]
 * [**] Refactor deleting media [#21748]
+* [*] [Jetpack-only] Add a dashboard card for Bloganuary. [https://github.com/wordpress-mobile/WordPress-iOS/pull/22136]
 
 23.7
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -12,7 +12,6 @@ enum FeatureFlag: Int, CaseIterable {
     case commentModerationUpdate
     case compliancePopover
     case domainFocus
-    case bloganuaryCardDebugOverride // TODO: Remove before shipping the feature.
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -41,8 +40,6 @@ enum FeatureFlag: Int, CaseIterable {
             return true
         case .domainFocus:
             return true
-        case .bloganuaryCardDebugOverride:
-            return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -85,8 +82,6 @@ extension FeatureFlag {
             return "Compliance Popover"
         case .domainFocus:
             return "Domain Focus"
-        case .bloganuaryCardDebugOverride:
-            return "Always Show Bloganuary Card (Debug)"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -67,7 +67,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .readerImprovements:
             return true
         case .bloganuaryDashboardNudge:
-            return false
+            return AppConfiguration.isJetpack
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
@@ -21,11 +21,6 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
     ///   - date: The date to check. Defaults to today.
     /// - Returns: `true` if the Bloganuary card should be shown. `false` otherwise.
     static func shouldShowCard(for blog: Blog, date: Date = Date()) -> Bool {
-        // TODO: Remove before this feature is shipped.
-        if FeatureFlag.bloganuaryCardDebugOverride.enabled {
-            return true
-        }
-
         guard RemoteFeatureFlag.bloganuaryDashboardNudge.enabled(),
               let context = blog.managedObjectContext else {
             return false


### PR DESCRIPTION
Refs pcdRpT-4FE-p2

This enables the Bloganuary dashboard card, which should only appear during December. The card is backed with a remote feature flag, so we can disable the feature anytime.

This feature includes these PRs:

- #22121 
- #22129
- #22130

#### Previews

Dashboard card | 'Learn more' modal
-|-
![card-light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/2d7c4144-eefd-43f3-a248-101e29e47d08) | ![light_enabled_new](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/349a84e5-5f8c-4a8a-8d59-e9dfeef2a0d1)


## To test

- Temporarily change your device date so sometime in December.
- Launch the Jetpack app.
- Log in with a WP.com account and switch to a site that has Blogging Prompts enabled.
- 🔎 Verify that the Bloganuary dashboard card appears on top of the prompts card.
- Tap 'Learn more'. 
- 🔎 Verify that the modal appears.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The components are entirely new, and it's gated behind a remote feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
Added some tests for the card's visibility logic in #22121.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)