### PR TITLE
Reader: Unsubscribe from Post object changes when toolbar disappears to avoid crashes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] [internal] Remove WPMediaPicker dependency [#22103]
 * [*] [internal] Rework Tenor (Free GIF) and Stock Photos (Free Photos) pickers [#22066, #22074]
 * [*] [internal] Remove MediaThumbnailService and reduce the size of the large thumbnails, reducing disk usage [#22106]
+* [*] [Jetpack-only] Fix an occassional crash when logging out after interacting with Reader [#22147]
 
 23.8
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -197,6 +197,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         super.viewWillAppear(animated)
         setupFeaturedImage()
         updateFollowButtonState()
+        toolbar.viewWillAppear()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -207,6 +208,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         featuredImage.viewWillDisappear()
+        toolbar.viewWillDisappear()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -59,6 +59,14 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         prepareActionButtonsForVoiceOver()
     }
 
+    func viewWillAppear() {
+        subscribePostChanges()
+    }
+
+    func viewWillDisappear() {
+        unsubscribePostChanges()
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
@@ -71,35 +79,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         self.post = post
         self.viewController = viewController
 
-        likeCountObserver = post.observe(\.likeCount, options: [.old, .new]) { [weak self] updatedPost, change in
-            // ensure that we only update the like button when there's actual change.
-            let oldValue = change.oldValue??.intValue ?? 0
-            let newValue = change.newValue??.intValue ?? 0
-            guard oldValue != newValue else {
-                return
-            }
-
-            self?.configureLikeActionButton(true)
-            self?.delegate?.didTapLikeButton(isLiked: updatedPost.isLiked)
-        }
-
-        commentCountObserver = post.observe(\.commentCount, options: [.old, .new]) { [weak self] _, change in
-            // ensure that we only update the like button when there's actual change.
-            let oldValue = change.oldValue??.intValue ?? 0
-            let newValue = change.newValue??.intValue ?? 0
-            guard oldValue != newValue else {
-                return
-            }
-
-            self?.configureCommentActionButton()
-        }
-
+        subscribePostChanges()
         configureActionButtons()
-    }
-
-    deinit {
-        likeCountObserver?.invalidate()
-        commentCountObserver?.invalidate()
     }
 
     // MARK: - Actions
@@ -577,5 +558,39 @@ private extension ReaderDetailToolbar {
                 Note: Since the display space is limited, a short or concise translation is preferred.
                 """
         )
+    }
+}
+
+// MARK: - Observe Post
+
+private extension ReaderDetailToolbar {
+    func subscribePostChanges() {
+        likeCountObserver = post?.observe(\.likeCount, options: [.old, .new]) { [weak self] updatedPost, change in
+            // ensure that we only update the like button when there's actual change.
+            let oldValue = change.oldValue??.intValue ?? 0
+            let newValue = change.newValue??.intValue ?? 0
+            guard oldValue != newValue else {
+                return
+            }
+
+            self?.configureLikeActionButton(true)
+            self?.delegate?.didTapLikeButton(isLiked: updatedPost.isLiked)
+        }
+
+        commentCountObserver = post?.observe(\.commentCount, options: [.old, .new]) { [weak self] _, change in
+            // ensure that we only update the like button when there's actual change.
+            let oldValue = change.oldValue??.intValue ?? 0
+            let newValue = change.newValue??.intValue ?? 0
+            guard oldValue != newValue else {
+                return
+            }
+
+            self?.configureCommentActionButton()
+        }
+    }
+
+    func unsubscribePostChanges() {
+        likeCountObserver?.invalidate()
+        commentCountObserver?.invalidate()
     }
 }


### PR DESCRIPTION
Fixes #22116

ReaderDetailToolbar can remain active in one tab while changes to the Post object can happen in another tab. To avoid issues, unsubscribe to Post changes when the view disappears.

I could not reproduce the crash but based on the logs the crash would happen during logout when accessing `likesCount` in `ReaderDetailToolbar`. It looks like Post observer is triggered during the logout process and the app crashes when we try to access no longer valid Post object. It happens because we remove Post observer in `ReaderDetailToolbar.deinit()` which isn't called when we switch from Reader tab to Me tab.

### Solution

Connect Post observing to `ReaderDetailViewController` life cycle. 

The other option I considered is moving all the observation logic to `ReaderDetailViewController` and then call specific methods of `ReaderDetailToolbar` to update the view. Do you think that would be preferable?

### To test:

Open Reader Details, and then switch tabs, for example:

1. Open Reader
2. Search for a site
3. Select site
4. Select post
5. Switch to another tab
6. Confirm `unsubscribePostChanges` is called
7. Come back to Reader tab
8. Confirm `subscribePostChanges` is called 


## Regression Notes
1. Potential unintended areas of impact

When Reader Detail view disappears, we stop observing likes and comments. If that wasn't intentional, then it could be an indented area of impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
