### PR TITLE
Add ability to hide dashboard dynamic cards

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardDynamicCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardDynamicCardCell.swift
@@ -24,7 +24,7 @@ final class BlogDashboardDynamicCardCell: DashboardCollectionViewCell {
 
     func configure(blog: Blog, viewController: BlogDashboardViewController?, model: DashboardDynamicCardModel) {
         self.presentingViewController = viewController
-        self.configureMoreButton(with: blog)
+        self.configureMoreButton(for: model, blog: blog)
 
         self.frameView.setTitle(model.payload.title)
         self.frameView.onViewTap = { [weak self] in
@@ -58,26 +58,26 @@ final class BlogDashboardDynamicCardCell: DashboardCollectionViewCell {
     }
 
     private func setupFrameView() {
-//        self.frameView.ellipsisButton.showsMenuAsPrimaryAction = true
+        self.frameView.ellipsisButton.showsMenuAsPrimaryAction = true
 //        self.frameView.onEllipsisButtonTap = { }
         self.frameView.translatesAutoresizingMaskIntoConstraints = false
         self.contentView.addSubview(frameView)
         self.contentView.pinSubviewToAllEdges(frameView, priority: .defaultHigh)
     }
 
-    private func configureMoreButton(with blog: Blog) {
-//        self.frameView.addMoreMenu(
-//            items:
-//                [
-//                    UIMenu(
-//                        options: .displayInline,
-//                        children: [
-//                            BlogDashboardHelpers.makeHideCardAction(for: .googleDomains, blog: blog)
-//                        ]
-//                    )
-//                ],
-//            card: .googleDomains
-//        )
+    private func configureMoreButton(for card: DashboardDynamicCardModel, blog: Blog) {
+        self.frameView.addMoreMenu(
+            items:
+                [
+                    UIMenu(
+                        options: .displayInline,
+                        children: [
+                            BlogDashboardHelpers.makeHideCardAction(for: card, blog: blog)
+                        ]
+                    )
+                ],
+            card: card.cardType
+        )
     }
 
     // MARK: - User Interaction

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardDynamicCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardDynamicCardCell.swift
@@ -76,7 +76,7 @@ final class BlogDashboardDynamicCardCell: DashboardCollectionViewCell {
                         ]
                     )
                 ],
-            card: card.cardType
+            card: card
         )
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -190,11 +190,11 @@ class BlogDashboardCardFrameView: UIView {
 
     /// Adds the "more" button with the given actions to the corner of the cell.
     func addMoreMenu(items: [UIMenuElement], card: BlogDashboardAnalyticPropertiesProviding) {
-        self.onEllipsisButtonTap = {
+        onEllipsisButtonTap = {
             BlogDashboardAnalytics.trackContextualMenuAccessed(for: card)
         }
-        self.ellipsisButton.showsMenuAsPrimaryAction = true
-        self.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: items)
+        ellipsisButton.showsMenuAsPrimaryAction = true
+        ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: items)
     }
 
     private func updateEllipsisButtonState() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -185,11 +185,16 @@ class BlogDashboardCardFrameView: UIView {
 
     /// Adds the "more" button with the given actions to the corner of the cell.
     func addMoreMenu(items: [UIMenuElement], card: DashboardCard) {
-        onEllipsisButtonTap = {
+        self.addMoreMenu(items: items, card: card as BlogDashboardAnalyticPropertiesProviding)
+    }
+
+    /// Adds the "more" button with the given actions to the corner of the cell.
+    func addMoreMenu(items: [UIMenuElement], card: BlogDashboardAnalyticPropertiesProviding) {
+        self.onEllipsisButtonTap = {
             BlogDashboardAnalytics.trackContextualMenuAccessed(for: card)
         }
-        ellipsisButton.showsMenuAsPrimaryAction = true
-        ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: items)
+        self.ellipsisButton.showsMenuAsPrimaryAction = true
+        self.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: items)
     }
 
     private func updateEllipsisButtonState() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -160,7 +160,11 @@ enum DashboardCard: String, CaseIterable {
 
     func shouldShow(
         for blog: Blog,
+<<<<<<< HEAD
         dynamicCardPayload: DashboardDynamicCardModel.Payload,
+=======
+        dynamicCardPayload: DashboardCardDynamicModel.Payload,
+>>>>>>> e83e22d721 (Show dynamic card when certain conditions are fulfilled)
         isJetpack: Bool = AppConfiguration.isJetpack
     ) -> Bool {
         return self == .dynamic

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
@@ -31,19 +31,19 @@ class BlogDashboardAnalytics {
         }
     }
 
-    static func trackContextualMenuAccessed(for propertiesProvider: BlogDashboardAnalyticPropertiesProviding) {
-        WPAnalytics.track(.dashboardCardContextualMenuAccessed, properties: propertiesProvider.blogDashboardAnalyticProperties)
+    static func trackContextualMenuAccessed(for card: BlogDashboardAnalyticPropertiesProviding) {
+        WPAnalytics.track(.dashboardCardContextualMenuAccessed, properties: card.analyticProperties)
     }
 
-    static func trackHideTapped(for propertiesProvider: BlogDashboardAnalyticPropertiesProviding) {
-        WPAnalytics.track(.dashboardCardHideTapped, properties: propertiesProvider.blogDashboardAnalyticProperties)
+    static func trackHideTapped(for card: BlogDashboardAnalyticPropertiesProviding) {
+        WPAnalytics.track(.dashboardCardHideTapped, properties: card.analyticProperties)
     }
 
     static func trackContextualMenuAccessed(for card: DashboardCard) {
-        Self.trackContextualMenuAccessed(for: card as BlogDashboardAnalyticPropertiesProviding)
+        self.trackContextualMenuAccessed(for: card as BlogDashboardAnalyticPropertiesProviding)
     }
 
     static func trackHideTapped(for card: DashboardCard) {
-        Self.trackHideTapped(for: card as BlogDashboardAnalyticPropertiesProviding)
+        self.trackHideTapped(for: card as BlogDashboardAnalyticPropertiesProviding)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
@@ -31,11 +31,19 @@ class BlogDashboardAnalytics {
         }
     }
 
+    static func trackContextualMenuAccessed(for propertiesProvider: BlogDashboardAnalyticPropertiesProviding) {
+        WPAnalytics.track(.dashboardCardContextualMenuAccessed, properties: propertiesProvider.blogDashboardAnalyticProperties)
+    }
+
+    static func trackHideTapped(for propertiesProvider: BlogDashboardAnalyticPropertiesProviding) {
+        WPAnalytics.track(.dashboardCardHideTapped, properties: propertiesProvider.blogDashboardAnalyticProperties)
+    }
+
     static func trackContextualMenuAccessed(for card: DashboardCard) {
-        WPAnalytics.track(.dashboardCardContextualMenuAccessed, properties: ["card": card.rawValue])
+        Self.trackContextualMenuAccessed(for: card as BlogDashboardAnalyticPropertiesProviding)
     }
 
     static func trackHideTapped(for card: DashboardCard) {
-        WPAnalytics.track(.dashboardCardHideTapped, properties: ["card": card.rawValue])
+        Self.trackHideTapped(for: card as BlogDashboardAnalyticPropertiesProviding)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -3,16 +3,16 @@ import Foundation
 struct BlogDashboardHelpers {
     typealias Card = BlogDashboardAnalyticPropertiesProviding & BlogDashboardPersonalizable
 
-    static func makeHideCardAction(for card: Card, blog: Blog) -> UIAction {
-        let service = BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-        return Self.makeHideCardAction {
-            BlogDashboardAnalytics.trackHideTapped(for: card)
-            service.setEnabled(false, for: card)
-        }
-    }
-
     static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
         Self.makeHideCardAction(for: card as Card, blog: blog)
+    }
+
+    static func makeHideCardAction(for card: Card, blog: Blog) -> UIAction {
+        makeHideCardAction {
+            BlogDashboardAnalytics.trackHideTapped(for: card)
+            BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
+                .setEnabled(false, for: card)
+        }
     }
 
     static func makeHideCardAction(_ handler: @escaping () -> Void) -> UIAction {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -1,12 +1,23 @@
 import Foundation
 
+protocol BlogDashboardAnalyticPropertiesProviding {
+
+    var blogDashboardAnalyticProperties: [AnyHashable: Any] { get }
+}
+
 struct BlogDashboardHelpers {
-    static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
-        makeHideCardAction {
+    typealias Card = BlogDashboardPersonalizable & BlogDashboardAnalyticPropertiesProviding
+
+    static func makeHideCardAction(for card: Card, blog: Blog) -> UIAction {
+        let service = BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
+        return Self.makeHideCardAction {
             BlogDashboardAnalytics.trackHideTapped(for: card)
-            BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
-                .setEnabled(false, for: card)
+            service.setEnabled(false, for: card)
         }
+    }
+
+    static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
+        return Self.makeHideCardAction(for: card as Card, blog: blog)
     }
 
     static func makeHideCardAction(_ handler: @escaping () -> Void) -> UIAction {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -1,12 +1,7 @@
 import Foundation
 
-protocol BlogDashboardAnalyticPropertiesProviding {
-
-    var blogDashboardAnalyticProperties: [AnyHashable: Any] { get }
-}
-
 struct BlogDashboardHelpers {
-    typealias Card = BlogDashboardPersonalizable & BlogDashboardAnalyticPropertiesProviding
+    typealias Card = BlogDashboardAnalyticPropertiesProviding & BlogDashboardPersonalizable
 
     static func makeHideCardAction(for card: Card, blog: Blog) -> UIAction {
         let service = BlogDashboardPersonalizationService(siteID: blog.dotComID?.intValue ?? 0)
@@ -17,7 +12,7 @@ struct BlogDashboardHelpers {
     }
 
     static func makeHideCardAction(for card: DashboardCard, blog: Blog) -> UIAction {
-        return Self.makeHideCardAction(for: card as Card, blog: blog)
+        Self.makeHideCardAction(for: card as Card, blog: blog)
     }
 
     static func makeHideCardAction(_ handler: @escaping () -> Void) -> UIAction {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/BlogDashboardAnalyticPropertiesProviding.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/BlogDashboardAnalyticPropertiesProviding.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol BlogDashboardAnalyticPropertiesProviding {
+
+    var analyticProperties: [AnyHashable: Any] { get }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard+Personalization.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard+Personalization.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension DashboardCard: BlogDashboardPersonalizable {
+
+    var blogDashboardPersonalizationKey: String? {
+        switch self {
+        case .todaysStats:
+            return "todays-stats-card-enabled-site-settings"
+        case .draftPosts:
+            return "draft-posts-card-enabled-site-settings"
+        case .scheduledPosts:
+            return "scheduled-posts-card-enabled-site-settings"
+        case .blaze:
+            return "blaze-card-enabled-site-settings"
+        case .bloganuaryNudge:
+            return "bloganuary-nudge-card-enabled-site-settings"
+        case .prompts:
+            // Warning: there is an irregularity with the prompts key that doesn't
+            // have a "-card" component in the key name. Keeping it like this to
+            // avoid having to migrate data.
+            return "prompts-enabled-site-settings"
+        case .freeToPaidPlansDashboardCard:
+            return "free-to-paid-plans-dashboard-card-enabled-site-settings"
+        case .domainRegistration:
+            return "register-domain-dashboard-card"
+        case .googleDomains:
+            return "google-domains-card-enabled-site-settings"
+        case .activityLog:
+            return "activity-log-card-enabled-site-settings"
+        case .pages:
+            return "pages-card-enabled-site-settings"
+        case .quickStart:
+            // The "Quick Start" cell used to use `BlogDashboardPersonalizationService`.
+            // It no longer does, but it's important to keep the flag around for
+            // users that hidden it using this flag.
+            return "quick-start-card-enabled-site-settings"
+        case .dynamic, .jetpackBadge, .jetpackInstall, .jetpackSocial, .failure, .ghost, .personalize, .empty:
+            return nil
+        }
+    }
+
+    /// Specifies whether the card settings should be applied across
+    /// different sites or only to a particular site.
+    var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope {
+        switch self {
+        case .googleDomains:
+            return .siteGeneric
+        default:
+            return .siteSpecific
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
@@ -149,11 +149,7 @@ enum DashboardCard: String, CaseIterable {
 
     func shouldShow(
         for blog: Blog,
-<<<<<<< HEAD
         dynamicCardPayload: DashboardDynamicCardModel.Payload,
-=======
-        dynamicCardPayload: DashboardCardDynamicModel.Payload,
->>>>>>> e83e22d721 (Show dynamic card when certain conditions are fulfilled)
         isJetpack: Bool = AppConfiguration.isJetpack
     ) -> Bool {
         return self == .dynamic

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
@@ -87,17 +87,6 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    /// Specifies whether the card settings should be applied across
-    /// different sites or only to a particular site.
-    var settingsType: SettingsType {
-        switch self {
-        case .googleDomains:
-            return .siteGeneric
-        default:
-            return .siteSpecific
-        }
-    }
-
     func shouldShow(
         for blog: Blog,
         apiResponse: BlogDashboardRemoteEntity? = nil,
@@ -228,11 +217,6 @@ enum DashboardCard: String, CaseIterable {
             }
         }
     }
-
-    enum SettingsType {
-        case siteSpecific
-        case siteGeneric
-    }
 }
 
 private extension BlogDashboardRemoteEntity {
@@ -256,3 +240,12 @@ private extension BlogDashboardRemoteEntity {
         return (self.activity?.value?.current?.orderedItems?.count ?? 0) > 0
     }
  }
+
+// MARK: - BlogDashboardAnalyticPropertiesProviding Protocol Conformance
+
+extension DashboardCard: BlogDashboardAnalyticPropertiesProviding {
+
+    var blogDashboardAnalyticProperties: [AnyHashable: Any] {
+        return ["card": rawValue]
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
@@ -245,7 +245,7 @@ private extension BlogDashboardRemoteEntity {
 
 extension DashboardCard: BlogDashboardAnalyticPropertiesProviding {
 
-    var blogDashboardAnalyticProperties: [AnyHashable: Any] {
+    var analyticProperties: [AnyHashable: Any] {
         return ["card": rawValue]
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
@@ -27,6 +27,35 @@ enum DashboardCardModel: Hashable {
     }
 }
 
+extension DashboardCardModel: BlogDashboardAnalyticPropertiesProviding {
+
+    var blogDashboardAnalyticProperties: [AnyHashable: Any] {
+        var properties = cardType.blogDashboardAnalyticProperties
+        if case let .dynamic(model) = self {
+            let extra: [AnyHashable: Any] = ["id": model.payload.id]
+            properties = properties.merging(extra, uniquingKeysWith: { first, second in
+                return first
+            })
+        }
+        return properties
+    }
+}
+
+extension DashboardCardModel: BlogDashboardPersonalizable {
+
+    var blogDashboardPersonalizationKey: String? {
+        switch self {
+        case .default(let card): return card.cardType.blogDashboardPersonalizationKey
+        case .dynamic(let card): return "dynamic_card_\(card.payload.id)"
+        }
+    }
+
+    var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope {
+        return cardType.blogDashboardPersonalizationSettingsScope
+    }
+}
+
+
 /// Represents a card in the dashboard collection view
 struct DashboardNormalCardModel: Hashable {
     let cardType: DashboardCard

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
@@ -29,23 +29,23 @@ enum DashboardCardModel: Hashable {
 
 extension DashboardCardModel: BlogDashboardPersonalizable, BlogDashboardAnalyticPropertiesProviding {
 
-    private var model: BlogDashboardPersonalizable & BlogDashboardAnalyticPropertiesProviding {
+    private var card: BlogDashboardPersonalizable & BlogDashboardAnalyticPropertiesProviding {
         switch self {
-        case .normal(let card): return card
-        case .dynamic(let card): return card
+        case .normal(let model): return model
+        case .dynamic(let model): return model
         }
     }
 
     var blogDashboardPersonalizationKey: String? {
-        return model.blogDashboardPersonalizationKey
+        return card.blogDashboardPersonalizationKey
     }
 
     var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope {
-        return model.blogDashboardPersonalizationSettingsScope
+        return card.blogDashboardPersonalizationSettingsScope
     }
 
     var analyticProperties: [AnyHashable: Any] {
-        return model.analyticProperties
+        return card.analyticProperties
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
@@ -121,7 +121,7 @@ extension DashboardDynamicCardModel: BlogDashboardPersonalizable, BlogDashboardA
     }
 
     var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope {
-        return .siteSpecific
+        return .siteGeneric
     }
 
     var analyticProperties: [AnyHashable: Any] {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCardModel.swift
@@ -44,8 +44,8 @@ extension DashboardCardModel: BlogDashboardPersonalizable, BlogDashboardAnalytic
         return model.blogDashboardPersonalizationSettingsScope
     }
 
-    var blogDashboardAnalyticProperties: [AnyHashable: Any] {
-        return model.blogDashboardAnalyticProperties
+    var analyticProperties: [AnyHashable: Any] {
+        return model.analyticProperties
     }
 }
 
@@ -97,8 +97,9 @@ extension DashboardNormalCardModel: BlogDashboardPersonalizable, BlogDashboardAn
     var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope {
         return cardType.blogDashboardPersonalizationSettingsScope
     }
-    var blogDashboardAnalyticProperties: [AnyHashable: Any] {
-        return cardType.blogDashboardAnalyticProperties
+
+    var analyticProperties: [AnyHashable: Any] {
+        return cardType.analyticProperties
     }
 }
 
@@ -123,9 +124,9 @@ extension DashboardDynamicCardModel: BlogDashboardPersonalizable, BlogDashboardA
         return .siteSpecific
     }
 
-    var blogDashboardAnalyticProperties: [AnyHashable: Any] {
+    var analyticProperties: [AnyHashable: Any] {
         let properties: [AnyHashable: Any] = ["id": payload.id]
-        return cardType.blogDashboardAnalyticProperties.merging(properties, uniquingKeysWith: { first, second in
+        return cardType.analyticProperties.merging(properties, uniquingKeysWith: { first, second in
             return first
         })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -1,10 +1,15 @@
 import Foundation
 
-///
+/// `BlogDashboardPersonalizable` is a protocol that defines the requirements for personalizing blog dashboard items.
+/// It provides properties to access personalization key and settings scope specific to the blog dashboard.
 protocol BlogDashboardPersonalizable {
 
+    /// The personalization key for the blog dashboard.
+    /// This key is used to identify and retrieve personalization settings specific to a dashboard item.
     var blogDashboardPersonalizationKey: String? { get }
 
+    /// The scope of the blog dashboard personalization settings.
+    /// This defines the extent to which the personalization settings are applied, such as site-agnostic or site-specific.
     var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope { get }
 }
 
@@ -59,8 +64,8 @@ struct BlogDashboardPersonalizationService {
 
     private func lookUpKey(from scope: SettingsScope) -> String {
         switch scope {
-        case .siteGeneric: return siteID
-        case .siteSpecific: return Constants.siteAgnosticVisibilityKey
+        case .siteSpecific: return siteID
+        case .siteGeneric: return Constants.siteAgnosticVisibilityKey
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+///
+protocol BlogDashboardPersonalizable {
+
+    var blogDashboardPersonalizationKey: String? { get }
+
+    var blogDashboardPersonalizationSettingsScope: BlogDashboardPersonalizationService.SettingsScope { get }
+}
+
 /// Manages dashboard settings such as card visibility.
 struct BlogDashboardPersonalizationService {
     private enum Constants {
@@ -13,6 +21,47 @@ struct BlogDashboardPersonalizationService {
          siteID: Int) {
         self.repository = repository
         self.siteID = String(siteID)
+    }
+
+    // MARK: - Core API
+
+    func setEnabled(_ isEnabled: Bool, forKey key: String, scope: SettingsScope) {
+        var settings = getSettings(for: key)
+        let lookUpKey = lookUpKey(from: scope)
+        settings[lookUpKey] = isEnabled
+        self.repository.set(settings, forKey: key)
+        NotificationCenter.default.post(name: .blogDashboardPersonalizationSettingsChanged, object: self)
+    }
+
+    func isEnabled(_ key: String, scope: SettingsScope) -> Bool {
+        let settings = getSettings(for: key)
+        let key = lookUpKey(from: scope)
+        return settings[key, default: true]
+    }
+
+    func setEnabled(_ isEnabled: Bool, for item: BlogDashboardPersonalizable) {
+        guard let key = item.blogDashboardPersonalizationKey else {
+            return
+        }
+        self.setEnabled(
+            isEnabled,
+            forKey: key,
+            scope: item.blogDashboardPersonalizationSettingsScope
+        )
+    }
+
+    func isEnabled(_ item: BlogDashboardPersonalizable) -> Bool {
+        guard let key = item.blogDashboardPersonalizationKey else {
+            return true
+        }
+        return self.isEnabled(key, scope: item.blogDashboardPersonalizationSettingsScope)
+    }
+
+    private func lookUpKey(from scope: SettingsScope) -> String {
+        switch scope {
+        case .siteGeneric: return siteID
+        case .siteSpecific: return Constants.siteAgnosticVisibilityKey
+        }
     }
 
     // MARK: - Quick Actions
@@ -39,8 +88,7 @@ struct BlogDashboardPersonalizationService {
     // MARK: - Dashboard Cards
 
     func isEnabled(_ card: DashboardCard) -> Bool {
-        let key = lookUpKey(for: card)
-        return getSettings(for: card)[key] ?? true
+        return self.isEnabled(card as BlogDashboardPersonalizable)
     }
 
     func hasPreference(for card: DashboardCard) -> Bool {
@@ -57,72 +105,30 @@ struct BlogDashboardPersonalizationService {
     ///   - isEnabled: A Boolean value indicating whether the `DashboardCard` should be enabled or disabled.
     ///   - card: The `DashboardCard` whose setting needs to be updated.
     func setEnabled(_ isEnabled: Bool, for card: DashboardCard) {
-        guard let key = makeKey(for: card) else { return }
-        var settings = getSettings(for: card)
-        let lookUpKey = lookUpKey(for: card)
-        settings[lookUpKey] = isEnabled
-
-        repository.set(settings, forKey: key)
-
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .blogDashboardPersonalizationSettingsChanged, object: self)
-        }
+        self.setEnabled(isEnabled, for: card as BlogDashboardPersonalizable)
     }
 
     private func getSettings(for card: DashboardCard) -> [String: Bool] {
-        guard let key = makeKey(for: card) else { return [:] }
+        guard let key = card.blogDashboardPersonalizationKey else {
+            return [:]
+        }
         return repository.dictionary(forKey: key) as? [String: Bool] ?? [:]
     }
 
     private func lookUpKey(for card: DashboardCard) -> String {
-        switch card.settingsType {
-        case .siteSpecific:
-            return siteID
-        case .siteGeneric:
-            return Constants.siteAgnosticVisibilityKey
-        }
+        return lookUpKey(from: card.blogDashboardPersonalizationSettingsScope)
+    }
+
+    // MARK: - Types
+
+    enum SettingsScope {
+        case siteSpecific
+        case siteGeneric
     }
 }
 
 private func makeKey(for action: DashboardQuickAction) -> String {
     "quick-action-\(action.rawValue)-hidden"
-}
-
-private func makeKey(for card: DashboardCard) -> String? {
-    switch card {
-    case .todaysStats:
-        return "todays-stats-card-enabled-site-settings"
-    case .draftPosts:
-        return "draft-posts-card-enabled-site-settings"
-    case .scheduledPosts:
-        return "scheduled-posts-card-enabled-site-settings"
-    case .blaze:
-        return "blaze-card-enabled-site-settings"
-    case .bloganuaryNudge:
-        return "bloganuary-nudge-card-enabled-site-settings"
-    case .prompts:
-        // Warning: there is an irregularity with the prompts key that doesn't
-        // have a "-card" component in the key name. Keeping it like this to
-        // avoid having to migrate data.
-        return "prompts-enabled-site-settings"
-    case .freeToPaidPlansDashboardCard:
-        return "free-to-paid-plans-dashboard-card-enabled-site-settings"
-    case .domainRegistration:
-        return "register-domain-dashboard-card"
-    case .googleDomains:
-        return "google-domains-card-enabled-site-settings"
-    case .activityLog:
-        return "activity-log-card-enabled-site-settings"
-    case .pages:
-        return "pages-card-enabled-site-settings"
-    case .quickStart:
-        // The "Quick Start" cell used to use `BlogDashboardPersonalizationService`.
-        // It no longer does, but it's important to keep the flag around for
-        // users that hidden it using this flag.
-        return "quick-start-card-enabled-site-settings"
-    case .dynamic, .jetpackBadge, .jetpackInstall, .jetpackSocial, .failure, .ghost, .personalize, .empty:
-        return nil
-    }
 }
 
 extension NSNotification.Name {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -112,14 +112,24 @@ private extension BlogDashboardService {
             )
         }
 
-        // Maps dynamic cards to `DashboardCardModel`.k
+        // Maps dynamic cards to `DashboardCardModel`.
         if let dynamic = entity?.dynamic?.value {
             let cards = dynamic.compactMap { payload in
-                return self.dashboardDynamicCardModel(for: blog, payload: payload, dotComID: dotComID)
+                return self.dashboardCardModel(
+                    for: blog,
+                    payload: payload,
+                    dotComID: dotComID,
+                    personalizationService: personalizationService
+                )
             }
-            let cardsByOrder = Dictionary(grouping: cards) { $0.payload.order ?? .bottom }
-            let topCards = cardsByOrder[.top, default: []].map { DashboardCardModel.dynamic($0) }
-            let bottomCards = cardsByOrder[.bottom, default: []].map { DashboardCardModel.dynamic($0) }
+            let cardsByOrder = Dictionary(grouping: cards) { card -> BlogDashboardRemoteEntity.BlogDashboardDynamic.Order in
+                guard case .dynamic(let model) = card, let order = model.payload.order else {
+                    return .bottom
+                }
+                return order
+            }
+            let topCards = cardsByOrder[.top, default: []]
+            let bottomCards = cardsByOrder[.bottom, default: []]
 
             // Adds "top" cards at the beginning of the list.
             allCards = topCards + allCards
@@ -165,19 +175,19 @@ private extension BlogDashboardService {
         return .normal(.init(cardType: card, dotComID: dotComID, entity: entity))
     }
 
-    func dashboardDynamicCardModel(
+    func dashboardCardModel(
         for blog: Blog,
-        payload: DashboardDynamicCardModel.Payload,
-        dotComID: Int
-    ) -> DashboardDynamicCardModel? {
-        guard DashboardCard.dynamic.shouldShow(
-            for: blog,
-            dynamicCardPayload: payload,
-            isJetpack: isJetpack
-        ) else {
+        payload: DashboardCardDynamicModel.Payload,
+        dotComID: Int,
+        personalizationService: BlogDashboardPersonalizationService
+    ) -> DashboardCardModel? {
+        let model: DashboardCardModel = .dynamic(.init(payload: payload, dotComID: dotComID))
+        guard model.cardType.shouldShow(for: blog, dynamicCardPayload: payload, isJetpack: isJetpack),
+              personalizationService.isEnabled(model)
+        else {
             return nil
         }
-        return .init(payload: payload, dotComID: dotComID)
+        return model
     }
 
     func decode(_ cardsDictionary: NSDictionary, blog: Blog) -> BlogDashboardRemoteEntity? {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -177,7 +177,7 @@ private extension BlogDashboardService {
 
     func dashboardCardModel(
         for blog: Blog,
-        payload: DashboardCardDynamicModel.Payload,
+        payload: DashboardDynamicCardModel.Payload,
         dotComID: Int,
         personalizationService: BlogDashboardPersonalizationService
     ) -> DashboardCardModel? {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3581,6 +3581,8 @@
 		F4026B1E2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4026B1C2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift */; };
 		F413F77A2B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7792B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift */; };
 		F413F77B2B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7792B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift */; };
+		F413F7882B2B253A00A64A94 /* DashboardCard+Personalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */; };
+		F413F7892B2B253A00A64A94 /* DashboardCard+Personalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */; };
 		F4141EE42AE7152F000D2AAE /* AllDomainsListViewController+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4141EE22AE7152F000D2AAE /* AllDomainsListViewController+Strings.swift */; };
 		F4141EE62AE71AF0000D2AAE /* AllDomainsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4141EE52AE71AF0000D2AAE /* AllDomainsListViewModel.swift */; };
 		F4141EE82AE72DC4000D2AAE /* AllDomainsListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4141EE72AE72DC4000D2AAE /* AllDomainsListTableViewCell.swift */; };
@@ -8967,6 +8969,7 @@
 		F4026B1C2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainRegistrationCardCell.swift; sourceTree = "<group>"; };
 		F40CC35C2954991C00D75A95 /* WordPress 146.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 146.xcdatamodel"; sourceTree = "<group>"; };
 		F413F7792B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardDynamicCardCell.swift; sourceTree = "<group>"; };
+		F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardCard+Personalization.swift"; sourceTree = "<group>"; };
 		F4141EE22AE7152F000D2AAE /* AllDomainsListViewController+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AllDomainsListViewController+Strings.swift"; sourceTree = "<group>"; };
 		F4141EE52AE71AF0000D2AAE /* AllDomainsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllDomainsListViewModel.swift; sourceTree = "<group>"; };
 		F4141EE72AE72DC4000D2AAE /* AllDomainsListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllDomainsListTableViewCell.swift; sourceTree = "<group>"; };
@@ -13933,9 +13936,9 @@
 		8B6214E127B1B2D6001DF7B6 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */,
 				8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */,
 				8BBC778A27B5531700DBA087 /* BlogDashboardPersistence.swift */,
-				0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */,
 				8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */,
 				8B15CDAA27EB89AC00A75749 /* BlogDashboardPostsParser.swift */,
 			);
@@ -14117,7 +14120,6 @@
 			isa = PBXGroup;
 			children = (
 				8B074A4F27AC3A64003A2EB8 /* BlogDashboardViewModel.swift */,
-				8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */,
 				806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */,
 			);
 			path = ViewModel;
@@ -17339,6 +17341,16 @@
 			path = Font;
 			sourceTree = "<group>";
 		};
+		F413F7832B2B251A00A64A94 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				8BF9E03227B1A8A800915B27 /* DashboardCard.swift */,
+				8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */,
+				F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		F4141EEF2AE99EE2000D2AAE /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -18145,12 +18157,12 @@
 		FA73D7D7278D9E6300DF24B3 /* Blog Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				F413F7832B2B251A00A64A94 /* Models */,
 				8B4DDF23278F3AED0022494D /* Cards */,
 				8B6214E127B1B2D6001DF7B6 /* Service */,
 				8BEE845B27B1DD8E0001A93C /* ViewModel */,
 				8BC81D6327CFC0C60057F790 /* Helpers */,
 				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
-				8BF9E03227B1A8A800915B27 /* DashboardCard.swift */,
 				80D9CFF929E5E6FE00FE3400 /* DashboardCardTableView.swift */,
 			);
 			path = "Blog Dashboard";
@@ -22823,6 +22835,7 @@
 				C81CCD6F243AF7D700A83E27 /* TenorReponseParser.swift in Sources */,
 				4020B2BD2007AC850002C963 /* WPStyleGuide+Gridicon.swift in Sources */,
 				982D261F2788DDF200A41286 /* ReaderCommentsFollowPresenter.swift in Sources */,
+				F413F7882B2B253A00A64A94 /* DashboardCard+Personalization.swift in Sources */,
 				F5E032D6240889EB003AF350 /* CreateButtonCoordinator.swift in Sources */,
 				74729CA32056FA0900D1394D /* SearchManager.swift in Sources */,
 				7E8980CA22E8C7A600C567B0 /* BlogToBlogMigration87to88.swift in Sources */,
@@ -24382,6 +24395,7 @@
 				0C0AD10B2B0CCFA400EC06E6 /* MediaPreviewController.swift in Sources */,
 				FABB222A2602FC2C00C8785C /* JetpackScanThreatSectionGrouping.swift in Sources */,
 				0839F88D2993C1B600415038 /* JetpackPluginOverlayCoordinator.swift in Sources */,
+				F413F7892B2B253A00A64A94 /* DashboardCard+Personalization.swift in Sources */,
 				FABB222B2602FC2C00C8785C /* MediaHelper.swift in Sources */,
 				FABB222C2602FC2C00C8785C /* ReaderActionHelpers.swift in Sources */,
 				FABB222D2602FC2C00C8785C /* NoteBlockUserTableViewCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3742,10 +3742,10 @@
 		F48D44BB2989A9070051EAA6 /* ReaderSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48D44B92989A58C0051EAA6 /* ReaderSiteService.swift */; };
 		F48D44BC2989AA8A0051EAA6 /* ReaderSiteService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D44EB371986D8BA008B7175 /* ReaderSiteService.m */; };
 		F48D44BD2989AA8C0051EAA6 /* ReaderSiteService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D44EB371986D8BA008B7175 /* ReaderSiteService.m */; };
-		F48EBF942B333550004CD561 /* dashboard-200-with-only-one-dynamic-card.json in Resources */ = {isa = PBXBuildFile; fileRef = F48EBF912B333111004CD561 /* dashboard-200-with-only-one-dynamic-card.json */; };
-		F48EBF952B333B31004CD561 /* dashboard-200-with-multiple-dynamic-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = F48EBF8C2B3262D5004CD561 /* dashboard-200-with-multiple-dynamic-cards.json */; };
 		F48EBF8A2B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */; };
 		F48EBF8B2B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */; };
+		F48EBF942B333550004CD561 /* dashboard-200-with-only-one-dynamic-card.json in Resources */ = {isa = PBXBuildFile; fileRef = F48EBF912B333111004CD561 /* dashboard-200-with-only-one-dynamic-card.json */; };
+		F48EBF952B333B31004CD561 /* dashboard-200-with-multiple-dynamic-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = F48EBF8C2B3262D5004CD561 /* dashboard-200-with-multiple-dynamic-cards.json */; };
 		F49B99FF2937C9B4000CEFCE /* MigrationEmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */; };
 		F49B9A0029393049000CEFCE /* MigrationAppDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33A5ADB2935848F00961E3A /* MigrationAppDetection.swift */; };
 		F49B9A06293A21BF000CEFCE /* MigrationAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */; };
@@ -9122,9 +9122,9 @@
 		F48D44B5298992C30051EAA6 /* BlockedSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedSite.swift; sourceTree = "<group>"; };
 		F48D44B7298993900051EAA6 /* WordPress 147.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 147.xcdatamodel"; sourceTree = "<group>"; };
 		F48D44B92989A58C0051EAA6 /* ReaderSiteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteService.swift; sourceTree = "<group>"; };
+		F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardAnalyticPropertiesProviding.swift; sourceTree = "<group>"; };
 		F48EBF8C2B3262D5004CD561 /* dashboard-200-with-multiple-dynamic-cards.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-multiple-dynamic-cards.json"; sourceTree = "<group>"; };
 		F48EBF912B333111004CD561 /* dashboard-200-with-only-one-dynamic-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-only-one-dynamic-card.json"; sourceTree = "<group>"; };
-		F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardAnalyticPropertiesProviding.swift; sourceTree = "<group>"; };
 		F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
 		F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F49B9A07293A21F4000CEFCE /* MigrationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationEvent.swift; sourceTree = "<group>"; };
@@ -10793,7 +10793,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+		29B97314FDCFA39411CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -18892,7 +18892,7 @@
 				E16AB92514D978240047A2E5 /* Sources */,
 				E16AB92614D978240047A2E5 /* Frameworks */,
 				E16AB92714D978240047A2E5 /* Resources */,
-				CDB91045FD48AA779DCF9C53 /* [CP] Embed Pods Frameworks */,
+				E42C39F1A003092A4AE8F2A2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -19176,13 +19176,13 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			mainGroup = 29B97314FDCFA39411CA2CEA;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				17A8858B2757B97F0071FCA3 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
 				3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */,
 				0CD9FB852AFA71B9009D9C7A /* XCRemoteSwiftPackageReference "Charts" */,
 			);
@@ -20698,26 +20698,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CDB91045FD48AA779DCF9C53 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-WordPressTest/Pods-WordPressTest-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Gutenberg/Gutenberg.framework/Gutenberg",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Gutenberg/hermes.framework/hermes",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Gutenberg.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPressTest/Pods-WordPressTest-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		D880C306E1943EA76DA53078 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -20788,11 +20768,11 @@
 			files = (
 			);
 			inputPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
 			);
 			outputPaths = (
 				"",
@@ -20800,6 +20780,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.sh\"\n";
+		};
+		E42C39F1A003092A4AE8F2A2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-WordPressTest/Pods-WordPressTest-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Gutenberg/Gutenberg.framework/Gutenberg",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Gutenberg/hermes.framework/hermes",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Gutenberg.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPressTest/Pods-WordPressTest-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		F9C5CF0222CD5DB0007CEF56 /* Copy Alternate Internal Icons (if needed) */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -20961,13 +20961,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
 			);
 			outputPaths = (
 			);
@@ -30390,7 +30390,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
+		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -30479,12 +30479,12 @@
 		};
 		3F411B6E28987E3F002513AE /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
 			productName = Lottie;
 		};
 		3F44DD57289C379C006334CD /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
 			productName = Lottie;
 		};
 		3F9F23242B0AE1AC00B56061 /* JetpackStatsWidgetsCore */ = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3744,6 +3744,8 @@
 		F48D44BD2989AA8C0051EAA6 /* ReaderSiteService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D44EB371986D8BA008B7175 /* ReaderSiteService.m */; };
 		F48EBF942B333550004CD561 /* dashboard-200-with-only-one-dynamic-card.json in Resources */ = {isa = PBXBuildFile; fileRef = F48EBF912B333111004CD561 /* dashboard-200-with-only-one-dynamic-card.json */; };
 		F48EBF952B333B31004CD561 /* dashboard-200-with-multiple-dynamic-cards.json in Resources */ = {isa = PBXBuildFile; fileRef = F48EBF8C2B3262D5004CD561 /* dashboard-200-with-multiple-dynamic-cards.json */; };
+		F48EBF8A2B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */; };
+		F48EBF8B2B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */; };
 		F49B99FF2937C9B4000CEFCE /* MigrationEmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */; };
 		F49B9A0029393049000CEFCE /* MigrationAppDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33A5ADB2935848F00961E3A /* MigrationAppDetection.swift */; };
 		F49B9A06293A21BF000CEFCE /* MigrationAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */; };
@@ -9122,6 +9124,7 @@
 		F48D44B92989A58C0051EAA6 /* ReaderSiteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteService.swift; sourceTree = "<group>"; };
 		F48EBF8C2B3262D5004CD561 /* dashboard-200-with-multiple-dynamic-cards.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-multiple-dynamic-cards.json"; sourceTree = "<group>"; };
 		F48EBF912B333111004CD561 /* dashboard-200-with-only-one-dynamic-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-only-one-dynamic-card.json"; sourceTree = "<group>"; };
+		F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardAnalyticPropertiesProviding.swift; sourceTree = "<group>"; };
 		F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
 		F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F49B9A07293A21F4000CEFCE /* MigrationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationEvent.swift; sourceTree = "<group>"; };
@@ -17347,6 +17350,7 @@
 				8BF9E03227B1A8A800915B27 /* DashboardCard.swift */,
 				8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */,
 				F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */,
+				F48EBF892B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -22352,6 +22356,7 @@
 				85B125461B0294F6008A3D95 /* UIAlertControllerProxy.m in Sources */,
 				73FF7030221F43CD00541798 /* StatsBarChartView.swift in Sources */,
 				F5E1BBE0253B74240091E9A6 /* URLQueryItem+Parameters.swift in Sources */,
+				F48EBF8A2B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift in Sources */,
 				0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */,
 				B5E51B7B203477DF00151ECD /* WordPressAuthenticationManager.swift in Sources */,
 				FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */,
@@ -25098,6 +25103,7 @@
 				FABB242E2602FC2C00C8785C /* OffsetTableViewHandler.swift in Sources */,
 				FABB242F2602FC2C00C8785C /* UINavigationController+SplitViewFullscreen.swift in Sources */,
 				803BB99029667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift in Sources */,
+				F48EBF8B2B2F94DD004CD561 /* BlogDashboardAnalyticPropertiesProviding.swift in Sources */,
 				0CE7833E2B08F3C300B114EB /* ExternalMediaPickerViewController.swift in Sources */,
 				FABB24302602FC2C00C8785C /* ReaderReblogPresenter.swift in Sources */,
 				0CE538D12B0E317000834BA2 /* StockPhotosWelcomeView.swift in Sources */,


### PR DESCRIPTION
Fixes #22226

This PR adds the ability to hide dynamic cards.

https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/366fa8cd-bdb0-45b7-b50e-de85af870510

## Test Instructions

#### Case 1: Hiding Dynamic Cards
1. Install Jetpack and login.
2. Enable `Dynamic Dashboard Cards` Feature Flag.
3. Navigate back to `My Site`.
4. **Expect** to see `New: Domains Management` cards at the top.
5. Tap the "3 dots" button.
6. **Expect** the "Hide this" button to appear.
7. **Expect** this event to be tracked `my_site_dashboard_contextual_menu_accessed <card: dynamic, id: domain_management_announcement>`
8. Tap "Hide this".
9. **Expect** the card to disappear.
10. **Expect** this event to be tracked `my_site_dashboard_card_hide_tapped <card: dynamic, id: domain_management_announcement>`
11. Switch to another site.
12. **Expect** the domain management card to remain hidden ( the personalization scope is site agnostic ).

#### Case 2: Hiding Normal Cards ( Regression )
1. Tap "3 dots" of any non-dynamic card.
2. **Expect** the "Hide this" button to appear.
3. **Expect** this event to be tracked `my_site_dashboard_contextual_menu_accessed <card: xyz>`
4. Tap "Hide this".
5. **Expect** the card to disappear.
6. **Expect** this event to be tracked `my_site_dashboard_card_hide_tapped <card: xyz>`

## Regression Notes
1. Potential unintended areas of impact
The personalization of non-dynamic cards should work as expected. See **Case 2** in **Test Instructions**.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
