### PR TITLE
Test branch for release automation in CI

### DIFF
--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -9,6 +9,6 @@ fi
 
 # Buildkite, by default, checks out a specific commit.
 # For many release actions, we need to be on a release branch instead.
-BRANCH_NAME="release/${RELEASE_NUMBER}"
+BRANCH_NAME="test-release/${RELEASE_NUMBER}"
 git fetch origin "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"

--- a/.buildkite/commands/checkout-release-branch.sh
+++ b/.buildkite/commands/checkout-release-branch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+RELEASE_NUMBER=$1
+
+if [[ -z "${RELEASE_NUMBER}" ]]; then
+    echo "Usage $0 <release number, e.g. 1.2.3>"
+    exit 1
+fi
+
+# Buildkite, by default, checks out a specific commit.
+# For many release actions, we need to be on a release branch instead.
+BRANCH_NAME="release/${RELEASE_NUMBER}"
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"

--- a/.buildkite/commands/complete-code-freeze.sh
+++ b/.buildkite/commands/complete-code-freeze.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+RELEASE_NUMBER=$1
+
+if [[ -z "${RELEASE_NUMBER}" ]]; then
+    echo "Usage $0 <release number>"
+    exit 1
+fi
+
+echo '--- :git: Configure Git for release management'
+.buildkite/commands/configure-git-for-release-management.sh
+
+echo '--- :git: Checkout release branch'
+.buildkite/commands/checkout-release-branch.sh "$RELEASE_NUMBER"
+
+echo '--- :ruby: Setup Ruby tools'
+install_gems
+
+echo '--- :closed_lock_with_key: Access secrets'
+bundle exec fastlane run configure_apply
+
+echo '--- :shipit: Complete code freeze'
+bundle exec fastlane complete_code_freeze skip_confirm:true

--- a/.buildkite/commands/configure-git-for-release-management.sh
+++ b/.buildkite/commands/configure-git-for-release-management.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+# The Git command line client is not configured in Buildkite.
+# At the moment, steps that need Git access can configure it on deman using this script.
+# Later on, we should be able to configure it on the agent instead.
+
+curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
+git config --global user.email "mobile+wpmobilebot@automattic.com"
+git config --global user.name "Automattic Release Bot"
+
+# Buildkite is currently using the HTTPS URL to checkout.
+# We need to override it to be able to use the deploy key.
+git remote set-url origin git@github.com:wordpress-mobile/WordPress-iOS.git

--- a/.buildkite/commands/finalize-release.sh
+++ b/.buildkite/commands/finalize-release.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+RELEASE_NUMBER=$1
+
+if [[ -z "${RELEASE_NUMBER}" ]]; then
+    echo "Usage $0 <release number>"
+    exit 1
+fi
+
+echo '--- :git: Configure Git for release management'
+.buildkite/commands/configure-git-for-release-management.sh
+
+echo '--- :git: Checkout release branch'
+# FIXME: Don't forget to revert to "release/" only
+.buildkite/commands/checkout-release-branch.sh "test-release/$RELEASE_NUMBER"
+
+echo '--- :ruby: Setup Ruby tools'
+install_gems
+
+echo '--- :closed_lock_with_key: Access secrets'
+bundle exec fastlane run configure_apply
+
+echo '--- :shipit: Finalize release'
+bundle exec fastlane finalize_release skip_confirm:true

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -1,0 +1,23 @@
+common_params:
+  - &common_plugins
+    - automattic/a8c-ci-toolkit#2.18.2
+
+steps:
+  - label: Code Freeze
+    plugins: *common_plugins
+    # The first client to implement releases in CI was Android so the automation works in that queue.
+    # We might want to move it to a leaner one in the future.
+    agents:
+        queue: android
+    command: |
+      echo '--- :git: Configure Git for release management'
+      .buildkite/commands/configure-git-for-release-management.sh
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :closed_lock_with_key: Access secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :shipit: Run code freeze'
+      bundle exec fastlane code_freeze skip_confirm:true

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -1,10 +1,7 @@
-common_params:
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#2.18.2
-
 steps:
   - label: Code Freeze
-    plugins: *common_plugins
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
     # The first client to implement releases in CI was Android so the automation works in that queue.
     # We might want to move it to a leaner one in the future.
     agents:

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: Complete Code Freeze
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The code freeze completion needs to run on macOS because it uses genstrings under the hood
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-14.3.1
+    command: ".buildkite/commands/complete-code-freeze.sh $RELEASE_VERSION"

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: Finalize Release
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The finalization needs to run on macOS because of localization linting
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-14.3.1
+    command: ".buildkite/commands/finalize-release.sh $RELEASE_VERSION"

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -1,0 +1,21 @@
+steps:
+  - label: New Beta Deployment
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The beta needs to run on macOS because it uses genstrings under the hood
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-14.3.1
+    command: |
+      echo '--- :git: Configure Git for release management'
+      .buildkite/commands/configure-git-for-release-management.sh
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :closed_lock_with_key: Access secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :shipit: Deploy new beta'
+      bundle exec fastlane new_beta_release skip_confirm:true

--- a/.buildkite/release-pipelines/update-app-store-strings.yml
+++ b/.buildkite/release-pipelines/update-app-store-strings.yml
@@ -1,0 +1,20 @@
+steps:
+  - label: Update App Store Strings
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The first client to implement releases in CI was Android so the automation works in that queue.
+    # We might want to move it to a leaner one in the future.
+    agents:
+        queue: android
+    command: |
+      echo '--- :git: Configure Git for release management'
+      .buildkite/commands/configure-git-for-release-management.sh
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :closed_lock_with_key: Access secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :shipit: Update relaese notes and other App Store metadata'
+      bundle exec fastlane update_appstore_strings skip_confirm:true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -299,6 +299,10 @@ def release_branch_name(version: release_version_current)
   "release/#{version}"
 end
 
+def editorial_branch_name(version: release_version_current)
+  "release_notes/#{version}"
+end
+
 def ensure_git_branch_is_release_branch
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
   ensure_git_branch(branch: '^release/')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,9 @@ PUBLIC_VERSION_FILE = Fastlane::Wpmreleasetoolkit::Versioning::IOSVersionFile.ne
 INTERNAL_BUILD_CODE_CALCULATOR = Fastlane::Wpmreleasetoolkit::Versioning::DateBuildCodeCalculator.new
 INTERNAL_VERSION_FILE = Fastlane::Wpmreleasetoolkit::Versioning::IOSVersionFile.new(xcconfig_path: INTERNAL_CONFIG_FILE)
 
+BUILDKITE_ORGANIZATION = 'automattic'
+BUILDKITE_PIPELINE = 'wordpress-ios'
+
 # Use this instead of getting values from ENV directly. It will throw an error if the requested value is missing
 def get_required_env(key)
   UI.user_error!("Environment variable '#{key}' is not set. Have you setup #{USER_ENV_FILE_PATH} correctly?") unless ENV.key?(key)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -296,7 +296,7 @@ def compute_release_branch_name(options:, version: release_version_current)
 end
 
 def release_branch_name(version: release_version_current)
-  "release/#{version}"
+  "test-release/#{version}"
 end
 
 def editorial_branch_name(version: release_version_current)
@@ -305,5 +305,5 @@ end
 
 def ensure_git_branch_is_release_branch
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-  ensure_git_branch(branch: '^release/')
+  ensure_git_branch(branch: '^test-release/')
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -279,6 +279,22 @@ before_all do |lane|
   # rubocop:enable Style/IfUnlessModifier
 end
 
+def compute_release_branch_name(options:, version: release_version_current)
+  branch_option = :branch
+  branch_name = options[branch_option]
+
+  if branch_name.nil?
+    branch_name = release_branch_name(version:)
+    UI.message("No branch given via option '#{branch_option}'. Defaulting to #{branch_name}.")
+  end
+
+  branch_name
+end
+
+def release_branch_name(version: release_version_current)
+  "release/#{version}"
+end
+
 def ensure_git_branch_is_release_branch
   # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
   ensure_git_branch(branch: '^release/')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -254,6 +254,7 @@ import 'lanes/codesign.rb'
 import 'lanes/localization.rb'
 import 'lanes/release.rb'
 import 'lanes/screenshots.rb'
+import 'lanes/release_management_in_ci.rb'
 
 ########################################################################
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,9 +26,6 @@ SECRETS_DIR = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets')
 PROJECT_ENV_FILE_PATH = File.join(SECRETS_DIR, 'project.env')
 APP_STORE_CONNECT_KEY_PATH = File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
 
-# Other defines used across multiple lanes
-REPOSITORY_NAME = 'WordPress-iOS'
-
 WORDPRESS_BUNDLE_IDENTIFIER = 'org.wordpress'
 WORDPRESS_EXTENSIONS_BUNDLE_IDENTIFIERS = %w[
   WordPressShare

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -278,3 +278,8 @@ before_all do |lane|
   end
   # rubocop:enable Style/IfUnlessModifier
 end
+
+def ensure_git_branch_is_release_branch
+  # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
+  ensure_git_branch(branch: '^release/')
+end

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -205,10 +205,15 @@ platform :ios do
 
     push_to_git_remote(tags: false)
 
-    create_release_management_pull_request(
+    pr_url = create_release_management_pull_request(
       base_branch: compute_release_branch_name(options:, version: release_version),
       title: "Merge editorialized release notes in #{release_version}"
     )
+
+    message = <<~MESSAGE
+      Release notes and metadata localization sources successfully generated. Next, review and merge the [integration PR](#{pr_url}).
+    MESSAGE
+    buildkite_annotate(context: 'editorialization-completed', style: 'success', message:) if is_ci
   end
 
   # Updates the `AppStoreStrings.po` file for WordPress, with the latest content from the `release_notes.txt` file and the other text sources

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -187,8 +187,28 @@ platform :ios do
   #
   desc 'Updates the AppStoreStrings.po file with the latest data'
   lane :update_appstore_strings do |options|
+    ensure_git_status_clean
+
+    release_version = release_version_current
+
+    unless Fastlane::Helper::GitHelper.checkout_and_pull(editorial_branch_name(version: release_version))
+      UI.user_error!("Editorialization branch for version #{release_version} doesn't exist.")
+    end
+
     update_wordpress_appstore_strings(options)
     update_jetpack_appstore_strings(options)
+
+    unless options[:skip_confirm] || UI.confirm('Ready to push changes to remote and continue with the editorialization process?')
+      UI.message("Aborting as requested. Don't forget to push the changes and create the integration PR manually.")
+      next
+    end
+
+    push_to_git_remote(tags: false)
+
+    create_release_management_pull_request(
+      base_branch: compute_release_branch_name(options:, version: release_version),
+      title: "Merge editorialized release notes in #{release_version}"
+    )
   end
 
   # Updates the `AppStoreStrings.po` file for WordPress, with the latest content from the `release_notes.txt` file and the other text sources

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -22,21 +22,24 @@ platform :ios do
     # Make sure that Gutenberg is configured as expected for a successful code freeze
     gutenberg_dep_check
 
-    # The `release_version_next` is used as the `new internal release version` value because the external and internal
-    # release versions are always the same.
-    message = <<-MESSAGE
-      Code Freeze:
-      • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
 
-      • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
+    unless options[:skip_confirm]
+      # The `release_version_next` is used as the `new internal release version` value because the external and internal
+      # release versions are always the same.
+      message = <<-MESSAGE
+        Code Freeze:
+        • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
 
-      • Current internal release version and build code: #{release_version_current_internal} (#{build_code_current_internal})
-      • New internal release version and build code: #{release_version_next} (#{build_code_code_freeze_internal})
-    MESSAGE
+        • Current release version and build code: #{release_version_current} (#{build_code_current}).
+        • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
 
-    UI.important(message)
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+        • Current internal release version and build code: #{release_version_current_internal} (#{build_code_current_internal})
+        • New internal release version and build code: #{release_version_next} (#{build_code_code_freeze_internal})
+      MESSAGE
+
+      UI.important(message)
+      UI.user_error!('Aborted by user request') unless UI.confirm('Do you want to continue?')
+    end
 
     # Create the release branch
     UI.message 'Creating release branch...'

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -99,7 +99,8 @@ platform :ios do
     )
 
     unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
-      UI.user_error!('Aborting code freeze completion as requested.')
+      UI.message('Aborting code freeze as requested.')
+      next
     end
 
     push_to_git_remote(tags: false)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -355,8 +355,8 @@ end
 #
 def trigger_buildkite_release_build(branch:, beta:)
   buildkite_trigger_build(
-    buildkite_organization: 'automattic',
-    buildkite_pipeline: 'wordpress-ios',
+    buildkite_organization: BUILDKITE_ORGANIZATION,
+    buildkite_pipeline: BUILDKITE_PIPELINE,
     branch:,
     environment: { BETA_RELEASE: beta },
     pipeline_file: 'release-builds.yml',

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -43,8 +43,9 @@ platform :ios do
     end
 
     # Create the release branch
+    release_branch_name = "release/#{release_version_next}"
     UI.message 'Creating release branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{release_version_next}", from: DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"
 
     # Bump the release version and build code and write it to the `xcconfig` file
@@ -97,11 +98,13 @@ platform :ios do
       release_notes_file_path: release_notes_source_path
     )
 
-    UI.user_error!('Aborting code freeze completion as requested.') unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
+      UI.user_error!('Aborting code freeze completion as requested.')
+    end
 
     push_to_git_remote(tags: false)
 
-    setbranchprotection(repository: GITHUB_REPO, branch: "release/#{new_version}")
+    setbranchprotection(repository: GITHUB_REPO, branch: release_branch_name)
     setfrozentag(repository: GITHUB_REPO, milestone: new_version)
 
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -112,6 +112,17 @@ platform :ios do
 
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))
     print_release_notes_reminder
+
+    message = <<~MESSAGE
+      Code freeze started successfully.
+
+      Next steps:
+
+      - Checkout `#{release_branch_name}` branch locally
+      - Update pods and release notes
+      - Finalize the code freeze
+    MESSAGE
+    buildkite_annotate(context: 'code-freeze-success', style: 'success', message:) if is_ci
   end
 
   # Executes the final steps for the code freeze
@@ -147,10 +158,15 @@ platform :ios do
 
     trigger_beta_build
 
-    create_release_management_pull_request(
+    pr_url = create_release_management_pull_request(
       base_branch: DEFAULT_BRANCH,
       title: "Merge #{version} code freeze"
     )
+
+    message = <<~MESSAGE
+      Code freeze completed successfully. Next, review and merge the [integration PR](#{pr_url}).
+    MESSAGE
+    buildkite_annotate(context: 'code-freeze-completed', style: 'success', message:) if is_ci
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI
@@ -204,7 +220,15 @@ platform :ios do
 
     trigger_beta_build
 
-    create_release_management_pull_request(base_branch: DEFAULT_BRANCH, title: "Merge changes from #{build_code_current}")
+    pr_url = create_release_management_pull_request(
+      base_branch: DEFAULT_BRANCH,
+      title: "Merge changes from #{build_code_current}"
+    )
+
+    message = <<~MESSAGE
+      Beta deployment was successful. Next, review and merge the [integration PR](#{pr_url}).
+    MESSAGE
+    buildkite_annotate(context: 'beta-completed', style: 'success', message:) if is_ci
   end
 
   lane :create_editorial_branch do |options|
@@ -364,10 +388,15 @@ platform :ios do
 
     trigger_release_build
 
-    create_release_management_pull_request(
+    pr_url = create_release_management_pull_request(
       base_branch: DEFAULT_BRANCH,
       title: "Merge #{version} release finalization"
     )
+
+    message = <<~MESSAGE
+      Release successfully finalized. Next, review and merge the [integration PR](#{pr_url}).
+    MESSAGE
+    buildkite_annotate(context: 'finalization-completed', style: 'success', message:) if is_ci
   end
 
   # Triggers a beta build on CI

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -209,6 +209,29 @@ platform :ios do
     create_release_management_pull_request(base_branch: DEFAULT_BRANCH, title: "Merge changes from #{build_code_current}")
   end
 
+  lane :create_editorial_branch do |options|
+    ensure_git_status_clean
+
+    release_version = release_version_current
+
+    unless Fastlane::Helper::GitHelper.checkout_and_pull(compute_release_branch_name(options:, version: release_version))
+      UI.user_error!("Release branch for version #{release_version} doesn't exist.")
+    end
+
+    ensure_git_branch_is_release_branch
+
+    git_pull
+
+    Fastlane::Helper::GitHelper.create_branch(editorial_branch_name(version: release_version))
+
+    unless options[:skip_confirm] || UI.confirm('Ready to push editorial branch to remote?')
+      UI.message("Aborting as requested. Don't forget to push the branch to the remote manually.")
+      next
+    end
+
+    push_to_git_remote(tags: false)
+  end
+
   # Sets the stage to start working on a hotfix
   #
   # - Cuts a new `release/x.y.z` branch from the tag from the latest (`x.y`) version

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -170,9 +170,7 @@ platform :ios do
       UI.user_error!("Release branch for version #{release_version} doesn't exist.")
     end
 
-    ensure_git_branch_is_release_branch
-
-    git_pull
+    ensure_git_branch_is_release_branch # This check is mostly redundant
 
     skip_user_confirmation = options[:skip_confirm]
 
@@ -218,7 +216,7 @@ platform :ios do
       UI.user_error!("Release branch for version #{release_version} doesn't exist.")
     end
 
-    ensure_git_branch_is_release_branch
+    ensure_git_branch_is_release_branch # This check is mostly redundant
 
     git_pull
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -177,7 +177,7 @@ platform :ios do
 
     generate_strings_file_for_glotpress
     download_localized_strings_and_metadata(options)
-    lint_localizations
+    lint_localizations(allow_retry: skip_user_confirmation == false)
 
     bump_build_codes
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -24,12 +24,14 @@ platform :ios do
 
     skip_user_confirmation = options[:skip_confirm]
 
+    release_branch_name = compute_release_branch_name(options:, version: release_version_next)
+
     unless skip_user_confirmation
       # The `release_version_next` is used as the `new internal release version` value because the external and internal
       # release versions are always the same.
       message = <<-MESSAGE
         Code Freeze:
-        • New release branch from #{DEFAULT_BRANCH}: release/#{release_version_next}
+        • New release branch from #{DEFAULT_BRANCH}: #{release_branch_name}
 
         • Current release version and build code: #{release_version_current} (#{build_code_current}).
         • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
@@ -229,7 +231,7 @@ platform :ios do
 
     # Create the hotfix branch
     UI.message 'Creating hotfix branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{new_version}", from: previous_version)
+    Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options:, version: new_version), from: previous_version)
     UI.success "Done! New hotfix branch is: #{git_branch}"
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
@@ -426,22 +428,6 @@ def prompt_for_confirmation(message:, bypass:)
   return true if bypass
 
   UI.confirm(message)
-end
-
-def compute_release_branch_name(options:)
-  branch_option = :branch
-  branch_name = options[branch_option]
-
-  if branch_name.nil?
-    branch_name = release_branch_name
-    UI.message("No branch given via option '#{branch_option}'. Defaulting to #{branch_name}.")
-  end
-
-  branch_name
-end
-
-def release_branch_name
-  "release/#{release_version_current}"
 end
 
 def bump_build_codes

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -197,6 +197,8 @@ platform :ios do
     push_to_git_remote(tags: false)
 
     trigger_beta_build
+
+    create_release_management_pull_request(base_branch: DEFAULT_BRANCH, title: "Merge changes from #{build_code_current}")
   end
 
   # Sets the stage to start working on a hotfix

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -337,35 +337,39 @@ platform :ios do
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
 
+    skip_user_confirmation = options[:skip_confirm]
+
     UI.important("Finalizing release: #{release_version_current}")
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+    UI.user_error!('Aborted by user request') unless skip_user_confirmation || UI.confirm('Do you want to continue?')
 
     git_pull
 
-    check_all_translations(interactive: true)
+    check_all_translations(interactive: skip_user_confirmation == false)
 
     download_localized_strings_and_metadata(options)
-    lint_localizations
+    lint_localizations(allow_retry: skip_user_confirmation == false)
 
     bump_build_codes
 
-    # Wrap up
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote and trigger the release build?')
+      UI.message('Aborting release finalization.')
+      next
+    end
+
+    push_to_git_remote(tags: false)
+
     version = release_version_current
     removebranchprotection(repository: GITHUB_REPO, branch: release_branch_name)
     setfrozentag(repository: GITHUB_REPO, milestone: version, freeze: false)
     create_new_milestone(repository: GITHUB_REPO)
     close_milestone(repository: GITHUB_REPO, milestone: version)
 
-    if prompt_for_confirmation(
-      message: 'Ready to push changes to remote and trigger the release build?',
-      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
+    trigger_release_build
+
+    create_release_management_pull_request(
+      base_branch: DEFAULT_BRANCH,
+      title: "Merge #{version} release finalization"
     )
-      push_to_git_remote(tags: false)
-      trigger_release_build
-    else
-      UI.message('Aborting release finalization. See you later.')
-      next
-    end
   end
 
   # Triggers a beta build on CI

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -45,7 +45,7 @@ platform :ios do
     end
 
     # Create the release branch
-    release_branch_name = "release/#{release_version_next}"
+    release_branch_name = compute_release_branch_name(options:, version: release_version_next)
     UI.message 'Creating release branch...'
     Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -458,3 +458,18 @@ def commit_version_and_build_files
     allow_nothing_to_commit: false
   )
 end
+
+def create_release_management_pull_request(base_branch:, title:)
+  token = ENV.fetch('GITHUB_TOKEN', nil)
+
+  UI.user_error!('Please export a GitHub API token in the environment as GITHUB_TOKEN') if token.nil?
+
+  create_pull_request(
+    api_token: token,
+    repo: 'wordpress-mobile/WordPress-iOS',
+    title:,
+    head: Fastlane::Helper::GitHelper.current_git_branch,
+    base: base_branch,
+    labels: 'Releases'
+  )
+end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -105,7 +105,7 @@ platform :ios do
 
     push_to_git_remote(tags: false)
 
-    setbranchprotection(repository: GITHUB_REPO, branch: release_branch_name)
+    set_branch_protection(repository: GITHUB_REPO, branch: release_branch_name)
     setfrozentag(repository: GITHUB_REPO, milestone: new_version)
 
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -121,8 +121,7 @@ platform :ios do
   #
   desc 'Completes the final steps for the code freeze'
   lane :complete_code_freeze do |options|
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
+    ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -150,11 +149,10 @@ platform :ios do
   #
   desc 'Trigger a new beta build on CI'
   lane :new_beta_release do |options|
+    ensure_git_branch_is_release_branch
+
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
-
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
 
     git_pull
 
@@ -259,8 +257,7 @@ platform :ios do
   #
   desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
+    ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -287,8 +284,7 @@ platform :ios do
   lane :finalize_release do |options|
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
-    # Verify that the current branch is a release branch. Notice that `ensure_git_branch` expects a RegEx parameter
-    ensure_git_branch(branch: '^release/')
+    ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -159,10 +159,18 @@ platform :ios do
   #
   desc 'Trigger a new beta build on CI'
   lane :new_beta_release do |options|
-    ensure_git_branch_is_release_branch
-
-    # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
+
+    Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
+
+    release_version = release_version_current
+
+    # Check branch
+    unless Fastlane::Helper::GitHelper.checkout_and_pull(compute_release_branch_name(options:, version: release_version))
+      UI.user_error!("Release branch for version #{release_version} doesn't exist.")
+    end
+
+    ensure_git_branch_is_release_branch
 
     git_pull
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -229,7 +229,9 @@ platform :ios do
       next
     end
 
-    push_to_git_remote(tags: false)
+    # We need to also set upstream so the branch created in our local tracks the remote counterpart.
+    # Otherwise, when the next automation step will run and try to push changes made on that branch, it will fail.
+    push_to_git_remote(tags: false, set_upstream: true)
   end
 
   # Sets the stage to start working on a hotfix

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -22,9 +22,9 @@ platform :ios do
     # Make sure that Gutenberg is configured as expected for a successful code freeze
     gutenberg_dep_check
 
-    skip_user_confirmation = options[:skip_confirm]
-
     release_branch_name = compute_release_branch_name(options:, version: release_version_next)
+
+    skip_user_confirmation = options[:skip_confirm]
 
     unless skip_user_confirmation
       # The `release_version_next` is used as the `new internal release version` value because the external and internal
@@ -158,17 +158,22 @@ platform :ios do
 
     git_pull
 
-    # Check versions
-    message = <<-MESSAGE
-      • Current build code: #{build_code_current}
-      • New build code: #{build_code_next}
+    skip_user_confirmation = options[:skip_confirm]
 
-      • Current internal build code: #{build_code_current_internal}
-      • New internal build code: #{build_code_next_internal}
-    MESSAGE
+    unless skip_user_confirmation
+      # The `release_version_next` is used as the `new internal release version` value because the external and internal
+      # release versions are always the same.
+      message = <<-MESSAGE
+        • Current build code: #{build_code_current}
+        • New build code: #{build_code_next}
 
-    UI.important(message)
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+        • Current internal build code: #{build_code_current_internal}
+        • New internal build code: #{build_code_next_internal}
+      MESSAGE
+
+      UI.important(message)
+      UI.user_error!('Aborted by user request') unless UI.confirm('Do you want to continue?')
+    end
 
     generate_strings_file_for_glotpress
     download_localized_strings_and_metadata(options)
@@ -176,16 +181,14 @@ platform :ios do
 
     bump_build_codes
 
-    if prompt_for_confirmation(
-      message: 'Ready to push changes to remote and trigger the beta build?',
-      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
-    )
-      push_to_git_remote(tags: false)
-      trigger_beta_build
-    else
-      UI.message('Aborting beta deployment. See you later.')
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote and trigger the beta build?')
+      UI.message('Aborting beta deployment.')
       next
     end
+
+    push_to_git_remote(tags: false)
+
+    trigger_beta_build
   end
 
   # Sets the stage to start working on a hotfix

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -128,7 +128,9 @@ platform :ios do
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
 
-    UI.important("Completing code freeze for: #{release_version_current}")
+    version = release_version_current
+
+    UI.important("Completing code freeze for: #{version}")
 
     skip_user_confirmation = options[:skip_confirm]
 
@@ -142,7 +144,13 @@ platform :ios do
     end
 
     push_to_git_remote(tags: false)
+
     trigger_beta_build
+
+    create_release_management_pull_request(
+      base_branch: DEFAULT_BRANCH,
+      title: "Merge #{version} code freeze"
+    )
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -128,20 +128,20 @@ platform :ios do
     ensure_git_status_clean
 
     UI.important("Completing code freeze for: #{release_version_current}")
-    UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
+
+    skip_user_confirmation = options[:skip_confirm]
+
+    UI.user_error!('Aborted by user request') unless skip_user_confirmation || UI.confirm('Do you want to continue?')
 
     generate_strings_file_for_glotpress
 
-    if prompt_for_confirmation(
-      message: 'Ready to push changes to remote and trigger the beta build?',
-      bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', false)
-    )
-      push_to_git_remote(tags: false)
-      trigger_beta_build
-    else
+    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote and trigger the beta build?')
       UI.message('Aborting code freeze completion. See you later.')
       next
     end
+
+    push_to_git_remote(tags: false)
+    trigger_beta_build
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -1,13 +1,31 @@
 # frozen_string_literal: true
 
+PIPELINES_ROOT = 'release-pipelines'
+
 platform :ios do
   lane :trigger_code_freeze_in_ci do
     buildkite_trigger_build(
       buildkite_organization: BUILDKITE_ORGANIZATION,
       buildkite_pipeline: BUILDKITE_PIPELINE,
       branch: DEFAULT_BRANCH,
-      pipeline_file: 'release-pipelines/code-freeze.yml',
+      pipeline_file: File.join(PIPELINES_ROOT, 'code-freeze.yml'),
       message: 'Code Freeze'
+    )
+  end
+
+  lane :trigger_complete_code_freeze_in_ci do |options|
+    release_version_key = :release_version
+    release_version = options[release_version_key]
+
+    UI.user_error!("Please specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version: release_version),
+      pipeline_file: File.join(PIPELINES_ROOT, 'complete-code-freeze.yml'),
+      message: 'Complete Code Freeze',
+      environment: { RELEASE_VERSION: release_version }
     )
   end
 end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -17,7 +17,7 @@ platform :ios do
     release_version_key = :release_version
     release_version = options[release_version_key]
 
-    UI.user_error!("Please specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
+    UI.user_error!("You must specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
 
     buildkite_trigger_build(
       buildkite_organization: BUILDKITE_ORGANIZATION,
@@ -33,7 +33,7 @@ platform :ios do
     release_version_key = :release_version
     release_version = options[release_version_key]
 
-    UI.user_error!("Please specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
+    UI.user_error!("You must specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
 
     buildkite_trigger_build(
       buildkite_organization: BUILDKITE_ORGANIZATION,
@@ -42,6 +42,21 @@ platform :ios do
       pipeline_file: File.join(PIPELINES_ROOT, 'new-beta-release.yml'),
       message: 'New Beta Release',
       environment: { RELEASE_VERSION: release_version }
+    )
+  end
+
+  lane :trigger_update_app_store_strings_in_ci do |options|
+    release_version_key = :release_version
+    release_version = options[release_version_key]
+
+    UI.user_error!("You must specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: editorial_branch_name(version: release_version),
+      pipeline_file: File.join(PIPELINES_ROOT, 'update-app-store-strings.yml'),
+      message: 'Update Editorialized Release Notes and App Store Metadata'
     )
   end
 end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+platform :ios do
+  lane :trigger_code_freeze_in_ci do
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: DEFAULT_BRANCH,
+      pipeline_file: 'release-pipelines/code-freeze.yml',
+      message: 'Code Freeze'
+    )
+  end
+end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -59,4 +59,20 @@ platform :ios do
       message: "Update Editorialized Release Notes and App Store Metadata for #{release_version}"
     )
   end
+
+  lane :trigger_finalize_release_in_ci do |options|
+    release_version_key = :release_version
+    release_version = options[release_version_key]
+
+    UI.user_error!("You must specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version: release_version),
+      pipeline_file: File.join(PIPELINES_ROOT, 'finalize-release.yml'),
+      message: "Finalize Release #{release_version}",
+      environment: { RELEASE_VERSION: release_version }
+    )
+  end
 end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -2,6 +2,9 @@
 
 PIPELINES_ROOT = 'release-pipelines'
 
+# Override DEFAULT_BRANCH to allow testing
+DEFAULT_BRANCH = git_branch
+
 platform :ios do
   lane :trigger_code_freeze_in_ci do
     buildkite_trigger_build(

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -28,4 +28,20 @@ platform :ios do
       environment: { RELEASE_VERSION: release_version }
     )
   end
+
+  lane :trigger_new_beta_release_in_ci do |options|
+    release_version_key = :release_version
+    release_version = options[release_version_key]
+
+    UI.user_error!("Please specify a release version by calling this lane with a  #{release_version_key} parameter") unless release_version
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version: release_version),
+      pipeline_file: File.join(PIPELINES_ROOT, 'new-beta-release.yml'),
+      message: 'New Beta Release',
+      environment: { RELEASE_VERSION: release_version }
+    )
+  end
 end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -24,7 +24,7 @@ platform :ios do
       buildkite_pipeline: BUILDKITE_PIPELINE,
       branch: compute_release_branch_name(options:, version: release_version),
       pipeline_file: File.join(PIPELINES_ROOT, 'complete-code-freeze.yml'),
-      message: 'Complete Code Freeze',
+      message: "Complete Code Freeze for #{release_version}",
       environment: { RELEASE_VERSION: release_version }
     )
   end
@@ -40,7 +40,7 @@ platform :ios do
       buildkite_pipeline: BUILDKITE_PIPELINE,
       branch: compute_release_branch_name(options:, version: release_version),
       pipeline_file: File.join(PIPELINES_ROOT, 'new-beta-release.yml'),
-      message: 'New Beta Release',
+      message: "New Beta Release for #{release_version}",
       environment: { RELEASE_VERSION: release_version }
     )
   end
@@ -56,7 +56,7 @@ platform :ios do
       buildkite_pipeline: BUILDKITE_PIPELINE,
       branch: editorial_branch_name(version: release_version),
       pipeline_file: File.join(PIPELINES_ROOT, 'update-app-store-strings.yml'),
-      message: 'Update Editorialized Release Notes and App Store Metadata'
+      message: "Update Editorialized Release Notes and App Store Metadata for #{release_version}"
     )
   end
 end


### PR DESCRIPTION
Will need to open a new PR because the branch name results in the builds being skipped

---

This is to test https://github.com/wordpress-mobile/WordPress-iOS/pull/22192

### Step 1 `trigger_code_freeze_in_ci`

<img width="2007" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/221021c8-a18f-408d-b8be-2e8e679faa95">

Build: https://buildkite.com/automattic/wordpress-ios/builds/18986