### PR TITLE
Reader: Hide no results view if there's content

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v2_read_tags_cards.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v2_read_tags_cards.json
@@ -3959,8 +3959,7 @@
             "use_excerpt": false
           }
         }
-      ],
-      "next_page_handle": "ZnJvbT04JnJlZnJlc2g9MQ=="
+      ]
     },
     "headers": {
       "Content-Type": "application/json",

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1562,6 +1562,8 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
     func tableViewDidChangeContent(_ tableView: UITableView) {
         if content.contentCount == 0 {
             displayNoResultsView()
+        } else {
+            hideResultsStatus()
         }
     }
 


### PR DESCRIPTION
Fixes #22510

## Description

Hides the no results view when the table view has content to display.

## Testing

To test:
- Set up an account with no subscribed blogs
- Launch Jetpack and login
- Navigate to the `Subscriptions` feed
- Tap on the `0 Blogs` button
- Search or manually subscribe to a blog
- Dismiss screens until back at the `Subscriptions` feed
- 🔎 **Verify** the no results view is now hidden and content is loaded for the newly followed blog

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
