### PR TITLE
Reader: Bump compression resistance of the title and summary

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -276,6 +276,7 @@ private extension ReaderPostCardCell {
         postTitleLabel.translatesAutoresizingMaskIntoConstraints = false
         postTitleLabel.font = .preferredFont(forTextStyle: .title3).semibold()
         postTitleLabel.numberOfLines = 2
+        postTitleLabel.setContentCompressionResistancePriority(.defaultHigh + 2, for: .vertical)
         contentStackView.addArrangedSubview(postTitleLabel)
     }
 
@@ -283,6 +284,7 @@ private extension ReaderPostCardCell {
         postSummaryLabel.translatesAutoresizingMaskIntoConstraints = false
         postSummaryLabel.font = .preferredFont(forTextStyle: .footnote)
         postSummaryLabel.numberOfLines = 3
+        postSummaryLabel.setContentCompressionResistancePriority(.defaultHigh + 1, for: .vertical)
         contentStackView.addArrangedSubview(postSummaryLabel)
     }
 


### PR DESCRIPTION
Fixes #22210 

This addresses an issue where the post titles in the Reader stream sometimes appear truncated after cell reuse (e.g. from scrolling up and down). When running a visual debugger, it seems that the cell height shrinks by around 0.5pt, which causes the title to wrap into 1 line due to the fractional height difference.

To solve this, I bumped the compression resistance for the title & summary. This means the featured image (if it exists) will be the one that's going to shrink (probably by around 1pt). I'm not sure what causes this to happen, but I suspect there's some weird behavior with multi-line labels and stack views.

Also, it's interesting that this issue only happens on real devices. It never happens on the Simulator.

## To test

- Launch the Jetpack app on a test device.
- Go to Reader.
- Scroll the stream, switch tabs, and return.
- 🔎  Verify that multi-line post titles and summaries are not truncated.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
