### PR TITLE
Fix crash when editor modifies a deleted post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] [internal] Refactor domain selection flows to use the same domain selection UI. [22254]
 * [**] Re-enable the support for using Security Keys as a second factor during login [#22258]
 * [*] Fix crash in editor that sometimes happens after modifying tags or categories [#22265]
+* [*] Add defensive code to make sure the retain cycles in the editor don't lead to crashes [#22252]
 
 23.9
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -6,8 +6,9 @@ import WordPressFlux
 /// navigation bar button of Gutenberg editor.
 extension GutenbergViewController {
 
-    private enum ErrorCode: Int {
+    enum ErrorCode: Int {
         case expectedSecondaryAction = 1
+        case managedObjectContextMissing = 2
     }
 
     func displayMoreSheet() {


### PR DESCRIPTION
Related https://github.com/wordpress-mobile/WordPress-iOS/issues/20647. 

To Test:

- Follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/pull/22265 and verify that the defensive code introduced in this PR prevents that crash from happening

## Regression Notes
1. Potential unintended areas of impact: Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
