### PR TITLE
Reader Navigation: Add state transition animations to the filter chips

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -87,6 +87,12 @@ class FilterProvider: Identifiable, Observable, FilterTabBarItem {
     }
 }
 
+extension FilterProvider: Equatable {
+    static func == (lhs: FilterProvider, rhs: FilterProvider) -> Bool {
+        return lhs.title == rhs.title
+    }
+}
+
 extension FilterProvider {
 
     func showAdd(on presenterViewController: UIViewController, sceneDelegate: ScenePresenterDelegate?) {


### PR DESCRIPTION
Refs #22205 

This adds the state transition animation for the filter bar. Here is a preview:



https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b0d5aaa6-be87-4ccb-b5ae-5d84da03ac1a


## To test

- Launch the Jetpack app
- Navigate to the Reader tab
- Tap the Reader Navigation button and select Subscriptions.
- 🔎 Verify that the filter chip buttons animate their transitions.
- Select one of the filter buttons.
- 🔎 Verify that the filter chip button animates the state transition.
- Select the highlighted filter button again.
- 🔎 Verify that it animates back to the previous step.
- Tap the Reader Navigation button again and select Discover.
- 🔎 Verify that the filter chip buttons are animated.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
