### PR TITLE
Site Monitoring: Add remote feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -26,6 +26,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case wordPressSotWCard
     case inAppRating
     case statsTrafficTab
+    case siteMonitoring
 
     var defaultValue: Bool {
         switch self {
@@ -76,6 +77,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .inAppRating:
             return false
         case .statsTrafficTab:
+            return false
+        case .siteMonitoring:
             return false
         }
     }
@@ -131,6 +134,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "in_app_rating_and_feedback"
         case .statsTrafficTab:
             return "stats_traffic_tab"
+        case .siteMonitoring:
+            return "site_monitoring"
         }
     }
 
@@ -184,6 +189,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "In-App Rating and Feedback"
         case .statsTrafficTab:
             return "Stats Traffic Tab"
+        case .siteMonitoring:
+            return "Site Monitoring"
         }
     }
 


### PR DESCRIPTION
Fixes #22455 

## Description
Adds a remote feature flag for site monitoring

## How to test
- Verify you can access the site monitoring feature flag under Remote Feature Flags

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/04e133b7-0ef2-434b-8b34-c9af3af2424d" width=200>

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


