### PR TITLE
Stats Traffic: Adapt existing views for a new Traffic tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsDashboardDeprecated.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsDashboardDeprecated.storyboard
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Stats Table View Controller-->
+        <scene sceneID="oK9-NU-1WR">
+            <objects>
+                <tableViewController storyboardIdentifier="SiteStatsPeriodTableViewControllerDeprecated" id="ueT-2n-duh" userLabel="Stats Table View Controller" customClass="SiteStatsPeriodTableViewControllerDeprecated" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Nnf-EQ-drj">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <connections>
+                            <outlet property="dataSource" destination="ueT-2n-duh" id="Hj6-IR-CEY"/>
+                            <outlet property="delegate" destination="ueT-2n-duh" id="n9u-OB-AJW"/>
+                        </connections>
+                    </tableView>
+                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="ab7-5s-Ose">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </refreshControl>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="RVq-1S-kDr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1030" y="1227"/>
+        </scene>
+    </scenes>
+</document>

--- a/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodTableViewControllerDeprecated.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodTableViewControllerDeprecated.swift
@@ -39,7 +39,7 @@ class SiteStatsPeriodTableViewControllerDeprecated: UITableViewController, Story
     private let store = StoreContainer.shared.statsPeriod
     private var changeReceipt: Receipt?
 
-    private var viewModel: SiteStatsPeriodViewModel?
+    private var viewModel: SiteStatsPeriodViewModelDeprecated?
     private var tableHeaderView: SiteStatsTableHeaderView?
 
     private let analyticsTracker = BottomScrollAnalyticsTracker()
@@ -107,11 +107,11 @@ private extension SiteStatsPeriodTableViewControllerDeprecated {
                 return
         }
 
-        viewModel = SiteStatsPeriodViewModel(store: store,
-                                             selectedDate: selectedDate,
-                                             selectedPeriod: selectedPeriod,
-                                             periodDelegate: self,
-                                             referrerDelegate: self)
+        viewModel = SiteStatsPeriodViewModelDeprecated(store: store,
+                                                       selectedDate: selectedDate,
+                                                       selectedPeriod: selectedPeriod,
+                                                       periodDelegate: self,
+                                                       referrerDelegate: self)
         viewModel?.statsBarChartViewDelegate = self
         addViewModelListeners()
         viewModel?.startFetchingOverview()

--- a/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodTableViewControllerDeprecated.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodTableViewControllerDeprecated.swift
@@ -1,0 +1,328 @@
+import UIKit
+import WordPressFlux
+
+/// ℹ️ SiteStatsPeriodTableViewControllerDeprecated is an outdated version of Stats Period (Traffic) view
+/// It's meant to be displayed when Stats Traffic Tab feature flag is disabled
+/// All deprecated files should be removed once Stats Traffic Tab feature flag is removed
+
+class SiteStatsPeriodTableViewControllerDeprecated: UITableViewController, StoryboardLoadable {
+    static var defaultStoryboardName: String = "SiteStatsDashboardDeprecated"
+
+    weak var bannerView: JetpackBannerView?
+
+    // MARK: - Properties
+
+    private lazy var mainContext: NSManagedObjectContext = {
+        return ContextManager.sharedInstance().mainContext
+    }()
+
+    var selectedDate: Date?
+    var selectedPeriod: StatsPeriodUnit? {
+        didSet {
+
+            guard selectedPeriod != nil else {
+                return
+            }
+
+            clearExpandedRows()
+
+            // If this is the first time setting the Period, need to initialize the view model.
+            // Otherwise, just refresh the data.
+            if oldValue == nil {
+                initViewModel()
+            } else {
+                refreshData()
+            }
+        }
+    }
+
+    private let store = StoreContainer.shared.statsPeriod
+    private var changeReceipt: Receipt?
+
+    private var viewModel: SiteStatsPeriodViewModel?
+    private var tableHeaderView: SiteStatsTableHeaderView?
+
+    private let analyticsTracker = BottomScrollAnalyticsTracker()
+
+    private lazy var tableHandler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self, with: analyticsTracker)
+    }()
+
+    // MARK: - View
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        clearExpandedRows()
+        WPStyleGuide.Stats.configureTable(tableView)
+        refreshControl?.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
+        ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
+        tableView.estimatedRowHeight = 500
+        tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
+        sendScrollEventsToBanner()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if !isMovingToParent {
+            guard let date = selectedDate, let period = selectedPeriod else {
+                return
+            }
+            addViewModelListeners()
+            viewModel?.refreshPeriodOverviewData(withDate: date, forPeriod: period)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let cell = Bundle.main.loadNibNamed("SiteStatsTableHeaderView", owner: nil, options: nil)?.first as? SiteStatsTableHeaderView else {
+            return nil
+        }
+
+        cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
+        cell.animateGhostLayers(viewModel?.isFetchingChart() == true)
+        tableHeaderView = cell
+        return cell
+    }
+
+}
+
+extension SiteStatsPeriodTableViewControllerDeprecated: StatsBarChartViewDelegate {
+    func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {
+        if let intervalDate = viewModel?.chartDate(for: entryIndex) {
+            tableHeaderView?.updateDate(with: intervalDate)
+        }
+    }
+}
+
+// MARK: - Private Extension
+
+private extension SiteStatsPeriodTableViewControllerDeprecated {
+
+    // MARK: - View Model
+
+    func initViewModel() {
+
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+
+        viewModel = SiteStatsPeriodViewModel(store: store,
+                                             selectedDate: selectedDate,
+                                             selectedPeriod: selectedPeriod,
+                                             periodDelegate: self,
+                                             referrerDelegate: self)
+        viewModel?.statsBarChartViewDelegate = self
+        addViewModelListeners()
+        viewModel?.startFetchingOverview()
+    }
+
+    func addViewModelListeners() {
+        if changeReceipt != nil {
+            return
+        }
+
+        changeReceipt = viewModel?.onChange { [weak self] in
+            self?.refreshTableView()
+        }
+    }
+
+    func removeViewModelListeners() {
+        changeReceipt = nil
+    }
+
+    func tableRowTypes() -> [ImmuTableRow.Type] {
+        return [PeriodEmptyCellHeaderRow.self,
+                CellHeaderRow.self,
+                TopTotalsPeriodStatsRow.self,
+                TopTotalsNoSubtitlesPeriodStatsRow.self,
+                CountriesStatsRow.self,
+                CountriesMapRow.self,
+                OverviewRow.self,
+                TableFooterRow.self,
+                StatsErrorRow.self,
+                StatsGhostChartImmutableRow.self,
+                StatsGhostTopImmutableRow.self]
+    }
+
+    // MARK: - Table Refreshing
+
+    func refreshTableView() {
+        guard let viewModel = viewModel else {
+            return
+        }
+
+        tableHandler.viewModel = viewModel.tableViewModel()
+
+        refreshControl?.endRefreshing()
+
+        if viewModel.fetchingFailed() {
+            displayFailureViewIfNecessary()
+        }
+    }
+
+    @objc func userInitiatedRefresh() {
+        clearExpandedRows()
+        refreshControl?.beginRefreshing()
+        refreshData()
+    }
+
+    func refreshData() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod,
+            viewIsVisible() else {
+                refreshControl?.endRefreshing()
+                return
+        }
+        addViewModelListeners()
+        viewModel?.refreshPeriodOverviewData(withDate: selectedDate, forPeriod: selectedPeriod)
+    }
+
+    func applyTableUpdates() {
+        tableView.performBatchUpdates({
+        })
+    }
+
+    func clearExpandedRows() {
+        StatsDataHelper.clearExpandedPeriods()
+    }
+
+    func viewIsVisible() -> Bool {
+        return isViewLoaded && view.window != nil
+    }
+}
+
+// MARK: - NoResultsViewHost
+
+extension SiteStatsPeriodTableViewControllerDeprecated: NoResultsViewHost {
+    private func displayFailureViewIfNecessary() {
+        guard tableHandler.viewModel.sections.isEmpty else {
+            return
+        }
+
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResultConstants.errorTitle,
+                                     subtitle: NoResultConstants.errorSubtitle,
+                                     buttonTitle: NoResultConstants.refreshButtonTitle, customizationBlock: { [weak self] noResults in
+                                        noResults.delegate = self
+                                        if !noResults.isReachable {
+                                            noResults.resetButtonText()
+                                        }
+                                     })
+    }
+
+    private enum NoResultConstants {
+        static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
+        static let errorSubtitle = NSLocalizedString("There was a problem loading your data, refresh your page to try again.", comment: "The loading view subtitle displayed when an error occurred")
+        static let refreshButtonTitle = NSLocalizedString("Refresh", comment: "The loading view button title displayed when an error occurred")
+    }
+}
+
+// MARK: - NoResultsViewControllerDelegate methods
+
+extension SiteStatsPeriodTableViewControllerDeprecated: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
+        hideNoResults()
+        refreshData()
+    }
+}
+
+// MARK: - SiteStatsPeriodDelegate Methods
+
+extension SiteStatsPeriodTableViewControllerDeprecated: SiteStatsPeriodDelegate {
+
+    func displayWebViewWithURL(_ url: URL) {
+        let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url, source: "site_stats_period")
+        let navController = UINavigationController.init(rootViewController: webViewController)
+        present(navController, animated: true)
+    }
+
+    func displayMediaWithID(_ mediaID: NSNumber) {
+
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID, let blog = Blog.lookup(withID: siteID, in: mainContext) else {
+            DDLogInfo("Unable to get blog when trying to show media from Stats.")
+            return
+        }
+
+        let coreDataStack = ContextManager.shared
+        let mediaRepository = MediaRepository(coreDataStack: coreDataStack)
+        let blogID = TaggedManagedObjectID(blog)
+        Task { @MainActor in
+            let media: Media
+            do {
+                let mediaID = try await mediaRepository.getMedia(withID: mediaID, in: blogID)
+                media = try mainContext.existingObject(with: mediaID)
+            } catch {
+                DDLogInfo("Unable to get media when trying to show from Stats: \(error.localizedDescription)")
+                return
+            }
+
+            let viewController = MediaItemViewController(media: media)
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }
+    }
+
+    func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool) {
+        if didSelectRow {
+            applyTableUpdates()
+        }
+        StatsDataHelper.updatedExpandedState(forRow: row)
+    }
+
+    func viewMoreSelectedForStatSection(_ statSection: StatSection) {
+        guard StatSection.allPeriods.contains(statSection) else {
+            return
+        }
+
+        removeViewModelListeners()
+
+        let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
+        detailTableViewController.configure(statSection: statSection,
+                                            selectedDate: selectedDate,
+                                            selectedPeriod: selectedPeriod)
+        navigationController?.pushViewController(detailTableViewController, animated: true)
+    }
+
+    func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
+        removeViewModelListeners()
+
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: postTitle,
+                                                                                            postURL: postURL)
+        navigationController?.pushViewController(postStatsTableViewController, animated: true)
+    }
+}
+
+// MARK: - SiteStatsReferrerDelegate
+
+extension SiteStatsPeriodTableViewControllerDeprecated: SiteStatsReferrerDelegate {
+    func showReferrerDetails(_ data: StatsTotalRowData) {
+        show(ReferrerDetailsTableViewController(data: data), sender: nil)
+    }
+}
+
+// MARK: - SiteStatsTableHeaderDelegate Methods
+
+extension SiteStatsPeriodTableViewControllerDeprecated: SiteStatsTableHeaderDateButtonDelegate {
+    func dateChangedTo(_ newDate: Date?) {
+        selectedDate = newDate
+        refreshData()
+    }
+
+    func didTouchHeaderButton(forward: Bool) {
+        if let intervalDate = viewModel?.updateDate(forward: forward) {
+            tableHeaderView?.updateDate(with: intervalDate)
+        }
+    }
+}
+
+// MARK: Jetpack powered banner
+
+private extension SiteStatsPeriodTableViewControllerDeprecated {
+
+    func sendScrollEventsToBanner() {
+        if let bannerView = bannerView {
+            analyticsTracker.addTranslationObserver(bannerView)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodViewModelDeprecated.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodViewModelDeprecated.swift
@@ -1,0 +1,666 @@
+import Foundation
+import WordPressFlux
+
+/// ℹ️ SiteStatsPeriodViewModelDeprecatedViewModel is an outdated version of Stats Period (Traffic) View Model
+/// It's meant to be used when Stats Traffic Tab feature flag is disabled
+/// All deprecated files should be removed once Stats Traffic Tab feature flag is removed
+
+class SiteStatsPeriodViewModelDeprecated: Observable {
+
+    // MARK: - Properties
+
+    let changeDispatcher = Dispatcher<Void>()
+
+    private weak var periodDelegate: SiteStatsPeriodDelegate?
+    private weak var referrerDelegate: SiteStatsReferrerDelegate?
+    private let store: StatsPeriodStore
+    private var selectedDate: Date
+    private var lastRequestedDate: Date
+    private var lastRequestedPeriod: StatsPeriodUnit {
+        didSet {
+            if lastRequestedPeriod != oldValue {
+                mostRecentChartData = nil
+            }
+        }
+    }
+    private var periodReceipt: Receipt?
+    private var changeReceipt: Receipt?
+    private typealias Style = WPStyleGuide.Stats
+
+    weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
+
+    private var mostRecentChartData: StatsSummaryTimeIntervalData? {
+        didSet {
+            if oldValue == nil {
+                guard let mostRecentChartData = mostRecentChartData else {
+                    return
+                }
+
+                currentEntryIndex = mostRecentChartData.summaryData.lastIndex(where: { $0.periodStartDate <= selectedDate })
+                    ?? max(mostRecentChartData.summaryData.count - 1, 0)
+            }
+        }
+    }
+
+    private var currentEntryIndex: Int = 0
+
+    private let calendar: Calendar = .current
+
+    // MARK: - Constructor
+
+    init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod,
+         selectedDate: Date,
+         selectedPeriod: StatsPeriodUnit,
+         periodDelegate: SiteStatsPeriodDelegate,
+         referrerDelegate: SiteStatsReferrerDelegate) {
+        self.periodDelegate = periodDelegate
+        self.referrerDelegate = referrerDelegate
+        self.store = store
+        self.selectedDate = selectedDate
+        self.lastRequestedDate = Date()
+        self.lastRequestedPeriod = selectedPeriod
+
+        changeReceipt = store.onChange { [weak self] in
+            self?.emitChange()
+        }
+    }
+
+    func startFetchingOverview() {
+        periodReceipt = store.query(.periods(date: lastRequestedDate, period: lastRequestedPeriod))
+        store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: lastRequestedDate,
+                                                                               period: lastRequestedPeriod,
+                                                                               forceRefresh: true))
+    }
+
+    func isFetchingChart() -> Bool {
+        return store.isFetchingSummary &&
+            mostRecentChartData == nil
+    }
+
+    func fetchingFailed() -> Bool {
+        return store.fetchingOverviewHasFailed
+    }
+
+    // MARK: - Table Model
+
+    func tableViewModel() -> ImmuTable {
+
+        var tableRows = [ImmuTableRow]()
+
+        if !store.containsCachedData && store.fetchingOverviewHasFailed {
+            return ImmuTable.Empty
+        }
+
+        let errorBlock: (StatSection) -> [ImmuTableRow] = { section in
+            return [CellHeaderRow(statSection: section),
+                    StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
+        }
+        let summaryErrorBlock: AsyncBlock<[ImmuTableRow]> = {
+            return [PeriodEmptyCellHeaderRow(),
+                    StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
+        }
+        let loadingBlock: (StatSection) -> [ImmuTableRow] = { section in
+            return [CellHeaderRow(statSection: section),
+                    StatsGhostTopImmutableRow()]
+        }
+
+        tableRows.append(contentsOf: blocks(for: .summary,
+                                            type: .period,
+                                            status: store.summaryStatus,
+                                            checkingCache: { [weak self] in
+                                                return self?.mostRecentChartData != nil
+            },
+                                            block: { [weak self] in
+                                                return self?.overviewTableRows() ?? summaryErrorBlock()
+            }, loading: {
+                return [PeriodEmptyCellHeaderRow(),
+                        StatsGhostChartImmutableRow()]
+        }, error: summaryErrorBlock))
+        tableRows.append(contentsOf: blocks(for: .topPostsAndPages,
+                                            type: .period,
+                                            status: store.topPostsAndPagesStatus,
+                                            block: { [weak self] in
+                                                return self?.postsAndPagesTableRows() ?? errorBlock(.periodPostsAndPages)
+            }, loading: {
+                return loadingBlock(.periodPostsAndPages)
+            }, error: {
+                return errorBlock(.periodPostsAndPages)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topReferrers,
+                                            type: .period,
+                                            status: store.topReferrersStatus,
+                                            block: { [weak self] in
+                                                return self?.referrersTableRows() ?? errorBlock(.periodReferrers)
+            }, loading: {
+                return loadingBlock(.periodReferrers)
+            }, error: {
+                return errorBlock(.periodReferrers)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topClicks,
+                                            type: .period,
+                                            status: store.topClicksStatus,
+                                            block: { [weak self] in
+                                                return self?.clicksTableRows() ?? errorBlock(.periodClicks)
+            }, loading: {
+                return loadingBlock(.periodClicks)
+            }, error: {
+                return errorBlock(.periodClicks)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topAuthors,
+                                            type: .period,
+                                            status: store.topAuthorsStatus,
+                                            block: { [weak self] in
+                                                return self?.authorsTableRows() ?? errorBlock(.periodAuthors)
+            }, loading: {
+                return loadingBlock(.periodAuthors)
+            }, error: {
+                return errorBlock(.periodAuthors)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topCountries,
+                                            type: .period,
+                                            status: store.topCountriesStatus,
+                                            block: { [weak self] in
+                                                return self?.countriesTableRows() ?? errorBlock(.periodCountries)
+            }, loading: {
+                return loadingBlock(.periodCountries)
+            }, error: {
+                return errorBlock(.periodCountries)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topSearchTerms,
+                                            type: .period,
+                                            status: store.topSearchTermsStatus,
+                                            block: { [weak self] in
+                                                return self?.searchTermsTableRows() ?? errorBlock(.periodSearchTerms)
+            }, loading: {
+                return loadingBlock(.periodSearchTerms)
+            }, error: {
+                return errorBlock(.periodSearchTerms)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topPublished,
+                                            type: .period,
+                                            status: store.topPublishedStatus,
+                                            block: { [weak self] in
+                                                return self?.publishedTableRows() ?? errorBlock(.periodPublished)
+            }, loading: {
+                return loadingBlock(.periodPublished)
+            }, error: {
+                return errorBlock(.periodPublished)
+        }))
+        tableRows.append(contentsOf: blocks(for: .topVideos,
+                                            type: .period,
+                                            status: store.topVideosStatus,
+                                            block: { [weak self] in
+                                                return self?.videosTableRows() ?? errorBlock(.periodVideos)
+            }, loading: {
+                return loadingBlock(.periodVideos)
+            }, error: {
+                return errorBlock(.periodVideos)
+        }))
+        if SiteStatsInformation.sharedInstance.supportsFileDownloads {
+            tableRows.append(contentsOf: blocks(for: .topFileDownloads,
+                                                type: .period,
+                                                status: store.topFileDownloadsStatus,
+                                                block: { [weak self] in
+                                                    return self?.fileDownloadsTableRows() ?? errorBlock(.periodFileDownloads)
+                }, loading: {
+                    return loadingBlock(.periodFileDownloads)
+                }, error: {
+                    return errorBlock(.periodFileDownloads)
+            }))
+        }
+
+        tableRows.append(TableFooterRow())
+
+        return ImmuTable(sections: [
+            ImmuTableSection(
+                rows: tableRows)
+            ])
+    }
+
+    // MARK: - Refresh Data
+
+    func refreshPeriodOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
+        selectedDate = date
+        lastRequestedPeriod = period
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: true))
+    }
+
+    // MARK: - Chart Date
+
+    func chartDate(for entryIndex: Int) -> Date? {
+        if let summaryData = mostRecentChartData?.summaryData,
+            summaryData.indices.contains(entryIndex) {
+            currentEntryIndex = entryIndex
+            return summaryData[entryIndex].periodStartDate
+        }
+        return nil
+    }
+
+    func updateDate(forward: Bool) -> Date? {
+        if forward {
+            currentEntryIndex += 1
+        } else {
+            currentEntryIndex -= 1
+        }
+
+        guard let nextDate = chartDate(for: currentEntryIndex) else {
+            // The date doesn't exist in the chart data... we need to manually calculate it and request
+            // a refresh.
+            let increment = forward ? 1 : -1
+            let nextDate = calendar.date(byAdding: lastRequestedPeriod.calendarComponent, value: increment, to: selectedDate)!
+            refreshPeriodOverviewData(withDate: nextDate, forPeriod: lastRequestedPeriod)
+            return nextDate
+        }
+
+        return nextDate
+    }
+}
+
+// MARK: - Private Extension
+
+private extension SiteStatsPeriodViewModelDeprecated {
+
+    // MARK: - Create Table Rows
+
+    func overviewTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(PeriodEmptyCellHeaderRow())
+
+        let periodSummary = store.getSummary()
+        let summaryData = periodSummary?.summaryData ?? []
+
+        if mostRecentChartData == nil {
+            mostRecentChartData = periodSummary
+        } else if let mostRecentChartData = mostRecentChartData,
+            let periodSummary = periodSummary,
+            mostRecentChartData.periodEndDate == periodSummary.periodEndDate {
+            self.mostRecentChartData = periodSummary
+        } else if let periodSummary = periodSummary,   // when there is API data that has more recent API period date
+                  let chartData = mostRecentChartData, // than our local chartData
+                  periodSummary.periodEndDate > chartData.periodEndDate {
+
+            // we validate if our periodDates match and if so we set the currentEntryIndex to the last index of the summaryData
+            // fixes issue #19688
+            if let lastSummaryDataEntry = summaryData.last,
+               periodSummary.periodEndDate == lastSummaryDataEntry.periodStartDate {
+                mostRecentChartData = periodSummary
+                currentEntryIndex = summaryData.count - 1
+            } else {
+                mostRecentChartData = chartData
+            }
+        }
+
+        let periodDate = summaryData.indices.contains(currentEntryIndex) ? summaryData[currentEntryIndex].periodStartDate : nil
+        let period = periodSummary?.period
+
+        let viewsData = intervalData(summaryType: .views)
+        let viewsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle,
+                                           tabData: viewsData.count,
+                                           difference: viewsData.difference,
+                                           differencePercent: viewsData.percentage,
+                                           date: periodDate,
+                                           period: period,
+                                           analyticsStat: .statsOverviewTypeTappedViews,
+                                           accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint)
+
+        let visitorsData = intervalData(summaryType: .visitors)
+        let visitorsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle,
+                                              tabData: visitorsData.count,
+                                              difference: visitorsData.difference,
+                                              differencePercent: visitorsData.percentage,
+                                              date: periodDate,
+                                              period: period,
+                                              analyticsStat: .statsOverviewTypeTappedVisitors,
+                                              accessibilityHint: StatSection.periodOverviewVisitors.tabAccessibilityHint)
+
+        let likesData = intervalData(summaryType: .likes)
+        // If Summary Likes is still loading, show dashes (instead of 0)
+        // to indicate it's still loading.
+        let likesLoadingStub = likesData.count > 0 ? nil : (store.isFetchingSummary ? "----" : nil)
+        let likesTabData = OverviewTabData(tabTitle: StatSection.periodOverviewLikes.tabTitle,
+                                           tabData: likesData.count,
+                                           tabDataStub: likesLoadingStub,
+                                           difference: likesData.difference,
+                                           differencePercent: likesData.percentage,
+                                           date: periodDate,
+                                           period: period,
+                                           analyticsStat: .statsOverviewTypeTappedLikes,
+                                           accessibilityHint: StatSection.periodOverviewLikes.tabAccessibilityHint)
+
+        let commentsData = intervalData(summaryType: .comments)
+        let commentsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle,
+                                              tabData: commentsData.count,
+                                              difference: commentsData.difference,
+                                              differencePercent: commentsData.percentage,
+                                              date: periodDate,
+                                              period: period,
+                                              analyticsStat: .statsOverviewTypeTappedComments,
+                                              accessibilityHint: StatSection.periodOverviewComments.tabAccessibilityHint)
+
+        var barChartData = [BarChartDataConvertible]()
+        var barChartStyling = [BarChartStyling]()
+        var indexToHighlight: Int?
+        if let chartData = mostRecentChartData {
+            let chart = PeriodChart(data: chartData)
+
+            barChartData.append(contentsOf: chart.barChartData)
+            barChartStyling.append(contentsOf: chart.barChartStyling)
+
+            indexToHighlight = chartData.summaryData.lastIndex(where: {
+                $0.periodStartDate.normalizedDate() <= selectedDate.normalizedDate()
+            })
+        }
+
+        let row = OverviewRow(
+            tabsData: [viewsTabData, visitorsTabData, likesTabData, commentsTabData],
+            chartData: barChartData,
+            chartStyling: barChartStyling,
+            period: lastRequestedPeriod,
+            statsBarChartViewDelegate: statsBarChartViewDelegate,
+            chartHighlightIndex: indexToHighlight)
+        tableRows.append(row)
+
+        return tableRows
+    }
+
+    func intervalData(summaryType: StatsSummaryType) -> (count: Int, difference: Int, percentage: Int) {
+            guard let summaryData = mostRecentChartData?.summaryData,
+                summaryData.indices.contains(currentEntryIndex) else {
+                return (0, 0, 0)
+            }
+
+            let currentInterval = summaryData[currentEntryIndex]
+            let previousInterval = currentEntryIndex >= 1 ? summaryData[currentEntryIndex-1] : nil
+
+            let currentCount: Int
+            let previousCount: Int
+            switch summaryType {
+            case .views:
+                currentCount = currentInterval.viewsCount
+                previousCount = previousInterval?.viewsCount ?? 0
+            case .visitors:
+                currentCount = currentInterval.visitorsCount
+                previousCount = previousInterval?.visitorsCount ?? 0
+            case .likes:
+                currentCount = currentInterval.likesCount
+                previousCount = previousInterval?.likesCount ?? 0
+            case .comments:
+                currentCount = currentInterval.commentsCount
+                previousCount = previousInterval?.commentsCount ?? 0
+            }
+
+            let difference = currentCount - previousCount
+            var roundedPercentage = 0
+
+            if previousCount > 0 {
+                let percentage = (Float(difference) / Float(previousCount)) * 100
+                roundedPercentage = Int(round(percentage))
+            }
+
+            return (currentCount, difference, roundedPercentage)
+    }
+
+    func postsAndPagesTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodPostsAndPages))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
+                                                 dataRows: postsAndPagesDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func postsAndPagesDataRows() -> [StatsTotalRowData] {
+        let postsAndPages = store.getTopPostsAndPages()?.topPosts.prefix(10) ?? []
+
+        return postsAndPages.map {
+            let icon: UIImage?
+
+            switch $0.kind {
+            case .homepage:
+                icon = Style.imageForGridiconType(.house, withTint: .icon)
+            case .page:
+                icon = Style.imageForGridiconType(.pages, withTint: .icon)
+            case .post:
+                icon = Style.imageForGridiconType(.posts, withTint: .icon)
+            case .unknown:
+                icon = Style.imageForGridiconType(.posts, withTint: .icon)
+            }
+
+            return StatsTotalRowData(name: $0.title,
+                                     data: $0.viewsCount.abbreviatedString(),
+                                     postID: $0.postID,
+                                     dataBarPercent: Float($0.viewsCount) / Float(postsAndPages.first!.viewsCount),
+                                     icon: icon,
+                                     showDisclosure: true,
+                                     disclosureURL: $0.postURL,
+                                     statSection: .periodPostsAndPages)
+        }
+    }
+
+    func referrersTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodReferrers))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodReferrers.dataSubtitle,
+                                                 dataRows: referrersDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate,
+                                                 siteStatsReferrerDelegate: referrerDelegate))
+
+        return tableRows
+    }
+
+    func referrersDataRows() -> [StatsTotalRowData] {
+        let referrers = store.getTopReferrers()?.referrers.prefix(10) ?? []
+
+        func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {
+            var icon: UIImage? = nil
+            var iconURL: URL? = nil
+
+            switch referrer.iconURL?.lastPathComponent {
+            case "search-engine.png":
+                icon = Style.imageForGridiconType(.search)
+            case nil:
+                icon = Style.imageForGridiconType(.globe)
+            default:
+                iconURL = referrer.iconURL
+            }
+
+            return StatsTotalRowData(name: referrer.title,
+                                     data: referrer.viewsCount.abbreviatedString(),
+                                     icon: icon,
+                                     socialIconURL: iconURL,
+                                     showDisclosure: true,
+                                     disclosureURL: referrer.url,
+                                     childRows: referrer.children.map { rowDataFromReferrer(referrer: $0) },
+                                     statSection: .periodReferrers,
+                                     isReferrerSpam: referrer.isSpam)
+        }
+
+        return referrers.map { rowDataFromReferrer(referrer: $0) }
+    }
+
+    func clicksTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodClicks))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodClicks.dataSubtitle,
+                                                 dataRows: clicksDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func clicksDataRows() -> [StatsTotalRowData] {
+        return store.getTopClicks()?.clicks.prefix(10).map { StatsTotalRowData(name: $0.title,
+                                                                               data: $0.clicksCount.abbreviatedString(),
+                                                                               showDisclosure: true,
+                                                                               disclosureURL: $0.clickedURL,
+                                                                               childRows: $0.children.map { StatsTotalRowData(name: $0.title,
+                                                                                                                              data: $0.clicksCount.abbreviatedString(),
+                                                                                                                              showDisclosure: true,
+                                                                                                                              disclosureURL: $0.clickedURL)
+            },
+                                                                               statSection: .periodClicks) }
+            ?? []
+    }
+
+    func authorsTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodAuthors))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodAuthors.dataSubtitle,
+                                                 dataRows: authorsDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func authorsDataRows() -> [StatsTotalRowData] {
+        let authors = store.getTopAuthors()?.topAuthors.prefix(10) ?? []
+
+        return authors.map { StatsTotalRowData(name: $0.name,
+                                               data: $0.viewsCount.abbreviatedString(),
+                                               dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
+                                               userIconURL: $0.iconURL,
+                                               showDisclosure: true,
+                                               childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
+                                               statSection: .periodAuthors)
+        }
+    }
+
+    func countriesTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodCountries))
+        let map = countriesMap()
+        if !map.data.isEmpty {
+            tableRows.append(CountriesMapRow(countriesMap: map))
+        }
+        tableRows.append(CountriesStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
+                                           dataSubtitle: StatSection.periodCountries.dataSubtitle,
+                                           dataRows: countriesDataRows(),
+                                           siteStatsPeriodDelegate: periodDelegate))
+        return tableRows
+    }
+
+    func countriesDataRows() -> [StatsTotalRowData] {
+        return store.getTopCountries()?.countries.prefix(10).map { StatsTotalRowData(name: $0.name,
+                                                                                     data: $0.viewsCount.abbreviatedString(),
+                                                                                     icon: UIImage(named: $0.code),
+                                                                                     statSection: .periodCountries) }
+            ?? []
+    }
+
+    func countriesMap() -> CountriesMap {
+        let countries = store.getTopCountries()?.countries ?? []
+        return CountriesMap(minViewsCount: countries.last?.viewsCount ?? 0,
+                            maxViewsCount: countries.first?.viewsCount ?? 0,
+                            data: countries.reduce([String: NSNumber]()) { (dict, country) in
+                                var nextDict = dict
+                                nextDict.updateValue(NSNumber(value: country.viewsCount), forKey: country.code)
+                                return nextDict
+        })
+    }
+
+    func searchTermsTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodSearchTerms))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
+                                                 dataRows: searchTermsDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func searchTermsDataRows() -> [StatsTotalRowData] {
+        guard let searchTerms = store.getTopSearchTerms() else {
+            return []
+        }
+
+        var mappedSearchTerms = searchTerms.searchTerms.prefix(10).map { StatsTotalRowData(name: $0.term,
+                                                                                           data: $0.viewsCount.abbreviatedString(),
+                                                                                           statSection: .periodSearchTerms) }
+
+        if !mappedSearchTerms.isEmpty && searchTerms.hiddenSearchTermsCount > 0 {
+            // We want to insert the "Unknown search terms" item only if there's anything to show in the first place — if the
+            // section is empty, it doesn't make sense to insert it here.
+
+            let unknownSearchTerm = StatsTotalRowData(name: NSLocalizedString("Unknown search terms",
+                                                                              comment: "Search Terms label for 'unknown search terms'."),
+                                                      data: searchTerms.hiddenSearchTermsCount.abbreviatedString(),
+                                                      statSection: .periodSearchTerms)
+
+            mappedSearchTerms.insert(unknownSearchTerm, at: 0)
+        }
+
+        return mappedSearchTerms
+    }
+
+    func publishedTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodPublished))
+        tableRows.append(TopTotalsNoSubtitlesPeriodStatsRow(dataRows: publishedDataRows(),
+                                                            siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func publishedDataRows() -> [StatsTotalRowData] {
+        return store.getTopPublished()?.publishedPosts.prefix(10).map { StatsTotalRowData.init(name: $0.title.stringByDecodingXMLCharacters(),
+                                                                                               data: "",
+                                                                                               showDisclosure: true,
+                                                                                               disclosureURL: $0.postURL,
+                                                                                               statSection: .periodPublished) }
+            ?? []
+    }
+
+    func videosTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodVideos))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodVideos.dataSubtitle,
+                                                 dataRows: videosDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func videosDataRows() -> [StatsTotalRowData] {
+        return store.getTopVideos()?.videos.prefix(10).map { StatsTotalRowData(name: $0.title,
+                                                                               data: $0.playsCount.abbreviatedString(),
+                                                                               mediaID: $0.postID as NSNumber,
+                                                                               icon: Style.imageForGridiconType(.video),
+                                                                               showDisclosure: true,
+                                                                               statSection: .periodVideos) }
+            ?? []
+    }
+
+    func fileDownloadsTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(statSection: StatSection.periodFileDownloads))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodFileDownloads.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodFileDownloads.dataSubtitle,
+                                                 dataRows: fileDownloadsDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func fileDownloadsDataRows() -> [StatsTotalRowData] {
+        return store.getTopFileDownloads()?.fileDownloads.prefix(10).map { StatsTotalRowData(name: $0.file,
+                                                                                             data: $0.downloadCount.abbreviatedString(),
+                                                                                             statSection: .periodFileDownloads) }
+            ?? []
+    }
+
+}
+
+extension SiteStatsPeriodViewModelDeprecated: AsyncBlocksLoadable {
+    typealias RowType = PeriodType
+
+    var currentStore: StatsPeriodStore {
+        return store
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import DesignSystem
 
 /// Base class for site stats table view controllers
 ///
@@ -47,5 +48,13 @@ extension SiteStatsBaseTableViewController: TableViewContainer, UITableViewDataS
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         return UITableViewCell()
+    }
+
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return Length.Padding.double
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 0
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -173,7 +173,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                      statSection: .insightsAllTime,
                                                                      siteStatsInsightsDelegate: nil)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsAllTime)
                 }, error: {
                     errorBlock(.insightsAllTime)
                 }))
@@ -187,7 +187,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         block: {
                     return TotalInsightStatsRow(dataRow: createLikesTotalInsightsRow(), statSection: .insightsLikesTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsLikesTotals)
                 }, error: {
                     errorBlock(.insightsLikesTotals)
                 }))
@@ -201,7 +201,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         block: {
                     return TotalInsightStatsRow(dataRow: createCommentsTotalInsightsRow(), statSection: .insightsCommentsTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsCommentsTotals)
                 }, error: {
                     errorBlock(.insightsCommentsTotals)
                 }))
@@ -212,7 +212,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         block: {
                     return TotalInsightStatsRow(dataRow: createFollowerTotalInsightsRow(), statSection: .insightsFollowerTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsFollowerTotals)
                 }, error: {
                     errorBlock(.insightsFollowerTotals)
                 }))
@@ -224,7 +224,7 @@ class SiteStatsInsightsViewModel: Observable {
                     return MostPopularTimeInsightStatsRow(data: createMostPopularStatsRowData(),
                                              siteStatsInsightsDelegate: nil)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsMostPopularTime)
                 }, error: {
                     errorBlock(.insightsMostPopularTime)
                 }))
@@ -252,7 +252,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                      statSection: .insightsAnnualSiteStats,
                                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsAnnualSiteStats)
                 }, error: {
                     errorBlock(.insightsAnnualSiteStats)
                 }))
@@ -287,7 +287,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                      statSection: .insightsTodaysStats,
                                                                      siteStatsInsightsDelegate: nil)
                 }, loading: {
-                    return StatsGhostTwoColumnImmutableRow()
+                    return StatsGhostTwoColumnImmutableRow(statSection: .insightsTodaysStats)
                 }, error: {
                     errorBlock(.insightsTodaysStats)
                 }))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -239,7 +239,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                             statSection: .insightsTagsAndCategories,
                                                                             siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostTopImmutableRow()
+                    return StatsGhostTopImmutableRow(statSection: .insightsTagsAndCategories)
                 }, error: {
                     errorBlock(.insightsTagsAndCategories)
                 }))
@@ -313,7 +313,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                             statSection: .insightsPublicize,
                                                                             siteStatsInsightsDelegate: nil)
                 }, loading: {
-                    return StatsGhostTopImmutableRow()
+                    return StatsGhostTopImmutableRow(statSection: .insightsPublicize)
                 }, error: {
                     errorBlock(.insightsPublicize)
                 }))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -263,7 +263,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         block: {
                                             return createCommentsRow()
                 }, loading: {
-                    return StatsGhostTabbedImmutableRow()
+                    return StatsGhostTabbedImmutableRow(statSection: .insightsCommentsAuthors)
                 }, error: {
                     errorBlock(.insightsCommentsPosts)
                 }))
@@ -274,7 +274,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         block: {
                                             return createFollowersRow()
                 }, loading: {
-                    return StatsGhostTabbedImmutableRow()
+                    return StatsGhostTabbedImmutableRow(statSection: .insightsFollowersWordPress)
                 }, error: {
                     errorBlock(.insightsFollowersWordPress)
                 }))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -298,7 +298,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         block: {
                                             return createPostingActivityRow()
                 }, loading: {
-                    return StatsGhostPostingActivitiesImmutableRow()
+                    return StatsGhostPostingActivitiesImmutableRow(statSection: .insightsPostingActivity)
                 }, error: {
                     errorBlock(.insightsPostingActivity)
                 }))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -147,7 +147,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                    isNudgeCompleted: isNudgeCompleted,
                                                                    siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostGrowAudienceImmutableRow()
+                    return StatsGhostGrowAudienceImmutableRow(statSection: InsightType.growAudience.statSection)
                 }, error: {
                     errorBlock(nil)
                 }))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -126,7 +126,7 @@ class SiteStatsInsightsViewModel: Observable {
                         block: { [weak self] in
                             return self?.overviewTableRows() ?? [errorBlock(.insightsViewsVisitors)]
                         }, loading: {
-                            return [StatsGhostChartImmutableRow()]
+                            return [StatsGhostChartImmutableRow(statSection: .insightsViewsVisitors)]
                         }, error: {
                             return [errorBlock(.insightsViewsVisitors)]
                         }))
@@ -160,7 +160,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                         chartData: insightsStore.getPostStats(),
                                                                         siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
-                    return StatsGhostChartImmutableRow()
+                    return StatsGhostChartImmutableRow(statSection: .insightsLatestPostSummary)
                 }, error: {
                     errorBlock(.insightsLatestPostSummary)
                 }))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -43,7 +43,7 @@ class StatsBaseCell: UITableViewCell {
         return stackView
     }()
 
-    @IBOutlet var topConstraint: NSLayoutConstraint!
+    @IBOutlet var topConstraint: NSLayoutConstraint?
 
     private var headingBottomConstraint: NSLayoutConstraint?
     private var headingWidthConstraint: NSLayoutConstraint?
@@ -51,12 +51,12 @@ class StatsBaseCell: UITableViewCell {
     /// Finds the item from the top constraint that's not the content view itself.
     /// - Returns: `topConstraint`'s `firstItem` or `secondItem`, whichever is not this cell's content view.
     private var topConstraintTargetView: UIView? {
-        if let firstItem = topConstraint.firstItem as? UIView,
+        if let firstItem = topConstraint?.firstItem as? UIView,
            firstItem != contentView {
             return firstItem
         }
 
-        return topConstraint.secondItem as? UIView
+        return topConstraint?.secondItem as? UIView
     }
 
     var statSection: StatSection? {
@@ -98,7 +98,7 @@ class StatsBaseCell: UITableViewCell {
     }
 
     private func updateHeader() {
-        if headingBottomConstraint == nil && headingLabel.superview == nil {
+        if let topConstraint, headingBottomConstraint == nil && headingLabel.superview == nil {
             configureHeading(with: topConstraint)
         }
 
@@ -126,7 +126,7 @@ class StatsBaseCell: UITableViewCell {
         let hasTitleOrButton = !title.isEmpty || !showDetailsButton.isHidden
 
         headingBottomConstraint?.isActive = hasTitleOrButton
-        topConstraint.isActive = !hasTitleOrButton
+        topConstraint?.isActive = !hasTitleOrButton
     }
 
     func shouldShowDetailsButton () -> Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
@@ -57,7 +57,7 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
         topConstraint = outerStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: StatsBaseCell.Metrics.padding)
 
         NSLayoutConstraint.activate([
-            topConstraint,
+            topConstraint!,
             outerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -StatsBaseCell.Metrics.padding),
             outerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: StatsBaseCell.Metrics.padding),
             outerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -StatsBaseCell.Metrics.padding),

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
@@ -47,7 +47,7 @@ class StatsMostPopularTimeInsightsCell: StatsBaseCell {
         topConstraint = outerStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: StatsBaseCell.Metrics.padding)
 
         NSLayoutConstraint.activate([
-            topConstraint,
+            topConstraint!,
             outerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -StatsBaseCell.Metrics.padding),
             outerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: StatsBaseCell.Metrics.padding),
             outerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -StatsBaseCell.Metrics.padding),

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -230,7 +230,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
         topConstraint = outerStackView.topAnchor.constraint(equalTo: contentView.topAnchor)
 
         NSLayoutConstraint.activate([
-            topConstraint,
+            topConstraint!,
             outerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -StatsBaseCell.Metrics.padding),
             outerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: StatsBaseCell.Metrics.padding),
             outerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -StatsBaseCell.Metrics.padding),

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -92,6 +92,8 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section == 0 else { return nil }
+
         guard let cell = Bundle.main.loadNibNamed("SiteStatsTableHeaderView", owner: nil, options: nil)?.first as? SiteStatsTableHeaderView else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -91,6 +91,7 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
         }
     }
 
+    // TODO: Replace with a new Date Picker
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard section == 0 else { return nil }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -105,6 +105,14 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
         return cell
     }
 
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if section == 0 {
+            return UITableView.automaticDimension
+        } else {
+            return super.tableView(tableView, heightForHeaderInSection: section)
+        }
+    }
+
 }
 
 extension SiteStatsPeriodTableViewController: StatsBarChartViewDelegate {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -13,7 +13,7 @@ protocol SiteStatsReferrerDelegate: AnyObject {
     func showReferrerDetails(_ data: StatsTotalRowData)
 }
 
-class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoadable {
+final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController {
     static var defaultStoryboardName: String = "SiteStatsDashboard"
 
     weak var bannerView: JetpackBannerView?
@@ -56,6 +56,16 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         return ImmuTableViewHandler(takeOver: self, with: analyticsTracker)
     }()
 
+    init() {
+        super.init(nibName: nil, bundle: nil)
+
+        tableStyle = .insetGrouped
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     // MARK: - View
 
     override func viewDidLoad() {
@@ -63,7 +73,7 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
 
         clearExpandedRows()
         WPStyleGuide.Stats.configureTable(tableView)
-        refreshControl?.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
+        refreshControl.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         tableView.estimatedRowHeight = 500
         tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
@@ -81,7 +91,7 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         }
     }
 
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let cell = Bundle.main.loadNibNamed("SiteStatsTableHeaderView", owner: nil, options: nil)?.first as? SiteStatsTableHeaderView else {
             return nil
         }
@@ -162,7 +172,7 @@ private extension SiteStatsPeriodTableViewController {
 
         tableHandler.viewModel = viewModel.tableViewModel()
 
-        refreshControl?.endRefreshing()
+        refreshControl.endRefreshing()
 
         if viewModel.fetchingFailed() {
             displayFailureViewIfNecessary()
@@ -171,7 +181,7 @@ private extension SiteStatsPeriodTableViewController {
 
     @objc func userInitiatedRefresh() {
         clearExpandedRows()
-        refreshControl?.beginRefreshing()
+        refreshControl.beginRefreshing()
         refreshData()
     }
 
@@ -179,7 +189,7 @@ private extension SiteStatsPeriodTableViewController {
         guard let selectedDate = selectedDate,
             let selectedPeriod = selectedPeriod,
             viewIsVisible() else {
-                refreshControl?.endRefreshing()
+            refreshControl.endRefreshing()
                 return
         }
         addViewModelListeners()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -438,10 +438,10 @@ private extension SiteStatsPeriodViewModel {
 
     func referrersTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodReferrers))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
                                                  dataSubtitle: StatSection.periodReferrers.dataSubtitle,
                                                  dataRows: referrersDataRows(),
+                                                 statSection: StatSection.periodReferrers,
                                                  siteStatsPeriodDelegate: periodDelegate,
                                                  siteStatsReferrerDelegate: referrerDelegate))
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -210,10 +210,8 @@ class SiteStatsPeriodViewModel: Observable {
 
         tableRows.append(TableFooterRow())
 
-        return ImmuTable(sections: [
-            ImmuTableSection(
-                rows: tableRows)
-            ])
+        let sections = tableRows.map({ ImmuTableSection(rows: [$0]) })
+        return ImmuTable(sections: sections)
     }
 
     // MARK: - Refresh Data

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -612,10 +612,10 @@ private extension SiteStatsPeriodViewModel {
 
     func videosTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodVideos))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
                                                  dataSubtitle: StatSection.periodVideos.dataSubtitle,
                                                  dataRows: videosDataRows(),
+                                                 statSection: StatSection.periodVideos,
                                                  siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -559,10 +559,10 @@ private extension SiteStatsPeriodViewModel {
 
     func searchTermsTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodSearchTerms))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
                                                  dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
                                                  dataRows: searchTermsDataRows(),
+                                                 statSection: StatSection.periodSearchTerms,
                                                  siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -525,13 +525,14 @@ private extension SiteStatsPeriodViewModel {
 
     func countriesTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodCountries))
         let map = countriesMap()
-        if !map.data.isEmpty {
-            tableRows.append(CountriesMapRow(countriesMap: map))
+        let isMapShown = !map.data.isEmpty
+        if isMapShown {
+            tableRows.append(CountriesMapRow(countriesMap: map, statSection: .periodCountries))
         }
         tableRows.append(CountriesStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
                                            dataSubtitle: StatSection.periodCountries.dataSubtitle,
+                                           statSection: isMapShown ? nil : .periodCountries,
                                            dataRows: countriesDataRows(),
                                            siteStatsPeriodDelegate: periodDelegate))
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -480,10 +480,10 @@ private extension SiteStatsPeriodViewModel {
 
     func clicksTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodClicks))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
                                                  dataSubtitle: StatSection.periodClicks.dataSubtitle,
                                                  dataRows: clicksDataRows(),
+                                                 statSection: StatSection.periodClicks,
                                                  siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -399,10 +399,10 @@ private extension SiteStatsPeriodViewModel {
 
     func postsAndPagesTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodPostsAndPages))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
                                                  dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
                                                  dataRows: postsAndPagesDataRows(),
+                                                 statSection: StatSection.periodPostsAndPages,
                                                  siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -505,10 +505,10 @@ private extension SiteStatsPeriodViewModel {
 
     func authorsTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodAuthors))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
                                                  dataSubtitle: StatSection.periodAuthors.dataSubtitle,
                                                  dataRows: authorsDataRows(),
+                                                 statSection: StatSection.periodAuthors,
                                                  siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -594,8 +594,8 @@ private extension SiteStatsPeriodViewModel {
 
     func publishedTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodPublished))
         tableRows.append(TopTotalsNoSubtitlesPeriodStatsRow(dataRows: publishedDataRows(),
+                                                            statSection: StatSection.periodPublished,
                                                             siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -88,16 +88,13 @@ class SiteStatsPeriodViewModel: Observable {
         }
 
         let errorBlock: (StatSection) -> [ImmuTableRow] = { section in
-            return [CellHeaderRow(statSection: section),
-                    StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
+            return [StatsErrorRow(rowStatus: .error, statType: .period, statSection: section)]
         }
         let summaryErrorBlock: AsyncBlock<[ImmuTableRow]> = {
-            return [PeriodEmptyCellHeaderRow(),
-                    StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
+            return [StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
         }
         let loadingBlock: (StatSection) -> [ImmuTableRow] = { section in
-            return [CellHeaderRow(statSection: section),
-                    StatsGhostTopImmutableRow()]
+            return [StatsGhostTopImmutableRow()]
         }
 
         var sections: [ImmuTableSection] = []
@@ -112,8 +109,7 @@ class SiteStatsPeriodViewModel: Observable {
                                             block: { [weak self] in
                                                 return self?.overviewTableRows() ?? summaryErrorBlock()
             }, loading: {
-                return [PeriodEmptyCellHeaderRow(),
-                        StatsGhostChartImmutableRow()]
+                return [StatsGhostChartImmutableRow()]
         }, error: summaryErrorBlock)))
 
         sections.append(.init(rows: blocks(for: .topPostsAndPages,
@@ -259,7 +255,6 @@ private extension SiteStatsPeriodViewModel {
 
     func overviewTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(PeriodEmptyCellHeaderRow())
 
         let periodSummary = store.getSummary()
         let summaryData = periodSummary?.summaryData ?? []

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -94,7 +94,7 @@ class SiteStatsPeriodViewModel: Observable {
             return [StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
         }
         let loadingBlock: (StatSection) -> [ImmuTableRow] = { section in
-            return [StatsGhostTopImmutableRow()]
+            return [StatsGhostTopImmutableRow(statSection: section)]
         }
 
         var sections: [ImmuTableSection] = []

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -83,9 +83,6 @@ class SiteStatsPeriodViewModel: Observable {
     // MARK: - Table Model
 
     func tableViewModel() -> ImmuTable {
-
-        var tableRows = [ImmuTableRow]()
-
         if !store.containsCachedData && store.fetchingOverviewHasFailed {
             return ImmuTable.Empty
         }
@@ -103,7 +100,9 @@ class SiteStatsPeriodViewModel: Observable {
                     StatsGhostTopImmutableRow()]
         }
 
-        tableRows.append(contentsOf: blocks(for: .summary,
+        var sections: [ImmuTableSection] = []
+
+        sections.append(.init(rows: blocks(for: .summary,
                                             type: .period,
                                             status: store.summaryStatus,
                                             checkingCache: { [weak self] in
@@ -114,8 +113,8 @@ class SiteStatsPeriodViewModel: Observable {
             }, loading: {
                 return [PeriodEmptyCellHeaderRow(),
                         StatsGhostChartImmutableRow()]
-        }, error: summaryErrorBlock))
-        tableRows.append(contentsOf: blocks(for: .topPostsAndPages,
+        }, error: summaryErrorBlock)))
+        sections.append(.init(rows: blocks(for: .topPostsAndPages,
                                             type: .period,
                                             status: store.topPostsAndPagesStatus,
                                             block: { [weak self] in
@@ -124,8 +123,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodPostsAndPages)
             }, error: {
                 return errorBlock(.periodPostsAndPages)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topReferrers,
+        })))
+        sections.append(.init(rows: blocks(for: .topReferrers,
                                             type: .period,
                                             status: store.topReferrersStatus,
                                             block: { [weak self] in
@@ -134,8 +133,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodReferrers)
             }, error: {
                 return errorBlock(.periodReferrers)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topClicks,
+        })))
+        sections.append(.init(rows: blocks(for: .topClicks,
                                             type: .period,
                                             status: store.topClicksStatus,
                                             block: { [weak self] in
@@ -144,8 +143,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodClicks)
             }, error: {
                 return errorBlock(.periodClicks)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topAuthors,
+        })))
+        sections.append(.init(rows: blocks(for: .topAuthors,
                                             type: .period,
                                             status: store.topAuthorsStatus,
                                             block: { [weak self] in
@@ -154,8 +153,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodAuthors)
             }, error: {
                 return errorBlock(.periodAuthors)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topCountries,
+        })))
+        sections.append(.init(rows: blocks(for: .topCountries,
                                             type: .period,
                                             status: store.topCountriesStatus,
                                             block: { [weak self] in
@@ -164,8 +163,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodCountries)
             }, error: {
                 return errorBlock(.periodCountries)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topSearchTerms,
+        })))
+        sections.append(.init(rows: blocks(for: .topSearchTerms,
                                             type: .period,
                                             status: store.topSearchTermsStatus,
                                             block: { [weak self] in
@@ -174,8 +173,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodSearchTerms)
             }, error: {
                 return errorBlock(.periodSearchTerms)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topPublished,
+        })))
+        sections.append(.init(rows: blocks(for: .topPublished,
                                             type: .period,
                                             status: store.topPublishedStatus,
                                             block: { [weak self] in
@@ -184,8 +183,8 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodPublished)
             }, error: {
                 return errorBlock(.periodPublished)
-        }))
-        tableRows.append(contentsOf: blocks(for: .topVideos,
+        })))
+        sections.append(.init(rows: blocks(for: .topVideos,
                                             type: .period,
                                             status: store.topVideosStatus,
                                             block: { [weak self] in
@@ -194,9 +193,9 @@ class SiteStatsPeriodViewModel: Observable {
                 return loadingBlock(.periodVideos)
             }, error: {
                 return errorBlock(.periodVideos)
-        }))
+        })))
         if SiteStatsInformation.sharedInstance.supportsFileDownloads {
-            tableRows.append(contentsOf: blocks(for: .topFileDownloads,
+            sections.append(.init(rows: blocks(for: .topFileDownloads,
                                                 type: .period,
                                                 status: store.topFileDownloadsStatus,
                                                 block: { [weak self] in
@@ -205,12 +204,9 @@ class SiteStatsPeriodViewModel: Observable {
                     return loadingBlock(.periodFileDownloads)
                 }, error: {
                     return errorBlock(.periodFileDownloads)
-            }))
+            })))
         }
 
-        tableRows.append(TableFooterRow())
-
-        let sections = tableRows.map({ ImmuTableSection(rows: [$0]) })
         return ImmuTable(sections: sections)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -102,6 +102,7 @@ class SiteStatsPeriodViewModel: Observable {
 
         var sections: [ImmuTableSection] = []
 
+        // TODO: Replace with a new Bar Chart
         sections.append(.init(rows: blocks(for: .summary,
                                             type: .period,
                                             status: store.summaryStatus,
@@ -114,6 +115,7 @@ class SiteStatsPeriodViewModel: Observable {
                 return [PeriodEmptyCellHeaderRow(),
                         StatsGhostChartImmutableRow()]
         }, error: summaryErrorBlock)))
+
         sections.append(.init(rows: blocks(for: .topPostsAndPages,
                                             type: .period,
                                             status: store.topPostsAndPagesStatus,

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -633,10 +633,10 @@ private extension SiteStatsPeriodViewModel {
 
     func fileDownloadsTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(statSection: StatSection.periodFileDownloads))
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodFileDownloads.itemSubtitle,
                                                  dataSubtitle: StatSection.periodFileDownloads.dataSubtitle,
                                                  dataRows: fileDownloadsDataRows(),
+                                                 statSection: StatSection.periodFileDownloads,
                                                  siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
@@ -1,10 +1,12 @@
-class StatsGhostBaseCell: UITableViewCell {
+class StatsGhostBaseCell: StatsBaseCell {
     private typealias Style = WPStyleGuide.Stats
     private(set) var topBorder: UIView?
     private(set) var bottomBorder: UIView?
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        headingLabel.isGhostableDisabled = true
         Style.configureCell(self)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostChartCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostChartCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,21 +19,21 @@
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xm7-B5-Mcg">
                         <rect key="frame" x="16" y="25" width="20" height="38"/>
+                        <viewLayoutGuide key="safeArea" id="oz5-1m-je4"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="20" id="SPf-NH-nmg"/>
                             <constraint firstAttribute="height" constant="38" id="XHE-JB-GBM"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="oz5-1m-je4"/>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TZ9-xg-9dO">
                         <rect key="frame" x="44" y="43" width="45" height="20"/>
+                        <viewLayoutGuide key="safeArea" id="51z-02-rBE"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="45" id="LIf-9c-4Qh"/>
                             <constraint firstAttribute="height" constant="20" id="ldd-tx-FTd"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="51z-02-rBE"/>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="hFy-8F-3wO">
                         <rect key="frame" x="40" y="79" width="264" height="100"/>
@@ -137,21 +137,21 @@
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ZN-V8-rLc">
                         <rect key="frame" x="16" y="187" width="65" height="8"/>
+                        <viewLayoutGuide key="safeArea" id="LtN-iQ-PWW"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="65" id="OGo-eH-tjD"/>
                             <constraint firstAttribute="height" constant="8" id="Ome-8h-o0J"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="LtN-iQ-PWW"/>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GTG-fs-LIN">
                         <rect key="frame" x="239" y="187" width="65" height="8"/>
+                        <viewLayoutGuide key="safeArea" id="XW5-dq-9RM"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="8" id="9c7-1x-tar"/>
                             <constraint firstAttribute="width" constant="65" id="Dyx-uY-hQU"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="XW5-dq-9RM"/>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="ew5-IW-6Hi">
                         <rect key="frame" x="16" y="79" width="16" height="100"/>
@@ -223,6 +223,9 @@
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="topConstraint" destination="TNz-c2-H9M" id="VB8-jr-OOc"/>
+            </connections>
             <point key="canvasLocation" x="339.13043478260875" y="186.16071428571428"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostGrowAudienceCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostGrowAudienceCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -92,6 +92,9 @@
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="topConstraint" destination="Qsg-0r-3Ia" id="sVY-g9-85F"/>
+            </connections>
             <point key="canvasLocation" x="139" y="153"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostPostingActivityCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostPostingActivityCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -44,6 +44,7 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="stackView" destination="qz9-Fi-Yby" id="k0s-X9-NiX"/>
+                <outlet property="topConstraint" destination="g1n-G1-9Pi" id="BST-Zz-7Xw"/>
             </connections>
             <point key="canvasLocation" x="67.391304347826093" y="152.67857142857142"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostSingleRowCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostSingleRowCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -71,6 +71,7 @@
                 <outlet property="borderLeadingConstraint" destination="Ld6-OS-DxY" id="WeO-za-Psa"/>
                 <outlet property="imageTopConstraint" destination="787-lu-CFf" id="hvQ-cB-gfc"/>
                 <outlet property="labelTopConstraint" destination="7Yk-Eo-k23" id="CvQ-56-gqt"/>
+                <outlet property="topConstraint" destination="mNY-IP-lQN" id="Aa8-BZ-bNU"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="161.38392857142856"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTabbedCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTabbedCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -100,6 +100,9 @@
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="topConstraint" destination="2r7-pi-m3Q" id="8Js-to-HyY"/>
+            </connections>
             <point key="canvasLocation" x="36.956521739130437" y="169.75446428571428"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -67,6 +67,8 @@ struct StatsGhostTabbedImmutableRow: StatsRowGhostable {
     static let cell: ImmuTableCell = {
         return ImmuTableCell.nib(StatsGhostTabbedCell.defaultNib, StatsGhostTabbedCell.self)
     }()
+
+    var statSection: StatSection? = nil
 }
 
 struct StatsGhostPostingActivitiesImmutableRow: StatsRowGhostable {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -85,6 +85,8 @@ struct StatsGhostChartImmutableRow: StatsRowGhostable {
     static let cell: ImmuTableCell = {
         return ImmuTableCell.nib(StatsGhostChartCell.defaultNib, StatsGhostChartCell.self)
     }()
+
+    var statSection: StatSection?
 }
 
 struct StatsGhostDetailRow: StatsRowGhostable {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -1,12 +1,22 @@
-protocol StatsRowGhostable: ImmuTableRow { }
+protocol StatsRowGhostable: ImmuTableRow {
+    var statSection: StatSection? { get }
+}
 extension StatsRowGhostable {
     var action: ImmuTableAction? {
+        return nil
+    }
+
+    var statSection: StatSection? {
         return nil
     }
 
     func configureCell(_ cell: UITableViewCell) {
         DispatchQueue.main.async {
             cell.startGhostAnimation(style: GhostCellStyle.muriel)
+        }
+
+        if let detailCell = cell as? StatsBaseCell {
+            detailCell.statSection = statSection
         }
     }
 }
@@ -15,6 +25,8 @@ struct StatsGhostGrowAudienceImmutableRow: StatsRowGhostable {
     static let cell: ImmuTableCell = {
         return ImmuTableCell.nib(StatsGhostGrowAudienceCell.defaultNib, StatsGhostGrowAudienceCell.self)
     }()
+
+    var statSection: StatSection? = nil
 }
 
 struct StatsGhostTwoColumnImmutableRow: StatsRowGhostable {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -33,6 +33,8 @@ struct StatsGhostTwoColumnImmutableRow: StatsRowGhostable {
     static let cell: ImmuTableCell = {
         return ImmuTableCell.nib(StatsGhostTwoColumnCell.defaultNib, StatsGhostTwoColumnCell.self)
     }()
+
+    var statSection: StatSection? = nil
 }
 
 struct StatsGhostTopImmutableRow: StatsRowGhostable {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -73,6 +73,8 @@ struct StatsGhostPostingActivitiesImmutableRow: StatsRowGhostable {
     static let cell: ImmuTableCell = {
         return ImmuTableCell.nib(StatsGhostPostingActivityCell.defaultNib, StatsGhostPostingActivityCell.self)
     }()
+
+    var statSection: StatSection? = nil
 }
 
 struct StatsGhostChartImmutableRow: StatsRowGhostable {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -30,6 +30,7 @@ struct StatsGhostTopImmutableRow: StatsRowGhostable {
 
     var hideTopBorder = false
     var hideBottomBorder = false
+    var statSection: StatSection? = nil
 
     func configureCell(_ cell: UITableViewCell) {
         DispatchQueue.main.async {
@@ -39,6 +40,7 @@ struct StatsGhostTopImmutableRow: StatsRowGhostable {
         if let detailCell = cell as? StatsGhostTopCell {
             detailCell.topBorder?.isHidden = hideTopBorder
             detailCell.bottomBorder?.isHidden = hideBottomBorder
+            detailCell.statSection = statSection
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTitleCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -42,6 +42,9 @@
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="topConstraint" destination="Y6J-U9-eEn" id="NdW-Xm-3s1"/>
+            </connections>
             <point key="canvasLocation" x="92.753623188405811" y="125.55803571428571"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTopCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTopCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -58,10 +58,10 @@
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="K4M-bQ-piX" firstAttribute="leading" secondItem="z3U-Dz-KW3" secondAttribute="leading" constant="16" id="08B-Ng-CS2"/>
+                    <constraint firstItem="aIz-HO-onk" firstAttribute="top" secondItem="DmG-JX-3gY" secondAttribute="top" id="0Uv-So-yIF"/>
                     <constraint firstItem="DmG-JX-3gY" firstAttribute="top" secondItem="z3U-Dz-KW3" secondAttribute="top" constant="7" id="6Wf-Xv-zCd"/>
                     <constraint firstItem="aIz-HO-onk" firstAttribute="leading" secondItem="z3U-Dz-KW3" secondAttribute="leading" constant="16" id="HRa-iE-rFC"/>
                     <constraint firstAttribute="bottom" secondItem="KAb-Vl-aXI" secondAttribute="bottom" constant="16" id="SBM-vd-ABT"/>
-                    <constraint firstItem="aIz-HO-onk" firstAttribute="top" secondItem="z3U-Dz-KW3" secondAttribute="top" constant="7" id="SjE-rm-daX"/>
                     <constraint firstItem="KAb-Vl-aXI" firstAttribute="top" secondItem="cpf-Oy-Tmi" secondAttribute="bottom" constant="5" id="WU2-9V-Z4Q"/>
                     <constraint firstItem="K4M-bQ-piX" firstAttribute="top" secondItem="aIz-HO-onk" secondAttribute="bottom" constant="22" id="ZfL-bL-kBB"/>
                     <constraint firstItem="cpf-Oy-Tmi" firstAttribute="leading" secondItem="K4M-bQ-piX" secondAttribute="trailing" constant="16" id="cZJ-bA-2o5"/>
@@ -75,6 +75,9 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="cpf-Oy-Tmi" secondAttribute="trailing" constant="16" id="AHP-3y-Wu8"/>
             </constraints>
+            <connections>
+                <outlet property="topConstraint" destination="6Wf-Xv-zCd" id="Ofu-JB-lIE"/>
+            </connections>
             <point key="canvasLocation" x="113.768115942029" y="153.34821428571428"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTopHeaderCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTopHeaderCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -39,14 +39,17 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="Yth-8k-r1U" secondAttribute="trailing" constant="16" id="5Rp-bq-Zmm"/>
+                    <constraint firstItem="Yac-EB-3AV" firstAttribute="top" secondItem="Yth-8k-r1U" secondAttribute="top" id="Bc1-7z-9fS"/>
                     <constraint firstAttribute="bottom" secondItem="Yac-EB-3AV" secondAttribute="bottom" constant="16" id="GOF-Di-lzB"/>
                     <constraint firstItem="Yac-EB-3AV" firstAttribute="leading" secondItem="FZl-8a-aiR" secondAttribute="leading" constant="16" id="PDx-aa-JSZ"/>
                     <constraint firstAttribute="bottom" secondItem="Yth-8k-r1U" secondAttribute="bottom" constant="16" id="VvT-WE-S82"/>
                     <constraint firstItem="Yac-EB-3AV" firstAttribute="top" secondItem="FZl-8a-aiR" secondAttribute="top" constant="7" id="aQN-Zr-UMD"/>
-                    <constraint firstItem="Yth-8k-r1U" firstAttribute="top" secondItem="FZl-8a-aiR" secondAttribute="top" constant="7" id="zEa-ST-uKv"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="topConstraint" destination="aQN-Zr-UMD" id="EYD-NE-REE"/>
+            </connections>
             <point key="canvasLocation" x="139" y="153"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTwoColumnCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTwoColumnCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -61,8 +61,8 @@
                     <constraint firstItem="LwP-eE-0z6" firstAttribute="leading" secondItem="IJy-7r-tHx" secondAttribute="trailing" constant="16" id="WkF-DV-VaB"/>
                     <constraint firstItem="TDF-ES-9nV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="aEB-AA-kPR"/>
                     <constraint firstItem="LwP-eE-0z6" firstAttribute="leading" secondItem="TDF-ES-9nV" secondAttribute="trailing" constant="16" id="cJk-2L-mvM"/>
-                    <constraint firstItem="6sw-Jb-0Q7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="13" id="gMb-uS-Cy6"/>
                     <constraint firstItem="IJy-7r-tHx" firstAttribute="top" secondItem="TDF-ES-9nV" secondAttribute="bottom" constant="5" id="gio-c0-qhq"/>
+                    <constraint firstItem="6sw-Jb-0Q7" firstAttribute="top" secondItem="TDF-ES-9nV" secondAttribute="top" id="pLy-RW-ETn"/>
                     <constraint firstAttribute="bottom" secondItem="IJy-7r-tHx" secondAttribute="bottom" constant="13" id="q84-l7-nHG"/>
                     <constraint firstItem="IJy-7r-tHx" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ttG-gH-92A"/>
                     <constraint firstAttribute="bottom" secondItem="LwP-eE-0z6" secondAttribute="bottom" constant="13" id="xzj-Pq-z3D"/>
@@ -70,8 +70,11 @@
                     <constraint firstItem="LwP-eE-0z6" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="zWq-TM-Zdo"/>
                 </constraints>
             </tableViewCellContentView>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="topConstraint" destination="yjP-fr-GyZ" id="b4p-YQ-aXL"/>
+            </connections>
             <point key="canvasLocation" x="251.44927536231887" y="239.39732142857142"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tqa-zb-Liz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tqa-zb-Liz">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
             <objects>
                 <navigationController id="Tqa-zb-Liz" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="5Sw-Z8-I7L">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -29,12 +29,12 @@
         <scene sceneID="TCQ-Sm-O2v">
             <objects>
                 <viewController storyboardIdentifier="SiteStatsDashboardViewController" id="vP4-Vk-Ilg" customClass="SiteStatsDashboardViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="IsW-kc-L5Q">
+                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="IsW-kc-L5Q">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="n8i-ag-Cgx">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="623"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R6d-mo-itW" customClass="FilterTabBar" customModule="WordPress">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="46"/>
@@ -75,28 +75,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ixM-JR-6YX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="240.80000000000001" y="232.53373313343329"/>
-        </scene>
-        <!--Stats Table View Controller-->
-        <scene sceneID="VVg-67-Gst">
-            <objects>
-                <tableViewController storyboardIdentifier="SiteStatsPeriodTableViewController" id="plb-uA-RCD" userLabel="Stats Table View Controller" customClass="SiteStatsPeriodTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="zaS-th-YDU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <connections>
-                            <outlet property="dataSource" destination="plb-uA-RCD" id="ArZ-Zu-Uyu"/>
-                            <outlet property="delegate" destination="plb-uA-RCD" id="2Qq-uI-Ae3"/>
-                        </connections>
-                    </tableView>
-                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="8ir-7a-bdo">
-                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </refreshControl>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="lv3-Hh-4h3" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1030" y="558"/>
         </scene>
         <!--Page View Controller-->
         <scene sceneID="RlY-v4-27D">

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -78,6 +78,7 @@ class SiteStatsDashboardViewController: UIViewController {
 
     private var insightsTableViewController = SiteStatsInsightsTableViewController.loadFromStoryboard()
     private lazy var periodTableViewControllerDeprecated = SiteStatsPeriodTableViewControllerDeprecated.loadFromStoryboard()
+    private lazy var trafficTableViewController = SiteStatsPeriodTableViewController.loadFromStoryboard()
     private var pageViewController: UIPageViewController?
     private lazy var displayedPeriods: [StatsPeriodType] = StatsPeriodType.displayedPeriods
 
@@ -97,7 +98,8 @@ class SiteStatsDashboardViewController: UIViewController {
         super.viewDidLoad()
         configureJetpackBanner()
         configureInsightsTableView()
-        configurePeriodTableViewController()
+        configurePeriodTableViewControllerDeprecated()
+        configureTrafficTableViewController()
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
         restoreSelectedPeriodFromUserDefaults()
@@ -116,8 +118,12 @@ class SiteStatsDashboardViewController: UIViewController {
         insightsTableViewController.bannerView = jetpackBannerView
     }
 
-    private func configurePeriodTableViewController() {
+    private func configurePeriodTableViewControllerDeprecated() {
         periodTableViewControllerDeprecated.bannerView = jetpackBannerView
+    }
+
+    private func configureTrafficTableViewController() {
+        trafficTableViewController.bannerView = jetpackBannerView
     }
 
     func configureNavBar() {
@@ -244,6 +250,7 @@ private extension SiteStatsDashboardViewController {
 
     func restoreSelectedDateFromUserDefaults() {
         periodTableViewControllerDeprecated.selectedDate = getLastSelectedDateFromUserDefaults()
+        trafficTableViewController.selectedDate = getLastSelectedDateFromUserDefaults()
         removeLastSelectedDateFromUserDefaults()
     }
 
@@ -267,12 +274,18 @@ private extension SiteStatsDashboardViewController {
             insightsTableViewController.refreshInsights()
         case .traffic:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
-                let viewController = UIViewController() // TODO
-                pageViewController?.setViewControllers([viewController],
+                pageViewController?.setViewControllers([trafficTableViewController],
                                                        direction: .forward,
                                                        animated: false)
             }
-        default:
+
+            if trafficTableViewController.selectedDate == nil {
+                trafficTableViewController.selectedDate = StatsDataHelper.currentDateForSite()
+            }
+
+            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+            trafficTableViewController.selectedPeriod = selectedPeriod
+        case .days, .weeks, .months, .years:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([periodTableViewControllerDeprecated],
                                                        direction: .forward,

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -78,7 +78,7 @@ class SiteStatsDashboardViewController: UIViewController {
 
     private var insightsTableViewController = SiteStatsInsightsTableViewController.loadFromStoryboard()
     private lazy var periodTableViewControllerDeprecated = SiteStatsPeriodTableViewControllerDeprecated.loadFromStoryboard()
-    private lazy var trafficTableViewController = SiteStatsPeriodTableViewController.loadFromStoryboard()
+    private lazy var trafficTableViewController = SiteStatsPeriodTableViewController()
     private var pageViewController: UIPageViewController?
     private lazy var displayedPeriods: [StatsPeriodType] = StatsPeriodType.displayedPeriods
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -77,7 +77,7 @@ class SiteStatsDashboardViewController: UIViewController {
     @IBOutlet weak var jetpackBannerView: JetpackBannerView!
 
     private var insightsTableViewController = SiteStatsInsightsTableViewController.loadFromStoryboard()
-    private var periodTableViewController = SiteStatsPeriodTableViewController.loadFromStoryboard()
+    private lazy var periodTableViewControllerDeprecated = SiteStatsPeriodTableViewControllerDeprecated.loadFromStoryboard()
     private var pageViewController: UIPageViewController?
     private lazy var displayedPeriods: [StatsPeriodType] = StatsPeriodType.displayedPeriods
 
@@ -117,7 +117,7 @@ class SiteStatsDashboardViewController: UIViewController {
     }
 
     private func configurePeriodTableViewController() {
-        periodTableViewController.bannerView = jetpackBannerView
+        periodTableViewControllerDeprecated.bannerView = jetpackBannerView
     }
 
     func configureNavBar() {
@@ -243,7 +243,7 @@ private extension SiteStatsDashboardViewController {
     }
 
     func restoreSelectedDateFromUserDefaults() {
-        periodTableViewController.selectedDate = getLastSelectedDateFromUserDefaults()
+        periodTableViewControllerDeprecated.selectedDate = getLastSelectedDateFromUserDefaults()
         removeLastSelectedDateFromUserDefaults()
     }
 
@@ -274,19 +274,19 @@ private extension SiteStatsDashboardViewController {
             }
         default:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
-                pageViewController?.setViewControllers([periodTableViewController],
+                pageViewController?.setViewControllers([periodTableViewControllerDeprecated],
                                                        direction: .forward,
                                                        animated: false)
             }
 
-            if periodTableViewController.selectedDate == nil
+            if periodTableViewControllerDeprecated.selectedDate == nil
                 || selectedPeriodChanged {
 
-                periodTableViewController.selectedDate = StatsDataHelper.currentDateForSite()
+                periodTableViewControllerDeprecated.selectedDate = StatsDataHelper.currentDateForSite()
             }
 
             let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
-            periodTableViewController.selectedPeriod = selectedPeriod
+            periodTableViewControllerDeprecated.selectedPeriod = selectedPeriod
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -467,6 +467,7 @@ struct TopTotalsNoSubtitlesPeriodStatsRow: ImmuTableRow {
     }()
 
     let dataRows: [StatsTotalRowData]
+    var statSection: StatSection? = nil
     weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     let action: ImmuTableAction? = nil
 
@@ -476,7 +477,7 @@ struct TopTotalsNoSubtitlesPeriodStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(dataRows: dataRows, siteStatsPeriodDelegate: siteStatsPeriodDelegate)
+        cell.configure(dataRows: dataRows, statSection: statSection, siteStatsPeriodDelegate: siteStatsPeriodDelegate)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -225,6 +225,10 @@
 		01D2FF6B2AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF692AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift */; };
 		01DBFD8729BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
 		01DBFD8829BDCBF200F3720F /* JetpackNativeConnectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */; };
+		01DC4CD82B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */; };
+		01DC4CD92B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */; };
+		01DC4CDB2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */; };
+		01DC4CDC2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */; };
 		01E258022ACC36FA00F09666 /* PlanStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E258012ACC36FA00F09666 /* PlanStep.swift */; };
 		01E258032ACC36FA00F09666 /* PlanStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E258012ACC36FA00F09666 /* PlanStep.swift */; };
 		01E258052ACC373800F09666 /* PlanWizardContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E258042ACC373800F09666 /* PlanWizardContent.swift */; };
@@ -5893,6 +5897,8 @@
 		01D2FF662AA780DC0038E040 /* LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01D2FF692AA782720038E040 /* LockScreenAllTimePostsBestViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimePostsBestViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
+		01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsPeriodTableViewControllerDeprecated.swift; sourceTree = "<group>"; };
+		01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SiteStatsDashboardDeprecated.storyboard; sourceTree = "<group>"; };
 		01E258012ACC36FA00F09666 /* PlanStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanStep.swift; sourceTree = "<group>"; };
 		01E258042ACC373800F09666 /* PlanWizardContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanWizardContent.swift; sourceTree = "<group>"; };
 		01E258082ACC3AA000F09666 /* iOS17WidgetAPIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS17WidgetAPIs.swift; sourceTree = "<group>"; };
@@ -9878,6 +9884,15 @@
 			name = UITesting;
 			sourceTree = "<group>";
 		};
+		01DC4CD32B5FC889000110E5 /* Deprecated */ = {
+			isa = PBXGroup;
+			children = (
+				01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */,
+				01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */,
+			);
+			path = Deprecated;
+			sourceTree = "<group>";
+		};
 		01E258002ACC36DC00F09666 /* Plan */ = {
 			isa = PBXGroup;
 			children = (
@@ -11164,6 +11179,7 @@
 		3792259E12F6DBCC00F2176A /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				01DC4CD32B5FC889000110E5 /* Deprecated */,
 				9AA0ADAF235F11500027AB5D /* Operation */,
 				73FF702D221F43BB00541798 /* Charts */,
 				98747670219638990080967F /* Extensions */,
@@ -19218,6 +19234,7 @@
 				931DF4D618D09A2F00540BDD /* InfoPlist.strings in Resources */,
 				D88106F820C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib in Resources */,
 				801D9511291AB3CF0051993E /* JetpackStatsLogoAnimation_ltr.json in Resources */,
+				01DC4CDB2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard in Resources */,
 				FE23EB4926E7C91F005A1698 /* richCommentTemplate.html in Resources */,
 				1761F18826209AEE000815EF /* pride-icon-app-76x76.png in Resources */,
 				17222D8A261DDDF90047B163 /* black-classic-icon-app-76x76@2x.png in Resources */,
@@ -19869,6 +19886,7 @@
 				FABB205E2602FC2C00C8785C /* postPreview.html in Resources */,
 				FABB20602602FC2C00C8785C /* MediaSizeSliderCell.xib in Resources */,
 				FABB20622602FC2C00C8785C /* ReaderBlockedSiteCell.xib in Resources */,
+				01DC4CDC2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard in Resources */,
 				FABB20632602FC2C00C8785C /* QuickStartChecklistCell.xib in Resources */,
 				FABB20652602FC2C00C8785C /* SiteSegmentsCell.xib in Resources */,
 				FABB20662602FC2C00C8785C /* ReaderSiteStreamHeader.xib in Resources */,
@@ -21321,6 +21339,7 @@
 				8B7F25A724E6EDB4007D82CC /* TopicsCollectionView.swift in Sources */,
 				D8CB56202181A8CE00554EAE /* SiteSegmentsService.swift in Sources */,
 				E11E775A1E72932F0072AD40 /* BlogListDataSource.swift in Sources */,
+				01DC4CD82B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */,
 				1730D4A31E97E3E400326B7C /* MediaItemHeaderView.swift in Sources */,
 				8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */,
 				1750BD6D201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift in Sources */,
@@ -25470,6 +25489,7 @@
 				FABB25842602FC2C00C8785C /* NoResultsViewController+FollowedSites.swift in Sources */,
 				F41E3302287B5FE500F89082 /* SuggestionViewModel.swift in Sources */,
 				DC76668626FD9AC9009254DD /* TimeZoneTableViewCell.swift in Sources */,
+				01DC4CD92B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */,
 				FABB25862602FC2C00C8785C /* WordPress-11-12.xcmappingmodel in Sources */,
 				C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */,
 				FABB25872602FC2C00C8785C /* DiffAbstractValue.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		01DC4CD92B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */; };
 		01DC4CDB2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */; };
 		01DC4CDC2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */; };
+		01DC4CDE2B5FCBBF000110E5 /* SiteStatsPeriodViewModelDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DC4CDD2B5FCBBE000110E5 /* SiteStatsPeriodViewModelDeprecated.swift */; };
+		01DC4CDF2B5FCBBF000110E5 /* SiteStatsPeriodViewModelDeprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DC4CDD2B5FCBBE000110E5 /* SiteStatsPeriodViewModelDeprecated.swift */; };
 		01E258022ACC36FA00F09666 /* PlanStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E258012ACC36FA00F09666 /* PlanStep.swift */; };
 		01E258032ACC36FA00F09666 /* PlanStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E258012ACC36FA00F09666 /* PlanStep.swift */; };
 		01E258052ACC373800F09666 /* PlanWizardContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E258042ACC373800F09666 /* PlanWizardContent.swift */; };
@@ -5899,6 +5901,7 @@
 		01DBFD8629BDCBF200F3720F /* JetpackNativeConnectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNativeConnectionService.swift; sourceTree = "<group>"; };
 		01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsPeriodTableViewControllerDeprecated.swift; sourceTree = "<group>"; };
 		01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = SiteStatsDashboardDeprecated.storyboard; sourceTree = "<group>"; };
+		01DC4CDD2B5FCBBE000110E5 /* SiteStatsPeriodViewModelDeprecated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsPeriodViewModelDeprecated.swift; sourceTree = "<group>"; };
 		01E258012ACC36FA00F09666 /* PlanStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanStep.swift; sourceTree = "<group>"; };
 		01E258042ACC373800F09666 /* PlanWizardContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanWizardContent.swift; sourceTree = "<group>"; };
 		01E258082ACC3AA000F09666 /* iOS17WidgetAPIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS17WidgetAPIs.swift; sourceTree = "<group>"; };
@@ -9887,6 +9890,7 @@
 		01DC4CD32B5FC889000110E5 /* Deprecated */ = {
 			isa = PBXGroup;
 			children = (
+				01DC4CDD2B5FCBBE000110E5 /* SiteStatsPeriodViewModelDeprecated.swift */,
 				01DC4CDA2B5FCA7B000110E5 /* SiteStatsDashboardDeprecated.storyboard */,
 				01DC4CD72B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift */,
 			);
@@ -22035,6 +22039,7 @@
 				5DB4683B18A2E718004A89A9 /* LocationService.m in Sources */,
 				173BCE791CEB780800AE8817 /* Domain.swift in Sources */,
 				C324D7A928C26F3F00310DEF /* SplashPrologueStyleGuide.swift in Sources */,
+				01DC4CDE2B5FCBBF000110E5 /* SiteStatsPeriodViewModelDeprecated.swift in Sources */,
 				4AA33F012999D11A005B6E23 /* ReaderSiteTopic+Lookup.swift in Sources */,
 				46B1A16B26A774E500F058AE /* CollapsableHeaderView.swift in Sources */,
 				590E873B1CB8205700D1B734 /* PostListViewController.swift in Sources */,
@@ -25658,6 +25663,7 @@
 				4A2172F928EAACFF0006F4F1 /* BlogQuery.swift in Sources */,
 				017008462B35C25C00C80490 /* SiteDomainsViewModel.swift in Sources */,
 				F1C740C026B1D4D2005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
+				01DC4CDF2B5FCBBF000110E5 /* SiteStatsPeriodViewModelDeprecated.swift in Sources */,
 				801D94F02919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift in Sources */,
 				FABB25FF2602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowDefinitions.swift in Sources */,
 				0CAE8EF72A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */,


### PR DESCRIPTION
Fixes #22443

Adapt existing Period views for a new Traffic tab and its styling.

Based on the conclusions from Analyze High-Level Stats architecture (https://github.com/wordpress-mobile/WordPress-iOS/issues/22383):

1. Created deprecated duplicates of `SiteStatsPeriodTableView` to be used for Days/Months/Weeks/Years tabs, so we could more easily modify `SiteStatsPeriodTableView` for Traffic tab without complicating development
2. Started using the same base class for Insights and Traffic tabs to share table view configuration and styles
3. Set `insetGrouped` style to show cards
4. Started displaying rows within `SiteStatsPeriodVC` in separate sections
5. Used `StatsBaseClass` mechanism to display titles within cell rather than in a separate row
6. Adjusted spacing

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/336cfd97-1494-48bc-9a37-83f957770eb2" width="200">

## To test:

### Stats Traffic Feature Flag Disabled

Days/Weeks/Months/Years tabs should work as before

### Stats Traffic Feature Flag enabled

- Traffic tab should display same rows as Days/Weeks/Months/Years tabs but with a new card style (except for bar chart and date picker which will be replaced later)
- Traffic tab and Insights tab should have common spacing and look for table view

## Regression Notes
1. Potential unintended areas of impact

Breaking existing Days/Weeks/Months/Years tabs. Part of my conclusion from the analysis is that we'll want to reuse the majority of the code but also make improvements and changes. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Creating new deprecated classes should help avoid all of the risks.

3. What automated tests I added (or what prevented me from doing so)

None so far

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
