### PR TITLE
Reader: Remove first tags recommendation card

### DIFF
--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -52,6 +52,12 @@ class ReaderCardService {
                                     }
 
                                     cards.enumerated().forEach { index, remoteCard in
+                                        if isFirstPage && index == 0 && remoteCard.type == .interests {
+                                            // Removes displaying the tags recommendation card
+                                            // first in the Discover feed
+                                            return
+                                        }
+
                                         let card = ReaderCard(context: context, from: remoteCard)
 
                                         // Assign each interest an endpoint

--- a/WordPress/WordPressTest/ReaderCardServiceTests.swift
+++ b/WordPress/WordPressTest/ReaderCardServiceTests.swift
@@ -77,7 +77,7 @@ class ReaderCardServiceTests: CoreDataTestCase {
 
         service.fetch(isFirstPage: true, success: { _, _ in
             let cards = try? self.mainContext.fetch(NSFetchRequest(entityName: ReaderCard.classNameWithoutNamespaces()))
-            expect(cards?.count).to(equal(10))
+            expect(cards?.count).to(equal(9))
             expectation.fulfill()
         }, failure: { _ in })
 
@@ -129,7 +129,7 @@ class ReaderCardServiceTests: CoreDataTestCase {
             // Fetch again, this time the 1st page
             service.fetch(isFirstPage: true, success: { _, _ in
                 let cards = try? self.mainContext.fetch(NSFetchRequest(entityName: ReaderCard.classNameWithoutNamespaces())) as? [ReaderCard]
-                expect(cards?.count).to(equal(10))
+                expect(cards?.count).to(equal(9))
                 expectation.fulfill()
             }, failure: { _ in })
         }, failure: {_ in })


### PR DESCRIPTION
Ref: pctCYC-195-p2#comment-1144

## Description

Hides the first tag recommendation card in the Discover feed.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the "Discover" feed in Reader
- 🔎 **Verify** the tags recommendation card is not displayed first
  - Note: It might require clearing our cached data

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
