### PR TITLE
Improved My Site header: Add site option

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -266,6 +266,7 @@ import Foundation
 
     // My Site: Header Actions
     case mySiteHeaderMoreTapped
+    case mySiteHeaderAddSiteTapped
     case mySiteHeaderPersonalizeHomeTapped
 
     // Site Switcher
@@ -1021,6 +1022,8 @@ import Foundation
         // My Site Header Actions
         case .mySiteHeaderMoreTapped:
             return "my_site_header_more_tapped"
+        case .mySiteHeaderAddSiteTapped:
+            return "my_site_header_add_site_tapped"
         case .mySiteHeaderPersonalizeHomeTapped:
             return "my_site_header_personalize_home_tapped"
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -16,7 +16,7 @@ class BlogDetailHeaderView: UIView {
 
     // MARK: - Child Views
 
-    private let titleView: TitleView
+    let titleView: TitleView
 
     // MARK: - Delegate
 
@@ -202,7 +202,7 @@ class BlogDetailHeaderView: UIView {
     }
 }
 
-fileprivate extension BlogDetailHeaderView {
+extension BlogDetailHeaderView {
     class TitleView: UIView {
         private enum Dimensions {
             static let siteSwitcherHeight: CGFloat = 36

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -124,8 +124,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         let configuration = AddNewSiteConfiguration(
             canCreateWPComSite: viewModel.defaultAccount != nil,
             canAddSelfHostedSite: AppConfiguration.showAddSelfHostedSiteButton,
-            launchSiteCreation: self.launchSiteCreationFromNoSites,
-            launchLoginForSelfHostedSite: self.launchLoginForSelfHostedSite
+            launchSiteCreation: { [weak self] in self?.launchSiteCreationFromNoSites() },
+            launchLoginForSelfHostedSite: { [weak self] in self?.launchLoginForSelfHostedSite() }
         )
         let noSiteView = NoSitesView(
             viewModel: noSitesViewModel,

--- a/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesView.swift
@@ -144,11 +144,7 @@ extension NoSitesView {
     func handleAddNewSiteButtonTapped() {
         WPAnalytics.track(.mySiteNoSitesViewActionTapped)
 
-        guard addNewSiteConfiguration.canCreateWPComSite else {
-            return
-        }
-
-        guard addNewSiteConfiguration.canAddSelfHostedSite else {
+        if addNewSiteConfiguration.canCreateWPComSite && !addNewSiteConfiguration.canAddSelfHostedSite {
             addNewSiteConfiguration.launchSiteCreation()
             return
         }
@@ -174,20 +170,5 @@ extension NoSitesView {
         static let accountAndSettings = NSLocalizedString("mySite.noSites.button.accountAndSettings", value: "Account and settings", comment: "Button title. Displays the account and setting screen.")
         static let createWPComSite = NSLocalizedString("mySite.noSites.actionSheet.createWPComSite", value: "Create WordPress.com site", comment: "Action sheet button title. Launches the flow to create a WordPress.com site.")
         static let addSelfHostedSite = NSLocalizedString("mySite.noSites.actionSheet.addSelfHostedSite", value: "Add self-hosted site", comment: "Action sheet button title. Launches the flow to a add self-hosted site.")
-    }
-}
-
-struct NoSitesView_Previews: PreviewProvider {
-    static var previews: some View {
-        let configuration = AddNewSiteConfiguration(
-            canCreateWPComSite: true,
-            canAddSelfHostedSite: true,
-            launchSiteCreation: {},
-            launchLoginForSelfHostedSite: {}
-        )
-        NoSitesView(
-            viewModel: NoSitesViewModel(appUIType: .simplified, account: nil),
-            addNewSiteConfiguration: configuration
-        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -22,18 +22,18 @@ extension SitePickerViewController {
 
     private func makePrimarySection() -> UIMenu {
         var menuItems = [
-            MenuItem.visitSite(visitSiteTapped),
-            MenuItem.addSite(addSiteTapped),
+            MenuItem.visitSite({ [weak self] in self?.visitSiteTapped() }),
+            MenuItem.addSite({ [weak self] in self?.addSiteTapped()} ),
         ]
         if numberOfBlogs() > 1 {
-            menuItems.append(MenuItem.switchSite(siteSwitcherTapped))
+            menuItems.append(MenuItem.switchSite({ [weak self] in self?.siteSwitcherTapped() }))
         }
         return UIMenu(options: .displayInline, children: menuItems.map { $0.toAction })
     }
 
     private func makeSecondarySection() -> UIMenu {
         UIMenu(options: .displayInline, children: [
-            MenuItem.siteTitle(siteTitleTapped).toAction,
+            MenuItem.siteTitle({ [weak self] in self?.siteTitleTapped() }).toAction,
             UIMenu(title: Strings.siteIcon, image: UIImage(systemName: "photo.circle"), children: [
                 makeSiteIconMenu() ?? UIMenu()
             ])
@@ -42,7 +42,7 @@ extension SitePickerViewController {
 
     private func makeTertiarySection() -> UIMenu {
         UIMenu(options: .displayInline, children: [
-            MenuItem.personalizeHome(personalizeHomeTapped).toAction
+            MenuItem.personalizeHome({ [weak self] in self?.personalizeHomeTapped() }).toAction
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -20,11 +20,14 @@ extension SitePickerViewController {
     }
 
     private func makePrimarySection() -> UIMenu {
-        UIMenu(options: .displayInline, children: [
+        var menuItems = [
             MenuItem.visitSite(visitSiteTapped),
             MenuItem.addSite(addSiteTapped),
-            MenuItem.switchSite(siteSwitcherTapped)
-        ].map { $0.toAction })
+        ]
+        if numberOfBlogs() > 1 {
+            menuItems.append(MenuItem.switchSite(siteSwitcherTapped))
+        }
+        return UIMenu(options: .displayInline, children: menuItems.map { $0.toAction })
     }
 
     private func makeSecondarySection() -> UIMenu {
@@ -63,6 +66,12 @@ extension SitePickerViewController {
         present(viewController, animated: true)
 
         WPAnalytics.trackEvent(.mySiteHeaderPersonalizeHomeTapped)
+    }
+
+    private func numberOfBlogs() -> Int {
+        let context = ContextManager.sharedInstance().mainContext
+        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        return defaultAccount?.blogs?.count ?? 0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -69,9 +69,9 @@ extension SitePickerViewController {
         let actionSheet = AddSiteAlertFactory().makeAddSiteAlert(
             source: "my_site",
             canCreateWPComSite: canCreateWPComSite,
-            createWPComSite: launchSiteCreation,
+            createWPComSite: { [weak self] in self?.launchSiteCreation() },
             canAddSelfHostedSite: canAddSelfHostedSite,
-            addSelfHostedSite: launchLoginForSelfHostedSite
+            addSelfHostedSite: { [weak self] in self?.launchLoginForSelfHostedSite() }
         )
 
         actionSheet.popoverPresentationController?.sourceView = sourceView

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -61,6 +61,8 @@ extension SitePickerViewController {
         showAddSiteActionSheet(from: blogDetailHeaderView.titleView.siteActionButton,
                                canCreateWPComSite: canCreateWPComSite,
                                canAddSelfHostedSite: canAddSelfHostedSite)
+
+        WPAnalytics.trackEvent(.mySiteHeaderAddSiteTapped)
     }
 
     private func showAddSiteActionSheet(from sourceView: UIView, canCreateWPComSite: Bool, canAddSelfHostedSite: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -22,6 +22,7 @@ extension SitePickerViewController {
     private func makePrimarySection() -> UIMenu {
         UIMenu(options: .displayInline, children: [
             MenuItem.visitSite(visitSiteTapped),
+            MenuItem.addSite(addSiteTapped),
             MenuItem.switchSite(siteSwitcherTapped)
         ].map { $0.toAction })
     }
@@ -39,6 +40,13 @@ extension SitePickerViewController {
         UIMenu(options: .displayInline, children: [
             MenuItem.personalizeHome(personalizeHomeTapped).toAction
         ])
+    }
+
+    private func addSiteTapped() {
+        guard let parent = parent as? MySiteViewController else {
+            return
+        }
+        parent.launchSiteCreation(source: "my_site")
     }
 
     private func personalizeHomeTapped() {
@@ -60,6 +68,7 @@ extension SitePickerViewController {
 
 private enum MenuItem {
     case visitSite(_ handler: () -> Void)
+    case addSite(_ handler: () -> Void)
     case switchSite(_ handler: () -> Void)
     case siteTitle(_ handler: () -> Void)
     case personalizeHome(_ handler: () -> Void)
@@ -67,6 +76,7 @@ private enum MenuItem {
     var title: String {
         switch self {
         case .visitSite: return Strings.visitSite
+        case .addSite: return Strings.addSite
         case .switchSite: return Strings.switchSite
         case .siteTitle: return Strings.siteTitle
         case .personalizeHome: return Strings.personalizeHome
@@ -76,6 +86,7 @@ private enum MenuItem {
     var icon: UIImage? {
         switch self {
         case .visitSite: return UIImage(systemName: "safari")
+        case .addSite: return UIImage(systemName: "plus")
         case .switchSite: return UIImage(systemName: "arrow.triangle.swap")
         case .siteTitle: return UIImage(systemName: "character")
         case .personalizeHome: return UIImage(systemName: "slider.horizontal.3")
@@ -85,6 +96,7 @@ private enum MenuItem {
     var toAction: UIAction {
         switch self {
         case .visitSite(let handler),
+             .addSite(let handler),
              .switchSite(let handler),
              .siteTitle(let handler),
              .personalizeHome(let handler):
@@ -95,6 +107,7 @@ private enum MenuItem {
 
 private enum Strings {
     static let visitSite = NSLocalizedString("mySite.siteActions.visitSite", value: "Visit site", comment: "Menu title for the visit site option")
+    static let addSite = NSLocalizedString("mySite.siteActions.addSite", value: "Add site", comment: "Menu title for the add site option")
     static let switchSite = NSLocalizedString("mySite.siteActions.switchSite", value: "Switch site", comment: "Menu title for the switch site option")
     static let siteTitle = NSLocalizedString("mySite.siteActions.siteTitle", value: "Change site title", comment: "Menu title for the change site title option")
     static let siteIcon = NSLocalizedString("mySite.siteActions.siteIcon", value: "Change site icon", comment: "Menu title for the change site icon option")


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/22151#discussion_r1416286638 (See: p1702904523516189/1702901771.547389-slack-C04SFL0RP51)

## Description
- Shows the "Add site" option in the My Site header actions
- Shows the "Switch site" option if there's more than 1 site 

1 site | Multiple sites
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/932fb9bd-d6e2-4f5c-bf39-eb84ddff8b05" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/53a59a8d-3c9f-4d07-b2bd-5b8faf5f4dea" width=200>

## How to test
- Log into an account w multiple sites
- Verify the add site and switch sites option is shown in the more menu
- Select the add site option
- Verify you can add a site
- Log into an account w only 1 site
- Verify the switch site option isn't shown in the more menu

## Regression Notes
1. Potential unintended areas of impact
My Site header site actions

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.