### PR TITLE
[Notifications P1] Improve row UI for accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -37,6 +37,7 @@ struct AvatarsView: View {
 
     private let style: Style
     private let borderColor: Color
+    @ScaledMetric private var scale = 1
 
     init(style: Style, borderColor: Color = .DS.Background.primary) {
         self.style = style
@@ -76,17 +77,17 @@ struct AvatarsView: View {
             Image("gravatar")
                 .resizable()
         }
-        .frame(width: style.diameter, height: style.diameter)
+        .frame(width: style.diameter * scale, height: style.diameter * scale)
         .clipShape(Circle())
     }
 
     private func doubleAvatarView(primaryURL: URL?, secondaryURL: URL?) -> some View {
         ZStack {
             avatar(url: secondaryURL)
-                .padding(.trailing, Constants.doubleAvatarHorizontalOffset)
+                .padding(.trailing, Constants.doubleAvatarHorizontalOffset * scale)
             avatar(url: primaryURL)
                 .avatarBorderOverlay()
-                .padding(.leading, Constants.doubleAvatarHorizontalOffset)
+                .padding(.leading, Constants.doubleAvatarHorizontalOffset * scale)
         }
     }
 
@@ -97,13 +98,13 @@ struct AvatarsView: View {
     ) -> some View {
         ZStack(alignment: .bottom) {
             avatar(url: tertiaryURL)
-                .padding(.trailing, Length.Padding.medium)
+                .padding(.trailing, Length.Padding.medium * scale)
             avatar(url: secondaryURL)
                 .avatarBorderOverlay()
-                .offset(x: 0, y: -Length.Padding.split)
+                .offset(x: 0, y: -Length.Padding.split * scale)
             avatar(url: primaryURL)
                 .avatarBorderOverlay()
-                .padding(.leading, Length.Padding.medium)
+                .padding(.leading, Length.Padding.medium * scale)
         }
         .padding(.top, Length.Padding.split)
     }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import DesignSystem
 
 struct NotificationsTableViewCellContent: View {
-
     static let reuseIdentifier = String(describing: Self.self)
 
     enum Style {
@@ -84,7 +83,6 @@ fileprivate extension NotificationsTableViewCellContent {
                 }
             }
             .padding(.trailing, Length.Padding.double)
-            .frame(maxHeight: 60)
         }
 
         private var avatarHStack: some View {
@@ -124,7 +122,7 @@ fileprivate extension NotificationsTableViewCellContent {
                         .style(.bodySmall(.regular))
                         .foregroundStyle(Color.DS.Foreground.secondary)
                         .layoutPriority(2)
-                        .lineLimit(2)
+                        .lineLimit(1)
                         .padding(.top, Length.Padding.half)
                 }
             }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -84,6 +84,7 @@ fileprivate extension NotificationsTableViewCellContent {
                 }
             }
             .padding(.trailing, Length.Padding.double)
+            .frame(maxHeight: 60)
         }
 
         private var avatarHStack: some View {
@@ -114,6 +115,7 @@ fileprivate extension NotificationsTableViewCellContent {
                     Text(title)
                         .style(.bodySmall(.regular))
                         .foregroundStyle(Color.DS.Foreground.primary)
+                        .layoutPriority(1)
                         .lineLimit(2)
                 }
 
@@ -121,6 +123,7 @@ fileprivate extension NotificationsTableViewCellContent {
                     Text(description)
                         .style(.bodySmall(.regular))
                         .foregroundStyle(Color.DS.Foreground.secondary)
+                        .layoutPriority(2)
                         .lineLimit(2)
                         .padding(.top, Length.Padding.half)
                 }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -51,6 +51,7 @@ fileprivate extension NotificationsTableViewCellContent {
 
         @State private var avatarSize: CGSize = .zero
         @State private var textsSize: CGSize = .zero
+        @ScaledMetric(relativeTo: .subheadline) private var textScale = 1
 
         private var rootStackAlignment: VerticalAlignment {
             return textsSize.height >= avatarSize.height ? .top : .center
@@ -67,7 +68,10 @@ fileprivate extension NotificationsTableViewCellContent {
                 avatarHStack
                     .saveSize(in: $avatarSize)
                 textsVStack
-                    .offset(x: -info.avatarStyle.leadingOffset*2)
+                    .offset(
+                        x: -info.avatarStyle.leadingOffset * 2,
+                        y: -3 * textScale
+                    )
                     .padding(.leading, Length.Padding.split)
                     .saveSize(in: $textsSize)
                 Spacer()


### PR DESCRIPTION
Fixes #22646 

## Description
Due to the complexities that come with trying to do conditional line limit on 2 Texts in SwiftUI, I set the line limit on description to 1. Big majority of the cases have 2 line title which would result in 1 line description anyway. Investing more time into this doesn't seem reasonable to me. We can get back to it if it need be after shipping the feature.

## Testing Steps
1. Install & Login Jetpack
2. Navigate to Notifications
3. ✅ Verify that the total line limit never exceeds 3.
4. ✅ Verify UI looks good when dynamic font size is modified. The avatar size should react to it now too. Before this PR only the fonts grew and avatars would remain the same size, making the UI look inconsistent.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
