### PR TITLE
Site Monitoring: Reorder site monitoring row

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1165,18 +1165,17 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *thirdSectionRows = [NSMutableArray array];
 
     // The 1st section
-    if ([RemoteFeature enabled:RemoteFeatureFlagSiteMonitoring] && [self.blog supports:BlogFeatureSiteMonitoring]) {
-        [firstSectionRows addObject:[self siteMonitoringRow]];
-    }
     if ([self.blog supports:BlogFeatureActivity] && ![self.blog isWPForTeams]) {
         [firstSectionRows addObject:[self activityRow]];
     }
     if ([self.blog isBackupsAllowed]) {
         [firstSectionRows addObject:[self backupRow]];
     }
-
     if ([self.blog isScanAllowed]) {
         [firstSectionRows addObject:[self scanRow]];
+    }
+    if ([RemoteFeature enabled:RemoteFeatureFlagSiteMonitoring] && [self.blog supports:BlogFeatureSiteMonitoring]) {
+        [firstSectionRows addObject:[self siteMonitoringRow]];
     }
 
     // The 2nd section

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/PHPLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/PHPLogsView.swift
@@ -5,7 +5,7 @@ import UIKit
 @available(iOS 16, *)
 struct PHPLogsView: View {
     @StateObject var viewModel: PHPLogsViewModel
-    @State private var searchCriteria = PHPLogsSearchCriteria(startDate: Date.oneWeekAgo)
+    @State private var searchCriteria = PHPLogsSearchCriteria(startDate: Date.oneWeekAgo())
     @Environment(\.colorScheme) var colorScheme: ColorScheme
 
     var body: some View {
@@ -200,7 +200,7 @@ final class PHPLogsViewModel: ObservableObject {
 
         do {
             let endDate = searchCriteria.endDate ?? Date.now
-            let startDate = searchCriteria.startDate ?? (Calendar.current.date(byAdding: .weekOfYear, value: -1, to: endDate) ?? endDate)
+            let startDate = searchCriteria.startDate ?? Date.oneWeekAgo(from: endDate)
 
             let response = try await atomicSiteService.errorLogs(
                 siteID: siteID,

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
@@ -92,5 +92,7 @@ private enum Strings {
 }
 
 extension Date {
-    static let oneWeekAgo = Calendar.current.date(byAdding: .weekOfYear, value: -1, to: Date.now) ?? Date()
+    static func oneWeekAgo(from date: Date = Date.now) -> Date {
+        Calendar.current.date(byAdding: .weekOfYear, value: -1, to: Date.now) ?? date
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
@@ -5,7 +5,7 @@ import UIKit
 @available(iOS 16, *)
 struct WebServerLogsView: View {
     @StateObject var viewModel: WebServerLogsViewModel
-    @State private var searchCriteria = WebServerLogsSearchCriteria(startDate: Date.oneWeekAgo)
+    @State private var searchCriteria = WebServerLogsSearchCriteria(startDate: Date.oneWeekAgo())
     @Environment(\.colorScheme) var colorScheme: ColorScheme
 
     var body: some View {
@@ -214,7 +214,7 @@ final class WebServerLogsViewModel: ObservableObject {
 
         do {
             let endDate = searchCriteria.endDate ?? Date.now
-            let startDate = searchCriteria.startDate ?? (Calendar.current.date(byAdding: .weekOfYear, value: -1, to: endDate) ?? endDate)
+            let startDate = searchCriteria.startDate ?? Date.oneWeekAgo(from: endDate)
 
             let response = try await atomicSiteService.webServerLogs(
                 siteID: siteID,

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
@@ -238,8 +238,7 @@ extension AtomicWebServerLogEntry: Identifiable {
     var requestTypeBackgroundColor: UIColor {
         switch requestType {
         case "GET": return .muriel(name: .green, .shade5)
-        case "HEAD": return .muriel(name: .gray, .shade5)
-        case "PUT": return .muriel(name: .yellow, .shade5)
+        case "HEAD", "PUT": return .muriel(name: .gray, .shade5)
         case "POST": return .muriel(name: .blue, .shade5)
         case "DELETE": return .muriel(name: .red, .shade5)
         default: return .clear
@@ -249,8 +248,7 @@ extension AtomicWebServerLogEntry: Identifiable {
     var requestTypeTextColor: UIColor {
         switch requestType {
         case "GET": return .muriel(name: .green, .shade80)
-        case "HEAD": return .muriel(name: .gray, .shade80)
-        case "PUT": return .muriel(name: .yellow, .shade80)
+        case "HEAD", "PUT": return .muriel(name: .gray, .shade80)
         case "POST": return .muriel(name: .blue, .shade80)
         case "DELETE": return .muriel(name: .red, .shade80)
         default: return .clear


### PR DESCRIPTION
## Description
- Reorders site monitoring row to appear below activity log/backup/scan (ref: p1706783341392669-slack-C06EFHCP0PN)
- Updates PUT badge color (ref: p1706783177260779-slack-C06EFHCP0PN)

## How to test
- Verify site monitoring is shown below activity log/backup/scan

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
