### PR TITLE
Fix crash when tapping Share on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -65,7 +65,7 @@ extension SitePickerViewController {
         }
         let viewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         if let popover = viewController.popoverPresentationController {
-            popover.barButtonItem = navigationItem.rightBarButtonItem
+            popover.sourceView = blogDetailHeaderView.titleView.siteActionButton
         }
         present(viewController, animated: true, completion: nil)
         WPAnalytics.trackEvent(.mySiteHeaderShareSiteTapped)


### PR DESCRIPTION
Fixes an issue with "Share Site" site menu action not working on iPad.

## Regression Notes
1. Potential unintended areas of impact: My Site / Site Header
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
