### PR TITLE
Refactor NotificationsViewController & Add NotificationsViewModel 2

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -1736,29 +1736,11 @@ private extension NotificationsViewController {
             return nil
         }
 
-        guard let noteIndex = notifications.firstIndex(of: note) else {
-            return nil
-        }
-
-        let targetIndex = noteIndex + delta
-        guard targetIndex >= 0 && targetIndex < notifications.count else {
-            return nil
-        }
-
-        func notMatcher(_ note: Notification) -> Bool {
-            return note.kind != .matcher
-        }
-
-        if delta > 0 {
-            return notifications
-                .suffix(from: targetIndex)
-                .first(where: notMatcher)
-        } else {
-            return notifications
-                .prefix(through: targetIndex)
-                .reversed()
-                .first(where: notMatcher)
-        }
+        return viewModel.loadNotification(
+            near: note,
+            allNotifications: notifications,
+            withIndexDelta: delta
+        )
     }
 
     func resetNotifications() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewModel.swift
@@ -43,4 +43,34 @@ final class NotificationsViewModel {
     func didChangeDefaultAccount() {
         lastSeenTime = nil
     }
+
+    func loadNotification(
+        near note: Notification,
+        allNotifications: [Notification],
+        withIndexDelta delta: Int
+    ) -> Notification? {
+        guard let noteIndex = allNotifications.firstIndex(of: note) else {
+            return nil
+        }
+
+        let targetIndex = noteIndex + delta
+        guard targetIndex >= 0 && targetIndex < allNotifications.count else {
+            return nil
+        }
+
+        func notMatcher(_ note: Notification) -> Bool {
+            return note.kind != .matcher
+        }
+
+        if delta > 0 {
+            return allNotifications
+                .suffix(from: targetIndex)
+                .first(where: notMatcher)
+        } else {
+            return allNotifications
+                .prefix(through: targetIndex)
+                .reversed()
+                .first(where: notMatcher)
+        }
+    }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10005,6 +10005,15 @@
 			path = "Feature Highlight";
 			sourceTree = "<group>";
 		};
+		082EA3D82B4DDF6800E7F361 /* NotificationsViewController */ = {
+			isa = PBXGroup;
+			children = (
+				B5DBE4FD1D21A700002E81D3 /* NotificationsViewController.swift */,
+				083683DC2B4859BB00331ED0 /* NotificationsViewModel.swift */,
+			);
+			path = NotificationsViewController;
+			sourceTree = "<group>";
+		};
 		0830538A2B272F9C00B889FE /* Dynamic */ = {
 			isa = PBXGroup;
 			children = (
@@ -15701,6 +15710,7 @@
 		B5FD453E199D0F2800286FBB /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				082EA3D82B4DDF6800E7F361 /* NotificationsViewController */,
 				98E14A3B27C9712D007B0896 /* NotificationCommentDetailViewController.swift */,
 				7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */,
 				B5120B371D47CC6C0059361A /* NotificationDetailsViewController.swift */,
@@ -15708,8 +15718,6 @@
 				B52F8CD71B43260C00D36025 /* NotificationSettingStreamsViewController.swift */,
 				B522C4F71B3DA79B00E47B59 /* NotificationSettingsViewController.swift */,
 				9F8E38BD209C6DE200454E3C /* NotificationSiteSubscriptionViewController.swift */,
-				B5DBE4FD1D21A700002E81D3 /* NotificationsViewController.swift */,
-				083683DC2B4859BB00331ED0 /* NotificationsViewModel.swift */,
 				4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */,
 				8236EB4F2024ED8C007C7CF9 /* NotificationsViewController+JetpackPrompt.swift */,
 				4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */,

--- a/WordPress/WordPressTest/NotificationsViewModelTests.swift
+++ b/WordPress/WordPressTest/NotificationsViewModelTests.swift
@@ -49,6 +49,18 @@ final class NotificationsViewModelTests: CoreDataTestCase {
         sut.didChangeDefaultAccount()
         XCTAssertNil(sut.lastSeenTime)
     }
+
+    func testLoadNotificationsReturnsNilWhenIndexIsNegative() {
+        let sut = NotificationsViewModel(userDefaults: sutUserDefaults)
+        let tempNotification = Notification()
+        let result = sut.loadNotification(
+            near: tempNotification,
+            allNotifications: [tempNotification],
+            withIndexDelta: -1
+        )
+
+        XCTAssertNil(result)
+    }
 }
 
 final class MockNotificationSyncMediator: NotificationSyncMediatorProtocol {

--- a/WordPress/WordPressTest/NotificationsViewModelTests.swift
+++ b/WordPress/WordPressTest/NotificationsViewModelTests.swift
@@ -61,6 +61,18 @@ final class NotificationsViewModelTests: CoreDataTestCase {
 
         XCTAssertNil(result)
     }
+
+    func testLoadNotificationsReturnsNilWhenArrayIsEmpty() {
+        let sut = NotificationsViewModel(userDefaults: sutUserDefaults)
+        let tempNotification = Notification()
+        let result = sut.loadNotification(
+            near: tempNotification,
+            allNotifications: [],
+            withIndexDelta: 0
+        )
+
+        XCTAssertNil(result)
+    }
 }
 
 final class MockNotificationSyncMediator: NotificationSyncMediatorProtocol {


### PR DESCRIPTION
Fixes pcdRpT-5aB-p2

## Testing Steps
1. Install & Login to Jetpack app.
2. Navigate to Notifications
3. Tap on a notification
4. ✅ Verify if the details load normally.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit tests

3. What automated tests I added (or what prevented me from doing so)
`testLoadNotificationsReturnsNilWhenIndexIsNegative`
`testLoadNotificationsReturnsNilWhenArrayIsEmpty`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
