### PR TITLE
Offline Mode: Remove status label from post cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -72,7 +72,9 @@ class PostCompactCell: UITableViewCell {
         WPStyleGuide.applyPostCardStyle(self)
         WPStyleGuide.applyPostProgressViewStyle(progressView)
         WPStyleGuide.configureLabel(timestampLabel, textStyle: .subheadline)
-        WPStyleGuide.configureLabel(badgesLabel, textStyle: .subheadline)
+        if !RemoteFeatureFlag.syncPublishing.enabled() {
+            WPStyleGuide.configureLabel(badgesLabel, textStyle: .subheadline)
+        }
 
         titleLabel.font = AppStyleGuide.prominentFont(textStyle: .headline, weight: .bold)
         titleLabel.adjustsFontForContentSizeCategory = true
@@ -142,6 +144,10 @@ class PostCompactCell: UITableViewCell {
     }
 
     private func configureStatus() {
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            badgesLabel.isHidden = true
+            return
+        }
         guard let viewModel = viewModel else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -65,9 +65,11 @@ final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
             imageLoader.loadImage(with: imageURL, from: host, preferredSize: Constants.imageSize)
         }
 
-        statusLabel.text = viewModel.status
-        statusLabel.textColor = viewModel.statusColor
-        statusLabel.isHidden = viewModel.status.isEmpty
+        if !RemoteFeatureFlag.syncPublishing.enabled() {
+            statusLabel.text = viewModel.status
+            statusLabel.textColor = viewModel.statusColor
+            statusLabel.isHidden = viewModel.status.isEmpty
+        }
 
         contentView.isUserInteractionEnabled = viewModel.isEnabled
 
@@ -94,9 +96,11 @@ final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.addArrangedSubviews([
             headerView,
-            contentStackView,
-            statusLabel
+            contentStackView
         ])
+        if !RemoteFeatureFlag.syncPublishing.enabled() {
+            mainStackView.addArrangedSubview(statusLabel)
+        }
         mainStackView.spacing = 4
         mainStackView.isLayoutMarginsRelativeArrangement = true
         mainStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
@@ -126,6 +130,9 @@ final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
     }
 
     private func setupStatusLabel() {
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            return
+        }
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         statusLabel.adjustsFontForContentSizeCategory = true
         statusLabel.numberOfLines = 1

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -54,7 +54,14 @@ private func makeAccessibilityLabel(for post: Post, statusViewModel: PostCardSta
         return String(format: Strings.Accessibility.exerptChunkFormat, excerpt)
     }()
 
-    return [titleAndDateChunk, authorChunk, stickyChunk, statusChunk, excerptChunk]
+    var chunks: [String?]
+    if RemoteFeatureFlag.syncPublishing.enabled() {
+        chunks = [titleAndDateChunk, authorChunk, excerptChunk]
+    } else {
+        chunks = [titleAndDateChunk, authorChunk, stickyChunk, statusChunk, excerptChunk]
+    }
+
+    return chunks
         .compactMap { $0 }
         .joined(separator: " ")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -103,6 +103,9 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
 
 private func makeBadgesString(for post: Post, syncStateViewModel: PostSyncStateViewModel, shouldHideAuthor: Bool) -> NSAttributedString {
     var badges: [(String, UIColor?)] = []
+    if RemoteFeatureFlag.syncPublishing.enabled() && post.status == .pending {
+        badges.append((Strings.Badges.pending, .warning))
+    }
     if RemoteFeatureFlag.syncPublishing.enabled() && post.isStickyPost && !post.isUploadingOrFailed {
         badges.append((Strings.Badges.sticky, nil))
     }
@@ -124,6 +127,11 @@ private enum Strings {
             "postList.badges.sticky",
             value: "Sticky",
             comment: "Label text that defines a post marked as sticky"
+        )
+        static let pending = NSLocalizedString(
+            "postList.badges.pending",
+            value: "Pending review",
+            comment: "Label text that defines a post marked as pending review"
         )
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -96,6 +96,9 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
 
 private func makeBadgesString(for post: Post, syncStateViewModel: PostSyncStateViewModel, shouldHideAuthor: Bool) -> NSAttributedString {
     var badges: [(String, UIColor?)] = []
+    if RemoteFeatureFlag.syncPublishing.enabled() && post.isStickyPost && !post.isUploadingOrFailed {
+        badges.append((Strings.Badges.sticky, nil))
+    }
     if let statusMessage = syncStateViewModel.statusMessage {
         badges.append((statusMessage, nil))
     } else if let date = AbstractPostHelper.getLocalizedStatusWithDate(for: post) {
@@ -109,6 +112,13 @@ private func makeBadgesString(for post: Post, syncStateViewModel: PostSyncStateV
 }
 
 private enum Strings {
+    enum Badges {
+        static let sticky = NSLocalizedString(
+            "postList.badges.sticky",
+            value: "Sticky",
+            comment: "Label text that defines a post marked as sticky"
+        )
+    }
 
     enum Accessibility {
         static let titleAndDateChunkFormat = NSLocalizedString(
@@ -134,5 +144,11 @@ private enum Strings {
             value: "Sticky.",
             comment: "Accessibility label for a sticky post in the post list."
         )
+    }
+}
+
+private extension Post {
+    var isUploadingOrFailed: Bool {
+        MediaCoordinator.shared.isUploadingMedia(for: self) || isFailed || remoteStatus == .pushing
     }
 }

--- a/WordPress/WordPressTest/PostCompactCellGhostableTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellGhostableTests.swift
@@ -6,10 +6,18 @@ import XCTest
 class PostCompactCellGhostableTests: CoreDataTestCase {
 
     var postCell: PostCompactCell!
+    private let featureFlags = FeatureFlagOverrideStore()
 
     override func setUp() {
+        super.setUp()
         postCell = postCellFromNib()
         postCell.ghostAnimationWillStart()
+        try? featureFlags.override(RemoteFeatureFlag.syncPublishing, withValue: false)
+    }
+
+    override func tearDown() {
+        try? featureFlags.override(RemoteFeatureFlag.syncPublishing, withValue: RemoteFeatureFlag.syncPublishing.originalValue)
+        super.tearDown()
     }
 
     func testIsNotInteractive() {

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -6,9 +6,17 @@ import XCTest
 class PostCompactCellTests: CoreDataTestCase {
 
     var postCell: PostCompactCell!
+    private let featureFlags = FeatureFlagOverrideStore()
 
     override func setUp() {
+        super.setUp()
         postCell = postCellFromNib()
+        try? featureFlags.override(RemoteFeatureFlag.syncPublishing, withValue: false)
+    }
+
+    override func tearDown() {
+        try? featureFlags.override(RemoteFeatureFlag.syncPublishing, withValue: RemoteFeatureFlag.syncPublishing.originalValue)
+        super.tearDown()
     }
 
     func testShowImageWhenAvailable() {


### PR DESCRIPTION
Part of #22578 

## Description 
- Removes the status label from the post cell
- Adds "sticky" label to the badges label

Idle | Syncing | Offline changes | Failed
-- | -- | -- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/461d4cf0-208b-4ad6-9b68-7c480091a088" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/48927419-a718-4ebd-8940-f09fa9811acf" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/9e667985-dcb5-4feb-ad47-991fee1032e0" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/390e9483-028c-49fc-b07b-33d5cc880478" width=200>

## How to test
- Posts list: Verify the status labels aren't displayed for any of the sync states
- Dashboard drafts/scheduled posts card: Verify status labels aren't displayed
 
## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
