### PR TITLE
Update dynamic cards filtering logic to take into account the remote feature flag key

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Models/DashboardCard.swift
@@ -147,15 +147,21 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    func shouldShow(
+    static func shouldShowDynamicCard(
         for blog: Blog,
-        dynamicCardPayload: DashboardDynamicCardModel.Payload,
+        payload: DashboardDynamicCardModel.Payload,
+        remoteFeatureFlagStore: RemoteFeatureFlagStore,
         isJetpack: Bool = AppConfiguration.isJetpack
     ) -> Bool {
-        return self == .dynamic
-        && isJetpack
+        let remoteFeatureFlagEnabled = {
+            guard let key = payload.remoteFeatureFlag else {
+                return true
+            }
+            return remoteFeatureFlagStore.value(for: key) ?? false
+        }()
+        return isJetpack
         && RemoteDashboardCard.dynamic.supported(by: blog)
-        /* && Check if the current user has `dynamicCardPayload.remoteFeatureFlag` */
+        && remoteFeatureFlagEnabled
     }
 
     private func shouldShowRemoteCard(apiResponse: BlogDashboardRemoteEntity?) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardRemoteEntity.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardRemoteEntity.swift
@@ -57,7 +57,7 @@ extension BlogDashboardRemoteEntity {
     struct BlogDashboardDynamic: Decodable, Hashable {
 
         let id: String
-        let remoteFeatureFlag: String
+        let remoteFeatureFlag: String?
         let title: String?
         let featuredImage: String?
         let url: String?

--- a/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
@@ -11,7 +11,17 @@ class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
     var removalPhaseSelfHosted = false
     var removalPhaseStaticScreens = false
 
+    var enabledFeatureFlags = Set<String>()
+    var disabledFeatureFlag = Set<String>()
+
+    // MARK: - Access Remote Feature Flag Value
+
     override func value(for flagKey: String) -> Bool? {
+        if enabledFeatureFlags.contains(flagKey) {
+            return true
+        } else if disabledFeatureFlag.contains(flagKey) {
+            return false
+        }
         switch flagKey {
         case RemoteFeatureFlag.jetpackFeaturesRemovalPhaseOne.remoteKey:
             return removalPhaseOne


### PR DESCRIPTION
Fixes #22288

This PR updates the cards display logic to take into account the `remoteFeatureFlagKey`. A dynamic card is shown when:
- The `remoteFeatureFlagKey` attribute is `null`.
- The `remoteFeatureFlagKey` exists in the remote feature flags endpoint and is enabled.

## Test Instructions

**Prerequisites**
1. Install Jetpack and login.
2. Enable **Dynamic Cards** feature flag.

#### Case 1: Unknown Feature Flag Key
1. Navigate to `My Site`.
2. **Expect** Domain Management card to be hidden.

#### Case 2: Enabled Feature Flag
1. Open `RemoteFeatureFlagStore.swift` file
2. Update existing `value(for:)` method implementation with:
```swift
    public func value(for flagKey: String) -> Bool? {
        if flagKey == "domain_management_announcement_card" {
            return true
        }
        return cache[flagKey]
    }
```
3. Build and run Jetpack app.
4. **Expect** Domain Management card to be visible.

#### Case 3: Disabled Feature Flag
1. Open `RemoteFeatureFlagStore.swift` file
2. Update existing `value(for:)` method implementation with:
```swift
    public func value(for flagKey: String) -> Bool? {
        if flagKey == "domain_management_announcement_card" {
            return false
        }
        return cache[flagKey]
    }
```
3. Build and run Jetpack app.
4. **Expect** Domain Management card to be hidden.

## Regression Notes
1. Potential unintended areas of impact
Existing dynamic cards filtering logic.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)
I've updated existing unit tests to take into account these changes.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
