### PR TITLE
Reader: Use `PlainButtonStyle` for Reader navigation menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
@@ -29,7 +29,7 @@ struct ReaderNavigationButton: View {
             }
         } label: {
             menuLabel
-        }
+        }.buttonStyle(PlainButtonStyle())
     }
 
     var menuLabel: some View {


### PR DESCRIPTION
Addresses comment about opacity: https://github.com/wordpress-mobile/WordPress-iOS/pull/22260#issuecomment-1864410296

## Description

Uses the `PlainButtonStyle` button style for the Reader navigation menu button. This makes the opacity change less intense when the menu is open.

## Screenshots

| Before | After |
|---|---|
| ![dark before](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/c77b6ed5-8b73-4a36-b9ae-5d429e4926bc) | ![dark after](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/0e5cd258-8a09-444e-b08f-8b66d11f2ed2) |
| ![Screenshot 2024-01-09 at 4 59 05 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/81bb2e38-6518-4f68-9420-ae420786ad6d) | ![Screenshot 2024-01-09 at 5 05 39 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/d05eeee2-4965-45c0-a172-55790143b405) |

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Tap on the navigation button menu
- 🔎 **Verify** the button isn't as grayed out and only slightly reduced in opacity
- Switch your theme to dark/light
- Tap on the navigation button menu
- 🔎 **Verify** the button isn't as grayed out and only slightly reduced in opacity


## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
