### PR TITLE
Add unit tests for Compliance Popover Coordinator and revert accidental change

### DIFF
--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/ComplianceLocationService.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/ComplianceLocationService.swift
@@ -1,6 +1,6 @@
 import WordPressKit
 
-final class ComplianceLocationService {
+class ComplianceLocationService {
     func getIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
         IPLocationRemote().fetchIPCountryCode(completion: completion)
     }

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 protocol CompliancePopoverCoordinatorProtocol: AnyObject {
-    func presentIfNeeded()
+    func presentIfNeeded(completion: ((Bool) -> Void)?)
     func navigateToSettings()
     func dismiss()
 }
@@ -10,8 +10,9 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
 
     // MARK: - Dependencies
 
-    private let complianceService = ComplianceLocationService()
+    private let complianceService: ComplianceLocationService
     private let defaults: UserDefaults
+    private let isFeatureFlagEnabled: () -> Bool
 
     // MARK: - Views
 
@@ -21,20 +22,31 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
 
     // MARK: - Init
 
-    init(defaults: UserDefaults = UserDefaults.standard) {
+    init(
+        defaults: UserDefaults = UserDefaults.standard,
+        complianceService: ComplianceLocationService = .init(),
+        isFeatureFlagEnabled: @autoclosure @escaping () -> Bool = FeatureFlag.compliancePopover.enabled
+    ) {
         self.defaults = defaults
+        self.complianceService = complianceService
+        self.isFeatureFlagEnabled = isFeatureFlagEnabled
     }
 
-    func presentIfNeeded() {
-        guard FeatureFlag.compliancePopover.enabled/*, !defaults.didShowCompliancePopup */else {
+    // MARK: - API
+
+    func presentIfNeeded(completion: ((Bool) -> Void)? = nil) {
+        guard isFeatureFlagEnabled(), !defaults.didShowCompliancePopup else {
+            completion?(false)
             return
         }
-        complianceService.getIPCountryCode { [weak self] result in
+        self.complianceService.getIPCountryCode { [weak self] result in
             guard let self, case .success(let countryCode) = result, self.shouldShowPrivacyBanner(countryCode: countryCode) else {
+                completion?(false)
                 return
             }
             DispatchQueue.main.async {
                 self.presentPopover()
+                completion?(Self.window != nil)
             }
         }
     }
@@ -52,8 +64,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
     // MARK: - Helpers
 
     private func shouldShowPrivacyBanner(countryCode: String) -> Bool {
-        let isCountryInEU = Self.gdprCountryCodes.contains(countryCode)
-        return isCountryInEU && !defaults.didShowCompliancePopup
+        return Self.gdprCountryCodes.contains(countryCode)
     }
 
     private func dismiss(completion: (() -> Void)? = nil) {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -12,7 +12,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
 
     private let complianceService: ComplianceLocationService
     private let defaults: UserDefaults
-    private let isFeatureFlagEnabled: () -> Bool
+    private let isFeatureFlagEnabled: Bool
 
     // MARK: - Views
 
@@ -25,7 +25,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
     init(
         defaults: UserDefaults = UserDefaults.standard,
         complianceService: ComplianceLocationService = .init(),
-        isFeatureFlagEnabled: @autoclosure @escaping () -> Bool = FeatureFlag.compliancePopover.enabled
+        isFeatureFlagEnabled: Bool = FeatureFlag.compliancePopover.enabled
     ) {
         self.defaults = defaults
         self.complianceService = complianceService
@@ -35,7 +35,7 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
     // MARK: - API
 
     func presentIfNeeded(completion: ((Bool) -> Void)? = nil) {
-        guard isFeatureFlagEnabled(), !defaults.didShowCompliancePopup else {
+        guard isFeatureFlagEnabled, !defaults.didShowCompliancePopup else {
             completion?(false)
             return
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3559,6 +3559,7 @@
 		F1F083F6241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F083F5241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift */; };
 		F4026B1D2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4026B1C2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift */; };
 		F4026B1E2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4026B1C2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift */; };
+		F406F3ED2B55960700AFC04A /* CompliancePopoverCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F406F3EC2B55960700AFC04A /* CompliancePopoverCoordinatorTests.swift */; };
 		F413F77A2B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7792B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift */; };
 		F413F77B2B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7792B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift */; };
 		F413F7882B2B253A00A64A94 /* DashboardCard+Personalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */; };
@@ -8920,6 +8921,7 @@
 		F1F163C825658B4D003DC13B /* IntentsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IntentsUI.framework; path = System/Library/Frameworks/IntentsUI.framework; sourceTree = SDKROOT; };
 		F373612EEEEF10E500093FF3 /* Pods-Apps-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F4026B1C2A1BC88A00CC7781 /* DashboardDomainRegistrationCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardDomainRegistrationCardCell.swift; sourceTree = "<group>"; };
+		F406F3EC2B55960700AFC04A /* CompliancePopoverCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompliancePopoverCoordinatorTests.swift; sourceTree = "<group>"; };
 		F40CC35C2954991C00D75A95 /* WordPress 146.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 146.xcdatamodel"; sourceTree = "<group>"; };
 		F413F7792B2A183E00A64A94 /* BlogDashboardDynamicCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardDynamicCardCell.swift; sourceTree = "<group>"; };
 		F413F7872B2B253A00A64A94 /* DashboardCard+Personalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardCard+Personalization.swift"; sourceTree = "<group>"; };
@@ -10041,6 +10043,7 @@
 			children = (
 				088134FE2A56C5240027C086 /* CompliancePopoverViewModelTests.swift */,
 				F4D7FD6B2A57030E00642E06 /* CompliancePopoverViewControllerTests.swift */,
+				F406F3EC2B55960700AFC04A /* CompliancePopoverCoordinatorTests.swift */,
 			);
 			path = EUUSCompliance;
 			sourceTree = "<group>";
@@ -23551,6 +23554,7 @@
 				40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */,
 				8BC6020D2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift in Sources */,
 				57B71D4E230DB5F200789A68 /* BlogBuilder.swift in Sources */,
+				F406F3ED2B55960700AFC04A /* CompliancePopoverCoordinatorTests.swift in Sources */,
 				D848CC1920FF3A2400A9038F /* FormattableNotIconTests.swift in Sources */,
 				32110547250BFC3E0048446F /* ImageDimensionParserTests.swift in Sources */,
 				E1AB5A3A1E0C464700574B4E /* DelayTests.swift in Sources */,

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverCoordinatorTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverCoordinatorTests.swift
@@ -1,0 +1,109 @@
+
+import XCTest
+
+@testable import WordPress
+
+final class CompliancePopoverCoordinatorTests: XCTestCase {
+
+    private var service: ComplianceLocationServiceMock!
+    private var defaults: UserDefaultsMock!
+    private var coordinator: CompliancePopoverCoordinator!
+
+    override func setUp() {
+        self.service = .init()
+        self.defaults = .init()
+        self.coordinator = .init(
+            defaults: defaults,
+            complianceService: service,
+            isFeatureFlagEnabled: true
+        )
+    }
+
+    // MARK: - Tests
+
+    func testPopoverIsShown() {
+        // Given
+        let expectation = expectation(description: "Should display popover")
+        self.defaults.didShowCompliancePopupOverride = false
+
+        // When
+        self.coordinator.presentIfNeeded { shown in
+            XCTAssertTrue(shown)
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testPopoverIsNotShownWhenShownBefore() {
+        // Given
+        let expectation = expectation(description: "Should not display popover")
+        self.defaults.didShowCompliancePopupOverride = true
+
+        // When
+        coordinator.presentIfNeeded { shown in
+            XCTAssertFalse(shown)
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testPopoverIsNotShownForNonEUCountry() {
+        // Given
+        let expectation = expectation(description: "Should not display popover for non-EU country")
+        self.service.countryCode = "MA"
+        self.defaults.didShowCompliancePopupOverride = true
+
+        // When
+        coordinator.presentIfNeeded { shown in
+            XCTAssertFalse(shown)
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator(
+        service: ComplianceLocationService = ComplianceLocationServiceMock(),
+        didShowCompliancePopup: Bool = false,
+        isFeatureFlagEnabled: Bool = true
+    ) -> CompliancePopoverCoordinator {
+        let defaults = UserDefaultsMock()
+        defaults.didShowCompliancePopupOverride = didShowCompliancePopup
+        return .init(
+            defaults: defaults,
+            complianceService: service,
+            isFeatureFlagEnabled: isFeatureFlagEnabled
+        )
+    }
+
+}
+
+// MARK: - Mocks
+
+private class ComplianceLocationServiceMock: ComplianceLocationService {
+
+    var countryCode = "DE"
+
+    override func getIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
+        completion(.success(countryCode))
+    }
+}
+
+private class UserDefaultsMock: UserDefaults {
+
+    var didShowCompliancePopupOverride: Bool = false
+
+    override func bool(forKey defaultName: String) -> Bool {
+        if defaultName == UserDefaults.didShowCompliancePopupKey {
+            return didShowCompliancePopupOverride
+        }
+        return super.bool(forKey: defaultName)
+    }
+}

--- a/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
+++ b/WordPress/WordPressTest/EUUSCompliance/CompliancePopoverViewModelTests.swift
@@ -81,7 +81,7 @@ private class MockCompliancePopoverCoordinator: CompliancePopoverCoordinatorProt
     private(set) var presentIfNeededCallCount = 0
     private(set) var dismissCallCount = 0
 
-    func presentIfNeeded() {
+    func presentIfNeeded(completion: ((Bool) -> Void)? = nil) {
         presentIfNeededCallCount += 1
     }
 


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/22052/files#r1447550435 

This PR reverts [this change](https://github.com/wordpress-mobile/WordPress-iOS/commit/ceca329b2d31ca76cdc7a619bfd3daae19738d06#diff-abd3a134a57b3db859304c8411110c2bfd8145d9259bcfc66e31c0c8a0849e40R29) and adds unit tests for the Compliance Popover Coordinator.

## Test Instructions

1. Make the following code changes to force the compliance popover to appear:
   - Go to `CompliancePopoverCoordinator.swift`
   - On line 38, comment this code: `defaults.didShowCompliancePopup`
   - On line 67, force the method to return `true`.
2. Run Jetpack and Login.
3. Expect the Compliance Popover to appear. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

