### PR TITLE
RFC – Add syntax sugar to `Package.swift` to add "standard shape" libraries

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,6 +2,21 @@
 
 import PackageDescription
 
+extension Package {
+
+    func with(_ libraries: [LibraryModule]) -> Package {
+        return Package(
+            name: name,
+            products: libraries.map { $0.product },
+            targets: libraries.flatMap { $0.targets }
+        )
+    }
+}
+
+/// Abstraction to describe the a standard library sub-package.
+/// That is, a library with both a production and test target, each located in the folder expected by SPM, <root>/Sources/LibraryName and <root>/Tests/LibrayNameTests respectively.
+///
+/// To describe such library, one can simply instantiate `LibrayModule(name: "LibraryName")`.
 struct LibraryModule {
 
     enum UnitTests {
@@ -53,12 +68,7 @@ struct LibraryModule {
     }
 }
 
-let jetpackStatsWidgetsCore = LibraryModule(name: "JetpackStatsWidgetsCore")
-
-let package = Package(
-    name: "Modules",
-    products: [
-        jetpackStatsWidgetsCore.product
-    ],
-    targets: jetpackStatsWidgetsCore.targets
-)
+let package = Package(name: "Modules")
+    .with([
+        LibraryModule(name: "JetpackStatsWidgetsCore")
+    ])

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,6 +2,13 @@
 
 import PackageDescription
 
+let package = Package(name: "Modules")
+    .with([
+        LibraryModule(name: "JetpackStatsWidgetsCore")
+    ])
+
+// MARK: -
+
 extension Package {
 
     func with(_ libraries: [LibraryModule]) -> Package {
@@ -53,7 +60,7 @@ struct LibraryModule {
         }
     }
 
-    var targets: [Target]  {
+    var targets: [Target] {
         [target, testTarget].compactMap { $0 }
     }
 
@@ -68,7 +75,3 @@ struct LibraryModule {
     }
 }
 
-let package = Package(name: "Modules")
-    .with([
-        LibraryModule(name: "JetpackStatsWidgetsCore")
-    ])

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,18 +2,63 @@
 
 import PackageDescription
 
-let jetpackStatsWidgetsCoreName = "JetpackStatsWidgetsCore"
+struct LibraryModule {
+
+    enum UnitTests {
+        case none
+        case some([Target.Dependency] = [])
+    }
+
+    /// The name of the library. Example: FeatureXBusinessLogic.
+    let name: String
+
+    /// The production code dependencies, if any.
+    let dependencies: [Target.Dependency]
+
+    /// The library unit tests configuration
+    let unitTests: UnitTests
+
+    var product: Product {
+        .library(name: name, targets: [name])
+    }
+
+    var target: Target {
+        .target(name: name, dependencies: dependencies)
+    }
+
+    var testTarget: Target? {
+        switch unitTests {
+        case .none:
+            return .none
+        case .some(let dependencies):
+            return .testTarget(
+                name: "\(name)Tests",
+                dependencies: [.target(name: target.name)] + dependencies
+            )
+        }
+    }
+
+    var targets: [Target]  {
+        [target, testTarget].compactMap { $0 }
+    }
+
+    init(
+        name: String,
+        dependencies: [Target.Dependency] = [],
+        unitTests: UnitTests = .some([])
+    ) {
+        self.name = name
+        self.dependencies = dependencies
+        self.unitTests = unitTests
+    }
+}
+
+let jetpackStatsWidgetsCore = LibraryModule(name: "JetpackStatsWidgetsCore")
 
 let package = Package(
     name: "Modules",
     products: [
-        .library(name: jetpackStatsWidgetsCoreName, targets: [jetpackStatsWidgetsCoreName]),
+        jetpackStatsWidgetsCore.product
     ],
-    targets: [
-        .target(name: jetpackStatsWidgetsCoreName),
-        .testTarget(
-            name: "\(jetpackStatsWidgetsCoreName)Tests",
-            dependencies: [.target(name: jetpackStatsWidgetsCoreName)]
-        )
-    ]
+    targets: jetpackStatsWidgetsCore.targets
 )


### PR DESCRIPTION
Good idea or bad idea? The conversation at https://github.com/wordpress-mobile/WordPress-iOS/pull/22092#issuecomment-1849400666 made me realize adding new modules might not be straightforward. Also, I dislike how SPM makes you repeat `String`s between products and targets etc.

I thought to add a bit of types to describe the standard setup we are following so far, with the intention of making it as simple as possible to add a standard module/sub-package (the definition of standard is in the `LibraryModule`. But I fear maybe this was premature optimization? 

@crazytonyli keen to hear what you think.

--- 
Builds on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/22200 with the idea of making integrating a new module in the internal Modules Swift package a one liner.

The `Package` definition is not written as

```swift
let package = Package(name: "Modules")
		.with([
				LibraryModule(name: "JetpackStatsWidgetsCore")
		])
```

Adding new _standalone_ modules with both sources and tests should be as simple as adding new `LibraryModule` entries


```swift
let package = Package(name: "Modules")
		.with([
				LibraryModule(name: "JetpackStatsWidgetsCore"),
				LibraryModule(name: "MyFeatureBusinessLogic")
		])
```

If a module has no unit tests, it can be defined as 

```swift
let package = Package(name: "Modules")
		.with([
				LibraryModule(name: "JetpackStatsWidgetsCore"),
				LibraryModule(name: "MyFeatureBusinessLogic"),
				LibraryModule(name: "ModuleWithoutTests", unitTests: .none)
		])
```

I built in support for dependencies as well, but since we have none at the moment I haven't had a chance to test it or move beyond the basic expectation of "source target has some dependencies" and "test target depends on source target plus other test dependencies".

## Regression Notes

1. Potential unintended areas of impact – The Modules package integration, but if CI is green, we're good
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.