### PR TITLE
Adopt `PluginDirectoryServiceRemote` changes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 13.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'ae8f83e5cffd14cc34cec863fc2d5c63e9658246'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '3df47e113c7647b76c049180e39489e3af7a27dc'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 13.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'dfb2134ca3b91233d44b3551d91844bf2087996f'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'ae8f83e5cffd14cc34cec863fc2d5c63e9658246'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,7 +120,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fa06fca7178b268d382d91861752b3be0729e8a8`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `ae8f83e5cffd14cc34cec863fc2d5c63e9658246`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `3df47e113c7647b76c049180e39489e3af7a27dc`)
   - WordPressShared (~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :commit: fa06fca7178b268d382d91861752b3be0729e8a8
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: ae8f83e5cffd14cc34cec863fc2d5c63e9658246
+    :commit: 3df47e113c7647b76c049180e39489e3af7a27dc
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -189,7 +189,7 @@ CHECKOUT OPTIONS:
     :commit: fa06fca7178b268d382d91861752b3be0729e8a8
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: ae8f83e5cffd14cc34cec863fc2d5c63e9658246
+    :commit: 3df47e113c7647b76c049180e39489e3af7a27dc
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -236,6 +236,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 951d83502d78264ef3f877d0472b009e53a61379
+PODFILE CHECKSUM: f732e6e39fc98112f1812c770b6bb5daf5a73672
 
 COCOAPODS: 1.14.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,7 +120,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fa06fca7178b268d382d91861752b3be0729e8a8`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `dfb2134ca3b91233d44b3551d91844bf2087996f`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `ae8f83e5cffd14cc34cec863fc2d5c63e9658246`)
   - WordPressShared (~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :commit: fa06fca7178b268d382d91861752b3be0729e8a8
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: dfb2134ca3b91233d44b3551d91844bf2087996f
+    :commit: ae8f83e5cffd14cc34cec863fc2d5c63e9658246
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -189,7 +189,7 @@ CHECKOUT OPTIONS:
     :commit: fa06fca7178b268d382d91861752b3be0729e8a8
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: dfb2134ca3b91233d44b3551d91844bf2087996f
+    :commit: ae8f83e5cffd14cc34cec863fc2d5c63e9658246
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -236,6 +236,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 91ca97cb58a7ec8391611ea499d341d47f633cda
+PODFILE CHECKSUM: 951d83502d78264ef3f877d0472b009e53a61379
 
 COCOAPODS: 1.14.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Multiple pre-publishing sheet fixes and improvements [#22606]
 * [*] Gravatar: Adds informative new view about Gravatar to the profile editing page. [#22615]
 * [**] [internal] Refactored .org REST API calls. [#22612]
+* [**] [internal] Refactored viewing plugins from self-hosted sites. [#22622]
 
 24.2
 -----


### PR DESCRIPTION
> [!Note]
> This PR is built on top of #22612.

This PR updates the app code to accept the `PluginDirectoryServiceRemote` breaking changes introduced in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/725.

## Test Instructions

1. Log into a self hosted site
2. Go to "Plugins"
3. Verify the Plugins screen can be loaded
4. Verify plugin details can be viewed.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the "Test Instructions"

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: N/A