### PR TITLE
Reader: Fix a crash where we access nil likeCount value

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -46,7 +46,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private var likeCount: Int {
-        post?.likeCount.intValue ?? 0
+        post?.likeCount?.intValue ?? 0
     }
 
     override func awakeFromNib() {


### PR DESCRIPTION
Fixes #22220

Sometimes crashes happen in Reader Details view when accessing non-existent `ReaderPost` values. According to stack traces some of the crashes happened when logging out, and I tried to address them in https://github.com/wordpress-mobile/WordPress-iOS/pull/22147 by unsubscribing to `ReaderPost` observation events. 

However, some crashes still get reported on 23.9. It looks like there can be cases where `ReaderPost` object exists while `likesCount` is nil. `ReaderPost` is an Objective-C class that doesn't have nullability identifiers, therefore crash happens.

I couldn't find a way to reproduce it. Since this crash is marked as a blocker, I'm making a quick fix that should help avoid the crash. 

## To test:

1. Open Reader
2. Open Post
3. Confirm likes button works and likes count updates

## Regression Notes
1. Potential unintended areas of impact

Shouldn't be any

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
