### PR TITLE
Site Monitoring: Add universal links

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum MySitesRoute {
+enum MySitesRoute: CaseIterable {
     case pages
     case posts
     case media
@@ -9,6 +9,9 @@ enum MySitesRoute {
     case people
     case plugins
     case managePlugins
+    case siteMonitoring
+    case phpLogs
+    case webServerLogs
 }
 
 extension MySitesRoute: Route {
@@ -38,6 +41,12 @@ extension MySitesRoute: Route {
             return "/plugins/:domain"
         case .managePlugins:
             return "/plugins/manage/:domain"
+        case .siteMonitoring:
+            return "/site-monitoring/:domain"
+        case .phpLogs:
+            return "/site-monitoring/:domain/php"
+        case .webServerLogs:
+            return "/site-monitoring/:domain/web"
         }
     }
 
@@ -52,6 +61,12 @@ extension MySitesRoute: Route {
         case .comments:
             return false
         case .sharing:
+            return true
+        case .siteMonitoring:
+            return true
+        case .phpLogs:
+            return true
+        case .webServerLogs:
             return true
         case .people:
             return true
@@ -107,6 +122,12 @@ extension MySitesRoute: NavigationAction {
             coordinator.showPlugins(for: blog)
         case .managePlugins:
             coordinator.showManagePlugins(for: blog)
+        case .siteMonitoring:
+            coordinator.showSiteMonitoring(for: blog, selectedTab: .metrics)
+        case .phpLogs:
+            coordinator.showSiteMonitoring(for: blog, selectedTab: .phpLogs)
+        case .webServerLogs:
+            coordinator.showSiteMonitoring(for: blog, selectedTab: .webServerLogs)
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -97,16 +97,7 @@ struct UniversalLinkRouter: LinkRouter {
         StatsRoute.activityLog
     ]
 
-    static let mySitesRoutes: [Route] = [
-        MySitesRoute.pages,
-        MySitesRoute.posts,
-        MySitesRoute.media,
-        MySitesRoute.comments,
-        MySitesRoute.sharing,
-        MySitesRoute.people,
-        MySitesRoute.plugins,
-        MySitesRoute.managePlugins
-    ]
+    static let mySitesRoutes: [Route] = MySitesRoute.allCases
 
     static let appBannerRoutes: [Route] = [
         AppBannerRoute()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -11,7 +11,7 @@ extension BlogDetailsSubsection {
             return .domainCredit
         case .quickStart:
             return .quickStart
-        case .activity, .jetpackSettings:
+        case .activity, .jetpackSettings, .siteMonitoring:
             return .jetpack
         case .stats where blog.shouldShowJetpackSection:
             return .jetpack

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SiteMonitoring.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SiteMonitoring.swift
@@ -7,7 +7,12 @@ extension BlogDetailsViewController {
     }
 
     @objc func showSiteMonitoring() {
-        let controller = SiteMonitoringViewController()
+        showSiteMonitoring(selectedTab: nil)
+    }
+
+    @objc func showSiteMonitoring(selectedTab: NSNumber?) {
+        let selectedTab = selectedTab.flatMap { SiteMonitoringTab(rawValue: $0.intValue) }
+        let controller = SiteMonitoringViewController(selectedTab: selectedTab)
         presentationDelegate?.presentBlogDetailsViewController(controller)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -47,8 +47,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionMigrationSuccess,
     BlogDetailsSubsectionJetpackBrandingCard,
     BlogDetailsSubsectionBlaze,
+    BlogDetailsSubsectionSiteMonitoring
 };
-
 
 typedef NS_ENUM(NSInteger, QuickStartTitleState) {
     QuickStartTitleStateUndefined = 0,
@@ -188,5 +188,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl onCompletion:(nullable void(^)(void))completion;
 
 + (nonnull NSString *)userInfoShowPickerKey;
++ (nonnull NSString *)userInfoSiteMonitoringTabKey;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -607,6 +607,17 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                 [self showPlugins];
             }
             break;
+        case BlogDetailsSubsectionSiteMonitoring:
+            if ([self shouldShowSiteMonitoring]) {
+                NSNumber *selectedTab = userInfo[[BlogDetailsViewController userInfoSiteMonitoringTabKey]];
+                self.restorableSelectedIndexPath = indexPath;
+                [self.tableView selectRowAtIndexPath:indexPath
+                                            animated:NO
+                                      scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+                [self showSiteMonitoringWithSelectedTab:selectedTab];
+            }
+            break;
+
     }
 }
 
@@ -629,6 +640,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionActivity:
             return [NSIndexPath indexPathForRow:0 inSection:section];
+        case BlogDetailsSubsectionSiteMonitoring:
+            return [NSIndexPath indexPathForRow:2 inSection:section];
         case BlogDetailsSubsectionBlaze:
             return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionJetpackSettings:
@@ -651,6 +664,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return [NSIndexPath indexPathForRow:1 inSection:section];
         case BlogDetailsSubsectionPlugins:
             return [NSIndexPath indexPathForRow:2 inSection:section];
+
     }
 }
 
@@ -2258,6 +2272,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 + (NSString *)userInfoShowPickerKey {
     return @"show-picker";
+}
+
++ (NSString *)userInfoSiteMonitoringTabKey {
+    return @"site-monitoring-tab";
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
@@ -7,9 +7,16 @@ struct SiteMonitoringView: View {
     }
 }
 
+enum SiteMonitoringTab: Int {
+    case metrics
+    case phpLogs
+    case webServerLogs
+}
+
 final class SiteMonitoringViewController: UIHostingController<SiteMonitoringView> {
 
-    init() {
+    init(selectedTab: SiteMonitoringTab? = nil) {
+        // TODO: Open the selected tab if passed
         super.init(rootView: .init())
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -234,6 +234,10 @@ class MySitesCoordinator: NSObject {
         showBlogDetails(for: blog, then: .plugins)
     }
 
+    func showSiteMonitoring(for blog: Blog, selectedTab: SiteMonitoringTab) {
+        showBlogDetails(for: blog, then: .siteMonitoring, userInfo: [BlogDetailsViewController.userInfoSiteMonitoringTabKey(): selectedTab.rawValue])
+    }
+
     func showManagePlugins(for blog: Blog) {
         guard blog.supports(.pluginManagement) else {
             return


### PR DESCRIPTION
Adds support for the following universal links:

- Metrics: https://wordpress.com/site-monitoring/{blog}
- PHP logs: https://wordpress.com/site-monitoring/{blog}/php
- Web Server Logs: https://wordpress.com/site-monitoring/{blog}/web

To test:

- Add `(scheme == "https" || scheme == "jpdebug")` to `UniversalLinkRouter:125`
- Set breakpoint on `init` ini `SiteMonitoringViewController:20`
- Open each of the listed universal links in simulator (optional: you can run `xcrun simctl openurl booted <link>`)
- Verify that the Site Monitoring screen is opened and the selectedTab is passed

**Note**: the `.well-known/apple-app-site-association` file will need to be updated to include the new paths in order for the https links to work. I added it on the board: https://github.com/orgs/wordpress-mobile/projects/225?pane=issue&itemId=51199495.

## Regression Notes
1. Potential unintended areas of impact: Site Monitoring
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
