### PR TITLE
Fix: Exclude sharing limit nudges from sites with Creator plan

### DIFF
--- a/WordPress/Classes/Models/Blog+JetpackSocial.swift
+++ b/WordPress/Classes/Models/Blog+JetpackSocial.swift
@@ -7,8 +7,8 @@ extension Blog {
     /// Whether the blog has Social auto-sharing limited.
     /// Note that sites hosted at WP.com has no Social sharing limitations.
     var isSocialSharingLimited: Bool {
-        let features = planActiveFeatures ?? []
-        return !isHostedAtWPcom && !features.contains(Constants.socialSharingFeature)
+        let hasUnlimitedSharing = (planActiveFeatures ?? []).contains(Constants.unlimitedSharingFeatureKey)
+        return !(isHostedAtWPcom || isAtomic() || hasUnlimitedSharing)
     }
 
     /// The auto-sharing limit information for the blog.
@@ -26,6 +26,6 @@ extension Blog {
     private enum Constants {
         /// The feature key listed in the blog's plan's features. At the moment, `social-shares-1000` means unlimited
         /// sharing, but in the future we might introduce a proper differentiation between 1000 and unlimited.
-        static let socialSharingFeature = "social-shares-1000"
+        static let unlimitedSharingFeatureKey = "social-shares-1000"
     }
 }

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
@@ -115,6 +115,27 @@ class DashboardJetpackSocialCardCellTests: CoreDataTestCase {
         // Then
         XCTAssertEqual(subject.displayState, .none)
     }
+
+    // MARK: Atomic Site Tests
+
+    // In some cases, atomic sites could sometimes get limited sharing from the API.
+    // We'll need to ignore any sharing limit information if it's a Simple or Atomic site.
+    // Refs: p9F6qB-dLk-p2#comment-56603
+    func testCardOutOfSharesDoesNotDisplayForAtomicSites() throws {
+        // Given, when
+        let blog = createTestBlog(isAtomic: true, hasConnections: true, publicizeInfoState: .exceedingLimit)
+
+        // Then
+        XCTAssertFalse(shouldShowCard(for: blog))
+    }
+
+    func testCardNoConnectionDisplaysForAtomicSites() throws {
+        // Given, when
+        let blog = createTestBlog(isAtomic: true)
+
+        // Then
+        XCTAssertTrue(shouldShowCard(for: blog))
+    }
 }
 
 // MARK: - Helpers
@@ -125,13 +146,22 @@ private extension DashboardJetpackSocialCardCellTests {
         return DashboardJetpackSocialCardCell.shouldShowCard(for: blog)
     }
 
+    enum PublicizeInfoState {
+        case none
+        case belowLimit
+        case exceedingLimit
+    }
+
     func createTestBlog(isPublicizeSupported: Bool = true,
+                        isAtomic: Bool = false,
                         hasServices: Bool = true,
-                        hasConnections: Bool = false) -> Blog {
+                        hasConnections: Bool = false,
+                        publicizeInfoState: PublicizeInfoState = .none) -> Blog {
         var builder = BlogBuilder(mainContext)
             .withAnAccount()
             .with(dotComID: 12345)
             .with(capabilities: [.PublishPosts])
+            .with(atomic: isAtomic)
 
         if isPublicizeSupported {
             builder = builder.with(modules: ["publicize"])
@@ -145,7 +175,27 @@ private extension DashboardJetpackSocialCardCellTests {
             let connection = PublicizeConnection(context: mainContext)
             builder = builder.with(connections: [connection])
         }
-        return builder.build()
+
+        let blog = builder.build()
+
+        switch publicizeInfoState {
+        case .belowLimit:
+            let publicizeInfo = PublicizeInfo(context: mainContext)
+            publicizeInfo.shareLimit = 30
+            publicizeInfo.sharesRemaining = 25
+            blog.publicizeInfo = publicizeInfo
+            break
+        case .exceedingLimit:
+            let publicizeInfo = PublicizeInfo(context: mainContext)
+            publicizeInfo.shareLimit = 30
+            publicizeInfo.sharesRemaining = 0
+            blog.publicizeInfo = publicizeInfo
+            break
+        default:
+            break
+        }
+
+        return blog
     }
 
     func createPublicizeService() -> PublicizeService {

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardJetpackSocialCardCellTests.swift
@@ -80,6 +80,14 @@ class DashboardJetpackSocialCardCellTests: CoreDataTestCase {
         XCTAssertFalse(shouldShowCard(for: blog))
     }
 
+    func testCardDisplaysWhenJetpackSiteRunsOutOfShares() throws {
+        // Given, when
+        let blog = createTestBlog(hasConnections: true, publicizeInfoState: .exceedingLimit)
+
+        // Then
+        XCTAssertTrue(shouldShowCard(for: blog))
+    }
+
     // MARK: - Card state tests
 
     func testInitialCardState() {
@@ -173,6 +181,7 @@ private extension DashboardJetpackSocialCardCellTests {
 
         if hasConnections {
             let connection = PublicizeConnection(context: mainContext)
+            connection.status = "ok"
             builder = builder.with(connections: [connection])
         }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/issues/19641

Sometimes, atomic sites can get social sharing limit information from the remote. This PR fixes the issue by adding a client-side guard that ignores this information for atomic and WP.com sites.

## To test

1. Create an atomic site
2. Connect a social account
3. Post until you've exhausted all social sharing limits.
4. Verify that the "Out of shares" card/nudges are not shown in the dashboard, Post Settings, and the Pre-publishing Sheet.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes with a site that could reproduce the issue.

6. What automated tests I added (or what prevented me from doing so)
Added unit tests to cover for atomic test scenarios.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:

N/A. This PR does not contain UI changes.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
