### PR TITLE
Fix: Expand the CTA button tap area on the Bloganuary overlay

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/Bloganuary/BloganuaryOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/Bloganuary/BloganuaryOverlayViewController.swift
@@ -228,6 +228,7 @@ private struct BloganuaryOverlayView: View {
             Text(viewModel.promptsEnabled ? Strings.buttonTitleForEnabledPrompts : Strings.buttonTitleForDisabledPrompts)
                 .multilineTextAlignment(.center)
                 .lineLimit(nil)
+                .frame(maxWidth: .infinity)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.vertical, 14.0)


### PR DESCRIPTION
Fixes #22174 

The CTA button of the Bloganuary overlay is only tappable over the text. This PR expands the tappable area. 

## To test

> [!Note]
> The Bloganuary card is only shown during December. If you are testing this PR in December, then it should appear without any further overrides. Otherwise, you'll probably need to temporarily change your device date OR override the `shouldShowCard(for blog: Blog, date: Date)` in `DashboardBloganuaryCardCell.swift` to always return `true` to make the card appear.

- Launch the Jetpack app.
- Tap the 'Learn more' button on the Bloganuary dashboard card.
- 🔎  Verify that the CTA button on the bottom is tapable outside the text area.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)