### PR TITLE
Site Monitoring: Some enhancements

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringEntryDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringEntryDetailsView.swift
@@ -2,18 +2,10 @@ import SwiftUI
 
 @available(iOS 16, *)
 struct SiteMonitoringEntryDetailsView: View {
-    private let text: NSAttributedString
-
-    init(entry: AtomicErrorLogEntry) {
-        self.text = makeAttributedText(for: entry)
-    }
-
-    init(entry: AtomicWebServerLogEntry) {
-        self.text = makeAttributedText(for: entry)
-    }
+    let text: NSAttributedString
 
     var body: some View {
-        TextView(text: text)
+        SiteMonitoringTextView(text: text)
             .navigationTitle(Strings.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -24,8 +16,9 @@ struct SiteMonitoringEntryDetailsView: View {
     }
 }
 
-private struct TextView: UIViewRepresentable {
+private struct SiteMonitoringTextView: UIViewRepresentable {
     let text: NSAttributedString
+    var isScrollEnabled = true
 
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
@@ -41,29 +34,33 @@ private struct TextView: UIViewRepresentable {
     }
 }
 
-private func makeAttributedText(for entry: AtomicErrorLogEntry) -> NSAttributedString {
-    makeAttributedText(metadata: [
-        (Strings.metadataKeyTimestamp, entry.timestamp.map(makeString)),
-        (Strings.metadataKeyKind, entry.kind),
-        (Strings.metadataKeyName, entry.name),
-        (Strings.metadataKeyFile, entry.file),
-        (Strings.metadataKeyLine, entry.line?.description)
-    ], message: entry.message)
+extension AtomicErrorLogEntry {
+    var attributedDescription: NSAttributedString {
+        makeAttributedText(metadata: [
+            (Strings.metadataKeyTimestamp, timestamp.map(makeString)),
+            (Strings.metadataKeyKind, kind),
+            (Strings.metadataKeyName, name),
+            (Strings.metadataKeyFile, file),
+            (Strings.metadataKeyLine, line?.description)
+        ], message: message)
+    }
 }
 
-private func makeAttributedText(for entry: AtomicWebServerLogEntry) -> NSAttributedString {
-    makeAttributedText(metadata: [
-        (Strings.metadataKeyRequestURL, entry.requestUrl),
-        (Strings.metadataKeyStatus, entry.status?.description),
-        (Strings.metadataKeyTimestamp, entry.date.map(makeString)),
-        (Strings.metadataKeyResponseBodySize, entry.bodyBytesSent.map {
-            ByteCountFormatter().string(fromByteCount: Int64($0))
-        }),
-        (Strings.metadataKeyRequestTime, entry.requestTime.map(makeString)),
-        (Strings.metadataKeyCached, (entry.cached == "true").description),
-        (Strings.metadataKeyHTTPHost, entry.httpHost),
-        (Strings.metadataKeyReferrer, entry.httpReferer)
-    ])
+extension AtomicWebServerLogEntry {
+    var attributedDescription: NSAttributedString {
+        makeAttributedText(metadata: [
+            (Strings.metadataKeyRequestURL, requestUrl),
+            (Strings.metadataKeyStatus, status?.description),
+            (Strings.metadataKeyTimestamp, date.map(makeString)),
+            (Strings.metadataKeyResponseBodySize, bodyBytesSent.map {
+                ByteCountFormatter().string(fromByteCount: Int64($0))
+            }),
+            (Strings.metadataKeyRequestTime, requestTime.map(makeString)),
+            (Strings.metadataKeyCached, (cached == "true").description),
+            (Strings.metadataKeyHTTPHost, httpHost),
+            (Strings.metadataKeyReferrer, httpReferer)
+        ])
+    }
 }
 
 private func makeAttributedText(metadata: [(String, String?)], message: String? = nil) -> NSAttributedString {
@@ -119,7 +116,7 @@ private enum Strings {
 #Preview("AtomicErrorLogEntry") {
     NavigationView {
         if #available(iOS 16, *) {
-            SiteMonitoringEntryDetailsView(entry: errorLogEntry)
+            SiteMonitoringEntryDetailsView(text: errorLogEntry.attributedDescription)
         }
     }
 }
@@ -127,7 +124,7 @@ private enum Strings {
 #Preview("AtomicWebServerLogEntry") {
     NavigationView {
         if #available(iOS 16, *) {
-            SiteMonitoringEntryDetailsView(entry: serverLogEntry)
+            SiteMonitoringEntryDetailsView(text: serverLogEntry.attributedDescription)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
@@ -6,17 +6,20 @@ import UIKit
 struct WebServerLogsView: View {
     @StateObject var viewModel: WebServerLogsViewModel
     @State private var searchCriteria = WebServerLogsSearchCriteria(startDate: Date.oneWeekAgo)
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
 
     var body: some View {
-        VStack {
-            filterBar
-            Spacer()
+        VStack(spacing: 0) {
+            VStack(spacing: 8) {
+                filterBar
+                Divider()
+            }
+            .background(colorScheme == .dark ? Color(uiColor: .secondarySystemBackground) : nil)
             main
-            Spacer()
         }
-        .onAppear(perform: {
+        .onAppear {
             loadLogs(searchCriteria: searchCriteria)
-        })
+        }
         .onChange(of: searchCriteria) { value in
             loadLogs(searchCriteria: value, reset: true)
         }
@@ -25,12 +28,10 @@ struct WebServerLogsView: View {
     @ViewBuilder
     private var main: some View {
         if viewModel.loadedLogs.isEmpty {
-            if viewModel.isLoading {
-                ProgressView()
-            } else if viewModel.error != nil {
-                NoAtomicLogsView(state: .error(reload))
-            } else {
-                NoAtomicLogsView(state: .empty)
+            VStack {
+                Spacer()
+                stateView
+                Spacer()
             }
         } else {
             List {
@@ -45,6 +46,17 @@ struct WebServerLogsView: View {
                 .listSectionSeparator(.hidden, edges: .bottom)
             }
             .listStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var stateView: some View {
+        if viewModel.isLoading {
+            ProgressView()
+        } else if viewModel.error != nil {
+            NoAtomicLogsView(state: .error(reload))
+        } else {
+            NoAtomicLogsView(state: .empty)
         }
     }
 
@@ -102,28 +114,24 @@ struct WebServerLogsView: View {
     }
 
     private func makeRow(for entry: AtomicWebServerLogEntry) -> some View {
-        NavigationLink(destination: { SiteMonitoringEntryDetailsView(entry: entry) }) {
-            VStack(alignment: .leading) {
-                HStack {
-                    Text(entry.requestType ?? "")
-                        .font(.system(size: 12, design: .monospaced))
-                        .textCase(.uppercase)
-                        .padding(4)
-                        .foregroundColor(Color(uiColor: entry.requestTypeTextColor))
-                        .background(Color(uiColor: entry.requestTypeBackgroundColor))
-                        .cornerRadius(4)
-                    Text(entry.status.flatMap(String.init) ?? "")
-                        .font(.system(size: 12, design: .monospaced))
-                        .textCase(.uppercase)
-                    Spacer()
-                    Text((entry.date?.mediumStringWithTime()) ?? "")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+        let attributedDescription = entry.attributedDescription
+        return NavigationLink(destination: { SiteMonitoringEntryDetailsView(text: attributedDescription) }) {
+            WebServerLogsRowView(entry: entry)
+                .swipeActions(edge: .trailing) {
+                    ShareLink(item: attributedDescription.string) {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                    .tint(Color.blue)
                 }
-                Text(entry.requestUrl ?? "")
-                    .font(.system(size: 15))
-                    .lineLimit(3)
-            }
+                .contextMenu {
+                    ShareLink(item: attributedDescription.string) {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                } preview: {
+                    Text(AttributedString(attributedDescription))
+                        .frame(width: 320)
+                        .padding()
+                }
         }
     }
 
@@ -135,6 +143,34 @@ struct WebServerLogsView: View {
 
     private func reload() {
         loadLogs(searchCriteria: searchCriteria, reset: true)
+    }
+}
+
+private struct WebServerLogsRowView: View {
+    let entry: AtomicWebServerLogEntry
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text(entry.requestType ?? "")
+                    .font(.system(.caption, design: .monospaced))
+                    .textCase(.uppercase)
+                    .padding(4)
+                    .foregroundColor(Color(uiColor: entry.requestTypeTextColor))
+                    .background(Color(uiColor: entry.requestTypeBackgroundColor))
+                    .cornerRadius(4)
+                Text(entry.status.flatMap(String.init) ?? "")
+                    .font(.system(.caption, design: .monospaced))
+                    .textCase(.uppercase)
+                Spacer()
+                Text((entry.date?.mediumStringWithTime()) ?? "")
+                    .font(.system(.footnote))
+                    .foregroundStyle(.secondary)
+            }
+            Text(entry.requestUrl ?? "")
+                .font(.system(.subheadline))
+                .lineLimit(3)
+        }
     }
 }
 
@@ -173,9 +209,12 @@ final class WebServerLogsViewModel: ObservableObject {
         error = nil
 
         do {
+            let endDate = searchCriteria.endDate ?? Date.now
+            let startDate = searchCriteria.startDate ?? (Calendar.current.date(byAdding: .weekOfYear, value: -1, to: endDate) ?? endDate)
+
             let response = try await atomicSiteService.webServerLogs(
                 siteID: siteID,
-                range: (searchCriteria.startDate ?? Date.oneWeekAgo)..<(searchCriteria.endDate ?? Date.now),
+                range: startDate..<endDate,
                 httpMethod: searchCriteria.requestType,
                 statusCode: searchCriteria.status,
                 scrollID: scrollId

--- a/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactButton.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterCompact/FilterCompactButton.swift
@@ -47,7 +47,7 @@ struct FilterCompactButton<Value, Content: View, Label: View>: View {
         let label = makeLabel()
             .lineLimit(1)
             .foregroundStyle(Color.primary)
-            .font(.callout)
+            .font(.subheadline)
         switch contentStyle {
         case .menu:
             Menu(content: content) { label }


### PR DESCRIPTION
- Slightly reduce the `FilterCompactButton` font
- Add divider to the filter bar since it's now fixed at the top and attempted to fix the dark mode appearance of this bar; I'm not sure it's the best solution as it'll likely break in future versions. I think it's probably easier to just stick this bar in the list.
- Extract row views (just for clarity)
- Add context menus and previews and swipe actions
- Add dynamic type support
- Fix a crash when you select an "End Date" that is before the default "Start Date" ("Start Date" not selected). I'm not sure the solution is ideal because it's not clear from the UI what range gets displayed. Maybe you should be able to clear the start and end date like on the web?

I wanted to also fix a potential performance n `NavigationLink(destination: { SiteMonitoringEntryDetailsView(entry: entry) })`. The `destination` closure gets called when `NavigationLink` is created, not when the new view is pushed, which is an odd design choice (it was fixed in iOS 17 with the introduction of the new navigation APIs). However since I also added context menus and previews that also get called when the view is created, it should be OK.

<img width="360" alt="Screenshot 2024-01-30 at 7 51 35 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/7cad29fb-a219-4294-8ead-2cc817842753">
<img width="360" alt="Screenshot 2024-01-30 at 7 51 39 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/baf8e831-bbac-4a15-985e-0d44743eef33">
<img width="360" alt="Screenshot 2024-01-30 at 7 51 41 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/771b4670-4ed9-4adc-8227-030e5c650b79">
<img width="360" alt="Screenshot 2024-01-30 at 7 56 11 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/73fbf56e-29b2-4fb4-9c65-17a9790a3f23">


To test: n/a

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
