### PR TITLE
Improved My Site Header: Show site actions in menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -288,7 +288,7 @@ fileprivate extension BlogDetailHeaderView {
             button.tintColor = .secondaryLabel
             button.accessibilityLabel = NSLocalizedString("mySite.siteActions.button", value: "Site Actions", comment: "Button that reveals more site actions")
             button.accessibilityHint = NSLocalizedString("mySite.siteActions.hint", value: "Tap to show more site actions", comment: "Accessibility hint for button used to show more site actions")
-            button.accessibilityIdentifier = .switchSiteAccessibilityId
+            button.accessibilityIdentifier = .siteActionAccessibilityId
 
             return button
         }()
@@ -368,7 +368,7 @@ private extension String {
     // MARK: Accessibility Identifiers
     static let siteTitleAccessibilityId = "site-title-button"
     static let siteUrlAccessibilityId = "site-url-button"
-    static let switchSiteAccessibilityId = "switch-site-button"
+    static let siteActionAccessibilityId = "site-action-button"
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -244,7 +244,7 @@ fileprivate extension BlogDetailHeaderView {
             button.configuration = configuration
 
             button.menu = UIMenu(children: [
-                UIAction(title: Strings.openInBrowser, image: UIImage(systemName: "link"), handler: { [weak button] _ in
+                UIAction(title: Strings.visitSite, image: UIImage(systemName: "safari"), handler: { [weak button] _ in
                     button?.sendActions(for: .touchUpInside)
                 }),
                 UIAction(title: Strings.actionCopyURL, image: UIImage(systemName: "doc.on.doc"), handler: { [weak button] _ in
@@ -372,7 +372,7 @@ private extension String {
 }
 
 private enum Strings {
-    static let openInBrowser = NSLocalizedString("blogHeader.actionOpenInBrowser", value: "Open in Browser", comment: "Context menu button title")
+    static let visitSite = NSLocalizedString("blogHeader.actionVisitSite", value: "Visit site", comment: "Context menu button title")
     static let actionCopyURL = NSLocalizedString("blogHeader.actionCopyURL", value: "Copy URL", comment: "Context menu button title")
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -275,7 +275,7 @@ fileprivate extension BlogDetailHeaderView {
 
         let siteActionButton: UIButton = {
             let button = UIButton(frame: .zero)
-            let image = UIImage(named: "chevron-down-slim")?.withRenderingMode(.alwaysTemplate)
+            let image = UIImage(named: "more-horizontal-mobile")?.withRenderingMode(.alwaysTemplate)
 
             button.setImage(image, for: .normal)
             button.contentMode = .center

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -342,8 +342,8 @@ fileprivate extension BlogDetailHeaderView {
             NSLayoutConstraint.activate([
                 mainStackView.topAnchor.constraint(equalTo: topAnchor, constant: Length.Padding.double),
                 mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-                mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
-                mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+                mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+                mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12)
             ])
 
             setupConstraintsForSiteSwitcher()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 @objc protocol BlogDetailHeaderViewDelegate {
     func makeSiteIconMenu() -> UIMenu?
+    func makeSiteActionsMenu() -> UIMenu?
     func didShowSiteIconMenu()
     func siteIconReceivedDroppedImage(_ image: UIImage?)
     func siteIconShouldAllowDroppedImages() -> Bool
@@ -116,8 +117,13 @@ class BlogDetailHeaderView: UIView {
     private func setupChildViews(items: [ActionRow.Item]) {
         assert(delegate != nil)
 
-        if let menu = delegate?.makeSiteIconMenu() {
-            titleView.siteIconView.setMenu(menu) { [weak self] in
+        if let siteActionsMenu = delegate?.makeSiteActionsMenu() {
+            titleView.siteActionButton.showsMenuAsPrimaryAction = true
+            titleView.siteActionButton.menu = siteActionsMenu
+        }
+
+        if let siteIconMenu = delegate?.makeSiteIconMenu() {
+            titleView.siteIconView.setMenu(siteIconMenu) { [weak self] in
                 self?.delegate?.didShowSiteIconMenu()
                 WPAnalytics.track(.siteSettingsSiteIconTapped)
                 self?.titleView.siteIconView.spotlightIsShown = false
@@ -130,7 +136,6 @@ class BlogDetailHeaderView: UIView {
 
         titleView.subtitleButton.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
         titleView.titleButton.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
-        titleView.siteActionButton.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
 
         titleView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -130,7 +130,7 @@ class BlogDetailHeaderView: UIView {
 
         titleView.subtitleButton.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
         titleView.titleButton.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
-        titleView.siteSwitcherButton.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
+        titleView.siteActionButton.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
 
         titleView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -207,7 +207,7 @@ fileprivate extension BlogDetailHeaderView {
             let stackView = UIStackView(arrangedSubviews: [
                 siteIconView,
                 titleStackView,
-                siteSwitcherButton
+                siteActionButton
             ])
 
             stackView.alignment = .center
@@ -273,7 +273,7 @@ fileprivate extension BlogDetailHeaderView {
             return button
         }()
 
-        let siteSwitcherButton: UIButton = {
+        let siteActionButton: UIButton = {
             let button = UIButton(frame: .zero)
             let image = UIImage(named: "chevron-down-slim")?.withRenderingMode(.alwaysTemplate)
 
@@ -281,8 +281,8 @@ fileprivate extension BlogDetailHeaderView {
             button.contentMode = .center
             button.translatesAutoresizingMaskIntoConstraints = false
             button.tintColor = .secondaryLabel
-            button.accessibilityLabel = NSLocalizedString("Switch Site", comment: "Button used to switch site")
-            button.accessibilityHint = NSLocalizedString("Tap to switch to another site, or add a new site", comment: "Accessibility hint for button used to switch site")
+            button.accessibilityLabel = NSLocalizedString("mySite.siteActions.button", value: "Site Actions", comment: "Button that reveals more site actions")
+            button.accessibilityHint = NSLocalizedString("mySite.siteActions.hint", value: "Tap to show more site actions", comment: "Accessibility hint for button used to show more site actions")
             button.accessibilityIdentifier = .switchSiteAccessibilityId
 
             return button
@@ -352,8 +352,8 @@ fileprivate extension BlogDetailHeaderView {
 
         private func setupConstraintsForSiteSwitcher() {
             NSLayoutConstraint.activate([
-                siteSwitcherButton.heightAnchor.constraint(equalToConstant: Dimensions.siteSwitcherHeight),
-                siteSwitcherButton.widthAnchor.constraint(equalToConstant: Dimensions.siteSwitcherWidth)
+                siteActionButton.heightAnchor.constraint(equalToConstant: Dimensions.siteSwitcherHeight),
+                siteActionButton.widthAnchor.constraint(equalToConstant: Dimensions.siteSwitcherWidth)
             ])
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -65,19 +65,19 @@ private enum MenuItem {
 
     var title: String {
         switch self {
-        case .visitSite: Strings.visitSite
-        case .switchSite: Strings.switchSite
-        case .siteTitle: Strings.siteTitle
-        case .personalizeHome: Strings.personalizeHome
+        case .visitSite: return Strings.visitSite
+        case .switchSite: return Strings.switchSite
+        case .siteTitle: return Strings.siteTitle
+        case .personalizeHome: return Strings.personalizeHome
         }
     }
 
     var icon: UIImage? {
         switch self {
-        case .visitSite: UIImage(systemName: "safari")
-        case .switchSite: UIImage(systemName: "arrow.triangle.swap")
-        case .siteTitle: UIImage(systemName: "character")
-        case .personalizeHome: UIImage(systemName: "slider.horizontal.3")
+        case .visitSite: return UIImage(systemName: "safari")
+        case .switchSite: return UIImage(systemName: "arrow.triangle.swap")
+        case .siteTitle: return UIImage(systemName: "character")
+        case .personalizeHome: return UIImage(systemName: "slider.horizontal.3")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -1,0 +1,101 @@
+import UIKit
+import SwiftUI
+
+extension SitePickerViewController {
+
+    func makeSiteActionsMenu() -> UIMenu? {
+        UIMenu(options: .displayInline, children: [
+            UIDeferredMenuElement.uncached { [weak self] in
+                $0(self?.makeSections() ?? [])
+            }
+        ])
+    }
+
+    private func makeSections() -> [UIMenu] {
+        [
+            makePrimarySection(),
+            makeSecondarySection(),
+            makeTertiarySection()
+        ]
+    }
+
+    private func makePrimarySection() -> UIMenu {
+        UIMenu(options: .displayInline, children: [
+            MenuItem.visitSite(visitSiteTapped),
+            MenuItem.switchSite(siteSwitcherTapped)
+        ].map { $0.toAction })
+    }
+
+    private func makeSecondarySection() -> UIMenu {
+        UIMenu(options: .displayInline, children: [
+            MenuItem.siteTitle(siteTitleTapped).toAction,
+            UIMenu(title: Strings.siteIcon, image: UIImage(systemName: "photo.circle"), children: [
+                makeSiteIconMenu() ?? UIMenu()
+            ])
+        ])
+    }
+
+    private func makeTertiarySection() -> UIMenu {
+        UIMenu(options: .displayInline, children: [
+            MenuItem.personalizeHome(personalizeHomeTapped).toAction
+        ])
+    }
+
+    private func personalizeHomeTapped() {
+        guard let siteID = blog.dotComID?.intValue else {
+            return DDLogError("Failed to show dashboard personalization screen: siteID is missing")
+        }
+
+        // TODO: track event
+        let viewController = UIHostingController(rootView: NavigationView {
+            BlogDashboardPersonalizationView(viewModel: .init(blog: self.blog, service: .init(siteID: siteID)))
+        }.navigationViewStyle(.stack)) // .stack is required for iPad
+        if UIDevice.isPad() {
+            viewController.modalPresentationStyle = .formSheet
+        }
+        present(viewController, animated: true)
+    }
+}
+
+private enum MenuItem {
+    case visitSite(_ handler: () -> Void)
+    case switchSite(_ handler: () -> Void)
+    case siteTitle(_ handler: () -> Void)
+    case personalizeHome(_ handler: () -> Void)
+
+    var title: String {
+        switch self {
+        case .visitSite: Strings.visitSite
+        case .switchSite: Strings.switchSite
+        case .siteTitle: Strings.siteTitle
+        case .personalizeHome: Strings.personalizeHome
+        }
+    }
+
+    var icon: UIImage? {
+        switch self {
+        case .visitSite: UIImage(systemName: "safari")
+        case .switchSite: UIImage(systemName: "arrow.triangle.swap")
+        case .siteTitle: UIImage(systemName: "character")
+        case .personalizeHome: UIImage(systemName: "slider.horizontal.3")
+        }
+    }
+
+    var toAction: UIAction {
+        switch self {
+        case .visitSite(let handler),
+             .switchSite(let handler),
+             .siteTitle(let handler),
+             .personalizeHome(let handler):
+            return UIAction(title: title, image: icon) { _ in handler() }
+        }
+    }
+}
+
+private enum Strings {
+    static let visitSite = NSLocalizedString("mySite.siteActions.visitSite", value: "Visit site", comment: "Menu title for the visit site option")
+    static let switchSite = NSLocalizedString("mySite.siteActions.switchSite", value: "Switch site", comment: "Menu title for the switch site option")
+    static let siteTitle = NSLocalizedString("mySite.siteActions.siteTitle", value: "Change site title", comment: "Menu title for the change site title option")
+    static let siteIcon = NSLocalizedString("mySite.siteActions.siteIcon", value: "Change site icon", comment: "Menu title for the change site icon option")
+    static let personalizeHome = NSLocalizedString("mySite.siteActions.personalizeHome", value: "Personalize home", comment: "Menu title for the personalize home option")
+}

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
@@ -9,7 +9,7 @@ import PhotosUI
 extension SitePickerViewController {
 
     func makeSiteIconMenu() -> UIMenu? {
-        return UIMenu(children: [
+        UIMenu(options: .displayInline, children: [
             UIDeferredMenuElement.uncached { [weak self] in
                 $0(self?.makeUpdateSiteIconActions() ?? [])
             }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -96,10 +96,13 @@ public class MySiteScreen: ScreenObject {
         $0.buttons["site-url-button"]
     }
 
-    private let switchSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["switch-site-button"]
+    private let siteActionButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["site-action-button"]
     }
 
+    private let switchSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Switch site"]
+    }
     var activityLogCard: XCUIElement { activityLogCardGetter(app) }
     var activityLogCardHeaderButton: XCUIElement { activityLogCardHeaderButtonGetter(app) }
     var blogDetailsRemoveSiteButton: XCUIElement { blogDetailsRemoveSiteButtonGetter(app) }
@@ -121,6 +124,7 @@ public class MySiteScreen: ScreenObject {
     var segmentedControlMenuButton: XCUIElement { segmentedControlMenuButtonGetter(app) }
     var siteTitleButton: XCUIElement { siteTitleButtonGetter(app) }
     var siteUrlButton: XCUIElement { siteUrlButtonGetter(app) }
+    var siteActionButton: XCUIElement { siteActionButtonGetter(app) }
     var switchSiteButton: XCUIElement { switchSiteButtonGetter(app) }
 
     // Timeout duration to overwrite value defined in XCUITestHelpers
@@ -129,7 +133,7 @@ public class MySiteScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                switchSiteButtonGetter,
+                siteActionButtonGetter,
                 createButtonGetter
             ],
             app: app
@@ -137,6 +141,7 @@ public class MySiteScreen: ScreenObject {
     }
 
     public func showSiteSwitcher() throws -> MySitesScreen {
+        siteActionButton.tap()
         switchSiteButton.tap()
         return try MySitesScreen()
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3992,6 +3992,8 @@
 		FAA9084D27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */; };
 		FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE3F02615996E00BF29FE /* AppConstants.swift */; };
 		FAADE43A26159B2800BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE42726159B1300BF29FE /* AppConstants.swift */; };
+		FAAEFAE02B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEFADF2B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift */; };
+		FAAEFAE12B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAEFADF2B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift */; };
 		FAB37D4627ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */; };
 		FAB37D4727ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */; };
 		FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */; };
@@ -9315,6 +9317,7 @@
 		FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MySiteViewController+QuickStart.swift"; sourceTree = "<group>"; };
 		FAADE3F02615996E00BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		FAADE42726159B1300BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
+		FAAEFADF2B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePickerViewController+SiteActions.swift"; sourceTree = "<group>"; };
 		FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsNudgeView.swift; sourceTree = "<group>"; };
 		FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsServiceTests.swift; sourceTree = "<group>"; };
 		FAB8004825AEDC2300D5D54A /* JetpackBackupCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupCompleteViewController.swift; sourceTree = "<group>"; };
@@ -18175,6 +18178,7 @@
 			isa = PBXGroup;
 			children = (
 				FA73D7E42798765B00DF24B3 /* SitePickerViewController.swift */,
+				FAAEFADF2B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift */,
 				FA73D7E827987BA500DF24B3 /* SitePickerViewController+SiteIcon.swift */,
 				FA73D7EB27987E4500DF24B3 /* SitePickerViewController+QuickStart.swift */,
 				17C1D67B2670E3DC006C8970 /* SiteIconPickerView.swift */,
@@ -21209,6 +21213,7 @@
 				E16A76F31FC4766900A661E3 /* CredentialsService.swift in Sources */,
 				F9B862C92478170A008B093C /* EncryptedLogTableViewController.swift in Sources */,
 				4070D75E20E6B4E4007CEBDA /* ActivityDateFormatting.swift in Sources */,
+				FAAEFAE02B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift in Sources */,
 				E2AA87A518523E5300886693 /* UIView+Subviews.m in Sources */,
 				FEFC0F892731182C001F7F1D /* CommentService+Replies.swift in Sources */,
 				803BB98F29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift in Sources */,
@@ -24061,6 +24066,7 @@
 				FABB21332602FC2C00C8785C /* TwoColumnCell.swift in Sources */,
 				C79C308326EA9A2300E88514 /* ReferrerDetailsCell.swift in Sources */,
 				FABB21342602FC2C00C8785C /* PostSettingsViewController.m in Sources */,
+				FAAEFAE12B1E29F0004AE802 /* SitePickerViewController+SiteActions.swift in Sources */,
 				FACF66CB2ADD4703008C3E13 /* PostListCell.swift in Sources */,
 				FABB21352602FC2C00C8785C /* MenuItem.m in Sources */,
 				FABB21362602FC2C00C8785C /* WPRichTextFormatter.swift in Sources */,


### PR DESCRIPTION
## Description
- Updates the My Site header to show site actions in a menu
  - pbArwn-6kb-p2#comment-7901
  - p1701711667406509/1701702771.100599-slack-C04SFL0RP51
- Updates "Open in Browser" menu option to "Visit site" for consistency
- Note: I'm using SFSymbols for the menu icons because system images are adaptive. I tried to find the most relevant icon for the action - happy to switch it out for a different icon if needed @osullivanchris, @kean 

Before | After
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/2e8ef2f0-9908-4e2b-ae56-8eaa1f49ea57" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/20f9f64a-a60a-4055-9e19-1860135dae7d" width=200>


## How to test
- Go to My Site
- Tap on the ellipsis button in the site header
- Verify you see the following options
  - Visit site
  - Switch site
  - Change site title
  - Change site icon
  - Personalize home
-  Verify each option works as expected


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/4cb04115-78c6-4529-8f7b-6506e26682a6


## Regression Notes
1. Potential unintended areas of impact
switching sites

2. What I did to test those areas of impact (or what existing automated tests I relied on)
updated UI test

3. What automated tests I added (or what prevented me from doing so)
see above

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (https://github.com/wordpress-mobile/WordPress-iOS/pull/22203)