### PR TITLE
Remove personalizeHomeTab feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Fix crash in editor that sometimes happens after modifying tags or categories [#22265]
 * [*] Add defensive code to make sure the retain cycles in the editor don't lead to crashes [#22252]
 * [**] [internal] [Jetpack-only] Adds support for dynamic dashboard cards driven by the backend [#22326]
+* [*] [internal] Remove personalizeHomeTab feature flag [#22280]
 * [*] Fix a rare crash in post search related to tags [#22275]
 * [*] Fix a rare crash when deleting posts [#22277]
 * [***] Block Editor: Avoid keyboard dismiss when interacting with text blocks [https://github.com/WordPress/gutenberg/pull/57070]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,7 +8,6 @@ enum FeatureFlag: Int, CaseIterable {
     case siteIconCreator
     case statsNewInsights
     case betaSiteDesigns
-    case personalizeHomeTab
     case commentModerationUpdate
     case compliancePopover
     case googleDomainsCard
@@ -32,8 +31,6 @@ enum FeatureFlag: Int, CaseIterable {
             return AppConfiguration.statsRevampV2Enabled
         case .betaSiteDesigns:
             return false
-        case .personalizeHomeTab:
-            return AppConfiguration.isJetpack
         case .commentModerationUpdate:
             return false
         case .compliancePopover:
@@ -74,8 +71,6 @@ extension FeatureFlag {
             return "New Cards for Stats Insights"
         case .betaSiteDesigns:
             return "Fetch Beta Site Designs"
-        case .personalizeHomeTab:
-            return "Personalize Home Tab"
         case .commentModerationUpdate:
             return "Comments Moderation Update"
         case .compliancePopover:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -109,8 +109,6 @@ extension DashboardPostsListCardCell {
     }
 
     private func addDraftsContextMenu(card: DashboardCard, blog: Blog) {
-        guard FeatureFlag.personalizeHomeTab.enabled else { return }
-
         frameView.addMoreMenu(items: [
             UIMenu(options: .displayInline, children: [
                 makeDraftsListMenuAction()
@@ -122,8 +120,6 @@ extension DashboardPostsListCardCell {
     }
 
     private func addScheduledContextMenu(card: DashboardCard, blog: Blog) {
-        guard FeatureFlag.personalizeHomeTab.enabled else { return }
-
         frameView.addMoreMenu(items: [
             UIMenu(options: .displayInline, children: [
                 makeScheduledListMenuAction()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -513,12 +513,6 @@ private extension DashboardPromptsCardCell {
         BlogDashboardAnalytics.trackHideTapped(for: .prompts)
         let service = BlogDashboardPersonalizationService(siteID: siteID)
         service.setEnabled(false, for: .prompts)
-        if !FeatureFlag.personalizeHomeTab.enabled {
-            let notice = Notice(title: Strings.promptRemovedTitle, message: Strings.promptRemovedSubtitle, feedbackType: .success, actionTitle: Strings.undoSkipTitle) { _ in
-                service.setEnabled(true, for: .prompts)
-            }
-            ActionDispatcher.dispatch(NoticeAction.post(notice))
-        }
     }
 
     func learnMoreTapped() {
@@ -547,12 +541,6 @@ private extension DashboardPromptsCardCell {
         static let errorTitle = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
         static let promptSkippedTitle = NSLocalizedString("Prompt skipped", comment: "Title of the notification presented when a prompt is skipped")
         static let undoSkipTitle = NSLocalizedString("Undo", comment: "Button in the notification presented when a prompt is skipped")
-        static let promptRemovedTitle = NSLocalizedString("prompts.notification.removed.title",
-                                                          value: "Blogging Prompts hidden",
-                                                          comment: "Title of the notification when prompts are hidden from the dashboard card")
-        static let promptRemovedSubtitle = NSLocalizedString("prompts.notification.removed.subtitle",
-                                                             value: "Visit Site Settings to turn back on",
-                                                             comment: "Subtitle of the notification when prompts are hidden from the dashboard card")
     }
 
     struct Style {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -76,16 +76,14 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
             self.showStats(for: blog, from: viewController)
         }
 
-        if FeatureFlag.personalizeHomeTab.enabled {
-            frameView.addMoreMenu(items: [
-                UIMenu(options: .displayInline, children: [
-                    makeShowStatsMenuAction(for: blog, in: viewController)
-                ]),
-                UIMenu(options: .displayInline, children: [
-                    BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, blog: blog)
-                ])
-            ], card: .todaysStats)
-        }
+        frameView.addMoreMenu(items: [
+            UIMenu(options: .displayInline, children: [
+                makeShowStatsMenuAction(for: blog, in: viewController)
+            ]),
+            UIMenu(options: .displayInline, children: [
+                BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, blog: blog)
+            ])
+        ], card: .todaysStats)
 
         statsStackView?.views = viewModel?.todaysViews
         statsStackView?.visitors = viewModel?.todaysVisitors

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
@@ -133,7 +133,7 @@ enum DashboardCard: String, CaseIterable {
         case .empty:
             return false // Controlled manually based on other cards visibility
         case .personalize:
-            return FeatureFlag.personalizeHomeTab.enabled
+            return true
         case .pages:
             return DashboardPagesListCardCell.shouldShowCard(for: blog) && shouldShowRemoteCard(apiResponse: apiResponse)
         case .activityLog:

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -55,7 +55,6 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         //
         // At the time of writing, the priority was getting some tests for new code to pass under the important Jetpac user path.
         // As such, here are a bunch of global-state feature flags overrides.
-        try? featureFlags.override(FeatureFlag.personalizeHomeTab, withValue: true)
         try? featureFlags.override(RemoteFeatureFlag.activityLogDashboardCard, withValue: true)
         try? featureFlags.override(RemoteFeatureFlag.pagesDashboardCard, withValue: true)
         try? featureFlags.override(FeatureFlag.googleDomainsCard, withValue: false)
@@ -66,7 +65,6 @@ class BlogDashboardServiceTests: CoreDataTestCase {
         super.tearDown()
         context = nil
 
-        try? featureFlags.override(FeatureFlag.personalizeHomeTab, withValue: FeatureFlag.personalizeHomeTab.originalValue)
         try? featureFlags.override(RemoteFeatureFlag.activityLogDashboardCard, withValue: RemoteFeatureFlag.activityLogDashboardCard.originalValue)
         try? featureFlags.override(RemoteFeatureFlag.pagesDashboardCard, withValue: RemoteFeatureFlag.pagesDashboardCard.originalValue)
         try? featureFlags.override(FeatureFlag.googleDomainsCard, withValue: FeatureFlag.googleDomainsCard.originalValue)


### PR DESCRIPTION
To test:

- Verify that "Personalize Home Tab" feature is still available.

## Regression Notes
1. Potential unintended areas of impact: Personalize Home Tab
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
