### PR TITLE
Reader: Update Reader strings to new terminologies

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -20,11 +20,15 @@ class ReaderManageScenePresenter: ScenePresenter {
         var tabbedItem: TabbedViewController.TabbedItem {
             switch self {
             case .tags:
-                return TabbedViewController.TabbedItem(title: NSLocalizedString("Followed Topics", comment: "Followed Topics Title"),
+                return TabbedViewController.TabbedItem(title: NSLocalizedString("reader.manage.tab.tags",
+                                                                                value: "Tags",
+                                                                                comment: "Manage tags tab title"),
                                                                viewController: makeViewController(),
                                                                accessibilityIdentifier: "FollowedTags")
             case .sites:
-                return TabbedViewController.TabbedItem(title: NSLocalizedString("Followed Sites", comment: "Followed Sites Title"),
+                return TabbedViewController.TabbedItem(title: NSLocalizedString("reader.manage.tab.blogs",
+                                                                                value: "Blogs",
+                                                                                comment: "Manage blogs tab title"),
                                                                 viewController: makeViewController(),
                                                                 accessibilityIdentifier: "FollowedSites")
             }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -502,9 +502,21 @@ extension WPStyleGuide {
 
     public struct FollowButton {
         struct Text {
-            static let accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
-            static let followStringForDisplay =  NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
-            static let followingStringForDisplay = NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
+            static let accessibilityHint = NSLocalizedString(
+                "reader.subscribe.button.accessibility.hint",
+                value: "Subscribes to the tag.",
+                comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag."
+            )
+            static let followStringForDisplay =  NSLocalizedString(
+                "reader.subscribe.button.title",
+                value: "Subscribe",
+                comment: "Verb. Button title. Subscribes to a new blog."
+            )
+            static let followingStringForDisplay = NSLocalizedString(
+                "reader.subscribed.button.title",
+                value: "Subscribed",
+                comment: "Verb. Button title. The user is subscribed to a blog."
+            )
         }
     }
 }


### PR DESCRIPTION
Part of #22436

## Description

I missed some of the Reader strings in the first pass. These were some I found. 

I thought about using `Tag Subscriptions` and `Blog Subscriptions` for the manage screen, but the strings were fairly long. So I cut down those strings to just `Tags` and `Blogs`.

## Testing

To test:
- Launch Jetpack and Login
- Navigate to Manage screen in the Reader
- 🔎 **Verify** the two tabs are updated to `Tags` and `Blogs`
- Tap on a post
- Tap on a tag from the post
- 🔎 **Verify** the tag has a `Subscribe` or `Subscribed` button, depending on your subscription state
- Tap on the `Subscribe`/`Subscribed` button
- 🔎 **Verify** the title of the button flips to the opposite state

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
