### PR TITLE
Avoid reloading user defaults sections on toggle switch

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
@@ -5,10 +5,10 @@ struct BooleanUserDefaultsDebugView: View {
 
     var body: some View {
         List {
-            ForEach(viewModel.userDefaultsSections, id: \.id) { section in
+            ForEach(viewModel.userDefaultsSections) { section in
                 Section(header: Text(section.key)
                     .font(.caption)) {
-                        ForEach(section.rows, id: \.id) { row in
+                        ForEach(section.rows) { row in
                             let isOn = Binding<Bool>(
                                 get: {
                                     row.value

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
@@ -5,10 +5,10 @@ struct BooleanUserDefaultsDebugView: View {
 
     var body: some View {
         List {
-            ForEach(viewModel.userDefaultsSections, id: \.key) { section in
+            ForEach(viewModel.userDefaultsSections, id: \.id) { section in
                 Section(header: Text(section.key)
                     .font(.caption)) {
-                        ForEach(section.rows, id: \.key) { row in
+                        ForEach(section.rows, id: \.id) { row in
                             let isOn = Binding<Bool>(
                                 get: {
                                     row.value
@@ -16,8 +16,8 @@ struct BooleanUserDefaultsDebugView: View {
                                 set: { newValue in
                                     viewModel.updateUserDefault(
                                         newValue,
-                                        forSection: section.key,
-                                        forRow: row.key
+                                        section: section,
+                                        row: row
                                     )
                                 }
                             )

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModel.swift
@@ -91,39 +91,16 @@ final class BooleanUserDefaultsDebugViewModel: ObservableObject {
         return try? Blog.lookup(withID: Int(id) ?? 0, in: coreDataStack.mainContext)
     }
 
-    func updateUserDefault(_ newValue: Bool, forSection targetSection: String, forRow targetRow: String) {
-        updateAllUserDefaultsSections(newValue, forSection: targetSection, forRow: targetRow)
-        if targetSection == Strings.otherBooleanUserDefaultsSectionID {
-            persistentRepository.set(newValue, forKey: targetRow)
-        } else {
-            guard let section = allUserDefaultsSections.first(where: { $0.key == targetSection }) else {
-                return
-            }
-            let entries = section.rows.reduce(into: [String: Bool]()) { result, row in
-                if row.key == targetRow {
-                    result[row.key] = newValue
-                } else {
-                    result[row.key] = row.value
-                }
-            }
-            persistentRepository.set(entries, forKey: targetSection)
-        }
-    }
+    func updateUserDefault(_ newValue: Bool, section: Section, row: Row) {
+        row.value = newValue
 
-    func updateAllUserDefaultsSections(_ newValue: Bool, forSection targetSection: String, forRow targetRow: String) {
-        allUserDefaultsSections = allUserDefaultsSections.map { currentSection in
-            if currentSection.key == targetSection {
-                let updatedRows = currentSection.rows.map { currentRow in
-                    if currentRow.key == targetRow {
-                        return Row(key: currentRow.key, title: currentRow.title, value: newValue)
-                    } else {
-                        return currentRow
-                    }
-                }
-                return Section(key: currentSection.key, rows: updatedRows)
-            } else {
-                return currentSection
+        if section.key == Strings.otherBooleanUserDefaultsSectionID {
+            persistentRepository.set(newValue, forKey: row.key)
+        } else {
+            let entries = section.rows.reduce(into: [String: Bool]()) { result, row in
+                result[row.key] = row.value
             }
+            persistentRepository.set(entries, forKey: section.key)
         }
     }
 
@@ -138,14 +115,17 @@ final class BooleanUserDefaultsDebugViewModel: ObservableObject {
     // MARK: - Types
 
     struct Section {
+        let id: String = UUID().uuidString
         let key: String
         let rows: [Row]
     }
 
     final class Row {
+        let id: String = UUID().uuidString
         let key: String
         let title: String
-        let value: Bool
+
+        var value: Bool
 
         init(key: String, title: String, value: Bool) {
             self.key = key

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModel.swift
@@ -125,7 +125,7 @@ final class BooleanUserDefaultsDebugViewModel: ObservableObject {
         let key: String
         let title: String
 
-        var value: Bool
+        fileprivate(set) var value: Bool
 
         init(key: String, title: String, value: Bool) {
             self.key = key

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModel.swift
@@ -114,13 +114,13 @@ final class BooleanUserDefaultsDebugViewModel: ObservableObject {
 
     // MARK: - Types
 
-    struct Section {
+    struct Section: Identifiable {
         let id: String = UUID().uuidString
         let key: String
         let rows: [Row]
     }
 
-    final class Row {
+    final class Row: Identifiable {
         let id: String = UUID().uuidString
         let key: String
         let title: String

--- a/WordPress/WordPressTest/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModelTests.swift
+++ b/WordPress/WordPressTest/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModelTests.swift
@@ -128,7 +128,9 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         viewModel.load()
 
         // When
-        viewModel.updateUserDefault(false, forSection: "Other", forRow: "entry1")
+        let section = viewModel.userDefaultsSections[0]
+        let row = section.rows[0]
+        viewModel.updateUserDefault(false, section: section, row: row)
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.count == 1)
@@ -145,7 +147,9 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         viewModel.load()
 
         // When
-        viewModel.updateUserDefault(false, forSection: "section1", forRow: "entry1")
+        let section = viewModel.userDefaultsSections[0]
+        let row = section.rows[0]
+        viewModel.updateUserDefault(false, section: section, row: row)
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.count == 1)


### PR DESCRIPTION
## Related PR
This PR depends on:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22488

## Description
In the base PR, the property `allUserDefaultsSections` was reloaded every time an entry toggle is switched. This was done as a workaround to fix a UI glitch when switching from another screen to User Defaults Debug screen.

## Test Instructions
Existing Test Instructions in  https://github.com/wordpress-mobile/WordPress-iOS/pull/22488 and:

1. Navigate to User Defaults Debug screen.
2. Toggle a switch.
3. Navigate to My Site.
4. Navigate back to User Defaults Debug screen.
5. **Expect** the previously toggled switch state to be maintained

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
