### PR TITLE
Add "all_domains" analytics source to some events fired during the All Domains flow

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -255,7 +255,7 @@ import Foundation
     case purchaseDomainChooseSiteTapped
     case purchaseDomainCompleted
     case myDomainsSearchDomainTapped
-
+    
     // My Site
     case mySitePullToRefresh
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -249,7 +249,7 @@ import Foundation
     case addDomainTapped
     case domainsSearchTransferDomainTapped
     case domainsSearchRowSelected
-    case siteSwitcherDomainSiteSelected
+    case siteSwitcherSiteSelected
     case purchaseDomainScreenShown
     case purchaseDomainGetDomainTapped
     case purchaseDomainChooseSiteTapped
@@ -994,7 +994,7 @@ import Foundation
             return "domains_dashboard_domains_search_transfer_domain_tapped"
         case .domainsSearchRowSelected:
             return "domain_management_domains_search_row_selected"
-        case .siteSwitcherDomainSiteSelected:
+        case .siteSwitcherSiteSelected:
             return "site_switcher_site_selected"
         case .purchaseDomainScreenShown:
             return "domain_management_purchase_domain_screen_shown"

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -253,7 +253,6 @@ import Foundation
     case purchaseDomainScreenShown
     case purchaseDomainGetDomainTapped
     case purchaseDomainChooseSiteTapped
-    case purchaseDomainSiteSelected
     case purchaseDomainCompleted
     case myDomainsSearchDomainTapped
 
@@ -1004,8 +1003,6 @@ import Foundation
             return "domain_management_purchase_domain_choose_site_tapped"
         case .purchaseDomainCompleted:
             return "domain_management_purchase_domain_completed"
-        case .purchaseDomainSiteSelected:
-            return "domain_management_purchase_domain_site_selected"
         case .myDomainsSearchDomainTapped:
             return "domain_management_my_domains_search_domain_tapped"
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -994,7 +994,7 @@ import Foundation
         case .domainsSearchRowSelected:
             return "domain_management_domains_search_row_selected"
         case .siteSwitcherDomainSiteSelected:
-            return "site_switcher_domain_site_selected"
+            return "site_switcher_site_selected"
         case .purchaseDomainScreenShown:
             return "domain_management_purchase_domain_screen_shown"
         case .purchaseDomainGetDomainTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -253,9 +253,10 @@ import Foundation
     case purchaseDomainScreenShown
     case purchaseDomainGetDomainTapped
     case purchaseDomainChooseSiteTapped
+    case purchaseDomainSiteSelected
     case purchaseDomainCompleted
     case myDomainsSearchDomainTapped
-    
+
     // My Site
     case mySitePullToRefresh
 
@@ -1003,6 +1004,8 @@ import Foundation
             return "domain_management_purchase_domain_choose_site_tapped"
         case .purchaseDomainCompleted:
             return "domain_management_purchase_domain_completed"
+        case .purchaseDomainSiteSelected:
+            return "domain_management_purchase_domain_site_selected"
         case .myDomainsSearchDomainTapped:
             return "domain_management_my_domains_search_domain_tapped"
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListConfiguration.swift
@@ -8,20 +8,24 @@ import Foundation
     @objc var backButtonTitle: String
     @objc var shouldHideSelfHostedSites: Bool
     @objc var shouldHideBlogsNotSupportingDomains: Bool
+    @objc var analyticsSource: String?
 
-    init(shouldShowCancelButton: Bool,
-         shouldShowNavBarButtons: Bool,
-         navigationTitle: String,
-         backButtonTitle: String,
-         shouldHideSelfHostedSites: Bool,
-         shouldHideBlogsNotSupportingDomains: Bool) {
+    init(
+        shouldShowCancelButton: Bool,
+        shouldShowNavBarButtons: Bool,
+        navigationTitle: String,
+        backButtonTitle: String,
+        shouldHideSelfHostedSites: Bool,
+        shouldHideBlogsNotSupportingDomains: Bool,
+        analyticsSource: String? = nil
+    ) {
         self.shouldShowCancelButton = shouldShowCancelButton
         self.shouldShowNavBarButtons = shouldShowNavBarButtons
         self.navigationTitle = navigationTitle
         self.backButtonTitle = backButtonTitle
         self.shouldHideSelfHostedSites = shouldHideSelfHostedSites
         self.shouldHideBlogsNotSupportingDomains = shouldHideBlogsNotSupportingDomains
-
+        self.analyticsSource = analyticsSource
         super.init()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -818,7 +818,7 @@ static NSInteger HideSearchMinSites = 3;
 - (void)setSelectedBlog:(Blog *)selectedBlog
 {
     [self setSelectedBlog:selectedBlog animated:[self isViewLoaded]];
-    [self trackEvent:WPAnalyticsEventSiteSwitcherDomainSiteSelected properties:nil];
+    [self trackEvent:WPAnalyticsEventSiteSwitcherSiteSelected properties:nil];
 }
 
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -418,6 +418,21 @@ static NSInteger HideSearchMinSites = 3;
     }
 }
 
+#pragma mark - Tracks
+
+- (void)trackEvent:(WPAnalyticsEvent)event properties:(NSDictionary<id, id> * _Nullable)properties
+{
+    NSMutableDictionary<id, id> *mergedProperties = [NSMutableDictionary dictionary];
+
+    if (self.configuration.analyticsSource) {
+        mergedProperties[WPAppAnalyticsKeySource] = self.configuration.analyticsSource;
+    }
+
+    [mergedProperties addEntriesFromDictionary:properties ?: @{}];
+
+    [WPAnalytics trackEvent:event properties:mergedProperties];
+}
+
 #pragma mark - Header methods
 
 - (UIView *)headerView
@@ -803,7 +818,7 @@ static NSInteger HideSearchMinSites = 3;
 - (void)setSelectedBlog:(Blog *)selectedBlog
 {
     [self setSelectedBlog:selectedBlog animated:[self isViewLoaded]];
-    [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherDomainSiteSelected];
+    [self trackEvent:WPAnalyticsEventSiteSwitcherDomainSiteSelected properties:nil];
 }
 
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -123,7 +123,6 @@ class RegisterDomainCoordinator {
                 case .success(let domain):
                     self.site = selectedBlog
                     self.domainAddedToCartAndLinkedToSiteCallback?(controller, domain.domainName, selectedBlog)
-                    self.track(.purchaseDomainSiteSelected)
                 case .failure:
                     controller.displayActionableNotice(title: TextContent.errorTitle, actionTitle: TextContent.errorDismiss)
                 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -99,12 +99,15 @@ class RegisterDomainCoordinator {
     /// Related to the `purchaseFromDomainManagement` Domain selection type.
     /// Adds the selected domain to the cart then presents a site picker view.
     func handleExistingSiteChoice(on viewController: UIViewController) {
-        let config = BlogListConfiguration(shouldShowCancelButton: false,
-                                           shouldShowNavBarButtons: false,
-                                           navigationTitle: TextContent.sitePickerNavigationTitle,
-                                           backButtonTitle: TextContent.sitePickerNavigationTitle,
-                                           shouldHideSelfHostedSites: true,
-                                           shouldHideBlogsNotSupportingDomains: true)
+        let config = BlogListConfiguration(
+            shouldShowCancelButton: false,
+            shouldShowNavBarButtons: false,
+            navigationTitle: TextContent.sitePickerNavigationTitle,
+            backButtonTitle: TextContent.sitePickerNavigationTitle,
+            shouldHideSelfHostedSites: true,
+            shouldHideBlogsNotSupportingDomains: true,
+            analyticsSource: analyticsSource
+        )
         let blogListViewController = BlogListViewController(configuration: config, meScenePresenter: nil)
 
         blogListViewController.blogSelected = { [weak self] controller, selectedBlog in

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -123,7 +123,7 @@ class RegisterDomainCoordinator {
                 case .success(let domain):
                     self.site = selectedBlog
                     self.domainAddedToCartAndLinkedToSiteCallback?(controller, domain.domainName, selectedBlog)
-                    self.track(.purchaseDomainSiteSelected, blog: selectedBlog)
+                    self.track(.purchaseDomainSiteSelected)
                 case .failure:
                     controller.displayActionableNotice(title: TextContent.errorTitle, actionTitle: TextContent.errorDismiss)
                 }
@@ -135,7 +135,7 @@ class RegisterDomainCoordinator {
     }
 
     func trackDomainPurchasingCompleted() {
-        self.track(.purchaseDomainCompleted, blog: site)
+        self.track(.purchaseDomainCompleted)
     }
 
     // MARK: Helpers
@@ -206,7 +206,7 @@ class RegisterDomainCoordinator {
                 return WPAnalytics.domainsProperties(usingCredit: false, origin: nil, domainOnly: true)
             }
         }()
-        self.track(.domainsPurchaseWebviewViewed, properties: properties, blog: site)
+        self.track(.domainsPurchaseWebviewViewed, properties: properties)
 
         webViewController.configureSandboxStore {
             if shouldPush {
@@ -263,14 +263,14 @@ class RegisterDomainCoordinator {
 
     // MARK: - Tracks
 
-    private func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]? = nil, blog: Blog?) {
+    private func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
         let defaultProperties: [AnyHashable: Any] = [WPAppAnalyticsKeySource: analyticsSource]
 
         let properties = defaultProperties.merging(properties ?? [:]) { first, second in
             return first
         }
 
-        if let blog {
+        if let blog = self.site {
             WPAnalytics.track(event, properties: properties, blog: blog)
         } else {
             WPAnalytics.track(event, properties: properties)

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -114,17 +114,20 @@ class RegisterDomainCoordinator {
             guard let self else {
                 return
             }
-            self.site = selectedBlog
             controller.showLoading()
             self.createCart { [weak self] result in
+                guard let self else {
+                    return
+                }
                 switch result {
                 case .success(let domain):
-                    self?.domainAddedToCartAndLinkedToSiteCallback?(controller, domain.domainName, selectedBlog)
-                    controller.hideLoading()
+                    self.site = selectedBlog
+                    self.domainAddedToCartAndLinkedToSiteCallback?(controller, domain.domainName, selectedBlog)
+                    self.track(.purchaseDomainSiteSelected, blog: selectedBlog)
                 case .failure:
                     controller.displayActionableNotice(title: TextContent.errorTitle, actionTitle: TextContent.errorDismiss)
-                    controller.hideLoading()
                 }
+                controller.hideLoading()
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -60,8 +60,9 @@ class RegisterDomainSuggestionsViewController: UIViewController {
             }
             let destination = TransferDomainsWebViewController(source: self.analyticsSource)
             self.present(UINavigationController(rootViewController: destination), animated: true)
+            self.track(.domainsSearchTransferDomainTapped)
         }
-        return .init(configuration: configuration)
+        return .init(configuration: configuration, analyticsSource: self.analyticsSource)
     }()
 
     /// Represents the layout constraints for the transfer footer view in its visible and hidden states.

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -418,15 +418,13 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
 
     private func pushPurchaseDomainChoiceScreen() {
         @ObservedObject var choicesViewModel = DomainPurchaseChoicesViewModel()
-        let view = DomainPurchaseChoicesView(viewModel: choicesViewModel) { [weak self] in
+        let view = DomainPurchaseChoicesView(viewModel: choicesViewModel, analyticsSource: analyticsSource) { [weak self] in
             guard let self else { return }
             choicesViewModel.isGetDomainLoading = true
             self.coordinator?.handleNoSiteChoice(on: self, choicesViewModel: choicesViewModel)
-            WPAnalytics.track(.purchaseDomainGetDomainTapped)
         } chooseSiteAction: { [weak self] in
             guard let self else { return }
             self.coordinator?.handleExistingSiteChoice(on: self)
-            WPAnalytics.track(.purchaseDomainChooseSiteTapped)
         }
         let hostingController = UIHostingController(rootView: view)
         hostingController.title = TextContent.domainChoiceTitle

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainTransferFooterView.swift
@@ -37,6 +37,10 @@ final class RegisterDomainTransferFooterView: UIView {
         )
     }
 
+    // MARK: - Properties
+
+    private let analyticsSource: String?
+
     // MARK: - Views
 
     private let titleLabel: UILabel = {
@@ -57,7 +61,8 @@ final class RegisterDomainTransferFooterView: UIView {
 
     // MARK: - Init
 
-    init(configuration: Configuration) {
+    init(configuration: Configuration, analyticsSource: String? = nil) {
+        self.analyticsSource = analyticsSource
         super.init(frame: .zero)
         self.backgroundColor = UIColor(light: .systemBackground, dark: .secondarySystemBackground)
         self.addTopBorder(withColor: .divider)
@@ -95,11 +100,9 @@ final class RegisterDomainTransferFooterView: UIView {
 
         let action = UIAction { _ in
             configuration.buttonAction()
-            WPAnalytics.track(.domainsSearchTransferDomainTapped)
         }
         self.titleLabel.text = configuration.title
         self.primaryButton.setTitle(configuration.buttonTitle, for: .normal)
         self.primaryButton.addAction(action, for: .touchUpInside)
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
@@ -5,7 +5,11 @@ struct DomainPurchaseChoicesView: View {
         static let imageLength: CGFloat = 36
     }
 
+
     @StateObject var viewModel = DomainPurchaseChoicesViewModel()
+
+    let analyticsSource: String?
+
     let buyDomainAction: (() -> Void)
     let chooseSiteAction: (() -> Void)
 
@@ -32,28 +36,35 @@ struct DomainPurchaseChoicesView: View {
         .padding(.horizontal, Length.Padding.double)
         .background(Color.DS.Background.secondary)
         .onAppear {
-            WPAnalytics.track(.purchaseDomainScreenShown)
+            self.track(.purchaseDomainScreenShown)
         }
     }
 
     private var getDomainCard: some View {
-        card(imageName: "site-menu-domains",
-             title: Strings.buyDomainTitle,
-             subtitle: Strings.buyDomainSubtitle,
-             buttonTitle: Strings.buyDomainButtonTitle,
-             isProgressViewActive: true,
-             action: buyDomainAction)
+        card(
+            imageName: "site-menu-domains",
+            title: Strings.buyDomainTitle,
+            subtitle: Strings.buyDomainSubtitle,
+            buttonTitle: Strings.buyDomainButtonTitle,
+            isProgressViewActive: true
+        ) {
+            self.track(.purchaseDomainGetDomainTapped)
+            self.buyDomainAction()
+        }
     }
 
     private var chooseSiteCard: some View {
-        card(imageName: "block-layout",
-             title: Strings.chooseSiteTitle,
-             subtitle: Strings.chooseSiteSubtitle,
-             buttonTitle: Strings.chooseSiteButtonTitle,
-             footer: Strings.chooseSiteFooter,
-             isProgressViewActive: false,
-             action: chooseSiteAction
-        )
+        card(
+            imageName: "block-layout",
+            title: Strings.chooseSiteTitle,
+            subtitle: Strings.chooseSiteSubtitle,
+            buttonTitle: Strings.chooseSiteButtonTitle,
+            footer: Strings.chooseSiteFooter,
+            isProgressViewActive: false
+        ) {
+            self.track(.purchaseDomainChooseSiteTapped)
+            self.chooseSiteAction()
+        }
     }
 
     private func card(
@@ -109,6 +120,21 @@ struct DomainPurchaseChoicesView: View {
             Text(Strings.chooseSiteFooter)
                 .foregroundStyle(Color.DS.Foreground.brand)
         }
+    }
+
+    private func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
+        let defaultProperties: [AnyHashable: Any] = {
+            guard let source = self.analyticsSource else {
+                return [:]
+            }
+            return [WPAppAnalyticsKeySource: source]
+        }()
+
+        let properties = defaultProperties.merging(properties ?? [:]) { first, second in
+            return first
+        }
+
+        WPAnalytics.track(event, properties: properties)
     }
 }
 
@@ -177,7 +203,7 @@ private extension DomainPurchaseChoicesView {
 
 struct DomainPurchaseChoicesView_Previews: PreviewProvider {
     static var previews: some View {
-        DomainPurchaseChoicesView(viewModel: DomainPurchaseChoicesViewModel()) {
+        DomainPurchaseChoicesView(viewModel: DomainPurchaseChoicesViewModel(), analyticsSource: nil) {
             print("Buy domain tapped.")
         } chooseSiteAction: {
             print("Choose site tapped")


### PR DESCRIPTION
Ref p1702639446034219/1702609353.389479-slack-C05NS0YV7HS

## Test Instructions

1. Navigate to the "Me" tab
2. Tap "Domains"
   - [x] Expect `me_all_domains_tapped` to be tracked.
3. Expect the domains list to be shown
   - [x] Expect `all_domains_list_shown` to be tracked.
4. Tap a domain from the list
5. Expect the domain details webview to be shown
   - [x] Expect `all_domains_domain_details_web_view_shown` to be tracked.
   - [x] Expect a `url` to be included in the event params.
6. Go back to the all domains screen
7. Tap the "+" button
   - [x] Expect `all_domains_add_domain_tapped` to be tracked
8. Expect the domain search screen to be shown
   - [x] Expect `domains_dashboard_domains_search_shown <source: all_domains>` to be tracked.
9. Type a query to search for a domain
10. Tap a domain from the results list then tap **Select Domain**
    - [x] Expect `domains_dashboard_select_domain_tapped <source: all_domains>` to be tracked.
    - [x] Expect the tracked event to include the `domain_name` property with a value set as the picked domain
11. Expect the purchase domain screen to be shown
    - [x] Expect `domain_management_purchase_domain_screen_shown <source: all_domains>` to be tracked.
12. Tap "Get domain"
    - [x] Expect `domain_management_purchase_domain_get_domain_tapped  <source: all_domains>` to be tracked.
13. Expect checkout webview to be shown
    - [x] Expect `domains_purchase_webview_viewed  <source: all_domains>` to be tracked.
    - [x] Expect the `domain_only` and `using_credit` to be included in the event params. 
14. Complete the purchase (can use the store sandbox if needed)
    - [x] Expect `domain_management_purchase_domain_completed <source: all_domains>` to be tracked.
15. Repeat the steps from the beginning but tap "Choose Site" this time.
    - [x] Expect `domain_management_purchase_domain_choose_site_tapped  <source: all_domains>` to be tracked.
16. Choose a site
    - [x] Expect `site_switcher_domain_site_selected <source: all_domains>` to be tracked.
    - Wait for the loading indicator to stop.
    - [x] Expect `domain_management_purchase_domain_site_selected <source: all_domains>` to be tracked.
17. Complete the purchase (can use the store sandbox if needed)
    - [x] Expect `domain_management_purchase_domain_completed <source: all_domains>` to be tracked.
18. Repeat steps 1 - 8
19. Tap "Transer domain" button
    - [x] Expect `domains_dashboard_domains_search_transfer_domain_tapped <origin: all_domains>` to be tracked
20. Navigate to the "My Site" tab
21. Tap "... More" button
22. Tap the "Domains" button (in the "Manage" section)
23. Tap the "ALL" button (on the top bar)
    - [x] Expect `domains_dashboard_all_domains_tapped` to be tracked

## Regression Notes
1. Potential unintended areas of impact
Existing domain management analytic events.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.