### PR TITLE
Renames Modules Swift Package to "Modules"

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,18 +2,18 @@
 
 import PackageDescription
 
-let librarySourceName = "JetpackStatsWidgetsCore"
+let jetpackStatsWidgetsCoreName = "JetpackStatsWidgetsCore"
 
 let package = Package(
-    name: librarySourceName,
+    name: jetpackStatsWidgetsCoreName,
     products: [
-        .library(name: librarySourceName, targets: [librarySourceName]),
+        .library(name: jetpackStatsWidgetsCoreName, targets: [jetpackStatsWidgetsCoreName]),
     ],
     targets: [
-        .target(name: librarySourceName),
+        .target(name: jetpackStatsWidgetsCoreName),
         .testTarget(
-            name: "\(librarySourceName)Tests",
-            dependencies: [.target(name: librarySourceName)]
+            name: "\(jetpackStatsWidgetsCoreName)Tests",
+            dependencies: [.target(name: jetpackStatsWidgetsCoreName)]
         )
     ]
 )

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let jetpackStatsWidgetsCoreName = "JetpackStatsWidgetsCore"
 
 let package = Package(
-    name: jetpackStatsWidgetsCoreName,
+    name: "Modules",
     products: [
         .library(name: jetpackStatsWidgetsCoreName, targets: [jetpackStatsWidgetsCoreName]),
     ],


### PR DESCRIPTION
See conversation at https://github.com/wordpress-mobile/WordPress-iOS/pull/22000#issuecomment-1809414106

## Regression Notes

1. Potential unintended areas of impact – The Modules package integration, but if CI is green, we're good
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.