### PR TITLE
Reader Navigation: Add Edit functionality to the filter sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -1,5 +1,10 @@
 import WordPressFlux
 
+protocol FilterSheetViewControllerDelegate {
+    func didSelectTopic(_ topic: ReaderAbstractTopic)
+    func didTapEdit()
+}
+
 class FilterSheetViewController: UIViewController {
 
     // MARK: Properties
@@ -10,6 +15,8 @@ class FilterSheetViewController: UIViewController {
 
     // closure that's called when a filter item is selected.
     private let changedFilter: (ReaderAbstractTopic) -> Void
+
+    private let onEditButtonTap: (UIViewController) -> Void
 
     private var receipt: Receipt?
 
@@ -53,6 +60,7 @@ class FilterSheetViewController: UIViewController {
         let labelView = UIView()
         let label = UILabel()
         label.font = HeaderConstants.font
+        label.adjustsFontForContentSizeCategory = true
         label.text = viewTitle
         label.translatesAutoresizingMaskIntoConstraints = false
         labelView.addSubview(label)
@@ -60,15 +68,43 @@ class FilterSheetViewController: UIViewController {
         return labelView
     }()
 
-    private lazy var stackView: UIStackView = {
+    private lazy var editButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle(Strings.editButtonTitle, for: .normal)
+        button.tintColor = .label
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+
+        button.configuration = .plain()
+        button.configuration?.contentInsets = .init(top: HeaderConstants.insets.top,
+                                                    leading: HeaderConstants.insets.left,
+                                                    bottom: HeaderConstants.insets.bottom,
+                                                    trailing: HeaderConstants.insets.right)
+        button.addTarget(self, action: #selector(didTapEditButton), for: .touchUpInside)
+
+        return button
+    }()
+
+    private lazy var headerStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [
             headerLabelView,
+            UIView(),
+            editButton
+        ])
+
+        stack.axis = .horizontal
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [
+            headerStackView,
             tableView,
             ghostableTableView,
             emptyView
         ])
 
-        stack.setCustomSpacing(HeaderConstants.spacing, after: headerLabelView)
+        stack.setCustomSpacing(HeaderConstants.spacing, after: headerStackView)
         stack.axis = .vertical
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
@@ -79,11 +115,13 @@ class FilterSheetViewController: UIViewController {
 
     init(filter: FilterProvider,
          viewTitle: String? = nil,
-         changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+         changedFilter: @escaping (ReaderAbstractTopic) -> Void,
+         onEditButtonTap: @escaping (UIViewController) -> Void) {
         let defaultTitle = filter.section == .sites ? Strings.blogFilterTitle : Strings.tagFilterTitle
         self.viewTitle = viewTitle ?? defaultTitle
         self.filterProvider = filter
         self.changedFilter = changedFilter
+        self.onEditButtonTap = onEditButtonTap
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -130,6 +168,11 @@ private extension FilterSheetViewController {
             "reader.filterSheet.select.tags.loading",
             value: "Following new tags...",
             comment: "Label displayed to the user while loading their selected interests"
+        )
+        static let editButtonTitle = NSLocalizedString(
+            "reader.filterSheet.button.edit",
+            value: "Edit",
+            comment: "Title for a button that allows user to edit their subscribed list from the filter sheet"
         )
     }
 
@@ -223,6 +266,11 @@ private extension FilterSheetViewController {
         ghostableTableView.removeGhostContent()
         ghostableTableView.isHidden = false
         ghostableTableView.displayGhostContent(options: ghostOptions, style: style)
+    }
+
+    @objc
+    func didTapEditButton() {
+        onEditButtonTap(self)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -2,7 +2,7 @@ extension NSNotification.Name {
     static let readerManageControllerWasDismissed = NSNotification.Name("ReaderManageControllerWasDismissed")
 }
 
-class ReaderManageScenePresenter: ScenePresenter {
+class ReaderManageScenePresenter {
 
     enum TabbedSection {
         case tags
@@ -34,22 +34,35 @@ class ReaderManageScenePresenter: ScenePresenter {
     weak var presentedViewController: UIViewController?
 
     private let sections: [TabbedSection]
-    private let selectedSection: TabbedSection?
+    private var selectedSection: TabbedSection?
     private weak var delegate: ScenePresenterDelegate?
 
     init(sections tabbedSections: [TabbedSection] = [TabbedSection.tags, TabbedSection.sites],
-         selected: TabbedSection? = nil, sceneDelegate: ScenePresenterDelegate? = nil) {
+         selected: TabbedSection? = nil,
+         sceneDelegate: ScenePresenterDelegate? = nil) {
         sections = tabbedSections
         selectedSection = selected
         delegate = sceneDelegate
     }
 
-    func present(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+    /// Presents the Reader Manage flow.
+    ///
+    /// - Parameters:
+    ///   - viewController: The presenting view controller.
+    ///   - selectedSection: The section that will be selected by default.
+    ///   - animated: Whether the presentation should be animated.
+    ///   - completion: Closure that's called after the user dismisses the Manage flow.
+    func present(on viewController: UIViewController,
+                 selectedSection: TabbedSection?,
+                 animated: Bool,
+                 completion: (() -> Void)?) {
         guard presentedViewController == nil else {
             completion?()
             return
         }
-        let navigationController = makeNavigationController()
+
+        self.selectedSection = selectedSection
+        let navigationController = UINavigationController(rootViewController: makeViewController(onDismiss: completion))
         presentedViewController = navigationController
         viewController.present(navigationController, animated: true, completion: nil)
 
@@ -58,13 +71,28 @@ class ReaderManageScenePresenter: ScenePresenter {
     }
 }
 
+// MARK: - ScenePresenter
+
+extension ReaderManageScenePresenter: ScenePresenter {
+    func present(on viewController: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        present(on: viewController, selectedSection: nil, animated: animated, completion: completion)
+    }
+}
+
+// MARK: - Private helpers
+
 private extension ReaderManageScenePresenter {
-    func makeViewController() -> TabbedViewController {
+    func makeViewController(onDismiss: (() -> Void)? = nil) -> TabbedViewController {
         let tabbedItems = sections.map({ item in
             return item.tabbedItem
         })
 
-        let tabbedViewController = TabbedViewController(items: tabbedItems, onDismiss: {
+        let tabbedViewController = TabbedViewController(items: tabbedItems, onDismiss: { [weak self] in
+            guard let self else {
+                return
+            }
+
+            onDismiss?()
             self.delegate?.didDismiss(presenter: self)
             NotificationCenter.default.post(name: .readerManageControllerWasDismissed, object: self)
             WPAnalytics.track(.readerManageViewDismissed)
@@ -77,8 +105,4 @@ private extension ReaderManageScenePresenter {
         return tabbedViewController
     }
 
-    func makeNavigationController() -> UINavigationController {
-        let navigationController = UINavigationController(rootViewController: makeViewController())
-        return navigationController
-    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -1,5 +1,5 @@
 import WordPressFlux
-
+import Combine
 
 @objc class ReaderTabViewModel: NSObject, ObservableObject {
 
@@ -46,11 +46,25 @@ import WordPressFlux
     /// Settings
     private let settingsPresenter: ScenePresenter
 
+    private var receipts = [Receipt]()
+
     /// The available filters for the current stream.
     @Published var streamFilters = [FilterProvider]() {
         didSet {
+            // clear the receipts each time we replace these with new filters.
+            receipts = []
+
             // refresh the filter list immediately upon update.
-            streamFilters.forEach { $0.refresh() }
+            streamFilters.forEach { [weak self] filter in
+                filter.refresh()
+
+                // listen to internal filter changes so that we can "force" the view model
+                // to push changes down to the SwiftUI view. This is to ensure that the strings
+                // are up-to-date (e.g., after subscribing to new blogs or tags from the manage flow.)
+                self?.receipts.append(filter.onChange {
+                    self?.objectWillChange.send()
+                })
+            }
         }
     }
 
@@ -186,8 +200,17 @@ extension ReaderTabViewModel {
         WPAnalytics.track(.readerFilterSheetDisplayed)
     }
 
-    func presentManage(from: UIViewController) {
-        settingsPresenter.present(on: from, animated: true, completion: nil)
+    func presentManage(filter: FilterProvider, from: UIViewController) {
+        guard let managePresenter = settingsPresenter as? ReaderManageScenePresenter else {
+            settingsPresenter.present(on: from, animated: true, completion: nil)
+            return
+        }
+
+        managePresenter.present(on: from, selectedSection: filter.section, animated: true) {
+            // on completion, ensure that the FilterProvider is refreshed so the latest changes
+            // can be reflected on the UI.
+            filter.refresh()
+        }
     }
 
     func didTapStreamFilterButton(with filter: FilterProvider) {
@@ -225,7 +248,9 @@ extension ReaderTabViewModel {
 extension ReaderTabViewModel {
     private func makeFilterSheetViewController(filter: FilterProvider,
                                                completion: @escaping (ReaderAbstractTopic) -> Void) -> FilterSheetViewController {
-        return FilterSheetViewController(filter: filter, changedFilter: completion)
+        return FilterSheetViewController(filter: filter, changedFilter: completion) { [weak self] viewController in
+            self?.presentManage(filter: filter, from: viewController)
+        }
     }
 }
 

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -88,7 +88,7 @@ class ReaderTabViewModelTests: CoreDataTestCase {
         settingsPresenter.presentExpectation = expectation(description: "Settings screen was presented")
         // When
         let controller = UIViewController()
-        viewModel.presentManage(from: controller)
+        viewModel.presentManage(filter: makeFilterProvider(), from: controller)
         // Then
         waitForExpectations(timeout: 4) { error in
             if let error = error {


### PR DESCRIPTION
Part of #22205 

- This PR adds the Edit button to the filter sheet.
- When tapped, it will present the legacy Manage flow on top of the filter sheet.
- Any changes or updates made from the Manage flow will be reflected on the filter sheet AND the navigation filter chips.

## To test

1. Launch the Jetpack app
2. Navigate to the Reader, and switch to the Subscriptions stream.
3. Tap the **Blogs** filter chip.
4. 🔎 Verify that the Edit button appears on the upper right part of the filter sheet.
5. Tap the Edit button.
6. 🔎 Verify that the Manage sheet opens and the Sites tab is selected by default (name change pending).
7. Type in some site URL to add, or delete one from your current list. Then tap Done to close the Manage sheet.
8. 🔎 Verify that the filter sheet AND the filter button chips in the background reflect the latest changes.

Repeat step 3 from above, this time selecting the **Tags** filter chip.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
