### PR TITLE
Fix: Hide Jetpack Social row if there are no publicize services

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -5,7 +5,7 @@ extension PrepublishingViewController {
     /// Determines whether the account and the post's blog is eligible to see the Jetpack Social row.
     func canDisplaySocialRow(isJetpack: Bool = AppConfiguration.isJetpack,
                              isFeatureEnabled: Bool = RemoteFeatureFlag.jetpackSocialImprovements.enabled()) -> Bool {
-        guard isJetpack && isFeatureEnabled && !isPostPrivate else {
+        guard isJetpack && isFeatureEnabled && !isPostPrivate && hasPublicizeServices else {
             return false
         }
 
@@ -73,6 +73,15 @@ private extension PrepublishingViewController {
             var dictionary = (persistentStore.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool]) ?? .init()
             dictionary["\(postBlogID)"] = newValue
             persistentStore.set(dictionary, forKey: Constants.noConnectionKey)
+        }
+    }
+
+    var hasPublicizeServices: Bool {
+        coreDataStack.performQuery { context in
+            guard let services = (try? PublicizeService.allSupportedServices(in: context)) else {
+                return false
+            }
+            return !services.isEmpty
         }
     }
 


### PR DESCRIPTION
As titled, this hides the Jetpack Social row in the Prepublishing Sheet if the user somehow has 0 external services. As we're targeting the beta, I'm keeping the changes small and scoped to the Prepublishing Sheet, to avoid potential side effects.

## To test

To simulate the "0 external services" state, you need to mock it via code or intercept through Charles. To mock the response via code, you can change the line below to `return []`:

https://github.com/wordpress-mobile/WordPress-iOS/blob/e4530ccb031a9d2402aa517f3994b1e6ad8b4399/WordPress/Classes/Models/PublicizeService%2BLookup.swift#L42

Otherwise, if you prefer mocking via Charles, you'd need to mock `/wpcom/v2/sites/(siteID)/external-services` and return:

```json
{
  "services": {}
}
```

- Launch the Jetpack app.
- Start a new draft post.
- Enter some title and text.
- Tap Publish.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
