### PR TITLE
Fix DomainsService crash when account.wordPressComRestApi nil

### DIFF
--- a/WordPress/Classes/Services/BlogService+Domains.swift
+++ b/WordPress/Classes/Services/BlogService+Domains.swift
@@ -18,17 +18,15 @@ extension BlogService {
             return
         }
 
-        guard account.wordPressComRestApi != nil else {
-            failure?(BlogServiceDomainError.noWordPressComRestApi(blog: blog))
-            return
-        }
-
         guard let siteID = blog.dotComID?.intValue else {
             failure?(BlogServiceDomainError.noSiteIDForSpecifiedBlog(blog: blog))
             return
         }
 
-        let service = DomainsService(coreDataStack: coreDataStack, account: account)
+        guard let service = DomainsService(coreDataStack: coreDataStack, account: account) else {
+            failure?(BlogServiceDomainError.noWordPressComRestApi(blog: blog))
+            return
+        }
 
         service.refreshDomains(siteID: siteID) { result in
             switch result {

--- a/WordPress/Classes/Services/BlogService+Domains.swift
+++ b/WordPress/Classes/Services/BlogService+Domains.swift
@@ -23,7 +23,7 @@ extension BlogService {
             return
         }
 
-        guard let service = DomainsService(coreDataStack: coreDataStack, account: account) else {
+        guard let service = DomainsService(coreDataStack: coreDataStack, wordPressComRestApi: account.wordPressComRestApi) else {
             failure?(BlogServiceDomainError.noWordPressComRestApi(blog: blog))
             return
         }

--- a/WordPress/Classes/Services/Domains/DomainsService.swift
+++ b/WordPress/Classes/Services/Domains/DomainsService.swift
@@ -225,8 +225,8 @@ struct DomainsService {
 }
 
 extension DomainsService {
-    init?(coreDataStack: CoreDataStack, account: WPAccount) {
-        guard let wordPressComRestApi = account.wordPressComRestApi else { return nil }
+    init?(coreDataStack: CoreDataStack, wordPressComRestApi: WordPressComRestApi?) {
+        guard let wordPressComRestApi = wordPressComRestApi else { return nil }
         self.init(coreDataStack: coreDataStack, remote: DomainsServiceRemote(wordPressComRestApi: wordPressComRestApi))
     }
 }

--- a/WordPress/Classes/Services/Domains/DomainsService.swift
+++ b/WordPress/Classes/Services/Domains/DomainsService.swift
@@ -225,8 +225,9 @@ struct DomainsService {
 }
 
 extension DomainsService {
-    init(coreDataStack: CoreDataStack, account: WPAccount) {
-        self.init(coreDataStack: coreDataStack, remote: DomainsServiceRemote(wordPressComRestApi: account.wordPressComRestApi))
+    init?(coreDataStack: CoreDataStack, account: WPAccount) {
+        guard let wordPressComRestApi = account.wordPressComRestApi else { return nil }
+        self.init(coreDataStack: coreDataStack, remote: DomainsServiceRemote(wordPressComRestApi: wordPressComRestApi))
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift
@@ -49,7 +49,7 @@ class AllDomainsListViewModel {
 
     init(coreDataStack: CoreDataStackSwift = ContextManager.shared) {
         if let account = defaultAccount(with: coreDataStack) {
-            self.domainsService = .init(coreDataStack: coreDataStack, account: account)
+            self.domainsService = .init(coreDataStack: coreDataStack, wordPressComRestApi: account.wordPressComRestApi)
         }
     }
 


### PR DESCRIPTION
Fixes #22171

In rare cases, `account.wordPressComRestApi` can be `nil`, and causes a crash in `AllDomainsListViewModel`. 
Similar issue: https://github.com/wordpress-mobile/WordPress-iOS/pull/20559

## Solution

Other service calls check for `wordPressComRestApi` since it can be `nil`. The long-term solution would be to make `wordPressComRestApi` nullable, which would force to handle `nil` scenarios in all the cases properly.

Made one of the `DomainsService` initializers failable when initializing with `account.wordPressComRestApi`. 

`AllDomainsListViewModel`already expects optional `DomainsService`, so no change is needed there.

## To test:

The easiest way to reproduce the issue is to return `nil` from `WPAccount.m` `wordPressComRestApi` (line 164). 

### Case 1:
1. Return `nil` from `WPAccount.m` `wordPressComRestApi` (line 164)
2. Launch Jetpack app
3. Log into .com account
4. Me -> All Domains
5. There shouldn't be any crash

## Regression Notes
1. Potential unintended areas of impact

None, in rare cases when `wordPressComRestApi` is `nil`, a sign-in screen should be presented.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
