### PR TITLE
My site header: Add site icon menu if user is admin

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -13,11 +13,12 @@ extension SitePickerViewController {
     }
 
     private func makeSections() -> [UIMenu] {
-        [
+        let sections = [
             makePrimarySection(),
             makeSecondarySection(),
             makeTertiarySection()
         ]
+        return sections.compactMap { $0 }
     }
 
     private func makePrimarySection() -> UIMenu {
@@ -31,7 +32,11 @@ extension SitePickerViewController {
         return UIMenu(options: .displayInline, children: menuItems.map { $0.toAction })
     }
 
-    private func makeSecondarySection() -> UIMenu {
+    private func makeSecondarySection() -> UIMenu? {
+        guard blog.isAdmin else {
+            return nil
+        }
+
         var menuItems: [UIMenuElement] = [
             MenuItem.siteTitle({ [weak self] in self?.siteTitleTapped() }).toAction
         ]

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -32,12 +32,17 @@ extension SitePickerViewController {
     }
 
     private func makeSecondarySection() -> UIMenu {
-        UIMenu(options: .displayInline, children: [
-            MenuItem.siteTitle({ [weak self] in self?.siteTitleTapped() }).toAction,
-            UIMenu(title: Strings.siteIcon, image: UIImage(systemName: "photo.circle"), children: [
-                makeSiteIconMenu() ?? UIMenu()
-            ])
-        ])
+        var menuItems: [UIMenuElement] = [
+            MenuItem.siteTitle({ [weak self] in self?.siteTitleTapped() }).toAction
+        ]
+        if siteIconShouldAllowDroppedImages() {
+            menuItems.append(
+                UIMenu(title: Strings.siteIcon, image: UIImage(systemName: "photo.circle"), children: [
+                    makeSiteIconMenu() ?? UIMenu()
+                ])
+            )
+        }
+        return UIMenu(options: .displayInline, children: menuItems)
     }
 
     private func makeTertiarySection() -> UIMenu {


### PR DESCRIPTION
Fixes https://a8c.slack.com/archives/C04SFL0RP51/p1705066965661869

## How to test

### Non-admin role
- Switch to a site where you're not an admin
- Verify that tapping the site icon doesn't bring up the site icon context menu
- Tap the more button 
- Verify the site title menu isn't present in the context menu
- Verify that the site icon menu item isn't present in the context menu

### Admin role
- Switch to a site where you're an admin
- Verify that tapping the site icon brings up the site icon context menu
- Tap the more button 
- Verify the site title menu is present in the context menu
- Verify that the site icon menu item is present in the context menu

Non-admin | Admin
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/abc6ec6a-7980-4fbe-a486-dc6b71c3471d" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f6e06c84-28d2-4f6f-b607-09bc016b8b0a" width=200>

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

