### PR TITLE
Enable In-App Feedback in beta builds

### DIFF
--- a/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
@@ -37,10 +37,11 @@ class AppRatingUtility: NSObject {
     /// http://stackoverflow.com/questions/26081543/how-to-tell-at-runtime-whether-an-ios-app-is-running-through-a-testflight-beta-i?noredirect=1&lq=1
     ///
     private var promptingDisabledLocal: Bool = {
-        guard let path = Bundle.main.appStoreReceiptURL?.path else {
-            return false
-        }
-        return path.contains("sandboxReceipt")
+//        guard let path = Bundle.main.appStoreReceiptURL?.path else {
+//            return false
+//        }
+//        return path.contains("sandboxReceipt")
+        return false
     }()
 
     private var promptingDisabled: Bool {

--- a/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
@@ -40,11 +40,11 @@ final class InAppFeedbackPromptCoordinator: InAppFeedbackPromptPresenting {
             message: Strings.FeedbackAlert.message,
             preferredStyle: .alert
         )
-        let yes = UIAlertAction(title: Strings.FeedbackAlert.yes, style: .default) { [weak self] _ in
-            self?.handlePositiveFeedback(in: controller)
+        let yes = UIAlertAction(title: Strings.FeedbackAlert.yes, style: .default) { _ in
+            self.handlePositiveFeedback(in: controller)
         }
-        let no = UIAlertAction(title: Strings.FeedbackAlert.no, style: .default) { [weak self] _ in
-            self?.handleNegativeFeedback(in: controller)
+        let no = UIAlertAction(title: Strings.FeedbackAlert.no, style: .default) { _ in
+            self.handleNegativeFeedback(in: controller)
         }
         alert.addAction(no)
         alert.addAction(yes)
@@ -77,16 +77,13 @@ final class InAppFeedbackPromptCoordinator: InAppFeedbackPromptPresenting {
             message: Strings.NegativeFeedbackAlert.message,
             preferredStyle: .alert
         )
-        let yes = UIAlertAction(title: Strings.NegativeFeedbackAlert.yes, style: .default) { [weak self] _ in
-            guard let self else {
-                return
-            }
-            let destination = UINavigationController(rootViewController: submitFeedbackViewController(in: controller))
+        let yes = UIAlertAction(title: Strings.NegativeFeedbackAlert.yes, style: .default) { _ in
+            let destination = UINavigationController(rootViewController: self.submitFeedbackViewController(in: controller))
             controller.present(destination, animated: true)
         }
-        let no = UIAlertAction(title: Strings.NegativeFeedbackAlert.no, style: .default) { [weak self] _ in
+        let no = UIAlertAction(title: Strings.NegativeFeedbackAlert.no, style: .default) { _ in
             WPAnalytics.track(.appReviewsDeclinedToRateApp)
-            self?.appRatingUtility.declinedToRateCurrentVersion()
+            self.appRatingUtility.declinedToRateCurrentVersion()
         }
         alert.addAction(no)
         alert.addAction(yes)


### PR DESCRIPTION
Ref pc8HXX-1uV-p2

This PR makes the following changes:
- It enables In-App Rating Prompt in beta builds.
- It resolves an issue where tapping the 1st alert actions does nothing.

## Test Instructions

1. Install Jetpack and login.
2. Perform a combination of the following actions. The total count of the actions should be 20.
    - User taps an unread notification
    - User publishes a pos
    - User visits stats
    - User reads a post
3. Navigate to My Site.
4. **Expect** the 1st alert to appear.
5. Tap either "Yes" or "No"
6. **Expect** the next alert to appear.

## Regression Notes

1. Potential unintended areas of impact
None.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

8. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.