### PR TITLE
[Notifications P1] Replace `AsyncImage` with `CachedAsyncImage`

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -70,7 +70,7 @@ struct AvatarsView: View {
             processedURL = url
         }
 
-        return AsyncImage(url: processedURL) { image in
+        return CachedAsyncImage(url: processedURL) { image in
             image.resizable()
         } placeholder: {
             Image("gravatar")

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -90,8 +90,7 @@ fileprivate extension NotificationsTableViewCellContent {
             HStack(spacing: 0) {
                 if info.shouldShowIndicator {
                     indicator
-                        .padding(.leading, Length.Padding.single)
-                        .padding(.trailing, Length.Padding.split)
+                        .padding(.horizontal, Length.Padding.single)
                     AvatarsView(style: info.avatarStyle)
                         .offset(x: -info.avatarStyle.leadingOffset)
                 } else {


### PR DESCRIPTION
Fixes #22642 & #22647

## Description
The current implementation has no caching mechanism. This PR introduces the newly added `CachedAsyncImage` to `AvatarsView`
It also fixes the horizontal margin mismatch between rows that have indicator and rows that don't.

## Testing Steps
1. Install & Login Jetpack
2. Navigate to Notifications tab
3. ✅ Verify that the replicating images are not being fetched again from network
4. ✅ Verify that the text line for each row is the same regardless of what style is the avatar and whether there's indicator or not. The trailing padding for indicator with multi-avatar views will be less than single avatar views.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
