### PR TITLE
Show Bloganuary card in January

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
@@ -27,14 +27,14 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
         }
 
         // Check for date eligibility.
-        let isDateInDecember: Bool = {
+        let isDateWithinEligibleMonths: Bool = {
             let components = date.dateAndTimeComponents()
             guard let month = components.month else {
                 return false
             }
 
-            // NOTE: For simplicity, we're going to hardcode the date check if the date is within December.
-            return month == 12
+            // NOTE: For simplicity, we're going to hardcode the date check if the date is within December or January.
+            return Constants.eligibleMonths.contains(month)
         }()
 
         // Check if the blog is marked as a potential blogging site.
@@ -42,7 +42,7 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
             return (try? BloggingPromptSettings.of(blog))?.isPotentialBloggingSite ?? false
         }
 
-        return isDateInDecember && isPotentialBloggingSite
+        return isDateWithinEligibleMonths && isPotentialBloggingSite
     }
 
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
@@ -111,6 +111,11 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
 
         return frameView
     }
+
+    struct Constants {
+        // Only show the card in December and January.
+        static let eligibleMonths = [1, 12]
+    }
 }
 
 // MARK: - SwiftUI
@@ -144,7 +149,7 @@ private struct BloganuaryNudgeCardView: View {
 
     var textContainer: some View {
         VStack(alignment: .leading, spacing: 8.0) {
-            Text(Strings.title)
+            Text(cardTitle)
                 .font(.headline)
                 .fontWeight(.semibold)
             Text(Strings.description)
@@ -153,11 +158,28 @@ private struct BloganuaryNudgeCardView: View {
         }
     }
 
+    var cardTitle: String {
+        let components = Date().dateAndTimeComponents()
+        guard let month = components.month,
+              DashboardBloganuaryCardCell.Constants.eligibleMonths.contains(month) else {
+            return Strings.title
+        }
+
+        return month == 1 ? Strings.runningTitle : Strings.title
+    }
+
     struct Strings {
         static let title = NSLocalizedString(
             "bloganuary.dashboard.card.title",
             value: "Bloganuary is coming!",
             comment: "Title for the Bloganuary dashboard card."
+        )
+
+        // The card title string to be shown while Bloganuary is running
+        static let runningTitle = NSLocalizedString(
+            "bloganuary.dashboard.card.runningTitle",
+            value: "Bloganuary is here!",
+            comment: "Title for the Bloganuary dashboard card while Bloganuary is running."
         )
 
         static let description = NSLocalizedString(

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -1354,6 +1354,9 @@
 /* Short description for the Bloganuary event, shown right below the title. */
 "bloganuary.dashboard.card.description" = "For the month of January, blogging prompts will come from Bloganuary — our community challenge to build a blogging habit for the new year.";
 
+/* Title for the Bloganuary dashboard card while Bloganuary is running. */
+"bloganuary.dashboard.card.runningTitle" = "Bloganuary is here!";
+
 /* Title for the Bloganuary dashboard card. */
 "bloganuary.dashboard.card.title" = "Bloganuary is coming!";
 

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardBloganuaryCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardBloganuaryCardCellTests.swift
@@ -49,14 +49,14 @@ final class DashboardBloganuaryCardCellTests: CoreDataTestCase {
         XCTAssertFalse(result)
     }
 
-    func testCardIsNotShownForEligibleSitesOutsideDecember() throws {
+    func testCardIsNotShownForEligibleSitesOutsideEligibleMonths() throws {
         // Given
         let blog = makeBlog()
         makeBloggingPromptSettings()
         try mainContext.save()
 
         // When
-        let result = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInJanuary)
+        let result = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInFebruary)
 
         // Then
         XCTAssertFalse(result)
@@ -69,10 +69,12 @@ final class DashboardBloganuaryCardCellTests: CoreDataTestCase {
         try mainContext.save()
 
         // When
-        let result = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInDecember)
+        let resultForDecember = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInDecember)
+        let resultForJanuary = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInJanuary)
 
         // Then
-        XCTAssertTrue(result)
+        XCTAssertTrue(resultForDecember)
+        XCTAssertTrue(resultForJanuary)
     }
 
     func testCardIsShownForEligibleSitesThatHavePromptsDisabled() throws {
@@ -107,6 +109,16 @@ private extension DashboardBloganuaryCardCellTests {
         let date = Date()
         var components = Self.calendar.dateComponents([.year, .month, .day], from: date)
         components.month = 1
+        components.year = 2024
+        components.day = 10
+
+        return Self.calendar.date(from: components) ?? date
+    }
+
+    var sometimeInFebruary: Date {
+        let date = Date()
+        var components = Self.calendar.dateComponents([.year, .month, .day], from: date)
+        components.month = 2
         components.year = 2024
         components.day = 10
 


### PR DESCRIPTION
### Copy of https://github.com/wordpress-mobile/WordPress-iOS/pull/22312 targeting `trunk`.

> [!NOTE]
> I also ran `bundle exec fastlane generate_strings_file_for_glotpress` and only committed the Bloganuary string changes.

---

Refs pcdRpT-4FE-p2#comment-8278

Show the Bloganuary card in January.

## To test

- Launch the Jetpack app
- Log in with your WP.com account
- 🔎  If you are testing in January, verify that the Bloganuary card is shown. 
  - Otherwise, you can modify your device's date temporarily to January.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
Updated the unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)