### PR TITLE
Improve Post List analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -284,6 +284,7 @@ import Foundation
     // Post List
     case postListItemSelected
     case postListShareAction
+    case postListBlazeAction
     case postListCommentsAction
     case postListSetAsPostsPageAction
     case postListSetHomePageAction
@@ -1058,6 +1059,8 @@ import Foundation
             return "post_list_item_selected"
         case .postListShareAction:
             return "post_list_button_pressed"
+        case .postListBlazeAction:
+            return "post_list_button_pressed"
         case .postListCommentsAction:
             return "post_list_button_pressed"
         case .postListSetAsPostsPageAction:
@@ -1545,6 +1548,8 @@ import Foundation
             return ["via": "tenor"]
         case .postListShareAction:
             return ["button": "share"]
+        case .postListBlazeAction:
+            return ["button": "blaze"]
         case .postListCommentsAction:
             return ["button": "comments"]
         case .postListSetAsPostsPageAction:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -282,6 +282,7 @@ import Foundation
     case siteSwitcherToggleBlogVisible
 
     // Post List
+    case postListItemSelected
     case postListShareAction
     case postListCommentsAction
     case postListSetAsPostsPageAction
@@ -1053,6 +1054,8 @@ import Foundation
             return "site_switcher_toggle_blog_visible"
 
         // Post List
+        case .postListItemSelected:
+            return "post_list_item_selected"
         case .postListShareAction:
             return "post_list_button_pressed"
         case .postListCommentsAction:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1217,8 +1217,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"post_list_load_more_triggered";
             break;
         case WPAnalyticsStatPostListNoResultsButtonPressed:
-            eventName = @"post_list_button_pressed";
-            eventProperties = @{ TracksEventPropertyButtonKey : @"no_results" };
+            eventName = @"post_list_create_post_tapped";
             break;
         case WPAnalyticsStatPostListOpenedCellMenu:
             eventName = @"post_list_cell_menu_opened";

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -5,10 +5,7 @@ extension PageListViewController: InteractivePostViewDelegate {
     func edit(_ apost: AbstractPost) {
         guard let page = apost as? Page else { return }
 
-        let didOpenEditor = PageEditorPresenter.handle(page: page, in: self, entryPoint: .pagesList)
-        if didOpenEditor {
-            WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: page)
-        }
+        PageEditorPresenter.handle(page: page, in: self, entryPoint: .pagesList)
     }
 
     func view(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -374,6 +374,7 @@ final class PageListViewController: AbstractPostListViewController, UIViewContro
             present(navigationController, animated: true)
         case .pages:
             let page = pages[indexPath.row]
+            WPAnalytics.track(.postListItemSelected, properties: propertiesForAnalytics())
             edit(page)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -215,6 +215,7 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
             return
         }
 
+        WPAnalytics.track(.postListItemSelected, properties: propertiesForAnalytics())
         editPost(post)
     }
 
@@ -251,7 +252,6 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
         guard let post = post as? Post else {
             return
         }
-        WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
         PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -368,6 +368,7 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
     }
 
     func blaze(_ post: AbstractPost) {
+        WPAnalytics.track(.postListBlazeAction, properties: propertiesForAnalytics())
         BlazeEventsTracker.trackEntryPointTapped(for: .postsList)
         BlazeFlowCoordinator.presentBlaze(in: self, source: .postsList, blog: blog, post: post)
     }


### PR DESCRIPTION
- Add `post_list_item_selected` event to replce `post_list_button_tapped` with `action: edit`  
- Add  `blaze` to `post_list_button_tapped`  to make it easier to track
- Remove `button: no_results`  tracking via `post_list_button_tapped ` and add `post_list_create_post_tapped` instead

To test: n/a

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
