### PR TITLE
Fix crash by not loading WP app asset on JP app

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -238,12 +238,6 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
 
         let coordinator = JetpackDefaultOverlayCoordinator()
         let viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source, blog: blog, coordinator: coordinator)
-        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
-        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
-        coordinator.navigationController = navigationViewController
-        coordinator.viewModel = viewModel
-        viewModel.onWillDismiss = onWillDismiss
-        viewModel.onDidDismiss = onDidDismiss
         let frequencyTracker = OverlayFrequencyTracker(source: source,
                                                        type: .featuresRemoval,
                                                        frequencyConfig: frequencyConfig,
@@ -253,6 +247,12 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             onDidDismiss?()
             return
         }
+        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
+        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
+        coordinator.navigationController = navigationViewController
+        coordinator.viewModel = viewModel
+        viewModel.onWillDismiss = onWillDismiss
+        viewModel.onDidDismiss = onDidDismiss
         presentOverlay(navigationViewController: navigationViewController, in: viewController, fullScreen: fullScreen)
         frequencyTracker.track()
     }


### PR DESCRIPTION
The JP app was loading an asset meant only for the WP app. This happens because the view controller containing this asset, `JetpackFullscreenOverlayViewController`, is loaded into memory before the code checks to confirm it's running on the WP app. The fix is to check first which app it's on, and then load the view controller if on the WP app.

Reported in p1708110375843149-slack-C012H19SZQ8

To test:
1. Log in to the JP app
2. Go to the My Sites tab
3. Background the app
4. Foreground the app
5. Verify the app didn't crash
6. Log in to the WP app
7. To to the My Sites tab and then to Stats
8. Verify that the full-screen overlay (static poster) shows up and the animation below appears


### Animation

![JetpackStatsLogoAnimation_ltr](https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/f28115d7-4d14-42d5-acee-db8b993853f1)


## Regression Notes
1. Potential unintended areas of impact

The static posters shown on the WP app

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing of both apps.

3. What automated tests I added (or what prevented me from doing so)

I didn't prioritize this because the static posters may be removed soon

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)