### PR TITLE
Notifications: Address rare crash when accessing Notification object with invalid IndexPath

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -439,7 +439,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
 
     func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         // skip when the notification is marked for deletion.
-        guard let note = tableViewHandler.resultsController?.object(at: indexPath) as? Notification,
+        guard let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification,
               deletionRequestForNoteWithID(note.objectID) == nil else {
             return nil
         }
@@ -466,7 +466,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         // skip when the notification is marked for deletion.
-        guard let note = tableViewHandler.resultsController?.object(at: indexPath) as? Notification,
+        guard let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification,
             let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment),
             deletionRequestForNoteWithID(note.objectID) == nil else {
             return nil
@@ -890,7 +890,7 @@ extension NotificationsViewController {
         }
 
         let noteIndexPath = tableView.indexPathsForVisibleRows?.first { indexPath in
-            return note == tableViewHandler.resultsController?.object(at: indexPath) as? Notification
+            return note == tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification
         }
 
         guard noteIndexPath == nil else {
@@ -1408,7 +1408,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
     }
 
     func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
-        guard let note = tableViewHandler.resultsController?.object(at: indexPath) as? Notification,
+        guard let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification,
               let cell = cell as? ListTableViewCell else {
             return
         }


### PR DESCRIPTION
Fixes #22162

`NSFetchedResultsController.object(at indexPath)` method is non-optional and throws an exception when an invalid IndexPath is passed.

Although passing an invalid IndexPath should not happen at all, there are rare occurrences when that does happen when navigating back and forth between notifications and notifications details view and making changes. I wasn't able to reproduce those cases myself.

### Solution

Use  `managedObject(atUnsafe: indexPath)` method call which is already used in other places of `NotificationsViewController`.

It's a solution that does not address the root cause of the crash but given it happens rarely, and I couldn't identify the root cause, I think it's an acceptable workaround.

To test:

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
