### PR TITLE
docs: Remove Android-specific release note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,6 @@
 24.2
 -----
 * [**] Prevent images from temporarily disappearing when uploading media [https://github.com/WordPress/gutenberg/pull/57869]
-* [**] Fix crash occurring on large post on Android [https://github.com/WordPress/gutenberg/pull/58266]
 * [*] [Jetpack-only] Site Monitoring: Add Metrics, PHP Logs, and Web Server Logs under Site Monitoring [#22475, #22499, #22504, #22500]
 * [***] [Jetpack-only] Reader: introduced new UI/UX for content navigation and filtering [#22536]
 


### PR DESCRIPTION
The referenced change does not relate to the WordPress iOS app and could cause confusion for users or contributors.

To test: N/A, no source code changes. 

## Regression Notes
1. Potential unintended areas of impact
    None, this is a small documentation update. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Nothing.
3. What automated tests I added (or what prevented me from doing so)
    None, not relevant for documentation. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
