### PR TITLE
Fix crash when search token are duplicated

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] Re-enable the support for using Security Keys as a second factor during login [#22258]
 * [*] Fix crash in editor that sometimes happens after modifying tags or categories [#22265]
 * [*] Add defensive code to make sure the retain cycles in the editor don't lead to crashes [#22252]
+* [*] Fix a rare crash in post search related to tags [#22275]
 
 23.9
 -----


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22269.

Adds defensive code to make sure the search tokens never have duplicates. It should not be possible to add duplicate tags in the first place, but evidently, there are some sites that do have duplicates.

To test:

- (Regression testing) Verify that tags are displayed as suggested search token

## Regression Notes
1. Potential unintended areas of impact: Post Search
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
