### PR TITLE
Add editor_upload_media_paused analytics event

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,10 +23,10 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-  pod 'WordPressShared', '~> 2.2'
+  # pod 'WordPressShared', '~> 2.2'
   # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', tag: ''
   # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', branch: 'trunk'
-  # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', commit: ''
+  pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', commit: '8b6bfeb70cb5f4ec8798cc9a0bbbec7bb07fe97c'
   # pod 'WordPressShared', path: '../WordPress-iOS-Shared'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -23,10 +23,10 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-  # pod 'WordPressShared', '~> 2.2'
+  pod 'WordPressShared', '~> 2.2'
   # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', tag: ''
   # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', branch: 'trunk'
-  pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', commit: '7e067061b2ef3b449c509ddff35dabd67fbe70c7'
+  # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', commit: ''
   # pod 'WordPressShared', path: '../WordPress-iOS-Shared'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -23,10 +23,10 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-  pod 'WordPressShared', '~> 2.2'
+  # pod 'WordPressShared', '~> 2.2'
   # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', tag: ''
   # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', branch: 'trunk'
-  # pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', commit: ''
+  pod 'WordPressShared', git: 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', commit: '7e067061b2ef3b449c509ddff35dabd67fbe70c7'
   # pod 'WordPressShared', path: '../WordPress-iOS-Shared'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -122,7 +122,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (>= 8.0.1, ~> 8.0)
   - WordPressKit (>= 9.0.3, ~> 9.0)
-  - WordPressShared (~> 2.2)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `8b6bfeb70cb5f4ec8798cc9a0bbbec7bb07fe97c`)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -159,7 +159,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -177,11 +176,17 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.111.0-alpha2.podspec
+  WordPressShared:
+    :commit: 8b6bfeb70cb5f4ec8798cc9a0bbbec7bb07fe97c
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressShared:
+    :commit: 8b6bfeb70cb5f4ec8798cc9a0bbbec7bb07fe97c
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -227,6 +232,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: d7a42312b8249374e94aecb6021ee06d137c7cfa
+PODFILE CHECKSUM: 3f93c2e970f0b3bf8752734ccf05a292587c706e
 
 COCOAPODS: 1.14.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -122,7 +122,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (>= 8.0.1, ~> 8.0)
   - WordPressKit (>= 9.0.3, ~> 9.0)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `7e067061b2ef3b449c509ddff35dabd67fbe70c7`)
+  - WordPressShared (~> 2.2)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -159,6 +159,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -176,17 +177,11 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.111.0-alpha2.podspec
-  WordPressShared:
-    :commit: 7e067061b2ef3b449c509ddff35dabd67fbe70c7
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
-  WordPressShared:
-    :commit: 7e067061b2ef3b449c509ddff35dabd67fbe70c7
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -232,6 +227,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: b2796422cb2a2218b6ce18190780559926400a55
+PODFILE CHECKSUM: d7a42312b8249374e94aecb6021ee06d137c7cfa
 
 COCOAPODS: 1.14.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -122,7 +122,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (>= 8.0.1, ~> 8.0)
   - WordPressKit (>= 9.0.3, ~> 9.0)
-  - WordPressShared (~> 2.2)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `7e067061b2ef3b449c509ddff35dabd67fbe70c7`)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -159,7 +159,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -177,11 +176,17 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.111.0-alpha2.podspec
+  WordPressShared:
+    :commit: 7e067061b2ef3b449c509ddff35dabd67fbe70c7
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressShared:
+    :commit: 7e067061b2ef3b449c509ddff35dabd67fbe70c7
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -227,6 +232,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: d7a42312b8249374e94aecb6021ee06d137c7cfa
+PODFILE CHECKSUM: b2796422cb2a2218b6ce18190780559926400a55
 
 COCOAPODS: 1.14.2

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -442,6 +442,16 @@ class MediaCoordinator: NSObject {
                              with: media.blog)
     }
 
+    func trackPausedUploadOf(_ media: Media, analyticsInfo: MediaAnalyticsInfo?) {
+        guard let info = analyticsInfo else {
+            return
+        }
+
+        let event = info.pausedEvent
+        let properties = info.properties(for: media)
+        WPAppAnalytics.track(event, withProperties: properties, with: media.blog)
+    }
+
     // MARK: - Progress
 
     /// - returns: The current progress for the specified media object.

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -167,24 +167,10 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 - (void)trackUploadError:(NSError *)error
                     blog:(Blog *)blog
 {
-    switch (error.code) {
-        case NSURLErrorCancelled:
-            [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadCanceled withBlog:blog];
-            break;
-        case NSURLErrorNetworkConnectionLost:
-        case NSURLErrorNotConnectedToInternet:
-            [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadPaused error:error withBlogID:blog.dotComID];
-            break;
-        case NSURLErrorTimedOut:
-            if (ReachabilityUtils.isInternetReachable) {
-                [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error withBlogID:blog.dotComID];
-            } else {
-                [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadPaused error:error withBlogID:blog.dotComID];
-            }
-            break;
-        default:
-            [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error withBlogID:blog.dotComID];
-            break;
+    if (error.code == NSURLErrorCancelled) {
+        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadCanceled withBlog:blog];
+    } else {
+        [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadFailed error:error withBlogID:blog.dotComID];
     }
 }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -650,6 +650,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatEditorUploadMediaFailed:
             eventName = @"editor_upload_media_failed";
             break;
+        case WPAnalyticsStatEditorUploadMediaPaused:
+            eventName = @"editor_upload_media_paused";
+            break;
         case WPAnalyticsStatEditorUploadMediaRetried:
             eventName = @"editor_upload_media_retried";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -650,9 +650,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatEditorUploadMediaFailed:
             eventName = @"editor_upload_media_failed";
             break;
-        case WPAnalyticsStatEditorUploadMediaPaused:
-            eventName = @"editor_upload_media_paused";
-            break;
         case WPAnalyticsStatEditorUploadMediaRetried:
             eventName = @"editor_upload_media_retried";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -948,9 +948,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMediaServiceUploadFailed:
             eventName = @"media_service_upload_failed";
             break;
-        case WPAnalyticsStatMediaServiceUploadPaused:
-            eventName = @"media_service_upload_paused";
-            break;
         case WPAnalyticsStatMediaServiceUploadSuccessful:
             eventName = @"media_service_upload_successful";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -948,6 +948,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMediaServiceUploadFailed:
             eventName = @"media_service_upload_failed";
             break;
+        case WPAnalyticsStatMediaServiceUploadPaused:
+            eventName = @"media_service_upload_paused";
+            break;
         case WPAnalyticsStatMediaServiceUploadSuccessful:
             eventName = @"media_service_upload_successful";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -77,6 +77,8 @@ public struct MediaAnalyticsInfo {
         }
     }
 
+    var pausedEvent: WPAnalyticsStat = .editorUploadMediaPaused
+
     func properties(for media: Media) -> [String: Any] {
         guard let selectionMethod = selectionMethod else {
             return WPAppAnalytics.properties(for: media)


### PR DESCRIPTION
When a device is offline and media uploads are ongoing, track a "paused" analytics event.

Resolves:

* https://github.com/wordpress-mobile/gutenberg-mobile/issues/6516


To test:

1. Create a post and upload an image
2. Turn off network connectivity (via airplane mode or similar)
3. Observe that paused event fires in addition to the failure event

## Regression Notes
1. Potential unintended areas of impact
Analytics events

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing in Tracks

5. What automated tests I added (or what prevented me from doing so)
N/A (analytics)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
