### PR TITLE
Stats Traffic: Create an empty Traffic tab behind the feature flag

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -56,7 +56,7 @@ fileprivate extension StatsPeriodType {
         case .weeks:    return .statsPeriodWeeksAccessed
         case .months:   return .statsPeriodMonthsAccessed
         case .years:    return .statsPeriodYearsAccessed
-        case .traffic:  return .statsPeriodDaysAccessed // TODO
+        case .traffic:  return .noStat // TODO
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -6,6 +6,7 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
     case weeks
     case months
     case years
+    case traffic
 
     // This is public as it is needed by FilterTabBarItem.
     var title: String {
@@ -15,6 +16,7 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
         case .weeks: return NSLocalizedString("Weeks", comment: "Title of Weeks stats filter.")
         case .months: return NSLocalizedString("Months", comment: "Title of Months stats filter.")
         case .years: return NSLocalizedString("Years", comment: "Title of Years stats filter.")
+        case .traffic: return NSLocalizedString("stats.dashboard.tab.traffic", value: "Traffic", comment: "Title of Traffic stats tab.")
         }
     }
 
@@ -30,6 +32,8 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
             self = .years
         case "insights":
             self = .insights
+        case "traffic":
+            self = .traffic
         default:
             return nil
         }
@@ -46,6 +50,7 @@ fileprivate extension StatsPeriodType {
         case .weeks:    return .statsPeriodWeeksAccessed
         case .months:   return .statsPeriodMonthsAccessed
         case .years:    return .statsPeriodYearsAccessed
+        case .traffic:  return .statsPeriodDaysAccessed // TODO
         }
     }
 }
@@ -252,6 +257,13 @@ private extension SiteStatsDashboardViewController {
                                                        animated: false)
             }
             insightsTableViewController.refreshInsights()
+        case .traffic:
+            if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
+                let viewController = UIViewController() // TODO
+                pageViewController?.setViewControllers([viewController],
+                                                       direction: .forward,
+                                                       animated: false)
+            }
         default:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([periodTableViewController],

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -79,6 +79,7 @@ class SiteStatsDashboardViewController: UIViewController {
     private var insightsTableViewController = SiteStatsInsightsTableViewController.loadFromStoryboard()
     private var periodTableViewController = SiteStatsPeriodTableViewController.loadFromStoryboard()
     private var pageViewController: UIPageViewController?
+    private lazy var displayedPeriods: [StatsPeriodType] = StatsPeriodType.displayedPeriods
 
     @objc lazy var manageInsightsButton: UIBarButtonItem = {
         let button = UIBarButtonItem(
@@ -172,10 +173,10 @@ private extension SiteStatsDashboardViewController {
     var currentSelectedPeriod: StatsPeriodType {
         get {
             let selectedIndex = filterTabBar?.selectedIndex ?? 0
-            return StatsPeriodType.displayedPeriods[selectedIndex]
+            return displayedPeriods[selectedIndex]
         }
         set {
-            let index = StatsPeriodType.displayedPeriods.firstIndex(of: newValue) ?? 0
+            let index = displayedPeriods.firstIndex(of: newValue) ?? 0
             filterTabBar?.setSelectedIndex(index)
             let oldSelectedPeriod = getSelectedPeriodFromUserDefaults()
             updatePeriodView(oldSelectedPeriod: oldSelectedPeriod)
@@ -191,13 +192,13 @@ private extension SiteStatsDashboardViewController {
 
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
-        filterTabBar.items = StatsPeriodType.displayedPeriods
+        filterTabBar.items = displayedPeriods
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         filterTabBar.accessibilityIdentifier = "site-stats-dashboard-filter-bar"
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
-        currentSelectedPeriod = StatsPeriodType.displayedPeriods[filterBar.selectedIndex]
+        currentSelectedPeriod = displayedPeriods[filterBar.selectedIndex]
 
         configureNavBar()
     }
@@ -227,7 +228,7 @@ private extension SiteStatsDashboardViewController {
 
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue,
               let periodType = StatsPeriodType(rawValue: UserPersistentStoreFactory.instance().integer(forKey: Self.lastSelectedStatsPeriodTypeKey(forSiteID: siteID))) else {
-            return StatsPeriodType.displayedPeriods[0]
+            return displayedPeriods[0]
         }
 
         return periodType


### PR DESCRIPTION
Fixes #22380

The goal of PR is to create a mechanism to support:
- Insights, Days, Weeks, Months, Years tabs when `stats_traffic_tab` feature flag is disabled
- Traffic, Insights when `stats_traffic_tab` feature flag is enabled

While continuing to support existing mechanisms of remembering previous tab or period selection.

## To test:

### Regression
1. Disable the feature flag
2. Open Stats
3. Confirm Insights, Days, Weeks, Months, Years tabs appear as before
4. Select Insights, Close and Open Stats
6. Confirm Insights is selected
7. Select Weeks, Close and Open Stats
9. Confirm Weeks is selected
10. Switch between Tabs and Date periods
11. Confirm mechanism works

### Stats Traffic tab
1. Enable feature flag
2. Open Stats
3. Confirm Traffic, Insights tabs appear
4. Select Insights
5. Confirm Insights appear as before, Close and Open Stats
7. Confirm Insights is still selected
8. Select Traffic, Close and Open Stats
10. Confirm Traffic is selected

### Stats Traffic tab after feature flag update update
1. Disable feature flag
2. Open Stats
3. Select Days/Weeks/Months/Years tab
4. Enable feature flag, Close and Open Stats
6. Confirm Traffic tab is open
7. Disable feature flag, Close and Open Stats
9. Select Insights tab
10. Enable feature flag, Close and Open Stats
12. Confirm Insights tab is open


https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/a31822d8-b2a7-4508-a590-aa35d7c5d81c

### Widgets and Deep Links regression

1. Disable feature flag
2. Add Today/This Week/All Time widgets
3. Confirm they open Days/Weeks/Insights
4. Open WordPress.com/stats
5. Tap on banners
6. Confirm they open appropriate tab

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/e826ae1e-85ec-444f-8a66-85ef6db191ea


## Regression Notes
1. Potential unintended areas of impact

Breaking current Stats tab switching functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
