### PR TITLE
Fix an issue with editable logs details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringEntryDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringEntryDetailsView.swift
@@ -26,6 +26,7 @@ private struct SiteMonitoringTextView: UIViewRepresentable {
         textView.textContainerInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
         textView.adjustsFontForContentSizeCategory = true
         textView.autocorrectionType = .no
+        textView.isEditable = false
         return textView
     }
 


### PR DESCRIPTION
Fixes an issue with logs details view being editable. It is still selectable:

<img width="420" alt="Screenshot 2024-02-09 at 3 55 46 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/87a31d78-3f33-4902-80a7-5ad7c008ccd3">

To test:

- Open an Atomic site with hosting enabled
- Open Site Monitoring / PHP Logs
- Open log details
- Verify that the text is selectable but not editable

## Regression Notes
1. Potential unintended areas of impact: Site Monitoring
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
