### PR TITLE
Posts & Pages: Add share action to pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -47,7 +47,12 @@ extension PageListViewController: InteractivePostViewDelegate {
     }
 
     func share(_ apost: AbstractPost, fromView view: UIView) {
-        // Not available for pages
+        guard let page = apost as? Page else { return }
+
+        WPAnalytics.track(.postListShareAction, properties: propertiesForAnalytics())
+
+        let shareController = PostSharingController()
+        shareController.sharePage(page, fromView: view, inViewController: self)
     }
 
     func blaze(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -24,7 +24,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.moveToDraft, .duplicate],
+            [.moveToDraft, .duplicate, .share],
             [.blaze],
             [.setParent, .setHomepage, .setPostsPage, .settings],
             [.trash]
@@ -52,7 +52,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.moveToDraft, .duplicate],
+            [.moveToDraft, .duplicate, .share],
             [.setParent, .setHomepage, .setPostsPage, .settings],
             [.trash]
         ]
@@ -79,7 +79,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.moveToDraft, .duplicate],
+            [.moveToDraft, .duplicate, .share],
             [.setParent, .setHomepage, .setPostsPage, .settings],
             [.trash]
         ]
@@ -106,7 +106,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.duplicate],
+            [.duplicate, .share],
             [.blaze],
             [.setParent, .setPostsPage, .settings]
         ]
@@ -133,7 +133,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.moveToDraft, .duplicate],
+            [.moveToDraft, .duplicate, .share],
             [.blaze],
             [.setParent, .setHomepage, .setRegularPage, .settings],
             [.trash]

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -57,6 +57,10 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             buttons.append(.duplicate)
         }
 
+        if page.status == .publish && page.hasRemote() {
+            buttons.append(.share)
+        }
+
         if page.status != .trash && page.isFailed {
             buttons.append(.retry)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -73,6 +73,16 @@ import SVProgressHUD
         }
     }
 
+    @objc func sharePage(_ page: Page, fromView anchorView: UIView, inViewController viewController: UIViewController) {
+
+        sharePost(
+            page.titleForDisplay(),
+            summary: page.contentPreviewForDisplay(),
+            link: page.permaLink,
+            fromView: anchorView,
+            inViewController: viewController)
+    }
+
     @objc func sharePost(_ post: Post, fromBarButtonItem anchorBarButtonItem: UIBarButtonItem, inViewController viewController: UIViewController) {
 
         sharePost(


### PR DESCRIPTION
Fixes p1704497445294539/1704278392.716869-slack-C04SFL0RP51

## Description
Adds the share action to the pages list screen

## How to test
- Go to the pages list screen
- Switch to the published tab
- Tap on the more context menu
- Verify you can share the page

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
updated PageMenuViewModelTests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
