### PR TITLE
[Notifications P1] Row UI Update

### DIFF
--- a/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
@@ -68,14 +68,14 @@ fileprivate extension UIFont {
         static let heading4 = DynamicFontHelper.fontForTextStyle(.title3, fontWeight: .semibold)
 
         enum Body {
-            static let small = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .regular)
+            static let small = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .regular)
             static let medium = DynamicFontHelper.fontForTextStyle(.callout, fontWeight: .regular)
-            static let large = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .regular)
+            static let large = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .regular)
 
             enum Emphasized {
-                static let small = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .semibold)
+                static let small = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .semibold)
                 static let medium = DynamicFontHelper.fontForTextStyle(.callout, fontWeight: .semibold)
-                static let large = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .semibold)
+                static let large = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .semibold)
             }
         }
 

--- a/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 // MARK: - UIKit.UIFont: TextStyle
-extension TextStyle {
+public extension TextStyle {
     var uiFont: UIFont {
         switch self {
         case .heading1:
@@ -50,13 +50,12 @@ extension TextStyle {
 }
 
 // MARK: - SwiftUI.Text
-extension UILabel {
-    func style(_ style: TextStyle) -> Self {
+public extension UILabel {
+    func setStyle(_ style: TextStyle) {
         self.font = style.uiFont
         if style.case == .uppercase {
             self.text = self.text?.uppercased()
         }
-        return self
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -163,6 +163,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
 
         tableView.tableHeaderView = tableHeaderView
         tableView.separatorStyle = .none
+        tableView.backgroundColor = .DS.Background.primary
         setupConstraints()
         configureJetpackBanner()
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -157,12 +157,12 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
         setupNavigationBar()
         setupTableHandler()
         setupTableView()
-        setupTableFooterView()
         setupRefreshControl()
         setupNoResultsView()
         setupFilterBar()
 
         tableView.tableHeaderView = tableHeaderView
+        tableView.separatorStyle = .none
         setupConstraints()
         configureJetpackBanner()
 
@@ -584,11 +584,6 @@ private extension NotificationsViewController {
         tableView.estimatedSectionHeaderHeight = UITableView.automaticDimension
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         WPStyleGuide.configureColors(view: view, tableView: tableView)
-    }
-
-    func setupTableFooterView() {
-        //  Fix: Hide the cellSeparators, when the table is empty
-        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.size.width, height: 1))
     }
 
     func setupTableHandler() {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
@@ -11,10 +11,10 @@ class SubjectContentStyles: FormattableContentStyles {
 
     var rangeStylesMap: [FormattableRangeKind: [NSAttributedString.Key: Any]]? {
         return [
-            .user: WPStyleGuide.Notifications.subjectSemiBoldStyle,
-            .post: WPStyleGuide.Notifications.subjectSemiBoldStyle,
-            .site: WPStyleGuide.Notifications.subjectSemiBoldStyle,
-            .comment: WPStyleGuide.Notifications.subjectSemiBoldStyle,
+            .user: WPStyleGuide.Notifications.subjectRegularStyle,
+            .post: WPStyleGuide.Notifications.subjectRegularStyle,
+            .site: WPStyleGuide.Notifications.subjectRegularStyle,
+            .comment: WPStyleGuide.Notifications.subjectRegularStyle,
             .blockquote: WPStyleGuide.Notifications.subjectQuotedStyle,
             .noticon: WPStyleGuide.Notifications.subjectNoticonStyle
         ]

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -1,3 +1,5 @@
+import DesignSystem
+
 /// Renders a table header view with bottom separator, and meant to be used
 /// alongside `ListTableViewCell`.
 ///
@@ -23,7 +25,7 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
             titleLabel.text
         }
         set {
-            titleLabel.text = newValue?.localizedUppercase ?? String()
+            titleLabel.text = newValue ?? String()
             accessibilityLabel = newValue
         }
     }
@@ -47,12 +49,12 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
         }()
 
         // configure title label
-        titleLabel.font = Style.sectionHeaderFont
-        titleLabel.textColor = Style.sectionHeaderTitleColor
+        titleLabel.setStyle(.bodyLarge(.emphasized))
+        titleLabel.textColor = .DS.Foreground.primary
 
         // configure separators view
         separatorsView.bottomColor = Style.separatorColor
-        separatorsView.bottomVisible = true
+        separatorsView.bottomVisible = false
     }
 
     // MARK: Convenience

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -54,7 +54,7 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
 
         // configure separators view
         separatorsView.bottomColor = Style.separatorColor
-        separatorsView.bottomVisible = false
+        separatorsView.bottomVisible = true
     }
 
     // MARK: Convenience

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -1,4 +1,5 @@
 import WordPressUI
+import DesignSystem
 
 /// Table view cell for the List component.
 ///
@@ -135,13 +136,13 @@ private extension ListTableViewCell {
         indicatorView.layer.cornerRadius = indicatorWidthConstraint.constant / 2
 
         // title label
-        titleLabel.font = Style.plainTitleFont
-        titleLabel.textColor = Style.titleTextColor
+        titleLabel.setStyle(.bodySmall(.regular))
+        titleLabel.textColor = .DS.Foreground.primary
         titleLabel.numberOfLines = Constants.titleNumberOfLinesWithSnippet
 
         // snippet label
-        snippetLabel.font = Style.snippetFont
-        snippetLabel.textColor = Style.snippetTextColor
+        snippetLabel.setStyle(.bodySmall(.regular))
+        snippetLabel.textColor = .DS.Foreground.secondary
         snippetLabel.numberOfLines = Constants.snippetNumberOfLines
     }
 

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -52,7 +52,7 @@ class ListTableViewCell: UITableViewCell, NibReusable {
         }
         set {
             titleLabel.attributedText = newValue ?? NSAttributedString()
-            // Updating snippetLabel's line count to keep the max total of both lines at 4.
+            // Updating snippetLabel's line count to keep the max total of both lines at 3.
             snippetLabel.numberOfLines = titleLabel.numberOfVisibleLines > 1 ? 1 : 2
         }
     }

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -52,6 +52,8 @@ class ListTableViewCell: UITableViewCell, NibReusable {
         }
         set {
             titleLabel.attributedText = newValue ?? NSAttributedString()
+            // Updating snippetLabel's line count to keep the max total of both lines at 4.
+            snippetLabel.numberOfLines = titleLabel.numberOfVisibleLines > 1 ? 1 : 2
         }
     }
 
@@ -165,5 +167,15 @@ private extension ListTableViewCell {
         static let titleNumberOfLinesWithoutSnippet = 3
         static let titleNumberOfLinesWithSnippet = 2
         static let snippetNumberOfLines = 2
+    }
+}
+
+private extension UILabel {
+    var numberOfVisibleLines: Int {
+        let textSize = CGSize(width: self.frame.size.width, height: CGFloat(Float.infinity))
+        let rHeight = lroundf(Float(self.sizeThatFits(textSize).height))
+        let charSize = lroundf(Float(self.font.lineHeight))
+        let lineCount = rHeight/charSize
+        return lineCount
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,16 +33,16 @@
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="lXc-gN-Ufo" userLabel="Label Stack View">
-                        <rect key="frame" x="68" y="10" width="280" height="47"/>
+                        <rect key="frame" x="68" y="10" width="280" height="45"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9EJ-O9-rUs" userLabel="Title Label">
-                                <rect key="frame" x="0.0" y="0.0" width="280" height="14.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="280" height="18"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ing-nT-4vc" userLabel="Snippet Label">
-                                <rect key="frame" x="0.0" y="16.5" width="280" height="30.5"/>
+                                <rect key="frame" x="0.0" y="20" width="280" height="25"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -51,13 +51,13 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="lXc-gN-Ufo" secondAttribute="bottom" constant="10" id="7wb-hA-Swk"/>
+                    <constraint firstAttribute="bottom" secondItem="lXc-gN-Ufo" secondAttribute="bottom" constant="12" id="7wb-hA-Swk"/>
                     <constraint firstAttribute="trailing" secondItem="lXc-gN-Ufo" secondAttribute="trailing" constant="20" id="BFj-Ur-toO"/>
                     <constraint firstItem="xzK-0R-8Uu" firstAttribute="leading" secondItem="oMd-3W-Kni" secondAttribute="trailing" constant="6" id="NYM-He-pS8"/>
                     <constraint firstItem="lXc-gN-Ufo" firstAttribute="leading" secondItem="xzK-0R-8Uu" secondAttribute="trailing" constant="10" id="SRW-jO-i3w"/>
                     <constraint firstItem="xzK-0R-8Uu" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="eNp-7q-Ne0"/>
                     <constraint firstItem="oMd-3W-Kni" firstAttribute="centerY" secondItem="xzK-0R-8Uu" secondAttribute="centerY" id="i4v-J7-Vvs"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="xzK-0R-8Uu" secondAttribute="bottom" constant="10" id="mLE-4b-5S0"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="xzK-0R-8Uu" secondAttribute="bottom" constant="12" id="mLE-4b-5S0"/>
                     <constraint firstItem="lXc-gN-Ufo" firstAttribute="top" secondItem="xzK-0R-8Uu" secondAttribute="top" constant="-2" id="udT-s4-eh8"/>
                     <constraint firstItem="oMd-3W-Kni" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="6" id="xjI-GL-V0e"/>
                 </constraints>


### PR DESCRIPTION
Fixes #22465 

## Description
Updates the styling of notifications cell to match the new designs by utilising Design System values.

## Testing Steps
1. Install & login to Jetpack App with an account that has any notifications.
2. Navigate to Notifications Tab.
3. Verify the rows match the designs:
a. ✅ Title should not contain any bold/semibold
b. ✅ Title and description should be the same size
c. ✅ There should be no separators.
d. ✅ Each cell should contain maximum 4 lines of text. i.e. if title has 2 lines, description can only have 1 line. If title has 1 line, description can have maximum 2 lines.

## Regression Notes
1. Potential unintended areas of impact
All UI changes that will be merged to the feature branch.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
