### PR TITLE
Reader: Fix Navigation Button text being truncated while in transition

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
@@ -46,6 +46,7 @@ struct ReaderNavigationButton: View {
             Text(item.title)
                 .foregroundStyle(Colors.primary)
                 .font(.subheadline.weight(.semibold))
+                .minimumScaleFactor(0.1) // prevents the text from truncating while in transition.
                 .frame(minHeight: 24.0)
             Image("reader-menu-chevron-down")
                 .frame(width: 16.0, height: 16.0)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -28,6 +28,7 @@ struct ReaderNavigationMenu: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     ReaderNavigationButton(viewModel: viewModel)
+                        .animation(.easeInOut, value: viewModel.selectedItem)
                     streamFilterView
                 }
             }


### PR DESCRIPTION
As titled, this adds a workaround to make the text animation feel smoother. The truncation effect is noticeable and feels janky when going to a longer text (e.g. from Discover -> Subscriptions). Below is a before/after comparison:

Before | After
-|-
![before_navbutton](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/afd4c0a0-1455-4515-8761-8fd645b576c0) | ![after_navbutton](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/0eccc23b-22cb-48d6-896a-87360cf22092)

## To test

- Launch the Jetpack app
- Go to the Reader tab
- Switch to the Subscriptions stream
- 🔎 Observe that the text no longer gets truncated during transition 

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
