### PR TITLE
Update UI tests for Reader

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v2_read_tags_cards.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v2_read_tags_cards.json
@@ -632,6 +632,31 @@
           }
         },
         {
+          "type": "interests_you_may_like",
+          "data": [
+            {
+              "slug": "blogging",
+              "title": "Blogging",
+              "score": 278
+            },
+            {
+              "slug": "travel",
+              "title": "Travel",
+              "score": 251
+            },
+            {
+              "slug": "photos",
+              "title": "Photos",
+              "score": 173
+            },
+            {
+              "slug": "technology",
+              "title": "Technology",
+              "score": 139
+            }
+          ]
+        },
+        {
           "type": "post",
           "data": {
             "ID": 37189,

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v2_read_tags_cards.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v2_read_tags_cards.json
@@ -41,6 +41,31 @@
           ]
         },
         {
+          "type": "interests_you_may_like",
+          "data": [
+            {
+              "slug": "blogging",
+              "title": "Blogging",
+              "score": 278
+            },
+            {
+              "slug": "travel",
+              "title": "Travel",
+              "score": 251
+            },
+            {
+              "slug": "photos",
+              "title": "Photos",
+              "score": 173
+            },
+            {
+              "slug": "technology",
+              "title": "Technology",
+              "score": 139
+            }
+          ]
+        },
+        {
           "type": "post",
           "data": {
             "ID": 37222,
@@ -630,31 +655,6 @@
             "use_excerpt": false,
             "is_following_conversation": false
           }
-        },
-        {
-          "type": "interests_you_may_like",
-          "data": [
-            {
-              "slug": "blogging",
-              "title": "Blogging",
-              "score": 278
-            },
-            {
-              "slug": "travel",
-              "title": "Travel",
-              "score": 251
-            },
-            {
-              "slug": "photos",
-              "title": "Photos",
-              "score": 173
-            },
-            {
-              "slug": "technology",
-              "title": "Technology",
-              "score": 139
-            }
-          ]
         },
         {
           "type": "post",

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
@@ -16,6 +16,7 @@ extension ReaderStreamViewController {
             ghostableTableView.centerYAnchor.constraint(equalTo: tableView.centerYAnchor)
         ])
 
+        ghostableTableView.accessibilityIdentifier = "Reader Ghost Loading"
         ghostableTableView.separatorStyle = .none
 
         let postCardTextCellNib = UINib(nibName: "OldReaderPostCardCell", bundle: Bundle.main)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -94,8 +94,9 @@ extension ReaderTopicsCardCell: UICollectionViewDelegate, UICollectionViewDataSo
 
         let title = data[indexPath.row].title
         cell.titleLabel.text = title
-        cell.titleLabel.accessibilityIdentifier = .topicsCardCellIdentifier
-        cell.titleLabel.accessibilityTraits = .button
+
+        cell.accessibilityLabel = title
+        cell.accessibilityIdentifier = .topicsCardCellIdentifier
 
         return cell
     }
@@ -177,6 +178,8 @@ class ReaderTopicCardCollectionViewCell: UICollectionViewCell, ReusableCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+
+        isAccessibilityElement = true
 
         contentView.addSubview(titleLabel)
         contentView.pinSubviewToAllEdges(titleLabel, insets: .init(top: 8.0, left: 16.0, bottom: 8.0, right: 16.0))

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
@@ -71,6 +71,7 @@ struct ReaderNavigationButton: View {
                 item.image
             }
         }
+        .accessibilityIdentifier(item.accessibilityIdentifier)
     }
 
     struct Colors {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
@@ -31,6 +31,7 @@ struct ReaderNavigationButton: View {
                 menuLabel(for: selectedItem)
             }
         }
+        .accessibilityIdentifier("reader-navigation-button")
         .buttonStyle(PlainButtonStyle())
         .onTapGesture {
             WPAnalytics.track(.readerDropdownOpened)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
@@ -8,7 +8,7 @@ struct ReaderTabItem: FilterTabBarItem, Hashable {
     let content: ReaderContent
 
     var accessibilityIdentifier: String {
-        return title
+        return "Reader Navigation Menu Item, \(title)"
     }
 
     /// initialize with topic

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -18,59 +18,62 @@ class ReaderTests: XCTestCase {
         takeScreenshotOfFailedTest()
     }
 
-//    func testViewPost() throws {
-//        try ReaderScreen()
-//            .openLastPost()
-//            .verifyPostContentEquals(.expectedPostContent)
-//    }
+    func testViewPost() throws {
+        try ReaderScreen()
+            .switchToStream(.subscriptions)
+            .openLastPost()
+            .verifyPostContentEquals(.expectedPostContent)
+    }
 
-//    func testViewPostInSafari() throws {
-//        try ReaderScreen()
-//            .openLastPostInSafari()
-//            .verifyPostContentEquals(.expectedPostContent)
-//    }
+    func testViewPostInSafari() throws {
+        try ReaderScreen()
+            .switchToStream(.subscriptions)
+            .openLastPostInSafari()
+            .verifyPostContentEquals(.expectedPostContent)
+    }
 
-//    func testAddCommentToPost() throws {
-//        try ReaderScreen()
-//            .openLastPostComments()
-//            .verifyCommentsListEmpty()
-//            .replyToPost(.commentContent)
-//            .verifyCommentSent(.commentContent)
-//    }
+    func testAddCommentToPost() throws {
+        try ReaderScreen()
+            .switchToStream(.subscriptions)
+            .openLastPostComments()
+            .verifyCommentsListEmpty()
+            .replyToPost(.commentContent)
+            .verifyCommentSent(.commentContent)
+    }
 
-//    func testFollowNewTopicOnDiscover() throws {
-//        try ReaderScreen()
-//            .openDiscoverTab()
-//            .selectTopic()
-//            .verifyTopicLoaded()
-//            .followTopic()
-//            .verifyTopicFollowed()
-//    }
+    func testFollowNewTopicOnDiscover() throws {
+        try ReaderScreen()
+            .switchToStream(.discover)
+            .selectTopic()
+            .verifyTopicLoaded()
+            .followTopic()
+            .verifyTopicFollowed()
+    }
 
-//    func testSavePost() throws {
-//        // Get saved post label
-//        let (updatedReaderScreen, savedPostLabel) = try ReaderScreen()
-//            .openSavedTab()
-//            .verifySavedPosts(state: .withoutPosts)
-//            .openFollowingTab()
-//            .saveFirstPost()
-//
-//        // Open saved posts tab and validate that the correct saved post is displayed
-//        updatedReaderScreen
-//            .openSavedTab()
-//            .verifySavedPosts(state: .withPosts, postLabel: savedPostLabel)
-//    }
+    func testSavePost() throws {
+        // Get saved post label
+        let (updatedReaderScreen, savedPostLabel) = try ReaderScreen()
+            .switchToStream(.saved)
+            .verifySavedPosts(state: .withoutPosts)
+            .switchToStream(.subscriptions)
+            .saveFirstPost()
 
-//    func testLikePost() throws {
-//        try ReaderScreen()
-//            .openLikesTab()
-//            .verifyLikedPosts(state: .withoutPosts)
-//            .openFollowingTab()
-//            .likeFirstPost()
-//            .verifyPostLikedOnFollowingTab()
-//            .openLikesTab()
-//            .verifyLikedPosts(state: .withPosts)
-//    }
+        // Open saved posts tab and validate that the correct saved post is displayed
+        updatedReaderScreen
+            .switchToStream(.saved)
+            .verifySavedPosts(state: .withPosts, postLabel: savedPostLabel)
+    }
+
+    func testLikePost() throws {
+        try ReaderScreen()
+            .switchToStream(.liked)
+            .verifyLikedPosts(state: .withoutPosts)
+            .switchToStream(.subscriptions)
+            .likeFirstPost()
+            .verifyPostLikedOnFollowingTab()
+            .switchToStream(.liked)
+            .verifyLikedPosts(state: .withPosts)
+    }
 }
 
 private extension String {

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -155,10 +155,7 @@ public class ReaderScreen: ScreenObject {
     }
 
     public func selectTopic() -> Self {
-        let topicCell = topicCellButton.firstMatch
-        scrollDownUntilElementIsFullyVisible(element: topicCell)
-
-        topicCell.tap()
+        topicCellButton.firstMatch.tap()
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -71,6 +71,10 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Save"]
     }
 
+    private let ghostLoadingGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["Reader Ghost Loading"]
+    }
+
     var readerNavigationMenuButton: XCUIElement { readerNavigationButtonGetter(app) }
     var backButton: XCUIElement { backButtonGetter(app) }
     var discoverButton: XCUIElement { discoverButtonGetter(app) }
@@ -88,6 +92,7 @@ public class ReaderScreen: ScreenObject {
     var savedButton: XCUIElement { savedButtonGetter(app) }
     var topicCellButton: XCUIElement { topicCellButtonGetter(app) }
     var visitButton: XCUIElement { visitButtonGetter(app) }
+    var ghostLoading: XCUIElement { ghostLoadingGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -203,7 +208,17 @@ public class ReaderScreen: ScreenObject {
         }
         menuButton.tap()
 
+        waitForLoadingToFinish()
+
         return self
+    }
+
+    // wait for the ghost loading view to be removed.
+    private func waitForLoadingToFinish() {
+        let doesNotExistPredicate = NSPredicate(format: "exists == FALSE")
+        let expectation = XCTNSPredicateExpectation(predicate: doesNotExistPredicate, object: ghostLoading)
+        let result = XCTWaiter.wait(for: [expectation], timeout: 5.0)
+        XCTAssertEqual(result, .completed)
     }
 
     @discardableResult

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -168,8 +168,7 @@ public class ReaderScreen: ScreenObject {
     }
 
     public func followTopic() -> Self {
-        _ = followButton.waitForExistence(timeout: 3)
-        followButton.tap()
+        waitForExistenceAndTap(followButton, timeout: 3)
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -3,6 +3,10 @@ import XCTest
 
 public class ReaderScreen: ScreenObject {
 
+    private let readerNavigationButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["reader-navigation-button"]
+    }
+
     private let discoverButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Discover"]
     }
@@ -43,12 +47,16 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Following"]
     }
 
+    private let subscriptionsMenuButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Subscriptions"]
+    }
+
     private let likesTabButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Likes"]
     }
 
     private let topicCellButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["topics-card-cell-button"]
+        $0.cells["topics-card-cell-button"]
     }
 
     private let noResultsViewGetter: (XCUIApplication) -> XCUIElement = {
@@ -63,12 +71,14 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Save"]
     }
 
+    var readerNavigationMenuButton: XCUIElement { readerNavigationButtonGetter(app) }
     var backButton: XCUIElement { backButtonGetter(app) }
     var discoverButton: XCUIElement { discoverButtonGetter(app) }
     var dismissButton: XCUIElement { dismissButtonGetter(app) }
     var firstPostLikeButton: XCUIElement { firstPostLikeButtonGetter(app) }
     var followButton: XCUIElement { followButtonGetter(app) }
     var followingButton: XCUIElement { followingButtonGetter(app) }
+    var subscriptionsMenuButton: XCUIElement { subscriptionsMenuButtonGetter(app) }
     var likesTabButton: XCUIElement { likesTabButtonGetter(app) }
     var noResultsView: XCUIElement { noResultsViewGetter(app) }
     var readerButton: XCUIElement { readerButtonGetter(app) }
@@ -144,20 +154,11 @@ public class ReaderScreen: ScreenObject {
         (try? ReaderScreen().isLoaded) ?? false
     }
 
-    public func openDiscoverTab() -> Self {
-        discoverButton.tap()
-
-        return self
-    }
-
     public func selectTopic() -> Self {
-        topicCellButton.firstMatch.tap()
+        let topicCell = topicCellButton.firstMatch
+        scrollDownUntilElementIsFullyVisible(element: topicCell)
 
-        return self
-    }
-
-    public func openSavedTab() -> Self {
-        savedButton.tap()
+        topicCell.tap()
 
         return self
     }
@@ -169,21 +170,42 @@ public class ReaderScreen: ScreenObject {
         return self
     }
 
-    public func openFollowingTab() -> Self {
-        followingButton.tap()
-
-        return self
-    }
-
-    public func openLikesTab() -> Self {
-        likesTabButton.tap()
-
-        return self
-    }
-
     public func followTopic() -> Self {
         _ = followButton.waitForExistence(timeout: 3)
         followButton.tap()
+
+        return self
+    }
+
+    // MARK: Stream switching actions
+
+    public enum ReaderStream: String {
+        case discover
+        case subscriptions
+        case saved
+        case liked
+
+        var buttonIdentifier: String {
+            "Reader Navigation Menu Item, \(rawValue.capitalized)"
+        }
+
+        func menuButton(_ app: XCUIApplication) -> XCUIElement {
+            return app.buttons[buttonIdentifier].firstMatch
+        }
+    }
+
+    private func openNavigationMenu() {
+        readerNavigationMenuButton.tap()
+    }
+
+    public func switchToStream(_ stream: ReaderStream) -> Self {
+        openNavigationMenu()
+
+        let menuButton = stream.menuButton(app)
+        guard menuButton.waitForIsHittable(timeout: 3) else {
+            fatalError("ReaderScreen: Discover menu button not loaded")
+        }
+        menuButton.tap()
 
         return self
     }


### PR DESCRIPTION
Refs #22463 

This updates the (previously disabled) Reader UI tests, along with some small fixes & improvements to identifiers for UI testing purposes. 

In the new version, we are moving away from "tabs" to "streams"; the biggest change is the stream switcher button. Within the UI test code, this replaces the previous `openDiscoverTab`, `openFollowingTab`, etc. to `switchToStream(_ stream: ReaderStream)`.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
The UI tests were re-enabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A. No user-facing UI changes in this PR.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
