### PR TITLE
Reader: Update likes and comments label to be tappable

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -709,6 +709,17 @@ extension ReaderDetailCoordinator: ReaderDetailHeaderViewDelegate {
     func didSelectTopic(_ topic: String) {
         showTopic(topic)
     }
+
+    func didTapLikes() {
+        showLikesList()
+    }
+
+    func didTapComments() {
+        guard let post, let viewController else {
+            return
+        }
+        ReaderCommentAction().execute(post: post, origin: viewController, source: .postDetails)
+    }
 }
 
 // MARK: - ReaderDetailFeaturedImageViewDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -7,6 +7,8 @@ protocol ReaderDetailHeaderViewDelegate: AnyObject {
     func didTapHeaderAvatar()
     func didTapFollowButton(completion: @escaping () -> Void)
     func didSelectTopic(_ topic: String)
+    func didTapLikes()
+    func didTapComments()
 }
 
 class ReaderDetailHeaderView: UIStackView, NibLoadable, ReaderDetailHeader {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -118,21 +118,18 @@ class ReaderDetailHeaderViewModel: ObservableObject {
 
     @Published var showsAuthorName: Bool = true
 
-    var postCounts: String? {
-        let likeCountString: String? = {
-            guard let count = likeCount, count > 0 else {
-                return nil
-            }
-            return WPStyleGuide.likeCountForDisplay(count)
-        }()
-        let commentCountString: String? = {
-            guard let count = commentCount, count > 0 else {
-                return nil
-            }
-            return WPStyleGuide.commentCountForDisplay(count)
-        }()
-        let countStrings = [likeCountString, commentCountString].compactMap { $0 }
-        return countStrings.count > 0 ? countStrings.joined(separator: " • ") : nil
+    var likeCountString: String? {
+        guard let count = likeCount, count > 0 else {
+            return nil
+        }
+        return WPStyleGuide.likeCountForDisplay(count)
+    }
+
+    var commentCountString: String? {
+        guard let count = commentCount, count > 0 else {
+            return nil
+        }
+        return WPStyleGuide.commentCountForDisplay(count)
     }
 
     init(coreDataStack: CoreDataStackSwift = ContextManager.shared) {
@@ -208,6 +205,14 @@ class ReaderDetailHeaderViewModel: ObservableObject {
             self?.isFollowButtonInteractive = true
         }
     }
+
+    func didTapLikes() {
+        headerDelegate?.didTapLikes()
+    }
+
+    func didTapComments() {
+        headerDelegate?.didTapComments()
+    }
 }
 
 // MARK: - SwiftUI
@@ -247,10 +252,8 @@ struct ReaderDetailNewHeaderView: View {
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true) // prevents the title from being truncated.
             }
-            if let postCounts = viewModel.postCounts {
-                Text(postCounts)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+            if viewModel.likeCountString != nil || viewModel.commentCountString != nil {
+                postCounts
             }
             if !viewModel.tags.isEmpty {
                 tagsView
@@ -333,6 +336,28 @@ struct ReaderDetailNewHeaderView: View {
             }
             .offset(x: 2.0, y: 2.0)
         }
+    }
+
+    var postCounts: some View {
+        HStack(spacing: 0) {
+            if let likeCount = viewModel.likeCountString {
+                Group {
+                    Button(action: viewModel.didTapLikes) {
+                        Text(likeCount)
+                    }
+                    if viewModel.commentCountString != nil {
+                        Text(" • ")
+                    }
+                }
+            }
+            if let commentCount = viewModel.commentCountString {
+                Button(action: viewModel.didTapComments) {
+                    Text(commentCount)
+                }
+            }
+        }
+        .font(.footnote)
+        .foregroundStyle(.secondary)
     }
 
     var tagsView: some View {


### PR DESCRIPTION
Closes #22158 

## Description

I didn't realize these labels were supposed to be tappable. This changes the like/comment labels to be tappable, opening the respective views when tapped.

## Testing

To test:

- Launch Jetpack and login
- Navigate to the Reader
- Open a post which has likes and comments
- Tap on the `Likes` label
- 🔎 **Verify** it opens the likes list view
- Navigate back
- Tap on the `Comments` label
- 🔎 **Verify** it opens the comments list view

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
