### PR TITLE
Update Release Toolkit to 9.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'fastlane-plugin-sentry'
 #
 # Attempt to address 'Bad CPU type in executable' on new Apple Silicon CI
 # See https://buildkite.com/automattic/wordpress-ios/builds/19609#018ced25-05f4-4c8b-9850-b314ea2f8d9e/1131-1330
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', ref: '2cb009edaee3d058a61cfeb503e533eb0647f108'
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.1'
+# gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '2cb009edaee3d058a61cfeb503e533eb0647f108'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.3'
 gem 'rake'
 gem 'rubocop', '~> 1.30'
 gem 'rubocop-rake', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,4 @@
 GIT
-  remote: git@github.com:wordpress-mobile/release-toolkit
-  revision: 2cb009edaee3d058a61cfeb503e533eb0647f108
-  ref: 2cb009edaee3d058a61cfeb503e533eb0647f108
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (9.2.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
-
-GIT
   remote: https://github.com/Automattic/dangermattic
   revision: 06a54db4f546d20c0465e4d144049d061a2a1e20
   specs:
@@ -235,6 +212,23 @@ GEM
     fastlane-plugin-appcenter (2.1.1)
     fastlane-plugin-sentry (1.15.0)
       os (~> 1.1, >= 1.1.4)
+    fastlane-plugin-wpmreleasetoolkit (9.3.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11, < 1.16)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
     ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -307,7 +301,7 @@ GEM
     naturally (2.2.1)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.16.0)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -414,7 +408,7 @@ DEPENDENCIES
   fastlane (~> 2.217)
   fastlane-plugin-appcenter (~> 2.1)
   fastlane-plugin-sentry
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 9.3)
   rake
   rmagick (~> 3.2.0)
   rubocop (~> 1.30)


### PR DESCRIPTION
Updating `release-toolkit` to its latest version.
This PR should also fix the problem we've observed on CI with jobs getting stuck due to the `release-toolkit` specific reference ssh fetch when running `bundle install`.