### PR TITLE
SFMU: Show error notice if QR code media deep link fails

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
+++ b/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
@@ -26,8 +26,9 @@ extension NavigationAction {
         return nil
     }
 
-    func postFailureNotice(title: String) {
+    func postFailureNotice(title: String, message: String? = nil) {
         let notice = Notice(title: title,
+                            message: message,
                             feedbackType: .error,
                             notificationInfo: nil)
         ActionDispatcher.dispatch(NoticeAction.post(notice))

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -93,6 +93,11 @@ extension MySitesRoute: NavigationAction {
             }
             WPAppAnalytics.track(.deepLinkFailed, withProperties: properties)
 
+            if campaign.flatMap(AppBannerCampaign.init) == .qrCodeMedia {
+                postFailureNotice(title: Strings.siteNotFound, message: Strings.checkAccount)
+                return
+            }
+
             if failAndBounce(values) == false {
                 coordinator.showRootViewController()
                 postFailureNotice(title: NSLocalizedString("Site not found",
@@ -130,4 +135,17 @@ extension MySitesRoute: NavigationAction {
             coordinator.showSiteMonitoring(for: blog, selectedTab: .webServerLogs)
         }
     }
+}
+
+private enum Strings {
+    static let siteNotFound = NSLocalizedString(
+        "universalLink.qrCodeMedia.error.title",
+        value: "Site not found",
+        comment: "Title for error notice shown if the app can't find a specific site belonging to the user"
+    )
+    static let checkAccount = NSLocalizedString(
+        "universalLink.qrCodeMedia.error.message",
+        value: "Check that you are logged into the correct account",
+        comment: "Message for error notice shown if the app can't find a specific site belonging to the user"
+    )
 }


### PR DESCRIPTION
Fixes p58i-gxT-p2#comment-61623

## Description
Shows an error notice if the QR code media deep link fails

## How to test
- Run `xcrun simctl openurl booted https://apps.wordpress.com/get/?campaign=qr-code-media#%2Fmedia%2F000` (We're using `000` as an arbitrary site id for a site that doesn't belong to you)
- Verify the error notice is shown
- Run `xcrun simctl openurl booted https://apps.wordpress.com/get/?campaign=qr-code-media#%2Fmedia%2F<siteId>` (Replace siteId with a site where you have permissions to upload media)
- Verify you navigate to the upload media screen

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/377d2333-019a-4113-a963-b1b49e3ef32c" width=200>


## Regression Notes
1. Potential unintended areas of impact
QR code media deep linking

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)