### PR TITLE
Offline Mode: Add PublishButton

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+struct PublishButton: View {
+    @ObservedObject var viewModel: PublishButtonViewModel
+
+    var body: some View {
+        ZStack {
+            Button(action: viewModel.onSubmitTapped) {
+                Text(viewModel.title)
+                    .font(.title3.weight(.medium))
+                    .frame(maxWidth: .infinity)
+                    .opacity(isDisabled ? 0 : 1)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(isDisabled)
+            .buttonBorderShape(.roundedRectangle(radius: 8))
+
+            switch viewModel.state {
+            case .default:
+                EmptyView()
+            case .loading:
+                ProgressView()
+                    .tint(Color.secondary)
+            case let .uploading(title, progress):
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .tint(Color.secondary)
+
+                    VStack(alignment: .leading) {
+                        Text(title)
+                            .font(.subheadline.weight(.medium))
+                        if let progress {
+                            Text(Strings.progress(progress))
+                                .foregroundStyle(Color.secondary)
+                                .font(.footnote)
+                                .monospacedDigit()
+                        }
+                    }
+                    .lineLimit(1)
+                    .foregroundStyle(Color.primary)
+
+                    Spacer()
+                }
+                .padding(.horizontal)
+            case let .failed(title, details, onRetryTapped):
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Color.red)
+                    VStack(alignment: .leading) {
+                        Text(title)
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(.primary)
+                        if let details {
+                            Text(details)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .lineLimit(1)
+
+                    Spacer()
+
+                    if let onRetryTapped {
+                        Button(Strings.retry, action: onRetryTapped)
+                            .font(.subheadline)
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    private var isDisabled: Bool {
+        switch viewModel.state {
+        case .default: false
+        case .loading, .uploading, .failed: true
+        }
+    }
+}
+
+final class PublishButtonViewModel: ObservableObject {
+    let title: String
+    let onSubmitTapped: () -> Void
+    @Published var state: PublishButtonState = .default
+
+    init(title: String, onSubmitTapped: @escaping () -> Void, state: PublishButtonState = .default) {
+        self.title = title
+        self.onSubmitTapped = onSubmitTapped
+        self.state = state
+    }
+}
+
+enum PublishButtonState {
+    case `default`
+    case loading
+    case uploading(title: String, progress: Progress?)
+    case failed(title: String, details: String? = nil, onRetryTapped: (() -> Void)? = nil)
+
+    struct Progress {
+        let completed: Int64
+        let total: Int64
+    }
+}
+
+private enum Strings {
+    static func progress(_ progress: PublishButtonState.Progress) -> String {
+        let format = NSLocalizedString("publishButton.progress", value: "%@ of %@", comment: "Shows the download or upload progress with two parameters: preformatted completed and total bytes")
+        return String(format: format, ByteCountFormatter.string(fromByteCount: progress.completed, countStyle: .file), ByteCountFormatter.string(fromByteCount: progress.total, countStyle: .file))
+    }
+
+    static let retry = NSLocalizedString("publishButton.retry", value: "Retry", comment: "Retry button title")
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .default))
+        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .loading))
+        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .uploading(title: "Uploading media...", progress: .init(completed: 100, total: 2000))))
+        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .failed(title: "Failed to upload media")))
+        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .failed(title: "Failed to upload media", details: "Not connected to Internet", onRetryTapped: {})))
+    }
+    .padding()
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -407,6 +407,8 @@
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
 		0C01A6EA2AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift */; };
 		0C01A6EB2AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift */; };
+		0C03AECA2B7D995F00B64A25 /* PublishButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03AEC92B7D995F00B64A25 /* PublishButton.swift */; };
+		0C03AECB2B7D995F00B64A25 /* PublishButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03AEC92B7D995F00B64A25 /* PublishButton.swift */; };
 		0C0453282AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C0453292AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C04532B2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */; };
@@ -6153,6 +6155,7 @@
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
 		0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellSelectionOverlayView.swift; sourceTree = "<group>"; };
+		0C03AEC92B7D995F00B64A25 /* PublishButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishButton.swift; sourceTree = "<group>"; };
 		0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaVideoDurationView.swift; sourceTree = "<group>"; };
 		0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaDocumentInfoView.swift; sourceTree = "<group>"; };
 		0C0AD1052B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaSelectionTitleView.swift; sourceTree = "<group>"; };
@@ -18529,6 +18532,7 @@
 				FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */,
 				FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */,
 				FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */,
+				0C03AEC92B7D995F00B64A25 /* PublishButton.swift */,
 			);
 			path = Prepublishing;
 			sourceTree = "<group>";
@@ -22868,6 +22872,7 @@
 				0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */,
 				E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */,
 				E1ADE0EB20A9EF6200D6AADC /* PrivacySettingsViewController.swift in Sources */,
+				0C03AECA2B7D995F00B64A25 /* PublishButton.swift in Sources */,
 				E6431DE61C4E892900FD8D90 /* SharingDetailViewController.m in Sources */,
 				FA8E2FE027C6377000DA0982 /* DashboardQuickStartCardCell.swift in Sources */,
 				B50EED791C0E5B2400D278CA /* SettingsPickerViewController.swift in Sources */,
@@ -25739,6 +25744,7 @@
 				0C748B4C2A9D71A100809E1A /* SiteMediaCollectionViewController.swift in Sources */,
 				FABB25C52602FC2C00C8785C /* MenusSelectionItemView.m in Sources */,
 				FABB25C62602FC2C00C8785C /* TenorReponseParser.swift in Sources */,
+				0C03AECB2B7D995F00B64A25 /* PublishButton.swift in Sources */,
 				FABB25C72602FC2C00C8785C /* WPStyleGuide+Gridicon.swift in Sources */,
 				FABB25C92602FC2C00C8785C /* CreateButtonCoordinator.swift in Sources */,
 				3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */,


### PR DESCRIPTION
Adds the `PublishButton` to cover the uploading scenarios from the project spec.

## To test:

Since it's not integrated yet, the best way to test it is by using the previews in a separate Xcode project. It supports the following states:

<img width="588" alt="Screenshot 2024-02-14 at 8 03 37 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/db90ae72-8f33-4bb1-8964-9a94d5528a7d">

I added a ViewModel to make it easy to update the state from UIKit.

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
