### PR TITLE
Reader: Show the last visited stream

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -7,6 +7,7 @@ import WordPressFlux
     /// tab bar items
     private let tabItemsStore: ItemsStore
     private var subscription: Receipt?
+    private let persistentRepository: UserPersistentRepository
     private var onTabBarItemsDidChange: [(([ReaderTabItem], Int) -> Void)] = []
 
     var tabItems: [ReaderTabItem] = [] {
@@ -24,6 +25,10 @@ import WordPressFlux
     var selectedIndex = 0
     var selectedItem: ReaderTabItem? {
         tabItems[safe: selectedIndex]
+    }
+
+    var lastVisitedIndex: Int {
+        persistentRepository.integer(forKey: Constants.lastVisitedStreamIndexKey)
     }
 
     /// completion handler for a tap on a tab on the toolbar
@@ -66,12 +71,17 @@ import WordPressFlux
     init(readerContentFactory: @escaping (ReaderContent) -> ReaderContentViewController,
          searchNavigationFactory: @escaping () -> Void,
          tabItemsStore: ItemsStore,
-         settingsPresenter: ScenePresenter) {
+         settingsPresenter: ScenePresenter,
+         persistentRepository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.makeReaderContentViewController = readerContentFactory
         self.navigateToSearch = searchNavigationFactory
         self.tabItemsStore = tabItemsStore
         self.settingsPresenter = settingsPresenter
+        self.persistentRepository = persistentRepository
         super.init()
+
+        // show the last visited index.
+        selectedIndex = lastVisitedIndex
 
         subscription = tabItemsStore.onChange { [weak self] in
             guard let viewModel = self else {
@@ -103,6 +113,10 @@ extension ReaderTabViewModel {
 // MARK: - Tab selection
 extension ReaderTabViewModel {
 
+    private enum Constants {
+        static let lastVisitedStreamIndexKey = "readerLastVisitedStreamIndexDefaultsKey"
+    }
+
     func showTab(at index: Int) {
         guard index < tabItems.count else {
             return
@@ -115,6 +129,9 @@ extension ReaderTabViewModel {
 
         // reload filters for the new stream.
         reloadStreamFilters()
+
+        // save the last visited index.
+        persistentRepository.set(index, forKey: Constants.lastVisitedStreamIndexKey)
 
         didSelectIndex?(index)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -80,16 +80,22 @@ import WordPressFlux
         self.persistentRepository = persistentRepository
         super.init()
 
-        // show the last visited index.
+        // show the last visited index as default.
         selectedIndex = lastVisitedIndex
 
         subscription = tabItemsStore.onChange { [weak self] in
-            guard let viewModel = self else {
+            guard let self else {
                 return
             }
-            viewModel.tabItems = viewModel.tabItemsStore.items
-            viewModel.reloadStreamFilters()
-            viewModel.onTabBarItemsDidChange.forEach { $0(viewModel.tabItemsStore.items, viewModel.selectedIndex) }
+            self.tabItems = self.tabItemsStore.items
+            self.reloadStreamFilters()
+
+            // reset if the selectedIndex is out of bounds to avoid showing a blank screen.
+            if self.selectedIndex >= self.tabItems.count {
+                self.selectedIndex = 0
+            }
+
+            self.onTabBarItemsDidChange.forEach { $0(self.tabItemsStore.items, self.selectedIndex) }
         }
         addNotificationsObservers()
         observeNetworkStatus()


### PR DESCRIPTION
Resolves #22445 

This saves the selected stream whenever the user switches to a different stream, and shows it again the next time the user opens the Jetpack app. 

Note that we also have an existing state restoration logic, which already works as expected. In this case, when the state restoration takes place, it will take precedence over the "last visited stream".

Additionally, I've also added a safeguard logic that prevents a selected index from going out-of-bounds. Previously,  when the index happened to exceed the number of available streams, it will only show a blank screen without any way to return to the Discover stream.

## To test

- Launch the Jetpack app.
- Go to the Reader tab.
- Switch to the Subscriptions stream.
- Kill the app and relaunch.
- Go to the Reader app.
- 🔎 Verify that the Subscriptions stream is shown by default.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
Added some unit tests to cover some possible and edge case scenarios.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
