### PR TITLE
Disable the ability of creating new Story posts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 * [*] [internal] Drop iOS 14 Support: Remove deprecated UIDocumentPickerViewController API [#22286]
 * [***] [internal] Refactor WP.com sign in API requests [#22421]
 * [*] Add In-App Feedback Prompt. [#22050]
+* [**] Disabled the ability of creating new Story posts. [#22453]
 
 24.0
 -----

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -705,9 +705,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (BOOL)supportsStories
 {
-    BOOL hasRequiredJetpack = [self hasRequiredJetpackVersion:@"9.1"];
-    // Stories are disabled in iPad until this Kanvas issue is solved: https://github.com/tumblr/kanvas-ios/issues/104
-    return (hasRequiredJetpack || self.isHostedAtWPcom) && ![UIDevice isPad] && [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled];
+    return NO;
 }
 
 - (BOOL)supportsContactInfo


### PR DESCRIPTION
## Description
This PR disables the stories feature for all users. It removes the story post option from the FAB sheet and also removes the story block from the editor. Existing stories are still editable, but this ability will be removed in a future PR.

## Testing Instructions

Install the Jetpack app
Tap on the FAB
Make sure that the "Story Post" option is not visible ✅ 
Tap on "Blog Post"
The editor shows up
Tap on the "+" button to add a new block
Search for the Story block and make sure it's not present ✅ 

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.