### PR TITLE
Reader: Improve navigation bar contrast and spacing

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -24,7 +24,7 @@ struct ReaderNavigationMenu: View {
     }
 
     var body: some View {
-        HStack(spacing: 8.0) {
+        HStack(spacing: 0) {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
                     ReaderNavigationButton(viewModel: viewModel)
@@ -44,7 +44,7 @@ struct ReaderNavigationMenu: View {
                                .frame(width: 16)
                 }
             })
-            Spacer()
+            Spacer(minLength: 0)
             Button {
                 viewModel.navigateToSearch()
             } label: {
@@ -115,7 +115,7 @@ struct ReaderNavigationMenu: View {
 
         struct StreamFilter {
             static let text = Color.primary
-            static let background = Color(uiColor: .secondarySystemBackground)
+            static let background = Color(uiColor: .init(light: .secondarySystemBackground, dark: .tertiarySystemBackground))
             static let selectedText = Color(uiColor: .systemBackground)
             static let selectedBackground = Color.primary
         }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -31,6 +31,8 @@ struct ReaderNavigationMenu: View {
                         .frame(maxHeight: .infinity)
                         .animation(.easeInOut, value: viewModel.selectedItem)
                     streamFilterView
+                    // add some empty space so that the last filter chip doesn't get covered by the gradient mask.
+                    Spacer(minLength: Metrics.gradientMaskWidth)
                 }
                 .fixedSize(horizontal: false, vertical: true)
             }
@@ -41,7 +43,7 @@ struct ReaderNavigationMenu: View {
                     LinearGradient(gradient: Gradient(colors: [.black, .clear]),
                                    startPoint: .leading,
                                    endPoint: .trailing)
-                               .frame(width: 16)
+                    .frame(width: Metrics.gradientMaskWidth)
                 }
             })
             Spacer(minLength: 0)
@@ -108,6 +110,10 @@ struct ReaderNavigationMenu: View {
             return filter.title
         }
         return String(format: Strings.activeFilterAccessibilityStringFormat, activeFilter.topic.title)
+    }
+
+    struct Metrics {
+        static let gradientMaskWidth: CGFloat = 16.0
     }
 
     struct Colors {


### PR DESCRIPTION
> [!WARNING]
> Auto-merge is enabled.

Minor improvements to the navigation bar:

- Bumped the filter chip background color in dark mode. In the Simulator, the previous color looks fine, but when tested on a real device, especially with Night Shift / modified color temperature and/or reduced brightness, it pales too much into the background.
- Reduced the spacing between the navigation bar's scroll view and the Search button, i.e. it should fit more content.

Before | After
-|-
![before-navbar](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/d4b6bda0-2970-4f90-9109-14a77fbecc8d) | ![after-navbar](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/9954d5cd-4499-4c58-931b-bbe815111da2)


## To test

- Launch the Jetpack app
- Navigate to the Reader
- 🔎 Verify the changes are visible and does not introduce any regression.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
