### PR TITLE
Load User Defaults list asynchronously to improve performance

### DIFF
--- a/WordPress/WordPressTest/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModelTests.swift
+++ b/WordPress/WordPressTest/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugViewModelTests.swift
@@ -1,16 +1,19 @@
 import XCTest
+import Combine
 @testable import WordPress
 
 private typealias Section = BooleanUserDefaultsDebugViewModel.Section
 private typealias Row = BooleanUserDefaultsDebugViewModel.Row
 
-class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
+@MainActor final class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
 
     var viewModel: BooleanUserDefaultsDebugViewModel!
     var mockPersistentRepository: InMemoryUserDefaults!
+    var cancellables: Set<AnyCancellable>!
 
     override func setUp() {
         super.setUp()
+        cancellables = .init()
         mockPersistentRepository = InMemoryUserDefaults()
         viewModel = BooleanUserDefaultsDebugViewModel(coreDataStack: contextManager,
                                                       persistentRepository: mockPersistentRepository)
@@ -22,12 +25,12 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         super.tearDown()
     }
 
-    func testLoadUserDefaults_WithOtherSection() {
+    func testLoadUserDefaults_WithOtherSection() async {
         // Given
         mockPersistentRepository.set(true, forKey: "entry1")
 
         // When
-        viewModel.load()
+        await viewModel.load()
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.count == 1)
@@ -38,12 +41,12 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         XCTAssertTrue(viewModel.userDefaultsSections.first?.rows.first?.value == true)
     }
 
-    func testLoadUserDefaults_WithoutOtherSection() {
+    func testLoadUserDefaults_WithoutOtherSection() async {
         // Given
         mockPersistentRepository.set(["entry1": true], forKey: "section1")
 
         // When
-        viewModel.load()
+        await viewModel.load()
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.count == 1)
@@ -54,10 +57,10 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         XCTAssertTrue(viewModel.userDefaultsSections.first?.rows.first?.value == true)
     }
 
-    func testUserDefaultsSections_MatchingQuery() {
+    func testUserDefaultsSections_MatchingQuery() async {
         // Given
         mockPersistentRepository.set(["match": true], forKey: "section1")
-        viewModel.load()
+        await viewModel.load()
 
         // When
         viewModel.searchQuery = "mat"
@@ -71,25 +74,33 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         XCTAssertTrue(viewModel.userDefaultsSections.first?.rows.first?.value == true)
     }
 
-    func testUserDefaultsSections_NotMatchingQuery() {
+    func testUserDefaultsSections_NotMatchingQuery() async {
         // Given
+        let expectation = expectation(description: "List should be empty when no matching entries")
         mockPersistentRepository.set(["entry1": true], forKey: "section1")
-        viewModel.load()
+        await viewModel.load()
 
         // When
+        viewModel.$userDefaultsSections
+            .dropFirst()
+            .sink { sections in
+                XCTAssertTrue(sections.isEmpty)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
         viewModel.searchQuery = "noMatch"
 
         // Then
-        XCTAssertTrue(viewModel.userDefaultsSections.isEmpty)
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
-    func testUserDefaultsSections_WithFilteredOutNonBooleanEntries() {
+    func testUserDefaultsSections_WithFilteredOutNonBooleanEntries() async {
         // Given
         mockPersistentRepository.set(["entry1": "NotBoolean"], forKey: "section1")
         mockPersistentRepository.set(["entry2": false], forKey: "section1")
 
         // When
-        viewModel.load()
+        await viewModel.load()
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.count == 1)
@@ -100,32 +111,32 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         XCTAssertTrue(viewModel.userDefaultsSections.first?.rows.first?.value == false)
     }
 
-    func testUserDefaultsSections_WithFilteredOutGutenbergItems() {
+    func testUserDefaultsSections_WithFilteredOutGutenbergItems() async {
         // Given
         mockPersistentRepository.set(true, forKey: "com.wordpress.gutenberg-entry")
 
         // When
-        viewModel.load()
+        await viewModel.load()
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.isEmpty)
     }
 
-    func testUserDefaultsSections_WithFilteredOutFeatureFlagSection() {
+    func testUserDefaultsSections_WithFilteredOutFeatureFlagSection() async {
         // Given
         mockPersistentRepository.set(["entry1": true], forKey: "FeatureFlagStoreCache")
 
         // When
-        viewModel.load()
+        await viewModel.load()
 
         // Then
         XCTAssertTrue(viewModel.userDefaultsSections.isEmpty)
     }
 
-    func testUpdateUserDefault_OtherSection() {
+    func testUpdateUserDefault_OtherSection() async {
         // Given
         mockPersistentRepository.set(true, forKey: "entry1")
-        viewModel.load()
+        await viewModel.load()
 
         // When
         let section = viewModel.userDefaultsSections[0]
@@ -141,10 +152,10 @@ class BooleanUserDefaultsDebugViewModelTests: CoreDataTestCase {
         XCTAssertTrue(viewModel.userDefaultsSections.first?.rows.first?.value == false)
     }
 
-    func testUpdateUserDefault_GivenSection() {
+    func testUpdateUserDefault_GivenSection() async {
         // Given
         mockPersistentRepository.set(["entry1": true], forKey: "section1")
-        viewModel.load()
+        await viewModel.load()
 
         // When
         let section = viewModel.userDefaultsSections[0]


### PR DESCRIPTION
## Related PR
This PR depends on:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22534

## Description

There was a short ( but noticeable ) delay when navigating to User Default Debug screen, this was due to running the `load` method on the main thread. This PR fixes the issue by running it asynchronously.

| Before | After |
| ------ | ------ |
|  <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/82eddaf7-e439-4dee-8d77-cdcd0c8dee52"></video> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/a0d21476-8952-465f-b923-73f9f8112e54" ></video> |

## Test Instructions

1. Navigate to User Defaults Debug screen
2. **Expect** User Defaults loading doesn't freeze the UI
3. **Expect** the User Defaults list to load

## Regression Notes
1. Potential unintended areas of impact
Double check the User Defaults can be loaded.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
