### PR TITLE
[Gravatar] Removing global `import WordPressUI` and adding localized ones

### DIFF
--- a/WordPress/Classes/Models/ManagedPerson.swift
+++ b/WordPress/Classes/Models/ManagedPerson.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 import WordPressKit
+import WordPressUI
 
 public typealias Person = RemotePerson
 

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -117,6 +117,5 @@
 #import <WordPressShared/WPStyleGuide.h>
 #import <WordPressShared/WPTableViewCell.h>
 #import <WordPressShared/WPAnalytics.h>
-#import <WordPressUI/UIImage+Util.h>
 
 FOUNDATION_EXTERN void SetCocoaLumberjackObjCLogLevel(NSUInteger ddLogLevelRawValue);

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -7,6 +7,7 @@ import WordPressShared
 import AlamofireNetworkActivityIndicator
 import AutomatticAbout
 import UIDeviceIdentifier
+import WordPressUI
 
 #if APPCENTER_ENABLED
 import AppCenter

--- a/WordPress/Classes/Utility/Media/ImageDownloader+Gravatar.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader+Gravatar.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 extension ImageDownloader {
 

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 protocol CalendarViewControllerDelegate: AnyObject {
     func didCancel(calendar: CalendarViewController)

--- a/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 typealias VerificationPromptCompletion = (Bool) -> ()
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -13,6 +13,7 @@ import MediaEditor
 import UniformTypeIdentifiers
 import Photos
 import PhotosUI
+import WordPressUI
 
 // MARK: - Aztec's Native Editor!
 //

--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 final class BlazeOverlayViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 import UIKit
+import WordPressUI
 
 protocol PagesCardView: AnyObject {
     var tableView: UITableView { get }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 import UIKit
+import WordPressUI
 
 protocol PostsCardView: AnyObject {
     var tableView: UITableView { get }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -1,6 +1,5 @@
 import UIKit
 import WordPressShared
-import WordPressUI
 import WordPressFlux
 
 class DashboardPromptsCardCell: UICollectionViewCell, Reusable {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Me.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Me.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 extension BlogDetailsViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 class BloggingRemindersFlow {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class BloggingRemindersFlowCompletionViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class BloggingRemindersFlowIntroViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressKit
+import WordPressUI
 
 protocol BloggingRemindersFlowDelegate: AnyObject {
     func didSetUpBloggingReminders()

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 protocol ChildDrawerPositionable {
     var preferredDrawerPosition: DrawerPosition { get }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class BloggingRemindersPushPromptViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/Time Selector/TimeSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/Time Selector/TimeSelectionViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class TimeSelectionViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1,6 +1,7 @@
 import WordPressAuthenticator
 import UIKit
 import SwiftUI
+import WordPressUI
 
 final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSitesViewDelegate {
     enum Section: Int, CaseIterable {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 struct NoSitesViewModel {
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 final class QuickStartPromptViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class CommentContentTableViewCell: UITableViewCell, NibReusable {
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import CoreData
+import WordPressUI
 
 // Notification sent when a Comment is permanently deleted so the Notifications list (NotificationsViewController) is immediately updated.
 extension NSNotification.Name {

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 protocol CompliancePopoverCoordinatorProtocol: AnyObject {
     func presentIfNeeded() async -> Bool

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class CollabsableHeaderFilterCollectionViewCell: UICollectionViewCell {
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class GutenGhostView: UIView {
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 /// A class containing convenience methods for the the Jetpack branding experience
 class JetpackBrandingCoordinator {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Lottie
+import WordPressUI
 
 final class MovedToJetpackViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class JetpackOverlayViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class JetpackScanStatusCell: UITableViewCell, NibReusable {
     @IBOutlet weak var iconContainerView: UIView!

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressFlux
+import WordPressUI
 
 protocol JetpackScanThreatDetailsViewControllerDelegate: AnyObject {
     func willFixThreat(_ threat: JetpackScanThreat, controller: JetpackScanThreatDetailsViewController)

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 class MyProfileHeaderView: UITableViewHeaderFooterView {
     // MARK: - Public Properties and Outlets

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -3,6 +3,7 @@ import CoreData
 import Gridicons
 import SVProgressHUD
 import WordPressShared
+import WordPressUI
 
 ///
 ///

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -6,6 +6,7 @@ import WordPressShared
 import WordPressAuthenticator
 import Gridicons
 import UIKit
+import WordPressUI
 
 /// The purpose of this class is to render the collection of Notifications, associated to the main
 /// WordPress.com account.

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockButtonTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class NoteBlockButtonTableViewCell: NoteBlockTableViewCell {
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressShared.WPStyleGuide
+import WordPressUI
 
 // MARK: - NoteBlockCommentTableViewCell Renders a Comment Block Onscreen
 //

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressShared.WPStyleGuide
+import WordPressUI
 
 // MARK: - NoteBlockHeaderTableViewCell
 //

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressShared
+import WordPressUI
 
 class NoteBlockUserTableViewCell: NoteBlockTableViewCell {
     typealias EventHandler = (() -> Void)

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -36,7 +36,7 @@ class PeopleCell: WPTableViewCell {
     }
 
     @objc func setAvatarURL(_ avatarURL: URL?) {
-        let gravatar = avatarURL.flatMap { WordPressUI.Gravatar($0) }
+        let gravatar = avatarURL.flatMap { Gravatar($0) }
         let placeholder = UIImage(named: "gravatar")!
         avatarImageView.downloadGravatar(gravatar, placeholder: placeholder, animate: false)
     }

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressShared
+import WordPressUI
 
 class PeopleCell: WPTableViewCell {
     @IBOutlet private weak var avatarImageView: CircularImageView!
@@ -35,7 +36,7 @@ class PeopleCell: WPTableViewCell {
     }
 
     @objc func setAvatarURL(_ avatarURL: URL?) {
-        let gravatar = avatarURL.flatMap { Gravatar($0) }
+        let gravatar = avatarURL.flatMap { WordPressUI.Gravatar($0) }
         let placeholder = UIImage(named: "gravatar")!
         avatarImageView.downloadGravatar(gravatar, placeholder: placeholder, animate: false)
     }

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import CocoaLumberjack
 import WordPressShared
+import WordPressUI
 
 /// Displays a Blog's User Details
 ///

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -5,6 +5,7 @@ import CocoaLumberjack
 import WordPressShared
 import wpxmlrpc
 import WordPressFlux
+import WordPressUI
 
 class AbstractPostListViewController: UIViewController,
                                       WPContentSyncHelperDelegate,

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -2,6 +2,7 @@ import AutomatticTracks
 import UIKit
 import Gridicons
 import WordPressShared
+import WordPressUI
 
 class PostCompactCell: UITableViewCell {
     @IBOutlet weak var titleLabel: UILabel!

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressFlux
+import WordPressUI
 
 protocol PublishingEditor where Self: UIViewController {
     //TODO: Add publishing things

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import WordPressShared
 import Gridicons
+import WordPressUI
 
 class PostPostViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CocoaLumberjack
 import WordPressShared
+import WordPressUI
 
 class PostTagPickerViewController: UIViewController {
     private let originalTags: [String]

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 protocol PrepublishingDismissible {
     func handleDismiss()

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WordPressAuthenticator
 import Combine
+import WordPressUI
 
 private struct PrepublishingOption {
     let id: PrepublishingIdentifier

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
@@ -1,4 +1,5 @@
 import Gridicons
+import WordPressUI
 
 class RevisionsTableViewCell: UITableViewCell {
     static let reuseIdentifier = "RevisionsTableViewCellIdentifier"

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 /// Methods used by the Reader in the Follow Conversation flow to:
 /// - subscribe to post comments

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsNotificationSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsNotificationSheetViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressFlux
+import WordPressUI
 
 @objc public protocol ReaderCommentsNotificationSheetDelegate: AnyObject {
     func didToggleNotificationSwitch(_ isOn: Bool, completion: @escaping (Bool) -> Void)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 typealias RelatedPostsSection = (postType: RemoteReaderSimplePost.PostType, posts: [RemoteReaderSimplePost])
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 class ReaderDetailLikesListController: UITableViewController, NoResultsViewHost {
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 protocol ReaderDetailToolbarDelegate: AnyObject {
     func didTapLikeButton(isLiked: Bool)

--- a/WordPress/Classes/ViewRelated/Reader/Filter/EmptyActionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/EmptyActionView.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 /// A view with a label and action button
 class EmptyActionView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -1,4 +1,5 @@
 import WordPressFlux
+import WordPressUI
 
 class FilterSheetView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 class FilterSheetViewController: UIViewController {
 
     private let viewTitle: String

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterTableData.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterTableData.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 struct TableDataItem {
     let topic: ReaderAbstractTopic
     let configure: (UITableViewCell) -> Void

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsFooter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsFooter.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 class ReaderTagsFooter: UITableViewHeaderFooterView, NibReusable {
 

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 class ReaderTagsTableViewModel: NSObject {
 
     private let tableViewHandler: OffsetTableViewHandler

--- a/WordPress/Classes/ViewRelated/Reader/OldReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/OldReaderPostCardCell.swift
@@ -2,6 +2,7 @@ import AutomatticTracks
 import Foundation
 import WordPressShared
 import Gridicons
+import WordPressUI
 
 protocol ReaderTopicsChipsDelegate: AnyObject {
     func didSelect(topic: String)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 // TODO: Consider deleting and moving actions when Reader Improvements v1 feature flag (`readerImprovements`) is removed
 /// Action commands in Reader cells
 class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 extension ReaderStreamViewController {
     /// Show ghost card cells at the top of the tableView

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -6,6 +6,7 @@ import WordPressShared
 import WordPressFlux
 import UIKit
 import Combine
+import WordPressUI
 
 /// Displays a list of posts for a particular reader topic.
 /// - note:

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressShared
+import WordPressUI
 
 class ReaderInterestsStyleGuide {
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 protocol ReaderDiscoverFlowDelegate: AnyObject {
     func didCompleteReaderDiscoverFlow()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -1,4 +1,5 @@
 import WordPressFlux
+import WordPressUI
 
 @objc class ReaderTabViewModel: NSObject {
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -1,5 +1,6 @@
 import FSInteractiveMap
 import WordPressShared
+import WordPressUI
 
 class CountriesMapView: UIView, NibLoadable {
     private var map = FSInteractiveMapView(frame: CGRect(x: 0, y: 0, width: 335, height: 224))

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 protocol StatsRowGhostable: ImmuTableRow { }
 extension StatsRowGhostable {
     var action: ImmuTableAction? {

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 struct ActionSheetButton {
     let title: String
     let image: UIImage

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BottomSheetPresentationController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BottomSheetPresentationController.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 /// A Presentation Controller which dims the background, allows the user to dismiss by tapping outside, and allows the user to swipit down
 class BottomSheetPresentationController: FancyAlertPresentationController {
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+AppIcons.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+AppIcons.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressUI
 
 extension FancyAlertViewController {
     private struct Strings {

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 extension FancyAlertViewController {
     private struct Strings {
         static let firstAlertTitleText = NSLocalizedString("Stay in the loop", comment: "Title of the first alert preparing users to grant permission for us to send them push notifications.")

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Gridicons
+import WordPressUI
 
 extension FancyAlertViewController {
     typealias ButtonConfig = FancyAlertViewController.Config.ButtonConfig

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+VerificationPrompt.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+VerificationPrompt.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import WordPressUI
 
 extension FancyAlertViewController {
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -1,5 +1,6 @@
 import Gridicons
 import WordPressFlux
+import WordPressUI
 
 @objc class CreateButtonCoordinator: NSObject {
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FancyAlertViewController+CreateButtonAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FancyAlertViewController+CreateButtonAnnouncement.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 extension FancyAlertViewController {
     private struct Strings {
         static let titleText = NSLocalizedString("Streamlined navigation", comment: "Title of alert announcing new Create Button feature.")

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressUI
 
 extension WPTabBarController {
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 class UserProfileSheetViewController: UITableViewController {
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -1,3 +1,5 @@
+import WordPressUI
+
 /// Table view cell for the List component.
 ///
 /// This is used in Comments and Notifications as part of the Comments

--- a/WordPress/Classes/ViewRelated/WhatsNew/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Views/WhatIsNewView.swift
@@ -1,3 +1,4 @@
+import WordPressUI
 
 /// Labels and button titles
 struct WhatIsNewViewTitles {


### PR DESCRIPTION
Fixes https://github.com/gravatar/Gravatar-SDK-iOS/issues/23

On this PR, we remove a global import of `<WordPressUI/UIImage+Util.h>` from the bridge header, which was importing the whole `WordPressUI` module throughout the project (instead of just a couple of `UIImage` extensions from `UIImage+Util.h`). Since the import wasn't explicitly on `WordPressUI`, this seemed to be unintentional.

This became an issue for us at Gravatar, since WordPressUI has a public struct named `Gravatar`, which conflicts with the `Gravatar` module name of the SDK we are building, and being this `Gravatar` struct globally available, it takes precedence and forbids us from using `Gravatar` as a module namespace. 

We also think that removing an unintended global import of a while module is a good thing for the project overall.

cc @pinarol @andrewdmontgomery 

To test:

- The project should build and run.
- No behavioural or logic changes were made.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
