### PR TITLE
Site Monitoring: Add compact filters

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactBar.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct FilterCompactBar<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        ScrollView(.horizontal) {
+            HStack {
+                content()
+            }
+            .padding(.horizontal, 16)
+        }
+        .scrollIndicators(.hidden)
+        .listRowSeparator(.hidden, edges: .all)
+        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactBar.swift
@@ -4,13 +4,12 @@ struct FilterCompactBar<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        ScrollView(.horizontal) {
+        ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 content()
             }
             .padding(.horizontal, 16)
         }
-        .scrollIndicators(.hidden)
         .listRowSeparator(.hidden, edges: .all)
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
     }

--- a/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactButton.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactButton.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct FilterCompactButton<Value, Content: View, Label: View>: View {
+    private let title: String
+    @Binding private var selection: Value?
+    private let content: () -> Content
+    private let label: (Value) -> Label
+    private var contentStyle: FilterCompactContentStyle = .popover
+
+    @State private var isShowingPopover = false
+
+    init(_ title: String, selection: Binding<Value?>, @ViewBuilder content: @escaping () -> Content, @ViewBuilder label: @escaping (Value) -> Label) {
+        self.title = title
+        self._selection = selection
+        self.content = content
+        self.label = label
+    }
+
+    /// Sets the style for the content view displayd when the button is tapped.
+    /// The default presentation style is `popover`.
+    ///
+    /// - note: By default, on iPhone, popovers are displayed as sheets. You can
+    /// use `presentationCompactAdaptation` to override this behavior.
+    func contentPresentationStyle(_ style: FilterCompactContentStyle) -> Self {
+        var copy = self
+        copy.contentStyle = style
+        return copy
+    }
+
+    var body: some View {
+        HStack {
+            mainButton
+            clearButton
+        }
+        .buttonStyle(.plain)
+        .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .stroke(Color(uiColor: .separator), lineWidth: 1)
+        )
+        .cornerRadius(40)
+        .popover(isPresented: $isShowingPopover, content: content)
+    }
+
+    @ViewBuilder
+    private var mainButton: some View {
+        let label = makeLabel()
+            .lineLimit(1)
+            .foregroundStyle(Color.primary)
+            .font(.callout)
+        switch contentStyle {
+        case .menu:
+            Menu(content: content) { label }
+        case .popover:
+            Button {
+                isShowingPopover = true
+            } label: {
+                label
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func makeLabel() -> some View {
+        if let selection {
+            label(selection)
+        } else {
+            Text(title)
+        }
+    }
+
+    @ViewBuilder
+    private var clearButton: some View {
+        if selection != nil {
+            Button(action: { selection = nil }) {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .foregroundStyle(Color.secondary)
+        }
+    }
+}
+
+enum FilterCompactContentStyle {
+    case menu
+    case popover
+}
+
+#Preview {
+    FilterCompactButtonPreview()
+}
+
+private struct FilterCompactButtonPreview: View {
+    @State var selection: SampleEnum?
+
+    enum SampleEnum: String, CaseIterable {
+        case a, b, c
+    }
+
+    var body: some View {
+        FilterCompactButton("Example", selection: $selection) {
+            Picker("", selection: $selection) {
+                ForEach(SampleEnum.allCases, id: \.self) {
+                    Text($0.rawValue).tag(Optional.some($0))
+                }
+            }.pickerStyle(.inline)
+        } label: {
+            Text($0.rawValue)
+        }
+        .contentPresentationStyle(.menu)
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactDatePicker.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactDatePicker.swift
@@ -42,8 +42,7 @@ struct FilterCompactDatePicker: View {
                         .navigationBarTitleDisplayMode(.inline)
                     }
                 } else {
-                    picker
-                        .frame(width: 360)
+                    picker.frame(width: 360)
                 }
             }
         } label: { value in
@@ -66,7 +65,7 @@ struct FilterCompactDatePicker: View {
 private struct FilterCompactDatePickerCompatibilityView<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
-    @Environment(\.dismiss) private var dismiss
+    @SwiftUI.Environment(\.dismiss) private var dismiss
 
     var body: some View {
         content()

--- a/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactDatePicker.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactDatePicker.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct FilterCompactDatePicker: View {
+    private let title: String
+    @Binding private var selection: Date?
+    private let range: ClosedRange<Date>
+    private let components: DatePickerComponents
+
+    init(_ title: String,
+         selection: Binding<Date?>,
+         in range: ClosedRange<Date> = Date.distantPast...Date.distantFuture,
+         components: DatePickerComponents = [.date, .hourAndMinute]) {
+        self.title = title
+        self._selection = selection
+        self.range = range
+        self.components = components
+    }
+
+    var body: some View {
+        FilterCompactButton(title, selection: $selection) {
+            let binding = Binding(get: { self.selection ?? Date() }, set: { self.selection = $0 })
+            let picker = DatePicker(title, selection: binding, in: range, displayedComponents: components)
+                .datePickerStyle(.graphical)
+
+            if #available(iOS 16.4, *) {
+                picker
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 10)
+                    .frame(width: 360)
+                    .presentationCompactAdaptation(.popover)
+            } else {
+                if UIDevice.current.userInterfaceIdiom == .phone {
+                    NavigationView {
+                        FilterCompactDatePickerCompatibilityView {
+                            VStack {
+                                picker
+                                    .padding(.horizontal, 8)
+                                Spacer()
+                            }
+                        }
+                        .navigationTitle(title)
+                        .navigationBarTitleDisplayMode(.inline)
+                    }
+                } else {
+                    picker
+                        .frame(width: 360)
+                }
+            }
+        } label: { value in
+            Text(string(from: value))
+        }
+    }
+
+    private func string(from date: Date) -> String {
+        let formatter = DateFormatter()
+        if components.contains(.date) {
+            formatter.dateStyle = .short
+        }
+        if components.contains(.hourAndMinute) {
+            formatter.timeStyle = .short
+        }
+        return formatter.string(from: date)
+    }
+}
+
+private struct FilterCompactDatePickerCompatibilityView<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        content()
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(NSLocalizedString("Done", comment: "A done button")) {
+                        dismiss()
+                    }
+                }
+            }
+    }
+}
+
+#Preview {
+    FilterCompactDatePickerPreview()
+}
+
+private struct FilterCompactDatePickerPreview: View {
+    @State var selection: Date?
+
+    var body: some View {
+        VStack {
+            FilterCompactDatePicker("Start Date", selection: $selection)
+            Spacer()
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -550,6 +550,9 @@
 		0CED20002B6809CB00E6DD52 /* FilterCompactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */; };
 		0CED20022B6809D600E6DD52 /* FilterCompactDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */; };
 		0CED20042B6809E200E6DD52 /* FilterCompactBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED20032B6809E200E6DD52 /* FilterCompactBar.swift */; };
+		0CED20052B681EA400E6DD52 /* FilterCompactBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED20032B6809E200E6DD52 /* FilterCompactBar.swift */; };
+		0CED20062B681EA700E6DD52 /* FilterCompactDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */; };
+		0CED20072B681EB100E6DD52 /* FilterCompactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */; };
 		0CED95602A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		0CF0C4232AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
@@ -23996,6 +23999,7 @@
 				FABB21262602FC2C00C8785C /* UIViewController+ChildViewController.swift in Sources */,
 				FABB21272602FC2C00C8785C /* Media+Blog.swift in Sources */,
 				FABB21282602FC2C00C8785C /* MenuItemEditingHeaderView.m in Sources */,
+				0CED20072B681EB100E6DD52 /* FilterCompactButton.swift in Sources */,
 				3F8B45AB292C42CC00730FA4 /* MigrationSuccessCell.swift in Sources */,
 				803BB984295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift in Sources */,
 				FABB21292602FC2C00C8785C /* Routes+Banners.swift in Sources */,
@@ -24656,6 +24660,7 @@
 				FABB23052602FC2C00C8785C /* WPAnalyticsEvent.swift in Sources */,
 				FABB23062602FC2C00C8785C /* Coordinate.m in Sources */,
 				F1D8C6EC26BABE3E002E3323 /* WeeklyRoundupDebugScreen.swift in Sources */,
+				0CED20052B681EA400E6DD52 /* FilterCompactBar.swift in Sources */,
 				0C896DE52A3A7C1F00D7D4E7 /* SiteVisibility+Extensions.swift in Sources */,
 				FABB23072602FC2C00C8785C /* SiteCreationRotatingMessageView.swift in Sources */,
 				FABB23082602FC2C00C8785C /* SignupUsernameViewController.swift in Sources */,
@@ -24994,6 +24999,7 @@
 				0C01A6EB2AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift in Sources */,
 				FABB24062602FC2C00C8785C /* UploadOperation.swift in Sources */,
 				FABB24072602FC2C00C8785C /* LayoutPickerAnalyticsEvent.swift in Sources */,
+				0CED20062B681EA700E6DD52 /* FilterCompactDatePicker.swift in Sources */,
 				F465462D2AEF22070017E3D1 /* AllDomainsListViewModel+Strings.swift in Sources */,
 				FABB24082602FC2C00C8785C /* ActivityRange.swift in Sources */,
 				FABB24092602FC2C00C8785C /* DiffAbstractValue+Attributes.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -547,6 +547,9 @@
 		0CE7833E2B08F3C300B114EB /* ExternalMediaPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */; };
 		0CE783412B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
 		0CE783422B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
+		0CED20002B6809CB00E6DD52 /* FilterCompactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */; };
+		0CED20022B6809D600E6DD52 /* FilterCompactDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */; };
+		0CED20042B6809E200E6DD52 /* FilterCompactBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED20032B6809E200E6DD52 /* FilterCompactBar.swift */; };
 		0CED95602A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		0CF0C4232AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
@@ -6202,6 +6205,9 @@
 		0CE58A2C2B35C91900E87D1E /* SiteMediaPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPreviewViewController.swift; sourceTree = "<group>"; };
 		0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerViewController.swift; sourceTree = "<group>"; };
 		0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerCollectionCell.swift; sourceTree = "<group>"; };
+		0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactButton.swift; sourceTree = "<group>"; };
+		0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactDatePicker.swift; sourceTree = "<group>"; };
+		0CED20032B6809E200E6DD52 /* FilterCompactBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactBar.swift; sourceTree = "<group>"; };
 		0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFeatureFlagsView.swift; sourceTree = "<group>"; };
 		0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostHelper.swift; sourceTree = "<group>"; };
 		0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageServiceTests.swift; sourceTree = "<group>"; };
@@ -10348,6 +10354,16 @@
 			path = External;
 			sourceTree = "<group>";
 		};
+		0CED1FFE2B6809C100E6DD52 /* FilterCompact */ = {
+			isa = PBXGroup;
+			children = (
+				0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */,
+				0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */,
+				0CED20032B6809E200E6DD52 /* FilterCompactBar.swift */,
+			);
+			path = FilterCompact;
+			sourceTree = "<group>";
+		};
 		1705CEE6260A57F900F23763 /* ContentViews */ = {
 			isa = PBXGroup;
 			children = (
@@ -13752,6 +13768,7 @@
 		8584FDB619243AC40019C02E /* System */ = {
 			isa = PBXGroup;
 			children = (
+				0CED1FFE2B6809C100E6DD52 /* FilterCompact */,
 				F5E032E22408D537003AF350 /* Action Sheet */,
 				F551E7F323F6EA1400751212 /* Floating Create Button */,
 				17A4A36A20EE551F0071C2CA /* Coordinators */,
@@ -21037,6 +21054,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */,
+				0CED20022B6809D600E6DD52 /* FilterCompactDatePicker.swift in Sources */,
 				B50C0C621EF42AF200372C65 /* TextList+WordPress.swift in Sources */,
 				B5722E421D51A28100F40C5E /* Notification.swift in Sources */,
 				1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */,
@@ -21490,6 +21508,7 @@
 				73CB13972289BEFB00265F49 /* Charts+LargeValueFormatter.swift in Sources */,
 				F4FF50E92B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift in Sources */,
 				ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */,
+				0CED20042B6809E200E6DD52 /* FilterCompactBar.swift in Sources */,
 				084A07062848E1820054508A /* FeatureHighlightStore.swift in Sources */,
 				17B7C89E20EC1D0D0042E260 /* UniversalLinkRouter.swift in Sources */,
 				F59AAC16235EA46D00385EE6 /* LightNavigationController.swift in Sources */,
@@ -21531,6 +21550,7 @@
 				3F8B45A8292C1F2500730FA4 /* MigrationSuccessCardView.swift in Sources */,
 				DC772AF5282009BA00664C02 /* StatsLineChartView.swift in Sources */,
 				74729CAE205722E300D1394D /* AbstractPost+Searchable.swift in Sources */,
+				0CED20002B6809CB00E6DD52 /* FilterCompactButton.swift in Sources */,
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
 				0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */,
 				F16C35DA23F3F76C00C81331 /* PostAutoUploadMessageProvider.swift in Sources */,


### PR DESCRIPTION
Adds components to implement filters on the PHP logs screen.

To test: n/a

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/d55db41a-e832-4557-a819-1df0ad99e4b9

Usage:

```swift
    @State private var searchCriteria = SiteLogsSearcCriteria()

    var body: some View {
        List {
            filterBar
           ...
        }
        .onChange(of: searchCriteria) { _, value in
            print("refresh: \(value)") // Have to use value from the closure
        }

    private var filterBar: some View {
        FilterCompactBar {
            FilterCompactDatePicker(Strings.filterStartDate, selection: $searchCriteria.startDate, in: Date.distantPast...(searchCriteria.endDate ?? Date.now))

            FilterCompactDatePicker(Strings.filterEndDate, selection: $searchCriteria.endDate, in: (searchCriteria.startDate ?? Date.distantPast)...Date.now)

            FilterCompactButton(Strings.filterSeverity, selection: $searchCriteria.severity) {
                Picker("", selection: $searchCriteria.severity) {
                    let cases = [AtomicErrorLogEntry.Severity.user, .warning, .deprecated, .fatalError]
                    ForEach(cases, id: \.self) {
                        Text($0.localizedTitle).tag(Optional.some($0))
                    }
                }.pickerStyle(.inline)
            } label: {
                Text($0.localizedTitle)
            }
            .contentPresentationStyle(.menu)
        }
    }
}

private struct SiteLogsSearcCriteria: Equatable {
    var startDate: Date?
    var endDate: Date?
    var severity: AtomicErrorLogEntry.Severity?
}

extension AtomicErrorLogEntry.Severity {
    var localizedTitle: String {
        switch self {
        case .user: NSLocalizedString("phpLogs.severityUser", value: "User", comment: "A title for the log serverity level")
        case .warning: NSLocalizedString("phpLogs.severityWarning", value: "Warning", comment: "A title for the log serverity level")
        case .deprecated: NSLocalizedString("phpLogs.severityDeprecated", value: "Deprecated", comment: "A title for the log serverity level")
        case .fatalError: NSLocalizedString("phpLogs.severityFatalError", value: "Fatal Error", comment: "A title for the log serverity level")
        }
    }
}

private enum Strings {
    static let filterStartDate = NSLocalizedString("phpLogs.filterStartDate", value: "Start Date", comment: "A title for the filter on the PHP logs screen")
    static let filterEndDate = NSLocalizedString("phpLogs.filterEndDate", value: "End Date", comment: "A title for the filter on the PHP logs screen")
    static let filterSeverity = NSLocalizedString("phpLogs.filterSeverity", value: "Severity", comment: "A title for the filter on the PHP logs screen")
}

```


## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
