### PR TITLE
Fix l10n for Site Monitoring title menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
@@ -88,7 +88,7 @@ final class SiteMonitoringViewModel: ObservableObject {
 private enum Strings {
     static let metrics = NSLocalizedString("siteMonitoring.metrics", value: "Metrics", comment: "Title for metrics screen.")
     static let phpLogs = NSLocalizedString("siteMonitoring.phpLogs", value: "PHP Logs", comment: "Title for PHP logs screen.")
-    static let webServerLogs = NSLocalizedString("siteMonitoring.metrics", value: "Web Server Logs", comment: "Title for web server log screen.")
+    static let webServerLogs = NSLocalizedString("siteMonitoring.webServerLogs", value: "Web Server Logs", comment: "Title for web server log screen.")
 }
 
 extension Date {


### PR DESCRIPTION
Fix l10n for Site Monitoring title menu

To test:

## Regression Notes
1. Potential unintended areas of impact: Site Monitoring


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
