### PR TITLE
Reader: Reuse the edit button action for the add tag logic in the filter sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -100,11 +100,6 @@ extension FilterProvider: Equatable {
 
 extension FilterProvider {
 
-    func showAdd(on presenterViewController: UIViewController, sceneDelegate: ScenePresenterDelegate?) {
-        let presenter = ReaderManageScenePresenter(selected: section, sceneDelegate: sceneDelegate)
-        presenter.present(on: presenterViewController, animated: true, completion: nil)
-    }
-
     static func filterItems(_ items: [TableDataItem], siteType: SiteOrganizationType?) -> [TableDataItem] {
         // If a site type is specified, filter items by it.
         // Otherwise, just return all items.

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -249,7 +249,8 @@ private extension FilterSheetViewController {
             present(navController, animated: true)
             break
         case .tag:
-            filterProvider.showAdd(on: self, sceneDelegate: self)
+            // Go to the Filter management view
+            didTapEditButton()
         }
     }
 


### PR DESCRIPTION
Fixes #22546 

The previous method call does not provide a way to retain the `presenter` object, which causes the callback to not be called after the Manage flow is dismissed. This is the root cause of why the filter sheet failed to update.

Additionally, I've also removed the `showAdd` method from the `FilterProvider` since we'd need to preserve the `presenter` object, which makes this method buggy.

## To test

- Launch the Jetpack app
- Log in to an account with 0 subscribed tags
- Go to the Reader tab
- Go to Subscribed stream, tap the Tags filter chip
- Tap 'Subscribe to a tag'
- Add any tag (for example: `technology`)
- Tap Done
- 🔎 Verify that the filter sheet now shows the newly added tag.
- Dismiss the Filter Sheet.
- 🔎 Verify that the tag filter chip button now shows the correct number of tags.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
