### PR TITLE
Reader: Update the active filter button behavior

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -51,51 +51,63 @@ struct ReaderNavigationMenu: View {
                 Image(uiImage: .gridicon(.search)
                     .withRenderingMode(.alwaysTemplate))
                     .foregroundStyle(Colors.searchIcon)
+                    .padding(4.0)
             }
+            .accessibilityLabel(Text(Strings.searchFilterAccessibilityLabel))
         }
     }
 
     @ViewBuilder
     var streamFilterView: some View {
         ForEach(filters) { filter in
-            Button {
-                if hasActiveFilter {
-                    viewModel.resetStreamFilter()
-                } else {
-                    viewModel.didTapStreamFilterButton(with: filter)
-                }
-            } label: {
-                streamFilterChip(title: viewModel.activeStreamFilter?.topic.title ?? filter.title, isSelected: hasActiveFilter)
-            }
-            .transition(
-                .asymmetric(insertion: .slide, removal: .move(edge: .leading))
-                .combined(with: .opacity)
-            )
+            streamFilterChip(filter: filter, isSelected: hasActiveFilter)
+                .transition(
+                    .asymmetric(insertion: .slide, removal: .move(edge: .leading))
+                    .combined(with: .opacity)
+                )
         }
     }
 
     @ViewBuilder
-    func streamFilterChip(title: String, isSelected: Bool = false) -> some View {
+    func streamFilterChip(filter: FilterProvider, isSelected: Bool) -> some View {
         HStack(alignment: .center, spacing: 8.0) {
-            Text(title)
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundStyle(isSelected ? Colors.StreamFilter.selectedText : Colors.StreamFilter.text)
+            Button {
+                viewModel.didTapStreamFilterButton(with: filter)
+            } label: {
+                Text(viewModel.activeStreamFilter?.topic.title ?? filter.title)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(isSelected ? Colors.StreamFilter.selectedText : Colors.StreamFilter.text)
+            }
+            .accessibilityLabel(Text(filterAccessibilityLabel(for: filter)))
+            .accessibilityHint(Text(isSelected ? Strings.activeFilterAccessibilityHint : String()))
 
             if isSelected {
-                Image("reader-menu-close")
-                    .frame(width: 24.0, height: 24.0)
-                    .foregroundStyle(Colors.StreamFilter.selectedText)
+                Button {
+                    withAnimation(.easeInOut) {
+                        viewModel.resetStreamFilter()
+                    }
+                } label: {
+                    Image("reader-menu-close")
+                        .frame(width: 24.0, height: 24.0)
+                        .foregroundStyle(Colors.StreamFilter.selectedText)
+                }
+                .accessibilityLabel(Text(Strings.resetFilterAccessibilityLabel))
             }
         }
-        // the inherent padding from the close image bumps the content height, so we'll need to reduce the padding
-        // when the close button is shown.
         .padding(.vertical, 6.0)
         .padding(.leading, 16.0)
         .padding(.trailing, isSelected ? 8.0 : 16.0)
         .frame(maxHeight: .infinity)
         .background(isSelected ? Colors.StreamFilter.selectedBackground : Colors.StreamFilter.background)
         .clipShape(Capsule())
+    }
+
+    private func filterAccessibilityLabel(for filter: FilterProvider) -> String {
+        guard let activeFilter = viewModel.activeStreamFilter else {
+            return filter.title
+        }
+        return String(format: Strings.activeFilterAccessibilityStringFormat, activeFilter.topic.title)
     }
 
     struct Colors {
@@ -109,4 +121,35 @@ struct ReaderNavigationMenu: View {
         }
     }
 
+    struct Strings {
+        static let activeFilterAccessibilityStringFormat = NSLocalizedString(
+            "reader.navigation.menu.activeFilter.a11y.label",
+            value: "Filtered by %1$@",
+            comment: """
+                Accessibility label for when the user has an active filter.
+                This informs the user that the currently displayed stream is being filtered.
+                """
+        )
+
+        static let activeFilterAccessibilityHint = NSLocalizedString(
+            "reader.navigation.menu.filter.a11y.hint",
+            value: "Opens the filter list",
+            comment: """
+                Accessibility hint that informs the user that the filter list will be opened when they interact
+                with the filter chip button.
+                """
+        )
+
+        static let resetFilterAccessibilityLabel = NSLocalizedString(
+            "reader.navigation.menu.reset.a11y.label",
+            value: "Reset",
+            comment: "Accessibility label for the Close icon button, to reset the active filter."
+        )
+
+        static let searchFilterAccessibilityLabel = NSLocalizedString(
+            "reader.navigation.menu.search.a11y.label",
+            value: "Search",
+            comment: "Accessibility label for the Search icon."
+        )
+    }
 }


### PR DESCRIPTION
Resolves #22548

As titled, this updates the active filter chip behavior when tapped. Tapping on the button will now open the filter list, but tapping the Close button should reset the active filter.

In addition, there are also some accessibility improvements:

- The active filter button and the reset button are now separated properly in VoiceOver.
- Added an accessibility label for the Search icon.

## To test

- Launch the Jetpack app.
- Go to the Reader tab and switch to the Subscriptions stream.
- 🔎  Using the Accessibility Inspector, verify that the Search icon now has an accessibility label.
- Apply a filter to the stream. It can be either by blog or by tag.
- 🔎 Using the Accessibility Inspector, verify that the active filter button now differentiates between the Reset button and the active filter button.
- Tap on the active filter button.
- 🔎 Verify that the filter sheet is opened.
- Close the filter sheet, and tap on the Close button.
- 🔎 Verify that the active filter state is reset.
- 🔎  Verify that the transition is animated from unfiltered -> filtered and vice versa.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
