### PR TITLE
Fix crash when accessing widget week summary data outside bounds

### DIFF
--- a/Modules/Sources/JetpackStatsWidgetsCore/Model/ThisWeekWidgetStats.swift
+++ b/Modules/Sources/JetpackStatsWidgetsCore/Model/ThisWeekWidgetStats.swift
@@ -1,35 +1,44 @@
 import Foundation
-import WordPressKit
 
 /// This struct contains data for 'Views This Week' stats to be displayed in the corresponding widget.
 ///
 
-struct ThisWeekWidgetStats: Codable {
-    let days: [ThisWeekWidgetDay]
+public struct ThisWeekWidgetStats: Codable {
+    public let days: [ThisWeekWidgetDay]
 
-    init(days: [ThisWeekWidgetDay]? = []) {
+    public init(days: [ThisWeekWidgetDay]? = []) {
         self.days = days ?? []
     }
 }
 
-struct ThisWeekWidgetDay: Codable, Hashable {
-    let date: Date
-    let viewsCount: Int
-    let dailyChangePercent: Float
+public struct ThisWeekWidgetDay: Codable, Hashable {
+    public let date: Date
+    public let viewsCount: Int
+    public let dailyChangePercent: Float
 
-    init(date: Date, viewsCount: Int, dailyChangePercent: Float) {
+    public init(date: Date, viewsCount: Int, dailyChangePercent: Float) {
         self.date = date
         self.viewsCount = viewsCount
         self.dailyChangePercent = dailyChangePercent
     }
 }
 
-extension ThisWeekWidgetStats {
+public extension ThisWeekWidgetStats {
+    struct Input {
+        public let periodStartDate: Date
+        public let viewsCount: Int
+
+        public init(periodStartDate: Date, viewsCount: Int) {
+            self.periodStartDate = periodStartDate
+            self.viewsCount = viewsCount
+        }
+    }
+
     static var maxDaysToDisplay: Int {
         return 7
     }
 
-    static func daysFrom(summaryData: [StatsSummaryData]) -> [ThisWeekWidgetDay] {
+    static func daysFrom(summaryData: [ThisWeekWidgetStats.Input]) -> [ThisWeekWidgetDay] {
         var days = [ThisWeekWidgetDay]()
 
         for index in 0..<maxDaysToDisplay {
@@ -59,13 +68,13 @@ extension ThisWeekWidgetStats {
 }
 
 extension ThisWeekWidgetStats: Equatable {
-    static func == (lhs: ThisWeekWidgetStats, rhs: ThisWeekWidgetStats) -> Bool {
+    public static func == (lhs: ThisWeekWidgetStats, rhs: ThisWeekWidgetStats) -> Bool {
         return lhs.days.elementsEqual(rhs.days)
     }
 }
 
 extension ThisWeekWidgetDay: Equatable {
-    static func == (lhs: ThisWeekWidgetDay, rhs: ThisWeekWidgetDay) -> Bool {
+    public static func == (lhs: ThisWeekWidgetDay, rhs: ThisWeekWidgetDay) -> Bool {
         return lhs.date == rhs.date &&
         lhs.viewsCount == rhs.viewsCount &&
         lhs.dailyChangePercent == rhs.dailyChangePercent

--- a/Modules/Tests/JetpackStatsWidgetsCoreTests/ThisWeekWidgetStatsTests.swift
+++ b/Modules/Tests/JetpackStatsWidgetsCoreTests/ThisWeekWidgetStatsTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import JetpackStatsWidgetsCore
+
+final class ThisWeekWidgetStatsTests: XCTestCase {
+    func testDaysFromSummaryData_moreSummaryData() {
+        var summaryData: [ThisWeekWidgetStats.Input] = []
+
+        // Given there's summary data for more than max days to display
+        for _ in 0..<ThisWeekWidgetStats.maxDaysToDisplay + 10 {
+            summaryData.append(ThisWeekWidgetStats.Input(periodStartDate: Date(), viewsCount: 1))
+        }
+
+        // Then the method should not crash
+        // and return maxDaysToDisplay number of days
+        let days = ThisWeekWidgetStats.daysFrom(summaryData: summaryData)
+        XCTAssertEqual(days.count, ThisWeekWidgetStats.maxDaysToDisplay)
+    }
+
+    func testDaysFromSummaryData_lessSummaryData() {
+        var summaryData: [ThisWeekWidgetStats.Input] = []
+
+        // Given there's summary data for less than max days to display
+        for _ in 0..<ThisWeekWidgetStats.maxDaysToDisplay - 1 {
+            summaryData.append(ThisWeekWidgetStats.Input(periodStartDate: Date(), viewsCount: 1))
+        }
+
+        // Then the method should not crash
+        // and have expected number of This Week data
+        let days = ThisWeekWidgetStats.daysFrom(summaryData: summaryData)
+        XCTAssertEqual(days.count, ThisWeekWidgetStats.maxDaysToDisplay - 2)
+    }
+}

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -251,7 +251,7 @@ extension StatsWidgetsStore {
             }
             let summaryData = Array(summary?.summaryData.reversed().prefix(ThisWeekWidgetStats.maxDaysToDisplay + 1) ?? [])
 
-            let stats = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
+            let stats = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData.map { ThisWeekWidgetStats.Input(periodStartDate: $0.periodStartDate, viewsCount: $0.viewsCount) }))
             StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetThisWeekData.self, stats: stats)
         case .week:
             WidgetCenter.shared.reloadThisWeekTimelines()

--- a/WordPress/JetpackStatsWidgets/Model/ListViewData.swift
+++ b/WordPress/JetpackStatsWidgets/Model/ListViewData.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import JetpackStatsWidgetsCore
 
 struct ListViewData {
 

--- a/WordPress/JetpackStatsWidgets/Model/ThisWeekWidgetStats.swift
+++ b/WordPress/JetpackStatsWidgets/Model/ThisWeekWidgetStats.swift
@@ -33,7 +33,7 @@ extension ThisWeekWidgetStats {
         var days = [ThisWeekWidgetDay]()
 
         for index in 0..<maxDaysToDisplay {
-            guard index + 1 <= summaryData.endIndex else {
+            guard index + 1 < summaryData.endIndex else {
                 break
             }
 

--- a/WordPress/JetpackStatsWidgets/Remote service/StatsWidgetsService.swift
+++ b/WordPress/JetpackStatsWidgets/Remote service/StatsWidgetsService.swift
@@ -156,7 +156,7 @@ class StatsWidgetsService {
                                                        url: widgetData.url,
                                                        timeZone: widgetData.timeZone,
                                                        date: Date(),
-                                                       stats: ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData)))
+                                                       stats: ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData.map { ThisWeekWidgetStats.Input(periodStartDate: $0.periodStartDate, viewsCount: $0.viewsCount) })))
             completion(.success(newWidgetData))
 
             DispatchQueue.global().async {

--- a/WordPress/JetpackStatsWidgets/Views/ListStatsView.swift
+++ b/WordPress/JetpackStatsWidgets/Views/ListStatsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WidgetKit
+import JetpackStatsWidgetsCore
 
 struct ListStatsView: View {
     @Environment(\.widgetFamily) var family: WidgetFamily

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
@@ -1,5 +1,6 @@
 import WidgetKit
 import SwiftUI
+import JetpackStatsWidgetsCore
 
 
 struct HomeWidgetThisWeek: Widget {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -72,7 +72,6 @@
 		0107E0C028F97D5000DE87DB /* HomeWidgetToday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F526C522538CF2A0069706C /* HomeWidgetToday.swift */; };
 		0107E0C128F97D5000DE87DB /* FlexibleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A2E254216550048A9E4 /* FlexibleCard.swift */; };
 		0107E0C228F97D5000DE87DB /* VerticalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A1E254213B60048A9E4 /* VerticalCard.swift */; };
-		0107E0C328F97D5000DE87DB /* ThisWeekWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F93181239AF64800E4E96E /* ThisWeekWidgetStats.swift */; };
 		0107E0C428F97D5000DE87DB /* HomeWidgetAllTimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5C861925C9EA2500BABE64 /* HomeWidgetAllTimeData.swift */; };
 		0107E0C528F97D5000DE87DB /* GroupedViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE20C1425CF165700A15525 /* GroupedViewData.swift */; };
 		0107E0C628F97D5000DE87DB /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
@@ -107,7 +106,6 @@
 		0107E11528FD7FE500DE87DB /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25FA332609AAAA0005E08F /* AppConfiguration.swift */; };
 		0107E11628FD7FE800DE87DB /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25FA332609AAAA0005E08F /* AppConfiguration.swift */; };
 		0107E13B28FE9DB200DE87DB /* Sites.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F46AB0225BF5D6300CE2E98 /* Sites.intentdefinition */; settings = {ATTRIBUTES = (codegen, ); }; };
-		0107E13C28FE9DB200DE87DB /* ThisWeekWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F93181239AF64800E4E96E /* ThisWeekWidgetStats.swift */; };
 		0107E13D28FE9DB200DE87DB /* HomeWidgetAllTimeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5C861925C9EA2500BABE64 /* HomeWidgetAllTimeData.swift */; };
 		0107E13E28FE9DB200DE87DB /* SitesDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1482CDF2575BDA4007E4DD6 /* SitesDataProvider.swift */; };
 		0107E13F28FE9DB200DE87DB /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
@@ -2606,7 +2604,6 @@
 		98ED5964265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */; };
 		98F537A722496CF300B334F9 /* SiteStatsTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F537A622496CF300B334F9 /* SiteStatsTableHeaderView.swift */; };
 		98F537A922496D0D00B334F9 /* SiteStatsTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98F537A822496D0D00B334F9 /* SiteStatsTableHeaderView.xib */; };
-		98F93182239AF64800E4E96E /* ThisWeekWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F93181239AF64800E4E96E /* ThisWeekWidgetStats.swift */; };
 		98FCFC232231DF43006ECDD4 /* PostStatsTitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FCFC212231DF43006ECDD4 /* PostStatsTitleCell.swift */; };
 		98FCFC242231DF43006ECDD4 /* PostStatsTitleCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98FCFC222231DF43006ECDD4 /* PostStatsTitleCell.xib */; };
 		98FF6A3E23A30A250025FD72 /* QuickStartNavigationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98FF6A3D23A30A240025FD72 /* QuickStartNavigationSettings.swift */; };
@@ -4511,7 +4508,6 @@
 		FABB22382602FC2C00C8785C /* EventLoggingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913BB0D24B3C58B00C19032 /* EventLoggingDelegate.swift */; };
 		FABB223B2602FC2C00C8785C /* AbstractPost+Searchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74729CAD205722E300D1394D /* AbstractPost+Searchable.swift */; };
 		FABB223C2602FC2C00C8785C /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
-		FABB223D2602FC2C00C8785C /* ThisWeekWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F93181239AF64800E4E96E /* ThisWeekWidgetStats.swift */; };
 		FABB223E2602FC2C00C8785C /* PostAutoUploadMessageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16C35D923F3F76C00C81331 /* PostAutoUploadMessageProvider.swift */; };
 		FABB223F2602FC2C00C8785C /* GutenbergMediaPickerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */; };
 		FABB22402602FC2C00C8785C /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
@@ -7928,7 +7924,6 @@
 		98F4044E26BB69A000BBD8B9 /* WordPress 131.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 131.xcdatamodel"; sourceTree = "<group>"; };
 		98F537A622496CF300B334F9 /* SiteStatsTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsTableHeaderView.swift; sourceTree = "<group>"; };
 		98F537A822496D0D00B334F9 /* SiteStatsTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SiteStatsTableHeaderView.xib; sourceTree = "<group>"; };
-		98F93181239AF64800E4E96E /* ThisWeekWidgetStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThisWeekWidgetStats.swift; sourceTree = "<group>"; };
 		98FB6E9F23074CE5002DDC8D /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		98FBA05426B228CB004E610A /* WordPress 129.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 129.xcdatamodel"; sourceTree = "<group>"; };
 		98FCFC212231DF43006ECDD4 /* PostStatsTitleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStatsTitleCell.swift; sourceTree = "<group>"; };
@@ -11863,7 +11858,6 @@
 			isa = PBXGroup;
 			children = (
 				98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */,
-				98F93181239AF64800E4E96E /* ThisWeekWidgetStats.swift */,
 				98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */,
 				3F6DA04025646F96002AB88F /* HomeWidgetData.swift */,
 				3F5C861925C9EA2500BABE64 /* HomeWidgetAllTimeData.swift */,
@@ -21032,7 +21026,6 @@
 				0107E0C128F97D5000DE87DB /* FlexibleCard.swift in Sources */,
 				0107E0C228F97D5000DE87DB /* VerticalCard.swift in Sources */,
 				C9B477A929CC13CB008CBF49 /* LockScreenSiteListProvider.swift in Sources */,
-				0107E0C328F97D5000DE87DB /* ThisWeekWidgetStats.swift in Sources */,
 				0107E0C428F97D5000DE87DB /* HomeWidgetAllTimeData.swift in Sources */,
 				0107E0C528F97D5000DE87DB /* GroupedViewData.swift in Sources */,
 				C9C21D7829BECFC7009F68E5 /* LockScreenStatsWidget.swift in Sources */,
@@ -21080,7 +21073,6 @@
 			files = (
 				0167F4B62AAA0342005B9E42 /* WidgetConfiguration.swift in Sources */,
 				0107E13B28FE9DB200DE87DB /* Sites.intentdefinition in Sources */,
-				0107E13C28FE9DB200DE87DB /* ThisWeekWidgetStats.swift in Sources */,
 				0107E16F28FFEF4500DE87DB /* AppConfiguration.swift in Sources */,
 				0107E13D28FE9DB200DE87DB /* HomeWidgetAllTimeData.swift in Sources */,
 				0107E13E28FE9DB200DE87DB /* SitesDataProvider.swift in Sources */,
@@ -21598,7 +21590,6 @@
 				DC772AF5282009BA00664C02 /* StatsLineChartView.swift in Sources */,
 				74729CAE205722E300D1394D /* AbstractPost+Searchable.swift in Sources */,
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
-				98F93182239AF64800E4E96E /* ThisWeekWidgetStats.swift in Sources */,
 				0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */,
 				F16C35DA23F3F76C00C81331 /* PostAutoUploadMessageProvider.swift in Sources */,
 				91D8364121946EFB008340B2 /* GutenbergMediaPickerHelper.swift in Sources */,
@@ -24428,7 +24419,6 @@
 				08E6E07F2A4C405500B807B0 /* CompliancePopoverViewModel.swift in Sources */,
 				FAA9084D27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */,
 				FABB223C2602FC2C00C8785C /* EditCommentViewController.m in Sources */,
-				FABB223D2602FC2C00C8785C /* ThisWeekWidgetStats.swift in Sources */,
 				FABB223E2602FC2C00C8785C /* PostAutoUploadMessageProvider.swift in Sources */,
 				FABB223F2602FC2C00C8785C /* GutenbergMediaPickerHelper.swift in Sources */,
 				0CB424EF2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift in Sources */,


### PR DESCRIPTION
Fixes #22313

`endIdex` is the array’s “past the end” position—that is, the position one greater than the last valid subscript argument. (https://developer.apple.com/documentation/swift/array/endindex)

If `summaryData.count` is n (5), `endIndex` will be equal to n (5). If we pass index 4, index + 1 will be outside the boundaries of summaryData, because array with n=5, has max index of n-1.

## To test:

I couldn't find ways to reproduce the issue but I wrote unit tests to confirm that it's fixed. You can revert the fix and run the unit test again to observe the crash.

## Regression Notes
1. Potential unintended areas of impact

Couldn't identify

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Added unit tests

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
