### PR TITLE
Add a nudge card in WordPress for SoTW 2023

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -541,6 +541,11 @@ import Foundation
     case freeToPaidPlansDashboardCardMenuTapped
     case freeToPaidPlansDashboardCardHidden
 
+    // SoTW 2023 Nudge
+    case sotw2023NudgePostEventCardShown
+    case sotw2023NudgePostEventCardCTATapped
+    case sotw2023NudgePostEventCardHideTapped
+
     // Widgets
     case widgetsLoadedOnApplicationOpened
 
@@ -1479,6 +1484,14 @@ import Foundation
             return "free_to_paid_plan_dashboard_card_tapped"
         case .freeToPaidPlansDashboardCardMenuTapped:
             return "free_to_paid_plan_dashboard_card_menu_tapped"
+
+        // SoTW 2023 Nudge
+        case .sotw2023NudgePostEventCardShown:
+            return "sotw_2023_nudge_post_event_card_shown"
+        case .sotw2023NudgePostEventCardCTATapped:
+            return "sotw_2023_nudge_post_event_card_cta_tapped"
+        case .sotw2023NudgePostEventCardHideTapped:
+            return "sotw_2023_nudge_post_event_card_hide_tapped"
 
         // Widgets
         case .widgetsLoadedOnApplicationOpened:

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -23,6 +23,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case plansInSiteCreation
     case readerImprovements // pcdRpT-3Eb-p2
     case bloganuaryDashboardNudge // pcdRpT-4FE-p2
+    case wordPressSotWCard
 
     var defaultValue: Bool {
         switch self {
@@ -67,6 +68,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .readerImprovements:
             return true
         case .bloganuaryDashboardNudge:
+            return false
+        case .wordPressSotWCard:
             return false
         }
     }
@@ -116,6 +119,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "reader_improvements"
         case .bloganuaryDashboardNudge:
             return "bloganuary_dashboard_nudge"
+        case .wordPressSotWCard:
+            return "wp_sotw_2023_nudge"
         }
     }
 
@@ -163,6 +168,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Reader Improvements v1"
         case .bloganuaryDashboardNudge:
             return "Bloganuary Dashboard Nudge"
+        case .wordPressSotWCard:
+            return "SoTW Nudge Card for WordPress App"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -70,7 +70,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .bloganuaryDashboardNudge:
             return false
         case .wordPressSotWCard:
-            return false
+            return true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -21,6 +21,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
     BlogDetailsSectionCategoryMigrationSuccess,
     BlogDetailsSectionCategoryJetpackBrandingCard,
     BlogDetailsSectionCategoryJetpackInstallCard,
+    BlogDetailsSectionCategorySotW2023Card,
     BlogDetailsSectionCategoryContent,
     BlogDetailsSectionCategoryTraffic,
     BlogDetailsSectionCategoryMaintenance

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -32,6 +32,7 @@ static NSString *const BlogDetailsSectionFooterIdentifier = @"BlogDetailsSection
 static NSString *const BlogDetailsMigrationSuccessCellIdentifier = @"BlogDetailsMigrationSuccessCell";
 static NSString *const BlogDetailsJetpackBrandingCardCellIdentifier = @"BlogDetailsJetpackBrandingCardCellIdentifier";
 static NSString *const BlogDetailsJetpackInstallCardCellIdentifier = @"BlogDetailsJetpackInstallCardCellIdentifier";
+static NSString *const BlogDetailsSotWCardCellIdentifier = @"BlogDetailsSotWCardCellIdentifier";
 
 NSString * const WPBlogDetailsRestorationID = @"WPBlogDetailsID";
 NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
@@ -384,7 +385,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self.tableView registerClass:[MigrationSuccessCell class] forCellReuseIdentifier:BlogDetailsMigrationSuccessCellIdentifier];
     [self.tableView registerClass:[JetpackBrandingMenuCardCell class] forCellReuseIdentifier:BlogDetailsJetpackBrandingCardCellIdentifier];
     [self.tableView registerClass:[JetpackRemoteInstallTableViewCell class] forCellReuseIdentifier:BlogDetailsJetpackInstallCardCellIdentifier];
-    
+    [self.tableView registerClass:[SotWTableViewCell class] forCellReuseIdentifier:BlogDetailsSotWCardCellIdentifier];
+
     self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
 
     self.hasLoggedDomainCreditPromptShownEvent = NO;
@@ -1017,6 +1019,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *marr = [NSMutableArray array];
 
     // TODO: Add the SoTW card here.
+    if ([self shouldShowSotW2023Card]) {
+        [marr addNullableObject:[self sotw2023SectionViewModel]];
+    }
 
     if (MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES) {
         [marr addNullableObject:[self migrationSuccessSectionViewModel]];
@@ -1579,6 +1584,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     BlogDetailsSection *section = [self.tableSections objectAtIndex:indexPath.section];
+
+    if (section.category == BlogDetailsSectionCategorySotW2023Card) {
+        SotWTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsSotWCardCellIdentifier];
+        return cell;
+    }
 
     if (section.category == BlogDetailsSectionCategoryJetpackInstallCard) {
         JetpackRemoteInstallTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsJetpackInstallCardCellIdentifier];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1587,6 +1587,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if (section.category == BlogDetailsSectionCategorySotW2023Card) {
         SotWTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsSotWCardCellIdentifier];
+        __weak __typeof(self) weakSelf = self;
+        [cell configureOnCardHidden:^{
+            [weakSelf configureTableViewData];
+            [weakSelf reloadTableViewPreservingSelection];
+        }];
+
         return cell;
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1015,7 +1015,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)configureTableViewData
 {
     NSMutableArray *marr = [NSMutableArray array];
-    
+
+    // TODO: Add the SoTW card here.
+
     if (MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES) {
         [marr addNullableObject:[self migrationSuccessSectionViewModel]];
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
@@ -125,7 +125,26 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowSotW2023Card() -> Bool {
-        return true
+        guard AppConfiguration.isWordPress && RemoteFeatureFlag.wordPressSotWCard.enabled() else {
+            return false
+        }
+
+        // ensure that the device language is in English.
+        let usesEnglish = WordPressComLanguageDatabase().deviceLanguageSlugString() == "en"
+
+        // ensure that the card is not displayed before Dec. 11, 2023 where the event takes place.
+        let dateComponents = Date().dateAndTimeComponents()
+        let isPostEvent = {
+            guard let day = dateComponents.day,
+                  let month = dateComponents.month,
+                  let year = dateComponents.year,
+                  year < 2024 else {
+                return true
+            }
+            return month == 12 && day > 11
+        }()
+
+        return usesEnglish && isPostEvent
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
@@ -1,0 +1,59 @@
+/// A seasonal card view shown in the WordPress app to promote State of the Word 2023.
+///
+class SOTWCardView: UIView {
+
+    // MARK: - Views
+
+    private lazy var bodyLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.setText(Strings.body)
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var watchNowButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Strings.button, for: .normal)
+        button.setTitleColor(.primary, for: .normal)
+        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.contentHorizontalAlignment = .leading
+        button.addTarget(self, action: #selector(onButtonTap), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var contentStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [bodyLabel, watchNowButton])
+        stackView.axis = .vertical
+        stackView.spacing = 12.0
+        stackView.isLayoutMarginsRelativeArrangement = true
+        return stackView
+    }()
+
+    private lazy var cardFrameView: BlogDashboardCardFrameView = {
+        let frameView = BlogDashboardCardFrameView()
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        frameView.setTitle(Strings.title)
+        frameView.onEllipsisButtonTap = {}
+        frameView.ellipsisButton.showsMenuAsPrimaryAction = true
+        frameView.ellipsisButton.menu = nil // TODO.
+        frameView.add(subview: contentStackView)
+
+        return frameView
+    }()
+}
+
+private extension SOTWCardView {
+
+    @objc func onButtonTap() {
+        // TODO: Redirect to livestream landing page.
+    }
+
+    struct Strings {
+        static let title = "State of the Word 2023"
+        static let body = "Check out WordPress co-founder Matt Mullenweg's annual keynote to stay on top of what's coming in 2024 and beyond."
+        static let button = "Watch now"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
@@ -1,12 +1,13 @@
 /// A seasonal card view shown in the WordPress app to promote State of the Word 2023.
 ///
-class SOTWCardView: UIView {
+class SotWCardView: UIView {
 
     // MARK: - Views
 
     private lazy var bodyLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        label.textColor = .secondaryLabel
         label.setText(Strings.body)
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
@@ -27,8 +28,9 @@ class SOTWCardView: UIView {
     private lazy var contentStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [bodyLabel, watchNowButton])
         stackView.axis = .vertical
-        stackView.spacing = 12.0
+        stackView.spacing = 8.0
         stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.directionalLayoutMargins = .init(top: 0, leading: 16, bottom: 4, trailing: 16)
         return stackView
     }()
 
@@ -43,9 +45,30 @@ class SOTWCardView: UIView {
 
         return frameView
     }()
+
+    // MARK: Initializers
+
+    init() {
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Methods
+
+    private func setupView() {
+        addSubview(cardFrameView)
+        pinSubviewToAllEdges(cardFrameView)
+    }
+
 }
 
-private extension SOTWCardView {
+// MARK: - Private Helpers
+
+private extension SotWCardView {
 
     @objc func onButtonTap() {
         // TODO: Redirect to livestream landing page.
@@ -56,4 +79,53 @@ private extension SOTWCardView {
         static let body = "Check out WordPress co-founder Matt Mullenweg's annual keynote to stay on top of what's coming in 2024 and beyond."
         static let button = "Watch now"
     }
+}
+
+// MARK: - UITableViewCell Wrapper
+
+class SotWTableViewCell: UITableViewCell {
+
+    private lazy var cardView: SotWCardView = {
+        let cardView = SotWCardView()
+        cardView.translatesAutoresizingMaskIntoConstraints = false
+        return cardView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.setText("Hello, world!")
+        contentView.addSubview(cardView)
+        contentView.pinSubviewToAllEdges(cardView, priority: .defaultHigh)
+    }
+
+}
+
+// MARK: - BlogDetailsViewController Registration
+
+extension BlogDetailsViewController {
+
+    @objc func sotw2023SectionViewModel() -> BlogDetailsSection {
+        let row = BlogDetailsRow()
+        row.callback = {}
+        let section = BlogDetailsSection(title: nil,
+                                         rows: [row],
+                                         footerTitle: nil,
+                                         category: .sotW2023Card)
+        return section
+    }
+
+    @objc func shouldShowSotW2023Card() -> Bool {
+        return true
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/SoTW 2023/SOTWCardView.swift
@@ -78,6 +78,8 @@ class SotWCardView: UIView {
         didTapButton?()
     }
 
+    // NOTE: These strings are purposely not going to be localized because we are specifically
+    // targeting `en` audiences only.
     struct Strings {
         static let title = "State of the Word 2023"
         static let body = "Check out WordPress co-founder Matt Mullenweg's annual keynote to stay on top of what's coming in 2024 and beyond."

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5578,6 +5578,7 @@
 		FE50965D2A20D0F300DDD071 /* CommentTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE50965B2A20D0F300DDD071 /* CommentTableHeaderView.swift */; };
 		FE6AFE432B18EDF200F76520 /* BloganuaryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */; };
 		FE6AFE442B18EDF200F76520 /* BloganuaryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */; };
+		FE6AFE472B1A351F00F76520 /* SOTWCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */; };
 		FE6BB143293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
 		FE6BB144293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
 		FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */; };
@@ -9447,6 +9448,7 @@
 		FE59DA9527D1FD0700624D26 /* WordPress 138.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 138.xcdatamodel"; sourceTree = "<group>"; };
 		FE5F52D82AF9461200371A3A /* WordPress 153.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 153.xcdatamodel"; sourceTree = "<group>"; };
 		FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloganuaryTracker.swift; sourceTree = "<group>"; };
+		FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SOTWCardView.swift; sourceTree = "<group>"; };
 		FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinator.swift; sourceTree = "<group>"; };
 		FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingSocialAccountsViewController.swift; sourceTree = "<group>"; };
@@ -11520,6 +11522,7 @@
 		3F43603423F368BF001DEE70 /* Blog Details */ = {
 			isa = PBXGroup;
 			children = (
+				FE6AFE452B1A343A00F76520 /* SoTW 2023 */,
 				462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */,
 				462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */,
 				74989B8B2088E3650054290B /* BlogDetailsViewController+Activity.swift */,
@@ -18455,6 +18458,14 @@
 			path = Migration;
 			sourceTree = "<group>";
 		};
+		FE6AFE452B1A343A00F76520 /* SoTW 2023 */ = {
+			isa = PBXGroup;
+			children = (
+				FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */,
+			);
+			path = "SoTW 2023";
+			sourceTree = "<group>";
+		};
 		FE6BB14129322798001E5F7A /* Migration */ = {
 			isa = PBXGroup;
 			children = (
@@ -22309,6 +22320,7 @@
 				174C11932624C78900346EC6 /* Routes+Start.swift in Sources */,
 				4AA33F04299A1F93005B6E23 /* ReaderTagTopic+Lookup.swift in Sources */,
 				FA347AED26EB6E300096604B /* GrowAudienceCell.swift in Sources */,
+				FE6AFE472B1A351F00F76520 /* SOTWCardView.swift in Sources */,
 				FE32F006275F62620040BE67 /* WebCommentContentRenderer.swift in Sources */,
 				B5CC05F61962150600975CAC /* Constants.m in Sources */,
 				4326191522FCB9DC003C7642 /* MurielColor.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2101,6 +2101,7 @@
 		8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
 		8332DD2529259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
 		8332DD2829259BEB00802F7D /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2729259BEB00802F7D /* DataMigratorTests.swift */; };
+		833441C82B1AA9DF00B1FD44 /* SOTWCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */; };
 		834A49D22A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834A49D12A0C23A90042ED3D /* TemplatePageTableViewCell.swift */; };
 		834A49D32A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 834A49D12A0C23A90042ED3D /* TemplatePageTableViewCell.swift */; };
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
@@ -25718,6 +25719,7 @@
 				FABB25D02602FC2C00C8785C /* SiteCreationWizardLauncher.swift in Sources */,
 				FABB25D12602FC2C00C8785C /* ReaderSitesCardCell.swift in Sources */,
 				46F583B02624CE790010A723 /* BlockEditorSettingElement+CoreDataProperties.swift in Sources */,
+				833441C82B1AA9DF00B1FD44 /* SOTWCardView.swift in Sources */,
 				FABB25D22602FC2C00C8785C /* SiteSegmentsWizardContent.swift in Sources */,
 				FABB25D32602FC2C00C8785C /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				FEC26034283FC902003D886A /* RootViewCoordinator+BloggingPrompt.swift in Sources */,


### PR DESCRIPTION
Refs pdb1SS-3F9-p2

> [!NOTE]
> This PR targets the WordPress app.

This adds a "dashboard-style" nudge card at the top of the My Sites screen **for the WordPress app**. This card is backed by a remote feature flag, and will only be shown to English language users (((**after**))) SoTW 2023, which takes place on Dec. 11, 2023.

- Tapping "Watch now" redirects the user to the event's landing page.
- An ellipsis button is provided to hide the card for good, for all sites.

Light mode | Dark mode
-|-
![sotw_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c20916d7-b74a-44f8-81a8-3eacc849b05a) | ![sotw_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/3906414a-b677-4778-a623-114e7d49f881)

## To test

You'll need to modify the code in `SOTWCardView.swift`. Add a new line in the `shouldShowSotW2023Card()` function and set it to always return true (except when the user hides it) to always make the card appear:

```swift
    @objc func shouldShowSotW2023Card() -> Bool {
        let repo = UserPersistentStoreFactory.instance()
        return !repo.bool(forKey: SotWConstants.hideCardPreferenceKey)
        // more code ...
```

- Launch the WordPress app.
- Log in with your WP.com account.
- 🔎 Verify that the SoTW nudge card appears on the top of My Sites, just below the Blog information.
- Tap 'Watch now'.
- 🔎 Verify that it takes you to the event's landing page.
- Go back to the WordPress app.
- Tap the ellipsis button and tap 'Hide this'.
- 🔎 Verify that the card is gone.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The card is a new component and doesn't modify any existing functionalities. Also, the card is controlled via a remote flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)