### PR TITLE
Fix rare crash when deleting posts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Fix crash in editor that sometimes happens after modifying tags or categories [#22265]
 * [*] Add defensive code to make sure the retain cycles in the editor don't lead to crashes [#22252]
 * [*] Fix a rare crash in post search related to tags [#22275]
+* [*] Fix a rare crash when deleting posts [#22277]
 * [***] Block Editor: Avoid keyboard dismiss when interacting with text blocks [https://github.com/WordPress/gutenberg/pull/57070]
 * [**] Block Editor: Auto-scroll upon block insertion [https://github.com/WordPress/gutenberg/pull/57273]
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -520,7 +520,8 @@ class PostCoordinator: NSObject {
             ActionDispatcher.dispatch(NoticeAction.dismiss)
             ActionDispatcher.dispatch(NoticeAction.post(notice))
 
-            setPendingDeletion(false, post: post)
+            // No need to notify as the object gets deleted
+            setPendingDeletion(false, post: post, notify: false)
         } catch {
             if let error = error as NSError?, error.code == Constants.httpCodeForbidden {
                 delegate?.postCoordinator(self, promptForPasswordForBlog: post.blog)
@@ -532,15 +533,17 @@ class PostCoordinator: NSObject {
         }
     }
 
-    private func setPendingDeletion(_ isDeleting: Bool, post: AbstractPost) {
+    private func setPendingDeletion(_ isDeleting: Bool, post: AbstractPost, notify: Bool = true) {
         if isDeleting {
             pendingDeletionPostIDs.insert(post.objectID)
         } else {
             pendingDeletionPostIDs.remove(post.objectID)
         }
-        NotificationCenter.default.post(name: .postCoordinatorDidUpdate, object: self, userInfo: [
-            NSUpdatedObjectsKey: Set([post])
-        ])
+        if notify {
+            NotificationCenter.default.post(name: .postCoordinatorDidUpdate, object: self, userInfo: [
+                NSUpdatedObjectsKey: Set([post])
+            ])
+        }
     }
 
     private func propertiesForAnalytics(for post: AbstractPost) -> [String: AnyObject] {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22247

I'm not entirely sure what leads to the crash https://a8c.sentry.io/issues/4716966489/?project=1438083&referrer=github_integration but it seems to be due to the order of updates/notifications when `PostCoordinator` deletes the post object and [sends](https://github.com/wordpress-mobile/WordPress-iOS/blob/706320690119b20e5f5e3553f45f243d05962634/WordPress/Classes/Services/PostCoordinator.swift#L523) the "object-did-update" notification at the same time. In order to address it, I simply removed the redundant "did-update" notification.

To test:

(In Posts Lists)

- Delete a post and verify that it gets deleted
- Mock the request failure or turn the connection off and verify that the post cell shows and hides the "Deleting.." message during the deletion attempt

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x]  I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
