### PR TITLE
Reader: Fix filtering by RSS in the subscription feed

### DIFF
--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -768,8 +768,8 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         [self deletePostsFromBlockedSitesInContext:context];
 
         BOOL spaceAvailable = ([self numberOfPostsForTopic:readerTopic inContext:context] < [self maxPostsToSaveForTopic:readerTopic]);
-        if ([ReaderHelpers isTopicTag:readerTopic]) {
-            // For tags, assume there is more content as long as more than zero results are returned.
+        if ([ReaderHelpers isTopicTag:readerTopic] || [ReaderHelpers isRSSFeed:readerTopic]) {
+            // For tags and RSS feeds, assume there is more content as long as more than zero results are returned.
             hasMore = (postsCount > 0 ) && spaceAvailable;
         } else {
             // For other topics, assume there is more content as long as the number of results requested is returned.
@@ -1153,8 +1153,8 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 - (BOOL)canLoadMorePostsForTopic:(ReaderAbstractTopic * _Nonnull)readerTopic remotePosts:(NSArray * _Nonnull)remotePosts inContext: (NSManagedObjectContext * _Nonnull)context {
     BOOL hasMore = NO;
     BOOL spaceAvailable = ([self numberOfPostsForTopic:readerTopic inContext:context] < [self maxPostsToSaveForTopic:readerTopic]);
-    if ([ReaderHelpers isTopicTag:readerTopic]) {
-        // For tags, assume there is more content as long as more than zero results are returned.
+    if ([ReaderHelpers isTopicTag:readerTopic] || [ReaderHelpers isRSSFeed:readerTopic]) {
+        // For tags and RSS feeds, assume there is more content as long as more than zero results are returned.
         hasMore = ([remotePosts count] > 0 ) && spaceAvailable;
     } else {
         // For other topics, assume there is more content as long as the number of results requested is returned.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -144,6 +144,20 @@ struct ReaderPostMenuButtonTitles {
         return topic.isKind(of: ReaderSiteTopic.self)
     }
 
+    /// Check if the specified topic is an RSS feed
+    ///
+    /// - Parameters:
+    ///     - topic: A ReaderAbstractTopic
+    ///
+    /// - Returns: True if the topic is an RSS feed
+    ///
+    @objc open class func isRSSFeed(_ topic: ReaderAbstractTopic) -> Bool {
+        guard let site = topic as? ReaderSiteTopic else {
+            return false
+        }
+        return site.siteID == 0
+    }
+
 
     /// Check if the specified topic is a tag topic
     ///


### PR DESCRIPTION
Fixes #22486 

## Description

When fetching the posts for RSS feeds, the API only returns 1 post at a time. Due to this, it would be marked as having no more additional posts.

To fix this, the `hasMore` boolean will return `true` for RSS feeds if there are any posts that return from the API.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Add an RSS feed if necessary, I used: https://hnrss.org/frontpage
- Navigate to the Subscriptions feed
- Tap on the Blog filter
- Select the RSS feed
- 🔎 **Verify** More than a couple of posts shows, and you can scroll down to load additional ones

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
