### PR TITLE
Add missing domain management analytic events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -14,7 +14,7 @@ extension WPAnalytics {
 
     static func domainsProperties(
         usingCredit: Bool? = nil,
-        origin: DomainsAnalyticsWebViewOrigin? = nil,
+        origin: String? = nil,
         domainOnly: Bool? = nil
     ) -> [AnyHashable: Any] {
         var dict: [AnyHashable: Any] = [:]
@@ -22,7 +22,7 @@ extension WPAnalytics {
             dict["using_credit"] = usingCredit.stringLiteral
         }
         if Self.domainPurchasingEnabled, let origin = origin {
-            dict["origin"] = origin.rawValue
+            dict["origin"] = origin
         }
         if let domainOnly, Self.domainManagementEnabled {
             dict["domain_only"] = domainOnly.stringLiteral
@@ -32,7 +32,7 @@ extension WPAnalytics {
 
     static func domainsProperties(
         for blog: Blog,
-        origin: DomainsAnalyticsWebViewOrigin? = .menu
+        origin: String?
     ) -> [AnyHashable: Any] {
         Self.domainsProperties(
             usingCredit: blog.canRegisterDomainWithPaidPlan,
@@ -40,10 +40,16 @@ extension WPAnalytics {
             domainOnly: nil
         )
     }
+
+    static func domainsProperties(
+        for blog: Blog,
+        origin: DomainsAnalyticsWebViewOrigin? = .menu
+    ) -> [AnyHashable: Any] {
+        Self.domainsProperties(for: blog, origin: origin?.rawValue)
+    }
 }
 
 enum DomainsAnalyticsWebViewOrigin: String {
     case siteCreation = "site_creation"
     case menu
-    case allDomains = "all_domains"
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -14,7 +14,7 @@ extension WPAnalytics {
 
     static func domainsProperties(
         usingCredit: Bool? = nil,
-        origin: SiteCreationWebViewViewOrigin? = nil,
+        origin: DomainsAnalyticsWebViewOrigin? = nil,
         domainOnly: Bool? = nil
     ) -> [AnyHashable: Any] {
         var dict: [AnyHashable: Any] = [:]
@@ -32,7 +32,7 @@ extension WPAnalytics {
 
     static func domainsProperties(
         for blog: Blog,
-        origin: SiteCreationWebViewViewOrigin? = .menu
+        origin: DomainsAnalyticsWebViewOrigin? = .menu
     ) -> [AnyHashable: Any] {
         Self.domainsProperties(
             usingCredit: blog.canRegisterDomainWithPaidPlan,
@@ -42,7 +42,7 @@ extension WPAnalytics {
     }
 }
 
-enum SiteCreationWebViewViewOrigin: String {
+enum DomainsAnalyticsWebViewOrigin: String {
     case siteCreation = "site_creation"
     case menu
     case allDomains = "all_domains"

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -13,33 +13,37 @@ extension WPAnalytics {
     }
 
     static func domainsProperties(
-        for blog: Blog,
-        origin: SiteCreationWebViewViewOrigin? = .menu
-    ) -> [AnyHashable: Any] {
-        domainsProperties(
-            usingCredit: blog.canRegisterDomainWithPaidPlan,
-            origin: origin,
-            domainOnly: false
-        )
-    }
-
-    static func domainsProperties(
-        usingCredit: Bool,
+        usingCredit: Bool? = nil,
         origin: SiteCreationWebViewViewOrigin? = nil,
-        domainOnly: Bool = false
+        domainOnly: Bool? = nil
     ) -> [AnyHashable: Any] {
-        var dict: [AnyHashable: Any] = ["using_credit": usingCredit.stringLiteral]
+        var dict: [AnyHashable: Any] = [:]
+        if let usingCredit {
+            dict["using_credit"] = usingCredit.stringLiteral
+        }
         if Self.domainPurchasingEnabled, let origin = origin {
             dict["origin"] = origin.rawValue
         }
-        if Self.domainManagementEnabled {
+        if let domainOnly, Self.domainManagementEnabled {
             dict["domain_only"] = domainOnly.stringLiteral
         }
         return dict
+    }
+
+    static func domainsProperties(
+        for blog: Blog,
+        origin: SiteCreationWebViewViewOrigin? = .menu
+    ) -> [AnyHashable: Any] {
+        Self.domainsProperties(
+            usingCredit: blog.canRegisterDomainWithPaidPlan,
+            origin: origin,
+            domainOnly: nil
+        )
     }
 }
 
 enum SiteCreationWebViewViewOrigin: String {
     case siteCreation = "site_creation"
     case menu
+    case allDomains = "all_domains"
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -241,6 +241,7 @@ import Foundation
 
     // Domain Management
     case meDomainsTapped
+    case allDomainsDomainDetailsWebViewShown
     case domainsDashboardAllDomainsTapped
     case domainsDashboardDomainsSearchShown
     case domainsListShown
@@ -961,12 +962,14 @@ import Foundation
         // Domain Management
         case .meDomainsTapped:
             return "me_all_domains_tapped"
+        case .allDomainsDomainDetailsWebViewShown:
+            return "all_domains_domain_details_web_view_shown"
         case .domainsDashboardAllDomainsTapped:
             return "domains_dashboard_all_domains_tapped"
         case .domainsDashboardDomainsSearchShown:
             return "domains_dashboard_domains_search_shown"
         case .domainsListShown:
-            return "all_domains_domains_list_shown"
+            return "all_domains_list_shown"
         case .allDomainsFindDomainTapped:
             return "domain_management_all_domains_find_domain_tapped"
         case .addDomainTapped:

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -58,7 +58,7 @@ class RegisterDomainDetailsViewController: UITableViewController {
             .domainsRegistrationFormViewed,
             properties: WPAnalytics.domainsProperties(
                 usingCredit: true,
-                origin: .menu
+                origin: DomainsAnalyticsWebViewOrigin.menu.rawValue
             )
         )
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -15,7 +15,8 @@ class RegisterDomainCoordinator {
     // MARK: Variables
 
     private let crashLogger: CrashLogging
-    private let analyticsSource: String?
+
+    let analyticsSource: String?
 
     var site: Blog?
     var domainPurchasedCallback: DomainPurchasedCallback?

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -128,6 +128,10 @@ class RegisterDomainCoordinator {
         viewController.navigationController?.pushViewController(blogListViewController, animated: true)
     }
 
+    func trackDomainPurchasingCompleted() {
+        WPAnalytics.track(.purchaseDomainCompleted)
+    }
+
     // MARK: Helpers
 
     private func createCart(completion: @escaping (Result<FullyQuotedDomainSuggestion, Swift.Error>) -> Void) {
@@ -185,7 +189,7 @@ class RegisterDomainCoordinator {
                 }
             }) { domain in
                 self.domainPurchasedCallback?(viewController, domain)
-                WPAnalytics.track(.purchaseDomainCompleted)
+                self.trackDomainPurchasingCompleted()
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -401,11 +401,11 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
 
         let controller = RegisterDomainDetailsViewController()
         controller.viewModel = RegisterDomainDetailsViewModel(siteID: siteID, domain: domain) { [weak self] name in
-            guard let self = self else {
+            guard let self = self, let coordinator else {
                 return
             }
-
-            self.coordinator?.domainPurchasedCallback?(self, name)
+            coordinator.domainPurchasedCallback?(self, name)
+            coordinator.trackDomainPurchasingCompleted()
         }
         self.navigationController?.pushViewController(controller, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -212,8 +212,6 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     /// Shows the domain picking button
     ///
     /// - Parameters:
-    ///
-    /// g
     ///     - animated: whether the transition is animated.
     ///
     private func showButton(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -296,19 +296,16 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     // MARK: - Tracks
 
     private func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any] = [:], blog: Blog? = nil) {
-        var properties = properties
-
-        let defaultProperties = { () -> [AnyHashable: Any]? in
-            guard let blog else {
-                return nil
+        let defaultProperties = { () -> [AnyHashable: Any] in
+            if let blog {
+                return WPAnalytics.domainsProperties(for: blog, origin: self.analyticsSource)
+            } else {
+                return WPAnalytics.domainsProperties(origin: self.analyticsSource)
             }
-            return WPAnalytics.domainsProperties(for: blog, origin: .allDomains)
         }()
 
-        if let defaultProperties {
-            properties = properties.merging(defaultProperties) { current, _ in
-                return current
-            }
+        let properties = properties.merging(defaultProperties) { current, _ in
+            return current
         }
 
         if let blog {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/SiteCreationPurchasingWebFlowController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/SiteCreationPurchasingWebFlowController.swift
@@ -27,7 +27,7 @@ final class SiteCreationPurchasingWebFlowController {
 
     /// The domain purchasing web view can be presented from multiple sources.
     /// This property represents this source, and it's used mostly for analytics.
-    private let origin: SiteCreationWebViewViewOrigin?
+    private let origin: DomainsAnalyticsWebViewOrigin?
 
     // MARK: - Execution Variables
 
@@ -42,7 +42,7 @@ final class SiteCreationPurchasingWebFlowController {
     init(viewController: UIViewController,
          shoppingCartService: ShoppingCartServiceProtocol = ShoppingCartService(),
          crashLogger: CrashLogging = .main,
-         origin: SiteCreationWebViewViewOrigin? = nil) {
+         origin: DomainsAnalyticsWebViewOrigin? = nil) {
         self.presentingViewController = viewController
         self.shoppingCartService = shoppingCartService
         self.crashLogger = crashLogger

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
@@ -19,9 +19,11 @@ import Foundation
 
         let domainAddedToCart = FreeToPaidPlansCoordinator.plansFlowAfterDomainAddedToCartBlock(
             customTitle: RegisterDomainCoordinator.TextContent.checkoutTitle,
-            analyticsSource: analyticsSource,
-            purchaseCallback: domainPurchasedCallback
-        )
+            analyticsSource: analyticsSource
+        ) { [weak coordinator] controller, domain in
+            domainPurchasedCallback(controller, domain)
+            coordinator?.trackDomainPurchasingCompleted()
+        }
 
         coordinator.domainPurchasedCallback = domainPurchasedCallback // For no site flow (domain only)
         coordinator.domainAddedToCartAndLinkedToSiteCallback = domainAddedToCart // For existing site flow (plans)

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -72,10 +72,6 @@ final class AllDomainsListViewController: UIViewController {
         self.setupSubviews()
         self.observeState()
         self.viewModel.loadData()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         WPAnalytics.track(.domainsListShown)
     }
 

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -188,7 +188,7 @@ final class AllDomainsListViewController: UIViewController {
             domain: domain.domain,
             siteSlug: domain.siteSlug,
             type: domain.type,
-            analyticsSource: "all-domains"
+            analyticsSource: Constants.analyticsSource
         )
         destination.configureSandboxStore {
             navigationController.pushViewController(destination, animated: true)

--- a/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
@@ -38,6 +38,7 @@ final class DomainDetailsWebViewController: WebKitViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.observeURL()
+        self.trackWebViewShownEvent(url: url)
     }
 
     // MARK: - Handling URL Changes
@@ -74,6 +75,11 @@ final class DomainDetailsWebViewController: WebKitViewController {
     }
 
     // MARK: - Helpers
+
+    private func trackWebViewShownEvent(url: URL?) {
+        let properties = ["url": url?.absoluteString ?? ""]
+        WPAnalytics.track(.allDomainsDomainDetailsWebViewShown, properties: properties)
+    }
 
     private func shouldAllowNavigation(for url: URL) -> Bool {
         return url.absoluteString == self.url?.absoluteString


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/22038#issuecomment-1836043387

This PR resolves these issues:
- The event `all_domains_domain_details_web_view_shown` wasn't fired.
- Rename `all_domains_domains_list_shown` to `all_domains_list_shown`
- The event `domain_management_purchase_domain_completed` wasn't fired when a domain is purchased through the "Purchase Domain Choices > Choose Site" flow.
- Pass correct `analyticsSource` param for events fired in `Domains Search` screen.
   - It should be `all_domains` when navigating to that screen through the `All Domains` flow.
   - It should be `domains_register` when navigating to that screen though `My Site > Domains` flow.

## Test Instructions

#### Case 1: All Domains Flow
1. Navigate to the "Me" tab
2. Tap "Domains"
   - [x] Expect `me_all_domains_tapped` to be tracked.
3. Expect the domains list to be shown
   - [x] Expect `all_domains_list_shown` to be tracked.
4. Tap a domain from the list
5. Expect the domain details webview to be shown
   - [x] Expect `all_domains_domain_details_web_view_shown` to be tracked.
   - [x] Expect a `url` to be included in the event params.
6. Go back to the all domains screen
7. Tap the "+" button
   - [x] Expect `all_domains_add_domain_tapped` to be tracked
8. Expect the domain search screen to be shown
   - [x] Expect `domains_dashboard_domains_search_shown <source: all_domains>` to be tracked.
9. Type a query to search for a domain
10. Tap a domain from the results list then tap **Select Domain**
    - [x] Expect `domains_dashboard_select_domain_tapped <source: all_domains>` to be tracked.
    - [x] Expect the tracked event to include the `domain_name` property with a value set as the picked domain
11. Expect the purchase domain screen to be shown
    - [x] Expect `domain_management_purchase_domain_screen_shown` to be tracked.
12. Tap "Get domain"
    - [x] Expect `domain_management_purchase_domain_get_domain_tapped` to be tracked.
13. Expect checkout webview to be shown
    - [x] Expect `domains_purchase_webview_viewed` to be tracked.
    - [x] Expect the `domain_only` and `using_credit` to be included in the event params. 
14. Complete the purchase (can use the store sandbox if needed)
    - [x] Expect `domain_management_purchase_domain_completed` to be tracked.
15. Repeat the steps from the beginning but tap "Choose Site" this time.
    - [x] Expect `domain_management_purchase_domain_choose_site_tapped` to be tracked.
16. Choose a site
    - [x] Expect `site_switcher_domain_site_selected` to be tracked.
17. Complete the purchase (can use the store sandbox if needed)
    - [x] Expect `domain_management_purchase_domain_completed` to be tracked.
18. Repeat steps 1 - 8
19. Tap "Transer domain" button
    - [x] Expect `domains_dashboard_domains_search_transfer_domain_tapped` to be tracked
20. Navigate to the "My Site" tab
21. Tap "... More" button
22. Tap the "Domains" button (in the "Manage" section)
23. Tap the "ALL" button (on the top bar)
    - [x] Expect `domains_dashboard_all_domains_tapped` to be tracked

#### Case 2: Site Domains Flow

1. Navigate to the "My Site" tab 
2. Tap "... More" button
3. Tap the "Domains" button (in the "Manage" section)
4. Tap "Add a domain"
5. Search for a domain then select "Select Domain"
6. Complete the purchase (can use the store sandbox if needed)
   - [x] Expect `domain_management_purchase_domain_completed` to be tracked

## Regression Notes
1. Potential unintended areas of impact
Re-test track events fired from Domain Management screens.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

8. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
