### PR TITLE
[Notifications P1] Notifications Cell Content Rewrite

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -3,7 +3,7 @@ import DesignSystem
 
 struct AvatarsView: View {
     private enum Constants {
-        static let doubleAvatarHorizontalOffset: CGFloat = 20
+        static let doubleAvatarHorizontalOffset: CGFloat = 18
         static let tripleAvatarViewHeight: CGFloat = 44
     }
 
@@ -20,6 +20,17 @@ struct AvatarsView: View {
                 return 34
             case .triple:
                 return 28
+            }
+        }
+
+        var leadingOffset: CGFloat {
+            switch self {
+            case .single:
+                return 0
+            case .double:
+                return 8
+            case .triple:
+                return Length.Padding.split/2
             }
         }
     }
@@ -100,7 +111,9 @@ struct AvatarsView: View {
 #Preview {
     VStack(spacing: Length.Padding.medium) {
         AvatarsView(
-            style: .single(URL(string: "https://i.pickadummy.com/index.php?imgsize=40x40")!)
+            style: .single(
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=40x40")!
+            )
         )
         AvatarsView(
             style: .double(

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import DesignSystem
+
+struct AvatarsView: View {
+    enum Style {
+        case single(URL)
+        case double(URL, URL)
+        case triple(URL, URL, URL)
+
+        var diameter: CGFloat {
+            switch self {
+            case .single:
+                return 40
+            case .double:
+                return 34
+            case .triple:
+                return 28
+            }
+        }
+    }
+
+    private let style: Style
+
+    init(style: Style) {
+        self.style = style
+    }
+
+    var body: some View {
+        switch style {
+        case let .single(primaryURL):
+            avatar(url: primaryURL)
+        case let .double(primaryURL, secondaryURL):
+            doubleAvatarView(
+                primaryURL: primaryURL,
+                secondaryURL: secondaryURL
+            )
+        case let .triple(primaryURL, secondaryURL, tertiaryURL):
+            tripleAvatarView(
+                primaryURL: primaryURL,
+                secondaryURL: secondaryURL,
+                tertiaryURL: tertiaryURL
+            )
+        }
+    }
+
+    private func avatar(url: URL) -> some View {
+        AsyncImage(url: url) { image in
+            image.resizable()
+                .background(Color.DS.Background.primary) // Only for testing
+        } placeholder: {
+            Color.DS.Background.secondary
+        }
+        .frame(width: style.diameter, height: style.diameter)
+        .clipShape(Circle())
+    }
+
+    private func doubleAvatarView(primaryURL: URL, secondaryURL: URL) -> some View {
+        ZStack {
+            HStack {
+                avatar(url: secondaryURL)
+                Spacer().frame(width: 20)
+            }
+            HStack {
+                Spacer().frame(width: 20)
+                avatar(url: primaryURL)
+            }
+        }
+        .frame(height: style.diameter)
+    }
+
+    private func tripleAvatarView(
+        primaryURL: URL,
+        secondaryURL: URL,
+        tertiaryURL: URL
+    ) -> some View {
+        ZStack {
+            HStack {
+                avatar(url: tertiaryURL)
+                Spacer().frame(width: Length.Padding.medium)
+            }
+            VStack {
+                avatar(url: secondaryURL)
+                Spacer().frame(height: Length.Padding.large)
+            }
+            HStack {
+                Spacer().frame(width: Length.Padding.medium)
+                avatar(url: primaryURL)
+            }
+        }
+        .frame(height: 44)
+    }
+}
+
+#if DEBUG
+#Preview {
+    VStack(spacing: Length.Padding.medium) {
+        AvatarsView(
+            style: .single(URL(string: "https://i.pickadummy.com/index.php?imgsize=40x40")!)
+        )
+        AvatarsView(
+            style: .double(
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!,
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!
+            )
+        )
+        AvatarsView(
+            style: .triple(
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!
+            )
+        )
+    }
+}
+#endif

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -36,9 +36,11 @@ struct AvatarsView: View {
     }
 
     private let style: Style
+    private let borderColor: Color
 
-    init(style: Style) {
+    init(style: Style, borderColor: Color = .DS.Background.primary) {
         self.style = style
+        self.borderColor = borderColor
     }
 
     var body: some View {
@@ -63,7 +65,7 @@ struct AvatarsView: View {
         AsyncImage(url: url) { image in
             image.resizable()
         } placeholder: {
-            Color.DS.Background.secondary
+            borderColor
         }
         .frame(width: style.diameter, height: style.diameter)
         .clipShape(Circle())

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -62,7 +62,6 @@ struct AvatarsView: View {
     private func avatar(url: URL) -> some View {
         AsyncImage(url: url) { image in
             image.resizable()
-                .background(Color.DS.Background.primary) // Only for testing
         } placeholder: {
             Color.DS.Background.secondary
         }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -79,6 +79,7 @@ struct AvatarsView: View {
             HStack {
                 Spacer().frame(width: Constants.doubleAvatarHorizontalOffset)
                 avatar(url: primaryURL)
+                    .avatarBorderOverlay()
             }
         }
         .frame(height: style.diameter)
@@ -96,14 +97,25 @@ struct AvatarsView: View {
             }
             VStack {
                 avatar(url: secondaryURL)
+                    .avatarBorderOverlay()
                 Spacer().frame(height: Length.Padding.large)
             }
             HStack {
                 Spacer().frame(width: Length.Padding.medium)
                 avatar(url: primaryURL)
+                    .avatarBorderOverlay()
             }
         }
         .frame(height: Constants.tripleAvatarViewHeight)
+    }
+}
+
+private extension View {
+    func avatarBorderOverlay() -> some View {
+        self.overlay(
+            Circle()
+                .stroke(Color.DS.Background.primary, lineWidth: 1)
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -17,7 +17,7 @@ struct AvatarsView: View {
             case .single:
                 return 40
             case .double:
-                return 34
+                return 32
             case .triple:
                 return 28
             }
@@ -28,7 +28,7 @@ struct AvatarsView: View {
             case .single:
                 return 0
             case .double:
-                return 8
+                return 5
             case .triple:
                 return Length.Padding.split/2
             }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -2,6 +2,11 @@ import SwiftUI
 import DesignSystem
 
 struct AvatarsView: View {
+    private enum Constants {
+        static let doubleAvatarHorizontalOffset: CGFloat = 20
+        static let tripleAvatarViewHeight: CGFloat = 44
+    }
+
     enum Style {
         case single(URL)
         case double(URL, URL)
@@ -58,10 +63,10 @@ struct AvatarsView: View {
         ZStack {
             HStack {
                 avatar(url: secondaryURL)
-                Spacer().frame(width: 20)
+                Spacer().frame(width: Constants.doubleAvatarHorizontalOffset)
             }
             HStack {
-                Spacer().frame(width: 20)
+                Spacer().frame(width: Constants.doubleAvatarHorizontalOffset)
                 avatar(url: primaryURL)
             }
         }
@@ -87,7 +92,7 @@ struct AvatarsView: View {
                 avatar(url: primaryURL)
             }
         }
-        .frame(height: 44)
+        .frame(height: Constants.tripleAvatarViewHeight)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import DesignSystem
+import WordPressUI
 
 struct AvatarsView: View {
     private enum Constants {
@@ -62,7 +63,15 @@ struct AvatarsView: View {
     }
 
     private func avatar(url: URL) -> some View {
-        AsyncImage(url: url) { image in
+        let processedURL: URL
+        if let gravatar = Gravatar(url) {
+            let size = Int(ceil(style.diameter * UIScreen.main.scale))
+            processedURL = gravatar.urlWithSize(size)
+        } else {
+            processedURL = url
+        }
+
+        return AsyncImage(url: processedURL) { image in
             image.resizable()
         } placeholder: {
             borderColor

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -111,6 +111,28 @@ struct AvatarsView: View {
     }
 }
 
+extension AvatarsView.Style {
+    init?(urls: [URL]) {
+        var tempURLs: [URL]
+        if urls.count > 3 {
+            tempURLs = Array(urls.prefix(3))
+        } else {
+            tempURLs = urls
+        }
+
+        switch UInt(tempURLs.count) {
+        case 0:
+            return nil
+        case 1:
+            self = AvatarsView.Style.single(tempURLs[0])
+        case 2:
+            self = AvatarsView.Style.double(tempURLs[0], tempURLs[1])
+        default:
+            self = AvatarsView.Style.triple(tempURLs[0], tempURLs[1], tempURLs[2])
+        }
+    }
+}
+
 private extension View {
     func avatarBorderOverlay() -> some View {
         self.overlay(
@@ -135,11 +157,13 @@ private extension View {
             )
         )
         AvatarsView(
-            style: .triple(
-                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
-                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
-                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!
-            )
+            style: .init(
+                urls: [
+                    URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
+                    URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
+                    URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!
+                ]
+            )!
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCell.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+final class NotificationsTableViewCell: UITableViewCell {
+    
+}

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCell.swift
@@ -1,5 +1,4 @@
 import UIKit
 
 final class NotificationsTableViewCell: UITableViewCell {
-    
 }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import DesignSystem
+
+extension NotificationsTableViewCell {
+    struct Content: View {
+        let title: String
+        let description: String
+        let shouldShowIndicator: Bool
+
+        var body: some View {
+            HStack(spacing: 0) {
+                indicator
+                    .padding(.horizontal, Length.Padding.half)
+            }
+        }
+
+        private var indicator: some View {
+            Circle()
+                .frame(width: Length.Padding.single)
+                .background(
+                    Color.DS.Background.brand(
+                        isJetpack: AppConfiguration.isJetpack
+                    )
+                )
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    NotificationsTableViewCell.Content(
+        title: "Something",
+        description: "Description",
+        shouldShowIndicator: true
+    )
+}
+#endif

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -124,7 +124,7 @@ fileprivate extension NotificationsTableViewCell.Content {
                     Text(info.text)
                         .style(.bodySmall(.regular))
                         .foregroundStyle(Color.white)
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .padding(.leading, Length.Padding.medium)
 
                     Spacer()

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -3,35 +3,103 @@ import DesignSystem
 
 extension NotificationsTableViewCell {
     struct Content: View {
-        let title: String
-        let description: String
-        let shouldShowIndicator: Bool
+        private let title: String
+        private let description: String?
+        private let shouldShowIndicator: Bool
+        private let avatarStyle: AvatarsView.Style
+
+        init(
+            title: String,
+            description: String?,
+            shouldShowIndicator: Bool,
+            avatarStyle: AvatarsView.Style
+        ) {
+            self.title = title
+            self.description = description
+            self.shouldShowIndicator = shouldShowIndicator
+            self.avatarStyle = avatarStyle
+        }
 
         var body: some View {
+            HStack(alignment: .top, spacing: 0) {
+                avatarHStack
+                textsVStack
+                    .offset(x: -avatarStyle.leadingOffset*2)
+                    .padding(.horizontal, Length.Padding.split)
+            }
+        }
+
+        private var avatarHStack: some View {
             HStack(spacing: 0) {
-                indicator
-                    .padding(.horizontal, Length.Padding.half)
+                if shouldShowIndicator {
+                    indicator
+                        .padding(.horizontal, Length.Padding.single)
+                    AvatarsView(style: avatarStyle)
+                        .offset(x: -avatarStyle.leadingOffset)
+                } else {
+                    AvatarsView(style: avatarStyle)
+                        .offset(x: -avatarStyle.leadingOffset)
+                        .padding(.leading, Length.Padding.medium)
+                }
             }
         }
 
         private var indicator: some View {
             Circle()
+                .fill(Color.DS.Background.brand(isJetpack: AppConfiguration.isJetpack))
                 .frame(width: Length.Padding.single)
-                .background(
-                    Color.DS.Background.brand(
-                        isJetpack: AppConfiguration.isJetpack
-                    )
-                )
+        }
+
+        private var textsVStack: some View {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .style(.bodySmall(.regular))
+                    .foregroundStyle(Color.DS.Foreground.primary)
+                    .lineLimit(2)
+
+                if let description {
+                    Text(description)
+                        .style(.bodySmall(.regular))
+                        .foregroundStyle(Color.DS.Foreground.secondary)
+                        .lineLimit(2)
+                }
+            }
         }
     }
 }
 
 #if DEBUG
 #Preview {
-    NotificationsTableViewCell.Content(
-        title: "Something",
-        description: "Description",
-        shouldShowIndicator: true
-    )
+    VStack(alignment: .leading, spacing: Length.Padding.medium) {
+        NotificationsTableViewCell.Content(
+            title: "John Smith liked your comment more than all other comments as asdf",
+            description: "Here is what I think of all this: Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+            shouldShowIndicator: true,
+            avatarStyle: .single(
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=40x40")!
+            )
+        )
+
+        NotificationsTableViewCell.Content(
+            title: "Albert Einstein and Marie Curie liked your comment on Quantum Mechanical solution for Hydrogen",
+            description: "Mary Carpenter • marycarpenter.com",
+            shouldShowIndicator: true,
+            avatarStyle: .double(
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!,
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!
+            )
+        )
+
+        NotificationsTableViewCell.Content(
+            title: "New likes on Night Time in Tokyo",
+            description: "Sarah, Céline and Amit",
+            shouldShowIndicator: true,
+            avatarStyle: .triple(
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
+                URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!
+            )
+        )
+    }
 }
 #endif

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -7,17 +7,20 @@ extension NotificationsTableViewCell {
         private let description: String?
         private let shouldShowIndicator: Bool
         private let avatarStyle: AvatarsView.Style
+        private let actionIconName: String? // TODO: Will be refactored to contain the action.
 
         init(
             title: String,
             description: String?,
             shouldShowIndicator: Bool,
-            avatarStyle: AvatarsView.Style
+            avatarStyle: AvatarsView.Style,
+            actionIconName: String?
         ) {
             self.title = title
             self.description = description
             self.shouldShowIndicator = shouldShowIndicator
             self.avatarStyle = avatarStyle
+            self.actionIconName = actionIconName
         }
 
         var body: some View {
@@ -26,7 +29,11 @@ extension NotificationsTableViewCell {
                 textsVStack
                     .offset(x: -avatarStyle.leadingOffset*2)
                     .padding(.horizontal, Length.Padding.split)
+                if let actionIconName {
+                    actionIcon(withName: actionIconName)
+                }
             }
+            .padding(.trailing, Length.Padding.double)
         }
 
         private var avatarHStack: some View {
@@ -65,6 +72,13 @@ extension NotificationsTableViewCell {
                 }
             }
         }
+
+        private func actionIcon(withName iconName: String) -> some View {
+            Image(systemName: iconName)
+                .imageScale(.small)
+                .foregroundStyle(Color.DS.Foreground.secondary)
+                .frame(width: Length.Padding.medium, height: Length.Padding.medium)
+        }
     }
 }
 
@@ -77,7 +91,8 @@ extension NotificationsTableViewCell {
             shouldShowIndicator: true,
             avatarStyle: .single(
                 URL(string: "https://i.pickadummy.com/index.php?imgsize=40x40")!
-            )
+            ),
+            actionIconName: "star"
         )
 
         NotificationsTableViewCell.Content(
@@ -87,7 +102,8 @@ extension NotificationsTableViewCell {
             avatarStyle: .double(
                 URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!,
                 URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!
-            )
+            ),
+            actionIconName: "plus"
         )
 
         NotificationsTableViewCell.Content(
@@ -98,7 +114,8 @@ extension NotificationsTableViewCell {
                 URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
                 URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
                 URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!
-            )
+            ),
+            actionIconName: nil
         )
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -304,6 +304,12 @@
 		0857C2781CE5375F0014AE99 /* MenuItemInsertionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2721CE5375F0014AE99 /* MenuItemInsertionView.m */; };
 		0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2741CE5375F0014AE99 /* MenuItemsVisualOrderingView.m */; };
 		0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2761CE5375F0014AE99 /* MenuItemView.m */; };
+		086023D42B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */; };
+		086023D52B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */; };
+		086023D72B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */; };
+		086023D82B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */; };
+		086023DB2B73BA67000D084A /* AvatarsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023DA2B73BA67000D084A /* AvatarsView.swift */; };
+		086023DC2B73BA67000D084A /* AvatarsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023DA2B73BA67000D084A /* AvatarsView.swift */; };
 		086103961EE09C91004D7C01 /* MediaVideoExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086103951EE09C91004D7C01 /* MediaVideoExporter.swift */; };
 		086C117C2A2F6451004A3821 /* CompliancePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C117B2A2F6451004A3821 /* CompliancePopover.swift */; };
 		086C117D2A2F6451004A3821 /* CompliancePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C117B2A2F6451004A3821 /* CompliancePopover.swift */; };
@@ -6023,6 +6029,9 @@
 		0857C2741CE5375F0014AE99 /* MenuItemsVisualOrderingView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemsVisualOrderingView.m; sourceTree = "<group>"; };
 		0857C2751CE5375F0014AE99 /* MenuItemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemView.h; sourceTree = "<group>"; };
 		0857C2761CE5375F0014AE99 /* MenuItemView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemView.m; sourceTree = "<group>"; };
+		086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTableViewCellContent.swift; sourceTree = "<group>"; };
+		086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTableViewCell.swift; sourceTree = "<group>"; };
+		086023DA2B73BA67000D084A /* AvatarsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarsView.swift; sourceTree = "<group>"; };
 		086103951EE09C91004D7C01 /* MediaVideoExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaVideoExporter.swift; sourceTree = "<group>"; };
 		086C117B2A2F6451004A3821 /* CompliancePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompliancePopover.swift; sourceTree = "<group>"; };
 		086C4D0F1E81F9240011D960 /* Media+Blog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Media+Blog.swift"; sourceTree = "<group>"; };
@@ -10084,6 +10093,16 @@
 				084FC3B629913B1B00A17BCF /* JetpackPluginOverlayViewModelTests.swift */,
 			);
 			name = JetpackOverlay;
+			sourceTree = "<group>";
+		};
+		086023D92B73BA47000D084A /* NotificationsList */ = {
+			isa = PBXGroup;
+			children = (
+				086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */,
+				086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */,
+				086023DA2B73BA67000D084A /* AvatarsView.swift */,
+			);
+			path = NotificationsList;
 			sourceTree = "<group>";
 		};
 		086C4D0C1E81F7920011D960 /* Media */ = {
@@ -18542,6 +18561,7 @@
 		FEA087FB2696DDE900193358 /* List */ = {
 			isa = PBXGroup;
 			children = (
+				086023D92B73BA47000D084A /* NotificationsList */,
 				FEA088002696E7F600193358 /* ListTableHeaderView.swift */,
 				FEA088022696E81F00193358 /* ListTableHeaderView.xib */,
 				FE39C134269C37C900EFB827 /* ListTableViewCell.swift */,
@@ -21363,6 +21383,7 @@
 				4A9314E7297A0C5000360232 /* PostCategory+Lookup.swift in Sources */,
 				738B9A5C21B85EB00005062B /* UIView+ContentLayout.swift in Sources */,
 				E1B9128F1BB05B1D003C25B9 /* PeopleCell.swift in Sources */,
+				086023D42B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */,
 				F15272FD243B27BC00C8DC7A /* AbstractPost+Local.swift in Sources */,
 				3F43603123F31E09001DEE70 /* MeScenePresenter.swift in Sources */,
 				FA98B61629A3B76A0071AAE8 /* DashboardBlazeCardCell.swift in Sources */,
@@ -21664,6 +21685,7 @@
 				98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */,
 				82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */,
 				435D101A2130C2AB00BB2AA8 /* BlogDetailsViewController+FancyAlerts.swift in Sources */,
+				086023D72B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */,
 				8000361D292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift in Sources */,
 				0C23F33E2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift in Sources */,
 				F1E72EBA267790110066FF91 /* UIViewController+Dismissal.swift in Sources */,
@@ -23006,6 +23028,7 @@
 				F4CBE3D6292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift in Sources */,
 				8F22804451E5812433733348 /* TimeZoneSearchHeaderView.swift in Sources */,
 				8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */,
+				086023DB2B73BA67000D084A /* AvatarsView.swift in Sources */,
 				8F228F2923045666AE456D2C /* TimeZoneSelectorViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -24756,6 +24779,7 @@
 				FABB23032602FC2C00C8785C /* CountriesMapCell.swift in Sources */,
 				FABB23042602FC2C00C8785C /* NavigationTitleView.swift in Sources */,
 				3FE3D1FE26A6F4AC00F3CD10 /* ListTableHeaderView.swift in Sources */,
+				086023D82B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */,
 				8B15D27528009EBF0076628A /* BlogDashboardAnalytics.swift in Sources */,
 				FABB23052602FC2C00C8785C /* WPAnalyticsEvent.swift in Sources */,
 				FABB23062602FC2C00C8785C /* Coordinate.m in Sources */,
@@ -24778,6 +24802,7 @@
 				8B92D69727CD51FA001F5371 /* DashboardGhostCardCell.swift in Sources */,
 				FABB23122602FC2C00C8785C /* WPImmuTableRows.swift in Sources */,
 				FEFA6AC42A83F4BE004EE5E6 /* PostHelper+JetpackSocial.swift in Sources */,
+				086023D52B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */,
 				800035BE291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift in Sources */,
 				08CBC77A29AE6CC4000026E7 /* SiteCreationEmptySiteTemplate.swift in Sources */,
 				FABB23132602FC2C00C8785C /* WordPress-87-88.xcmappingmodel in Sources */,
@@ -25047,6 +25072,7 @@
 				FABB23D72602FC2C00C8785C /* MenuItemSourceViewController.m in Sources */,
 				FABB23D82602FC2C00C8785C /* WPReusableTableViewCells.swift in Sources */,
 				FABB23D92602FC2C00C8785C /* HomepageSettingsService.swift in Sources */,
+				086023DC2B73BA67000D084A /* AvatarsView.swift in Sources */,
 				FABB23DA2602FC2C00C8785C /* ReaderSearchSuggestionsViewController.swift in Sources */,
 				FABB23DB2602FC2C00C8785C /* SentryStartupEvent.swift in Sources */,
 				FABB23DC2602FC2C00C8785C /* JetpackScanThreatCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10098,9 +10098,9 @@
 		086023D92B73BA47000D084A /* NotificationsList */ = {
 			isa = PBXGroup;
 			children = (
-				086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */,
-				086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */,
 				086023DA2B73BA67000D084A /* AvatarsView.swift */,
+				086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */,
+				086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */,
 			);
 			path = NotificationsList;
 			sourceTree = "<group>";


### PR DESCRIPTION
Refs: #22472 

## Description
It was decided to rewrite the Cell for Notifications List due to the fact that the current cell being reused in Comments. This invites regression or increases code complexity to avoid regression.

This PR implements an adaptable UI for the requirements. Also an `AvatarsView` is added as a reusable multi-avatar view. We can use this in Comments in the future if we wish to adopt it there as well.

## Screenshot Reference
From the Swift Preview:

![Screenshot 2024-02-07 at 23 18 06](https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/34073a1c-3589-4546-9405-203f4aaca7b7)


## Testing Steps
Since this PR does not replace the cell just yet, we can test the additions with the Preview.
1. (If Needed) Open Xcode and go to `WordpressAppDelegate` & disable the willFinish/didFinish functions so Previews can run successfully.
2. Navigate to `NotificationsTableViewCell` and scroll below to Preview.
3. ✅ Verify the UI matches Figma.
4. Modify the test values to test for different cases.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
