### PR TITLE
Fix a crash in external media picker

### DIFF
--- a/WordPress/Classes/Extensions/Array.swift
+++ b/WordPress/Classes/Extensions/Array.swift
@@ -19,9 +19,17 @@ extension Array where Element: Hashable {
         return Array(Set(self))
     }
 
+    /// Removes the duplicates from the array while maintaining the original order.
     public func deduplicated() -> [Element] {
-        var seen = Set<Element>()
-        return filter { seen.insert($0).inserted }
+        deduplicated(by: { $0 })
+    }
+}
+
+extension Array {
+    /// Removes the duplicates from the array while maintaining the original order.
+    public func deduplicated<Identifier: Hashable>(by identifier: (Element) -> Identifier) -> [Element] {
+        var seen = Set<Identifier>()
+        return filter { seen.insert(identifier($0)).inserted }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataSource.swift
@@ -67,6 +67,7 @@ extension StockPhotosDataSource: StockPhotosDataLoaderDelegate {
         } else {
             self.assets += media
         }
+        self.assets = self.assets.deduplicated(by: \.id)
         onUpdatedAssets?()
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorDataSource.swift
@@ -69,6 +69,7 @@ extension TenorDataSource: TenorDataLoaderDelegate {
         } else {
             self.assets += media
         }
+        self.assets = self.assets.deduplicated(by: \.id)
         onUpdatedAssets?()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchSuggestionsService.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchSuggestionsService.swift
@@ -34,6 +34,7 @@ actor PostSearchSuggestionsService {
             .sorted { ($0.score, $0.token.value) > ($1.score, $1.token.value) }
             .map { $0.token }
             .prefix(3))
+            .deduplicated(by: \.id)
     }
 
     private struct RankedToken {


### PR DESCRIPTION
Cherry pick of https://github.com/wordpress-mobile/WordPress-iOS/pull/22363 onto the hotfix 23.9.1 branch.

---

Unfortunately, because we shut down the Intel-CI and have no Xcode 14.3.1 image in the Apple Silicon CI, all CI builds based of the 23.9 tag will fail.

Here's a screenshot of the tests passing on my machine.

To replicate locally, you might want to 

1. Run `bundle exec pod install` to ensure the pods are in sync and avoid failure on the first run
2. `export FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK=1` to disable the release-toolkit update check prompt, which enables running `fastlane` commands one after the other without user input (the `&&` below)

### Unit tests

```
DEVICE='iPhone 15 Pro' && bundle exec fastlane build_wordpress_for_testing device:"$DEVICE" && bundle exec fastlane test_without_building name:UnitTests device:"$DEVICE"
```

<img width="1070" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/a2b66cab-45c2-4a86-9e6f-1bd3f16968e2">

### Testing Update

When starting to test locally, I didn't account for the fact that all the Xcode 14.3.1 vs 15.1 (15.2, actually because my local auto-updated) limitation that afflict CI also afflict local testing. That is, these unit tests will fail locally unless:

- Run on the Xcode 14.3.1 toolchain; or
- We cherry pick the necessary test fixes

I went for the latter approach. I didn't push those changes here, but you can check the and use them via [`mokagio/helper-23.9.1-xcode-15.1-unit-tests-support`](https://github.com/wordpress-mobile/WordPress-iOS/compare/release/23.9.1...mokagio/helper-23.9.1-xcode-15.1-unit-tests-support). I imagine they'll be useful when addressing the remainder of the blockers that prompted this hotfix