### PR TITLE
Reader: Update Reader select interests styles

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -24,7 +24,11 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 
     private lazy var selectInterestsViewController: ReaderSelectInterestsViewController = {
         let title = NSLocalizedString("Discover and follow blogs you love", comment: "Reader select interests title label text")
-        let subtitle = NSLocalizedString("Choose your topics", comment: "Reader select interests subtitle label text")
+        let subtitle = NSLocalizedString(
+            "reader.select.tags.subtitle",
+            value: "Choose your tags",
+            comment: "Reader select interests subtitle label text"
+        )
         let buttonTitleEnabled = NSLocalizedString("Done", comment: "Reader select interests next button enabled title text")
         let buttonTitleDisabled = NSLocalizedString("Select a few to continue", comment: "Reader select interests next button disabled title text")
         let loading = NSLocalizedString("Finding blogs and stories you’ll love...", comment: "Label displayed to the user while loading their selected interests")

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -25,29 +25,29 @@ class ReaderInterestsStyleGuide {
 
     // MARK: - View Styles
     public class func applyTitleLabelStyles(label: UILabel) {
-        label.font = WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .medium)
+        label.font = .preferredFont(forTextStyle: .title1).bold()
         label.textColor = .text
     }
 
     public class func applySubtitleLabelStyles(label: UILabel) {
-        label.font = WPStyleGuide.fontForTextStyle(.body)
+        label.font = .preferredFont(forTextStyle: .body)
         label.textColor = .text
     }
 
     // MARK: - Collection View Cell Styles
     public class var cellLabelTitleFont: UIFont {
-        return WPStyleGuide.fontForTextStyle(.body)
+        .preferredFont(forTextStyle: .subheadline)
     }
 
     public class func applyCellLabelStyle(label: UILabel, isSelected: Bool) {
-        label.font = WPStyleGuide.fontForTextStyle(.body)
-        label.textColor = isSelected ? .white : .text
-        label.backgroundColor = isSelected ? .muriel(color: .primary, .shade40) : .quaternaryBackground
+        label.font = cellLabelTitleFont
+        label.textColor = isSelected ? .systemBackground : .text
+        label.backgroundColor = isSelected ? .text : .systemBackground
     }
 
     // MARK: - Compact Collection View Cell Styles
     public class var compactCellLabelTitleFont: UIFont {
-        return WPStyleGuide.fontForTextStyle(.footnote)
+        .preferredFont(forTextStyle: .footnote)
     }
 
     public class func applyCompactCellLabelStyle(label: UILabel) {
@@ -57,23 +57,25 @@ class ReaderInterestsStyleGuide {
     }
 
     // MARK: - Next Button
-    public static let buttonContainerViewBackgroundColor: UIColor = .tertiarySystemBackground
+    public static let buttonContainerViewBackgroundColor: UIColor = .systemBackground
 
-    public class func applyNextButtonStyle(button: FancyButton) {
-        let disabledBackgroundColor: UIColor
-        let titleColor: UIColor
-
-        disabledBackgroundColor = UIColor(light: .systemGray4, dark: .systemGray3)
-        titleColor = .textTertiary
-
-        button.disabledTitleColor = titleColor
-        button.disabledBorderColor = disabledBackgroundColor
-        button.disabledBackgroundColor = disabledBackgroundColor
+    public class func applyNextButtonStyle(button: UIButton) {
+        button.configuration = {
+            var config = UIButton.Configuration.plain()
+            config.contentInsets = NSDirectionalEdgeInsets(top: 12.0, leading: 0.0, bottom: 12.0, trailing: 0.0)
+            config.titleTextAttributesTransformer = .transformer(with: .preferredFont(forTextStyle: .body).semibold())
+            return config
+        }()
+        button.setTitleColor(.systemBackground, for: .normal)
+        button.setTitleColor(.systemBackground, for: .disabled)
+        button.setTitleColor(.systemBackground.withAlphaComponent(0.7), for: .highlighted)
+        button.backgroundColor = .text
+        button.layer.cornerRadius = 5.0
     }
 
     // MARK: - Loading
     public class func applyLoadingLabelStyles(label: UILabel) {
-        label.font = WPStyleGuide.fontForTextStyle(.body)
+        label.font = .preferredFont(forTextStyle: .body)
         label.textColor = .textSubtle
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -14,11 +14,11 @@ struct ReaderSelectInterestsConfiguration {
 class ReaderSelectInterestsViewController: UIViewController {
     private struct Constants {
         static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()
-        static let interestsLabelMargin: CGFloat = 10
+        static let interestsLabelMargin: CGFloat = 12
 
-        static let cellCornerRadius: CGFloat = 8
+        static let cellCornerRadius: CGFloat = 5
         static let cellSpacing: CGFloat = 6
-        static let cellHeight: CGFloat = 40
+        static let cellHeight: CGFloat = 36
         static let animationDuration: TimeInterval = 0.2
         static let isCentered: Bool = true
     }
@@ -34,7 +34,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     @IBOutlet weak var subTitleLabel: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var buttonContainerView: UIView!
-    @IBOutlet weak var nextButton: FancyButton!
+    @IBOutlet weak var nextButton: UIButton!
     @IBOutlet weak var contentContainerView: UIStackView!
 
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
@@ -186,7 +186,6 @@ class ReaderSelectInterestsViewController: UIViewController {
 
         styleGuide.applyLoadingLabelStyles(label: loadingLabel)
         styleGuide.applyActivityIndicatorStyles(indicator: activityIndicatorView)
-
     }
 
     private func configureNavigationBar() {
@@ -200,14 +199,8 @@ class ReaderSelectInterestsViewController: UIViewController {
     }
 
     private func configureI18N() {
-
-        if isModal() {
-            title = configuration.title
-            titleLabel.isHidden = true
-        } else {
-            titleLabel.text = configuration.title
-            titleLabel.isHidden = false
-        }
+        titleLabel.text = configuration.title
+        titleLabel.isHidden = false
 
         if let subtitle = configuration.subtitle {
             subTitleLabel.text = subtitle
@@ -328,6 +321,8 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
         ReaderInterestsStyleGuide.applyCellLabelStyle(label: cell.label,
                                                       isSelected: interest.isSelected)
 
+        cell.layer.borderWidth = interest.isSelected ? 0 : 1
+        cell.layer.borderColor = UIColor.separator.cgColor
         cell.layer.cornerRadius = Constants.cellCornerRadius
         cell.label.text = interest.title
         cell.label.accessibilityTraits = interest.isSelected ? [.selected, .button] : .button

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,22 +30,22 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Bt3-aY-FXs" userLabel="Content Container View">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                    <rect key="frame" x="0.0" y="20" width="414" height="716"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="2ka-fB-oWM">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="670"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="650"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="rOi-KY-muX">
-                                    <rect key="frame" x="20" y="12" width="374" height="111"/>
+                                    <rect key="frame" x="20" y="12" width="374" height="121"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover and follow blogs you love" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sln-01-DYL" userLabel="Header Label">
-                                            <rect key="frame" x="0.0" y="0.0" width="374" height="75"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="81.666666666666671"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose your topics" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efr-XO-GjF" userLabel="Subtitle Label">
-                                            <rect key="frame" x="0.0" y="94" width="374" height="17"/>
+                                            <rect key="frame" x="0.0" y="100.66666666666666" width="374" height="20.333333333333329"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -53,7 +53,7 @@
                                     </subviews>
                                 </stackView>
                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="fUq-vV-Pah">
-                                    <rect key="frame" x="20" y="133" width="374" height="537"/>
+                                    <rect key="frame" x="20" y="143" width="374" height="507"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="IKi-eM-O1E" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
                                         <size key="itemSize" width="128" height="128"/>
@@ -70,9 +70,9 @@
                             <edgeInsets key="layoutMargins" top="12" left="20" bottom="0.0" right="20"/>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X4F-fc-WqY" userLabel="Button Container View">
-                            <rect key="frame" x="0.0" y="670" width="414" height="66"/>
+                            <rect key="frame" x="0.0" y="650" width="414" height="66"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5kh-rf-B5P" customClass="FancyButton" customModule="WordPressUI">
+                                <button opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5kh-rf-B5P">
                                     <rect key="frame" x="20" y="10" width="374" height="46"/>
                                     <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="20" bottom="8" trailing="20"/>
                                     <state key="normal" title="Select a few to continue">
@@ -96,7 +96,7 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="be9-lX-CD7">
-                            <rect key="frame" x="0.0" y="736" width="414" height="0.0"/>
+                            <rect key="frame" x="0.0" y="716" width="414" height="0.0"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" id="XCs-b1-Ce2"/>


### PR DESCRIPTION
Part of #22403
Merges into #22405

## Description

Updates the tags cloud picker UI to the newer styles.

> [!NOTE]
> Not all the styles were in Figma. Some of the styles I had to pick what I thought was correct.

## Screenshots

| Light | Dark |
|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-16 at 18 36 51](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/e7e2f516-b840-44f8-b851-2036c4e8bd64) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-16 at 18 36 59](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/7710ec5c-5df7-4e84-91a8-00a0ad4ea920) |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-16 at 18 38 12](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/cd29e50d-1fc3-4970-96ab-b086bde55f70) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-16 at 18 37 10](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/e04e8b86-10a0-4cfe-9df8-093ee2fbf6fe) 

## Testing

To test:
- Setup an account with no followed tags
- Launch Jetpack and login
- Navigate to the `Discover` Reader feed
- 🔎 **Verify** the tags cloud picker UI matches the new styles
- Navigate to the `Subscriptions` Reader feed
- Tap on `0 Tags`
- Tap on `Suggested tags`
- 🔎 **Verify** the tags cloud picker UI matches the new styles

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
