### PR TITLE
UI Test: Update Follow terms to Subscribe

### DIFF
--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -46,8 +46,8 @@ class ReaderTests: XCTestCase {
             .switchToStream(.discover)
             .selectTopic()
             .verifyTopicLoaded()
-            .followTopic()
-            .verifyTopicFollowed()
+            .subscribeToTopic()
+            .verifyTopicSubscribed()
     }
 
     func testSavePost() throws {

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -39,11 +39,11 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Dismiss"]
     }
 
-    private let followButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let subscribeButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Subscribe"]
     }
 
-    private let followingButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let subscribedButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["Subscribed"]
     }
 
@@ -80,8 +80,8 @@ public class ReaderScreen: ScreenObject {
     var discoverButton: XCUIElement { discoverButtonGetter(app) }
     var dismissButton: XCUIElement { dismissButtonGetter(app) }
     var firstPostLikeButton: XCUIElement { firstPostLikeButtonGetter(app) }
-    var followButton: XCUIElement { followButtonGetter(app) }
-    var followingButton: XCUIElement { followingButtonGetter(app) }
+    var subscribeButton: XCUIElement { subscribeButtonGetter(app) }
+    var subscribedButton: XCUIElement { subscribedButtonGetter(app) }
     var subscriptionsMenuButton: XCUIElement { subscriptionsMenuButtonGetter(app) }
     var likesTabButton: XCUIElement { likesTabButtonGetter(app) }
     var noResultsView: XCUIElement { noResultsViewGetter(app) }
@@ -167,13 +167,13 @@ public class ReaderScreen: ScreenObject {
 
     public func verifyTopicLoaded(file: StaticString = #file, line: UInt = #line) -> Self {
         XCTAssertTrue(readerButton.waitForExistence(timeout: 3), file: file, line: line)
-        XCTAssertTrue(followButton.waitForExistence(timeout: 3), file: file, line: line)
+        XCTAssertTrue(subscribeButton.waitForExistence(timeout: 3), file: file, line: line)
 
         return self
     }
 
-    public func followTopic() -> Self {
-        waitForExistenceAndTap(followButton, timeout: 3)
+    public func subscribeToTopic() -> Self {
+        waitForExistenceAndTap(subscribeButton, timeout: 3)
 
         return self
     }
@@ -222,9 +222,9 @@ public class ReaderScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifyTopicFollowed(file: StaticString = #file, line: UInt = #line) -> Self {
-        XCTAssertTrue(followingButton.waitForExistence(timeout: 3), file: file, line: line)
-        XCTAssertTrue(followingButton.isSelected, file: file, line: line)
+    public func verifyTopicSubscribed(file: StaticString = #file, line: UInt = #line) -> Self {
+        XCTAssertTrue(subscribedButton.waitForExistence(timeout: 3), file: file, line: line)
+        XCTAssertTrue(subscribedButton.isSelected, file: file, line: line)
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -40,11 +40,11 @@ public class ReaderScreen: ScreenObject {
     }
 
     private let followButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Follow"]
+        $0.buttons["Subscribe"]
     }
 
     private let followingButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Following"]
+        $0.buttons["Subscribed"]
     }
 
     private let subscriptionsMenuButtonGetter: (XCUIApplication) -> XCUIElement = {


### PR DESCRIPTION
Fixes another UI testing error where the test case looks for the "Follow" button after it's been updated to "Subscribe".

## To test

- Run the `testFollowNewTopicOnDiscover` test case.
- 🔎  Verify that it passes.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The Follow button getters are isolated to the `ReaderTests` suite.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes locally.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
