### PR TITLE
Fix an issue where the All Domains flow wasn't taking into account sites with existing plan

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/FreeToPaidPlansCoordinator.swift
@@ -34,10 +34,6 @@ import SwiftUI
             PlansTracker.trackPurchaseResult(source: "plan_selection")
         }
 
-        let domainAddedToCart = plansFlowAfterDomainAddedToCartBlock(customTitle: nil, purchaseCallback: purchaseCallback)
-
-        coordinator.domainAddedToCartAndLinkedToSiteCallback = domainAddedToCart
-
         let navigationController = UINavigationController(rootViewController: domainSuggestionsViewController)
         dashboardViewController.present(navigationController, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -23,7 +23,9 @@ class RegisterDomainCoordinator {
 
     let analyticsSource: String
 
+    // TODO: This can cause Core Data crashes. Pass `NSManagedObjectID` instead.
     var site: Blog?
+
     var domain: DomainSuggestion?
 
     var domainPurchasedCallback: DomainPurchasedCallback?

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -13,13 +13,12 @@ class RegisterDomainCoordinator {
     typealias DomainPurchasedCallback = ((UIViewController, String) -> Void)
     typealias DomainAddedToCartCallback = ((UIViewController, String, Blog) -> Void)
 
-    // MARK: - Dependencies
+    // MARK: Dependencies
 
     private let domainRegistrationService: RegisterDomainDetailsServiceProxyProtocol
+    private let crashLogger: CrashLogging
 
     // MARK: Variables
-
-    private let crashLogger: CrashLogging
 
     let analyticsSource: String
 
@@ -29,9 +28,10 @@ class RegisterDomainCoordinator {
     var domain: DomainSuggestion?
 
     var domainPurchasedCallback: DomainPurchasedCallback?
-    var domainAddedToCartAndLinkedToSiteCallback: DomainAddedToCartCallback?
 
     private var webViewURLChangeObservation: NSKeyValueObservation?
+
+    // MARK: - Init
 
     /// Initializes a `RegisterDomainCoordinator` with the specified parameters.
     ///
@@ -52,7 +52,7 @@ class RegisterDomainCoordinator {
         self.domainRegistrationService = domainRegistrationService
     }
 
-    // MARK: Public Functions
+    // MARK: - Public Functions
 
     /// Adds the selected domain to the cart then launches the checkout webview.
     /// This flow support purchasing domains only, without plans.

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -13,6 +13,10 @@ class RegisterDomainCoordinator {
     typealias DomainPurchasedCallback = ((UIViewController, String) -> Void)
     typealias DomainAddedToCartCallback = ((UIViewController, String, Blog) -> Void)
 
+    // MARK: - Dependencies
+
+    private let domainRegistrationService: RegisterDomainDetailsServiceProxyProtocol
+
     // MARK: Variables
 
     private let crashLogger: CrashLogging
@@ -20,9 +24,10 @@ class RegisterDomainCoordinator {
     let analyticsSource: String
 
     var site: Blog?
+    var domain: DomainSuggestion?
+
     var domainPurchasedCallback: DomainPurchasedCallback?
     var domainAddedToCartAndLinkedToSiteCallback: DomainAddedToCartCallback?
-    var domain: DomainSuggestion?
 
     private var webViewURLChangeObservation: NSKeyValueObservation?
 
@@ -36,11 +41,13 @@ class RegisterDomainCoordinator {
     init(site: Blog?,
          domainPurchasedCallback: RegisterDomainCoordinator.DomainPurchasedCallback? = nil,
          analyticsSource: String = "domains_register",
-         crashLogger: CrashLogging = .main) {
+         crashLogger: CrashLogging = .main,
+         domainRegistrationService: RegisterDomainDetailsServiceProxyProtocol = RegisterDomainDetailsServiceProxy()) {
         self.site = site
         self.domainPurchasedCallback = domainPurchasedCallback
         self.crashLogger = crashLogger
         self.analyticsSource = analyticsSource
+        self.domainRegistrationService = domainRegistrationService
     }
 
     // MARK: Public Functions
@@ -50,6 +57,7 @@ class RegisterDomainCoordinator {
     func handlePurchaseDomainOnly(on viewController: UIViewController,
                                   onSuccess: @escaping () -> (),
                                   onFailure: @escaping () -> ()) {
+        // TODO: Refactor `handlePurchaseDomainOnly` to use `purchaseDomain` helper.
         createCart { [weak self] result in
             switch result {
             case .success:
@@ -66,6 +74,7 @@ class RegisterDomainCoordinator {
     func addDomainToCartLinkedToCurrentSite(on viewController: UIViewController,
                          onSuccess: @escaping () -> (),
                          onFailure: @escaping () -> ()) {
+        // TODO: Refactor `addDomainToCartLinkedToCurrentSite` to use `purchaseDomain` helper.
         guard let blog = site else {
             return
         }
@@ -83,18 +92,9 @@ class RegisterDomainCoordinator {
     /// Related to the `purchaseFromDomainManagement` Domain selection type.
     /// Adds the selected domain to the cart then launches the checkout webview
     /// The checkout webview is configured for the domain management flow
-    func handleNoSiteChoice(on viewController: UIViewController,
-                            choicesViewModel: DomainPurchaseChoicesViewModel?) {
-        createCart { [weak self] result in
-            switch result {
-            case .success:
-                self?.presentCheckoutWebview(on: viewController, title: TextContent.checkoutTitle)
-                choicesViewModel?.isGetDomainLoading = false
-
-            case .failure:
-                viewController.displayActionableNotice(title: TextContent.errorTitle, actionTitle: TextContent.errorDismiss)
-                choicesViewModel?.isGetDomainLoading = false
-            }
+    func handleNoSiteChoice(on viewController: UIViewController, choicesViewModel: DomainPurchaseChoicesViewModel?) {
+        self.purchaseDomain(for: site, on: viewController) { _ in
+            choicesViewModel?.isGetDomainLoading = false
         }
     }
 
@@ -117,18 +117,11 @@ class RegisterDomainCoordinator {
                 return
             }
             controller.showLoading()
-            self.createCart { [weak self] result in
-                guard let self else {
-                    return
-                }
-                switch result {
-                case .success(let domain):
-                    self.site = selectedBlog
-                    self.domainAddedToCartAndLinkedToSiteCallback?(controller, domain.domainName, selectedBlog)
-                case .failure:
-                    controller.displayActionableNotice(title: TextContent.errorTitle, actionTitle: TextContent.errorDismiss)
-                }
+            self.purchaseDomain(for: selectedBlog, on: controller) { result in
                 controller.hideLoading()
+                if case .success = result {
+                    self.site = selectedBlog
+                }
             }
         }
 
@@ -141,20 +134,39 @@ class RegisterDomainCoordinator {
 
     // MARK: Helpers
 
+    private func purchaseDomain(for site: Blog?, on viewController: UIViewController, completion: @escaping (Result<Void, Swift.Error>) -> Void) {
+        self.createCart { [weak self] result in
+            guard let self else {
+                return
+            }
+            switch result {
+            case .success(let domain):
+                if let site, site.canRegisterDomainWithPaidPlan {
+                    self.domainAddedToCartAndLinkedToSiteCallback?(viewController, domain.domainName, site)
+                } else {
+                    self.presentCheckoutWebview(on: viewController, title: TextContent.checkoutTitle)
+                }
+                completion(.success(()))
+            case .failure(let error):
+                viewController.displayActionableNotice(title: TextContent.errorTitle, actionTitle: TextContent.errorDismiss)
+                completion(.failure(error))
+            }
+        }
+    }
+
     private func createCart(completion: @escaping (Result<DomainSuggestion, Swift.Error>) -> Void) {
         guard let domain else {
             completion(.failure(Error.noDomainWhenCreatingCart))
             return
         }
         let siteID = site?.dotComID?.intValue
-        let proxy = RegisterDomainDetailsServiceProxy()
-        proxy.createPersistentDomainShoppingCart(siteID: siteID,
-                                                 domainSuggestion: domain,
-                                                 privacyProtectionEnabled: domain.supportsPrivacy ?? false,
-                                                 success: { _ in
+        self.domainRegistrationService.createPersistentDomainShoppingCart(siteID: siteID,
+                                                                          domainSuggestion: domain,
+                                                                          privacyProtectionEnabled: domain.supportsPrivacy ?? false,
+                                                                          success: { _ in
             completion(.success(domain))
         },
-                                                 failure: { error in
+                                                                          failure: { error in
             completion(.failure(error))
         })
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -136,6 +136,18 @@ class RegisterDomainCoordinator {
 
     // MARK: Helpers
 
+    /// Initiates the process of purchasing a domain for a specified site.
+    ///
+    /// - Parameters:
+    ///   - site: The blog site for which the domain is being purchased. Optional.
+    ///   - viewController: The UIViewController from which the domain registration or checkout process is presented.
+    ///   - completion: A closure that is called upon the completion of the purchase attempt.
+    ///     It returns a `Result` indicating either success or failure.
+    ///
+    /// The method follows this logic:
+    /// - The "Register Domain" screen is presented when `site.canRegisterDomainWithPaidPlan` is `true`.
+    /// - If the site does not have any domains (`!site.hasDomains`), the Plans web view is shown.
+    /// - For sites with existing domains, the Checkout web view is presented,
     private func purchaseDomain(for site: Blog?, on viewController: UIViewController, completion: @escaping (Result<Void, Swift.Error>) -> Void) {
         guard let domain else {
             completion(.failure(Error.noDomainWhenCreatingCart))

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -83,7 +83,7 @@ class RegisterDomainCoordinator {
         createCart { [weak self] result in
             switch result {
             case .success(let domain):
-                self?.domainAddedToCartAndLinkedToSiteCallback?(viewController, domain.domainName, blog)
+                self?.presentPlansWebview(for: blog, domain: domain, on: viewController)
                 onSuccess()
             case .failure:
                 onFailure()
@@ -136,7 +136,7 @@ class RegisterDomainCoordinator {
 
     // MARK: Helpers
 
-    /// Initiates the process of purchasing a domain for a specified site.
+    /// Initiates the process of purchasing a domain with or without a site.
     ///
     /// - Parameters:
     ///   - site: The blog site for which the domain is being purchased. Optional.
@@ -165,7 +165,7 @@ class RegisterDomainCoordinator {
             switch result {
             case .success(let domain):
                 if let site, !site.hasDomains {
-                    self.domainAddedToCartAndLinkedToSiteCallback?(viewController, domain.domainName, site)
+                    self.presentPlansWebview(for: site, domain: domain, on: viewController)
                 } else {
                     self.presentCheckoutWebview(on: viewController, title: TextContent.checkoutTitle)
                 }
@@ -193,6 +193,8 @@ class RegisterDomainCoordinator {
             completion(.failure(error))
         })
     }
+
+    // MARK: - Presenting Checkout Web View
 
     private func presentCheckoutWebview(on viewController: UIViewController,
                                         title: String?) {
@@ -256,24 +258,6 @@ class RegisterDomainCoordinator {
         }
     }
 
-    private func presentDomainRegistration(
-        for site: Blog,
-        domain: DomainSuggestion,
-        on viewController: UIViewController
-    ) {
-        guard let siteID = site.dotComID?.intValue else {
-            return
-        }
-        let destination = RegisterDomainDetailsViewController()
-        destination.viewModel = RegisterDomainDetailsViewModel(siteID: siteID, domain: domain) { [weak self] name in
-            guard let self = self else {
-                return
-            }
-            self.domainPurchasedCallback?(viewController, name)
-            self.trackDomainPurchasingCompleted()
-        }
-    }
-
     /// Handles URL changes in the web view.  We only allow the user to stay within certain URLs.  Falling outside these URLs
     /// results in the web view being dismissed.  This method also handles the success condition for a successful domain registration
     /// through said web view.
@@ -303,6 +287,46 @@ class RegisterDomainCoordinator {
             onSuccess(domain)
 
         }
+    }
+
+    // MARK: - Presenting Domain Registration View
+
+    private func presentDomainRegistration(
+        for site: Blog,
+        domain: DomainSuggestion,
+        on viewController: UIViewController
+    ) {
+        guard let siteID = site.dotComID?.intValue else {
+            return
+        }
+        let destination = RegisterDomainDetailsViewController()
+        destination.viewModel = RegisterDomainDetailsViewModel(siteID: siteID, domain: domain) { [weak self] name in
+            guard let self = self else {
+                return
+            }
+            self.domainPurchasedCallback?(viewController, name)
+            self.trackDomainPurchasingCompleted()
+        }
+    }
+
+    // MARK: - Presenting Plans
+
+    private func presentPlansWebview(
+        for site: Blog,
+        domain: DomainSuggestion,
+        on viewController: UIViewController
+    ) {
+        let presentPlansFlow = FreeToPaidPlansCoordinator.plansFlowAfterDomainAddedToCartBlock(
+            customTitle: nil,
+            analyticsSource: analyticsSource
+        ) { [weak self] controller, domain in
+            guard let self else {
+                return
+            }
+            self.domainPurchasedCallback?(controller, domain)
+            self.trackDomainPurchasingCompleted()
+        }
+        presentPlansFlow(viewController, domain.domainName, site)
     }
 
     // MARK: - Tracks

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardFactory.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardFactory.swift
@@ -9,7 +9,7 @@ struct DomainsDashboardFactory {
     }
 
     static func makeDomainsSuggestionViewController(blog: Blog, domainSelectionType: DomainSelectionType, onDismiss: @escaping () -> Void) -> DomainSelectionViewController {
-        let coordinator = RegisterDomainCoordinator(site: blog)
+        let coordinator = RegisterDomainCoordinator(site: blog, analyticsSource: "site_domains")
         let viewController = DomainSelectionViewController(
             service: DomainsServiceAdapter(coreDataStack: ContextManager.shared),
             domainSelectionType: domainSelectionType,
@@ -28,16 +28,6 @@ struct DomainsDashboardFactory {
             }
             viewController.present(controller, animated: true)
         }
-
-        let domainAddedToCart = FreeToPaidPlansCoordinator.plansFlowAfterDomainAddedToCartBlock(
-            customTitle: nil,
-            analyticsSource: "site_domains"
-        ) { [weak coordinator] controller, domain in
-            coordinator?.domainPurchasedCallback?(controller, domain)
-            coordinator?.trackDomainPurchasingCompleted()
-        }
-
-        coordinator.domainAddedToCartAndLinkedToSiteCallback = domainAddedToCart
 
         return viewController
     }

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift
@@ -17,16 +17,7 @@ import Foundation
             }
         }
 
-        let domainAddedToCart = FreeToPaidPlansCoordinator.plansFlowAfterDomainAddedToCartBlock(
-            customTitle: nil,
-            analyticsSource: analyticsSource
-        ) { [weak coordinator] controller, domain in
-            domainPurchasedCallback(controller, domain)
-            coordinator?.trackDomainPurchasingCompleted()
-        }
-
         coordinator.domainPurchasedCallback = domainPurchasedCallback // For no site flow (domain only)
-        coordinator.domainAddedToCartAndLinkedToSiteCallback = domainAddedToCart // For existing site flow (plans)
 
         let navigationController = UINavigationController(rootViewController: domainSuggestionsViewController)
         navigationController.isModalInPresentation = true


### PR DESCRIPTION
Fixes #22268

## Description

This PR resolves an issue where users purchasing a domain, linked to a site that already has a plan, through the All Domains flow get stuck  in the **Plans** flow.

## Test Instructions

**N.B: Sandboxing is required to test domain checkout**

#### Case 1: Site with Existing Plan

1. Log into the site that already has a plan
2. Navigate to Me > All Domains
3. Tap "+"
4. Select a domain
5. Tap "Choose Site" button
6. **Expect** the **Checkout** web view to appear
7. Purchase the domain to verify the checkout flow works.

#### Case 2: Site without plan ( Regression )

1. Log into the site that doesn't have a plan
2. Navigate to Me > All Domains
3. Tap "+"
4. Select a domain
5. Tap "Get Domain" button
6. **Expect** the **Plans** web view to appear
7. Select a plan, go verify the checkout flow works as expected.

#### Case 3: Domain with No-Site ( Regression )

1. Log into the site that already has a plan
2. Navigate to Me > All Domains
3. Tap "+"
4. Select a domain
5. Tap "Get Domain" button
6. **Expect** the **Checkout** web view to appear
7. Purchase the domain to verify the checkout flow works.

## Next
- Address the  `// TODO:` I added in `RegisterDomainCoordinator.swift`.
- Add Unit Tests for `RegisterDomainCoordinator`.

## Regression Notes
1. Potential unintended areas of impact
Purchasing a domain through the All Domains flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.