### PR TITLE
Reader: Add vertical animation to Reader navigation menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -47,6 +47,8 @@ import Combine
         return tableViewController.tableView
     }
 
+    weak var navigationMenuDelegate: ReaderNavigationMenuDelegate?
+
     var jetpackBannerView: JetpackBannerView?
 
     private var syncHelpers: [ReaderAbstractTopic: WPContentSyncHelper] = [:]
@@ -1537,6 +1539,9 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         }
     }
 
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        navigationMenuDelegate?.scrollViewWillEndDragging(scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset)
+    }
 
     // MARK: - Fetched Results Related
 
@@ -2145,5 +2150,8 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
 extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         processJetpackBannerVisibility(scrollView)
+
+        let velocity = tableView.panGestureRecognizer.velocity(in: tableView)
+        navigationMenuDelegate?.scrollViewDidScroll(scrollView, velocity: velocity)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+protocol ReaderNavigationMenuDelegate: AnyObject {
+    func scrollViewDidScroll(_ scrollView: UIScrollView, velocity: CGPoint)
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>)
+}
+
 struct ReaderNavigationMenu: View {
 
     @ObservedObject var viewModel: ReaderTabViewModel

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -161,7 +161,7 @@ extension ReaderTabView {
 
         isMenuHidden = hidden
         mainStackViewTopAnchor?.constant = hidden ? -buttonContainer.frame.height : 0
-        UIView.animate(withDuration: 0.2) {
+        UIView.animate(withDuration: Appearance.hideShowBarDuration) {
             self.layoutIfNeeded()
         }
     }
@@ -203,6 +203,7 @@ private extension ReaderTabView {
     enum Appearance {
         static let barHeight: CGFloat = 48
         static let dividerColor: UIColor = .divider
+        static let hideShowBarDuration: CGFloat = 0.2
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -1,9 +1,9 @@
 import UIKit
 
-
 class ReaderTabView: UIView {
 
     private let mainStackView: UIStackView
+    private var mainStackViewTopAnchor: NSLayoutConstraint?
     private let containerView: UIView
     private let buttonContainer: UIView
     private lazy var navigationMenu: UIView = {
@@ -15,6 +15,7 @@ class ReaderTabView: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+    private var isMenuHidden = false
 
     private let viewModel: ReaderTabViewModel
 
@@ -106,6 +107,10 @@ extension ReaderTabView {
                 return
         }
 
+        if let childController = childController as? ReaderStreamViewController {
+            childController.navigationMenuDelegate = self
+        }
+
         containerView.translatesAutoresizingMaskIntoConstraints = false
         childController.view.translatesAutoresizingMaskIntoConstraints = false
 
@@ -122,6 +127,8 @@ extension ReaderTabView {
     }
 
     private func activateConstraints() {
+        mainStackViewTopAnchor = mainStackView.topAnchor.constraint(equalTo: buttonContainer.bottomAnchor)
+        guard let mainStackViewTopAnchor else { return }
         NSLayoutConstraint.activate([
             navigationMenu.leadingAnchor.constraint(equalTo: buttonContainer.leadingAnchor, constant: 12.0),
             navigationMenu.trailingAnchor.constraint(equalTo: buttonContainer.trailingAnchor, constant: -16.0),
@@ -130,7 +137,7 @@ extension ReaderTabView {
             buttonContainer.topAnchor.constraint(equalTo: safeTopAnchor),
             buttonContainer.leadingAnchor.constraint(equalTo: safeLeadingAnchor),
             buttonContainer.trailingAnchor.constraint(equalTo: safeTrailingAnchor),
-            mainStackView.topAnchor.constraint(equalTo: buttonContainer.bottomAnchor),
+            mainStackViewTopAnchor,
             mainStackView.trailingAnchor.constraint(equalTo: safeTrailingAnchor),
             mainStackView.leadingAnchor.constraint(equalTo: safeLeadingAnchor),
             mainStackView.bottomAnchor.constraint(equalTo: safeBottomAnchor),
@@ -147,6 +154,16 @@ extension ReaderTabView {
         // Remove any filters for selected index, then add new filter to array.
         self.filteredTabs.removeAll(where: { $0.index == selectedIndex })
         self.filteredTabs.append((index: selectedIndex, topic: selectedTopic))
+    }
+
+    private func updateMenuDisplay(hidden: Bool) {
+        guard isMenuHidden != hidden else { return }
+
+        isMenuHidden = hidden
+        mainStackViewTopAnchor?.constant = hidden ? -buttonContainer.frame.height : 0
+        UIView.animate(withDuration: 0.2) {
+            self.layoutIfNeeded()
+        }
     }
 }
 
@@ -187,4 +204,42 @@ private extension ReaderTabView {
         static let barHeight: CGFloat = 48
         static let dividerColor: UIColor = .divider
     }
+}
+
+// MARK: - ReaderNavigationMenuDelegate
+
+extension ReaderTabView: ReaderNavigationMenuDelegate {
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView, velocity: CGPoint) {
+        let isContentOffsetNearTop = scrollView.contentOffset.y < scrollView.frame.height / 2
+        let isUserScrollingDown = velocity.y < -400
+        let isUserScrollingUp = velocity.y > 400
+
+        if !isMenuHidden && !isContentOffsetNearTop && isUserScrollingDown {
+            updateMenuDisplay(hidden: true)
+        }
+
+        if isMenuHidden && isUserScrollingUp {
+            updateMenuDisplay(hidden: false)
+        }
+
+        // Accounts for a user scrolling slowly enough to not trigger displaying the menu near the top of the content
+        if isMenuHidden && isContentOffsetNearTop && velocity.y > 0 {
+            updateMenuDisplay(hidden: false)
+        }
+
+    }
+
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        let isTargetContentNearTop = targetContentOffset.pointee.y < scrollView.frame.height / 2
+
+        // Accounts for the case where a user quickly swipes the scroll view without holding their
+        // finger on it.
+        // Note: velocity here is opposite of the velocity in `scrollViewDidScroll`. Postive values
+        // are scrolling down. The scale is also much different.
+        if !isMenuHidden && !isTargetContentNearTop && velocity.y > 0.5 {
+            updateMenuDisplay(hidden: true)
+        }
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -236,7 +236,7 @@ extension ReaderTabView: ReaderNavigationMenuDelegate {
 
         // Accounts for the case where a user quickly swipes the scroll view without holding their
         // finger on it.
-        // Note: velocity here is opposite of the velocity in `scrollViewDidScroll`. Postive values
+        // Note: velocity here is opposite of the velocity in `scrollViewDidScroll`. Positive values
         // are scrolling down. The scale is also much different.
         if !isMenuHidden && !isTargetContentNearTop && velocity.y > 0.5 {
             updateMenuDisplay(hidden: true)


### PR DESCRIPTION
Closes #22352 

## Description

Adds a vertical animation to the Reader navigation menu to hide/show it depending on the user's scrolling.

## Video

https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/c7087547-3bfa-437f-8f86-154c02a92265

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Scroll down on the content
- 🔎 **Verify** the navigation menu is hidden
- Scroll up on the content
- 🔎 **Verify** the navigation menu is shown

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
