### PR TITLE
Stats: Remove statsRevampV2 feature flag

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -379,10 +379,8 @@ private extension StatsPeriodStore {
 
         let group = DispatchGroup()
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching posts.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching posts.")
         let topPostsOperation = PeriodOperation(service: service, for: period, date: date) { [weak self] (posts: StatsTopPostsTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching posts: \(String(describing: error?.localizedDescription))")
@@ -392,17 +390,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedPostsAndPages(posts, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching posts.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching posts.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching referrers.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching referrers.")
         let topReferrers = PeriodOperation(service: service, for: period, date: date) { [weak self] (referrers: StatsTopReferrersTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching referrers: \(String(describing: error?.localizedDescription))")
@@ -412,17 +406,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedReferrers(referrers, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching referrers.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching referrers.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching published.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching published.")
         let topPublished = PublishedPostOperation(service: service, for: period, date: date) { [weak self] (published: StatsPublishedPostsTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching published: \(String(describing: error?.localizedDescription))")
@@ -432,17 +422,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedPublished(published, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching published.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching published.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching clicks.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching clicks.")
         let topClicks = PeriodOperation(service: service, for: period, date: date) { [weak self] (clicks: StatsTopClicksTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching clicks: \(String(describing: error?.localizedDescription))")
@@ -452,17 +438,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedClicks(clicks, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching clicks.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching clicks.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching authors.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching authors.")
         let topAuthors = PeriodOperation(service: service, for: period, date: date) { [weak self] (authors: StatsTopAuthorsTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching authors: \(String(describing: error?.localizedDescription))")
@@ -472,17 +454,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedAuthors(authors, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching authors.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching authors.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching search terms.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching search terms.")
         let topSearchTerms = PeriodOperation(service: service, for: period, date: date) { [weak self] (searchTerms: StatsSearchTermTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching search terms: \(String(describing: error?.localizedDescription))")
@@ -492,17 +470,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedSearchTerms(searchTerms, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching search terms.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching search terms.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching countries.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching countries.")
         let topCountries = PeriodOperation(service: service, for: period, date: date, limit: 0) { [weak self] (countries: StatsTopCountryTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching countries: \(String(describing: error?.localizedDescription))")
@@ -512,17 +486,13 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedCountries(countries, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching countries.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching countries.")
+                group.leave()
             }
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching videos.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching videos.")
         let topVideos = PeriodOperation(service: service, for: period, date: date) { [weak self] (videos: StatsTopVideosTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error fetching videos: \(String(describing: error?.localizedDescription))")
@@ -532,19 +502,15 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedVideos(videos, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching videos.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching videos.")
+                group.leave()
             }
         }
 
         // 'limit' in this context is used for the 'num' parameter for the 'file-downloads' endpoint.
         // 'num' relates to the "number of periods to include in the query".
-        if AppConfiguration.statsRevampV2Enabled {
-            group.enter()
-            DDLogInfo("Stats Period: Enter group fetching file downloads.")
-        }
+        group.enter()
+        DDLogInfo("Stats Period: Enter group fetching file downloads.")
         let topFileDownloads = PeriodOperation(service: service, for: period, date: date, limit: 1) { [weak self] (downloads: StatsFileDownloadsTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Period: Error file downloads: \(String(describing: error?.localizedDescription))")
@@ -554,10 +520,8 @@ private extension StatsPeriodStore {
 
             DispatchQueue.main.async {
                 self?.receivedFileDownloads(downloads, error)
-                if AppConfiguration.statsRevampV2Enabled {
-                    DDLogInfo("Stats Period: Leave group fetching file downloads.")
-                    group.leave()
-                }
+                DDLogInfo("Stats Period: Leave group fetching file downloads.")
+                group.leave()
             }
         }
 
@@ -572,11 +536,9 @@ private extension StatsPeriodStore {
                                       topFileDownloads],
                                      waitUntilFinished: false)
 
-        if AppConfiguration.statsRevampV2Enabled {
-            group.notify(queue: .main) { [weak self] in
-                DDLogInfo("Stats Period: Finished fetchAsyncData.")
-                self?.storeDataInCache()
-            }
+        group.notify(queue: .main) { [weak self] in
+            DDLogInfo("Stats Period: Finished fetchAsyncData.")
+            self?.storeDataInCache()
         }
     }
 

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -22,5 +22,4 @@ import Foundation
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
     @objc static let qrLoginEnabled: Bool = false
-    @objc static let statsRevampV2Enabled: Bool = false
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,7 +6,6 @@ enum FeatureFlag: Int, CaseIterable {
     case jetpackDisconnect
     case debugMenu
     case siteIconCreator
-    case statsNewInsights
     case betaSiteDesigns
     case commentModerationUpdate
     case compliancePopover
@@ -28,8 +27,6 @@ enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .siteIconCreator:
             return BuildConfiguration.current != .appStore
-        case .statsNewInsights:
-            return AppConfiguration.statsRevampV2Enabled
         case .betaSiteDesigns:
             return false
         case .commentModerationUpdate:
@@ -70,8 +67,6 @@ extension FeatureFlag {
             return "Debug menu"
         case .siteIconCreator:
             return "Site Icon Creator"
-        case .statsNewInsights:
-            return "New Cards for Stats Insights"
         case .betaSiteDesigns:
             return "Fetch Beta Site Designs"
         case .commentModerationUpdate:

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -44,7 +44,7 @@ extension WPStyleGuide {
         }
 
         static func configureViewAsSeparator(_ separatorView: UIView) {
-            separatorView.backgroundColor = AppConfiguration.statsRevampV2Enabled ? .clear : separatorColor
+            separatorView.backgroundColor = .clear
             separatorView.constraints.first(where: { $0.firstAttribute == .height })?.isActive = false
             separatorView.heightAnchor.constraint(equalToConstant: separatorHeight).isActive = true
         }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -34,42 +34,44 @@
     case postStatsAverageViews
     case postStatsRecentWeeks
 
-    static var allInsights: [StatSection] {
-        return [.insightsViewsVisitors,
-                .insightsLikesTotals,
-                .insightsCommentsTotals,
-                .insightsFollowerTotals,
-                .insightsMostPopularTime,
-                .insightsLatestPostSummary,
-                .insightsAllTime,
-                .insightsAnnualSiteStats,
-                .insightsTodaysStats,
-                .insightsPostingActivity,
-                .insightsTagsAndCategories,
-                .insightsFollowersWordPress,
-                .insightsFollowersEmail,
-                .insightsPublicize]
-    }
-
-    static let allPeriods = [StatSection.periodOverviewViews,
-                             .periodOverviewVisitors,
-                             .periodOverviewLikes,
-                             .periodOverviewComments,
-                             .periodPostsAndPages,
-                             .periodReferrers,
-                             .periodClicks,
-                             .periodAuthors,
-                             .periodCountries,
-                             .periodSearchTerms,
-                             .periodPublished,
-                             .periodVideos,
-                             .periodFileDownloads
+    static let allInsights: [StatSection] = [
+        .insightsViewsVisitors,
+        .insightsLikesTotals,
+        .insightsCommentsTotals,
+        .insightsFollowerTotals,
+        .insightsMostPopularTime,
+        .insightsLatestPostSummary,
+        .insightsAllTime,
+        .insightsAnnualSiteStats,
+        .insightsTodaysStats,
+        .insightsPostingActivity,
+        .insightsTagsAndCategories,
+        .insightsFollowersWordPress,
+        .insightsFollowersEmail,
+        .insightsPublicize
     ]
 
-    static let allPostStats = [StatSection.postStatsGraph,
-                               .postStatsMonthsYears,
-                               .postStatsAverageViews,
-                               .postStatsRecentWeeks
+    static let allPeriods: [StatSection] = [
+        .periodOverviewViews,
+        .periodOverviewVisitors,
+        .periodOverviewLikes,
+        .periodOverviewComments,
+        .periodPostsAndPages,
+        .periodReferrers,
+        .periodClicks,
+        .periodAuthors,
+        .periodCountries,
+        .periodSearchTerms,
+        .periodPublished,
+        .periodVideos,
+        .periodFileDownloads
+    ]
+
+    static let allPostStats: [StatSection] = [
+        .postStatsGraph,
+        .postStatsMonthsYears,
+        .postStatsAverageViews,
+        .postStatsRecentWeeks
     ]
 
     // MARK: - String Accessors

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -35,37 +35,20 @@
     case postStatsRecentWeeks
 
     static var allInsights: [StatSection] {
-        if AppConfiguration.statsRevampV2Enabled {
-            return [.insightsViewsVisitors,
-                    .insightsLikesTotals,
-                    .insightsCommentsTotals,
-                    .insightsFollowerTotals,
-                    .insightsMostPopularTime,
-                    .insightsLatestPostSummary,
-                    .insightsAllTime,
-                    .insightsAnnualSiteStats,
-                    .insightsTodaysStats,
-                    .insightsPostingActivity,
-                    .insightsTagsAndCategories,
-                    .insightsFollowersWordPress,
-                    .insightsFollowersEmail,
-                    .insightsPublicize]
-        } else {
-            return [.insightsLatestPostSummary,
-                    .insightsAllTime,
-                    .insightsFollowerTotals,
-                    .insightsMostPopularTime,
-                    .insightsTagsAndCategories,
-                    .insightsAnnualSiteStats,
-                    .insightsCommentsAuthors,
-                    .insightsCommentsPosts,
-                    .insightsFollowersWordPress,
-                    .insightsFollowersEmail,
-                    .insightsTodaysStats,
-                    .insightsPostingActivity,
-                    .insightsPublicize,
-                    .insightsAddInsight]
-        }
+        return [.insightsViewsVisitors,
+                .insightsLikesTotals,
+                .insightsCommentsTotals,
+                .insightsFollowerTotals,
+                .insightsMostPopularTime,
+                .insightsLatestPostSummary,
+                .insightsAllTime,
+                .insightsAnnualSiteStats,
+                .insightsTodaysStats,
+                .insightsPostingActivity,
+                .insightsTagsAndCategories,
+                .insightsFollowersWordPress,
+                .insightsFollowersEmail,
+                .insightsPublicize]
     }
 
     static let allPeriods = [StatSection.periodOverviewViews,
@@ -112,18 +95,14 @@
         case .insightsAnnualSiteStats:
             return InsightsHeaders.annualSiteStats
         case .insightsCommentsAuthors, .insightsCommentsPosts:
-            if AppConfiguration.statsRevampV2Enabled {
-                switch self {
-                case .insightsCommentsAuthors:
-                    return InsightsHeaders.topCommenters
-                case .insightsCommentsPosts:
-                    return InsightsHeaders.posts
-                default:
-                    return InsightsHeaders.comments
-                }
+            switch self {
+            case .insightsCommentsAuthors:
+                return InsightsHeaders.topCommenters
+            case .insightsCommentsPosts:
+                return InsightsHeaders.posts
+            default:
+                return InsightsHeaders.comments
             }
-
-            return InsightsHeaders.comments
         case .insightsFollowersWordPress, .insightsFollowersEmail:
             return InsightsHeaders.followers
         case .insightsTodaysStats:
@@ -405,13 +384,7 @@
         static let viewsVisitors = NSLocalizedString("Views & Visitors", comment: "Insights views and visitors header")
         static let latestPostSummary = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
         static let allTimeStats = NSLocalizedString("All-Time", comment: "Insights 'All-Time' header")
-        static var mostPopularTime: String {
-            if AppConfiguration.statsRevampV2Enabled {
-                return NSLocalizedString("stats.insights.mostPopularCard.title", value: "🔥 Most Popular Time", comment: "Insights 'Most Popular Time' header. Fire emoji should remain part of the string.")
-            } else {
-                return NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
-            }
-        }
+        static let mostPopularTime = NSLocalizedString("stats.insights.mostPopularCard.title", value: "🔥 Most Popular Time", comment: "Insights 'Most Popular Time' header. Fire emoji should remain part of the string.")
         static let likesTotals = NSLocalizedString("Total Likes", comment: "Insights 'Total Likes' header")
         static let commentsTotals = NSLocalizedString("Total Comments", comment: "Insights 'Total Comments' header")
         static let followerTotals = NSLocalizedString("Total Followers", comment: "Insights 'Total Followers' header")

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -106,28 +106,12 @@ class StatsPeriodHelper {
             return adjustedDate.normalizedDate()
 
         case .week:
-            if FeatureFlag.statsNewInsights.enabled {
-                guard let endDate = currentDate.lastDayOfTheWeek(in: calendar, with: count) else {
-                    DDLogError("[Stats] Couldn't determine the last day of the week for a given date in Stats. Returning original value.")
-                    return currentDate
-                }
-
-                return endDate.normalizedDate()
-            } else {
-                // The hours component here is because the `dateInterval` returned by Calendar is a closed range
-                // — so the "end" of a specific week is also simultenously a 'start' of the next one.
-                // This causes problem when calling this math on dates that _already are_ an end/start of a week.
-                // This doesn't work for our calculations, so we force it to rollover using this hack.
-                // (I *think* that's what's happening here. Doing Calendar math on this method has broken my brain.
-                // I spend like 10h on this ~50 LoC method. Beware.)
-                let components = DateComponents(day: 7 * count, hour: -12)
-
-                guard let weekAdjusted = calendar.date(byAdding: components, to: currentDate.normalizedDate()) else {
-                    DDLogError("[Stats] Couldn't add a multiple of 7 days and -12 hours to a date in Stats. Returning original value.")
-                    return currentDate
-                }
-                return calendar.dateInterval(of: .weekOfYear, for: weekAdjusted)?.end.normalizedDate()
+            guard let endDate = currentDate.lastDayOfTheWeek(in: calendar, with: count) else {
+                DDLogError("[Stats] Couldn't determine the last day of the week for a given date in Stats. Returning original value.")
+                return currentDate
             }
+
+            return endDate.normalizedDate()
         case .month:
             guard let endDate = adjustedDate.lastDayOfTheMonth(in: calendar) else {
                 DDLogError("[Stats] Couldn't determine number of days in a given month in Stats. Returning original value.")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
@@ -25,24 +25,24 @@ enum InsightType: Int, SiteStatsPinnable {
     case commentsTotals
 
     // These Insights will be displayed in this order if a site's Insights have not been customized.
-    static var defaultInsights: [InsightType] {
-        return [.viewsVisitors,
-                .likesTotals,
-                .commentsTotals,
-                .followersTotals,
-                .mostPopularTime,
-                .latestPostSummary]
-    }
+    static let defaultInsights: [InsightType] = [
+        .viewsVisitors,
+        .likesTotals,
+        .commentsTotals,
+        .followersTotals,
+        .mostPopularTime,
+        .latestPostSummary
+    ]
 
     // This property is here to update the default list on existing installations.
     // If the list saved on UserDefaults matches the old one, it will be updated to the new one above.
-    static var oldDefaultInsights: [InsightType] {
-        return [.mostPopularTime,
-                .allTimeStats,
-                .todaysStats,
-                .followers,
-                .comments]
-    }
+    static let oldDefaultInsights: [InsightType] = [
+        .mostPopularTime,
+        .allTimeStats,
+        .todaysStats,
+        .followers,
+        .comments
+    ]
 
     static let defaultInsightsValues = InsightType.defaultInsights.map { $0.rawValue }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
@@ -26,37 +26,22 @@ enum InsightType: Int, SiteStatsPinnable {
 
     // These Insights will be displayed in this order if a site's Insights have not been customized.
     static var defaultInsights: [InsightType] {
-        if AppConfiguration.statsRevampV2Enabled {
-            return [.viewsVisitors,
-                    .likesTotals,
-                    .commentsTotals,
-                    .followersTotals,
-                    .mostPopularTime,
-                    .latestPostSummary]
-        } else {
-            return [.mostPopularTime,
-                    .allTimeStats,
-                    .todaysStats,
-                    .followers,
-                    .comments]
-        }
+        return [.viewsVisitors,
+                .likesTotals,
+                .commentsTotals,
+                .followersTotals,
+                .mostPopularTime,
+                .latestPostSummary]
     }
 
     // This property is here to update the default list on existing installations.
     // If the list saved on UserDefaults matches the old one, it will be updated to the new one above.
     static var oldDefaultInsights: [InsightType] {
-        if AppConfiguration.statsRevampV2Enabled {
-            return [.mostPopularTime,
-                    .allTimeStats,
-                    .todaysStats,
-                    .followers,
-                    .comments]
-        } else {
-            return [.latestPostSummary,
-                    .todaysStats,
-                    .allTimeStats,
-                    .followersTotals]
-        }
+        return [.mostPopularTime,
+                .allTimeStats,
+                .todaysStats,
+                .followers,
+                .comments]
     }
 
     static let defaultInsightsValues = InsightType.defaultInsights.map { $0.rawValue }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -138,8 +138,7 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        return [InsightCellHeaderRow.self,
-                ViewsVisitorsRow.self,
+        return [ViewsVisitorsRow.self,
                 GrowAudienceRow.self,
                 CustomizeInsightsRow.self,
                 LatestPostSummaryRow.self,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -69,10 +69,7 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
         sendScrollEventsToBanner()
         tableView.estimatedRowHeight = 500
         tableView.rowHeight = UITableView.automaticDimension
-
-        if AppConfiguration.statsRevampV2Enabled {
-            tableView.cellLayoutMarginsFollowReadableWidth = true
-        }
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         displayEmptyViewIfNecessary()
     }
@@ -121,10 +118,7 @@ private extension SiteStatsInsightsTableViewController {
                                                pinnedItemStore: pinnedItemStore)
         addViewModelListeners()
         viewModel?.fetchInsights()
-
-        if AppConfiguration.statsRevampV2Enabled {
-            viewModel?.startFetchingPeriodOverview()
-        }
+        viewModel?.startFetchingPeriodOverview()
     }
 
     func addViewModelListeners() {
@@ -423,14 +417,10 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             selectedDate = Calendar.current.date(from: dateComponents)
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            switch statSection {
-            case .insightsViewsVisitors, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
-                segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate)
-            default:
-                segueToDetails(statSection: statSection, selectedDate: selectedDate)
-            }
-        } else {
+        switch statSection {
+        case .insightsViewsVisitors, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
+            segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate)
+        default:
             segueToDetails(statSection: statSection, selectedDate: selectedDate)
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -152,8 +152,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(nil)
                 }))
             case .latestPostSummary:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsLatestPostSummary,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .latestPostSummary,
                                         type: .insights,
                                         status: insightsStore.lastPostSummaryStatus,
@@ -167,8 +165,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsLatestPostSummary)
                 }))
             case .allTimeStats:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsAllTime,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .allTimeStats,
                                         type: .insights,
                                         status: insightsStore.allTimeStatus,
@@ -182,8 +178,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsAllTime)
                 }))
             case .likesTotals:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsLikesTotals,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .likesTotals,
                                         type: .period,
                                         status: periodStore.summaryStatus,
@@ -198,8 +192,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsLikesTotals)
                 }))
             case .commentsTotals:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsCommentsTotals,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .commentsTotals,
                                         type: .period,
                                         status: periodStore.summaryStatus,
@@ -214,8 +206,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsCommentsTotals)
                 }))
             case .followersTotals:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsFollowerTotals,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .followersTotals,
                                         type: .insights,
                                         status: insightsStore.followersTotalsStatus,
@@ -227,8 +217,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsFollowerTotals)
                 }))
             case .mostPopularTime:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsMostPopularTime,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .mostPopularTime,
                                         type: .insights,
                                         status: insightsStore.annualAndMostPopularTimeStatus,
@@ -241,8 +229,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsMostPopularTime)
                 }))
             case .tagsAndCategories:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsTagsAndCategories,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .tagsAndCategories,
                                         type: .insights,
                                         status: insightsStore.tagsAndCategoriesStatus,
@@ -258,8 +244,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsTagsAndCategories)
                 }))
             case .annualSiteStats:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsAnnualSiteStats,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .annualSiteStats,
                                         type: .insights,
                                         status: insightsStore.annualAndMostPopularTimeStatus,
@@ -273,8 +257,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsAnnualSiteStats)
                 }))
             case .comments:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsCommentsPosts,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .comments,
                                         type: .insights,
                                         status: insightsStore.commentsInsightStatus,
@@ -286,8 +268,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsCommentsPosts)
                 }))
             case .followers:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsFollowersWordPress,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .followers,
                                         type: .insights,
                                         status: insightsStore.followersTotalsStatus,
@@ -299,8 +279,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsFollowersWordPress)
                 }))
             case .todaysStats:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsTodaysStats,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .todaysStats,
                                         type: .insights,
                                         status: insightsStore.todaysStatsStatus,
@@ -314,8 +292,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsTodaysStats)
                 }))
             case .postingActivity:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsPostingActivity,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .postingActivity,
                                         type: .insights,
                                         status: insightsStore.postingActivityStatus,
@@ -327,8 +303,6 @@ class SiteStatsInsightsViewModel: Observable {
                     errorBlock(.insightsPostingActivity)
                 }))
             case .publicize:
-                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsPublicize,
-                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .publicize,
                                         type: .insights,
                                         status: insightsStore.publicizeFollowersStatus,
@@ -348,13 +322,9 @@ class SiteStatsInsightsViewModel: Observable {
             }
         }
 
-        tableRows.append(TableFooterRow())
         tableRows.append(AddInsightRow(action: { [weak self] _ in
             self?.siteStatsInsightsDelegate?.showAddInsight?()
         }))
-
-        tableRows.append(TableFooterRow())
-        tableRows = tableRows.filter({ !($0 is InsightCellHeaderRow || $0 is TableFooterRow) })
 
         let sections = tableRows.map({ ImmuTableSection(rows: [$0]) })
         return ImmuTable(sections: sections)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -70,11 +70,9 @@ class SiteStatsInsightsViewModel: Observable {
             self?.emitChange()
         }
 
-        if AppConfiguration.statsRevampV2Enabled {
-            periodChangeReceipt = self.periodStore.onChange { [weak self] in
-                self?.updateMostRecentChartData(self?.periodStore.getSummary())
-                self?.emitChange()
-            }
+        periodChangeReceipt = self.periodStore.onChange { [weak self] in
+            self?.updateMostRecentChartData(self?.periodStore.getSummary())
+            self?.emitChange()
         }
     }
 
@@ -222,13 +220,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         type: .insights,
                                         status: insightsStore.followersTotalsStatus,
                                         block: {
-                    if AppConfiguration.statsRevampV2Enabled {
-                        return TotalInsightStatsRow(dataRow: createFollowerTotalInsightsRow(), statSection: .insightsFollowerTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
-                    } else {
-                                            return TwoColumnStatsRow(dataRows: createTotalFollowersRows(),
-                                                                     statSection: .insightsFollowerTotals,
-                                                                     siteStatsInsightsDelegate: nil)
-                    }
+                    return TotalInsightStatsRow(dataRow: createFollowerTotalInsightsRow(), statSection: .insightsFollowerTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
                 }, error: {
@@ -241,14 +233,8 @@ class SiteStatsInsightsViewModel: Observable {
                                         type: .insights,
                                         status: insightsStore.annualAndMostPopularTimeStatus,
                                         block: {
-                    if AppConfiguration.statsRevampV2Enabled {
-                        return MostPopularTimeInsightStatsRow(data: createMostPopularStatsRowData(),
-                                                 siteStatsInsightsDelegate: nil)
-                    } else {
-                        return TwoColumnStatsRow(dataRows: createMostPopularStatsRows(),
-                                                 statSection: .insightsMostPopularTime,
-                                                 siteStatsInsightsDelegate: nil)
-                    }
+                    return MostPopularTimeInsightStatsRow(data: createMostPopularStatsRowData(),
+                                             siteStatsInsightsDelegate: nil)
                 }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
                 }, error: {
@@ -368,19 +354,10 @@ class SiteStatsInsightsViewModel: Observable {
         }))
 
         tableRows.append(TableFooterRow())
+        tableRows = tableRows.filter({ !($0 is InsightCellHeaderRow || $0 is TableFooterRow) })
 
-        if AppConfiguration.statsRevampV2Enabled {
-            // Remove any header rows for the new appearance
-            tableRows = tableRows.filter({ !($0 is InsightCellHeaderRow || $0 is TableFooterRow) })
-
-            let sections = tableRows.map({ ImmuTableSection(rows: [$0]) })
-            return ImmuTable(sections: sections)
-        }
-
-        return ImmuTable(sections: [
-            ImmuTableSection(
-                rows: tableRows)
-            ])
+        let sections = tableRows.map({ ImmuTableSection(rows: [$0]) })
+        return ImmuTable(sections: sections)
     }
 
     func fetchingFailed() -> Bool {
@@ -786,7 +763,7 @@ private extension SiteStatsInsightsViewModel {
                                                tabDataForFollowerType(.insightsFollowersEmail)],
                                     statSection: .insightsFollowersWordPress,
                                     siteStatsInsightsDelegate: siteStatsInsightsDelegate,
-                                    showTotalCount: AppConfiguration.statsRevampV2Enabled ? false : true)
+                                    showTotalCount: false)
     }
 
     func tabDataForFollowerType(_ followerType: StatSection) -> TabData {
@@ -815,8 +792,8 @@ private extension SiteStatsInsightsViewModel {
         }
 
         return TabData(tabTitle: tabTitle,
-                       itemSubtitle: AppConfiguration.statsRevampV2Enabled ? "" : followerType.itemSubtitle,
-                       dataSubtitle: AppConfiguration.statsRevampV2Enabled ? "" : followerType.dataSubtitle,
+                       itemSubtitle: "",
+                       dataSubtitle: "",
                        totalCount: totalCount,
                        dataRows: followersData ?? [])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -72,10 +72,6 @@ class StatsBaseCell: UITableViewCell {
     }
 
     private func configureHeading(with topConstraint: NSLayoutConstraint) {
-        guard AppConfiguration.statsRevampV2Enabled else {
-            return
-        }
-
         contentView.addSubview(stackView)
 
         NSLayoutConstraint.activate([
@@ -102,10 +98,6 @@ class StatsBaseCell: UITableViewCell {
     }
 
     private func updateHeader() {
-        guard AppConfiguration.statsRevampV2Enabled else {
-            return
-        }
-
         if headingBottomConstraint == nil && headingLabel.superview == nil {
             configureHeading(with: topConstraint)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -103,7 +103,7 @@ class TabbedTotalsCell: StatsBaseCell, NibLoadable {
 private extension TabbedTotalsCell {
 
     func setupFilterBar(selectedIndex: Int) {
-        if AppConfiguration.statsRevampV2Enabled && (statSection == .insightsFollowersWordPress || statSection == .insightsFollowersEmail) {
+        if statSection == .insightsFollowersWordPress || statSection == .insightsFollowersEmail {
             WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forNewInsightsCard: true)
         } else {
             WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forTabbedCard: true)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -174,9 +174,7 @@ private extension OverviewCell {
         filterTabBar.equalWidthSpacing = 12
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
 
-        if AppConfiguration.statsRevampV2Enabled {
-            filterTabBar.dividerColor = .clear
-        }
+        filterTabBar.dividerColor = .clear
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
@@ -6,7 +6,6 @@ class StatsGhostBaseCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         Style.configureCell(self)
-        setupBorders()
     }
 
     override func tintColorDidChange() {
@@ -18,18 +17,6 @@ class StatsGhostBaseCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         stopGhostAnimation()
-    }
-
-    private func setupBorders() {
-        if AppConfiguration.statsRevampV2Enabled {
-            return
-        }
-
-        topBorder = addTopBorder(withColor: .divider)
-        topBorder?.isGhostableDisabled = true
-
-        bottomBorder = addBottomBorder(withColor: .divider)
-        bottomBorder?.isGhostableDisabled = true
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -76,10 +76,6 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         selectionStyle = .none
         backgroundColor = .listForeground
 
-        if !AppConfiguration.statsRevampV2Enabled {
-            addBottomBorder(withColor: .divider)
-        }
-
         viewCountLabel.font = WPStyleGuide.fontForTextStyle(.title1)
         viewCountLabel.textColor = .textSubtle
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsStackViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsStackViewCell.swift
@@ -1,14 +1,7 @@
 class StatsStackViewCell: StatsBaseCell, NibLoadable {
     private typealias Style = WPStyleGuide.Stats
 
-    @IBOutlet private(set) var stackView: UIStackView! {
-        didSet {
-            if !AppConfiguration.statsRevampV2Enabled {
-                contentView.addTopBorder(withColor: Style.separatorColor)
-                contentView.addBottomBorder(withColor: Style.separatorColor)
-            }
-        }
-    }
+    @IBOutlet private(set) var stackView: UIStackView!
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -40,7 +40,7 @@ private extension ViewMoreRow {
         backgroundColor = .listForeground
         viewMoreLabel.text = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         viewMoreLabel.textColor = WPStyleGuide.Stats.actionTextColor
-        if AppConfiguration.statsRevampV2Enabled && (statSection == .insightsFollowersWordPress || statSection == .insightsFollowersEmail) {
+        if statSection == .insightsFollowersWordPress || statSection == .insightsFollowersEmail {
             disclosureImageView.isHidden = true
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -112,7 +112,7 @@ class SiteStatsDashboardViewController: UIViewController {
     }
 
     func configureInsightsTableView() {
-        insightsTableViewController.tableStyle = AppConfiguration.statsRevampV2Enabled ? .insetGrouped : .grouped
+        insightsTableViewController.tableStyle = .insetGrouped
         insightsTableViewController.bannerView = jetpackBannerView
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -171,11 +171,7 @@ struct CustomizeInsightsRow: ImmuTableRow {
 struct LatestPostSummaryRow: ImmuTableRow {
 
     static var cell: ImmuTableCell {
-        if AppConfiguration.statsRevampV2Enabled {
-            return ImmuTableCell.class(StatsLatestPostSummaryInsightsCell.self)
-        } else {
-            return ImmuTableCell.nib(LatestPostSummaryCell.defaultNib, LatestPostSummaryCell.self)
-        }
+        return ImmuTableCell.class(StatsLatestPostSummaryInsightsCell.self)
     }
 
     let summaryData: StatsLastPostInsight?
@@ -374,23 +370,20 @@ struct AddInsightStatRow: ImmuTableRow {
         cell.textLabel?.text = title
         cell.textLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         cell.textLabel?.adjustsFontForContentSizeCategory = true
-        cell.textLabel?.textColor = AppConfiguration.statsRevampV2Enabled || enabled ? .text : .textPlaceholder
+        cell.textLabel?.textColor = enabled ? .text : .textPlaceholder
         cell.selectionStyle = .none
 
         cell.accessibilityLabel = title
         cell.isAccessibilityElement = true
 
-        let canTap = AppConfiguration.statsRevampV2Enabled ? action != nil : enabled
+        let canTap = action != nil
         cell.accessibilityTraits = canTap ? .button : .notEnabled
         cell.accessibilityHint = canTap && enabled ? disabledHint : enabledHint
+        cell.accessoryView = canTap ? UIImageView(image: UIImage(systemName: Constants.plusIconName)) : nil
 
-        if AppConfiguration.statsRevampV2Enabled {
-            cell.accessoryView = canTap ? UIImageView(image: UIImage(systemName: Constants.plusIconName)) : nil
-
-            let editingImageView = UIImageView(image: UIImage(systemName: Constants.minusIconName))
-            editingImageView.tintColor = .textSubtle
-            cell.editingAccessoryView = editingImageView
-        }
+        let editingImageView = UIImageView(image: UIImage(systemName: Constants.minusIconName))
+        editingImageView.tintColor = .textSubtle
+        cell.editingAccessoryView = editingImageView
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -97,28 +97,6 @@ struct TableFooterRow: ImmuTableRow {
 
 // MARK: - Insights Rows
 
-struct InsightCellHeaderRow: ImmuTableRow {
-
-    typealias CellType = StatsCellHeader
-
-    static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
-    }()
-
-    let statSection: StatSection
-    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
-    let action: ImmuTableAction? = nil
-
-    func configureCell(_ cell: UITableViewCell) {
-
-        guard let cell = cell as? CellType else {
-            return
-        }
-
-        cell.configure(statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
-    }
-}
-
 struct GrowAudienceRow: ImmuTableRow {
 
     typealias CellType = GrowAudienceCell

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -22,5 +22,4 @@ import Foundation
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
     @objc static let qrLoginEnabled: Bool = true
-    @objc static let statsRevampV2Enabled: Bool = true
 }

--- a/WordPress/WordPressTest/StatsPeriodHelperTests.swift
+++ b/WordPress/WordPressTest/StatsPeriodHelperTests.swift
@@ -6,12 +6,10 @@ final class StatsPeriodHelperTests: XCTestCase {
 
     override func setUpWithError() throws {
         sut = StatsPeriodHelper()
-        try? FeatureFlagOverrideStore().override(FeatureFlag.statsNewInsights, withValue: true)
     }
 
     override func tearDownWithError() throws {
         sut = nil
-        try? FeatureFlagOverrideStore().override(FeatureFlag.statsNewInsights, withValue: false)
     }
 
     func testEndOfWeekWhenMondayIsSetAsFirstWeekday() {


### PR DESCRIPTION
Remove statsRevampV2 feature flag and the code that falls under the disabled flag.

## To test:

I think the most important part is code review. However, quick visual review of Insights would also be good

1. Open Jetpack app
2. Stats
3. Insights
4. Confirm cells contain headers, data loads, Insight management works, navigation works

## Regression Notes
1. Potential unintended areas of impact

Affecting Stats Insights

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- Compiler
- Running existing tests
- Manual testing

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
