### PR TITLE
Reader: Use new button styles for Reader no results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -17,7 +17,11 @@ import Gridicons
         var title: String {
             switch self {
             case .posts: return NSLocalizedString("Posts", comment: "Title of a Reader tab showing Posts matching a user's search query")
-            case .sites: return NSLocalizedString("Sites", comment: "Title of a Reader tab showing Sites matching a user's search query")
+            case .sites: return NSLocalizedString(
+                "reader.search.tab.blogs",
+                value: "Blogs",
+                comment: "Title of a Reader tab showing Sites matching a user's search query"
+            )
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1947,8 +1947,16 @@ extension ReaderStreamViewController {
         static let loadingStreamTitle = NSLocalizedString("Loading stream...", comment: "A short message to inform the user the requested stream is being loaded.")
         static let loadingErrorTitle = NSLocalizedString("Problem loading content", comment: "Error message title informing the user that reader content could not be loaded.")
         static let loadingErrorMessage = NSLocalizedString("Sorry. The content could not be loaded.", comment: "A short error message letting the user know the requested reader content could not be loaded.")
-        static let manageSitesButtonTitle = NSLocalizedString("Manage Sites", comment: "Button title. Tapping lets the user manage the sites they follow.")
-        static let followingButtonTitle = NSLocalizedString("Go to Following", comment: "Button title. Tapping lets the user view the sites they follow.")
+        static let manageSitesButtonTitle = NSLocalizedString(
+            "reader.no.results.manage.blogs",
+            value: "Manage Blogs",
+            comment: "Button title. Tapping lets the user manage the blogs they follow."
+        )
+        static let followingButtonTitle = NSLocalizedString(
+            "reader.no.results.subscriptions.button",
+            value: "Go to Subscriptions",
+            comment: "Button title. Tapping lets the user view the blogs they're subscribed to."
+        )
         static let noConnectionTitle = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1895,6 +1895,8 @@ extension ReaderStreamViewController {
         resetNoFollowedSitesViewController()
 
         resultsStatusView.configure(title: title, buttonTitle: buttonTitle, subtitle: subtitle, image: imageName, accessoryView: accessoryView)
+        resultsStatusView.loadViewIfNeeded()
+        resultsStatusView.setupReaderButtonStyles()
     }
 
     private func displayNoResultsForSavedPosts() {


### PR DESCRIPTION
## Description

Makes the following changes:

- Updates the "Liked" screen's empty state to use the new colors to match the rest of the new theme.
- Updates some Reader strings to their new terminologies

## Screenshots

| Before | After |
|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-26 at 13 19 04](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/8487a230-ab9d-4ca3-a05f-60a9ff018947) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-26 at 13 17 59](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/88723c34-5a16-4c20-9ea3-18d163cf69ac) |

## Testing

To test:

- Use an account with no liked content from the Reader
- Launch Jetpack and login
- Navigate to the "Liked" feed
- 🔎 **Verify** the colors of the button match the new Reader color scheme

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
