### PR TITLE
Fix an issue with local thumbnails not loading using ImageDownloader

### DIFF
--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -111,7 +111,7 @@ actor ImageDownloader {
 
     private func validate(response: URLResponse) throws {
         guard let response = response as? HTTPURLResponse else {
-            throw ImageDownloaderError.unexpectedResponse
+            return // The request was made not over HTTP, e.g. a `file://` request
         }
         guard (200..<400).contains(response.statusCode) else {
             throw ImageDownloaderError.unacceptableStatusCode(response.statusCode)
@@ -183,7 +183,6 @@ private struct AnonymousImageDownloadTask: ImageDownloaderTask {
 }
 
 enum ImageDownloaderError: Error {
-    case unexpectedResponse
     case unacceptableStatusCode(_ statusCode: Int?)
 }
 


### PR DESCRIPTION
Fixes pcdRpT-4ZQ-p2#comment-8124

**RCA**

`ImageDownloader` is indirectly used by the classic editor to load local images (`file://` schema). The following recently added validation was too strict and was failing because the response wasn't an `HTTPURLResponse`:

```swift
    private func validate(response: URLResponse) throws {
        guard let response = response as? HTTPURLResponse else {
            throw ImageDownloaderError.unexpectedResponse
        }
        guard (200..<400).contains(response.statusCode) else {
            throw ImageDownloaderError.unacceptableStatusCode(response.statusCode)
        }
    }
```

To test:

- Open a post using the Classic Editor (one way to do that is by modifying `EditorFactory.swift`)
- Add an image from the device
- Verify that the thumbnail is displayed

## Regression Notes
1. Potential unintended areas of impact: Classic Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)