### PR TITLE
Provide fallback URLs to load P2s in web view

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -809,7 +809,11 @@ extension NotificationsViewController {
         if let postID = note.metaPostID,
             let siteID = note.metaSiteID,
             note.kind == .matcher || note.kind == .newPost {
-            let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
+            var fallbackURL: URL?
+            if let permalink = note.url {
+                fallbackURL = URL(string: permalink)
+            }
+            let readerViewController = ReaderDetailViewController.controllerWithXPostID(postID, siteID: siteID, fallbackURL: fallbackURL)
             readerViewController.navigationItem.largeTitleDisplayMode = .never
             showDetailViewController(readerViewController, sender: nil)
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -758,6 +758,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         return controller
     }
 
+    class func controllerWithXPostID(_ postID: NSNumber, siteID: NSNumber, isFeed: Bool = false, fallbackURL: URL? = nil) -> ReaderDetailViewController {
+        let controller = ReaderDetailViewController.loadFromStoryboard()
+        let coordinator = ReaderDetailCoordinator(view: controller)
+        coordinator.set(postID: postID, siteID: siteID, isFeed: isFeed)
+        coordinator.postURL = fallbackURL
+        controller.coordinator = coordinator
+
+        return controller
+    }
+
     /// A View Controller that displays a Post content.
     ///
     /// Use this method to present content for the user.
@@ -804,7 +814,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             post.sourceAttribution.blogID != nil {
             return ReaderDetailViewController.controllerWithPostID(post.sourceAttribution.postID!, siteID: post.sourceAttribution.blogID!)
         } else if post.isCross() {
-            return ReaderDetailViewController.controllerWithPostID(post.crossPostMeta.postID, siteID: post.crossPostMeta.siteID)
+            var fallbackURL: URL?
+            if let permalink = post.permaLink {
+                fallbackURL = URL(string: permalink)
+            }
+            return ReaderDetailViewController.controllerWithXPostID(post.crossPostMeta.postID, siteID: post.crossPostMeta.siteID, fallbackURL: fallbackURL)
         } else {
             let controller = ReaderDetailViewController.loadFromStoryboard()
             let coordinator = ReaderDetailCoordinator(view: controller)


### PR DESCRIPTION
This PR aims to provide a workaround for loading P2 content when your user doesn't have membership.

**Before:** An error was shown that the post couldn't be loaded. There was no way to grant membership.
**After:** An error is shown with the option to load the post in the browser. Once the post is loaded the user can grant themselves membership.

**Note:** This would need to be heavily tested for regressions unless we can add checks to filter only for A8C users.

| Option to open in browser | P2 opened in browser |
| - | - |
| ![Simulator Screenshot - iPhone 15 - 2024-02-06 at 14 44 00](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/1a3b434b-8c90-4f65-8875-b05c6ac064ca) | ![Simulator Screenshot - iPhone 15 - 2024-02-06 at 14 44 09](https://github.com/wordpress-mobile/WordPress-iOS/assets/2092798/441b26eb-c0e9-4e28-96e2-3517f85101d6) |


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
