### PR TITLE
Add github.com to `known_hosts` on Danger Buildkite Step

### DIFF
--- a/.buildkite/commands/danger-pr-check.sh
+++ b/.buildkite/commands/danger-pr-check.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+HOST="github.com"
+echo "--- :github: Adding ${HOST} to '~/.ssh/known_hosts'..."
+for ip in $(dig @8.8.8.8 "${HOST}" +short); do ssh-keyscan "${HOST}","$ip"; ssh-keyscan "$ip"; done 2>/dev/null >> ~/.ssh/known_hosts || true
+
 echo "--- :rubygems: Setting up Gems"
 bundle install
 


### PR DESCRIPTION
Danger CI jobs are timing out due to the `release-toolkit` [ssh reference](https://github.com/wordpress-mobile/WordPress-iOS/blob/40e76fa9d08d6768aa09031838e3d7a1b2877157/Gemfile#L17C23-L17C23) recently added, with the following error:
```
Fetching git@github.com:wordpress-mobile/release-toolkit
The authenticity of host 'github.com' can't be established.
...
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```
To handle such cases (ssh references in the Gemfile), I've added `GitHub.com` to `known_hosts`.

To test, just confirm CI is green and Danger can successfully run.