### PR TITLE
Pre-publishing sheet: Fix typo

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -78,6 +78,6 @@ final class PrepublishingHeaderView: UIView {
 }
 
 private enum Strings {
-    static let close = NSLocalizedString("prepublishing.pubishingTo", value: "Close", comment: "Voiceover accessibility label informing the user that this button dismiss the current view")
-    static let publishingTo = NSLocalizedString("prepublishing.pubishingTo", value: "Publishing to", comment: "Label in the header in the pre-publishing sheet")
+    static let close = NSLocalizedString("prepublishing.close", value: "Close", comment: "Voiceover accessibility label informing the user that this button dismiss the current view")
+    static let publishingTo = NSLocalizedString("prepublishing.publishingTo", value: "Publishing to", comment: "Label in the header in the pre-publishing sheet")
 }

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -6994,21 +6994,23 @@ Please install the %3$@ to use the app with this site.";
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categories";
 
+/* Voiceover accessibility label informing the user that this button dismiss the current view */
+"prepublishing.close" = "Close";
+
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.jetpackSocial" = "Jetpack Social";
 
 /* Placeholder for a cell in the pre-publishing sheet */
 "prepublishing.postTitle" = "Title";
 
-/* Label in the header in the pre-publishing sheet
-   Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.pubishingTo" = "Close";
-
 /* Primary button label in the pre-publishing sheet */
 "prepublishing.publish" = "Publish";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.publishDate" = "Publish Date";
+
+/* Label in the header in the pre-publishing sheet */
+"prepublishing.publishingTo" = "Publishing to";
 
 /* Primary button label in the pre-publishing shee */
 "prepublishing.schedule" = "Schedule";


### PR DESCRIPTION
Fixes a typo in the pre-publishing sheet

## How to test
- Verify the pre-publishing sheet displays "PUBLISHING TO" instead of "CLOSE"

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
