### PR TITLE
Reader: Fix plural string typo for the tags filter chip

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -366,7 +366,7 @@ extension ReaderTagTopic {
         )
 
         static let pluralFilterTitle = NSLocalizedString(
-            "reader.navigation.filter.blog.plural",
+            "reader.navigation.filter.tag.plural",
             value: "%1$d Tags",
             comment: """
                 Plural button title to filter the Reader stream by tag.


### PR DESCRIPTION
Fixes #22549 

> [!WARNING]
> This targets the `release/24.2` branch. Auto-merge is switched **on**.

Due to a typo, when a user subscribes to more than 1 tag, the filter chip shows "Blogs" instead of "Tags". This PR fixes that.

Before | After
-|-
![IMG_5469](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/40e50b08-b08d-481b-9eb5-4afef4381cba) | ![after](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/87df26da-1055-468d-98ba-76e4d7992a36)

## To test

- Launch the Jetpack app.
- Select the Reader tab. 
- Ensure that your site subscribes to more than one tag.
- Switch to the Subscriptions stream.
- 🔎 Verify that the filter chip button for tags shows "N Tags".

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

UI Changes testing checklist:
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
