### PR TITLE
Reference PR for hotfix automation test

### DIFF
--- a/.buildkite/commands/finalize-hotfix.sh
+++ b/.buildkite/commands/finalize-hotfix.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+RELEASE_NUMBER=$1
+
+if [[ -z "${RELEASE_NUMBER}" ]]; then
+    echo "Usage $0 <release number>"
+    exit 1
+fi
+
+echo '--- :git: Configure Git for release management'
+.buildkite/commands/configure-git-for-release-management.sh
+
+echo '--- :git: Checkout release branch'
+.buildkite/commands/checkout-release-branch.sh "$RELEASE_NUMBER"
+
+echo '--- :ruby: Setup Ruby tools'
+install_gems
+
+echo '--- :closed_lock_with_key: Access secrets'
+bundle exec fastlane run configure_apply
+
+echo '--- :shipit: Finalize hotfix'
+bundle exec fastlane finalize_hotfix_release skip_confirm:true

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -15,28 +15,9 @@ common_params:
 
 steps:
 
-  - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
-    command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
-    # The TestFlight build has a priority of 2 so that it is higher than the AppCenter build
-    priority: 2
+  - label: "Test release build for hotfix "
+    command: |
+      echo "beta release parameter: $BETA_RELEASE"
+      echo "beta release parameter: $BETA_RELEASE"
     env: *common_env
     plugins: *common_plugins
-    notify:
-    - slack: "#build-and-ship"
-
-  - label: ":wordpress: :appcenter: WordPress Release Build (App Center)"
-    command: ".buildkite/commands/release-build-wordpress-internal.sh"
-    priority: 1
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-    - slack: "#build-and-ship"
-
-  - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
-    command: ".buildkite/commands/release-build-jetpack.sh"
-    # The TestFlight build has a priority of 2 so that it is higher than the AppCenter build
-    priority: 2
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-    - slack: "#build-and-ship"

--- a/.buildkite/release-pipelines/finalize-hotfix.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: Finalize Release
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The finalization needs to run on macOS because of localization linting
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-15.1
+    command: ".buildkite/commands/finalize-hotfix.sh $VERSION"

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -1,0 +1,21 @@
+steps:
+  - label: New Hotfix Deployment
+    plugins:
+      - automattic/a8c-ci-toolkit#2.18.2
+    # The beta needs to run on macOS because it uses genstrings under the hood
+    agents:
+        queue: mac
+    env:
+      IMAGE_ID: xcode-15.1
+    command: |
+      echo '--- :git: Configure Git for release management'
+      .buildkite/commands/configure-git-for-release-management.sh
+
+      echo '--- :ruby: Setup Ruby tools'
+      install_gems
+
+      echo '--- :closed_lock_with_key: Access secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :shipit: Start new hotfix'
+      bundle exec fastlane new_hotfix_release skip_confirm:true version:"$VERSION"

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -84,7 +84,7 @@ platform :ios do
       buildkite_pipeline: BUILDKITE_PIPELINE,
       branch: git_branch, # use current branch to get all the hacks
       pipeline_file: File.join(PIPELINES_ROOT, 'new-hotfix.yml'),
-      message: "Set up new hotfix version #{release_version}",
+      message: "Set up new hotfix version #{version}",
       environment: { VERSION: version }
     )
   end
@@ -97,7 +97,7 @@ platform :ios do
       buildkite_pipeline: BUILDKITE_PIPELINE,
       branch: compute_release_branch_name(options:, version:),
       pipeline_file: File.join(PIPELINES_ROOT, 'finalize-hotfix.yml'),
-      message: "Finalize hotfix version #{release_version}",
+      message: "Finalize hotfix version #{version}",
       environment: { VERSION: version }
     )
   end

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -82,7 +82,7 @@ platform :ios do
     buildkite_trigger_build(
       buildkite_organization: BUILDKITE_ORGANIZATION,
       buildkite_pipeline: BUILDKITE_PIPELINE,
-      branch: compute_release_branch_name(options:, version:),
+      branch: git_branch, # use current branch to get all the hacks
       pipeline_file: File.join(PIPELINES_ROOT, 'new-hotfix.yml'),
       message: "Set up new hotfix version #{release_version}",
       environment: { VERSION: version }

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -78,12 +78,28 @@ platform :ios do
 
   lane :trigger_new_hotfix_in_ci do |options|
     version = extract_hotfix_version_from_lane_options!(options)
-    UI.message("TODO: Will start hotfix #{version}")
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version:),
+      pipeline_file: File.join(PIPELINES_ROOT, 'new-hotfix.yml'),
+      message: "Set up new hotfix version #{release_version}",
+      environment: { VERSION: version }
+    )
   end
 
   lane :trigger_finalize_hotfix_in_ci do |options|
     version = extract_hotfix_version_from_lane_options!(options)
-    UI.message("TODO: Will finish hotfix #{version}")
+
+    buildkite_trigger_build(
+      buildkite_organization: BUILDKITE_ORGANIZATION,
+      buildkite_pipeline: BUILDKITE_PIPELINE,
+      branch: compute_release_branch_name(options:, version:),
+      pipeline_file: File.join(PIPELINES_ROOT, 'finalize-hotfix.yml'),
+      message: "Finalize hotfix version #{release_version}",
+      environment: { VERSION: version }
+    )
   end
 end
 

--- a/fastlane/lanes/release_management_in_ci.rb
+++ b/fastlane/lanes/release_management_in_ci.rb
@@ -95,7 +95,7 @@ platform :ios do
     buildkite_trigger_build(
       buildkite_organization: BUILDKITE_ORGANIZATION,
       buildkite_pipeline: BUILDKITE_PIPELINE,
-      branch: compute_release_branch_name(options:, version:),
+      branch: git_branch, # need this branch because of the hacks
       pipeline_file: File.join(PIPELINES_ROOT, 'finalize-hotfix.yml'),
       message: "Finalize hotfix version #{version}",
       environment: { VERSION: version }


### PR DESCRIPTION
From this branch, running...

**`bundle exec fastlane trigger_new_hotfix_in_ci`** resulted in a failure because no version was given

<img width="1513" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/1bfc589f-127f-407c-b7fc-98848e8fa513">

**`bundle exec fastlane trigger_new_hotfix_in_ci version:24.1.1`** resulted in [this CI build starting](https://buildkite.com/automattic/wordpress-ios/builds/20325).

<img width="1728" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/a91a632c-68c1-4075-9d4a-925092a52785">

which succeeded and created `release/24.1.1`

<img width="1177" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/cb8ae826-df88-4bbb-9d67-b5415652fa95">

<img width="1438" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/b49e5b97-67bf-4a0a-aa82-14b56930dd02">

(that branch has now been deleted)

**`bundle exec fastlane trigger_finalize_hotfix_in_ci`** resulted in a failure because no version was given

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/9330da5a-d074-45ec-aa50-9847295473fd)

**`bundle exec fastlane trigger_finalize_hotfix_in_ci version:24.1.1`** resulted in [this CI build](https://buildkite.com/automattic/wordpress-ios/builds/20329)

<img width="1725" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/f829f76b-2094-4ae6-b2dc-13d85f5df05e">

which succeeded to trigger the [release build in CI for the `release/24.1.1` branch](https://buildkite.com/automattic/wordpress-ios/builds/20330):

<img width="1162" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/0ad5d480-3fe7-45c8-a506-f8051c173a21">

which I cancelled:

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/ab2a5fcd-de28-42bf-b616-1b930e9ea529)

