### PR TITLE
Reader: Update Reader `hasMore` API logic

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/__files/__admin/scenarios.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/__files/__admin/scenarios.json
@@ -13,6 +13,12 @@
       "possibleStates" : [ "Started", "initial_likes_list", "post_liked", "new_likes_list" ]
     },
     {
+      "id" : "reader_subscriptions_flow",
+      "name" : "reader_subscriptions_flow",
+      "state" : "Started",
+      "possibleStates" : [ "Started", "initial_subscriptions_list", "empty_subscriptions_list" ]
+    },
+    {
       "id" : "new_page_flow",
       "name" : "new_page_flow",
       "state" : "Started",

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_following.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_following.json
@@ -1,4 +1,7 @@
 {
+  "scenarioName": "reader_subscriptions_flow",
+  "requiredScenarioState": "Started",
+  "newScenarioState": "initial_subscriptions_list",
   "request": {
     "method": "GET",
     "urlPath": "/rest/v1.2/read/following"

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_following_empty.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/reader/rest_v12_read_following_empty.json
@@ -1,0 +1,26 @@
+{
+  "scenarioName": "reader_subscriptions_flow",
+  "requiredScenarioState": "initial_subscriptions_list",
+  "newScenarioState": "empty_subscriptions_list",
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/v1.2/read/following"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "date_range": {
+        "before": "2019-05-23T13:00:09+00:00",
+        "after": "2021-05-17T16:34:44+00:00"
+      },
+      "number": 0,
+      "posts": [
+      ]
+    },
+    "headers": {
+      "Content-Type": "application/json",
+      "Connection": "keep-alive",
+      "Cache-Control": "no-cache, must-revalidate, max-age=0"
+    }
+  }
+}

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -768,13 +768,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         [self deletePostsFromBlockedSitesInContext:context];
 
         BOOL spaceAvailable = ([self numberOfPostsForTopic:readerTopic inContext:context] < [self maxPostsToSaveForTopic:readerTopic]);
-        if ([ReaderHelpers isTopicTag:readerTopic] || [ReaderHelpers isRSSFeed:readerTopic]) {
-            // For tags and RSS feeds, assume there is more content as long as more than zero results are returned.
-            hasMore = (postsCount > 0 ) && spaceAvailable;
-        } else {
-            // For other topics, assume there is more content as long as the number of results requested is returned.
-            hasMore = ([remotePosts count] == [self numberToSyncForTopic:readerTopic]) && spaceAvailable;
-        }
+        hasMore = postsCount > 0 && spaceAvailable;
     } completion:^{
         if (success) {
             success(postsCount, hasMore);
@@ -1151,16 +1145,8 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 #pragma mark Internal
 
 - (BOOL)canLoadMorePostsForTopic:(ReaderAbstractTopic * _Nonnull)readerTopic remotePosts:(NSArray * _Nonnull)remotePosts inContext: (NSManagedObjectContext * _Nonnull)context {
-    BOOL hasMore = NO;
     BOOL spaceAvailable = ([self numberOfPostsForTopic:readerTopic inContext:context] < [self maxPostsToSaveForTopic:readerTopic]);
-    if ([ReaderHelpers isTopicTag:readerTopic] || [ReaderHelpers isRSSFeed:readerTopic]) {
-        // For tags and RSS feeds, assume there is more content as long as more than zero results are returned.
-        hasMore = ([remotePosts count] > 0 ) && spaceAvailable;
-    } else {
-        // For other topics, assume there is more content as long as the number of results requested is returned.
-        hasMore = ([remotePosts count] == [self numberToSyncForTopic:readerTopic]) && spaceAvailable;
-    }
-    return hasMore;
+    return [remotePosts count] > 0 && spaceAvailable;
 }
 
 @end

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -6,6 +6,7 @@ class ReaderTests: XCTestCase {
     @MainActor
     override func setUp() async throws {
         setUpTestSuite()
+        try await WireMock.setUpScenario(scenario: "reader_subscriptions_flow")
         try await WireMock.setUpScenario(scenario: "reader_like_post_flow")
 
         try LoginFlow


### PR DESCRIPTION
## Description

With some feeds, we get less than the requested amount, causing the app to prematurely stop fetching new content. This updates the logic for the infinite scroll to check if there's more than 0 posts returned instead.

## Testing

To test:
- Launch Jetpack and login
- Navigate to a Reader feed
- Scroll down to trigger loading more content
- 🔎 **Verify** the scroll behavior matches the previous behavior
- Switch to a feed with a limited number of posts
- Scroll to the end of the content
- 🔎 **Verify** the app doesn't keep trying to request more content

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
