### PR TITLE
My site header: Always show switch site option

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -21,13 +21,11 @@ extension SitePickerViewController {
     }
 
     private func makePrimarySection() -> UIMenu {
-        var menuItems = [
+        let menuItems = [
             MenuItem.visitSite({ [weak self] in self?.visitSiteTapped() }),
             MenuItem.addSite({ [weak self] in self?.addSiteTapped()} ),
+            MenuItem.switchSite({ [weak self] in self?.siteSwitcherTapped() })
         ]
-        if numberOfBlogs() > 1 {
-            menuItems.append(MenuItem.switchSite({ [weak self] in self?.siteSwitcherTapped() }))
-        }
         return UIMenu(options: .displayInline, children: menuItems.map { $0.toAction })
     }
 
@@ -111,10 +109,6 @@ extension SitePickerViewController {
     }
 
     // MARK: - Helpers
-
-    private func numberOfBlogs() -> Int {
-        defaultAccount()?.blogs?.count ?? 0
-    }
 
     private func defaultAccount() -> WPAccount? {
         try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)


### PR DESCRIPTION
Fixes #22371 

Fixes an issue where the switch site option wasn’t available for users that aren’t logged into a wp.com account (problem for users logged into self-hosted sites)

Slack ref: p1704902286130609-slack-C0180B5PRJ4

I will change the base branch to the 23.9 hotfix branch as soon as it's available

## How to test
- Login to a self-hosted site
- Verify the switch site option is available
- Tap on switch site and add a new site
- Verify you can switch between sites

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/569b444a-de74-45ce-a6fd-de09acd09200" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
