### PR TITLE
Bottom tab improvements: Enable feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -39,7 +39,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .googleDomainsCard:
             return false
         case .newTabIcons:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -109,8 +109,13 @@ extension WPTabBarController {
 
     @objc func animateSelectedItem(_ item: UITabBarItem, for tabBar: UITabBar) {
 
-        guard let index = tabBar.items?.firstIndex(of: item), tabBar.subviews.count > index + 1,
-              let imageView = tabBar.subviews[index + 1].subviews.last as? UIImageView else {
+        guard let index = tabBar.items?.firstIndex(of: item), tabBar.subviews.count > index + 1 else {
+            return
+        }
+
+        let button = tabBar.subviews[(index + 1)]
+
+        guard let imageView = button.subviews.lazy.compactMap({ $0 as? UIImageView }).first else {
             return
         }
 


### PR DESCRIPTION
Enables https://github.com/wordpress-mobile/WordPress-iOS/pull/22325

## How to test
- Verify new bottom tab icons are enabled
- Verify icon animation work

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


