### PR TITLE
Prevent iPad crash when collapsing secondary vc

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -512,6 +512,7 @@ extension WPSplitViewController: UISplitViewControllerDelegate {
 
                 if (!isShowingInitialDetail && detailNavigationStackHasBeenModified) || forceKeepDetail {
                     primaryViewController.viewControllers.append(contentsOf: secondaryViewController.viewControllers)
+                    secondaryViewController.viewControllers = [] // This prevents a crash that manifests on Xcode 15.0 / iOS 17.0
                 }
             }
 


### PR DESCRIPTION
Fixes #22373

## Description
Addresses a crash that manifests on Xcode 15/iOS 17 when collapsing the secondary vc in split view

https://stackoverflow.com/questions/77228311/nsinternalinconsistencyexception-reason-layout-requested-for-visible-naviga

## How to test
- Verify the app doesn't crash on the following screens when going into Split view mode. To go into split view, tap 3 dot menu at top of screen to open Full Screen / Split View / Slide Over options, then select Split View
  - Posts list
  - Pages list
  - Notifications tab > Notifications detail
  - Me tab > App settings 

## Regression Notes
1. Potential unintended areas of impact
split view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
manually tested

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
