### PR TITLE
Update Domain Registration card description message

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardDomainRegistrationCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardDomainRegistrationCardCell.swift
@@ -103,7 +103,7 @@ extension DashboardDomainRegistrationCardCell {
             comment: "Action to redeem domain credit."
         )
         static let content = NSLocalizedString(
-            "All WordPress.com plans include a custom domain name. Register your free premium domain now.",
+            "All WordPress.com annual plans include a custom domain name. Register your free domain now.",
             comment: "Information about redeeming domain credit on site dashboard."
         )
         static let hideThis = NSLocalizedString(


### PR DESCRIPTION
Convo: p1702527756668429-slack-C0JJ0C1UL

This PR changes the Domain Registration card description to:

> All WordPress.com annual plans include a custom domain name. Register your free domain now.

## Test Instructions

**Natural steps:**

The "Register Domain" card appears when the user.
- Has a Free Dotcom site.
- Purchases a Paid Plan.
- The Paid Plan comes with a credit to redeem a custom domain.

**Quick steps:**
- Apply this changes:
   - Go to `DashboardCard.swift` file.
   - Change **line 140** to return `true`.
- Build the app and select any WP site.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
