### PR TITLE
Reader: Show Reader navigation menu when scrolling to top

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -787,6 +787,7 @@ import WordPressUI
 
     /// Scrolls to the top of the list of posts.
     @objc func scrollViewToTop() {
+        navigationMenuDelegate?.didScrollToTop()
         guard tableView.numberOfRows(inSection: .zero) > 0 else {
             tableView.setContentOffset(.zero, animated: true)
             return

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -4,6 +4,7 @@ protocol ReaderNavigationMenuDelegate: AnyObject {
     func scrollViewDidScroll(_ scrollView: UIScrollView, velocity: CGPoint)
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>)
     func didTapDiscoverBlogs()
+    func didScrollToTop()
 }
 
 struct ReaderNavigationMenu: View {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -249,4 +249,8 @@ extension ReaderTabView: ReaderNavigationMenuDelegate {
         viewModel.showTab(at: discoverIndex)
     }
 
+    func didScrollToTop() {
+        updateMenuDisplay(hidden: false)
+    }
+
 }


### PR DESCRIPTION
Fixes #22572

## Description

Updates the Reader scroll to top function to also reveal the navigation menu.

## Testing

To test:
- Launch Jetpack and login
- Navigate to a Reader feed
- Scroll down to hide the navigation menu
- Tap on the Reader tab bar item
- 🔎 **Verify** the navigation menu is shown

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
