### PR TITLE
Reader: Apply equal heights between navigation and filter buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -28,9 +28,11 @@ struct ReaderNavigationMenu: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     ReaderNavigationButton(viewModel: viewModel)
+                        .frame(maxHeight: .infinity)
                         .animation(.easeInOut, value: viewModel.selectedItem)
                     streamFilterView
                 }
+                .fixedSize(horizontal: false, vertical: true)
             }
             .animation(.easeInOut, value: filters)
             .mask({
@@ -88,12 +90,12 @@ struct ReaderNavigationMenu: View {
         }
         // the inherent padding from the close image bumps the content height, so we'll need to reduce the padding
         // when the close button is shown.
-        .padding(.vertical, isSelected ? 6.0 : 10.0)
+        .padding(.vertical, 6.0)
         .padding(.leading, 16.0)
         .padding(.trailing, isSelected ? 8.0 : 16.0)
+        .frame(maxHeight: .infinity)
         .background(isSelected ? Colors.StreamFilter.selectedBackground : Colors.StreamFilter.background)
         .clipShape(Capsule())
-
     }
 
     struct Colors {


### PR DESCRIPTION
Fixes #22533

Fixes a case where the buttons' height are different as the display size changes. To fix this, I applied `frame(maxWidth: .infinity)` to all the children of `HStack` and applied `fixedSize` to the stack view. This will cause the stack view to grow up to the tallest child, and all the remaining children will expand to fill the gap, matching the height of the tallest child.

Due to the contrast, it may appear that the buttons have a slight 1px height difference but that's probably an optical illusion! When measured through the visual debugger, they match:

<img width="400" alt="Screenshot 2024-02-05 at 20 29 06" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/24d69b90-7213-4d2c-b241-dde3a194ea09">

## To test

- Configure the phone or Simulator to use a larger display size
- Launch the Jetpack app
- Navigate to Reader and switch to Subscriptions
- 🔎 Verify that the Reader navigation buttons have equal heights

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
