### PR TITLE
Add `is_free` property to the `jpios_enhanced_site_creation_domains_selected` event

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
@@ -425,7 +425,8 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     private func trackDomainsSelection(_ domainSuggestion: DomainSuggestion) {
         var domainSuggestionProperties: [String: Any] = [
             "chosen_domain": domainSuggestion.domainName as AnyObject,
-            "search_term": lastSearchQuery as AnyObject
+            "search_term": lastSearchQuery as AnyObject,
+            "is_free": domainSuggestion.isFree.stringLiteral
         ]
 
         if domainPurchasingEnabled {


### PR DESCRIPTION
is_free property was added to the jpandroid_enhanced_site_creation_domains_selected event.
More context: pcdRpT-3RO-p2#comment-7769

Fixes #22164

To test:

1. Launch the JP app.
2. Log in.
4. Tap the ... button near the site name.
5. Tap the Switch site button
6. Tap the + button and Create WordPress.com site.
7. Skip the topic screen.
8. Skip the theme screen.
9. Search for a domain name.
10. Select a free domain.
11. Check app logs and verify that `jpios_enhanced_site_creation_domains_selected` has `"is_free":true` property.
12. Navigate back to the domain selection screen.
13. Select a paid domain.
14. Check app logs and verify that `jpios_enhanced_site_creation_domains_selected` has `"is_free":false` property.

## Regression Notes
1. Potential unintended areas of impact
Sending `enhanced_site_creation_domains_selected` event`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on "Tracks Live View"

3. What automated tests I added (or what prevented me from doing so)
There was no test for Tracks, so I followed the same.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)