### PR TITLE
[Dynamic Dashboard Cards] Card Actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
@@ -27,12 +27,46 @@ final class BlogDashboardDynamicCardCoordinator {
 
     func didTapCard() {
         let payload = model.payload
+        if let urlString = model.payload.url,
+           let url = URL(string: urlString) {
+            routeToCardDestination(url: url)
+        }
         self.track(.cardTapped(id: payload.id, url: payload.url))
     }
 
     func didTapCardCTA() {
         let payload = model.payload
+        if let urlString = model.payload.url,
+           let url = URL(string: urlString) {
+            routeToCardDestination(url: url)
+        }
         self.track(.cardCtaTapped(id: payload.id, url: payload.url))
+    }
+
+    private func routeToCardDestination(url: URL) {
+        if UniversalLinkRouter.shared.canHandle(url: url) {
+            routeToUniversalURL(url: url)
+        } else {
+            routeToWebView(url: url)
+        }
+    }
+
+    private func routeToWebView(url: URL) {
+        guard UIApplication.shared.canOpenURL(url) else {
+            return
+        }
+        let configuration = WebViewControllerConfiguration(url: url)
+        configuration.authenticateWithDefaultAccount()
+        let controller = WebViewControllerFactory.controller(configuration: configuration, source: "dashboard")
+        let navController = UINavigationController(rootViewController: controller)
+        viewController?.present(navController, animated: true)
+    }
+
+    private func routeToUniversalURL(url: URL) {
+        if let urlString = model.payload.url,
+           let url = URL(string: urlString) {
+            UniversalLinkRouter.shared.handle(url: url)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
@@ -30,7 +30,7 @@ final class BlogDashboardDynamicCardCoordinator {
 
     func didTapCard() {
         let payload = model.payload
-        if let urlString = model.payload.url,
+        if let urlString = payload.url,
            let url = URL(string: urlString) {
             routeToCardDestination(url: url)
         }
@@ -66,10 +66,7 @@ final class BlogDashboardDynamicCardCoordinator {
     }
 
     private func routeToUniversalURL(url: URL) {
-        if let urlString = model.payload.url,
-           let url = URL(string: urlString) {
-            linkRouter.handle(url: url, shouldTrack: true, source: nil)
-        }
+        linkRouter.handle(url: url, shouldTrack: true, source: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
@@ -6,6 +6,7 @@ final class BlogDashboardDynamicCardCoordinator {
 
     private let analyticsTracker: AnalyticsEventTracking.Type
     private let model: DashboardDynamicCardModel
+    private let linkRouter: LinkRouter
 
     private weak var viewController: UIViewController?
 
@@ -13,9 +14,11 @@ final class BlogDashboardDynamicCardCoordinator {
 
     init(viewController: UIViewController?,
          model: DashboardDynamicCardModel,
+         linkRouter: LinkRouter = UniversalLinkRouter.shared,
          analyticsTracker: AnalyticsEventTracking.Type = WPAnalytics.self) {
         self.viewController = viewController
         self.model = model
+        self.linkRouter = linkRouter
         self.analyticsTracker = analyticsTracker
     }
 
@@ -44,7 +47,7 @@ final class BlogDashboardDynamicCardCoordinator {
     }
 
     private func routeToCardDestination(url: URL) {
-        if UniversalLinkRouter.shared.canHandle(url: url) {
+        if linkRouter.canHandle(url: url) {
             routeToUniversalURL(url: url)
         } else {
             routeToWebView(url: url)
@@ -65,7 +68,7 @@ final class BlogDashboardDynamicCardCoordinator {
     private func routeToUniversalURL(url: URL) {
         if let urlString = model.payload.url,
            let url = URL(string: urlString) {
-            UniversalLinkRouter.shared.handle(url: url)
+            linkRouter.handle(url: url, shouldTrack: true, source: nil)
         }
     }
 }

--- a/WordPress/WordPressTest/Dashboard/Dynamic Cards/BlogDashboardDynamicCardCoordinatorTests.swift
+++ b/WordPress/WordPressTest/Dashboard/Dynamic Cards/BlogDashboardDynamicCardCoordinatorTests.swift
@@ -65,9 +65,95 @@ final class BlogDashboardDynamicCardCoordinatorTests: XCTestCase {
         }))
     }
 
+    func test_didTapCardInvokesLinkRouterWhenURLMatches() {
+        // Given
+        let (id, url) = ("123", "https://wordpress.com")
+        var mockRouter = MockRouter(routes: [])
+        let expectation = expectation(description: "LinkRouter must invoke completion")
+        var isLinkInvoked = false
+
+        mockRouter.completion = { _, _ in
+            isLinkInvoked = true
+            expectation.fulfill()
+        }
+        let coordinator = makeCoordinator(id: id, url: url, linkRouter: mockRouter)
+
+        // When
+        coordinator.didTapCard()
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+        XCTAssert(isLinkInvoked)
+    }
+
+    func test_didTapCardDoesNotInvokeLinkRouterWhenURLInvalid() {
+        // Given
+        let (id, url) = ("123", "gibberish")
+        var mockRouter = MockRouter(routes: [])
+        mockRouter.canHandle = false
+        var isLinkInvoked = false
+
+        mockRouter.completion = { _, _ in
+            isLinkInvoked = true
+            XCTFail("completion shouldn't have ran")
+        }
+        let coordinator = makeCoordinator(id: id, url: url, linkRouter: mockRouter)
+
+        // When
+        coordinator.didTapCard()
+
+        // Then
+        XCTAssertFalse(isLinkInvoked)
+    }
+
+    func test_didTapCardCTAInvokesLinkRouterWhenURLMatches() {
+        // Given
+        let (id, url) = ("123", "https://wordpress.com")
+        var mockRouter = MockRouter(routes: [])
+        let expectation = expectation(description: "LinkRouter must invoke completion")
+        var isLinkInvoked = false
+
+        mockRouter.completion = { _, _ in
+            isLinkInvoked = true
+            expectation.fulfill()
+        }
+        let coordinator = makeCoordinator(id: id, url: url, linkRouter: mockRouter)
+
+        // When
+        coordinator.didTapCardCTA()
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+        XCTAssert(isLinkInvoked)
+    }
+
+    func test_didTapCardCTADoesNotInvokeLinkRouterWhenURLInvalid() {
+        // Given
+        let (id, url) = ("123", "gibberish")
+        var mockRouter = MockRouter(routes: [])
+        mockRouter.canHandle = false
+        var isLinkInvoked = false
+
+        mockRouter.completion = { _, _ in
+            isLinkInvoked = true
+            XCTFail("completion shouldn't have ran")
+        }
+        let coordinator = makeCoordinator(id: id, url: url, linkRouter: mockRouter)
+
+        // When
+        coordinator.didTapCardCTA()
+
+        // Then
+        XCTAssertFalse(isLinkInvoked)
+    }
+
     // MARK: - Helpers
 
-    private func makeCoordinator(id: String, url: String? = nil) -> BlogDashboardDynamicCardCoordinator {
+    private func makeCoordinator(
+        id: String,
+        url: String? = nil,
+        linkRouter: LinkRouter = MockRouter(routes: [])
+    ) -> BlogDashboardDynamicCardCoordinator {
         let payload = DashboardDynamicCardModel.Payload(
             id: id,
             remoteFeatureFlag: "default",
@@ -81,6 +167,7 @@ final class BlogDashboardDynamicCardCoordinatorTests: XCTestCase {
         return .init(
             viewController: UIViewController(),
             model: .init(payload: payload, dotComID: 1),
+            linkRouter: linkRouter,
             analyticsTracker: AnalyticsEventTrackingSpy.self
         )
     }

--- a/WordPress/WordPressTest/MBarRouteTests.swift
+++ b/WordPress/WordPressTest/MBarRouteTests.swift
@@ -4,6 +4,7 @@ import OHHTTPStubs
 
 struct MockRouter: LinkRouter {
     let matcher: RouteMatcher
+    var canHandle: Bool = true
     var completion: ((URL, DeepLinkSource?) -> Void)?
 
     init(routes: [Route]) {
@@ -11,7 +12,7 @@ struct MockRouter: LinkRouter {
     }
 
     func canHandle(url: URL) -> Bool {
-        return true
+        canHandle
     }
 
     func handle(url: URL, shouldTrack track: Bool, source: DeepLinkSource?) {


### PR DESCRIPTION
Fixes #22166

## Testing Steps
Install, launch and login Jetpack App. 
Enable Dynamic Dashboard Cards feature flag

### 🧪  Card Action
1. Expect the "Domains Management" card to appear.
2. Tap on the card and expect to be navigated to the All Domains Screen in `Me` tab.

### 🧪 Card CTA Action
1. Go back to My Site
2. Tap on the CTA and expect to be navigated to the same All Domains Screen

### 🧪 WebView 
1. Manipulate the URL to a random valid url like "https://google.com" Domains Management Card (the url in `BlogDashboardDynamicCardCoordinator` can be manipulated too on lines 32 and 41).
2. Tap on the card and expect the url will open in a web view.

### 🧪 Invalid URL Action
1. Manipulate the URL to an invalid URL for the Domains Management Card (the url in `BlogDashboardDynamicCardCoordinator` can be manipulated too on lines 32 and 41)
2. Tap on the card and expect that no navigation. The tap shouldn't cause any action. The same applies to the CTA.

## Regression Notes
1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
Added unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [ ] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)