### PR TITLE
Fix incorrectly tracking reader accessed event in the WordPress app

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -1,6 +1,21 @@
 
 // MARK: - Tab Access Tracking
 
+extension WPTab {
+    var hasStaticScreen: Bool {
+        switch self {
+        case .reader:
+            return true
+        case .notifications:
+            return true
+        case .mySites:
+            return false
+        case .me:
+            return false
+        }
+    }
+}
+
 extension WPTabBarController {
     private static let tabIndexToStatMap: [WPTab: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]
 
@@ -82,6 +97,10 @@ extension WPTabBarController {
         guard let tabType = WPTab(rawValue: Int(tabIndex)),
             let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
                 return false
+        }
+
+        if tabType.hasStaticScreen && shouldUseStaticScreens {
+            return false
         }
 
         WPAppAnalytics.track(stat)

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -1,7 +1,7 @@
 
 // MARK: - Tab Access Tracking
 
-extension WPTab {
+fileprivate extension WPTab {
     var hasStaticScreen: Bool {
         switch self {
         case .reader:

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -31,6 +31,7 @@ extern NSNotificationName const WPTabBarHeightChangedNotification;
 @property (nonatomic, strong, readonly, nullable) ReaderCoordinator *readerCoordinator;
 @property (nonatomic, strong) id<ScenePresenter> meScenePresenter;
 @property (nonatomic, strong, readonly) ReaderTabViewModel *readerTabViewModel;
+@property (nonatomic, assign) BOOL shouldUseStaticScreens;
 
 - (instancetype)initWithStaticScreens:(BOOL)shouldUseStaticScreens;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -49,8 +49,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 @interface WPTabBarController () <UITabBarControllerDelegate, UIViewControllerRestoration>
 
-@property (nonatomic, assign) BOOL shouldUseStaticScreens;
-
 @property (nonatomic, strong) NotificationsViewController *notificationsViewController;
 
 @property (nonatomic, strong) UINavigationController *readerNavigationController;


### PR DESCRIPTION
## Description
This PR fixes an issue where we were tracking `reader_accessed` even if the reader was hidden behind the static screens phase.

## Testing Instructions

### WordPress app
1. Install the WP app
2. Navigate to the Reader tab
3. You should see the static poster
4. ✅ Make sure that the `remove_static_poster_displayed <source: reader>` event is tracked
5. ✅ Make sure that the `reader_accessed` event is not tracked

### Jetpack app
1. Install the JP app
2. Navigate to the Reader tab
3. You should see the reader normally
4. ✅ Make sure that the `reader_accessed` event is tracked
5. ✅ Make sure that the `remove_static_poster_displayed <source: reader>` event is not tracked


## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.