### PR TITLE
Explicitly mark blog.timeZone as nullable

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -236,7 +236,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (readonly) BOOL hasIcon;
 
 /** Determine timezone for blog from blog options.  If no timezone information is stored on the device, then assume GMT+0 is the default. */
-@property (readonly) NSTimeZone *timeZone;
+@property (readonly, nullable) NSTimeZone *timeZone;
 
 #pragma mark - Blog information
 

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -326,7 +326,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     return self.icon.length > 0 ? [NSURL URLWithString:self.icon].pathComponents.count > 1 : NO;
 }
 
-- (NSTimeZone *)timeZone
+- (nullable NSTimeZone *)timeZone
 {
     CGFloat const OneHourInSeconds = 60.0 * 60.0;
 

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -96,7 +96,7 @@ class StatsWidgetsStore {
             homeWidgetCache[siteID.intValue] = HomeWidgetTodayData(siteID: siteID.intValue,
                                                                    siteName: blog.title ?? oldData.siteName,
                                                                    url: blog.url ?? oldData.url,
-                                                                   timeZone: blog.timeZone,
+                                                                   timeZone: blog.timeZone ?? TimeZone.current,
                                                                    date: Date(),
                                                                    stats: stats) as? T
 
@@ -107,7 +107,7 @@ class StatsWidgetsStore {
             homeWidgetCache[siteID.intValue] = HomeWidgetAllTimeData(siteID: siteID.intValue,
                                                                      siteName: blog.title ?? oldData.siteName,
                                                                      url: blog.url ?? oldData.url,
-                                                                     timeZone: blog.timeZone,
+                                                                     timeZone: blog.timeZone ?? TimeZone.current,
                                                                      date: Date(),
                                                                      stats: stats) as? T
 
@@ -117,7 +117,7 @@ class StatsWidgetsStore {
             homeWidgetCache[siteID.intValue] = HomeWidgetThisWeekData(siteID: siteID.intValue,
                                                                       siteName: blog.title ?? oldData.siteName,
                                                                       url: blog.url ?? oldData.url,
-                                                                      timeZone: blog.timeZone,
+                                                                      timeZone: blog.timeZone ?? TimeZone.current,
                                                                       date: Date(),
                                                                       stats: stats) as? T
         }
@@ -163,7 +163,7 @@ private extension StatsWidgetsStore {
             var timeZone = existingSite?.timeZone ?? TimeZone.current
 
             if let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext) {
-                timeZone = blog.timeZone
+                timeZone = blog.timeZone ?? TimeZone.current
             }
 
             let date = existingSite?.date ?? Date()
@@ -217,21 +217,21 @@ private extension StatsWidgetsStore {
                     result[blogID.intValue] = HomeWidgetTodayData(siteID: blogID.intValue,
                                                                   siteName: title,
                                                                   url: url,
-                                                                  timeZone: timeZone,
+                                                                  timeZone: timeZone ?? TimeZone.current,
                                                                   date: Date(timeIntervalSinceReferenceDate: 0),
                                                                   stats: TodayWidgetStats()) as? T
                 } else if type == HomeWidgetAllTimeData.self {
                     result[blogID.intValue] = HomeWidgetAllTimeData(siteID: blogID.intValue,
                                                                     siteName: title,
                                                                     url: url,
-                                                                    timeZone: timeZone,
+                                                                    timeZone: timeZone ?? TimeZone.current,
                                                                     date: Date(timeIntervalSinceReferenceDate: 0),
                                                                     stats: AllTimeWidgetStats()) as? T
                 } else if type == HomeWidgetThisWeekData.self {
                     result[blogID.intValue] = HomeWidgetThisWeekData(siteID: blogID.intValue,
                                                                      siteName: title,
                                                                      url: url,
-                                                                     timeZone: timeZone,
+                                                                     timeZone: timeZone ?? TimeZone.current,
                                                                      date: Date(timeIntervalSinceReferenceDate: 0),
                                                                      stats: ThisWeekWidgetStats(days: initializedWeekdays)) as? T
                 }

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -14,6 +14,7 @@ private class WeeklyRoundupDataProvider {
         case authTokenNotFound
         case failedToMakePeriodEndDate
         case dotComSiteWithoutDotComID(_ site: NSManagedObjectID)
+        case timezoneError
         case siteFetchingError(_ error: Error)
         case unknownErrorRetrievingStats(_ site: NSManagedObjectID)
         case errorRetrievingStats(_ blogID: Int?, error: Error)
@@ -253,8 +254,11 @@ private class WeeklyRoundupDataProvider {
         guard let dotComID = site.dotComID else {
             throw DataRequestError.dotComSiteWithoutDotComID(site.managedObjectID)
         }
+        guard let siteTimezone = site.timeZone else {
+            throw DataRequestError.timezoneError
+        }
         let wpApi = WordPressComRestApi.defaultApi(oAuthToken: authToken, userAgent: WPUserAgent.wordPress())
-        return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: dotComID, siteTimezone: site.timeZone)
+        return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: dotComID, siteTimezone: siteTimezone)
     }
 
     // MARK: - Types
@@ -264,7 +268,7 @@ private class WeeklyRoundupDataProvider {
         let managedObjectID: NSManagedObjectID
         let authToken: String?
         let dotComID: Int?
-        let timeZone: TimeZone
+        let timeZone: TimeZone?
         let isAdmin: Bool
         let isAutomatticP2: Bool
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDateFormatting.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDateFormatting.swift
@@ -29,6 +29,6 @@ struct ActivityDateFormatting {
             return TimeZone(secondsFromGMT: 0)!
         }
 
-        return blog.timeZone
+        return blog.timeZone ?? TimeZone.current
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -49,7 +49,7 @@ struct PublishSettingsViewModel {
         self.post = post
 
         title = post.postTitle
-        timeZone = post.blog.timeZone
+        timeZone = post.blog.timeZone ?? TimeZone.current
 
         dateFormatter = SiteDateFormatters.dateFormatter(for: timeZone, dateStyle: .long, timeStyle: .none)
         dateTimeFormatter = SiteDateFormatters.dateFormatter(for: timeZone, dateStyle: .medium, timeStyle: .short)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22131

## Description
Fixes a crash that manifests when casting a nil `blog.timeZone` value to `TimeZone`, by explicitly marking `blog.timeZone` as nullable

## How to test
- Return nil for `blog.timeZone`
- Verify app doesn't crash when viewing the posts list screen

## Regression Notes
1. Potential unintended areas of impact
weekly background task, stats widget store

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a - passed TimeZone.current (system timezone)

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
