### PR TITLE
Fix locally broken blogging prompts unit test

### DIFF
--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -157,7 +157,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         // with the v3 implementation, we no longer have access to intercept at the method level.
         // this means, we lose the time information of the passed date.
         // In this case, we can only compare the year, month, and day components.
-        let expectedDate = BloggingPromptsServiceRemoteMock.dateFormatter.date(from: "2022-01-02")!
+        let expectedDate = try XCTUnwrap(BloggingPromptsServiceRemoteMock.dateFormatter.date(from: "2022-01-02"))
         let expectedDateComponents = Self.calendar.dateComponents(in: Self.utcTimeZone, from: expectedDate)
         let expectedNumber = 10
 
@@ -418,6 +418,9 @@ private extension BloggingPromptsServiceTests {
         dateComponents.year = forcedYear
         dateComponents.month = month
         dateComponents.day = day
+        dateComponents.hour = 0
+        dateComponents.minute = 0
+        dateComponents.second = 0
 
         return try XCTUnwrap(Self.calendar.date(from: dateComponents))
     }


### PR DESCRIPTION
One of the test cases in `BloggingPromptsServiceTests` is broken when run locally, due to a bug that causes the difference between UTC and local timezone to make a difference between the expected and the asserted date—depending on what time you run the test.

This PR fixes that by resetting the hour, minute, and second components of the `passedDate` to 0, allowing this to match the date expectations, which always has 00:00:00 and therefore will always be offset into the same date due to the difference between local and UTC timezone.

## To test

Run the `BloggingPromptsServiceTests` test suite and ensure that it passes.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes were locally confined to the `BloggingPromptsServiceTests` test suite.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes in multiple timezones.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A. This change does not introduce or modify UI components.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
