### PR TITLE
More release automation

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -166,7 +166,10 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    upload_build_to_testflight(whats_new_path: WORDPRESS_RELEASE_NOTES_PATH)
+    upload_build_to_testflight(
+      whats_new_path: WORDPRESS_RELEASE_NOTES_PATH,
+      distribution_groups: ['Internal a8c Testers', 'Public Beta Testers']
+    )
 
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
@@ -212,7 +215,10 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
-    upload_build_to_testflight(whats_new_path: JETPACK_RELEASE_NOTES_PATH)
+    upload_build_to_testflight(
+      whats_new_path: JETPACK_RELEASE_NOTES_PATH,
+      distribution_groups: ['Beta Testers']
+    )
 
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
@@ -442,12 +448,16 @@ platform :ios do
     ENV.fetch('BUILDKITE', false)
   end
 
-  def upload_build_to_testflight(whats_new_path:)
+  def upload_build_to_testflight(whats_new_path:, distribution_groups:)
     upload_to_testflight(
       skip_waiting_for_build_processing: true,
       team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
       api_key_path: APP_STORE_CONNECT_KEY_PATH,
-      changelog: File.read(whats_new_path)
+      changelog: File.read(whats_new_path),
+      distribute_external: true,
+      # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
+      reject_build_waiting_for_review: true,
+      groups: distribution_groups
     )
   end
 end

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -265,6 +265,7 @@ platform :ios do
       name: 'WP-Internal',
       file: lane_context[SharedValues::IPA_OUTPUT_PATH],
       dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+      release_notes: File.read(WORDPRESS_RELEASE_NOTES_PATH),
       distribute_to_everyone: true
     )
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -261,14 +261,11 @@ platform :ios do
       export_options: { **COMMON_EXPORT_OPTIONS, method: 'enterprise' }
     )
 
-    appcenter_upload(
-      api_token: get_required_env('APPCENTER_API_TOKEN'),
-      owner_name: APPCENTER_OWNER_NAME,
-      owner_type: APPCENTER_OWNER_TYPE,
-      app_name: 'WP-Internal',
+    upload_build_to_app_center(
+      name: 'WP-Internal',
       file: lane_context[SharedValues::IPA_OUTPUT_PATH],
       dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
-      notify_testers: false
+      distribute_to_everyone: true
     )
 
     sentry_upload_dsym(
@@ -380,16 +377,12 @@ platform :ios do
       - Pull Request: [##{pr}](https://github.com/#{GITHUB_REPO}/pull/#{pr})\n
     NOTES
 
-    appcenter_upload(
-      api_token: get_required_env('APPCENTER_API_TOKEN'),
-      owner_name: APPCENTER_OWNER_NAME,
-      owner_type: APPCENTER_OWNER_TYPE,
-      app_name: appcenter_app_name,
+    upload_build_to_app_center(
+      name: appcenter_app_name,
       file: lane_context[SharedValues::IPA_OUTPUT_PATH],
       dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
       release_notes:,
-      destinations: 'Collaborators',
-      notify_testers: false
+      distribute_to_everyone: false
     )
 
     # Upload dSYMs to Sentry
@@ -458,6 +451,26 @@ platform :ios do
       # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
       reject_build_waiting_for_review: true,
       groups: distribution_groups
+    )
+  end
+
+  def upload_build_to_app_center(
+    name:,
+    file:,
+    dsym:,
+    release_notes:,
+    distribute_to_everyone:
+  )
+    appcenter_upload(
+      api_token: get_required_env('APPCENTER_API_TOKEN'),
+      owner_name: APPCENTER_OWNER_NAME,
+      owner_type: APPCENTER_OWNER_TYPE,
+      app_name: name,
+      file:,
+      dsym:,
+      release_notes:,
+      destinations: distribute_to_everyone ? '*' : 'Collaborators',
+      notify_testers: false
     )
   end
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -578,7 +578,7 @@ def create_release_management_pull_request(release_version:, base_branch:, title
   # We don't know the id of the milestone, but we can use a different action to set it.
   #
   # PR URLs are in the format github.com/org/repo/pull/id
-  pr_number = pr_url.split('/').last
+  pr_number = File.basename(pr_url)
   update_pull_requests_milestone(pr_numbers: [pr_number], to_milestone: release_version)
 
   # Return the PR URL

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -171,6 +171,7 @@ platform :ios do
     trigger_beta_build
 
     pr_url = create_release_management_pull_request(
+      release_version: version,
       base_branch: DEFAULT_BRANCH,
       title: "Merge #{version} code freeze"
     )
@@ -236,6 +237,7 @@ platform :ios do
     push_to_git_remote(tags: false)
 
     pr_url = create_release_management_pull_request(
+      release_version:,
       base_branch: DEFAULT_BRANCH,
       title: "Merge changes from #{build_code_current}"
     )
@@ -411,6 +413,7 @@ platform :ios do
     trigger_release_build
 
     pr_url = create_release_management_pull_request(
+      release_version: release_version_next,
       base_branch: DEFAULT_BRANCH,
       title: "Merge #{version} release finalization"
     )
@@ -555,12 +558,12 @@ def commit_version_and_build_files
   )
 end
 
-def create_release_management_pull_request(base_branch:, title:)
+def create_release_management_pull_request(release_version:, base_branch:, title:)
   token = ENV.fetch('GITHUB_TOKEN', nil)
 
   UI.user_error!('Please export a GitHub API token in the environment as GITHUB_TOKEN') if token.nil?
 
-  create_pull_request(
+  pr_url = create_pull_request(
     api_token: token,
     repo: 'wordpress-mobile/WordPress-iOS',
     title:,
@@ -568,4 +571,16 @@ def create_release_management_pull_request(base_branch:, title:)
     base: base_branch,
     labels: 'Releases'
   )
+
+  # Next, set the milestone for the PR
+  #
+  # The create_pull_request action has a 'milestone' prameter, but it expects the milestone id.
+  # We don't know the id of the milestone, but we can use a different action to set it.
+  #
+  # PR URLs are in the format github.com/org/repo/pull/id
+  pr_number = pr_url.split('/').last
+  update_pull_requests_milestone(pr_numbers: [pr_number], to_milestone: release_version)
+
+  # Return the PR URL
+  pr_url
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -574,7 +574,7 @@ def create_release_management_pull_request(release_version:, base_branch:, title
 
   # Next, set the milestone for the PR
   #
-  # The create_pull_request action has a 'milestone' prameter, but it expects the milestone id.
+  # The create_pull_request action has a 'milestone' parameter, but it expects the milestone id.
   # We don't know the id of the milestone, but we can use a different action to set it.
   #
   # PR URLs are in the format github.com/org/repo/pull/id


### PR DESCRIPTION
In preparation of handing releases over, here are a few automation improvements.

- Automatically distribute builds uploaded to TestFlight
- Automatically distribute builds uploaded to App Center
- Automatically add release notes to App Center build
- Add milestone to release PRs

The changes seem straightforward and I plan to test them in `release/24.3` directly rather than hacking a test release for them.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.