### PR TITLE
Use raw value for the `quality` parameter in `app_settings_image_quality_changed` event

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -217,7 +217,7 @@ class AppSettingsViewController: UITableViewController {
                 MediaSettings().imageQualitySetting = newQuality
 
                 // Track setting changes
-                WPAnalytics.track(.appSettingsImageQualityChanged, properties: ["quality": newQuality.description])
+                WPAnalytics.track(.appSettingsImageQualityChanged, properties: ["quality": newQuality.rawValue])
             }
 
             self?.navigationController?.pushViewController(viewController!, animated: true)


### PR DESCRIPTION
This PR updates the value sent in the `quality` property of the event `app_settings_image_quality_changed` introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/21981. The reason for the change is that the value currently sent is localized:

<img width="89" alt="Screenshot 2024-01-15 at 18 14 01" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/14905380/5c33537b-e96c-4f66-830a-ee422432a2f9">

**To test:**
1. Navigate to the _Me_ screen.
2. Tap on _App Settings_ button.
3. Tap on the _Image Quality_ button.
4. Change the quality setting.
5. Navigate back.
6. Observe that the event `app_settings_image_quality_changed` is generated with the proper `quality` value.

The values are mapped with the following strings:
https://github.com/wordpress-mobile/WordPress-iOS/blob/350bc50aac26dc416f6124f85aa7989c259c084d/WordPress/Classes/Services/MediaSettings.swift#L23-L26

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
