### PR TITLE
[Design System] Fix wrong font values in UILabel extension

### DIFF
--- a/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 // MARK: - UIKit.UIFont: TextStyle
-extension TextStyle {
+public extension TextStyle {
     var uiFont: UIFont {
         switch self {
         case .heading1:
@@ -50,13 +50,12 @@ extension TextStyle {
 }
 
 // MARK: - SwiftUI.Text
-extension UILabel {
-    func style(_ style: TextStyle) -> Self {
+public extension UILabel {
+    func setStyle(_ style: TextStyle) {
         self.font = style.uiFont
         if style.case == .uppercase {
             self.text = self.text?.uppercased()
         }
-        return self
     }
 }
 

--- a/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Components/Modifiers/UILabel+DesignSystem.swift
@@ -69,14 +69,14 @@ fileprivate extension UIFont {
         static let heading4 = DynamicFontHelper.fontForTextStyle(.title3, fontWeight: .semibold)
 
         enum Body {
-            static let small = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .regular)
+            static let small = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .regular)
             static let medium = DynamicFontHelper.fontForTextStyle(.callout, fontWeight: .regular)
-            static let large = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .regular)
+            static let large = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .regular)
 
             enum Emphasized {
-                static let small = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .semibold)
+                static let small = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .semibold)
                 static let medium = DynamicFontHelper.fontForTextStyle(.callout, fontWeight: .semibold)
-                static let large = DynamicFontHelper.fontForTextStyle(.subheadline, fontWeight: .semibold)
+                static let large = DynamicFontHelper.fontForTextStyle(.body, fontWeight: .semibold)
             }
         }
 


### PR DESCRIPTION
## Description
`UIFont.body` has font size of 17.0
`UIFont.subheadline` has font size of 15.0

So the former had to be `large` and the latter `small` like it is the case for `Swift.Font` extension.

Also the `public` access modifier was missing. Signature of `setStyle` is changed to be a void function as returning self is irrelevant in UIKit usage.

## Testing Steps
The modified code wasn't being consumed yet (only SwiftUI counterpart was being used so far). So there is nothing to test for in the existing functionality.

Using `UILabel.setStyle` with the following values (on any screen/component) and verifying their UI is the only way I can think of:
- `.bodySmall(weight: .regular)`
- `.bodySmall(weight: .emphasized)`
- `.bodyLarge(weight: .regular)`
- `.bodyLarge(weight: .emphasized)`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
