### PR TITLE
Offline Mode: Draft sync states

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -37,7 +37,7 @@ final class PostListHeaderView: UIView {
         configureIcon(with: syncStateViewModel)
 
         ellipsisButton.isHidden = !syncStateViewModel.isShowingEllipsis
-        icon.isHidden = !syncStateViewModel.isShowingIcon
+        icon.isHidden = syncStateViewModel.iconInfo == nil
         indicator.isHidden = !syncStateViewModel.isShowingIndicator
 
         if syncStateViewModel.isShowingIndicator {

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -33,19 +33,24 @@ final class PostListHeaderView: UIView {
         }
         textLabel.attributedText = viewModel.badges
 
-        let syncStateViewModel = viewModel.syncStateViewModel
-        configureIcon(with: syncStateViewModel)
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            let syncStateViewModel = viewModel.syncStateViewModel
+            configureIcon(with: syncStateViewModel)
 
-        ellipsisButton.isHidden = !syncStateViewModel.isShowingEllipsis
-        icon.isHidden = syncStateViewModel.iconInfo == nil
-        indicator.isHidden = !syncStateViewModel.isShowingIndicator
+            ellipsisButton.isHidden = !syncStateViewModel.isShowingEllipsis
+            icon.isHidden = syncStateViewModel.iconInfo == nil
+            indicator.isHidden = !syncStateViewModel.isShowingIndicator
 
-        if syncStateViewModel.isShowingIndicator {
-            indicator.startAnimating()
+            if syncStateViewModel.isShowingIndicator {
+                indicator.startAnimating()
+            }
         }
     }
 
     private func configureIcon(with viewModel: PostSyncStateViewModel) {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return
+        }
         guard let iconInfo = viewModel.iconInfo else {
             return
         }
@@ -65,10 +70,15 @@ final class PostListHeaderView: UIView {
         setupIcon()
         setupEllipsisButton()
 
-        let innerStackView = UIStackView(arrangedSubviews: [icon, indicator, ellipsisButton])
-        innerStackView.spacing = 4
+        let stackView: UIStackView
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            let innerStackView = UIStackView(arrangedSubviews: [icon, indicator, ellipsisButton])
+            innerStackView.spacing = 4
+            stackView = UIStackView(arrangedSubviews: [textLabel, innerStackView])
+        } else {
+            stackView = UIStackView(arrangedSubviews: [textLabel, ellipsisButton])
+        }
 
-        let stackView = UIStackView(arrangedSubviews: [textLabel, innerStackView])
         stackView.spacing = 12
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -76,6 +86,9 @@ final class PostListHeaderView: UIView {
     }
 
     private func setupIcon() {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return
+        }
         NSLayoutConstraint.activate([
             icon.widthAnchor.constraint(equalToConstant: 24),
             icon.heightAnchor.constraint(equalToConstant: 24)

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -5,6 +5,8 @@ final class PostListHeaderView: UIView {
     // MARK: - Views
 
     private let textLabel = UILabel()
+    private let icon = UIImageView()
+    private let indicator = UIActivityIndicatorView(style: .medium)
     private let ellipsisButton = UIButton(type: .custom)
 
     // MARK: - Properties
@@ -30,6 +32,25 @@ final class PostListHeaderView: UIView {
             configureEllipsisButton(with: viewModel.post, delegate: delegate)
         }
         textLabel.attributedText = viewModel.badges
+
+        let syncStateViewModel = viewModel.syncStateViewModel
+        configureIcon(with: syncStateViewModel)
+
+        ellipsisButton.isHidden = !syncStateViewModel.isShowingEllipsis
+        icon.isHidden = !syncStateViewModel.isShowingIcon
+        indicator.isHidden = !syncStateViewModel.isShowingIndicator
+
+        if syncStateViewModel.isShowingIndicator {
+            indicator.startAnimating()
+        }
+    }
+
+    private func configureIcon(with viewModel: PostSyncStateViewModel) {
+        guard let iconInfo = viewModel.iconInfo else {
+            return
+        }
+        icon.image = iconInfo.image
+        icon.tintColor = iconInfo.color
     }
 
     private func configureEllipsisButton(with post: Post, delegate: InteractivePostViewDelegate) {
@@ -41,13 +62,24 @@ final class PostListHeaderView: UIView {
     // MARK: - Setup
 
     private func setupView() {
+        setupIcon()
         setupEllipsisButton()
 
-        let stackView = UIStackView(arrangedSubviews: [textLabel, ellipsisButton])
+        let innerStackView = UIStackView(arrangedSubviews: [icon, indicator, ellipsisButton])
+        innerStackView.spacing = 4
+
+        let stackView = UIStackView(arrangedSubviews: [textLabel, innerStackView])
         stackView.spacing = 12
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         pinSubviewToAllEdges(stackView)
+    }
+
+    private func setupIcon() {
+        NSLayoutConstraint.activate([
+            icon.widthAnchor.constraint(equalToConstant: 24),
+            icon.heightAnchor.constraint(equalToConstant: 24)
+        ])
     }
 
     private func setupEllipsisButton() {

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -62,12 +62,13 @@ private func makeAccessibilityLabel(for post: Post, statusViewModel: PostCardSta
 private func makeContentString(for post: Post, syncStateViewModel: PostSyncStateViewModel) -> NSAttributedString {
     let title = post.titleForDisplay()
     let snippet = post.contentPreviewForDisplay()
+    let foregroundColor = syncStateViewModel.isEditable ? UIColor.text : UIColor.textTertiary
 
     let string = NSMutableAttributedString()
     if !title.isEmpty {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold),
-            .foregroundColor: syncStateViewModel.isEditable ? UIColor.text : UIColor.textTertiary
+            .foregroundColor: RemoteFeatureFlag.syncPublishing.enabled() ? foregroundColor : UIColor.text
         ]
         let titleAttributedString = NSAttributedString(string: title, attributes: attributes)
         string.append(titleAttributedString)
@@ -80,7 +81,7 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
         }
         let attributes: [NSAttributedString.Key: Any] = [
             .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular),
-            .foregroundColor: syncStateViewModel.isEditable ? UIColor.textSubtle : UIColor.textTertiary
+            .foregroundColor: RemoteFeatureFlag.syncPublishing.enabled() ? foregroundColor : UIColor.text
         ]
         let snippetAttributedString = NSAttributedString(string: adjustedSnippet, attributes: attributes)
         string.append(snippetAttributedString)

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -29,10 +29,6 @@ final class PostSyncStateViewModel {
         isEditable
     }
 
-    var isShowingIcon: Bool {
-        state == .offlineChanges || state == .failed
-    }
-
     var isShowingIndicator: Bool {
         state == .syncing
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+final class PostSyncStateViewModel {
+    enum State {
+        case idle
+        case syncing
+        case offlineChanges
+        case failed
+    }
+
+    private let post: Post
+    private let isInternetReachable: Bool
+
+    var state: State {
+        if post.remoteStatus == .pushing || PostCoordinator.shared.isDeleting(post) {
+            return .syncing
+        }
+        if post.isFailed {
+            return isInternetReachable ? .failed : .offlineChanges
+        }
+        return .idle
+    }
+
+    var isEditable: Bool {
+        state == .idle || state == .offlineChanges || state == .failed
+    }
+
+    var isShowingEllipsis: Bool {
+        isEditable
+    }
+
+    var isShowingIcon: Bool {
+        state == .offlineChanges || state == .failed
+    }
+
+    var isShowingIndicator: Bool {
+        state == .syncing
+    }
+
+    var iconInfo: (image: UIImage?, color: UIColor)? {
+        switch state {
+        case .offlineChanges:
+            return (UIImage(systemName: "wifi.slash"), UIColor.listIcon)
+        case .failed:
+            return (UIImage.gridicon(.notice), UIColor.error)
+        case .idle, .syncing:
+            return nil
+        }
+    }
+
+    var statusMessage: String? {
+        switch state {
+        case .offlineChanges:
+            return Strings.offlineChanges
+        case .failed, .idle, .syncing:
+            return nil
+        }
+    }
+
+    init(post: Post, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
+        self.post = post
+        self.isInternetReachable = isInternetReachable
+    }
+}
+
+private enum Strings {
+    static let offlineChanges = NSLocalizedString(
+        "postList.offlineChanges",
+        value: "Offline changes",
+        comment: "Label for a post in the post list. Indicates that the post has offline changes."
+    )
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -45,6 +45,9 @@ final class PostSyncStateViewModel {
     }
 
     var statusMessage: String? {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return nil
+        }
         switch state {
         case .offlineChanges:
             return Strings.offlineChanges

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4060,6 +4060,8 @@
 		FAA4012E27B405DB009E1137 /* DashboardQuickActionsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4012C27B405DB009E1137 /* DashboardQuickActionsCardCell.swift */; };
 		FAA4013427B52455009E1137 /* DashboardQuickActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4013327B52455009E1137 /* DashboardQuickActionCell.swift */; };
 		FAA4013527B52455009E1137 /* DashboardQuickActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4013327B52455009E1137 /* DashboardQuickActionCell.swift */; };
+		FAA5C90F2B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */; };
+		FAA5C9102B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */; };
 		FAA9084C27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */; };
 		FAA9084D27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */; };
 		FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE3F02615996E00BF29FE /* AppConstants.swift */; };
@@ -9375,6 +9377,7 @@
 		FA98B61B29A3DB840071AAE8 /* BlazeHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeHelper.swift; sourceTree = "<group>"; };
 		FAA4012C27B405DB009E1137 /* DashboardQuickActionsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionsCardCell.swift; sourceTree = "<group>"; };
 		FAA4013327B52455009E1137 /* DashboardQuickActionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionCell.swift; sourceTree = "<group>"; };
+		FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSyncStateViewModel.swift; sourceTree = "<group>"; };
 		FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MySiteViewController+QuickStart.swift"; sourceTree = "<group>"; };
 		FAADE3F02615996E00BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		FAADE42726159B1300BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
@@ -12777,6 +12780,7 @@
 				FAD3DE802AE2965A00A3B031 /* AbstractPostMenuHelper.swift */,
 				FAEC116D2AEBEEA600F9DA54 /* AbstractPostMenuViewModel.swift */,
 				FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */,
+				FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -22607,6 +22611,7 @@
 				9A8ECE0C2254A3260043C8DA /* JetpackLoginViewController.swift in Sources */,
 				46F583A92624CE790010A723 /* BlockEditorSettings+CoreDataClass.swift in Sources */,
 				B50C0C641EF42B3A00372C65 /* Header+WordPress.swift in Sources */,
+				FAA5C90F2B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */,
 				F504D2B125D60C5900A2764C /* StoryMediaLoader.swift in Sources */,
 				7E7BEF7322E1DD27009A880D /* EditorSettingsService.swift in Sources */,
 				C76F48EE25BA20EF00BFEC87 /* JetpackScanHistoryCoordinator.swift in Sources */,
@@ -25152,6 +25157,7 @@
 				98517E5A28220411001FFD45 /* BloggingPromptTableViewCell.swift in Sources */,
 				FAC1B81F29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */,
 				FABB23B02602FC2C00C8785C /* Data.swift in Sources */,
+				FAA5C9102B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */,
 				FA111E392A2F474600896FCE /* BlazeCampaignsViewController.swift in Sources */,
 				FABB23B12602FC2C00C8785C /* AccountSettingsViewController.swift in Sources */,
 				FABB23B22602FC2C00C8785C /* StatsChildRowsView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4062,6 +4062,7 @@
 		FAA4013527B52455009E1137 /* DashboardQuickActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4013327B52455009E1137 /* DashboardQuickActionCell.swift */; };
 		FAA5C90F2B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */; };
 		FAA5C9102B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */; };
+		FAA5C9132B837D9A002E073B /* PostSyncStateViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5C9112B837D9A002E073B /* PostSyncStateViewModelTests.swift */; };
 		FAA9084C27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */; };
 		FAA9084D27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */; };
 		FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE3F02615996E00BF29FE /* AppConstants.swift */; };
@@ -9378,6 +9379,7 @@
 		FAA4012C27B405DB009E1137 /* DashboardQuickActionsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionsCardCell.swift; sourceTree = "<group>"; };
 		FAA4013327B52455009E1137 /* DashboardQuickActionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionCell.swift; sourceTree = "<group>"; };
 		FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSyncStateViewModel.swift; sourceTree = "<group>"; };
+		FAA5C9112B837D9A002E073B /* PostSyncStateViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSyncStateViewModelTests.swift; sourceTree = "<group>"; };
 		FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MySiteViewController+QuickStart.swift"; sourceTree = "<group>"; };
 		FAADE3F02615996E00BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		FAADE42726159B1300BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
@@ -14342,6 +14344,7 @@
 				E10F3DA01E5C2CE0008FAADA /* PostListFilterTests.swift */,
 				57D6C83D22945A10003DDC7E /* PostCompactCellTests.swift */,
 				575E126222973EBB0041B3EB /* PostCompactCellGhostableTests.swift */,
+				FAA5C9112B837D9A002E073B /* PostSyncStateViewModelTests.swift */,
 			);
 			name = Post;
 			sourceTree = "<group>";
@@ -23949,6 +23952,7 @@
 				8B6214E627B1B446001DF7B6 /* BlogDashboardServiceTests.swift in Sources */,
 				C856749A243F4292001A995E /* TenorMockDataHelper.swift in Sources */,
 				01E78D1D296EA54F00FB6863 /* StatsPeriodHelperTests.swift in Sources */,
+				FAA5C9132B837D9A002E073B /* PostSyncStateViewModelTests.swift in Sources */,
 				3FFE3C0828FE00D10021BB96 /* StatsSegmentedControlDataTests.swift in Sources */,
 				015BA4EB29A788A300920F4B /* StatsTotalInsightsCellTests.swift in Sources */,
 				0C1DB60B2B0A9A570028F200 /* ImageDownloaderTests.swift in Sources */,

--- a/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
+++ b/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
@@ -1,0 +1,70 @@
+import Nimble
+import XCTest
+@testable import WordPress
+
+final class PostSyncStateViewModelTests: CoreDataTestCase {
+
+    func testIdleState() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .with(remoteStatus: .sync)
+            .build()
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true)
+
+        // When & Then
+        expect(viewModel.state).to(equal(.idle))
+        expect(viewModel.isEditable).to(beTrue())
+        expect(viewModel.isShowingEllipsis).to(beTrue())
+        expect(viewModel.isShowingIcon).to(beFalse())
+        expect(viewModel.isShowingIndicator).to(beFalse())
+        expect(viewModel.iconInfo).to(beNil())
+    }
+
+    func testSyncingState() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .with(remoteStatus: .pushing)
+            .build()
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true)
+
+        // When & Then
+        expect(viewModel.state).to(equal(.syncing))
+        expect(viewModel.isEditable).to(beFalse())
+        expect(viewModel.isShowingEllipsis).to(beFalse())
+        expect(viewModel.isShowingIcon).to(beFalse())
+        expect(viewModel.isShowingIndicator).to(beTrue())
+        expect(viewModel.iconInfo).to(beNil())
+    }
+
+    func testOfflineChangesState() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .with(remoteStatus: .failed)
+            .build()
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: false)
+
+        // When & Then
+        expect(viewModel.state).to(equal(.offlineChanges))
+        expect(viewModel.isEditable).to(beTrue())
+        expect(viewModel.isShowingEllipsis).to(beTrue())
+        expect(viewModel.isShowingIcon).to(beTrue())
+        expect(viewModel.isShowingIndicator).to(beFalse())
+        expect(viewModel.iconInfo).toNot(beNil())
+    }
+
+    func testFailedState() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .with(remoteStatus: .failed)
+            .build()
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true)
+
+        // When & Then
+        expect(viewModel.state).to(equal(.failed))
+        expect(viewModel.isEditable).to(beTrue())
+        expect(viewModel.isShowingEllipsis).to(beTrue())
+        expect(viewModel.isShowingIcon).to(beTrue())
+        expect(viewModel.isShowingIndicator).to(beFalse())
+        expect(viewModel.iconInfo).toNot(beNil())
+    }
+}

--- a/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
+++ b/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
@@ -15,7 +15,6 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         expect(viewModel.state).to(equal(.idle))
         expect(viewModel.isEditable).to(beTrue())
         expect(viewModel.isShowingEllipsis).to(beTrue())
-        expect(viewModel.isShowingIcon).to(beFalse())
         expect(viewModel.isShowingIndicator).to(beFalse())
         expect(viewModel.iconInfo).to(beNil())
     }
@@ -31,7 +30,6 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         expect(viewModel.state).to(equal(.syncing))
         expect(viewModel.isEditable).to(beFalse())
         expect(viewModel.isShowingEllipsis).to(beFalse())
-        expect(viewModel.isShowingIcon).to(beFalse())
         expect(viewModel.isShowingIndicator).to(beTrue())
         expect(viewModel.iconInfo).to(beNil())
     }
@@ -47,7 +45,6 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         expect(viewModel.state).to(equal(.offlineChanges))
         expect(viewModel.isEditable).to(beTrue())
         expect(viewModel.isShowingEllipsis).to(beTrue())
-        expect(viewModel.isShowingIcon).to(beTrue())
         expect(viewModel.isShowingIndicator).to(beFalse())
         expect(viewModel.iconInfo).toNot(beNil())
     }
@@ -63,7 +60,6 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         expect(viewModel.state).to(equal(.failed))
         expect(viewModel.isEditable).to(beTrue())
         expect(viewModel.isShowingEllipsis).to(beTrue())
-        expect(viewModel.isShowingIcon).to(beTrue())
         expect(viewModel.isShowingIndicator).to(beFalse())
         expect(viewModel.iconInfo).toNot(beNil())
     }


### PR DESCRIPTION
Part of #22578

## Description
- Adds new "sync states" for draft post cells (idle, syncing, offline changes, failed)
- Removing the status label will be addressed in a future PR (https://github.com/wordpress-mobile/WordPress-iOS/pull/22648)

## How to test
- Open a draft
- Verify the following conditions based on the state

State | Activity indicator? | Icon? | Ellipsis button?
 -- | -- | -- | --
Idle (Successfully uploaded) | No | No | Yes
Syncing (Uploading, trashing) | Yes | No | No
Offline changes (No internet connection) | No | Yes | Yes
Failed (Other errors) | No | Yes | Yes

## Regression Notes
1. Potential unintended areas of impact
Post cell

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added tests for the view model

3. What automated tests I added (or what prevented me from doing so)
Added tests for the view model

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
