### PR TITLE
Fix retain cycle in GutenbergViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [***] [Jetpack-only] Plans: Upgrade to a WPCOM plan from domains dashboard in Jetpack app. [#22261]
 * [**] [internal] Refactor domain selection flows to use the same domain selection UI. [22254]
 * [**] Re-enable the support for using Security Keys as a second factor during login [#22258]
+* [*] Fix crash in editor that sometimes happens after modifying tags or categories [#22265]
 
 23.9
 -----

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -47,9 +47,9 @@ class PrepublishingViewController: UITableViewController {
         return PublishSettingsViewModel(post: post)
     }()
 
-    private lazy var presentedVC: DrawerPresentationController? = {
+    private var presentedVC: DrawerPresentationController? {
         return (navigationController as? PrepublishingNavigationController)?.presentedVC
-    }()
+    }
 
     enum CompletionResult {
         case completed(AbstractPost)
@@ -133,13 +133,11 @@ class PrepublishingViewController: UITableViewController {
     /// Toggles `keyboardShown` as the keyboard notifications come in
     private func configureKeyboardToggle() {
         NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)
-            .map { _ in return true }
-            .assign(to: \.keyboardShown, on: self)
+            .sink { [weak self] _ in self?.keyboardShown = true }
             .store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)
-            .map { _ in return false }
-            .assign(to: \.keyboardShown, on: self)
+            .sink { [weak self] _ in self?.keyboardShown = false }
             .store(in: &cancellables)
     }
 


### PR DESCRIPTION
Fix some of the occurrences of https://github.com/wordpress-mobile/WordPress-iOS/issues/20647, namely the ones references in https://github.com/wordpress-mobile/WordPress-iOS/issues/20647#issuecomment-1865183321.

**RCA**

`PrepublishingViewController` had a retain cycle "thanks" to `assign(to:)`.

When "Tags" screen was presented this property was called for the first time:

```swift
private lazy var presentedVC: DrawerPresentationController? {
	return (navigationController as? PrepublishingNavigationController)?.presentedVC
}
```

I haven't followed the entire memory graph, but this property was evidently indirectly retaining the main `GutenbergViewController`. And because `PrepublishingViewController` had a retain cycle, it was also permanently retaining whatever was referenced by `presentedVC`.

To test:

- Set the breakpoint on `GutenbergViewController/deinit`
- Follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/issues/20647#issuecomment-1865183321
- Verify that the deinit is called

**Regression Testing**

- Verify that publishing and settings tags still work

## Regression Notes
1. Potential unintended areas of impact: Gutenberg
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
