### PR TITLE
Tracks: Include blog ID in events when media uploads fail

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -170,7 +170,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     if (error.code == NSURLErrorCancelled) {
         [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadCanceled withBlog:blog];
     } else {
-        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error withBlog:blog];
+        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error withBlogID:blog.dotComID];
     }
 }
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -82,7 +82,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     void (^failureBlock)(NSError *error) = ^(NSError *error) {
         [self.managedObjectContext performBlock:^{
             if (error) {
-                [self trackUploadError:error];
+                [self trackUploadError:error blog:blog];
                 DDLogError(@"Error uploading media: %@", error);
             }
             NSError *customError = [self customMediaUploadError:error remote:remote];
@@ -165,11 +165,12 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 #pragma mark - Private helpers
 
 - (void)trackUploadError:(NSError *)error
+                    blog:(Blog *)blog
 {
     if (error.code == NSURLErrorCancelled) {
-        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadCanceled];
+        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadCanceled withBlog:blog];
     } else {
-        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error];
+        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed withBlog:blog error:error];
     }
 }
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -170,7 +170,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     if (error.code == NSURLErrorCancelled) {
         [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadCanceled withBlog:blog];
     } else {
-        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed withBlog:blog error:error];
+        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error withBlog:blog];
     }
 }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -141,4 +141,8 @@ extern NSString * const WPAppAnalyticsValueSiteTypeP2;
  */
 + (void)track:(WPAnalyticsStat)stat error:(NSError *)error;
 
+/**
+ *  @brief      Track Anaylytics with associate error that is translated to properties, along with available blog details
+ */
++ (void)track:(WPAnalyticsStat)stat error:(NSError *)error withBlog:(Blog *)blog;
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -144,5 +144,5 @@ extern NSString * const WPAppAnalyticsValueSiteTypeP2;
 /**
  *  @brief      Track Anaylytics with associate error that is translated to properties, along with available blog details
  */
-+ (void)track:(WPAnalyticsStat)stat error:(NSError *)error withBlog:(Blog *)blog;
++ (void)track:(WPAnalyticsStat)stat error:(NSError *)error withBlogID:(NSNumber *)blogID;
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -338,14 +338,18 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
     [WPAnalytics track:stat withProperties:properties];
 }
 
-+ (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error {
++ (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error withBlog:(Blog *)blog {
     NSError *err = [self sanitizedErrorFromError:error];
     NSDictionary *properties = @{
                                  @"error_code": [@(err.code) stringValue],
                                  @"error_domain": err.domain,
                                  @"error_description": err.description
     };
-    [self track:stat withProperties: properties];
+    [self track:stat withProperties: properties withBlogID:blog.dotComID];
+}
+
++ (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error {
+    [self track:stat error:error withBlog:nil];
 }
 
 /**

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -338,18 +338,18 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
     [WPAnalytics track:stat withProperties:properties];
 }
 
-+ (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error withBlog:(Blog *)blog {
++ (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error withBlogID:(NSNumber *)blogID {
     NSError *err = [self sanitizedErrorFromError:error];
     NSDictionary *properties = @{
                                  @"error_code": [@(err.code) stringValue],
                                  @"error_domain": err.domain,
                                  @"error_description": err.description
     };
-    [self track:stat withProperties: properties withBlogID:blog.dotComID];
+    [self track:stat withProperties: properties withBlogID:blogID];
 }
 
 + (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error {
-    [self track:stat error:error withBlog:nil];
+    [self track:stat error:error withBlogID:nil];
 }
 
 /**


### PR DESCRIPTION
##  Description

When the following track events are fired, they don't currently include a blog's ID, which limits the data we're able to gather around failed media uploads:

* `jpios_media_service_upload_canceled`
* `jpios_media_service_upload_failed`

With this PR, the events are updated so that they'll include a blog's ID when fired.

It's worth highlighting that the blog ID is already collected when `jpios_media_service_upload_started` and `jpios_media_service_upload_successful` fire. So, this PR will only be bringing the cancelled/fired events inline with the started/successful events.

## Testing

**Verify events don't currently include details of blog ID**

* Navigate to the **Live View** tab in Tracks.
* Enter `jpios_media_service_upload_canceled` or `jpios_media_service_upload_failed` into the **Event Name** field, and search for recent events.
* Expand a recent event for further details.
* Verify that blog ID shows up as **null**.

**Verify events will include blog ID with changes from this PR**

* Install the build available in this PR's comments or checkout this branch locally.
* Navigate to the post editor and upload an image from your device's library.
* Before the image finished uploading, tap on it to cancel the process.
* Next, go through the steps to upload another image.
* Before the process finishes, turn off the WiFi so that the upload fails.
* Navigate to the **Live View** tab in Tracks.
* Enter the username associated with your testing account into the **Username, ID, or Email** field. 
* Wait until the `jpios_media_service_upload_canceled` and `jpios_media_service_upload_failed` events show up in your history. _Note, this can take up to 20 minutes._
* When the events show up, verify that the blog ID is visible when expanding their details.

## Regression Notes

1. Potential unintended areas of impact

Any other changes to the way we collect data, beyond adding blog ID to the `*_media_service_upload_canceled` and `*_media_service_upload_failed` events, would be unintentional. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I compared the props for the `*_media_service_upload_canceled` and `*_media_service_upload_failed` events before this change and then after to verify there was nothing unexpected. 

3. What automated tests I added (or what prevented me from doing so)

There are no existing tests in place for events, so I did not add any. As this PR only attaches a new piece of data to existing events, I did not feel a need to further investigate ways to automate testing for events in general.

<hr />

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.