### PR TITLE
Revert Site Header change and re-introducing quick site switching

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -119,9 +119,9 @@ class BlogDetailHeaderView: UIView {
         assert(delegate != nil)
 
         if let siteActionsMenu = delegate?.makeSiteActionsMenu() {
-            titleView.siteActionButton.showsMenuAsPrimaryAction = true
-            titleView.siteActionButton.menu = siteActionsMenu
-            titleView.siteActionButton.addAction(UIAction { _ in
+            titleView.siteSwitcherButton.menu = siteActionsMenu
+            titleView.siteSwitcherButton.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
+            titleView.siteSwitcherButton.addAction(UIAction { _ in
                 WPAnalytics.trackEvent(.mySiteHeaderMoreTapped)
             }, for: .menuActionTriggered)
         }
@@ -214,7 +214,7 @@ extension BlogDetailHeaderView {
             let stackView = UIStackView(arrangedSubviews: [
                 siteIconView,
                 titleStackView,
-                siteActionButton
+                siteSwitcherButton
             ])
 
             stackView.alignment = .center
@@ -280,9 +280,9 @@ extension BlogDetailHeaderView {
             return button
         }()
 
-        let siteActionButton: UIButton = {
+        let siteSwitcherButton: UIButton = {
             let button = UIButton(frame: .zero)
-            let image = UIImage(named: "more-horizontal-mobile")?.withRenderingMode(.alwaysTemplate)
+            let image = UIImage(named: "chevron-down-slim")?.withRenderingMode(.alwaysTemplate)
 
             button.setImage(image, for: .normal)
             button.contentMode = .center
@@ -359,8 +359,8 @@ extension BlogDetailHeaderView {
 
         private func setupConstraintsForSiteSwitcher() {
             NSLayoutConstraint.activate([
-                siteActionButton.heightAnchor.constraint(equalToConstant: Dimensions.siteSwitcherHeight),
-                siteActionButton.widthAnchor.constraint(equalToConstant: Dimensions.siteSwitcherWidth)
+                siteSwitcherButton.heightAnchor.constraint(equalToConstant: Dimensions.siteSwitcherHeight),
+                siteSwitcherButton.widthAnchor.constraint(equalToConstant: Dimensions.siteSwitcherWidth)
             ])
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -290,7 +290,7 @@ extension BlogDetailHeaderView {
             button.tintColor = .secondaryLabel
             button.accessibilityLabel = NSLocalizedString("mySite.siteActions.button", value: "Site Actions", comment: "Button that reveals more site actions")
             button.accessibilityHint = NSLocalizedString("mySite.siteActions.hint", value: "Tap to show more site actions", comment: "Accessibility hint for button used to show more site actions")
-            button.accessibilityIdentifier = .siteActionAccessibilityId
+            button.accessibilityIdentifier = .switchSiteAccessibilityId
 
             return button
         }()
@@ -370,7 +370,7 @@ private extension String {
     // MARK: Accessibility Identifiers
     static let siteTitleAccessibilityId = "site-title-button"
     static let siteUrlAccessibilityId = "site-url-button"
-    static let siteActionAccessibilityId = "site-action-button"
+    static let switchSiteAccessibilityId = "switch-site-button"
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -65,7 +65,7 @@ extension SitePickerViewController {
         }
         let viewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         if let popover = viewController.popoverPresentationController {
-            popover.sourceView = blogDetailHeaderView.titleView.siteActionButton
+            popover.sourceView = blogDetailHeaderView.titleView.siteSwitcherButton
         }
         present(viewController, animated: true, completion: nil)
         WPAnalytics.trackEvent(.mySiteHeaderShareSiteTapped)
@@ -83,7 +83,7 @@ extension SitePickerViewController {
             return
         }
 
-        showAddSiteActionSheet(from: blogDetailHeaderView.titleView.siteActionButton,
+        showAddSiteActionSheet(from: blogDetailHeaderView.titleView.siteSwitcherButton,
                                canCreateWPComSite: canCreateWPComSite,
                                canAddSelfHostedSite: canAddSelfHostedSite)
 

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -96,13 +96,10 @@ public class MySiteScreen: ScreenObject {
         $0.buttons["site-url-button"]
     }
 
-    private let siteActionButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["site-action-button"]
+    private let switchSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["switch-site-button"]
     }
 
-    private let switchSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Switch site"]
-    }
     var activityLogCard: XCUIElement { activityLogCardGetter(app) }
     var activityLogCardHeaderButton: XCUIElement { activityLogCardHeaderButtonGetter(app) }
     var blogDetailsRemoveSiteButton: XCUIElement { blogDetailsRemoveSiteButtonGetter(app) }
@@ -124,7 +121,6 @@ public class MySiteScreen: ScreenObject {
     var segmentedControlMenuButton: XCUIElement { segmentedControlMenuButtonGetter(app) }
     var siteTitleButton: XCUIElement { siteTitleButtonGetter(app) }
     var siteUrlButton: XCUIElement { siteUrlButtonGetter(app) }
-    var siteActionButton: XCUIElement { siteActionButtonGetter(app) }
     var switchSiteButton: XCUIElement { switchSiteButtonGetter(app) }
 
     // Timeout duration to overwrite value defined in XCUITestHelpers
@@ -133,7 +129,7 @@ public class MySiteScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
-                siteActionButtonGetter,
+                switchSiteButtonGetter,
                 createButtonGetter
             ],
             app: app
@@ -141,7 +137,6 @@ public class MySiteScreen: ScreenObject {
     }
 
     public func showSiteSwitcher() throws -> MySitesScreen {
-        siteActionButton.tap()
         switchSiteButton.tap()
         return try MySitesScreen()
     }


### PR DESCRIPTION
This PR fixes a UX issue where quick site switching was no longer available on My Site.

To test:

- Open the "Home" tab and verify that the site switcher is back and it works

**Note**: I left the menu there as a sort of an easter egg; it opens only no long-press.

## Regression Notes
1. Potential unintended areas of impact: My Site
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
