### PR TITLE
[gravatar] Using Gravatar.fetchProfile from Gravatar SDK

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WordPressShared
 import WordPressAuthenticator
+import Gravatar
 
 // MARK: - LoginEpilogueTableViewController
 //
@@ -299,13 +300,20 @@ private extension LoginEpilogueTableViewController {
 
             /// Load: Gravatar's Metadata
             ///
-            let service = GravatarService()
-            service.fetchProfile(email: userProfile.email) { gravatarProfile in
-                if let gravatarProfile = gravatarProfile {
+            let service = ProfileService()
+            service.fetchProfile(with: userProfile.email) { response in
+                switch response {
+                case .success(let gravatarProfile):
                     epilogueInfo.update(with: gravatarProfile)
+                    DispatchQueue.main.async {
+                        completion(epilogueInfo)
+                    }
+                case .failure(let error):
+                    print("Error: \(error)")
+                    DispatchQueue.main.async {
+                        completion(nil)
+                    }
                 }
-
-                completion(epilogueInfo)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressAuthenticator
+import Gravatar
 
 /// A simple container for the user info shown on the login epilogue screen.
 ///
@@ -39,7 +40,7 @@ extension LoginEpilogueUserInfo {
 
     /// Updates the Epilogue properties, given a GravatarProfile instance.
     ///
-    mutating func update(with profile: GravatarProfile) {
+    mutating func update(with profile: Gravatar.GravatarProfile) {
         gravatarUrl = profile.thumbnailUrl
         fullName = profile.displayName
     }


### PR DESCRIPTION
This PR updates the usage of Gravatar Profile fetch with the Gravatar SDK.

Note that this code is currently unreachable. It's used on Self Hosted epilogue screen, but since https://github.com/wordpress-mobile/WordPress-iOS/pull/18608 , the epilogue is not shown on Self Hosted login. 

Still, the implementation has been updated to use Gravatar SDK.

### To test:

To make the code reachable, comment out:

https://github.com/wordpress-mobile/WordPress-iOS/blob/d6978e2f309d65d05559eb6646c63f6c8a2e3b89/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift#L314-L325

Other pre- requisites: 
- Have a self-hosted site with Jetpack.
- If you don't have any, you can create one fast using https://jurassic.ninja/ (the default will install Jetpack connected to your logged-in WPCom account).

After commenting and building the app again:
- Log out of any WPCom account.
- Log in using the self hosted site.
  - Check that you see your information from Gravatar in the epilogue screen.

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9772967/c44da733-5500-4101-a16f-f0827f3dc24a" width="40%">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
