### PR TITLE
Hide bottom tab bar when display Reader comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentAction.swift
@@ -13,6 +13,7 @@ final class ReaderCommentAction {
         controller.navigateToCommentID = navigateToCommentID as NSNumber?
         controller.promptToAddComment = promptToAddComment
         controller.trackCommentsOpened()
+        controller.hidesBottomBarWhenPushed = true
         origin.navigationController?.pushViewController(controller, animated: true)
     }
 }


### PR DESCRIPTION
Fixes #22604

This PR fixes redundant displaying of the bottom tab bar on the Reader tab when tapping a comment button placed on a reader post's card.

https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/cfb7c56f-0e8f-4f61-9ffc-0dded26c1700

To test:

- Go to the Reader tab.
- Tap on any post's "Comment" CTA button.
- [ ] Make sure the bottom tab bar is not visible on the Comments screen.

## Regression Notes
1. Potential unintended areas of impact
Comments screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
UI changes only

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
