### PR TITLE
Remove a fatal error upon unexpected post instances types

### DIFF
--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -497,9 +497,11 @@ extension PostRepository {
                 purgeExisting: deleteOtherLocalPosts,
                 in: context
             )
-            return updatedPosts.map {
-                guard let post = $0 as? P else {
-                    fatalError("Expecting a \(postType) as \(type), but got \($0)")
+            return updatedPosts.compactMap { aPost -> TaggedManagedObjectID<P>? in
+                guard let post = aPost as? P else {
+                    // FIXME: This issue is tracked in https://github.com/wordpress-mobile/WordPress-iOS/issues/22255
+                    DDLogWarn("Expecting a \(postType) as \(type), but got \(aPost)")
+                    return nil
                 }
                 return TaggedManagedObjectID(post)
             }


### PR DESCRIPTION
Relates to https://github.com/wordpress-mobile/WordPress-iOS/issues/22255. I'll leave the issue open, because the root cause is not actually addressed.

## Regression Notes
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A
