### PR TITLE
Respect safe area for "Reply to post" section on the Comments screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -361,6 +361,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)configureKeyboardManager
 {
+    // The variable introduced because we cannot reuse the same constraint for the keyboard manager and the reply text view.
     self.replyTextViewBottomConstraint = [self.view.keyboardLayoutGuide.topAnchor constraintEqualToAnchor:self.replyTextView.bottomAnchor];
     self.keyboardManager = [[KeyboardDismissHelper alloc] initWithParentView:self.view
                                                                   scrollView:self.tableView

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -43,7 +43,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 @property (nonatomic, strong) SuggestionsTableView *suggestionsTableView;
 @property (nonatomic, strong) NSIndexPath *indexPathForCommentRepliedTo;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
-@property (nonatomic, strong) NSLayoutConstraint *replyTextViewBottomConstraint;
 @property (nonatomic, strong) NSCache *estimatedRowHeights;
 @property (nonatomic) BOOL isLoggedIn;
 @property (nonatomic) BOOL needsUpdateAttachmentsAfterScrolling;
@@ -364,7 +363,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     self.keyboardManager = [[KeyboardDismissHelper alloc] initWithParentView:self.view
                                                                   scrollView:self.tableView
                                                           dismissableControl:self.replyTextView
-                                                      bottomLayoutConstraint:self.replyTextViewBottomConstraint];
+                                                      bottomLayoutConstraint:self.keyboardManager.bottomLayoutConstraint];
 
     __weak UITableView *weakTableView = self.tableView;
     __weak ReaderCommentsViewController *weakSelf = self;

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -43,6 +43,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 @property (nonatomic, strong) SuggestionsTableView *suggestionsTableView;
 @property (nonatomic, strong) NSIndexPath *indexPathForCommentRepliedTo;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
+@property (nonatomic, strong) NSLayoutConstraint *replyTextViewBottomConstraint;
 @property (nonatomic, strong) NSCache *estimatedRowHeights;
 @property (nonatomic) BOOL isLoggedIn;
 @property (nonatomic) BOOL needsUpdateAttachmentsAfterScrolling;
@@ -360,10 +361,11 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)configureKeyboardManager
 {
+    self.replyTextViewBottomConstraint = [self.view.keyboardLayoutGuide.topAnchor constraintEqualToAnchor:self.replyTextView.bottomAnchor];
     self.keyboardManager = [[KeyboardDismissHelper alloc] initWithParentView:self.view
                                                                   scrollView:self.tableView
                                                           dismissableControl:self.replyTextView
-                                                      bottomLayoutConstraint:self.keyboardManager.bottomLayoutConstraint];
+                                                      bottomLayoutConstraint:self.replyTextViewBottomConstraint];
 
     __weak UITableView *weakTableView = self.tableView;
     __weak ReaderCommentsViewController *weakSelf = self;

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -401,20 +401,11 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                                                       metrics:nil
                                                                         views:views]];
 
-    // ReplyTextView Constraints
-    [[self.replyTextView.leftAnchor constraintEqualToAnchor:self.tableView.leftAnchor] setActive:YES];
-    [[self.replyTextView.rightAnchor constraintEqualToAnchor:self.tableView.rightAnchor] setActive:YES];
-
-    self.replyTextViewBottomConstraint = [NSLayoutConstraint constraintWithItem:self.view
-                                                                      attribute:NSLayoutAttributeBottom
-                                                                      relatedBy:NSLayoutRelationEqual
-                                                                         toItem:self.replyTextView
-                                                                      attribute:NSLayoutAttributeBottom
-                                                                     multiplier:1.0
-                                                                       constant:0.0];
-    self.replyTextViewBottomConstraint.priority = UILayoutPriorityDefaultHigh;
-
-    [self.view addConstraint:self.replyTextViewBottomConstraint];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.replyTextView.leadingAnchor constraintEqualToAnchor:self.replyTextView.leadingAnchor],
+        [self.replyTextView.trailingAnchor constraintEqualToAnchor:self.replyTextView.trailingAnchor],
+        [self.view.keyboardLayoutGuide.topAnchor constraintEqualToAnchor:self.replyTextView.bottomAnchor]
+    ]];
 
     // Suggestions Constraints
     // Pin the suggestions view left and right edges to the reply view edges


### PR DESCRIPTION
Fixes #22603

This PR fixes missing padding for the reply section on the Comments screen that ignored the safe area and was overlayed by the Home indicator.

https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/5528b870-a707-4ef0-a62e-6506851babfd

To test:
- Go to Reader -> Comments
- Make sure the `Reply` section respects the bottom safe area
- Tap on it to reveal the keyboard
- Make sure that the `Reply` section is visible above the keyboard

## Regression Notes
1. Potential unintended areas of impact
Comments screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing, UI tests.

3. What automated tests I added (or what prevented me from doing so)
Automated tests already exist.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
