### PR TITLE
SFMU: Phase One

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [**] Updated login screen's colors to highlight WordPress - Jetpack brand relationship
 * [*] Add defensive code to make sure the retain cycles in the editor don't lead to crashes [#22252]
 * [**] [internal] [Jetpack-only] Adds support for dynamic dashboard cards driven by the backend [#22326]
+* [**] [internal] Add support for the Phase One Fast Media Uploads banner [#22330]
 * [*] [internal] Remove personalizeHomeTab feature flag [#22280]
 * [*] Fix a rare crash in post search related to tags [#22275]
 * [*] Fix a rare crash when deleting posts [#22277]

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -91,7 +91,7 @@ extension Route {
 ///
 enum DeepLinkSource: Equatable {
     case link
-    case banner
+    case banner(campaign: String? = nil)
     case email(campaign: String)
     case widget
     case lockScreenWidget
@@ -122,6 +122,8 @@ enum DeepLinkSource: Equatable {
     var trackingInfo: String? {
         switch self {
         case .email(let campaign):
+            return campaign
+        case .banner(let campaign):
             return campaign
         default:
             return nil

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -12,7 +12,7 @@ import Foundation
 struct AppBannerRoute: Route {
     let path = "/get"
     let section: DeepLinkSection? = nil
-    let source: DeepLinkSource = .banner
+    let source: DeepLinkSource = .banner()
     let shouldTrack: Bool = false
     let jetpackPowered: Bool = false
 
@@ -28,15 +28,29 @@ extension AppBannerRoute: NavigationAction {
                 return
         }
 
+        let campaign = (values[MatchedRouteURLComponentKey.url.rawValue])
+            .flatMap(getCampaign)
+
         // Convert the fragment into a URL and ask the link router to handle
         // it like a normal route.
         var components = URLComponents()
         components.scheme = "https"
         components.host = "wordpress.com"
         components.path = fragment
+        if let campaign {
+            components.queryItems = [
+                URLQueryItem(name: "campaign", value: campaign)
+            ]
+        }
 
         if let url = components.url {
-            router.handle(url: url, shouldTrack: true, source: .banner)
+            router.handle(url: url, shouldTrack: true, source: .banner(campaign: campaign))
         }
     }
+}
+
+private func getCampaign(from url: String) -> String? {
+    URLComponents(string: url)?.queryItems?
+        .first { $0.name == "campaign"
+    }?.value
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -49,6 +49,15 @@ extension AppBannerRoute: NavigationAction {
     }
 }
 
+enum AppBannerCampaign: String {
+    case qrCodeMedia = "qr-code-media"
+
+    static func make(from values: [String: String]) -> AppBannerCampaign? { values[MatchedRouteURLComponentKey.url.rawValue]
+            .flatMap(getCampaign)
+            .flatMap(AppBannerCampaign.init)
+    }
+}
+
 private func getCampaign(from url: String) -> String? {
     URLComponents(string: url)?.queryItems?
         .first { $0.name == "campaign"

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -28,8 +28,7 @@ extension AppBannerRoute: NavigationAction {
                 return
         }
 
-        let campaign = (values[MatchedRouteURLComponentKey.url.rawValue])
-            .flatMap(getCampaign)
+        let campaign = AppBannerCampaign.getCampaign(from: values)
 
         // Convert the fragment into a URL and ask the link router to handle
         // it like a normal route.
@@ -52,14 +51,11 @@ extension AppBannerRoute: NavigationAction {
 enum AppBannerCampaign: String {
     case qrCodeMedia = "qr-code-media"
 
-    static func make(from values: [String: String]) -> AppBannerCampaign? { values[MatchedRouteURLComponentKey.url.rawValue]
-            .flatMap(getCampaign)
-            .flatMap(AppBannerCampaign.init)
+    static func getCampaign(from values: [String: String]) -> String? {
+        guard let url = values[MatchedRouteURLComponentKey.url.rawValue],
+              let queryItems = URLComponents(string: url)?.queryItems else {
+            return nil
+        }
+        return queryItems.first(where: { $0.name == "campaign" })?.value
     }
-}
-
-private func getCampaign(from url: String) -> String? {
-    URLComponents(string: url)?.queryItems?
-        .first { $0.name == "campaign"
-    }?.value
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -84,7 +84,11 @@ extension MySitesRoute: NavigationAction {
         case .posts:
             coordinator.showPosts(for: blog)
         case .media:
-            coordinator.showMedia(for: blog)
+            if AppBannerCampaign.make(from: values) == .qrCodeMedia {
+                coordinator.showMediaPicker(for: blog)
+            } else {
+                coordinator.showMedia(for: blog)
+            }
         case .comments:
             coordinator.showComments(for: blog)
         case .sharing:

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -66,9 +66,17 @@ extension MySitesRoute: Route {
 extension MySitesRoute: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         let coordinator = RootViewCoordinator.sharedPresenter.mySitesCoordinator
+        let campaign = AppBannerCampaign.getCampaign(from: values)
 
         guard let blog = blog(from: values) else {
-            WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
+            var properties: [AnyHashable: Any] = [
+                "route": path,
+                "error": "invalid_site_id"
+            ]
+            if let campaign {
+                properties["campaign"] = campaign
+            }
+            WPAppAnalytics.track(.deepLinkFailed, withProperties: properties)
 
             if failAndBounce(values) == false {
                 coordinator.showRootViewController()
@@ -84,7 +92,7 @@ extension MySitesRoute: NavigationAction {
         case .posts:
             coordinator.showPosts(for: blog)
         case .media:
-            if AppBannerCampaign.make(from: values) == .qrCodeMedia {
+            if campaign.flatMap(AppBannerCampaign.init) == .qrCodeMedia {
                 coordinator.showMediaPicker(for: blog)
             } else {
                 coordinator.showMedia(for: blog)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -171,6 +171,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 - (id _Nonnull)init;
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;
+- (void)showDetailViewForSubsection:(BlogDetailsSubsection)section userInfo:(nonnull NSDictionary *)userInfo;
 - (NSIndexPath * _Nonnull)indexPathForSubsection:(BlogDetailsSubsection)subsection;
 - (void)reloadTableViewPreservingSelection;
 - (void)configureTableViewData;
@@ -185,4 +186,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)updateTableView:(nullable void(^)(void))completion;
 - (void)preloadMetadata;
 - (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl onCompletion:(nullable void(^)(void))completion;
+
++ (nonnull NSString *)userInfoShowPickerKey;
+
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -529,7 +529,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            BOOL showPicker = userInfo[[BlogDetailsViewController userInfoShowPickerKey]] != NULL;
+            BOOL showPicker = userInfo[[BlogDetailsViewController userInfoShowPickerKey]] ?: NO;
             [self showMediaLibraryFromSource:BlogDetailsNavigationSourceLink showPicker: showPicker];
             break;
         case BlogDetailsSubsectionPages:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -473,7 +473,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self reloadTableViewPreservingSelection];
 }
 
-- (void)showDetailViewForSubsection:(BlogDetailsSubsection)section
+- (void)showDetailViewForSubsection:(BlogDetailsSubsection)section 
+{
+    [self showDetailViewForSubsection:section userInfo:@{}];
+}
+
+- (void)showDetailViewForSubsection:(BlogDetailsSubsection)section userInfo:(NSDictionary *)userInfo
 {
     NSIndexPath *indexPath = [self indexPathForSubsection:section];
 
@@ -524,7 +529,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showMediaLibraryFromSource:BlogDetailsNavigationSourceLink];
+            BOOL showPicker = userInfo[[BlogDetailsViewController userInfoShowPickerKey]] != NULL;
+            [self showMediaLibraryFromSource:BlogDetailsNavigationSourceLink showPicker: showPicker];
             break;
         case BlogDetailsSubsectionPages:
             self.restorableSelectedIndexPath = indexPath;
@@ -1818,10 +1824,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide shared] visited:QuickStartTourElementPages];
 }
 
-- (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source
+- (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source {
+    [self showMediaLibraryFromSource:source showPicker:false];
+}
+
+- (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source showPicker:(BOOL)showPicker
 {
     [self trackEvent:WPAnalyticsStatOpenedMediaLibrary fromSource:source];
-    SiteMediaViewController *controller = [[SiteMediaViewController alloc] initWithBlog:self.blog];
+    SiteMediaViewController *controller = [[SiteMediaViewController alloc] initWithBlog:self.blog showPicker:showPicker];
     [self.presentationDelegate presentBlogDetailsViewController:controller];
     [[QuickStartTourGuide shared] visited:QuickStartTourElementMediaScreen];
 }
@@ -2227,6 +2237,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             completion();
         });
     }];
+}
+
+#pragma mark - Constants
+
++ (NSString *)userInfoShowPickerKey {
+    return @"show-picker";
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -888,6 +888,10 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
         blogDetailsViewController?.showDetailView(for: subsection)
     }
 
+    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection, userInfo: [AnyHashable: Any]) {
+        blogDetailsViewController?.showDetailView(for: subsection, userInfo: userInfo)
+    }
+
     // TODO: Refactor presentation from routes
     // More context: https://github.com/wordpress-mobile/WordPress-iOS/issues/21759
     func presentBlogDetailsViewController(_ viewController: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
@@ -34,6 +34,11 @@ final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDel
         return UIMenu(options: [.displayInline], children: children)
     }
 
+    func showPhotosPicker(from viewController: UIViewController) {
+        MediaPickerMenu(viewController: viewController, isMultipleSelectionEnabled: true)
+            .showPhotosPicker(delegate: self)
+    }
+
     // MARK: - PHPickerViewControllerDelegate
 
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -17,9 +17,12 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
 
     private var isPreparingToShare = false
     private var isFirstAppearance = true
+    private var showPicker = false
 
-    @objc init(blog: Blog) {
+    @objc init(blog: Blog, showPicker: Bool = false) {
         self.blog = blog
+        self.showPicker = showPicker
+
         super.init(nibName: nil, bundle: nil)
 
         hidesBottomBarWhenPushed = true
@@ -51,6 +54,11 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
             navigationItem.hidesSearchBarWhenScrolling = false
         }
         buttonAddMedia.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.mediaUpload)
+
+        if showPicker {
+            buttonAddMediaMenuController.showPhotosPicker(from: self)
+            showPicker = false
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -55,7 +55,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
         }
         buttonAddMedia.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.mediaUpload)
 
-        if showPicker {
+        if showPicker && blog.userCanUploadMedia {
             buttonAddMediaMenuController.showPhotosPicker(from: self)
             showPicker = false
         }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -115,11 +115,11 @@ class MySitesCoordinator: NSObject {
         }
     }
 
-    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection) {
+    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection, userInfo: [AnyHashable: Any] = [:]) {
         showBlogDetails(for: blog)
 
         if let mySiteViewController = navigationController.topViewController as? MySiteViewController {
-            mySiteViewController.showBlogDetailsSubsection(subsection)
+            mySiteViewController.showBlogDetailsSubsection(subsection, userInfo: userInfo)
         }
     }
 
@@ -207,6 +207,10 @@ class MySitesCoordinator: NSObject {
 
     func showMedia(for blog: Blog) {
         showBlogDetails(for: blog, then: .media)
+    }
+
+    func showMediaPicker(for blog: Blog) {
+        showBlogDetails(for: blog, then: .media, userInfo: [BlogDetailsViewController.userInfoShowPickerKey(): true])
     }
 
     func showComments(for blog: Blog) {

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -169,7 +169,7 @@ class RouteMatcherTests: XCTestCase {
         var router = MockRouter(routes: [])
         router.completion = { url, source in
             // THEN it opens a universal link from a fragement and passes the campaign
-            XCTAssertEqual(url, URL(string: "https://wordpress.com/media/1234567?campaign=qr-code-media)"))
+            XCTAssertEqual(url, URL(string: "https://wordpress.com/media/1234567?campaign=qr-code-media"))
             XCTAssertEqual(source, DeepLinkSource.banner(campaign: "qr-code-media"))
         }
         AppBannerRoute().perform(match.values, router: router)

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -147,4 +147,31 @@ class RouteMatcherTests: XCTestCase {
         XCTAssertEqual(match.values[MatchedRouteURLComponentKey.source.rawValue], "widget")
         XCTAssertEqual(match.source, DeepLinkSource.widget)
     }
+
+    // MARK: - AppBanner
+
+    func testAppBannerRouter() throws {
+        // GIVEN a banner URL with a redirect in a fragment
+        let route = "https://apps.wordpress.com/get/?campaign=qr-code-media#%2Fmedia%2F1234567"
+
+        // WHEN
+        routes = [AppBannerRoute()]
+        matcher = RouteMatcher(routes: routes)
+        let matches = matcher.routesMatching(URL(string: route)!)
+
+        // THEN a match if found
+        let match = try XCTUnwrap(matches.first)
+        XCTAssert(match.values.count == 2)
+        XCTAssertNotNil(match.values[MatchedRouteURLComponentKey.url.rawValue])
+        XCTAssertEqual(match.values[MatchedRouteURLComponentKey.fragment.rawValue], "%2Fmedia%2F1234567")
+
+        // WHEN invoking a URL
+        var router = MockRouter(routes: [])
+        router.completion = { url, source in
+            // THEN it opens a universal link from a fragement and passes the campaign
+            XCTAssertEqual(url, URL(string: "https://wordpress.com/media/1234567?campaign=qr-code-media)"))
+            XCTAssertEqual(source, DeepLinkSource.banner(campaign: "qr-code-media"))
+        }
+        AppBannerRoute().perform(match.values, router: router)
+    }
 }


### PR DESCRIPTION
To test:

**Happy Path**

- Invoke the following universal link: https://apps.wordpress.com/get/?campaign=qr-code-media#%2Fmedia%2F<siteID> with <siteID> replaced with an actual siteID.
- **Verify** that the `deep_linked` event is send with the following properties:

```
{
    "source": "banner"
    "section": "my_site"
    "url": "/media/:domain"
    "source_info":  "qr-code-media"
}
```

- **Verify** that the Site Media screens opens and the "Choose from Device" picker is automatically invoked

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b1c50ac4-b5ad-4827-b44d-5905e0f070d2

**Invalid Site ID**

- Invoke the universal link with an invalid Site ID or a Site ID belonging to a different user
- **Verify** that the `deep_link_failed` event is send with the following properties:

```
{
    "error": "invalid_site_id"
    "campaign": "qr-code-media"
    "route": "/media/:domain"
}
```

- **Verify** that the link is redirected to the browser (unless you have a WP-iOS app installed then it goes into recursion...)

**Different Site**

- Invoke the universal link with a Site ID that belongs to the user but is not currently selected
- **Verify** that the app switches to a new site

## Regression Notes
1. Potential unintended areas of impact: Media, Universal Links
2. What I did to test those areas of impact (or what existing automated tests I relied on): yes
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
