### PR TITLE
Posts & Page: Fix everyone icon tint

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
@@ -34,8 +34,7 @@ final class AuthorFilterButton: UIControl {
         didSet {
             switch filterType {
             case .everyone:
-                authorImageView.image = UIImage(named: "icon-people")?.withRenderingMode(.alwaysTemplate)
-                authorImageView.tintColor = .text
+                authorImageView.image = UIImage(named: "icon-people")?.withTintColor(.text, renderingMode: .alwaysTemplate)
                 authorImageView.contentMode = .center
             case .user(let email):
                 authorImageView.contentMode = .scaleAspectFill

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
@@ -34,7 +34,8 @@ final class AuthorFilterButton: UIControl {
         didSet {
             switch filterType {
             case .everyone:
-                authorImageView.image = UIImage(named: "icon-people")
+                authorImageView.image = UIImage(named: "icon-people")?.withRenderingMode(.alwaysTemplate)
+                authorImageView.tintColor = .text
                 authorImageView.contentMode = .center
             case .user(let email):
                 authorImageView.contentMode = .scaleAspectFill


### PR DESCRIPTION
## Description

Fixes an issue where the everyone icon was the wrong color in dark mode

Before | After (dark mode) | After (light mode)
-- | -- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/729f562f-f120-439b-aad2-ce334e992f2b" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/e9003740-df47-426c-9d77-702a26e1a781" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/9d9766ca-d963-4b51-a9e9-f1ddbb4934cb" width=200>



## How to test
- Turn on dark mode
- Switch to a site that has multiple authors
- Go to posts and pages
- Verify the everyone icon is white

## Regression Notes
1. Potential unintended areas of impact
Posts & Pages light mode

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
See screenshot above

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
