### PR TITLE
Fastlane setup improvements before release in CI automation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -279,6 +279,22 @@ before_all do |lane|
   # rubocop:enable Style/IfUnlessModifier
 end
 
+def compute_release_branch_name(options:, version: release_version_current)
+  branch_option = :branch
+  branch_name = options[branch_option]
+
+  if branch_name.nil?
+    branch_name = release_branch_name(version:)
+    UI.message("No branch given via option '#{branch_option}'. Defaulting to #{branch_name}.")
+  end
+
+  branch_name
+end
+
+def release_branch_name(version: release_version_current)
+  "release/#{version}"
+end
+
 def ensure_git_branch_is_release_branch
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
   ensure_git_branch(branch: '^release/')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,9 +26,6 @@ SECRETS_DIR = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets')
 PROJECT_ENV_FILE_PATH = File.join(SECRETS_DIR, 'project.env')
 APP_STORE_CONNECT_KEY_PATH = File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
 
-# Other defines used across multiple lanes
-REPOSITORY_NAME = 'WordPress-iOS'
-
 WORDPRESS_BUNDLE_IDENTIFIER = 'org.wordpress'
 WORDPRESS_EXTENSIONS_BUNDLE_IDENTIFIERS = %w[
   WordPressShare

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -278,3 +278,8 @@ before_all do |lane|
   end
   # rubocop:enable Style/IfUnlessModifier
 end
+
+def ensure_git_branch_is_release_branch
+  # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
+  ensure_git_branch(branch: '^release/')
+end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -22,21 +22,24 @@ platform :ios do
     # Make sure that Gutenberg is configured as expected for a successful code freeze
     gutenberg_dep_check
 
-    # The `release_version_next` is used as the `new internal release version` value because the external and internal
-    # release versions are always the same.
-    message = <<-MESSAGE
-      Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
 
-      • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
+    unless options[:skip_confirm]
+      # The `release_version_next` is used as the `new internal release version` value because the external and internal
+      # release versions are always the same.
+      message = <<-MESSAGE
+        Code Freeze:
+        • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
 
-      • Current internal release version and build code: #{release_version_current_internal} (#{build_code_current_internal})
-      • New internal release version and build code: #{release_version_next} (#{build_code_code_freeze_internal})
-    MESSAGE
+        • Current release version and build code: #{release_version_current} (#{build_code_current}).
+        • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
 
-    UI.important(message)
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+        • Current internal release version and build code: #{release_version_current_internal} (#{build_code_current_internal})
+        • New internal release version and build code: #{release_version_next} (#{build_code_code_freeze_internal})
+      MESSAGE
+
+      UI.important(message)
+      UI.user_error!('Aborted by user request') unless UI.confirm('Do you want to continue?')
+    end
 
     # Create the release branch
     UI.message 'Creating release branch...'

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -99,7 +99,8 @@ platform :ios do
     )
 
     unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
-      UI.user_error!('Aborting code freeze completion as requested.')
+      UI.message('Aborting code freeze as requested.')
+      next
     end
 
     push_to_git_remote(tags: false)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -43,8 +43,9 @@ platform :ios do
     end
 
     # Create the release branch
+    release_branch_name = "release/#{release_version_next}"
     UI.message 'Creating release branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{release_version_next}", from: DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"
 
     # Bump the release version and build code and write it to the `xcconfig` file
@@ -97,11 +98,13 @@ platform :ios do
       release_notes_file_path: release_notes_source_path
     )
 
-    UI.user_error!('Aborting code freeze completion as requested.') unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
+      UI.user_error!('Aborting code freeze completion as requested.')
+    end
 
     push_to_git_remote(tags: false)
 
-    setbranchprotection(repository: GITHUB_REPO, branch: "release/#{new_version}")
+    setbranchprotection(repository: GITHUB_REPO, branch: release_branch_name)
     setfrozentag(repository: GITHUB_REPO, milestone: new_version)
 
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -177,7 +177,7 @@ platform :ios do
 
     generate_strings_file_for_glotpress
     download_localized_strings_and_metadata(options)
-    lint_localizations
+    lint_localizations(allow_retry: skip_user_confirmation == false)
 
     bump_build_codes
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -24,12 +24,14 @@ platform :ios do
 
     skip_user_confirmation = options[:skip_confirm]
 
+    release_branch_name = compute_release_branch_name(options:, version: release_version_next)
+
     unless skip_user_confirmation
       # The `release_version_next` is used as the `new internal release version` value because the external and internal
       # release versions are always the same.
       message = <<-MESSAGE
         Code Freeze:
-        • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
+        • New release branch from #{DEFAULT_BRANCH}: #{release_branch_name}
 
         • Current release version and build code: #{release_version_current} (#{build_code_current}).
         • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
@@ -229,7 +231,7 @@ platform :ios do
 
     # Create the hotfix branch
     UI.message 'Creating hotfix branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{new_version}", from: previous_version)
+    Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options:, version: new_version), from: previous_version)
     UI.success "Done! New hotfix branch is: #{git_branch}"
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
@@ -426,22 +428,6 @@ def prompt_for_confirmation(message:, bypass:)
   return true if bypass
 
   UI.confirm(message)
-end
-
-def compute_release_branch_name(options:)
-  branch_option = :branch
-  branch_name = options[branch_option]
-
-  if branch_name.nil?
-    branch_name = release_branch_name
-    UI.message("No branch given via option '#{branch_option}'. Defaulting to #{branch_name}.")
-  end
-
-  branch_name
-end
-
-def release_branch_name
-  "release/#{release_version_current}"
 end
 
 def bump_build_codes

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -45,7 +45,7 @@ platform :ios do
     end
 
     # Create the release branch
-    release_branch_name = "release/#{release_version_next}"
+    release_branch_name = compute_release_branch_name(options:, version: release_version_next)
     UI.message 'Creating release branch...'
     Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -105,7 +105,7 @@ platform :ios do
 
     push_to_git_remote(tags: false)
 
-    setbranchprotection(repository: GITHUB_REPO, branch: release_branch_name)
+    set_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
     setfrozentag(repository: GITHUB_REPO, milestone: new_version)
 
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -121,8 +121,7 @@ platform :ios do
   #
   desc 'Completes the final steps for the code freeze'
   lane :complete_code_freeze do |options|
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
+    ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -150,11 +149,10 @@ platform :ios do
   #
   desc 'Trigger a new beta build on CI'
   lane :new_beta_release do |options|
+    ensure_git_branch_is_release_branch
+
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
-
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
 
     git_pull
 
@@ -259,8 +257,7 @@ platform :ios do
   #
   desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
+    ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -287,8 +284,7 @@ platform :ios do
   lane :finalize_release do |options|
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
+    ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -22,9 +22,9 @@ platform :ios do
     # Make sure that Gutenberg is configured as expected for a successful code freeze
     gutenberg_dep_check
 
-    skip_user_confirmation = options[:skip_confirm]
-
     release_branch_name = compute_release_branch_name(options:, version: release_version_next)
+
+    skip_user_confirmation = options[:skip_confirm]
 
     unless skip_user_confirmation
       # The `release_version_next` is used as the `new internal release version` value because the external and internal
@@ -158,17 +158,22 @@ platform :ios do
 
     git_pull
 
-    # Check versions
-    message = <<-MESSAGE
-      • Current build code: #{build_code_current}
-      • New build code: #{build_code_next}
+    skip_user_confirmation = options[:skip_confirm]
 
-      • Current internal build code: #{build_code_current_internal}
-      • New internal build code: #{build_code_next_internal}
-    MESSAGE
+    unless skip_user_confirmation
+      # The `release_version_next` is used as the `new internal release version` value because the external and internal
+      # release versions are always the same.
+      message = <<-MESSAGE
+        • Current build code: #{build_code_current}
+        • New build code: #{build_code_next}
 
-    UI.important(message)
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+        • Current internal build code: #{build_code_current_internal}
+        • New internal build code: #{build_code_next_internal}
+      MESSAGE
+
+      UI.important(message)
+      UI.user_error!('Aborted by user request') unless UI.confirm('Do you want to continue?')
+    end
 
     generate_strings_file_for_glotpress
     download_localized_strings_and_metadata(options)
@@ -176,16 +181,14 @@ platform :ios do
 
     bump_build_codes
 
-    if prompt_for_confirmation(
-      message: 'Ready to push changes to remote and trigger the beta build?',
-      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
-    )
-      push_to_git_remote(tags: false)
-      trigger_beta_build
-    else
-      UI.message('Aborting beta deployment. See you later.')
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote and trigger the beta build?')
+      UI.message('Aborting beta deployment.')
       next
     end
+
+    push_to_git_remote(tags: false)
+
+    trigger_beta_build
   end
 
   # Sets the stage to start working on a hotfix

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -128,20 +128,20 @@ platform :ios do
     ensure_git_status_clean
 
     UI.important("Completing code freeze for: #{release_version_current}")
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+
+    skip_user_confirmation = options[:skip_confirm]
+
+    UI.user_error!('Aborted by user request') unless skip_user_confirmation || UI.confirm('Do you want to continue?')
 
     generate_strings_file_for_glotpress
 
-    if prompt_for_confirmation(
-      message: 'Ready to push changes to remote and trigger the beta build?',
-      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
-    )
-      push_to_git_remote(tags: false)
-      trigger_beta_build
-    else
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote and trigger the beta build?')
       UI.message('Aborting code freeze completion. See you later.')
       next
     end
+
+    push_to_git_remote(tags: false)
+    trigger_beta_build
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI


### PR DESCRIPTION
This does some tidy up before we add additional lanes and CI pipelines for release automation.

The main changes are:

- Centralize the release branch name definition and check, which makes it handy to change the branch name for testing
- Use one parameter only, `skip_confirm` to drive all the interactive settings of various commands. This way, CI can pass `skip_confirm:true` and run everything in non-interactive mode.

---

## Regression Notes
1. Potential unintended areas of impact – Some of the release automation might have broken. As the release manager, I'll deal with if I run into it.


2. What I did to test those areas of impact (or what existing automated tests I relied on) – Run it on test branches.


3. What automated tests I added (or what prevented me from doing so) – N.A.

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.