### PR TITLE
Improve Publish context menu action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,8 @@
 * [*] Add prefetching to Site Media details screen [#22292]
 * [*] Allow trashing draft and scheduled posts with no confirmation [#22337]
 * [*] Add "Share" action to the site context menu [#22298]
+* [*] Update the post "Publish" context action for Contributors to  "Submit for Review" instead of "Publish" [#22358]
+* [**] Add a pre-publishing sheet to the "Publish" flow invoked from the post context menu as a replacement for a simple confirmation sheet [#22358]
 * [**] Block Editor: Media uploads that failed due to lack of internet connectivity automatically retry once a connection is re-established [https://github.com/wordpress-mobile/WordPress-iOS/pull/22238]
 * [**] Block Editor: Manually retrying a single failed media upload will retry all failed media uploads in a post [https://github.com/wordpress-mobile/WordPress-iOS/pull/22240]
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -24,10 +24,6 @@ extension PageListViewController: InteractivePostViewDelegate {
         copyPage(page)
     }
 
-    func publish(_ apost: AbstractPost) {
-        publishPost(apost)
-    }
-
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
         guard let page = post as? Page else { return }
         trashPage(page, completion: completion)

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 enum AbstractPostHelper {
+    static func editorPublishAction(for post: AbstractPost) -> PostEditorAction {
+        post.blog.isPublishingPostsAllowed() ? .publish : .submitForReview
+    }
+
     static func getLocalizedStatusWithDate(for post: AbstractPost) -> String? {
         let timeZone = post.blog.timeZone
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -613,7 +613,7 @@ class AbstractPostListViewController: UIViewController,
             bottomSheet.show(from: self)
         }
 
-        func showPublshingConfirmation() {
+        func showPublishingConfirmation() {
             let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
 
             let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
@@ -630,7 +630,7 @@ class AbstractPostListViewController: UIViewController,
         if let post = post as? Post {
             showPrepublishingFlow(for: post)
         } else {
-            showPublshingConfirmation()
+            showPublishingConfirmation()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -596,24 +596,51 @@ class AbstractPostListViewController: UIViewController,
 
     // MARK: - Actions
 
-    @objc func publishPost(_ post: AbstractPost, completion: (() -> Void)? = nil) {
-        let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish in the post list.")
+    func publish(_ post: AbstractPost) {
+        let action = AbstractPostHelper.editorPublishAction(for: post)
 
-        let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
-        let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
-
-        let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
-        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
-
-        alertController.addCancelActionWithTitle(cancelTitle)
-        alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
-            WPAnalytics.track(.postListPublishAction, withProperties: self.propertiesForAnalytics())
-
-            PostCoordinator.shared.publish(post)
-            completion?()
+        func showPrepublishingFlow(for post: Post) {
+            let prepublishing = PrepublishingViewController(post: post, identifiers: PrepublishingIdentifier.defaultIdentifiers) { [weak self] result in
+                switch result {
+                case .completed(let post):
+                    self?.didConfirmPublish(for: post)
+                case .dismissed:
+                    break
+                }
+            }
+            let navigationController = PrepublishingNavigationController(rootViewController: prepublishing, shouldDisplayPortrait: false)
+            let bottomSheet = BottomSheetViewController(childViewController: navigationController, customHeaderSpacing: 0)
+            bottomSheet.show(from: self)
         }
 
-        present(alertController, animated: true)
+        func showPublshingConfirmation() {
+            let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
+
+            let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
+            let alertController = UIAlertController(title: action.publishingActionQuestionLabel, message: nil, preferredStyle: style)
+
+            alertController.addCancelActionWithTitle(cancelTitle)
+            alertController.addDefaultActionWithTitle(action.publishingActionQuestionLabel) { [unowned self] _ in
+                self.didConfirmPublish(for: post)
+            }
+
+            present(alertController, animated: true)
+        }
+
+        if let post = post as? Post {
+            showPrepublishingFlow(for: post)
+        } else {
+            showPublshingConfirmation()
+        }
+    }
+
+    private func didConfirmPublish(for post: AbstractPost) {
+        WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
+        PostCoordinator.shared.publish(post)
+
+        if post is Post {
+            BloggingRemindersFlow.present(from: self, for: post.blog, source: .publishFlow, alwaysShow: false)
+        }
     }
 
     @objc func moveToDraft(_ post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -91,7 +91,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         switch self {
         case .retry: return UIImage(systemName: "arrow.clockwise")
         case .view: return UIImage(systemName: "safari")
-        case .publish: return UIImage(systemName: "globe")
+        case .publish: return UIImage(systemName: "tray.and.arrow.up")
         case .stats: return UIImage(systemName: "chart.bar.xaxis")
         case .duplicate: return UIImage(systemName: "doc.on.doc")
         case .moveToDraft: return UIImage(systemName: "pencil.line")

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -122,7 +122,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         switch self {
         case .retry: return Strings.retry
         case .view: return post.status == .publish ? Strings.view : Strings.preview
-        case .publish: return Strings.publish
+        case .publish: return AbstractPostHelper.editorPublishAction(for: post).publishActionLabel
         case .stats: return Strings.stats
         case .duplicate: return Strings.duplicate
         case .moveToDraft: return Strings.draft
@@ -185,7 +185,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let comments = NSLocalizedString("posts.comments.actionTitle", value: "Comments", comment: "Label for post comments option. Tapping displays comments for a post.")
         static let settings = NSLocalizedString("posts.settings.actionTitle", value: "Settings", comment: "Label for post settings option. Tapping displays settings for a post.")
         static let duplicate = NSLocalizedString("posts.duplicate.actionTitle", value: "Duplicate", comment: "Label for post duplicate option. Tapping creates a copy of the post.")
-        static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish now", comment: "Label for an option that moves a publishes a post immediately")
         static let draft = NSLocalizedString("posts.draft.actionTitle", value: "Move to draft", comment: "Label for an option that moves a post to the draft folder")
         static let delete = NSLocalizedString("posts.delete.actionTitle", value: "Delete permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
         static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to trash", comment: "Label for a option that moves a post to the trash folder")

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -128,11 +128,7 @@ extension PostEditor {
     }
 
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
-        if RemoteFeatureFlag.jetpackSocialImprovements.enabled() {
-            return [.visibility, .schedule, .tags, .categories, .autoSharing]
-        }
-
-        return [.visibility, .schedule, .tags, .categories]
+        PrepublishingIdentifier.defaultIdentifiers
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -307,15 +307,6 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
         editDuplicatePost(post)
     }
 
-    func publish(_ post: AbstractPost) {
-        publishPost(post) {
-            BloggingRemindersFlow.present(from: self,
-                                          for: post.blog,
-                                          source: .publishFlow,
-                                          alwaysShow: false)
-        }
-    }
-
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
         if post.status == .draft ||
             post.status == .scheduled {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -21,6 +21,13 @@ enum PrepublishingIdentifier {
     case tags
     case categories
     case autoSharing
+
+    static var defaultIdentifiers: [PrepublishingIdentifier] {
+        if RemoteFeatureFlag.jetpackSocialImprovements.enabled() {
+            return [.visibility, .schedule, .tags, .categories, .autoSharing]
+        }
+        return [.visibility, .schedule, .tags, .categories]
+    }
 }
 
 class PrepublishingViewController: UITableViewController {


### PR DESCRIPTION
Addressed the following user feedback p1704477092863059-slack-C0180B5PRJ4 (more info in the thread).

- Rename the context menu action to "Publish" (was "Publish Now")
- Rename the action to "Submit for Review" if the user can't publish
- Show the pre-publishing flow when you tap "Publish" (only applies to Posts)

Instead of a more or less useless confirmation alert, the app shows a pre-publishing sheet with some useful customization options and the ability to schedule a post instead of publishing it immediately.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/55035682-6ecc-4e1c-8359-bcced2787635


## To test

**Contributor Role**

- Log in as a Contibutor
- Create and save a draft post
- Invoke the context menu
- **Verify** that the publishing action says "Submit for Review"
- Tap "Submit for Review"
- **Verify** that the pre-publishing sheet is shown
- Change some of the options and confirm
- **Verify** that the post was submitted for review with the selected options

**Admin**

Repeat the steps from the previous test but now as admin. **Verify** that instead of "Submit for Review" the buttons say "Publish".

## Technical Notes

Initially, I wanted to reuse the entire `PostEditor+Publish` [infrastructure](https://github.com/wordpress-mobile/WordPress-iOS/blob/40e76fa9d08d6768aa09031838e3d7a1b2877157/WordPress/Classes/ViewRelated/Post/PostEditor%2BPublish.swift#L97) for publishing, which has a couple of more details in addition to republishing. Unfortunately, it doesn't seem to be feasible because of how closely it's coupled with the editing.

I tried the following option:

- Using an invisible editor instance for publishing (not ideal because it starts up an edtitor; not a good long-term solution)
- Conforming `AbstractPostListViewController` to `PublishingEditor`  – too many properties to implement, too complicated, not and editor
- Extracting the flow from `PublishingEditor` – not feasible at the moment, especially with my limited understanding of how it works

As the first step, I decided to address the immediate issue reported by the user with the minimum amount of code and (potentially) iterate on it later. I think it's an improvement and the rest of the details from the flow can wait or might not even be necessary.

## Regression Notes
1. Potential unintended areas of impact: Post List Context Menu
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
