### PR TITLE
Preemptively add a if block to replace the one referencing `AFError`

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -815,6 +815,14 @@ extension Media {
             // and if we only have the NSError-level of data, let's just fall back on best-effort guess.
             return true
         } else if let nsError = error as NSError?,
+            nsError.domain == "Alamofire.AFError",
+            nsError.code == 2 /* AFError.multipartEncodingFailed */ {
+            // Check if the original error is `AFError.multipartEncodingFailed`.
+            // We will soon remove Alamofire from the app, and the above `if` statement will be delete along with Alamofire,
+            // which is why actual values—instead of `AFError` references-are used here.
+
+            return true
+        } else if let nsError = error as NSError?,
             nsError.domain == MediaServiceErrorDomain,
             nsError.code == MediaServiceError.fileDoesNotExist.rawValue {
             // if for some reason, the app crashed when trying to create a media object (like, for example, in this crash):


### PR DESCRIPTION
Reiterating the code comment: The new code in this PR is a duplication of the `if` block above, which will be removed along with Alamofire.

> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/22398.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist: N/A