### PR TITLE
Reader: Update Reader quick start tour with new message

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -69,7 +69,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementSharing = 8,
     QuickStartTourElementConnections = 9,
     QuickStartTourElementReaderTab = 10,
-    QuickStartTourElementReaderDiscoverSettings = 12,
+    QuickStartTourElementReaderDiscoverSubscriptions = 12,
     QuickStartTourElementTourCompleted = 13,
     QuickStartTourElementCongratulations = 14,
     QuickStartTourElementSiteIcon = 15,

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -184,15 +184,27 @@ struct QuickStartFollowTour: QuickStartTour {
         let step2DiscoverDescriptionTarget = NSLocalizedString("Discover", comment: "The menu item to select during a guided tour.")
         let step2DiscoverDescription = step2DiscoverDescriptionBase.highlighting(phrase: step2DiscoverDescriptionTarget, icon: nil)
 
-        let step2SettingsDescriptionBase = NSLocalizedString("Try selecting %@ to add topics you like.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step2SettingsDescriptionTarget = NSLocalizedString("Settings", comment: "The menu item to select during a guided tour.")
-        let step2SettingsDescription = step2SettingsDescriptionBase.highlighting(phrase: step2SettingsDescriptionTarget, icon: .gridicon(.cog))
+        let step2SubscriptionDescriptionBase = NSLocalizedString(
+            "quick.start.reader.2.subscriptions.base",
+            value: "Try selecting %@ to view subscribed content and manage your subscriptions.",
+            comment: "A step in a guided tour for quick start. %@ will be a bolded Subscriptions text."
+        )
+        let step2SubscriptionDescriptionTarget = NSLocalizedString(
+            "quick.start.reader.2.subscriptions.target",
+            value: "Subscriptions",
+            comment: "The bolded Subscriptions text in the Reader step 2 description for the quick start tour."
+        )
+        let step2SubscriptionDescription = step2SubscriptionDescriptionBase.highlighting(
+            phrase: step2SubscriptionDescriptionTarget,
+            icon: nil
+        )
 
         /// Combined description for step 2
         let step2Format = NSAttributedString(string: "%@ %@")
-        let step2Description = NSAttributedString(format: step2Format, args: step2DiscoverDescription, step2SettingsDescription)
+        let step2Description = NSAttributedString(format: step2Format,
+                                                  args: step2DiscoverDescription, step2SubscriptionDescription)
 
-        let step2: WayPoint = (element: .readerDiscoverSettings, description: step2Description)
+        let step2: WayPoint = (element: .readerDiscoverSubscriptions, description: step2Description)
 
         return [step1, step2]
     }()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -176,7 +176,9 @@ struct QuickStartFollowTour: QuickStartTour {
     var waypoints: [WayPoint] = {
         let step1DescriptionBase = NSLocalizedString("Select %@ to find other sites.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
-        let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
+        let step1: WayPoint = (element: .readerTab,
+                               description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget,
+                                                                              icon: UIImage(named: "tab-bar-reader-selected")))
 
         let step2DiscoverDescriptionBase = NSLocalizedString("Use %@ to find sites and tags.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step2DiscoverDescriptionTarget = NSLocalizedString("Discover", comment: "The menu item to select during a guided tour.")

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -70,7 +70,6 @@ class ReaderManageScenePresenter {
         presentedViewController = navigationController
         viewController.present(navigationController, animated: true, completion: nil)
 
-        QuickStartTourGuide.shared.visited(.readerDiscoverSettings)
         WPAnalytics.track(.readerManageViewDisplayed)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -344,9 +344,6 @@ extension ReaderSelectInterestsViewController: UICollectionViewDelegate {
             spotlightIsShown = false
         }
 
-        // End reader quick start tour if user selects a topic.
-        QuickStartTourGuide.shared.visited(.readerDiscoverSettings)
-
         dataSource.interest(for: indexPath.row).toggleSelected()
         updateNextButtonState()
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -61,14 +61,6 @@ class ReaderTabViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if QuickStartTourGuide.shared.isCurrentElement(.readerDiscoverSettings) {
-
-            if viewModel.selectedIndex != ReaderTabConstants.discoverIndex {
-                viewModel.showTab(at: ReaderTabConstants.discoverIndex)
-            }
-
-            // TODO: Revisit Reader spotlight
-        }
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 


### PR DESCRIPTION
Fixes #22555

## Description

Updates:
- Reader icon in the quick start tour message to match the current Reader tab icon
- Step 2 of the Reader tour to show a message and auto-dismiss after 5 seconds

## Video

https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/30244995-3404-4b5b-adb3-d66910756540

## Testing

- Launch Jetpack and login
- Start the quick start tour
  - Note: An easy way to do this is in the developer menu > `Enable Quick Start for Existing Site`
- Tap on the quick start dashboard card
- Tap on `Connect with other sites` on the modal popup
- 🔎 **Verify** the first message's Reader icon matches the new Reader icon
- Tap on the Reader tab
- 🔎 **Verify** with the second message:
  - Text is: `Use **Discover** to find sites and tags. Try selecting **Subscriptions** to view subscribed content and manage your subscriptions.`
  - Auto dismisses after 5 seconds

To test:

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
