### PR TITLE
[Do not merge] Revert "Show Bloganuary card in January (#22312)"

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
@@ -27,14 +27,14 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
         }
 
         // Check for date eligibility.
-        let isDateWithinEligibleMonths: Bool = {
+        let isDateInDecember: Bool = {
             let components = date.dateAndTimeComponents()
             guard let month = components.month else {
                 return false
             }
 
-            // NOTE: For simplicity, we're going to hardcode the date check if the date is within December or January.
-            return Constants.eligibleMonths.contains(month)
+            // NOTE: For simplicity, we're going to hardcode the date check if the date is within December.
+            return month == 12
         }()
 
         // Check if the blog is marked as a potential blogging site.
@@ -42,7 +42,7 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
             return (try? BloggingPromptSettings.of(blog))?.isPotentialBloggingSite ?? false
         }
 
-        return isDateWithinEligibleMonths && isPotentialBloggingSite
+        return isDateInDecember && isPotentialBloggingSite
     }
 
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
@@ -111,11 +111,6 @@ class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
 
         return frameView
     }
-
-    struct Constants {
-        // Only show the card in December and January.
-        static let eligibleMonths = [1, 12]
-    }
 }
 
 // MARK: - SwiftUI
@@ -149,7 +144,7 @@ private struct BloganuaryNudgeCardView: View {
 
     var textContainer: some View {
         VStack(alignment: .leading, spacing: 8.0) {
-            Text(cardTitle)
+            Text(Strings.title)
                 .font(.headline)
                 .fontWeight(.semibold)
             Text(Strings.description)
@@ -158,28 +153,11 @@ private struct BloganuaryNudgeCardView: View {
         }
     }
 
-    var cardTitle: String {
-        let components = Date().dateAndTimeComponents()
-        guard let month = components.month,
-              DashboardBloganuaryCardCell.Constants.eligibleMonths.contains(month) else {
-            return Strings.title
-        }
-
-        return month == 1 ? Strings.runningTitle : Strings.title
-    }
-
     struct Strings {
         static let title = NSLocalizedString(
             "bloganuary.dashboard.card.title",
             value: "Bloganuary is coming!",
             comment: "Title for the Bloganuary dashboard card."
-        )
-
-        // The card title string to be shown while Bloganuary is running
-        static let runningTitle = NSLocalizedString(
-            "bloganuary.dashboard.card.runningTitle",
-            value: "Bloganuary is here!",
-            comment: "Title for the Bloganuary dashboard card while Bloganuary is running."
         )
 
         static let description = NSLocalizedString(

--- a/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardBloganuaryCardCellTests.swift
+++ b/WordPress/WordPressTest/Blog Dashboard/Cards/DashboardBloganuaryCardCellTests.swift
@@ -49,14 +49,14 @@ final class DashboardBloganuaryCardCellTests: CoreDataTestCase {
         XCTAssertFalse(result)
     }
 
-    func testCardIsNotShownForEligibleSitesOutsideEligibleMonths() throws {
+    func testCardIsNotShownForEligibleSitesOutsideDecember() throws {
         // Given
         let blog = makeBlog()
         makeBloggingPromptSettings()
         try mainContext.save()
 
         // When
-        let result = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInFebruary)
+        let result = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInJanuary)
 
         // Then
         XCTAssertFalse(result)
@@ -69,12 +69,10 @@ final class DashboardBloganuaryCardCellTests: CoreDataTestCase {
         try mainContext.save()
 
         // When
-        let resultForDecember = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInDecember)
-        let resultForJanuary = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInJanuary)
+        let result = DashboardBloganuaryCardCell.shouldShowCard(for: blog, date: sometimeInDecember)
 
         // Then
-        XCTAssertTrue(resultForDecember)
-        XCTAssertTrue(resultForJanuary)
+        XCTAssertTrue(result)
     }
 
     func testCardIsShownForEligibleSitesThatHavePromptsDisabled() throws {
@@ -109,16 +107,6 @@ private extension DashboardBloganuaryCardCellTests {
         let date = Date()
         var components = Self.calendar.dateComponents([.year, .month, .day], from: date)
         components.month = 1
-        components.year = 2024
-        components.day = 10
-
-        return Self.calendar.date(from: components) ?? date
-    }
-
-    var sometimeInFebruary: Date {
-        let date = Date()
-        var components = Self.calendar.dateComponents([.year, .month, .day], from: date)
-        components.month = 2
         components.year = 2024
         components.day = 10
 


### PR DESCRIPTION
> [!CAUTION]
> Do not merge. This is only necessary if we cannot get translations by this Friday (2024-01-05).

Refs:
- p1704229942875869-slack-C02AED43D
- p1704210528902609-slack-CC7L49W13

## Description

This reverts the changes made by #22312.

## Testing

To test:
- Launch the Jetpack app
- Log in with your WP.com account
- 🔎 If you are testing in January, verify that the Bloganuary card is **NOT** shown.
  - Otherwise, you can modify your device's date temporarily to January.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)