### PR TITLE
[Notifications P1] Replace Notifications Cell Content

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -363,6 +363,21 @@ extension Notification {
         }
         return content.last
     }
+
+    var allAvatarURLs: [URL] {
+        let firstMedias: [AnyObject] = body?.compactMap {
+            let allMedia = $0["media"] as? [AnyObject]
+            return allMedia?.first as? AnyObject
+        } ?? []
+
+        let urlStrings = firstMedias.compactMap {
+            $0["url"] as? String
+        }
+
+        return urlStrings.compactMap {
+            URL(string: $0)
+        }
+    }
 }
 
 // MARK: - Update Helpers

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
@@ -63,7 +63,7 @@ final class NotificationsTableHeaderView: UITableViewHeaderFooterView {
         static let textColor = UIColor.DS.Foreground.primary ?? .text
         static let textFont = UIFont.DS.font(.bodyLarge(.emphasized))
         static let layoutMargins = NSDirectionalEdgeInsets(
-            top: Length.Padding.single,
+            top: Length.Padding.double,
             leading: Length.Padding.double,
             bottom: Length.Padding.double,
             trailing: Length.Padding.double

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
@@ -65,7 +65,7 @@ final class NotificationsTableHeaderView: UITableViewHeaderFooterView {
         static let layoutMargins = NSDirectionalEdgeInsets(
             top: Length.Padding.single,
             leading: Length.Padding.double,
-            bottom: Length.Padding.single,
+            bottom: Length.Padding.double,
             trailing: Length.Padding.double
         )
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -337,38 +337,31 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
             return UITableViewCell()
         }
         cell.selectionStyle = .none
+        let style: NotificationsTableViewCellContent.Style
         if let deletionRequest = notificationDeletionRequests[note.objectID] {
-            cell.host(
-                NotificationsTableViewCellContent(
-                    style: .altered(
-                        .init(
-                            text: deletionRequest.kind.legendText,
-                            action: { [weak self] in
-                                self?.cancelDeletionRequestForNoteWithID(note.objectID)
-                            }
-                        )
-                    )
-                ),
-                parent: self
+            style = .altered(
+                .init(
+                    text: deletionRequest.kind.legendText,
+                    action: { [weak self] in
+                        self?.cancelDeletionRequestForNoteWithID(note.objectID)
+                    }
+                )
             )
         } else {
-            cell.host(
-                NotificationsTableViewCellContent(
-                    style: .regular(
-                        .init(
-                            title: note.renderSubject()?.string ?? "",
-                            description: note.renderSnippet()?.string,
-                            shouldShowIndicator: !note.read,
-                            avatarStyle: .init(urls: note.allAvatarURLs) ?? .single(note.iconURL!),
-                            actionIconName: nil
-                        )
-                    )
-                ),
-                parent: self
+            style = .regular(
+                .init(
+                    title: note.renderSubject()?.string ?? "",
+                    description: note.renderSnippet()?.string,
+                    shouldShowIndicator: !note.read,
+                    avatarStyle: .init(urls: note.allAvatarURLs) ?? .single(note.iconURL),
+                    actionIconName: nil
+                )
             )
         }
 
         cell.accessibilityHint = Self.accessibilityHint(for: note)
+        cell.host(NotificationsTableViewCellContent(style: style), parent: self)
+
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -348,7 +348,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
                         title: note.renderSubject()?.string ?? "",
                         description: note.renderSnippet()?.string,
                         shouldShowIndicator: !note.read,
-                        avatarStyle: .single(note.iconURL!),
+                        avatarStyle: .init(urls: note.allAvatarURLs) ?? .single(note.iconURL!),
                         actionIconName: nil
                     )
                 )

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -336,6 +336,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
               let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification else {
             return UITableViewCell()
         }
+        cell.selectionStyle = .none
         cell.host(
             NotificationsTableViewCellContent(
                 style: .regular(

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -348,9 +348,15 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
                 )
             )
         } else {
+            let attributedTitle: AttributedString?
+            if let attributedSubject = note.renderSubject() {
+                attributedTitle = AttributedString(attributedSubject)
+            } else {
+                attributedTitle = nil
+            }
             style = .regular(
                 .init(
-                    title: note.renderSubject()?.string ?? "",
+                    title: attributedTitle,
                     description: note.renderSnippet()?.string,
                     shouldShowIndicator: !note.read,
                     avatarStyle: .init(urls: note.allAvatarURLs) ?? .single(note.iconURL),

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -332,12 +332,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(
-            withIdentifier: "NotificationsTableViewCell",
-            for: indexPath
-        )
-
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "NotificationsTableViewCell") as? HostingTableViewCell<NotificationsTableViewCellContent>,
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: NotificationsTableViewCellContent.reuseIdentifier) as? HostingTableViewCell<NotificationsTableViewCellContent>,
               let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification else {
             return UITableViewCell()
         }
@@ -612,7 +607,10 @@ private extension NotificationsViewController {
     func setupTableView() {
         // Register the cells
         tableView.register(NotificationsTableHeaderView.self, forHeaderFooterViewReuseIdentifier: NotificationsTableHeaderView.reuseIdentifier)
-        tableView.register(HostingTableViewCell<NotificationsTableViewCellContent>.self, forCellReuseIdentifier: "NotificationsTableViewCell")
+        tableView.register(
+            HostingTableViewCell<NotificationsTableViewCellContent>.self,
+            forCellReuseIdentifier: NotificationsTableViewCellContent.reuseIdentifier
+        )
 
         // UITableView
         tableView.accessibilityIdentifier  = "notifications-table"

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -7,6 +7,7 @@ import WordPressAuthenticator
 import Gridicons
 import UIKit
 import WordPressUI
+import SwiftUI
 
 /// The purpose of this class is to render the collection of Notifications, associated to the main
 /// WordPress.com account.
@@ -331,8 +332,31 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: ListTableViewCell.defaultReuseID, for: indexPath)
-        configureCell(cell, at: indexPath)
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: "NotificationsTableViewCell",
+            for: indexPath
+        )
+
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "NotificationsTableViewCell") as? HostingTableViewCell<NotificationsTableViewCellContent>,
+              let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification else {
+            return UITableViewCell()
+        }
+        cell.host(
+            NotificationsTableViewCellContent(
+                style: .regular(
+                    .init(
+                        title: note.renderSubject()?.string ?? "",
+                        description: note.renderSnippet()?.string,
+                        shouldShowIndicator: !note.read,
+                        avatarStyle: .single(note.iconURL!),
+                        actionIconName: nil
+                    )
+                )
+            ),
+            parent: self
+        )
+
+        cell.accessibilityHint = Self.accessibilityHint(for: note)
         return cell
     }
 
@@ -588,13 +612,14 @@ private extension NotificationsViewController {
     func setupTableView() {
         // Register the cells
         tableView.register(NotificationsTableHeaderView.self, forHeaderFooterViewReuseIdentifier: NotificationsTableHeaderView.reuseIdentifier)
-        tableView.register(ListTableViewCell.defaultNib, forCellReuseIdentifier: ListTableViewCell.defaultReuseID)
+        tableView.register(HostingTableViewCell<NotificationsTableViewCellContent>.self, forCellReuseIdentifier: "NotificationsTableViewCell")
 
         // UITableView
         tableView.accessibilityIdentifier  = "notifications-table"
         tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.estimatedSectionHeaderHeight = UITableView.automaticDimension
         tableView.backgroundColor = .systemBackground
+        tableView.separatorStyle = .none
         view.backgroundColor = .systemBackground
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -337,20 +337,36 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
             return UITableViewCell()
         }
         cell.selectionStyle = .none
-        cell.host(
-            NotificationsTableViewCellContent(
-                style: .regular(
-                    .init(
-                        title: note.renderSubject()?.string ?? "",
-                        description: note.renderSnippet()?.string,
-                        shouldShowIndicator: !note.read,
-                        avatarStyle: .init(urls: note.allAvatarURLs) ?? .single(note.iconURL!),
-                        actionIconName: nil
+        if let deletionRequest = notificationDeletionRequests[note.objectID] {
+            cell.host(
+                NotificationsTableViewCellContent(
+                    style: .altered(
+                        .init(
+                            text: deletionRequest.kind.legendText,
+                            action: { [weak self] in
+                                self?.cancelDeletionRequestForNoteWithID(note.objectID)
+                            }
+                        )
                     )
-                )
-            ),
-            parent: self
-        )
+                ),
+                parent: self
+            )
+        } else {
+            cell.host(
+                NotificationsTableViewCellContent(
+                    style: .regular(
+                        .init(
+                            title: note.renderSubject()?.string ?? "",
+                            description: note.renderSnippet()?.string,
+                            shouldShowIndicator: !note.read,
+                            avatarStyle: .init(urls: note.allAvatarURLs) ?? .single(note.iconURL!),
+                            actionIconName: nil
+                        )
+                    )
+                ),
+                parent: self
+            )
+        }
 
         cell.accessibilityHint = Self.accessibilityHint(for: note)
         return cell

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
@@ -11,10 +11,10 @@ class SubjectContentStyles: FormattableContentStyles {
 
     var rangeStylesMap: [FormattableRangeKind: [NSAttributedString.Key: Any]]? {
         return [
-            .user: WPStyleGuide.Notifications.subjectSemiBoldStyle,
-            .post: WPStyleGuide.Notifications.subjectSemiBoldStyle,
-            .site: WPStyleGuide.Notifications.subjectSemiBoldStyle,
-            .comment: WPStyleGuide.Notifications.subjectSemiBoldStyle,
+            .user: WPStyleGuide.Notifications.subjectRegularStyle,
+            .post: WPStyleGuide.Notifications.subjectRegularStyle,
+            .site: WPStyleGuide.Notifications.subjectRegularStyle,
+            .comment: WPStyleGuide.Notifications.subjectRegularStyle,
             .blockquote: WPStyleGuide.Notifications.subjectQuotedStyle,
             .noticon: WPStyleGuide.Notifications.subjectNoticonStyle
         ]

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -5,7 +5,6 @@ import WordPressUI
 struct AvatarsView: View {
     private enum Constants {
         static let doubleAvatarHorizontalOffset: CGFloat = 18
-        static let tripleAvatarViewHeight: CGFloat = 44
     }
 
     enum Style {
@@ -116,7 +115,7 @@ struct AvatarsView: View {
                     .avatarBorderOverlay()
             }
         }
-        .frame(height: Constants.tripleAvatarViewHeight)
+        .frame(height: Length.Padding.large + style.diameter)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -33,15 +33,6 @@ struct AvatarsView: View {
                 return Length.Padding.split/2
             }
         }
-
-        var verticalOffset: CGFloat {
-            switch self {
-            case .single, .double:
-                return 0
-            case .triple:
-                return Length.Padding.large/2
-            }
-        }
     }
 
     private let style: Style
@@ -91,15 +82,11 @@ struct AvatarsView: View {
 
     private func doubleAvatarView(primaryURL: URL?, secondaryURL: URL?) -> some View {
         ZStack {
-            HStack {
-                avatar(url: secondaryURL)
-                Spacer().frame(width: Constants.doubleAvatarHorizontalOffset)
-            }
-            HStack {
-                Spacer().frame(width: Constants.doubleAvatarHorizontalOffset)
-                avatar(url: primaryURL)
-                    .avatarBorderOverlay()
-            }
+            avatar(url: secondaryURL)
+                .padding(.trailing, Constants.doubleAvatarHorizontalOffset)
+            avatar(url: primaryURL)
+                .avatarBorderOverlay()
+                .padding(.leading, Constants.doubleAvatarHorizontalOffset)
         }
     }
 
@@ -108,22 +95,17 @@ struct AvatarsView: View {
         secondaryURL: URL?,
         tertiaryURL: URL?
     ) -> some View {
-        ZStack {
-            HStack {
-                avatar(url: tertiaryURL)
-                Spacer().frame(width: Length.Padding.medium)
-            }
-            VStack {
-                avatar(url: secondaryURL)
-                    .avatarBorderOverlay()
-                Spacer().frame(height: Length.Padding.large)
-            }
-            HStack {
-                Spacer().frame(width: Length.Padding.medium)
-                avatar(url: primaryURL)
-                    .avatarBorderOverlay()
-            }
+        ZStack(alignment: .bottom) {
+            avatar(url: tertiaryURL)
+                .padding(.trailing, Length.Padding.medium)
+            avatar(url: secondaryURL)
+                .avatarBorderOverlay()
+                .offset(x: 0, y: -Length.Padding.split)
+            avatar(url: primaryURL)
+                .avatarBorderOverlay()
+                .padding(.leading, Length.Padding.medium)
         }
+        .padding(.top, Length.Padding.split)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -33,6 +33,15 @@ struct AvatarsView: View {
                 return Length.Padding.split/2
             }
         }
+
+        var verticalOffset: CGFloat {
+            switch self {
+            case .single, .double:
+                return 0
+            case .triple:
+                return Length.Padding.large/2
+            }
+        }
     }
 
     private let style: Style
@@ -92,7 +101,6 @@ struct AvatarsView: View {
                     .avatarBorderOverlay()
             }
         }
-        .frame(height: style.diameter)
     }
 
     private func tripleAvatarView(
@@ -116,7 +124,6 @@ struct AvatarsView: View {
                     .avatarBorderOverlay()
             }
         }
-        .frame(height: Length.Padding.large + style.diameter)
     }
 }
 
@@ -150,30 +157,3 @@ private extension View {
         )
     }
 }
-
-#if DEBUG
-#Preview {
-    VStack(spacing: Length.Padding.medium) {
-        AvatarsView(
-            style: .single(
-                URL(string: "https://i.pickadummy.com/index.php?imgsize=40x40")!
-            )
-        )
-        AvatarsView(
-            style: .double(
-                URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!,
-                URL(string: "https://i.pickadummy.com/index.php?imgsize=34x34")!
-            )
-        )
-        AvatarsView(
-            style: .init(
-                urls: [
-                    URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
-                    URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!,
-                    URL(string: "https://i.pickadummy.com/index.php?imgsize=28x28")!
-                ]
-            )!
-        )
-    }
-}
-#endif

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -8,9 +8,9 @@ struct AvatarsView: View {
     }
 
     enum Style {
-        case single(URL)
-        case double(URL, URL)
-        case triple(URL, URL, URL)
+        case single(URL?)
+        case double(URL?, URL?)
+        case triple(URL?, URL?, URL?)
 
         var diameter: CGFloat {
             switch self {
@@ -70,9 +70,9 @@ struct AvatarsView: View {
         }
     }
 
-    private func avatar(url: URL) -> some View {
-        let processedURL: URL
-        if let gravatar = Gravatar(url) {
+    private func avatar(url: URL?) -> some View {
+        let processedURL: URL?
+        if let url, let gravatar = Gravatar(url) {
             let size = Int(ceil(style.diameter * UIScreen.main.scale))
             processedURL = gravatar.urlWithSize(size)
         } else {
@@ -89,7 +89,7 @@ struct AvatarsView: View {
         .clipShape(Circle())
     }
 
-    private func doubleAvatarView(primaryURL: URL, secondaryURL: URL) -> some View {
+    private func doubleAvatarView(primaryURL: URL?, secondaryURL: URL?) -> some View {
         ZStack {
             HStack {
                 avatar(url: secondaryURL)
@@ -104,9 +104,9 @@ struct AvatarsView: View {
     }
 
     private func tripleAvatarView(
-        primaryURL: URL,
-        secondaryURL: URL,
-        tertiaryURL: URL
+        primaryURL: URL?,
+        secondaryURL: URL?,
+        tertiaryURL: URL?
     ) -> some View {
         ZStack {
             HStack {

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -73,7 +73,8 @@ struct AvatarsView: View {
         return AsyncImage(url: processedURL) { image in
             image.resizable()
         } placeholder: {
-            borderColor
+            Image("gravatar")
+                .resizable()
         }
         .frame(width: style.diameter, height: style.diameter)
         .clipShape(Circle())

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
@@ -13,15 +13,12 @@ class HostingTableViewCell<Content: View>: UITableViewCell {
             controller = swiftUICellViewController
             swiftUICellViewController.view.backgroundColor = .clear
 
-            layoutIfNeeded()
-
             parent.addChild(swiftUICellViewController)
             contentView.addSubview(swiftUICellViewController.view)
             swiftUICellViewController.view.translatesAutoresizingMaskIntoConstraints = false
             contentView.pinSubviewToAllEdges(swiftUICellViewController.view)
 
             swiftUICellViewController.didMove(toParent: parent)
-            swiftUICellViewController.view.layoutIfNeeded()
         }
 
         self.controller?.view.invalidateIntrinsicContentSize()

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
@@ -23,5 +23,7 @@ class HostingTableViewCell<Content: View>: UITableViewCell {
             swiftUICellViewController.didMove(toParent: parent)
             swiftUICellViewController.view.layoutIfNeeded()
         }
+
+        self.controller?.view.invalidateIntrinsicContentSize()
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
@@ -18,50 +18,7 @@ class HostingTableViewCell<Content: View>: UITableViewCell {
             parent.addChild(swiftUICellViewController)
             contentView.addSubview(swiftUICellViewController.view)
             swiftUICellViewController.view.translatesAutoresizingMaskIntoConstraints = false
-            contentView.addConstraint(
-                NSLayoutConstraint(
-                    item: swiftUICellViewController.view!,
-                    attribute: NSLayoutConstraint.Attribute.leading,
-                    relatedBy: NSLayoutConstraint.Relation.equal,
-                    toItem: contentView,
-                    attribute: NSLayoutConstraint.Attribute.leading,
-                    multiplier: 1.0,
-                    constant: 0.0
-                )
-            )
-            contentView.addConstraint(
-                NSLayoutConstraint(
-                    item: swiftUICellViewController.view!,
-                    attribute: NSLayoutConstraint.Attribute.trailing,
-                    relatedBy: NSLayoutConstraint.Relation.equal,
-                    toItem: contentView,
-                    attribute: NSLayoutConstraint.Attribute.trailing,
-                    multiplier: 1.0,
-                    constant: 0.0
-                )
-            )
-            contentView.addConstraint(
-                NSLayoutConstraint(
-                    item: swiftUICellViewController.view!,
-                    attribute: NSLayoutConstraint.Attribute.top,
-                    relatedBy: NSLayoutConstraint.Relation.equal,
-                    toItem: contentView,
-                    attribute: NSLayoutConstraint.Attribute.top,
-                    multiplier: 1.0,
-                    constant: 0.0
-                )
-            )
-            contentView.addConstraint(
-                NSLayoutConstraint(
-                    item: swiftUICellViewController.view!,
-                    attribute: NSLayoutConstraint.Attribute.bottom,
-                    relatedBy: NSLayoutConstraint.Relation.equal,
-                    toItem: contentView,
-                    attribute: NSLayoutConstraint.Attribute.bottom,
-                    multiplier: 1.0,
-                    constant: 0.0
-                )
-            )
+            contentView.pinSubviewToAllEdges(swiftUICellViewController.view)
 
             swiftUICellViewController.didMove(toParent: parent)
             swiftUICellViewController.view.layoutIfNeeded()

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
@@ -1,0 +1,70 @@
+import UIKit
+import SwiftUI
+
+class HostingTableViewCell<Content: View>: UITableViewCell {
+    private weak var controller: UIHostingController<Content>?
+
+    func host(_ view: Content, parent: UIViewController) {
+        if let controller = controller {
+            controller.rootView = view
+            controller.view.layoutIfNeeded()
+        } else {
+            let swiftUICellViewController = UIHostingController(rootView: view)
+            controller = swiftUICellViewController
+            swiftUICellViewController.view.backgroundColor = .clear
+
+            layoutIfNeeded()
+
+            parent.addChild(swiftUICellViewController)
+            contentView.addSubview(swiftUICellViewController.view)
+            swiftUICellViewController.view.translatesAutoresizingMaskIntoConstraints = false
+            contentView.addConstraint(
+                NSLayoutConstraint(
+                    item: swiftUICellViewController.view!,
+                    attribute: NSLayoutConstraint.Attribute.leading,
+                    relatedBy: NSLayoutConstraint.Relation.equal,
+                    toItem: contentView,
+                    attribute: NSLayoutConstraint.Attribute.leading,
+                    multiplier: 1.0,
+                    constant: 0.0
+                )
+            )
+            contentView.addConstraint(
+                NSLayoutConstraint(
+                    item: swiftUICellViewController.view!,
+                    attribute: NSLayoutConstraint.Attribute.trailing,
+                    relatedBy: NSLayoutConstraint.Relation.equal,
+                    toItem: contentView,
+                    attribute: NSLayoutConstraint.Attribute.trailing,
+                    multiplier: 1.0,
+                    constant: 0.0
+                )
+            )
+            contentView.addConstraint(
+                NSLayoutConstraint(
+                    item: swiftUICellViewController.view!,
+                    attribute: NSLayoutConstraint.Attribute.top,
+                    relatedBy: NSLayoutConstraint.Relation.equal,
+                    toItem: contentView,
+                    attribute: NSLayoutConstraint.Attribute.top,
+                    multiplier: 1.0,
+                    constant: 0.0
+                )
+            )
+            contentView.addConstraint(
+                NSLayoutConstraint(
+                    item: swiftUICellViewController.view!,
+                    attribute: NSLayoutConstraint.Attribute.bottom,
+                    relatedBy: NSLayoutConstraint.Relation.equal,
+                    toItem: contentView,
+                    attribute: NSLayoutConstraint.Attribute.bottom,
+                    multiplier: 1.0,
+                    constant: 0.0
+                )
+            )
+
+            swiftUICellViewController.didMove(toParent: parent)
+            swiftUICellViewController.view.layoutIfNeeded()
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCell.swift
@@ -1,4 +1,0 @@
-import UIKit
-
-final class NotificationsTableViewCell: UITableViewCell {
-}

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -14,7 +14,6 @@ struct NotificationsTableViewCellContent: View {
 
         struct Altered {
             let text: String
-            let actionTitle: String
             let action: (() -> Void)?
         }
 
@@ -111,6 +110,16 @@ fileprivate extension NotificationsTableViewCellContent {
 
 // MARK: - Regular Style
 fileprivate extension NotificationsTableViewCellContent {
+    private enum Strings {
+        static let undoButtonText = NSLocalizedString(
+            "Undo",
+            comment: "Revert an operation"
+        )
+        static let undoButtonHint = NSLocalizedString(
+            "Reverts the action performed on this notification.",
+            comment: "Accessibility hint describing what happens if the undo button is tapped."
+        )
+    }
     struct Altered: View {
         private let info: Style.Altered
 
@@ -134,13 +143,15 @@ fileprivate extension NotificationsTableViewCellContent {
                     Button(action: {
                         info.action?()
                     }, label: {
-                        Text(info.actionTitle)
+                        Text(Strings.undoButtonText)
                             .style(.bodySmall(.regular))
                             .foregroundStyle(Color.white)
-                        .padding(.trailing, Length.Padding.medium)
+                            .accessibilityHint(Strings.undoButtonHint)
+                            .padding(.trailing, Length.Padding.medium)
                     })
                 }
             }
+            .frame(height: 60)
             .background(Color.DS.Foreground.error)
         }
     }
@@ -197,7 +208,6 @@ fileprivate extension NotificationsTableViewCellContent {
             style: .altered(
                 .init(
                     text: "Comment has been marked as Spam",
-                    actionTitle: "Undo",
                     action: nil
                 )
             )

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -5,7 +5,7 @@ struct NotificationsTableViewCellContent: View {
     static let reuseIdentifier = String(describing: Self.self)
     enum Style {
         struct Regular {
-            let title: String
+            let title: AttributedString?
             let description: String?
             let shouldShowIndicator: Bool
             let avatarStyle: AvatarsView.Style
@@ -83,13 +83,15 @@ fileprivate extension NotificationsTableViewCellContent {
                 .fill(Color.DS.Background.brand(isJetpack: AppConfiguration.isJetpack))
                 .frame(width: Length.Padding.single)
         }
-
+        
         private var textsVStack: some View {
             VStack(alignment: .leading, spacing: 0) {
-                Text(info.title)
-                    .style(.bodySmall(.regular))
-                    .foregroundStyle(Color.DS.Foreground.primary)
-                    .lineLimit(2)
+                if let title = info.title {
+                    Text(title)
+                        .style(.bodySmall(.regular))
+                        .foregroundStyle(Color.DS.Foreground.primary)
+                        .lineLimit(2)
+                }
 
                 if let description = info.description {
                     Text(description)

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -84,7 +84,7 @@ fileprivate extension NotificationsTableViewCellContent {
         }
 
         private var textsVStack: some View {
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Length.Padding.half) {
                 Text(info.title)
                     .style(.bodySmall(.regular))
                     .foregroundStyle(Color.DS.Foreground.primary)

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import DesignSystem
 
 struct NotificationsTableViewCellContent: View {
+    static let reuseIdentifier = String(describing: Self.self)
     enum Style {
         struct Regular {
             let title: String

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -140,7 +140,6 @@ fileprivate extension NotificationsTableViewCellContent {
                     })
                 }
             }
-            .frame(height: 60)
             .background(Color.DS.Foreground.error)
         }
     }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -59,7 +59,6 @@ fileprivate extension NotificationsTableViewCellContent {
                 }
                 Spacer()
             }
-            .offset(x: 0, y: info.avatarStyle.verticalOffset)
             .padding(.trailing, Length.Padding.double)
         }
 
@@ -67,7 +66,8 @@ fileprivate extension NotificationsTableViewCellContent {
             HStack(spacing: 0) {
                 if info.shouldShowIndicator {
                     indicator
-                        .padding(.horizontal, Length.Padding.single)
+                        .padding(.leading, Length.Padding.single)
+                        .padding(.trailing, Length.Padding.split)
                     AvatarsView(style: info.avatarStyle)
                         .offset(x: -info.avatarStyle.leadingOffset)
                 } else {
@@ -85,7 +85,7 @@ fileprivate extension NotificationsTableViewCellContent {
         }
 
         private var textsVStack: some View {
-            VStack(alignment: .leading, spacing: Length.Padding.half) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text(info.title)
                     .style(.bodySmall(.regular))
                     .foregroundStyle(Color.DS.Foreground.primary)
@@ -96,6 +96,7 @@ fileprivate extension NotificationsTableViewCellContent {
                         .style(.bodySmall(.regular))
                         .foregroundStyle(Color.DS.Foreground.secondary)
                         .lineLimit(2)
+                        .padding(.top, Length.Padding.half)
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -1,46 +1,46 @@
 import SwiftUI
 import DesignSystem
 
-extension NotificationsTableViewCell {
-    struct Content: View {
-        enum Style {
-            struct Regular {
-                let title: String
-                let description: String?
-                let shouldShowIndicator: Bool
-                let avatarStyle: AvatarsView.Style
-                let actionIconName: String? // TODO: Will be refactored to contain the action.
-            }
-
-            struct Altered {
-                let text: String
-                let actionTitle: String
-                let action: (() -> Void)?
-            }
-
-            case regular(Regular)
-            case altered(Altered)
+struct NotificationsTableViewCellContent: View {
+    enum Style {
+        struct Regular {
+            let title: String
+            let description: String?
+            let shouldShowIndicator: Bool
+            let avatarStyle: AvatarsView.Style
+            let actionIconName: String? // TODO: Will be refactored to contain the action.
         }
 
-        private let style: Style
-
-        init(style: Style) {
-            self.style = style
+        struct Altered {
+            let text: String
+            let actionTitle: String
+            let action: (() -> Void)?
         }
 
-        var body: some View {
-            switch style {
-            case .regular(let regular):
-                Regular(info: regular)
-            case .altered(let altered):
-                Altered(info: altered)
-            }
+        case regular(Regular)
+        case altered(Altered)
+    }
+
+    private let style: Style
+
+    init(style: Style) {
+        self.style = style
+    }
+
+    var body: some View {
+        switch style {
+        case .regular(let regular):
+            Regular(info: regular)
+                .padding(.bottom, Length.Padding.medium)
+        case .altered(let altered):
+            Altered(info: altered)
+                .padding(.bottom, Length.Padding.medium)
         }
     }
 }
 
 // MARK: - Regular Style
-fileprivate extension NotificationsTableViewCell.Content {
+fileprivate extension NotificationsTableViewCellContent {
     struct Regular: View {
         private let info: Style.Regular
 
@@ -57,6 +57,7 @@ fileprivate extension NotificationsTableViewCell.Content {
                 if let actionIconName = info.actionIconName {
                     actionIcon(withName: actionIconName)
                 }
+                Spacer()
             }
             .padding(.trailing, Length.Padding.double)
         }
@@ -108,7 +109,7 @@ fileprivate extension NotificationsTableViewCell.Content {
 }
 
 // MARK: - Regular Style
-fileprivate extension NotificationsTableViewCell.Content {
+fileprivate extension NotificationsTableViewCellContent {
     struct Altered: View {
         private let info: Style.Altered
 
@@ -148,7 +149,7 @@ fileprivate extension NotificationsTableViewCell.Content {
 #if DEBUG
 #Preview {
     VStack(alignment: .leading, spacing: Length.Padding.medium) {
-        NotificationsTableViewCell.Content(
+        NotificationsTableViewCellContent(
             style: .regular(
                 .init(
                     title: "John Smith liked your comment more than all other comments as asdf",
@@ -162,7 +163,7 @@ fileprivate extension NotificationsTableViewCell.Content {
             )
         )
 
-        NotificationsTableViewCell.Content(
+        NotificationsTableViewCellContent(
             style: .regular(
                 .init(
                     title: "Albert Einstein and Marie Curie liked your comment on Quantum Mechanical solution for Hydrogen",
@@ -176,7 +177,7 @@ fileprivate extension NotificationsTableViewCell.Content {
                 )
             )
         )
-        NotificationsTableViewCell.Content(
+        NotificationsTableViewCellContent(
             style: .regular(
                 .init(
                     title: "New likes on Night Time in Tokyo",
@@ -192,7 +193,7 @@ fileprivate extension NotificationsTableViewCell.Content {
             )
         )
 
-        NotificationsTableViewCell.Content(
+        NotificationsTableViewCellContent(
             style: .altered(
                 .init(
                     text: "Comment has been marked as Spam",

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -59,6 +59,7 @@ fileprivate extension NotificationsTableViewCellContent {
                 }
                 Spacer()
             }
+            .offset(x: 0, y: info.avatarStyle.verticalOffset)
             .padding(.trailing, Length.Padding.double)
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -306,8 +306,8 @@
 		0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2761CE5375F0014AE99 /* MenuItemView.m */; };
 		086023D42B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */; };
 		086023D52B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */; };
-		086023D72B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */; };
-		086023D82B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */; };
+		086023D72B73B44A000D084A /* HostingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D62B73B44A000D084A /* HostingTableViewCell.swift */; };
+		086023D82B73B44A000D084A /* HostingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023D62B73B44A000D084A /* HostingTableViewCell.swift */; };
 		086023DB2B73BA67000D084A /* AvatarsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023DA2B73BA67000D084A /* AvatarsView.swift */; };
 		086023DC2B73BA67000D084A /* AvatarsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086023DA2B73BA67000D084A /* AvatarsView.swift */; };
 		086103961EE09C91004D7C01 /* MediaVideoExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086103951EE09C91004D7C01 /* MediaVideoExporter.swift */; };
@@ -6032,7 +6032,7 @@
 		0857C2751CE5375F0014AE99 /* MenuItemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemView.h; sourceTree = "<group>"; };
 		0857C2761CE5375F0014AE99 /* MenuItemView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemView.m; sourceTree = "<group>"; };
 		086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTableViewCellContent.swift; sourceTree = "<group>"; };
-		086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsTableViewCell.swift; sourceTree = "<group>"; };
+		086023D62B73B44A000D084A /* HostingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingTableViewCell.swift; sourceTree = "<group>"; };
 		086023DA2B73BA67000D084A /* AvatarsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarsView.swift; sourceTree = "<group>"; };
 		086103951EE09C91004D7C01 /* MediaVideoExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaVideoExporter.swift; sourceTree = "<group>"; };
 		086C117B2A2F6451004A3821 /* CompliancePopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompliancePopover.swift; sourceTree = "<group>"; };
@@ -10103,7 +10103,7 @@
 			isa = PBXGroup;
 			children = (
 				086023DA2B73BA67000D084A /* AvatarsView.swift */,
-				086023D62B73B44A000D084A /* NotificationsTableViewCell.swift */,
+				086023D62B73B44A000D084A /* HostingTableViewCell.swift */,
 				086023D32B73AFD0000D084A /* NotificationsTableViewCellContent.swift */,
 			);
 			path = NotificationsList;
@@ -21689,7 +21689,7 @@
 				98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */,
 				82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */,
 				435D101A2130C2AB00BB2AA8 /* BlogDetailsViewController+FancyAlerts.swift in Sources */,
-				086023D72B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */,
+				086023D72B73B44A000D084A /* HostingTableViewCell.swift in Sources */,
 				8000361D292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift in Sources */,
 				0C23F33E2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift in Sources */,
 				F1E72EBA267790110066FF91 /* UIViewController+Dismissal.swift in Sources */,
@@ -24784,7 +24784,7 @@
 				FABB23032602FC2C00C8785C /* CountriesMapCell.swift in Sources */,
 				FABB23042602FC2C00C8785C /* NavigationTitleView.swift in Sources */,
 				3FE3D1FE26A6F4AC00F3CD10 /* ListTableHeaderView.swift in Sources */,
-				086023D82B73B44A000D084A /* NotificationsTableViewCell.swift in Sources */,
+				086023D82B73B44A000D084A /* HostingTableViewCell.swift in Sources */,
 				8B15D27528009EBF0076628A /* BlogDashboardAnalytics.swift in Sources */,
 				FABB23052602FC2C00C8785C /* WPAnalyticsEvent.swift in Sources */,
 				FABB23062602FC2C00C8785C /* Coordinate.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */; };
 		088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */; };
 		088CC594282BEC41007B9421 /* TooltipPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088CC593282BEC41007B9421 /* TooltipPresenter.swift */; };
+		089D4EBE2B7BBE0D0009CF2F /* notifications-like-multiple-avatar.json in Resources */ = {isa = PBXBuildFile; fileRef = 089D4EBD2B7BBE0D0009CF2F /* notifications-like-multiple-avatar.json */; };
 		08A250F828D9E87600F50420 /* CommentDetailInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A250F728D9E87600F50420 /* CommentDetailInfoViewController.swift */; };
 		08A250F928D9E87600F50420 /* CommentDetailInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A250F728D9E87600F50420 /* CommentDetailInfoViewController.swift */; };
 		08A250FC28D9F0E200F50420 /* CommentDetailInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A250FB28D9F0E200F50420 /* CommentDetailInfoViewModel.swift */; };
@@ -6046,6 +6047,7 @@
 		0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLIncrementalFilenameTests.swift; sourceTree = "<group>"; };
 		088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCardContentLabel.swift; sourceTree = "<group>"; };
 		088CC593282BEC41007B9421 /* TooltipPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenter.swift; sourceTree = "<group>"; };
+		089D4EBD2B7BBE0D0009CF2F /* notifications-like-multiple-avatar.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-like-multiple-avatar.json"; sourceTree = "<group>"; };
 		08A250F728D9E87600F50420 /* CommentDetailInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentDetailInfoViewController.swift; sourceTree = "<group>"; };
 		08A250FB28D9F0E200F50420 /* CommentDetailInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentDetailInfoViewModel.swift; sourceTree = "<group>"; };
 		08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagServiceTests.m; sourceTree = "<group>"; };
@@ -15526,6 +15528,7 @@
 		B58CE5DD1DC1284C004AA81D /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				089D4EBD2B7BBE0D0009CF2F /* notifications-like-multiple-avatar.json */,
 				E150275E1E03E51500B847E3 /* notes-action-delete.json */,
 				E150275F1E03E51500B847E3 /* notes-action-push.json */,
 				E15027601E03E51500B847E3 /* notes-action-unsupported.json */,
@@ -19756,6 +19759,7 @@
 				8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */,
 				D8A468E02181C6450094B82F /* site-segment.json in Resources */,
 				7E4A772B20F7E5FD001C706D /* activity-log-site-content.json in Resources */,
+				089D4EBE2B7BBE0D0009CF2F /* notifications-like-multiple-avatar.json in Resources */,
 				8BEE845A27B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json in Resources */,
 				7EF2EEA0210A67B60007A76B /* notifications-unapproved-comment.json in Resources */,
 				175CC1772721814C00622FB4 /* domain-service-updated-domains.json in Resources */,

--- a/WordPress/WordPressTest/NotificationTests.swift
+++ b/WordPress/WordPressTest/NotificationTests.swift
@@ -84,6 +84,11 @@ class NotificationTests: CoreDataTestCase {
         XCTAssertNotNil(note.metaPostID)
     }
 
+    func testAllAvatarURLsReturnMultipleURLs() throws {
+        let note = try loadLikeMultipleAvatarNotification()
+        XCTAssertEqual(note.allAvatarURLs.count, 3)
+    }
+
     func testFollowerNotificationReturnsTheProperKindValue() throws {
         let note = try loadFollowerNotification()
         XCTAssert(note.kind == .follow)
@@ -265,6 +270,10 @@ class NotificationTests: CoreDataTestCase {
 
     func loadLikeNotification() throws -> WordPress.Notification {
         return try utility.loadLikeNotification()
+    }
+
+    func loadLikeMultipleAvatarNotification() throws -> WordPress.Notification {
+        return try utility.loadLikeMultipleAvatarNotification()
     }
 
     func loadFollowerNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -25,6 +25,10 @@ class NotificationUtility {
         return try .fixture(fromFile: "notifications-like.json", insertInto: context)
     }
 
+    func loadLikeMultipleAvatarNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-like-multiple-avatar.json", insertInto: context)
+    }
+
     func loadFollowerNotification() throws -> WordPress.Notification {
         return try .fixture(fromFile: "notifications-new-follower.json", insertInto: context)
     }

--- a/WordPress/WordPressTest/Test Data/notifications-like-multiple-avatar.json
+++ b/WordPress/WordPressTest/Test Data/notifications-like-multiple-avatar.json
@@ -60,7 +60,42 @@
                     "height": "256",
                     "width": "256",
                     "url": "https:\/\/2.gravatar.com\/avatar\/292929292929"
+                }
+            ],
+            "actions": {
+                "follow": true
+            },
+            "meta": {
+                "links": {
+                    "email": "some@thing.com",
+                    "home": "http:\/\/something.com"
                 },
+                "ids": {
+                    "user": 1919191,
+                    "site": 2929292
+                },
+                "titles": {
+                    "home": "Something"
+                }
+            },
+            "type": "user"
+        },
+        {
+            "text": "XXX",
+            "ranges": [
+                {
+                    "email": "some@thing.com",
+                    "url": "http:\/\/something.com",
+                    "id": 44444,
+                    "site_id": 55555,
+                    "type": "user",
+                    "indices": [
+                        0,
+                        3
+                    ]
+                }
+            ],
+            "media": [
                 {
                     "type": "image",
                     "indices": [
@@ -70,7 +105,42 @@
                     "height": "256",
                     "width": "256",
                     "url": "https:\/\/2.gravatar.com\/avatar\/292929292929"
+                }
+            ],
+            "actions": {
+                "follow": true
+            },
+            "meta": {
+                "links": {
+                    "email": "some@thing.com",
+                    "home": "http:\/\/something.com"
                 },
+                "ids": {
+                    "user": 1919191,
+                    "site": 2929292
+                },
+                "titles": {
+                    "home": "Something"
+                }
+            },
+            "type": "user"
+        },
+        {
+            "text": "XXX",
+            "ranges": [
+                {
+                    "email": "some@thing.com",
+                    "url": "http:\/\/something.com",
+                    "id": 44444,
+                    "site_id": 55555,
+                    "type": "user",
+                    "indices": [
+                        0,
+                        3
+                    ]
+                }
+            ],
+            "media": [
                 {
                     "type": "image",
                     "indices": [

--- a/WordPress/WordPressTest/Test Data/notifications-like-multiple-avatar.json
+++ b/WordPress/WordPressTest/Test Data/notifications-like-multiple-avatar.json
@@ -1,0 +1,146 @@
+{
+    "notificationId": "11111",
+    "type": "like",
+    "read": 0,
+    "noticon": "\uf408",
+    "timestamp": "2015-03-28T00:23:41+00:00",
+    "icon": "https:\/\/2.gravatar.com\/avatar\/33333333",
+    "url": "https:\/\/somethingthatmightnotexist.wordpress.com\/2015\/03\/26\/something\/",
+    "subject": [
+        {
+            "text": "XXXX and 2 others liked your post YYYYY",
+            "ranges": [
+                {
+                    "type": "user",
+                    "indices": [
+                        0,
+                        3
+                    ],
+                    "url": "http:\/\/something.com",
+                    "site_id": 4836651,
+                    "email": "some@thing.com",
+                    "id": 5073742
+                },
+                {
+                    "type": "post",
+                    "indices": [
+                        33,
+                        49
+                    ],
+                    "url": "https:\/\/somethingthatmightnotexist.wordpress.com\/2015\/03\/26\/something\/",
+                    "site_id": 444444,
+                    "id": 44
+                }
+            ]
+        }
+    ],
+    "body": [
+        {
+            "text": "XXX",
+            "ranges": [
+                {
+                    "email": "some@thing.com",
+                    "url": "http:\/\/something.com",
+                    "id": 44444,
+                    "site_id": 55555,
+                    "type": "user",
+                    "indices": [
+                        0,
+                        3
+                    ]
+                }
+            ],
+            "media": [
+                {
+                    "type": "image",
+                    "indices": [
+                        0,
+                        0
+                    ],
+                    "height": "256",
+                    "width": "256",
+                    "url": "https:\/\/2.gravatar.com\/avatar\/292929292929"
+                },
+                {
+                    "type": "image",
+                    "indices": [
+                        0,
+                        0
+                    ],
+                    "height": "256",
+                    "width": "256",
+                    "url": "https:\/\/2.gravatar.com\/avatar\/292929292929"
+                },
+                {
+                    "type": "image",
+                    "indices": [
+                        0,
+                        0
+                    ],
+                    "height": "256",
+                    "width": "256",
+                    "url": "https:\/\/2.gravatar.com\/avatar\/292929292929"
+                }
+            ],
+            "actions": {
+                "follow": true
+            },
+            "meta": {
+                "links": {
+                    "email": "some@thing.com",
+                    "home": "http:\/\/something.com"
+                },
+                "ids": {
+                    "user": 1919191,
+                    "site": 2929292
+                },
+                "titles": {
+                    "home": "Something"
+                }
+            },
+            "type": "user"
+        }
+    ],
+    "meta": {
+        "ids": {
+            "site": 23123129321,
+            "post": 972
+        },
+        "links": {
+            "site": "https:\/\/public-api.wordpress.com\/rest\/v1\/sites\/321312",
+            "post": "https:\/\/public-api.wordpress.com\/rest\/v1\/posts\/292912"
+        }
+    },
+    "title": "1 Like",
+    "header": [
+        {
+            "text": "Your Name",
+            "ranges": [
+                {
+                    "type": "user",
+                    "indices": [
+                        0,
+                        19
+                    ],
+                    "email": "you@domain.com",
+                    "id": 2929292939
+                }
+            ],
+            "media": [
+                {
+                    "type": "image",
+                    "indices": [
+                        0,
+                        0
+                    ],
+                    "height": "256",
+                    "width": "256",
+                    "url": "https:\/\/2.gravatar.com\/avatar\/1929230392012"
+                }
+            ]
+        },
+        {
+            "text": "Some Title!"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #22465 | #22472

## Description
Utilises the newly added `NotificationsTableViewCellContent` to replace the old cells used in NotificationsViewController.
Also contains improvements to `AvatarsView` like placeholder image and parsing multiple image urls from the `Notification` response.

## Testing Steps
1. Install & login to Jetpack App
2. Navigate to `Notifications` tab.
3. ✅ Verify that the UI matches the designs.
4. ✅ Verify, cell selection does not highlight the cell.
5. ✅ Verify various avatar styles: single, double, triple.
6. ✅ Retry steps 3, 4 and 5 after toggling the theme color.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
