### PR TITLE
Add CI automation to drive hotfix releases

### DIFF
--- a/.buildkite/commands/finalize-hotfix.sh
+++ b/.buildkite/commands/finalize-hotfix.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+RELEASE_NUMBER=$1
+
+if [[ -z "${RELEASE_NUMBER}" ]]; then
+    echo "Usage $0 <release number>"
+    exit 1
+fi
+
+echo '--- :git: Configure Git for release management'
+.buildkite/commands/configure-git-for-release-management.sh
+
+echo '--- :git: Checkout release branch'
+.buildkite/commands/checkout-release-branch.sh "$RELEASE_NUMBER"
+
+echo '--- :ruby: Setup Ruby tools'
+install_gems
+
+echo '--- :closed_lock_with_key: Access secrets'
+bundle exec fastlane run configure_apply
+
+echo '--- :shipit: Finalize hotfix'
+bundle exec fastlane finalize_hotfix_release skip_confirm:true

--- a/.buildkite/release-pipelines/finalize-hotfix.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: Finalize Release
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The finalization needs to run on macOS because of localization linting
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-15.1
+    command: ".buildkite/commands/finalize-hotfix.sh $VERSION"

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -1,0 +1,21 @@
+steps:
+  - label: New Hotfix Deployment
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The beta needs to run on macOS because it uses genstrings under the hood
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-15.1
+    command: |
+      echo '--- :git: Configure Git for release management'
+      .buildkite/commands/configure-git-for-release-management.sh
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :closed_lock_with_key: Access secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :shipit: Start new hotfix'
+      bundle exec fastlane new_hotfix_release skip_confirm:true version:"$VERSION"

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -78,12 +78,28 @@ platform :ios do
 
   lane :trigger_new_hotfix_in_ci do |options|
     version = extract_hotfix_version_from_lane_options!(options)
-    UI.message("TODO: Will start hotfix #{version}")
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version:),
+      pipeline_file: File.join(PIPELINES_ROOT, 'new-hotfix.yml'),
+      message: "Set up new hotfix version #{version}",
+      environment: { VERSION: version }
+    )
   end
 
   lane :trigger_finalize_hotfix_in_ci do |options|
     version = extract_hotfix_version_from_lane_options!(options)
-    UI.message("TODO: Will finish hotfix #{version}")
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version:),
+      pipeline_file: File.join(PIPELINES_ROOT, 'finalize-hotfix.yml'),
+      message: "Finalize hotfix version #{version}",
+      environment: { VERSION: version }
+    )
   end
 end
 

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -75,4 +75,12 @@ platform :ios do
       environment: { RELEASE_VERSION: release_version }
     )
   end
+
+  lane :trigger_new_hotfix_in_ci do
+    UI.message('TODO')
+  end
+
+  lane :trigger_finalize_hotfix_in_ci do
+    UI.message('TODO')
+  end
 end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -76,11 +76,22 @@ platform :ios do
     )
   end
 
-  lane :trigger_new_hotfix_in_ci do
-    UI.message('TODO')
+  lane :trigger_new_hotfix_in_ci do |options|
+    version = extract_hotfix_version_from_lane_options!(options)
+    UI.message("TODO: Will start hotfix #{version}")
   end
 
-  lane :trigger_finalize_hotfix_in_ci do
-    UI.message('TODO')
+  lane :trigger_finalize_hotfix_in_ci do |options|
+    version = extract_hotfix_version_from_lane_options!(options)
+    UI.message("TODO: Will finish hotfix #{version}")
   end
+end
+
+def extract_hotfix_version_from_lane_options!(options)
+  version_key = :version
+  version = options[version_key]
+
+  UI.user_error!("You must specify a version for the hotfix by calling this lane with a '#{version_key}:' parameter.") unless version
+
+  version
 end


### PR DESCRIPTION
Adds lanes and pipelines to run the hotfix release cycle in CI.

I tested the flow with https://github.com/wordpress-mobile/WordPress-iOS/pull/22608 and left notes about how it behaved accordingly to my expectations.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.