### PR TITLE
Stats Traffic: Revert Stats Total Row style

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -233,8 +233,8 @@ private extension StatsTotalRow {
     func applyStyles() {
         backgroundColor = .listForeground
         contentView.backgroundColor = .listForeground
-        Style.configureLabelAsCellValueTitle(itemLabel)
-        Style.configureLabelAsCellValue(itemDetailLabel)
+        Style.configureLabelAsCellRowTitle(itemLabel)
+        Style.configureLabelItemDetail(itemDetailLabel)
         Style.configureLabelAsData(dataLabel)
         Style.configureViewAsSeparator(separatorLine)
         Style.configureViewAsSeparator(topExpandedSeparatorLine)


### PR DESCRIPTION
This last commit https://github.com/wordpress-mobile/WordPress-iOS/pull/22433/commits/0dd87d549336b12562c4622288f829ae16c35ef4 meant to change the style for `Latest Post Summary` cell also changed the style for all the cells that use `StatsTotalsRow`. This change wasn't necessary and introduced label color changes to `Days/Weeks/Months/Years` tabs. 

Reverting the change.

## To test:

1. Launch Jetpack
2. Disable `Stats Traffic` feature flag
3. Open Stats Period (Days/Weeks/Months/Years) tab
4. Confirm that all the rows within `Posts And Pages` or `Referrers` appear in black and not in light grey

## Regression Notes
1. Potential unintended areas of impact

None, reverting the changes

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
