### PR TITLE
Reader: Update the Select Interests presentation logic

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -36,9 +36,9 @@ extension Post {
             """
     }
 
-    private enum Strings {
+    enum Strings {
         static let promptTag = "dailyprompt"
-        static let emptyParagraphBlock = """
+        fileprivate static let emptyParagraphBlock = """
         <!-- wp:paragraph -->
         <p></p>
         <!-- /wp:paragraph -->

--- a/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
@@ -42,7 +42,17 @@ class ReaderSelectInterestsCoordinator {
                 return
             }
 
-            let isFollowingInterests = interests.count > 0
+            let isFollowingInterests = {
+                // New users are automatically subscribed to the 'dailyprompt' tag by default.
+                // Let's ignore this value and keep showing the Select Interests view if the user
+                // is not subscribed to any other tags.
+                if let interest = interests.first,
+                   interests.count == 1 {
+                    return interest.slug != Post.Strings.promptTag
+                }
+                return interests.count > 0
+            }()
+
             completion(isFollowingInterests)
         }
     }


### PR DESCRIPTION
Resolves #22514

Previously, we only showed the Select Interests view (i.e., the tag cloud) when the user has 0 tags. Now that the backend auto-subscribes new users to the `dailyprompt` tag, this change will cause them to see the Select Interests view despite having subscribed to the `dailyprompt` tag.

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1d4d51a5-1e99-45d3-9fa4-dd565c3c0f69" width=320>

## To test

- Prepare an account that either has 0 subscribed tags or only subscribed to the `dailyprompt` tag.
- Launch the Jetpack app and log in to this account.
- Go to Reader.
- 🔎  Verify that the Select Interests view is shown.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The change specifically affects users only subscribing to the `dailyprompt` tag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
N/A — this change does not modify any UIs.

- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
