### PR TITLE
Fix: Use weak reference in ReaderCardService 

### DIFF
--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -25,8 +25,10 @@ class ReaderCardService {
     }
 
     func fetch(isFirstPage: Bool, refreshCount: Int = 0, success: @escaping (Int, Bool) -> Void, failure: @escaping (Error?) -> Void) {
-        followedInterestsService.fetchFollowedInterestsLocally { [unowned self] topics in
-            guard let interests = topics, !interests.isEmpty else {
+        followedInterestsService.fetchFollowedInterestsLocally { [weak self] topics in
+            guard let self,
+                  let interests = topics,
+                  !interests.isEmpty else {
                 failure(Errors.noInterests)
                 return
             }


### PR DESCRIPTION
Fixes #22640 

The `ReaderCardsStreamViewController` may be already deallocated once the service object completes fetching, causing it to access an invalid `unowned` reference to `self`. 

This fixes the issue by using a `weak` reference. With this, when the view controller deallocates early, we'll return `Error.noInterests` instead of crashing. For more investigation notes, refer to the description in #22640.

## To test

Unfortunately, there's no sure way to reproduce the issue. However, based on the breadcrumbs available in Sentry, and the notes from the description in #22640, we can deduce a possible "path" to the crash:

#### Case 1: Trigger the Reader onboarding screen

- You can either create a new account or unsubscribe from all tags and then restart the app.
- Launch the Jetpack app. 
- Select the Reader tab. 
- Go to the Discover stream (if you're not already there). The tag selection screen should appear.
- Select several tags to subscribe, then press the primary button on the bottom.
- 🔎 Verify that the Discover stream now displays a list of posts without crashing.

#### Case 2: Spam-switch the Reader stream

- It might be good to use a slow network connection in this case. Or simulate it with Network Link Conditioner.
- Launch the Jetpack app. 
- Select the Reader tab. 
- From the Discover tab, quickly switch between the streams (e.g. Discover > Subscriptions > Discover > Saved).
- 🔎 Verify that the app does not crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Change is minimal.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A. `ReaderCardService` is retained in `ReaderCardsStreamViewController`, and this bug happens on a race condition where the view controller is deallocated (for example because of switching to a different stream) before the fetch completes. This makes it rather tricky to unit test. Refactoring it now is also not feasible as this is part of a legacy code.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
