### PR TITLE
Tab bar animation: filter and sort tab bar subviews

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -109,12 +109,23 @@ extension WPTabBarController {
 
     @objc func animateSelectedItem(_ item: UITabBarItem, for tabBar: UITabBar) {
 
-        guard let index = tabBar.items?.firstIndex(of: item), tabBar.subviews.count > index + 1 else {
+        // Order of subviews may not be guaranteed, so filter and sort them
+        let tabBarButtons = tabBar.subviews
+            .filter { $0 is UIControl }
+            .sorted { $0.frame.minX < $1.frame.minX }
+
+        // The number of buttons should be the same as the number of tab bar items
+        guard tabBarButtons.count == tabBar.items?.count else {
             return
         }
 
-        let button = tabBar.subviews[(index + 1)]
+        // Get the button that corresponds to the selected tab bar item
+        guard let index = tabBar.items?.firstIndex(of: item),
+              let button = tabBarButtons[safe: index] else {
+            return
+        }
 
+        // Get the button's image view
         guard let imageView = button.subviews.lazy.compactMap({ $0 as? UIImageView }).first else {
             return
         }


### PR DESCRIPTION
Fixes #22428

## Description
Filters and sorts the tab bar buttons in case they aren't in order. 

One possible reason the wrong icon is animated is if the [subviews aren't in the order we expect](https://stackoverflow.com/a/51542606), so we end up grabbing the wrong subview.

https://github.com/wordpress-mobile/WordPress-iOS/blob/d786b201759165dae9fd9d1e9e1cc99be2ca42b2/WordPress/Classes/ViewRelated/System/WPTabBarController%2BSwift.swift#L112-L116

To mitigate this, I've added an extra step to filter then sort the tab bar subviews, so we can find the correct subview.

## How to to test
I don't know how to reproduce the reported issue.

## Regression Notes
1. Potential unintended areas of impact
tab bar animation

2. What I did to test those areas of impact (or what existing automated tests I relied on)
manual

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

