### PR TITLE
Merge `strings` update from release branch

### DIFF
--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -899,18 +899,6 @@
 /* Title for the image quality settings option. */
 "appSettings.media.imageQualityRow" = "Image Quality";
 
-/* Message of an alert informing users to enable image optimization in uploads. */
-"appSettings.optimizeImagesPopup.message" = "Image optimization shrinks images for faster uploading.\n\nThis option is enabled by default, but you can change it in the app settings at any time.";
-
-/* Title of an alert informing users to enable image optimization in uploads. */
-"appSettings.optimizeImagesPopup.title" = "Keep optimizing images?";
-
-/* Title of button for turning off image optimization, displayed in the alert informing users to enable image optimization in uploads. */
-"appSettings.optimizeImagesPopup.turnOff" = "No, turn off";
-
-/* Title of button for leaving on image optimization, displayed in the alert informing users to enable image optimization in uploads. */
-"appSettings.optimizeImagesPopup.turnOn" = "Yes, leave on";
-
 /* Menus alert message for alerting the user to unsaved changes while trying back out of Menus. */
 "Are you sure you want to cancel and discard changes?" = "Are you sure you want to cancel and discard changes?";
 


### PR DESCRIPTION
Three strings were removed in 043df6ac0bc31d7db773bfd7a34d157b7d9a154a. This update will let the removals land on `trunk`, go to GlotPress, and then be downloaded on the next beta deployment.

See failed beta deployment attempt at
https://buildkite.com/automattic/wordpress-ios/builds/19985

FYI @SiobhyB as the author, until we find a good way to enforce `strings` regeneration when targeting or on `release/*` branches (maybe via Danger, cc @iangmaia)

Note: I'll admin-merge this PR to get the process moving along ASAP.