### PR TITLE
Replace "download gravatar by email" methods

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -68,7 +68,7 @@ fileprivate extension UIBarButtonItem {
         gravatarImageView.contentMode = .scaleAspectFill
 
         if let email = email {
-            gravatarImageView.downloadGravatarWithEmail(email, placeholderImage: GravatarConfiguration.fallBackImage)
+            gravatarImageView.downloadGravatar(for: email, placeholderImage: GravatarConfiguration.fallBackImage)
         } else {
             gravatarImageView.image = GravatarConfiguration.fallBackImage
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -375,7 +375,7 @@ private extension CommentContentTableViewCell {
             return
         }
 
-        avatarImageView.downloadGravatarWithEmail(someEmail, placeholderImage: Style.placeholderImage)
+        avatarImageView.downloadGravatar(for: someEmail, placeholderImage: Style.placeholderImage)
     }
 
     func updateContainerLeadingConstraint() {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
@@ -25,7 +25,7 @@ class MyProfileHeaderView: UITableViewHeaderFooterView {
     var gravatarEmail: String? = nil {
         didSet {
             if let email = gravatarEmail {
-                gravatarImageView.downloadGravatarWithEmail(email, rating: GravatarRatings.x)
+                gravatarImageView.downloadGravatar(for: email, gravatarRating: .x)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Me/Views/Header/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/Views/Header/MeHeaderView.m
@@ -1,6 +1,7 @@
 #import "MeHeaderView.h"
 #import "Blog.h"
 #import "WordPress-Swift.h"
+#import "Gravatar-Swift.h"
 
 const CGFloat MeHeaderViewHeight = 154;
 const CGFloat MeHeaderViewGravatarSize = 64.0;
@@ -67,7 +68,7 @@ const CGFloat MeHeaderViewVerticalSpacing = 10.0;
 - (void)setGravatarEmail:(NSString *)gravatarEmail
 {    
     // Since this view is only visible to the current user, we should show all ratings
-    [self.gravatarImageView downloadGravatarWithEmail:gravatarEmail rating:GravatarRatingsX];
+    [self.gravatarImageView downloadGravatarFor:gravatarEmail gravatarRating:GravatarRatingX];
     _gravatarEmail = gravatarEmail;
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -60,7 +60,7 @@ class EpilogueUserInfoCell: UITableViewCell {
                 gravatarView.downloadImage(from: url)
             } else {
                 let placeholder: UIImage = allowGravatarUploads ? .gravatarUploadablePlaceholderImage : .gravatarPlaceholderImage
-                gravatarView.downloadGravatarWithEmail(userInfo.email, rating: .x, placeholderImage: placeholder)
+                gravatarView.downloadGravatar(for: userInfo.email, gravatarRating: .x, placeholderImage: placeholder)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -111,7 +111,7 @@ class NoteBlockCommentTableViewCell: NoteBlockTextTableViewCell {
             return
         }
 
-        gravatarImageView.downloadGravatarWithEmail(unwrappedEmail, placeholderImage: placeholderImage)
+        gravatarImageView.downloadGravatar(for: unwrappedEmail, placeholderImage: placeholderImage)
     }
 
     // MARK: - View Methods

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
@@ -39,7 +39,7 @@ final class AuthorFilterButton: UIControl {
             case .user(let email):
                 authorImageView.contentMode = .scaleAspectFill
                 if let email = email {
-                    authorImageView.downloadGravatarWithEmail(email, placeholderImage: gravatarPlaceholder)
+                    authorImageView.downloadGravatar(for: email, placeholderImage: gravatarPlaceholder)
                 } else {
                     authorImageView.image = gravatarPlaceholder
                 }

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -253,7 +253,7 @@ private class AuthorFilterCell: UITableViewCell {
 
                 let placeholder = UIImage(named: "comment-author-gravatar")
                 if let email = email {
-                    gravatarImageView.downloadGravatarWithEmail(email, placeholderImage: placeholder ?? UIImage())
+                    gravatarImageView.downloadGravatar(for: email, placeholderImage: placeholder ?? UIImage())
                 } else {
                     gravatarImageView.image = placeholder
                 }

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -102,7 +102,7 @@ class ListTableViewCell: UITableViewCell, NibReusable {
             return
         }
 
-        avatarView.downloadGravatarWithEmail(someEmail, placeholderImage: placeholderImage)
+        avatarView.downloadGravatar(for: someEmail, placeholderImage: placeholderImage)
     }
 
     // MARK: Overlay View Support


### PR DESCRIPTION
Fixes part of https://github.com/wordpress-mobile/WordPress-iOS/issues/22543
WPUI PR: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/144

To test:

Prerequisites: 
Checkout `wppinar/replace-download-by-email` in both WPiOS, WPUI.

Check the avatars listed here: https://github.com/wordpress-mobile/WordPress-iOS/issues/22543#issuecomment-1953982734 (I checked all of them but I don't think checking the whole list is that mandatory at this stage) 

## Regression Notes
1. Potential unintended areas of impact


3. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
