### PR TITLE
Remove WPImageSource usages

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -7,7 +7,6 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "WordPress-Swift.h"
 #import "WPXMLRPCDecoder.h"
-#import <WordPressShared/WPImageSource.h>
 #import <WordPressShared/WPAnalytics.h>
 
 @import WordPressKit;

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -107,15 +107,10 @@ class JetpackSocialNoConnectionViewModel: ObservableObject {
 
             for task in downloadTasks {
                 let (url, index) = task
-                WPImageSource.shared().downloadImage(for: url) { image in
-                    guard let image else {
-                        return
-                    }
-                    DispatchQueue.main.async {
+                Task { @MainActor in
+                    if let image = try? await ImageDownloader.shared.image(from: url) {
                         self.icons[index] = image
                     }
-                } failure: { error in
-                    DDLogError("Error downloading icon: \(String(describing: error))")
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -335,13 +335,16 @@ private extension StatsTotalRow {
     }
 
     func downloadImageFrom(_ iconURL: URL) {
-        WPImageSource.shared()?.downloadImage(for: iconURL, withSuccess: { image in
-            self.imageView.image = image
-            self.imageView.backgroundColor = .clear
-        }, failure: { error in
-            DDLogInfo("Error downloading image: \(String(describing: error?.localizedDescription)). From URL: \(iconURL).")
-            self.imageView.isHidden = true
-        })
+        Task { @MainActor [weak self] in
+            do {
+                let image = try await ImageDownloader.shared.image(from: iconURL)
+                self?.imageView.image = image
+                self?.imageView.backgroundColor = .clear
+            } catch {
+                DDLogInfo("Error downloading image: \(error.localizedDescription). From URL: \(iconURL).")
+                self?.imageView.isHidden = true
+            }
+        }
     }
 
     func configureDataBar() {


### PR DESCRIPTION
Remove WPImageSource usage from MediaExternalExporter, JetpackSocialNoConnectionView, and StatsTotalRow. The app now uses an improved `ImageDownloader` that has memory cache, HTTP disk cache, and supports background decompression – among other things.

To test:

**MediaExternalExporter  (External Images)**

- Create a new Post
- Add "Image"
- Select "Free Photo Library" and pick an image
- Verify that the image got uploaded

**JetpackSocialNoConnectionView**

- Verify that Jetpack connection card images get downloaded

<img width="453" alt="Screenshot 2023-12-27 at 10 44 38 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b4a4c705-3042-4760-ad0d-5497235a906b">

**StatsTotalRow**

- Verify that Stats / Referrer images get downloaded and displayed

<img width="453" alt="Screenshot 2023-12-27 at 10 47 35 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/4b553fc3-8347-4a4d-9afc-dac97efd517c">

## Regression Notes
1. Potential unintended areas of impact: multiple
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
