### PR TITLE
Fix showing non-user media as an avatar in Notifications screen

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -365,18 +365,21 @@ extension Notification {
     }
 
     var allAvatarURLs: [URL] {
-        let firstMedias: [AnyObject] = body?.compactMap {
-            let allMedia = $0["media"] as? [AnyObject]
-            return allMedia?.first as? AnyObject
-        } ?? []
+        let users = body?.filter({ element in
+            let type = element["type"] as? String
+            return type == "user"
+        }) ?? []
 
-        let urlStrings = firstMedias.compactMap {
-            $0["url"] as? String
+        let avatars: [URL] = users.compactMap {
+            guard let allMedia = $0["media"] as? [AnyObject],
+                  let firstMedia = allMedia.first,
+                  let urlString = firstMedia["url"] as? String else {
+                return nil
+            }
+            return URL(string: urlString)
         }
 
-        return urlStrings.compactMap {
-            URL(string: $0)
-        }
+        return avatars
     }
 }
 

--- a/WordPress/WordPressTest/Test Data/notifications-like-multiple-avatar.json
+++ b/WordPress/WordPressTest/Test Data/notifications-like-multiple-avatar.json
@@ -169,6 +169,22 @@
                 }
             },
             "type": "user"
+        },
+        {
+          "text": "View likes on your post.",
+          "ranges": [
+            {
+              "type": "post",
+              "indices": [
+                14,
+                23
+              ],
+              "id": 16082,
+              "parent": null,
+              "url": "https:\/\/somethingthatmightnotexist.wordpress.com\/2015\/03\/26\/something\/",
+              "site_id": 180619633
+            }
+          ]
         }
     ],
     "meta": {


### PR DESCRIPTION
## Description
This PR fixes an issue where we would show non-user media as an avatar in some cases. This would happen when the notification body contained an emoji or an image.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-19 at 05 36 43](https://github.com/wordpress-mobile/WordPress-iOS/assets/25306722/b419a2b4-ceec-4b37-8b62-3e5b671a5211) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-02-19 at 05 38 55](https://github.com/wordpress-mobile/WordPress-iOS/assets/25306722/095bc8cd-db54-449c-9df8-3b032af11723) |

## Testing Instructions

1. Set up two accounts. Account A and account B.
2. Publish a post from account A
3. Comment on that post from account B and include an emoji or an image in the comment
4. Install the app
5. Login using account A
6. Go to Notifications
7. Make sure that only the avatar of account B shows up in the notification row
8. Repeat the same steps for getting a notification for a new post that includes media/emoji in its body.


## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.