### PR TITLE
Remove a deadcode - the `error` variable will never be an `AFError`

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -809,22 +809,7 @@ extension Media {
         let multipartEncodingFailedSampleError = AFError.multipartEncodingFailed(reason: .bodyPartFileNotReachable(at: URL(string: "https://wordpress.com")!)) as NSError
         // (yes, yes, I know, unwrapped optional. but if creating a URL from this string fails, then something is probably REALLY wrong and we should bail anyway.)
 
-        // If we still have enough data to know this is a Swift Error, let's do the actual right thing here:
-        if let afError = error as? AFError {
-            guard
-                case .multipartEncodingFailed = afError,
-                case .multipartEncodingFailed(let encodingFailure) = afError else {
-                    return false
-            }
-
-            switch encodingFailure {
-            case .bodyPartFileNotReachableWithError,
-                 .bodyPartFileNotReachable:
-                return true
-            default:
-                return false
-            }
-        } else if let nsError = error as NSError?,
+        if let nsError = error as NSError?,
             nsError.domain == multipartEncodingFailedSampleError.domain,
             nsError.code == multipartEncodingFailedSampleError.code {
             // and if we only have the NSError-level of data, let's just fall back on best-effort guess.


### PR DESCRIPTION
[`Media.error`][Link] is an `NSError` instance. The casting here `error as? AFError` always fails.

[Link]: https://github.com/wordpress-mobile/WordPress-iOS/blob/23.9/WordPress/Classes/Models/Media.m#L215

## Tests

I didn't do any testing, because I'm pretty sure the deleted code is deadcode—it never runs in the app.

Second, I have verified the chance that the `error` is originally an `AFError` is pretty low: 1 out of 1627. So, it'd be low impact if go one step further and stop checking `AFError`.

The apps send events to Sentry when `hasMissingFileError` (which is where the deleted code resides) is true. All of these events are associated with this Sentry issue #15096.

https://github.com/wordpress-mobile/WordPress-iOS/blob/a464f7cb9e3dffe8cb4cd2bc49d53c48bfa19c84/WordPress/Classes/Services/MediaCoordinator.swift#L788-L794

I have grabbed all 1627 events from the Sentry issue and find only one 'AFError' occurrence.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None. See the "Tests" section for reasons.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A