### PR TITLE
Reader Navigation: Add a blur effect to the trailing end

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -21,6 +21,15 @@ struct ReaderNavigationMenu: View {
                     streamFilterView
                 }
             }
+            .mask({
+                HStack(spacing: .zero) {
+                    Rectangle().fill(.black)
+                    LinearGradient(gradient: Gradient(colors: [.black, .clear]),
+                                   startPoint: .leading,
+                                   endPoint: .trailing)
+                               .frame(width: 16)
+                }
+            })
             Spacer()
             Button {
                 viewModel.navigateToSearch()


### PR DESCRIPTION
Refs #22205 

This adds a fading mask at the trailing end of the Reader navigation buttons. Here's what it looks like:

![Simulator Screenshot - iPhone 15 - 2024-01-17 at 22 53 17](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/935343d7-2794-414e-b595-83567fc7db97)


## To test

- Launch the Jetpack app
- Go to the Reader tab
- Switch to Subscriptions. Make sure that you have some blogs and tags followed.
- 🔎 Observe that the blur view is there.
- 🔎 Verify that the blur view appears correctly in dark mode.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
