### PR TITLE
Use GravatarURL instead of Gravatar

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -79,7 +79,7 @@ PODS:
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.3.0)
-  - WordPressUI (1.15.0):
+  - WordPressUI (1.15.1):
     - Gravatar (~> 0.1.0)
   - wpxmlrpc (0.10.0)
   - ZendeskCommonUISDK (6.1.2)
@@ -234,7 +234,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: ba69878bfa1368636e92d29fcfb5bd1e0a11a3ef
   WordPressKit: 7e5250e9e28fcdca787f8d313a7dc89a8571d774
   WordPressShared: cad7777b283d3ce2752f283df587342a581cd49b
-  WordPressUI: 01b8d3169ecc7ed240c17555dd4d9a28f0dd04ee
+  WordPressUI: 88c808b8a6ed7002fea945a3af9147a9e093a413
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
   ZendeskCoreSDK: 19a18e5ef2edcb18f4dbc0ea0d12bd31f515712a

--- a/WordPress/Classes/Models/ManagedPerson.swift
+++ b/WordPress/Classes/Models/ManagedPerson.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import WordPressKit
 import WordPressUI
+import Gravatar
 
 public typealias Person = RemotePerson
 
@@ -10,7 +11,7 @@ public typealias Person = RemotePerson
 class ManagedPerson: NSManagedObject {
 
     func updateWith<T: Person>(_ person: T) {
-        let canonicalAvatarURL = person.avatarURL.flatMap { Gravatar($0)?.canonicalURL }
+        let canonicalAvatarURL = person.avatarURL.flatMap { GravatarURL($0)?.canonicalURL }
 
         avatarURL = canonicalAvatarURL?.absoluteString
         displayName = person.displayName

--- a/WordPress/Classes/Utility/Media/ImageDownloader+Gravatar.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader+Gravatar.swift
@@ -1,11 +1,12 @@
 import Foundation
 import WordPressUI
+import Gravatar
 
 extension ImageDownloader {
 
     nonisolated func downloadGravatarImage(with email: String, completion: @escaping (UIImage?) -> Void) {
 
-        guard let url = Gravatar.gravatarUrl(for: email) else {
+        guard let url = GravatarURL.url(for: email) else {
             completion(nil)
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Me.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Me.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressUI
+import Gravatar
 
 extension BlogDetailsViewController {
 
@@ -27,7 +28,7 @@ extension BlogDetailsViewController {
         guard let userInfo = notification.userInfo,
             let email = userInfo["email"] as? String,
             let image = userInfo["image"] as? UIImage,
-            let url = Gravatar.gravatarUrl(for: email),
+            let url = GravatarURL.url(for: email),
             let gravatarIcon = image.gravatarIcon(size: Metrics.iconSize) else {
                 return
         }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/NoSitesViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressUI
+import Gravatar
 
 struct NoSitesViewModel {
 
@@ -16,7 +17,7 @@ struct NoSitesViewModel {
         self.appUIType = appUIType
         self.displayName = account?.displayName ?? "-"
         if let email = account?.email {
-            self.gravatarURL = Gravatar.gravatarUrl(for: email)
+            self.gravatarURL = GravatarURL.url(for: email)
         } else {
             self.gravatarURL = nil
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressUI
+import Gravatar
 
 extension WPTabBarController {
 
@@ -41,7 +42,7 @@ extension WPTabBarController {
         guard let userInfo = notification.userInfo,
             let email = userInfo["email"] as? String,
             let image = userInfo["image"] as? UIImage,
-            let url = Gravatar.gravatarUrl(for: email) else {
+            let url = GravatarURL.url(for: email) else {
                 return
         }
 

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -1,4 +1,5 @@
 import WordPressUI
+import Gravatar
 
 /// Table view cell for the List component.
 ///
@@ -84,7 +85,7 @@ class ListTableViewCell: UITableViewCell, NibReusable {
     /// If the URL does not contain any image, the default placeholder image will be displayed.
     /// - Parameter url: The URL containing the image.
     func configureImage(with url: URL?) {
-        if let someURL = url, let gravatar = Gravatar(someURL) {
+        if let someURL = url, let gravatar = GravatarURL(someURL) {
             avatarView.downloadGravatar(gravatar, placeholder: placeholderImage, animate: true)
             return
         }


### PR DESCRIPTION
This is part of the effort: https://github.com/wordpress-mobile/WordPress-iOS/issues/22543

To test:

Point your WordPressUI to this branch: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/142

Go to Notifications and see avatars are loading fine.
Go to My Site > comments and see avatars are loading fine.
Smoke test the app and see if avatars are loading fine in general.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
