### PR TITLE
Improved My Site header: Add tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -264,6 +264,8 @@ import Foundation
     case mySiteNoSitesViewActionTapped
     case mySiteNoSitesViewHidden
 
+    // My Site: Header Actions
+    case mySiteHeaderMoreTapped
     // Site Switcher
     case mySiteSiteSwitcherTapped
     case siteSwitcherDisplayed
@@ -1014,6 +1016,9 @@ import Foundation
         case .mySiteNoSitesViewHidden:
             return "my_site_no_sites_view_hidden"
 
+        // My Site Header Actions
+        case .mySiteHeaderMoreTapped:
+            return "my_site_header_more_tapped"
         // Site Switcher
         case .mySiteSiteSwitcherTapped:
             return "my_site_site_switcher_tapped"

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -266,6 +266,8 @@ import Foundation
 
     // My Site: Header Actions
     case mySiteHeaderMoreTapped
+    case mySiteHeaderPersonalizeHomeTapped
+
     // Site Switcher
     case mySiteSiteSwitcherTapped
     case siteSwitcherDisplayed
@@ -1019,6 +1021,9 @@ import Foundation
         // My Site Header Actions
         case .mySiteHeaderMoreTapped:
             return "my_site_header_more_tapped"
+        case .mySiteHeaderPersonalizeHomeTapped:
+            return "my_site_header_personalize_home_tapped"
+
         // Site Switcher
         case .mySiteSiteSwitcherTapped:
             return "my_site_site_switcher_tapped"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -120,6 +120,9 @@ class BlogDetailHeaderView: UIView {
         if let siteActionsMenu = delegate?.makeSiteActionsMenu() {
             titleView.siteActionButton.showsMenuAsPrimaryAction = true
             titleView.siteActionButton.menu = siteActionsMenu
+            titleView.siteActionButton.addAction(UIAction { _ in
+                WPAnalytics.trackEvent(.mySiteHeaderMoreTapped)
+            }, for: .menuActionTriggered)
         }
 
         if let siteIconMenu = delegate?.makeSiteIconMenu() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -46,7 +46,6 @@ extension SitePickerViewController {
             return DDLogError("Failed to show dashboard personalization screen: siteID is missing")
         }
 
-        // TODO: track event
         let viewController = UIHostingController(rootView: NavigationView {
             BlogDashboardPersonalizationView(viewModel: .init(blog: self.blog, service: .init(siteID: siteID)))
         }.navigationViewStyle(.stack)) // .stack is required for iPad
@@ -54,6 +53,8 @@ extension SitePickerViewController {
             viewController.modalPresentationStyle = .formSheet
         }
         present(viewController, animated: true)
+
+        WPAnalytics.trackEvent(.mySiteHeaderPersonalizeHomeTapped)
     }
 }
 


### PR DESCRIPTION
## Description
- Adds tracking for
  - more menu tapped
  - personalize home option tapped 

## How to test
- Tap the site header more menu
- Verify `my_site_header_more_tapped` is tracked
- Tap the personalize home option
- Verify `my_site_header_personalize_home_tapped` is tracked

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
