### PR TITLE
[Cobranding] Update splash logo

### DIFF
--- a/WordPress/Jetpack/Launch Screen.storyboard
+++ b/WordPress/Jetpack/Launch Screen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,10 +17,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="jetpack-logo" translatesAutoresizingMaskIntoConstraints="NO" id="JZ4-ST-36F">
-                                <rect key="frame" x="182" y="423" width="50" height="50"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="wp-jp-circular-lockup" translatesAutoresizingMaskIntoConstraints="NO" id="JZ4-ST-36F">
+                                <rect key="frame" x="154.5" y="395.5" width="105" height="105"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="50" id="V6u-HF-Ery"/>
+                                    <constraint firstAttribute="width" constant="105" id="V6u-HF-Ery"/>
                                     <constraint firstAttribute="width" secondItem="JZ4-ST-36F" secondAttribute="height" multiplier="1:1" id="fjK-Ng-KG1"/>
                                 </constraints>
                             </imageView>
@@ -39,7 +39,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="jetpack-logo" width="80" height="80"/>
+        <image name="wp-jp-circular-lockup" width="133" height="80"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
Fixes #p1703363229811979-slack-C0JJ0C1UL

## Testing Steps
1. Run the app and verify the logo is updated and matches the design:
qk5s4q4mZsXknwhMWo2vIY-fi-11042%3A1651
2. Make sure to check both light and dark theme.

## Screenshot Reference
| Light  | Dark |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-05 at 12 54 14](https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/a0ca00b1-5c4b-497b-bcd5-37f7aab16a7b) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-05 at 12 54 50](https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/ff094b6f-7073-4eb1-9e0c-0d45e532e2ca) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

4. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
_I think mentioning the Cobranding should suffice for Release Notes. This was done on the previous cobranding PR._

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)