### PR TITLE
Fix an issue with BlogDashboardPersonalizationService being used on the background thread

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * [*] Fix a rare crash in post search related to tags [#22275]
 * [*] Fix a rare crash when deleting posts [#22277]
 * [*] Fix a rare crash in Site Media prefetching cancellation [#22278]
+* [*] Fix an issue with BlogDashboardPersonalizationService being used on the background thread [#22335]
 * [***] Block Editor: Avoid keyboard dismiss when interacting with text blocks [https://github.com/WordPress/gutenberg/pull/57070]
 * [**] Block Editor: Auto-scroll upon block insertion [https://github.com/WordPress/gutenberg/pull/57273]
 

--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -48,12 +48,13 @@ public class BloggingPromptSettings: NSManagedObject {
     }
 
     private func updatePromptSettingsIfNecessary(siteID: Int, enabled: Bool) {
-        let service = BlogDashboardPersonalizationService(siteID: siteID)
-        if !service.hasPreference(for: .prompts) {
-            service.setEnabled(enabled, for: .prompts)
+        DispatchQueue.main.async {
+            let service = BlogDashboardPersonalizationService(siteID: siteID)
+            if !service.hasPreference(for: .prompts) {
+                service.setEnabled(enabled, for: .prompts)
+            }
         }
     }
-
 }
 
 extension RemoteBloggingPromptsSettings {


### PR DESCRIPTION
`BlogDashboardPersonalizationService` has to be main thread confined because it directly triggers the updates in the UI.

To test: 

- Comment out `if !service.hasPreference(for: .prompts) {` to make sure the service triggers the update every time
- Open the app with Xcode debugger attaches
- Verify that Xcode doesn't throw a runtime error

## Regression Notes
1. Potential unintended areas of impact: My Site
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
