### PR TITLE
Offline Mode: Media Upload Status

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -60,6 +60,7 @@ class MediaCoordinator: NSObject {
     ///
     /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
     ///
+    @discardableResult
     func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
         let failedMedia: [Media] = post.media.filter({ $0.remoteStatus == .failed })
         let mediasToUpload: [Media]
@@ -230,6 +231,7 @@ class MediaCoordinator: NSObject {
         trackUploadOf(media, analyticsInfo: analyticsInfo)
 
         let uploadProgress = uploadMedia(media)
+        totalProgress.setUserInfoObject(uploadProgress, forKey: .uploadProgress)
         totalProgress.addChild(uploadProgress, withPendingUnitCount: MediaExportProgressUnits.uploadDone)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -13,6 +13,7 @@ extension ProgressUserInfoKey {
     static let mediaID = ProgressUserInfoKey("mediaID")
     static let mediaError = ProgressUserInfoKey("mediaError")
     static let mediaObject = ProgressUserInfoKey("mediaObject")
+    static let uploadProgress = ProgressUserInfoKey("uploadProgress")
 }
 
 /// Media Progress Coordinator allow the tracking of progress on multiple media objects.

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -99,8 +99,40 @@ enum PublishButtonState {
     case failed(title: String, details: String? = nil, onRetryTapped: (() -> Void)? = nil)
 
     struct Progress {
-        let completed: Int64
-        let total: Int64
+        var completed: Int64
+        var total: Int64
+    }
+
+    /// Returns the state of the button based on the current upload progress
+    /// for the given post.
+    static func uploadingState(for post: AbstractPost, coordinator: MediaCoordinator = .shared) -> PublishButtonState? {
+        if post.hasFailedMedia {
+            return .failed(title: Strings.mediaUploadFailed, onRetryTapped: {
+                coordinator.uploadMedia(for: post)
+            })
+        }
+        if coordinator.isUploadingMedia(for: post) {
+            var totalUploadProgress = Progress(completed: 0, total: 0)
+            var completedUploadCount = 0
+            var totalUploadCount = 0
+
+            for media in post.media {
+                if let progress = coordinator.progress(for: media) {
+                    if let uploadProgress = progress.userInfo[.uploadProgress] as? Foundation.Progress,
+                    let filesize = media.filesize?.int64Value {
+                        totalUploadProgress.completed += Int64(Double(filesize) * uploadProgress.fractionCompleted)
+                        totalUploadProgress.total += filesize
+                    }
+
+                    if progress.fractionCompleted >= 1.0 {
+                        completedUploadCount += 1
+                    }
+                    totalUploadCount += 1
+                }
+            }
+            return .uploading(title: Strings.uploadingMedia + ": \(completedUploadCount) / \(totalUploadCount)", progress: totalUploadProgress)
+        }
+        return nil
     }
 }
 
@@ -111,6 +143,8 @@ private enum Strings {
     }
 
     static let retry = NSLocalizedString("publishButton.retry", value: "Retry", comment: "Retry button title")
+    static let mediaUploadFailed = NSLocalizedString("prepublishing.mediaUploadFailed", value: "Failed to upload media", comment: "Title for an error messaage in the pre-publishing sheet")
+    static let uploadingMedia = NSLocalizedString("prepublishing.uploadingMedia", value: "Uploading media", comment: "Title for a publish button state in the pre-publishing sheet")
 }
 
 #Preview {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -15,6 +15,7 @@ struct PublishButton: View {
             .controlSize(.large)
             .disabled(isDisabled)
             .buttonBorderShape(.roundedRectangle(radius: 8))
+            .accessibilityIdentifier("publish")
 
             switch viewModel.state {
             case .default:
@@ -80,11 +81,11 @@ struct PublishButton: View {
 }
 
 final class PublishButtonViewModel: ObservableObject {
-    let title: String
-    let onSubmitTapped: () -> Void
+    @Published var title: String
     @Published var state: PublishButtonState = .default
+    let onSubmitTapped: () -> Void
 
-    init(title: String, onSubmitTapped: @escaping () -> Void, state: PublishButtonState = .default) {
+    init(title: String, state: PublishButtonState = .default, onSubmitTapped: @escaping () -> Void) {
         self.title = title
         self.onSubmitTapped = onSubmitTapped
         self.state = state
@@ -114,11 +115,11 @@ private enum Strings {
 
 #Preview {
     VStack(spacing: 16) {
-        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .default))
-        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .loading))
-        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .uploading(title: "Uploading media...", progress: .init(completed: 100, total: 2000))))
-        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .failed(title: "Failed to upload media")))
-        PublishButton(viewModel: .init(title: "Publish", onSubmitTapped: {}, state: .failed(title: "Failed to upload media", details: "Not connected to Internet", onRetryTapped: {})))
+        PublishButton(viewModel: .init(title: "Publish", state: .default) {})
+        PublishButton(viewModel: .init(title: "Publish", state: .loading) {})
+        PublishButton(viewModel: .init(title: "Publish", state: .uploading(title: "Uploading media...", progress: .init(completed: 100, total: 2000))) {})
+        PublishButton(viewModel: .init(title: "Publish", state: .failed(title: "Failed to upload media")) {})
+        PublishButton(viewModel: .init(title: "Publish", state: .failed(title: "Failed to upload media", details: "Not connected to Internet", onRetryTapped: {})) {})
     }
     .padding()
 }


### PR DESCRIPTION
This PR is the first part of the "synchronous publishing" change.

- Integrate `PublishButton` in the pre-publishing sheet
- Add media progress reporting


https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/4658f1d1-9a50-4fcf-8f1c-132010e3facb



## To test:

> [!IMPORTANT]  
> Make sure to enable the `.offlineMode` feature flag.

**Uploading Assets**

- Create a new post
- Add one or more media assets
- Tap "Publish" before the upload completes
- **Verify** that the publishing sheet disables the "Publish" button and displays the upload progress instead
- **Verify** that the number of uploads matches the number of uploads from the current session
- **Verify** that the uploads progress is displayed in bytes
- **Verify** that accurate upload size is displayed

**Upload Sessions**

- Create a new post
- Add one or more media assets
- Wait until the uploads complete
- Add one more asset
- Tap "Publish" before the upload completes
- **Verify** that the media upload progress is displayed only for the new asset

**Failed Uploads**

- Create a new post
- Add one or more media assets
- Mock the scenario where upload fails (could be done with Charles or hardcoded)
- Tap "Publish" before the upload completes
- Wait until one of the uploads fail
- **Verify** that the progress is replaced with a failure state and a "Retry" button
- Tap "Retry"
- **Verify** that the failed uploads get restarted. Note: the non-failed uploads should continue despite one of them failing.

**Existing Failed Uploads**

- Create a new post
- Add one or more media assets
- Wait until the uploads fail
- Tap "Publish"
- **Verify** that the failure state is displayed with a "Retry" button; you can't publish

**Progress Accuracy**

- Set Network Link Conditioner to 100% loss
- Add an image
- Tap "Publish"
- **Verify** that the upload status shows "Zero KB of X"

## Regression Notes
1. Potential unintended areas of impact: Publishing Sheet
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
