### PR TITLE
Bloganuary: Replace hyphen with dash in Bloganuary nudge text

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
@@ -162,10 +162,7 @@ private struct BloganuaryNudgeCardView: View {
 
         static let description = NSLocalizedString(
             "bloganuary.dashboard.card.description",
-            value: """
-            For the month of January, blogging prompts will come from Bloganuary — \
-            our community challenge to build a blogging habit for the new year.
-            """,
+            value: "For the month of January, blogging prompts will come from Bloganuary — our community challenge to build a blogging habit for the new year.",
             comment: "Short description for the Bloganuary event, shown right below the title."
         )
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
@@ -163,7 +163,7 @@ private struct BloganuaryNudgeCardView: View {
         static let description = NSLocalizedString(
             "bloganuary.dashboard.card.description",
             value: """
-            For the month of January, blogging prompts will come from Bloganuary - \
+            For the month of January, blogging prompts will come from Bloganuary — \
             our community challenge to build a blogging habit for the new year.
             """,
             comment: "Short description for the Bloganuary event, shown right below the title."

--- a/WordPress/Resources/ar.lproj/Localizable.strings
+++ b/WordPress/Resources/ar.lproj/Localizable.strings
@@ -9562,7 +9562,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "bloganuary.dashboard.card.button.learnMore" = "معرفة المزيد";
 
 /* Short description for the Bloganuary event, shown right below the title. */
-"bloganuary.dashboard.card.description" = "بالنسبة إلى شهر يناير، ستأتي موجّهات التدوين من Bloganuary - تحدٍّ مجتمعي لدينا لإنشاء عادة التدوين الخاصة بالعام الجديد.";
+"bloganuary.dashboard.card.description" = "بالنسبة إلى شهر يناير، ستأتي موجّهات التدوين من Bloganuary — تحدٍّ مجتمعي لدينا لإنشاء عادة التدوين الخاصة بالعام الجديد.";
 
 /* Title for the Bloganuary dashboard card. */
 "bloganuary.dashboard.card.title" = "Bloganuary قادمة!";

--- a/WordPress/Resources/en-GB.lproj/Localizable.strings
+++ b/WordPress/Resources/en-GB.lproj/Localizable.strings
@@ -9568,7 +9568,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "bloganuary.dashboard.card.button.learnMore" = "Learn more";
 
 /* Short description for the Bloganuary event, shown right below the title. */
-"bloganuary.dashboard.card.description" = "For the month of January, blogging prompts will come from Bloganuary – our community challenge to build a blogging habit for the new year.";
+"bloganuary.dashboard.card.description" = "For the month of January, blogging prompts will come from Bloganuary — our community challenge to build a blogging habit for the new year.";
 
 /* Title for the Bloganuary dashboard card. */
 "bloganuary.dashboard.card.title" = "Bloganuary is coming!";

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -1367,7 +1367,7 @@
 "bloganuary.dashboard.card.button.learnMore" = "Learn more";
 
 /* Short description for the Bloganuary event, shown right below the title. */
-"bloganuary.dashboard.card.description" = "For the month of January, blogging prompts will come from Bloganuary - our community challenge to build a blogging habit for the new year.";
+"bloganuary.dashboard.card.description" = "For the month of January, blogging prompts will come from Bloganuary — our community challenge to build a blogging habit for the new year.";
 
 /* Title for the Bloganuary dashboard card. */
 "bloganuary.dashboard.card.title" = "Bloganuary is coming!";

--- a/WordPress/Resources/ro.lproj/Localizable.strings
+++ b/WordPress/Resources/ro.lproj/Localizable.strings
@@ -9568,7 +9568,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "bloganuary.dashboard.card.button.learnMore" = "Află mai multe";
 
 /* Short description for the Bloganuary event, shown right below the title. */
-"bloganuary.dashboard.card.description" = "În luna ianuarie, îndemnurile de a scrie vor veni de la Bloganuary - provocarea comunității noastre de a crea un obicei de a scrie pe bloguri în noul an.";
+"bloganuary.dashboard.card.description" = "În luna ianuarie, îndemnurile de a scrie vor veni de la Bloganuary — provocarea comunității noastre de a crea un obicei de a scrie pe bloguri în noul an.";
 
 /* Title for the Bloganuary dashboard card. */
 "bloganuary.dashboard.card.title" = "Bloganuary vine în curând!";


### PR DESCRIPTION
Ref: pcdRpT-4FE-p2#comment-7965

## Description

Replaces the hyphen (-) with a dash (—) in the Bloganuary nudge text on the dashboard card. Matching Android's string change here: https://github.com/wordpress-mobile/WordPress-Android/pull/19774

## Screenshot

<img width="332" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/e27350fd-9fa8-447d-a128-4e3170b8fa15">

## Testing

To test:
- Set device to English
- Launch Jetpack and login
- Navigate to the dashboard if necessary
- 🔎 **Verify** the Bloganuary nudge text on the dashboard card uses a dash (—) instead of a hyphen (-)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)