### PR TITLE
Support dark mode in navigation bar when presenting DomainSelection from SiteDomains

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
@@ -22,10 +22,10 @@ struct DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable {
         )
     }
 
-    func makeUIViewController(context: Context) -> LightNavigationController {
-        let navigationController = LightNavigationController(rootViewController: domainSuggestionViewController)
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let navigationController = UINavigationController(rootViewController: domainSuggestionViewController)
         return navigationController
     }
 
-    func updateUIViewController(_ uiViewController: LightNavigationController, context: Context) { }
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) { }
 }


### PR DESCRIPTION
Fixes #22378

Use `UINavigationController` instead `LightNavigationController`.

## To test:

1. Menu
2. Site Domains
3. Add Domain
4. Switch to dark mode
5. Confirm navigation bar is dark

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/2d740a35-a2e8-4127-8666-2e469b292f57

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3 What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
