### PR TITLE
fix: Allow unlimited manual upload retries

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -122,8 +122,8 @@ class GutenbergMediaInserterHelper: NSObject {
         mediaCoordinator.retryMedia(media)
     }
 
-    func retryFailedMediaUploads() {
-        _ = mediaCoordinator.uploadMedia(for: post, automatedRetry: true)
+    func retryFailedMediaUploads(automatedRetry: Bool = false) {
+        _ = mediaCoordinator.uploadMedia(for: post, automatedRetry: automatedRetry)
     }
 
     func hasFailedMedia() -> Bool {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1102,7 +1102,7 @@ extension GutenbergViewController: NetworkStatusDelegate {
         gutenberg.connectionStatusChange(isConnected: active)
         #if DEBUG || INTERNAL_BUILD
             if active {
-                mediaInserterHelper.retryFailedMediaUploads()
+                mediaInserterHelper.retryFailedMediaUploads(automatedRetry: true)
             }
         #endif
     }


### PR DESCRIPTION
## Description

There is logic to limit automatic upload retries to three attempts. This
logic was inadvertently applied to manual retries, which can result in a
scenario where it is not possible to retry an upload, even if a user
explicitly requests a retry.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/6511.

## Testing Instructions
**Automatic upload retries succeed**
1. Add a media block.
1. Attach media to the block.
1. Disable your device's network connection.
1. Enable your device's network connection.
1. Repeat the steps 3 and 4 _two_ more times.
1. Verify the automatic retry succeeds.

**Manual upload retries are always available**
1. Add a media block.
1. Attach media to the block.
1. Disable your device's network connection.
1. Enable your device's network connection.
1. Repeat the steps 3 and 4 _three_ more times.
1. Verify an automatic retry is not attempted.
1. Tap the media for the block.
1. Select "Retry" from the Action Sheet.
1. Verify the manual upload retry succeeds.

## Regression Notes
1. Potential unintended areas of impact
    Modifying the retry logic could break automatic or manual retries.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verified both types of retries succeed.
3. What automated tests I added (or what prevented me from doing so)
    None, chose to forgo creating testing boilerplate required this untested
module due to unfamiliarity with the testing setup.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
