### PR TITLE
Add "Share" site header action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 24.1
 -----
 * [*] Allow trashing draft and scheduled posts with no confirmation [#22337]
+* [*] Add "Share" action to the site context menu [#22298]
 
 24.0
 -----

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -269,6 +269,7 @@ import Foundation
     // My Site: Header Actions
     case mySiteHeaderMoreTapped
     case mySiteHeaderAddSiteTapped
+    case mySiteHeaderShareSiteTapped
     case mySiteHeaderPersonalizeHomeTapped
 
     // Site Switcher
@@ -1030,6 +1031,8 @@ import Foundation
             return "my_site_header_more_tapped"
         case .mySiteHeaderAddSiteTapped:
             return "my_site_header_add_site_tapped"
+        case .mySiteHeaderShareSiteTapped:
+            return "my_site_header_share_site_tapped"
         case .mySiteHeaderPersonalizeHomeTapped:
             return "my_site_header_personalize_home_tapped"
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -23,6 +23,7 @@ extension SitePickerViewController {
     private func makePrimarySection() -> UIMenu {
         var menuItems = [
             MenuItem.visitSite({ [weak self] in self?.visitSiteTapped() }),
+            MenuItem.shareSite { [weak self] in self?.buttonShareSiteTapped() },
             MenuItem.addSite({ [weak self] in self?.addSiteTapped()} ),
         ]
         if numberOfBlogs() > 1 {
@@ -44,6 +45,22 @@ extension SitePickerViewController {
         UIMenu(options: .displayInline, children: [
             MenuItem.personalizeHome({ [weak self] in self?.personalizeHomeTapped() }).toAction
         ])
+    }
+
+    // MARK: - Actions
+
+    private func buttonShareSiteTapped() {
+        guard let urlString = blog.homeURL as String?,
+              let url = URL(string: urlString) else {
+            assertionFailure("Site has no URL")
+            return
+        }
+        let viewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        if let popover = viewController.popoverPresentationController {
+            popover.barButtonItem = navigationItem.rightBarButtonItem
+        }
+        present(viewController, animated: true, completion: nil)
+        WPAnalytics.trackEvent(.mySiteHeaderShareSiteTapped)
     }
 
     // MARK: - Add site
@@ -123,6 +140,7 @@ extension SitePickerViewController {
 
 private enum MenuItem {
     case visitSite(_ handler: () -> Void)
+    case shareSite(_ handler: () -> Void)
     case addSite(_ handler: () -> Void)
     case switchSite(_ handler: () -> Void)
     case siteTitle(_ handler: () -> Void)
@@ -131,6 +149,7 @@ private enum MenuItem {
     var title: String {
         switch self {
         case .visitSite: return Strings.visitSite
+        case .shareSite: return Strings.shareSite
         case .addSite: return Strings.addSite
         case .switchSite: return Strings.switchSite
         case .siteTitle: return Strings.siteTitle
@@ -141,6 +160,7 @@ private enum MenuItem {
     var icon: UIImage? {
         switch self {
         case .visitSite: return UIImage(systemName: "safari")
+        case .shareSite: return UIImage(systemName: "square.and.arrow.up")
         case .addSite: return UIImage(systemName: "plus")
         case .switchSite: return UIImage(systemName: "arrow.triangle.swap")
         case .siteTitle: return UIImage(systemName: "character")
@@ -151,6 +171,7 @@ private enum MenuItem {
     var toAction: UIAction {
         switch self {
         case .visitSite(let handler),
+             .shareSite(let handler),
              .addSite(let handler),
              .switchSite(let handler),
              .siteTitle(let handler),
@@ -163,6 +184,7 @@ private enum MenuItem {
 private enum Strings {
     static let visitSite = NSLocalizedString("mySite.siteActions.visitSite", value: "Visit site", comment: "Menu title for the visit site option")
     static let addSite = NSLocalizedString("mySite.siteActions.addSite", value: "Add site", comment: "Menu title for the add site option")
+    static let shareSite = NSLocalizedString("mySite.siteActions.shareSite", value: "Share site", comment: "Menu title for the share site option")
     static let switchSite = NSLocalizedString("mySite.siteActions.switchSite", value: "Switch site", comment: "Menu title for the switch site option")
     static let siteTitle = NSLocalizedString("mySite.siteActions.siteTitle", value: "Change site title", comment: "Menu title for the change site title option")
     static let siteIcon = NSLocalizedString("mySite.siteActions.siteIcon", value: "Change site icon", comment: "Menu title for the change site icon option")


### PR DESCRIPTION
- Adds "Share" action

**RFC**

- Is it the right place for the new action?
- Does this action make sense?
- Would it make sense to expand the list of shortcuts further? It might be worth adding "Site Settings" that are currently hard to reach: you need to tap "More" and then scroll to the very bottom.
- Is there a better grouping for sections? I would suggest the following grouping: "Site Actions", "Site Settings", "Manage Sites", "Manage Dashboard".
- Are "Change Title" and "Change Icon" common actions and should they be in this menu? Can the new "Site Settings" action replace them?

<img width="389" alt="Screenshot 2023-12-27 at 11 21 10 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/a6cc3169-e4cb-482c-8913-adc683106305"> <img width="389" alt="Screenshot 2023-12-27 at 11 33 53 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/7944ca3b-714e-4311-bbcd-744e809cfeed">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
