### PR TITLE
Reader: Add like and comment counts to reader post details

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -186,6 +186,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         coordinator?.start()
 
+        startObservingPost()
+
         // Fixes swipe to go back not working when leftBarButtonItem is set
         navigationController?.interactivePopGestureRecognizer?.delegate = self
 
@@ -812,6 +814,31 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         static let toolbarHeight: CGFloat = 50
         static let delay: Double = 50
         static let preferredToolbarHeight: CGFloat = 58.0
+    }
+
+    // MARK: - Managed object observer
+
+    func startObservingPost() {
+        guard let post else {
+            return
+        }
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleObjectsChange(_:)),
+                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+                                               object: post.managedObjectContext)
+    }
+
+
+    @objc func handleObjectsChange(_ notification: Foundation.Notification) {
+        guard let post else {
+            return
+        }
+        let updated = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> ?? Set()
+        let refreshed = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> ?? Set()
+
+        if updated.contains(post) || refreshed.contains(post) {
+            header.configure(for: post)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -112,9 +112,28 @@ class ReaderDetailHeaderViewModel: ObservableObject {
     @Published var relativePostTime = String()
     @Published var siteName = String()
     @Published var postTitle: String? = nil // post title can be empty.
+    @Published var likeCount: Int? = nil
+    @Published var commentCount: Int? = nil
     @Published var tags: [String] = []
 
     @Published var showsAuthorName: Bool = true
+
+    var postCounts: String? {
+        let likeCountString: String? = {
+            guard let count = likeCount, count > 0 else {
+                return nil
+            }
+            return WPStyleGuide.likeCountForDisplay(count)
+        }()
+        let commentCountString: String? = {
+            guard let count = commentCount, count > 0 else {
+                return nil
+            }
+            return WPStyleGuide.commentCountForDisplay(count)
+        }()
+        let countStrings = [likeCountString, commentCountString].compactMap { $0 }
+        return countStrings.count > 0 ? countStrings.joined(separator: " • ") : nil
+    }
 
     init(coreDataStack: CoreDataStackSwift = ContextManager.shared) {
         self.coreDataStack = coreDataStack
@@ -150,6 +169,8 @@ class ReaderDetailHeaderViewModel: ObservableObject {
             self.showsAuthorName = self.authorName != self.siteName && !self.authorName.isEmpty
 
             self.postTitle = post.titleForDisplay() ?? nil
+            self.likeCount = post.likeCount?.intValue
+            self.commentCount = post.commentCount?.intValue
             self.tags = post.tagsForDisplay() ?? []
         }
 
@@ -225,6 +246,11 @@ struct ReaderDetailNewHeaderView: View {
                     .fontWeight(.bold)
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true) // prevents the title from being truncated.
+            }
+            if let postCounts = viewModel.postCounts {
+                Text(postCounts)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
             if !viewModel.tags.isEmpty {
                 tagsView


### PR DESCRIPTION
See #22158

## Description

Adds a likes/comments count to the post details screen in the Reader.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Find posts which have:
  - No likes, no comments
  - No likes, has comments
  - Has likes, no comments
  - Has both likes and comments
- 🔎 **Verify** each variation appears correctly on the details screen

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
