### PR TITLE
Reader: Update Reader strings to new terminologies

### DIFF
--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -287,7 +287,12 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
 - (NSError *)errorForAlreadyFollowingSiteOrFeed
 {
-    NSString *description = NSLocalizedString(@"You are already following this site.", @"Error message informing the user that they are already following a site in their reader.");
+
+    NSString *description = NSLocalizedStringWithDefaultValue(@"reader.error.already.subscribed.message",
+                                                              nil,
+                                                              [NSBundle mainBundle],
+                                                              @"You are already subscribed to this blog.",
+                                                              @"Error message informing the user that they are already following a blog in their reader.");
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey:description};
     NSError *error = [[NSError alloc] initWithDomain:ReaderSiteServiceErrorDomain code:ReaderSiteServiceErrorAlreadyFollowingSite userInfo:userInfo];
     return error;

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -236,7 +236,11 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable, ReaderDetailHeader {
 
         blogNameButton.isAccessibilityElement = true
         blogNameButton.accessibilityTraits = [.staticText, .button]
-        blogNameButton.accessibilityHint = NSLocalizedString("Shows the site's posts.", comment: "Accessibility hint for the site name and URL button on Reader's Post Details.")
+        blogNameButton.accessibilityHint = NSLocalizedString(
+            "reader.blog.name.accessibility.hint",
+            value: "Shows the blog's posts.",
+            comment: "Accessibility hint for the blog name and URL button on Reader's Post Details."
+        )
         if let label = blogNameLabel(post) {
             blogNameButton.accessibilityLabel = label
         }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -139,8 +139,16 @@ extension ReaderSiteTopic {
             }
         }
 
-        let emptyTitle = NSLocalizedString("Add a site", comment: "No Tags View Button Label")
-        let emptyActionTitle = NSLocalizedString("You can follow posts on a specific site by following it.", comment: "No Sites View Label")
+        let emptyTitle = NSLocalizedString(
+            "reader.no.tags.title",
+            value: "Add a blog",
+            comment: "No Tags View Button Label"
+        )
+        let emptyActionTitle = NSLocalizedString(
+            "reader.no.tags.action",
+            value: "You can subscribe to posts on a specific blog by subscribing to it.",
+            comment: "No Sites View Label"
+        )
 
         return FilterProvider(title: titleFunction,
                               accessibilityIdentifier: "SitesFilterTab",
@@ -282,8 +290,16 @@ extension ReaderTagTopic {
             }
         }
 
-        let emptyTitle = NSLocalizedString("Add a topic", comment: "No Topics View Button Label")
-        let emptyActionTitle = NSLocalizedString("You can follow posts on a specific subject by adding a topic.", comment: "No Topics View Label")
+        let emptyTitle = NSLocalizedString(
+            "reader.no.tags.title",
+            value: "Add a tag",
+            comment: "No Tags View Button Label"
+        )
+        let emptyActionTitle = NSLocalizedString(
+            "reader.no.tags.action",
+            value: "You can subscribe to posts on a specific subject by adding a tag.",
+            comment: "No Topics View Label"
+        )
 
         return FilterProvider(title: titleFunction,
                               accessibilityIdentifier: "TagsFilterTab",

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -128,7 +128,7 @@ private extension FilterSheetViewController {
         )
         static let selectInterestsLoading = NSLocalizedString(
             "reader.filterSheet.select.tags.loading",
-            value: "Following new tags...",
+            value: "Subscribing to new tags...",
             comment: "Label displayed to the user while loading their selected interests"
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewController+Cells.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewController+Cells.swift
@@ -9,14 +9,22 @@ extension ReaderTagsTableViewModel {
 
         let button = UIButton.closeAccessoryButton()
         button.addTarget(self, action: #selector(tappedAccessory(_:)), for: .touchUpInside)
-        let unfollowString = NSLocalizedString("Unfollow %@", comment: "Accessibility label for unfollowing a tag")
+        let unfollowString = NSLocalizedString(
+            "reader.tags.unsubscribe.accessibility.label",
+            value: "Unsubscribe from %@",
+            comment: "Accessibility label for unsubscribing from a tag"
+        )
         button.accessibilityLabel = String(format: unfollowString, topic.title)
         cell.accessoryView = button
         cell.accessibilityElements = [button]
     }
 
     private func configureAddTag(cell: UITableViewCell) {
-        cell.textLabel?.text = NSLocalizedString("Add a Topic", comment: "Title of a feature to add a new topic to the topics subscribed by the user.")
+        cell.textLabel?.text = NSLocalizedString(
+            "reader.tags.add.tag",
+            value: "Add a Tag",
+            comment: "Title of a feature to add a new tag to the tags subscribed by the user."
+        )
         cell.accessoryView = UIImageView(image: UIImage.gridicon(.plusSmall))
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -65,7 +65,11 @@ extension ReaderTagsTableViewModel: WPTableViewHandlerDelegate {
             return nil
         }
 
-        let title = NSLocalizedString("Discover more topics", comment: "Button title. Tapping shows the Follow Topics screen.")
+        let title = NSLocalizedString(
+            "reader.tags.discover.more.tags",
+            value: "Discover more tags",
+            comment: "Button title. Tapping shows the Subscribe to Tags screen."
+        )
         footer.actionButton.setTitle(title, for: .normal)
 
         footer.actionButtonHandler = { [weak self] in
@@ -96,15 +100,27 @@ extension ReaderTagsTableViewModel {
     /// Presents a new view controller for subscribing to a new tag.
     private func showAddTag() {
 
-        let placeholder = NSLocalizedString("Add any topic", comment: "Placeholder text. A call to action for the user to type any topic to which they would like to subscribe.")
+        let placeholder = NSLocalizedString(
+            "reader.tags.add.tag.placeholder",
+            value: "Add any tag",
+            comment: "Placeholder text. A call to action for the user to type any tag to which they would like to subscribe."
+        )
         let controller = SettingsTextViewController(text: nil, placeholder: placeholder, hint: nil)
-        controller.title = NSLocalizedString("Add a Topic", comment: "Title of a feature to add a new topic to the topics subscribed by the user.")
+        controller.title = NSLocalizedString(
+            "reader.tags.add.tag.title",
+            value: "Add a Tag",
+            comment: "Title of a feature to add a new tag to the tags subscribed by the user."
+        )
         controller.onValueChanged = { [weak self] value in
             self?.follow(tagName: value)
         }
         controller.mode = .lowerCaseText
         controller.displaysActionButton = true
-        controller.actionText = NSLocalizedString("Add Topic", comment: "Button Title. Tapping subscribes the user to a new topic.")
+        controller.actionText = NSLocalizedString(
+            "reader.tags.add.tag.action",
+            value: "Add Tag",
+            comment: "Button Title. Tapping subscribes the user to a new tag."
+        )
         controller.onActionPress = { [weak self] in
             self?.dismissModal()
         }
@@ -121,10 +137,18 @@ extension ReaderTagsTableViewModel {
     /// Presents a new view controller for selecting topics to follow.
     private func showSelectInterests() {
         let configuration = ReaderSelectInterestsConfiguration(
-            title: NSLocalizedString("Follow topics", comment: "Screen title. Reader select interests title label text."),
+            title: NSLocalizedString(
+                "reader.select.interests.title",
+                value: "Subscribe to tags",
+                comment: "Screen title. Reader select interests title label text."
+            ),
             subtitle: nil,
             buttonTitle: nil,
-            loading: NSLocalizedString("Following new topics...", comment: "Label displayed to the user while loading their selected interests")
+            loading: NSLocalizedString(
+                "reader.select.interests.loading",
+                value: "Subscribing to new tags...",
+                comment: "Label displayed to the user while loading their selected interests"
+            )
         )
 
         let topics = tableViewHandler.resultsController?.fetchedObjects as? [ReaderTagTopic] ?? []

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
@@ -19,8 +19,11 @@ open class ReaderBlockedSiteCell: UITableViewCell {
     }
 
     @objc open func setSiteName(_ name: String) {
-        let format = NSLocalizedString("The site %@ will no longer appear in your reader. Tap to undo.",
-            comment: "Message expliaining that the specified site will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the site.")
+        let format = NSLocalizedString(
+            "reader.blocked.site.message",
+            value: "The blog %@ will no longer appear in your reader. Tap to undo.",
+            comment: "Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog."
+        )
         let str = NSString(format: format as NSString, name)
         let range = str.range(of: name)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
@@ -20,7 +20,7 @@ open class ReaderBlockedSiteCell: UITableViewCell {
 
     @objc open func setSiteName(_ name: String) {
         let format = NSLocalizedString(
-            "reader.blocked.site.message",
+            "reader.blocked.blog.message",
             value: "The blog %@ will no longer appear in your reader. Tap to undo.",
             comment: "Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog."
         )

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -124,7 +124,11 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
 
     @objc func configureSearchBar() {
-        let placeholderText = NSLocalizedString("Enter the URL of a site to follow", comment: "Placeholder text prompting the user to type the name of the URL they would like to follow.")
+        let placeholderText = NSLocalizedString(
+            "reader.subscribed.blogs.search.placeholder",
+            value: "Enter the URL of a blog to subscribe to",
+            comment: "Placeholder text prompting the user to type the name of the URL they would like to follow."
+        )
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self, ReaderFollowedSitesViewController.self]).placeholder = placeholderText
         WPStyleGuide.configureSearchBar(searchBar)
 
@@ -136,7 +140,11 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         searchBar.keyboardType = .URL
         searchBar.setImage(clearImage, for: .clear, state: UIControl.State())
         searchBar.setImage(addOutline, for: .search, state: UIControl.State())
-        searchBar.searchTextField.accessibilityLabel = NSLocalizedString("Site URL", comment: "The accessibility label for the followed sites search field")
+        searchBar.searchTextField.accessibilityLabel = NSLocalizedString(
+            "reader.subscribed.blogs.search.accessibility.label",
+            value: "Blog URL",
+            comment: "The accessibility label for the followed blogs search field"
+        )
         searchBar.searchTextField.accessibilityValue = nil
         searchBar.searchTextField.accessibilityHint = placeholderText
     }
@@ -215,7 +223,9 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.toggleFollowing(forSite: site, success: { [weak self] follow in
             let siteURL = URL(string: site.siteURL)
-            let notice = Notice(title: NSLocalizedString("Unfollowed site", comment: "User unfollowed a site."),
+            let notice = Notice(title: NSLocalizedString("reader.notice.blog.unsubscribed.success",
+                                                         value: "Unsubscribed from blog",
+                                                         comment: "User unsubscribed from a blog."),
                                 message: siteURL?.host,
                                 feedbackType: .success)
             self?.post(notice)
@@ -225,7 +235,9 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         }, failure: { [weak self] (follow, error) in
             DDLogError("Could not unfollow site: \(String(describing: error))")
 
-            let notice = Notice(title: NSLocalizedString("Could not unfollow site", comment: "Title of a prompt."),
+            let notice = Notice(title: NSLocalizedString("reader.notice.blog.unsubscribed.error",
+                                                         value: "Could not unsubscribe from blog",
+                                                         comment: "Title of a prompt."),
                                 message: error?.localizedDescription,
                                 feedbackType: .error)
             self?.post(notice)
@@ -242,7 +254,9 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
         let service = ReaderSiteService(coreDataStack: ContextManager.shared)
         service.followSite(by: url, success: { [weak self] in
-            let notice = Notice(title: NSLocalizedString("Followed site", comment: "User followed a site."),
+            let notice = Notice(title: NSLocalizedString("reader.notice.blog.subscribe.success",
+                                                         value: "Subscribed to blog",
+                                                         comment: "User subscribed to a blog."),
                                 message: url.host,
                                 feedbackType: .success)
             self?.post(notice)
@@ -253,7 +267,9 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         }, failure: { [weak self] error in
             DDLogError("Could not follow site: \(String(describing: error))")
 
-            let title = error?.localizedDescription ?? NSLocalizedString("Could not follow site", comment: "Title of a prompt.")
+            let title = error?.localizedDescription ?? NSLocalizedString("reader.notice.blog.unsubscribe.error",
+                                                                         value: "Could not unsubscribe from blog",
+                                                                         comment: "Title of a prompt.")
             let notice = Notice(title: title,
                                 message: url.host,
                                 feedbackType: .error)
@@ -509,7 +525,11 @@ extension ReaderFollowedSitesViewController: WPTableViewHandlerDelegate {
 
     func tableView(_ tableView: UITableView,
                    titleForDeleteConfirmationButtonForRowAt indexPath: IndexPath) -> String? {
-        return NSLocalizedString("Unfollow", comment: "Label of the table view cell's delete button, when unfollowing a site.")
+        return NSLocalizedString(
+            "reader.unsubscribe.button",
+            value: "Unsubscribe",
+            comment: "Label of the table view cell's delete button, when unsubscribing from a blog."
+        )
     }
 
     func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -51,7 +51,7 @@ enum ReaderPostMenuSource {
 struct ReaderPostMenuButtonTitles {
     static let cancel = NSLocalizedString("Cancel", comment: "The title of a cancel button.")
     static let blockSite = NSLocalizedString(
-        "reader.post.menu.block.site",
+        "reader.post.menu.block.blog",
         value: "Block this blog",
         comment: "The title of a button that triggers blocking a blog from the user's reader."
     )
@@ -586,12 +586,12 @@ struct ReaderPostMenuButtonTitles {
         )
         static let enableButtonLabel = NSLocalizedString("Enable", comment: "Button title for the enable site notifications action.")
         static let blockSiteSuccess = NSLocalizedString(
-            "reader.notice.site.blocked.success",
+            "reader.notice.blog.blocked.success",
             value: "Blocked blog",
             comment: "Notice title when blocking a site succeeds."
         )
         static let blockSiteFail = NSLocalizedString(
-            "reader.notice.site.blocked.failure",
+            "reader.notice.blog.blocked.failure",
             value: "Unable to block blog",
             comment: "Notice title when blocking a blog fails."
         )
@@ -614,7 +614,7 @@ struct ReaderPostMenuButtonTitles {
         static let commentFollowError = NSLocalizedString("Could not subscribe to comments", comment: "The app failed to subscribe to the comments for the post")
         static let commentUnfollowError = NSLocalizedString("Could not unsubscribe from comments", comment: "The app failed to unsubscribe from the comments for the post")
         static let unknownSiteText = NSLocalizedString(
-            "reader.notice.subscribe.site.unknown",
+            "reader.notice.subscribe.blog.unknown",
             value: "this blog",
             comment: """
                 A default value used to fill in the site name when the followed site somehow has missing site name or URL.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -50,7 +50,11 @@ enum ReaderPostMenuSource {
 // Titles for post menu options
 struct ReaderPostMenuButtonTitles {
     static let cancel = NSLocalizedString("Cancel", comment: "The title of a cancel button.")
-    static let blockSite = NSLocalizedString("Block this site", comment: "The title of a button that triggers blocking a site from the user's reader.")
+    static let blockSite = NSLocalizedString(
+        "reader.post.menu.block.site",
+        value: "Block this blog",
+        comment: "The title of a button that triggers blocking a blog from the user's reader."
+    )
     static let blockUser = NSLocalizedString(
         "reader.post.menu.block.user",
         value: "Block this user",
@@ -64,10 +68,26 @@ struct ReaderPostMenuButtonTitles {
     )
     static let share = NSLocalizedString("Share", comment: "Verb. Title of a button. Pressing lets the user share a post to others.")
     static let visit = NSLocalizedString("Visit", comment: "An option to visit the site to which a specific post belongs")
-    static let unfollow = NSLocalizedString("Unfollow site", comment: "Verb. An option to unfollow a site.")
-    static let follow = NSLocalizedString("Follow site", comment: "Verb. An option to follow a site.")
-    static let subscribe = NSLocalizedString("Turn on site notifications", comment: "Verb. An option to switch on site notifications.")
-    static let unsubscribe = NSLocalizedString("Turn off site notifications", comment: "Verb. An option to switch off site notifications.")
+    static let unfollow = NSLocalizedString(
+        "reader.post.menu.unsubscribe.blog",
+        value: "Unsubscribe from blog",
+        comment: "Verb. An option to unsubscribe from a blog."
+    )
+    static let follow = NSLocalizedString(
+        "reader.post.menu.subscribe.blog",
+        value: "Subscribe to blog",
+        comment: "Verb. An option to subscribe to a blog."
+    )
+    static let subscribe = NSLocalizedString(
+        "reader.post.menu.notifications.on",
+        value: "Turn on blog notifications",
+        comment: "Verb. An option to switch on blog notifications."
+    )
+    static let unsubscribe = NSLocalizedString(
+        "reader.post.menu.notifications.off",
+        value: "Turn off blog notifications",
+        comment: "Verb. An option to switch off site notifications."
+    )
     static let markSeen = NSLocalizedString("Mark as seen", comment: "An option to mark a post as seen.")
     static let markUnseen = NSLocalizedString("Mark as unseen", comment: "An option to mark a post as unseen.")
     static let followConversation = NSLocalizedString("Follow conversation", comment: "Verb. Button title. Follow the comments on a post.")
@@ -519,18 +539,62 @@ struct ReaderPostMenuButtonTitles {
         static let unseenFail = NSLocalizedString("Unable to mark post unseen", comment: "Notice title when updating a post's unseen status failed.")
         static let seenSuccess = NSLocalizedString("Marked post as seen", comment: "Notice title when updating a post's seen status succeeds.")
         static let unseenSuccess = NSLocalizedString("Marked post as unseen", comment: "Notice title when updating a post's unseen status succeeds.")
-        static let followSuccess = NSLocalizedString("Following %1$@", comment: "Notice title when following a site succeeds. %1$@ is a placeholder for the site name.")
-        static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when unfollowing a site succeeds.")
-        static let followFail = NSLocalizedString("Unable to follow site", comment: "Notice title when following a site fails.")
-        static let unfollowFail = NSLocalizedString("Unable to unfollow site", comment: "Notice title when unfollowing a site fails.")
-        static let notificationOnFail = NSLocalizedString("Unable to turn on site notifications", comment: "Notice title when turning site notifications on fails.")
-        static let notificationOffFail = NSLocalizedString("Unable to turn off site notifications", comment: "Notice title when turning site notifications off fails.")
-        static let notificationOnSuccess = NSLocalizedString("Turned on site notifications", comment: "Notice title when turning site notifications on succeeds.")
-        static let notificationOffSuccess = NSLocalizedString("Turned off site notifications", comment: "Notice title when turning site notifications off succeeds.")
-        static let enableNotifications = NSLocalizedString("Enable site notifications?", comment: "Message prompting user to enable site notifications.")
+        static let followSuccess = NSLocalizedString(
+            "reader.notice.subscribe.success",
+            value: "Subscribed to %1$@",
+            comment: "Notice title when following a blog succeeds. %1$@ is a placeholder for the site name."
+        )
+        static let unfollowSuccess = NSLocalizedString(
+            "reader.notice.unsubscribe.success",
+            value: "Unsubscribed from blog",
+            comment: "Notice title when unfollowing a blog succeeds."
+        )
+        static let followFail = NSLocalizedString(
+            "reader.notice.subscribe.failure",
+            value: "Unable to subscribe to blog",
+            comment: "Notice title when subscribing to a blog fails."
+        )
+        static let unfollowFail = NSLocalizedString(
+            "reader.notice.unsubscribe.failure",
+            value: "Unable to unsubscribe from blog",
+            comment: "Notice title when unsubscribing to a blog fails."
+        )
+        static let notificationOnFail = NSLocalizedString(
+            "reader.notice.enable.notification.failure",
+            value: "Unable to turn on blog notifications",
+            comment: "Notice title when turning blog notifications on fails."
+        )
+        static let notificationOffFail = NSLocalizedString(
+            "reader.notice.disable.notification.failure",
+            value: "Unable to turn off blog notifications",
+            comment: "Notice title when turning blog notifications off fails."
+        )
+        static let notificationOnSuccess = NSLocalizedString(
+            "reader.notice.enable.notification.success",
+            value: "Turned on blog notifications",
+            comment: "Notice title when turning blog notifications on succeeds."
+        )
+        static let notificationOffSuccess = NSLocalizedString(
+            "reader.notice.disable.notification.success",
+            value: "Turned off blog notifications",
+            comment: "Notice title when turning blog notifications off succeeds."
+        )
+        static let enableNotifications = NSLocalizedString(
+            "reader.notice.enable.notification.prompt",
+            value: "Enable blog notifications?",
+            comment: "Message prompting user to enable blog notifications."
+        )
         static let enableButtonLabel = NSLocalizedString("Enable", comment: "Button title for the enable site notifications action.")
-        static let blockSiteSuccess = NSLocalizedString("Blocked site", comment: "Notice title when blocking a site succeeds.")
-        static let blockSiteFail = NSLocalizedString("Unable to block site", comment: "Notice title when blocking a site fails.")
+        static let blockSiteSuccess = NSLocalizedString(
+            "reader.notice.site.blocked.success",
+            value: "Blocked blog",
+            comment: "Notice title when blocking a site succeeds."
+        )
+        static let blockSiteFail = NSLocalizedString(
+            "reader.notice.site.blocked.failure",
+            value: "Unable to block blog",
+            comment: "Notice title when blocking a blog fails."
+        )
         static let blockUserSuccess = NSLocalizedString(
             "Blocked user",
             value: "Blocked user",
@@ -550,11 +614,11 @@ struct ReaderPostMenuButtonTitles {
         static let commentFollowError = NSLocalizedString("Could not subscribe to comments", comment: "The app failed to subscribe to the comments for the post")
         static let commentUnfollowError = NSLocalizedString("Could not unsubscribe from comments", comment: "The app failed to unsubscribe from the comments for the post")
         static let unknownSiteText = NSLocalizedString(
-            "reader.notice.follow.site.unknown",
-            value: "this site",
+            "reader.notice.subscribe.site.unknown",
+            value: "this blog",
             comment: """
                 A default value used to fill in the site name when the followed site somehow has missing site name or URL.
-                Example: given a notice format "Following %@" and empty site name, this will be "Following this site".
+                Example: given a notice format "Following %@" and empty site name, this will be "Following this blog".
                 """
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -4,17 +4,17 @@ class ReaderReblogPresenter {
 
     private struct NoSitesConfiguration {
         static let noSitesTitle = NSLocalizedString(
-            "reader.reblog.no.sites.title",
+            "reader.reblog.no.blogs.title",
             value: "No available WordPress.com blogs",
             comment: "A short message that informs the user no WordPress.com blogs could be found."
         )
         static let noSitesSubtitle = NSLocalizedString(
-            "reader.reblog.no.sites.subtitle",
+            "reader.reblog.no.blogs.subtitle",
             value: "Once you create a WordPress.com blog, you can reblog content that you like to your own blog.",
             comment: "A subtitle with more detailed info for the user when no WordPress.com blogs could be found."
         )
         static let manageSitesLabel = NSLocalizedString(
-            "reader.reblog.manage.sites",
+            "reader.reblog.manage.blogs",
             value: "Manage Blogs",
             comment: "Button title. Tapping lets the user manage the blogs they follow."
         )

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -3,12 +3,21 @@ class ReaderReblogPresenter {
     private let postService: PostService
 
     private struct NoSitesConfiguration {
-        static let noSitesTitle = NSLocalizedString("No available WordPress.com sites",
-                                                    comment: "A short message that informs the user no WordPress.com sites could be found.")
-        static let noSitesSubtitle = NSLocalizedString("Once you create a WordPress.com site, you can reblog content that you like to your own site.",
-                                                       comment: "A subtitle with more detailed info for the user when no WordPress.com sites could be found.")
-        static let manageSitesLabel = NSLocalizedString("Manage Sites",
-                                                        comment: "Button title. Tapping lets the user manage the sites they follow.")
+        static let noSitesTitle = NSLocalizedString(
+            "reader.reblog.no.sites.title",
+            value: "No available WordPress.com blogs",
+            comment: "A short message that informs the user no WordPress.com blogs could be found."
+        )
+        static let noSitesSubtitle = NSLocalizedString(
+            "reader.reblog.no.sites.subtitle",
+            value: "Once you create a WordPress.com blog, you can reblog content that you like to your own blog.",
+            comment: "A subtitle with more detailed info for the user when no WordPress.com blogs could be found."
+        )
+        static let manageSitesLabel = NSLocalizedString(
+            "reader.reblog.manage.sites",
+            value: "Manage Blogs",
+            comment: "Button title. Tapping lets the user manage the blogs they follow."
+        )
         static let backButtonTitle = NSLocalizedString("Back",
                                                        comment: "Back button title.")
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -116,12 +116,12 @@ struct ReaderSiteHeader: View {
 
     struct Constants {
         static let defaultSiteImage = "blavatar-default"
-        static let countsFormat = NSLocalizedString("reader.site.header.counts",
-                                                    value: "%1$@ posts • %2$@ followers",
+        static let countsFormat = NSLocalizedString("reader.site.header.values",
+                                                    value: "%1$@ posts • %2$@ subscribers",
                                                     comment: "The formatted number of posts and followers for a site. " +
-                                                    "'%1$@' is a placeholder for the site post count. " +
-                                                    "'%2$@' is a placeholder for the site follower count. " +
-                                                    "Example: `5,000 posts • 10M followers`")
+                                                    "'%1$@' is a placeholder for the blog post count. " +
+                                                    "'%2$@' is a placeholder for the blog subscriber count. " +
+                                                    "Example: `5,000 posts • 10M subscribers`")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -116,7 +116,7 @@ struct ReaderSiteHeader: View {
 
     struct Constants {
         static let defaultSiteImage = "blavatar-default"
-        static let countsFormat = NSLocalizedString("reader.site.header.values",
+        static let countsFormat = NSLocalizedString("reader.blog.header.values",
                                                     value: "%1$@ posts • %2$@ subscribers",
                                                     comment: "The formatted number of posts and followers for a site. " +
                                                     "'%1$@' is a placeholder for the blog post count. " +

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -255,23 +255,23 @@ private extension ReaderSiteSearchViewController {
 
     struct StatusText {
         static let loadingTitle = NSLocalizedString(
-            "reader.site.search.loading.title",
+            "reader.blog.search.loading.title",
             value: "Fetching blogs...",
             comment: "A brief prompt when the user is searching for blogs in the Reader."
         )
         static let loadingFailedTitle = NSLocalizedString(
-            "reader.site.search.loading.error",
+            "reader.blog.search.loading.error",
             value: "Problem loading blogs",
             comment: "Error message title informing the user that a search for sites in the Reader could not be loaded."
         )
         static let loadingFailedMessage = NSLocalizedString("Sorry. Your search results could not be loaded.", comment: "A short error message leting the user know the requested search could not be performed.")
         static let noResultsTitle = NSLocalizedString(
-            "reader.site.search.no.results.title",
+            "reader.blog.search.no.results.title",
             value: "No blogs found",
             comment: "A message title"
         )
         static let messageFormat = NSLocalizedString(
-            "reader.site.search.no.results.message.format",
+            "reader.blog.search.no.results.message.format",
             value: "No blogs found matching %@ in your language.",
             comment: "Message shown when the reader finds no blogs for the specified search phrase. The %@ is a placeholder for the search phrase."
         )

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -254,11 +254,27 @@ private extension ReaderSiteSearchViewController {
     }
 
     struct StatusText {
-        static let loadingTitle = NSLocalizedString("Fetching sites...", comment: "A brief prompt when the user is searching for sites in the Reader.")
-        static let loadingFailedTitle = NSLocalizedString("Problem loading sites", comment: "Error message title informing the user that a search for sites in the Reader could not be loaded.")
+        static let loadingTitle = NSLocalizedString(
+            "reader.site.search.loading.title",
+            value: "Fetching blogs...",
+            comment: "A brief prompt when the user is searching for blogs in the Reader."
+        )
+        static let loadingFailedTitle = NSLocalizedString(
+            "reader.site.search.loading.error",
+            value: "Problem loading blogs",
+            comment: "Error message title informing the user that a search for sites in the Reader could not be loaded."
+        )
         static let loadingFailedMessage = NSLocalizedString("Sorry. Your search results could not be loaded.", comment: "A short error message leting the user know the requested search could not be performed.")
-        static let noResultsTitle = NSLocalizedString("No sites found", comment: "A message title")
-        static let messageFormat = NSLocalizedString("No sites found matching %@ in your language.", comment: "Message shown when the reader finds no sites for the specified search phrase. The %@ is a placeholder for the search phrase.")
+        static let noResultsTitle = NSLocalizedString(
+            "reader.site.search.no.results.title",
+            value: "No blogs found",
+            comment: "A message title"
+        )
+        static let messageFormat = NSLocalizedString(
+            "reader.site.search.no.results.message.format",
+            value: "No blogs found matching %@ in your language.",
+            comment: "Message shown when the reader finds no blogs for the specified search phrase. The %@ is a placeholder for the search phrase."
+        )
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -87,7 +87,11 @@ import Gridicons
         numberFormatter.numberStyle = .decimal
 
         let count = numberFormatter.string(from: topic.subscriberCount) ?? "0"
-        let pattern = NSLocalizedString("%@ followers", comment: "The number of followers of a site. The '%@' is a placeholder for the numeric value. Example: `1000 followers`")
+        let pattern = NSLocalizedString(
+            "reader.site.stream.subscribers",
+            value: "%@ subscribers",
+            comment: "The number of followers of a site. The '%@' is a placeholder for the numeric value. Example: `1000 followers`"
+        )
         let str = String(format: pattern, count)
 
         return str

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -88,7 +88,7 @@ import Gridicons
 
         let count = numberFormatter.string(from: topic.subscriberCount) ?? "0"
         let pattern = NSLocalizedString(
-            "reader.site.stream.subscribers",
+            "reader.blog.stream.subscribers",
             value: "%@ subscribers",
             comment: "The number of followers of a site. The '%@' is a placeholder for the numeric value. Example: `1000 followers`"
         )

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSitesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSitesCardCell.swift
@@ -40,7 +40,11 @@ class ReaderSitesCardCell: ReaderTopicsTableCardCell {
     }
 
     private enum Constants {
-        static let title = NSLocalizedString("Sites to follow", comment: "A suggestion of topics the user might ")
+        static let title = NSLocalizedString(
+            "reader.suggested.blogs.title",
+            value: "Blogs to subscribe to",
+            comment: "A suggestion of topics the user might want to subscribe to"
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -68,7 +68,11 @@ extension ReaderStreamViewController {
         if ReaderHelpers.topicIsFollowing(topic) {
             return NoResultsResponse(
                 title: NSLocalizedString("Welcome to the Reader", comment: "A message title"),
-                message: NSLocalizedString("Recent posts from blogs and sites you follow will appear here.", comment: "A message explaining the Following topic in the reader")
+                message: NSLocalizedString(
+                    "reader.no.results.response.message",
+                    value: "Recent posts from blogs and sites you subscribe to will appear here.",
+                    comment: "A message explaining the Following topic in the reader"
+                )
             )
         }
 
@@ -92,7 +96,11 @@ extension ReaderStreamViewController {
         if ReaderHelpers.isTopicSite(topic) {
             return NoResultsResponse(
                 title: NSLocalizedString("No posts", comment: "A message title"),
-                message: NSLocalizedString("This site has not posted anything yet. Try back later.", comment: "Message shown when the reader finds no posts for the chosen site")
+                message: NSLocalizedString(
+                    "reader.no.results.blog.response.message",
+                    value: "This blog has not posted anything yet. Try back later.",
+                    comment: "Message shown when the reader finds no posts for the chosen blog"
+                )
             )
         }
 
@@ -100,7 +108,11 @@ extension ReaderStreamViewController {
         if ReaderHelpers.isTopicList(topic) {
             return NoResultsResponse(
                 title: NSLocalizedString("No recent posts", comment: "A message title"),
-                message: NSLocalizedString("The sites in this list have not posted anything recently.", comment: "Message shown when the reader finds no posts for the chosen list")
+                message: NSLocalizedString(
+                    "reader.no.results.list.response.message",
+                    value: "The blogs in this list have not posted anything recently.",
+                    comment: "Message shown when the reader finds no posts for the chosen list"
+                )
             )
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -24,7 +24,11 @@ class ReaderSelectInterestsViewController: UIViewController {
     }
 
     private struct Strings {
-        static let noSearchResultsTitle = NSLocalizedString("No new topics to follow", comment: "Message shown when there are no new topics to follow.")
+        static let noSearchResultsTitle = NSLocalizedString(
+            "reader.select.tags.no.results.title",
+            value: "No new tags to subscribe to",
+            comment: "Message shown when there are no new topics to follow."
+        )
         static let tryAgainNoticeTitle = NSLocalizedString("Something went wrong. Please try again.", comment: "Error message shown when the app fails to save user selected interests")
         static let tryAgainButtonTitle = NSLocalizedString("Try Again", comment: "Try to load the list of interests again.")
     }

--- a/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCellActionsTests.swift
@@ -7,7 +7,7 @@ final class ReaderPostCellActionsTests: CoreDataTestCase {
     // MARK: - Constants
 
     private enum Constants {
-        static let blockAndReportActions = ["Block this site", "Block this user", "Report this post", "Report this user"]
+        static let blockAndReportActions = ["Block this blog", "Block this user", "Report this post", "Report this user"]
     }
 
     // MARK: - Tests


### PR DESCRIPTION
Ref: pctCYC-195-p2#comment-1144

## Description

Update Reader strings to new terminologies:

- `Site` -> `Blog`
- `Follow` -> `Subscribe`
- `Topic` -> `Tag`

## Updated Strings

| Previous String | Updated String |
|---|---|
| You are already following this site. | You are already subscribed to this blog. |
| Shows the site's posts. | Shows the blog's posts. |
| Add a site | Add a blog |
| You can follow posts on a specific site by following it. | You can subscribe to posts on a specific blog by subscribing to it. |
| Add a topic | Add a tag |
| You can follow posts on a specific subject by adding a topic. | You can subscribe to posts on a specific subject by adding a tag. |
| Unfollow %@ | Unsubscribe from %@ |
| Add a Topic | Add a Tag |
| Discover more topics | Discover more tags |
| Add any topic | Add any tag |
| Add a Topic | Add a Tag |
| Add Topic | Add Tag |
| Follow topics | Subscribe to tags |
| Following new topics... | Subscribing to new tags... |
| The site %@ will no longer appear in your reader. Tap to undo. | The blog %@ will no longer appear in your reader. Tap to undo. |
| Enter the URL of a site to follow | Enter the URL of a blog to subscribe to |
| Site URL | Blog URL |
| Unfollowed site | Unsubscribed from blog |
| Could not unfollow site | Could not unsubscribe from blog |
| Followed site | Subscribed to blog |
| Could not follow site | Could not unsubscribe from blog |
| Unfollow | Unsubscribe |
| Block this site | Block this blog |
| Unfollow site | Unsubscribe from blog |
| Follow site | Subscribe to blog |
| Turn on site notifications | Turn on blog notifications |
| Turn off site notifications | Turn off blog notifications |
| Following %1$@ | Subscribed to %1$@ |
| Unfollowed site | Unsubscribed from blog |
| Unable to follow site | Unable to subscribe to blog |
| Unable to unfollow site | Unable to unsubscribe from blog |
| Unable to turn on site notifications | Unable to turn on blog notifications |
| Unable to turn off site notifications | Unable to turn off blog notifications |
| Turned on site notifications | Turned on blog notifications |
| Turned off site notifications | Turned off blog notifications |
| Enable site notifications? | Enable blog notifications? |
| Blocked site | Blocked blog |
| Unable to block site | Unable to block blog |
| this site | this blog |
| No available WordPress.com sites | No available WordPress.com blogs |
| Once you create a WordPress.com site, you can reblog content that you like to your own site. | Once you create a WordPress.com blog, you can reblog content that you like to your own blog. |
| Manage Sites | Manage Blogs |
| %1$@ posts • %2$@ followers | %1$@ posts • %2$@ subscribers |
| Fetching sites... | Fetching blogs... |
| Problem loading sites | Problem loading blogs |
| No sites found | No blogs found |
| No sites found matching %@ in your language. | No blogs found matching %@ in your language. |
| %@ followers | %@ subscribers |
| Sites to follow | Blogs to subscribe to |
| Recent posts from blogs and sites you follow will appear here. | Recent posts from blogs and sites you subscribe to will appear here. |
| This site has not posted anything yet. Try back later. | This blog has not posted anything yet. Try back later. |
| The sites in this list have not posted anything recently. | The blogs in this list have not posted anything recently. |
| No new topics to follow | No new tags to subscribe to |

## Testing

To test:
- Launch Jetpack and login
- Do a general smoke test of Reader screens
- Look for any of the following strings:
  - Follow, follows, unfollow, following, etc
  - Site, sites
  - topic, topics

## Regression Notes
1. Potential unintended areas of impact
Screens outside of Reader

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually checking files strings are changed in

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
