### PR TITLE
[Gravatar] Image upload using Gravatar SDK

### DIFF
--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CocoaLumberjack
 import WordPressKit
+import Gravatar
 
 @objc public enum GravatarServiceError: Int, Error {
     case invalidAccountInfo
@@ -53,8 +54,8 @@ open class GravatarService {
 
         let email = accountEmail.trimmingCharacters(in: CharacterSet.whitespaces).lowercased()
 
-        let remote = gravatarServiceRemote()
-        remote.uploadImage(image, accountEmail: email, accountToken: accountToken) { (error) in
+        let imageService = ImageService()
+        imageService.uploadImage(image, accountEmail: email, accountToken: accountToken) { (error) in
             if let theError = error {
                 DDLogError("GravatarService.uploadImage Error: \(theError)")
             } else {

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -54,7 +54,7 @@ open class GravatarService {
 
         let email = accountEmail.trimmingCharacters(in: CharacterSet.whitespaces).lowercased()
 
-        let imageService = ImageService()
+        let imageService = gravatarImageService()
         imageService.uploadImage(image, accountEmail: email, accountToken: accountToken) { (error) in
             if let theError = error {
                 DDLogError("GravatarService.uploadImage Error: \(theError)")
@@ -68,6 +68,10 @@ open class GravatarService {
 
     /// Overridden by tests for mocking.
     ///
+    func gravatarImageService() -> ImageServing {
+        return ImageService()
+    }
+
     func gravatarServiceRemote() -> GravatarServiceRemote {
         return GravatarServiceRemote()
     }

--- a/WordPress/WordPressTest/GravatarServiceTests.swift
+++ b/WordPress/WordPressTest/GravatarServiceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 import WordPressKit
+import Gravatar
 @testable import WordPress
 
 /// GravatarService Unit Tests
@@ -18,14 +19,45 @@ class GravatarServiceTests: CoreDataTestCase {
                 completion(nil)
             }
         }
+    }
 
+    class ImageServiceMock: ImageServing {
+        var capturedAccountToken: String = ""
+        var capturedAccountEmail: String = ""
+
+        func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String) async throws -> URLResponse {
+            capturedAccountEmail = accountEmail
+            capturedAccountToken = accountToken
+            return URLResponse()
+        }
+
+        func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String, completion: ((NSError?) -> Void)?) {
+            capturedAccountEmail = accountEmail
+            capturedAccountToken = accountToken
+        }
+
+        func fetchImage(with email: String, options: Gravatar.GravatarImageDownloadOptions, completionHandler: Gravatar.ImageDownloadCompletion?) -> Gravatar.CancellableDataTask {
+            fatalError("Not implemented")
+        }
+
+        func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.ImageProcessor, completionHandler: Gravatar.ImageDownloadCompletion?) -> Gravatar.CancellableDataTask? {
+            fatalError("Not implemented")
+        }
+
+        func fetchImage(with email: String, options: Gravatar.GravatarImageDownloadOptions) async throws -> Gravatar.GravatarImageDownloadResult {
+            fatalError("Not implemented")
+        }
+
+        func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.ImageProcessor) async throws -> Gravatar.GravatarImageDownloadResult {
+            fatalError("Not implemented")
+        }
     }
 
     class GravatarServiceTester: GravatarService {
-        var gravatarServiceRemoteMock: GravatarServiceRemoteMock?
+        var gravatarServiceRemoteMock: ImageServiceMock?
 
-        override func gravatarServiceRemote() -> GravatarServiceRemote {
-            gravatarServiceRemoteMock = GravatarServiceRemoteMock()
+        override func gravatarImageService() -> ImageServing {
+            gravatarServiceRemoteMock = ImageServiceMock()
             return gravatarServiceRemoteMock!
         }
     }


### PR DESCRIPTION
Fixes part of https://github.com/wordpress-mobile/WordPress-iOS/issues/22543

Implementing Gravatar Image Upload from the Gravatar SDK.

## To test:

Checkout Gravatar branch: https://github.com/Automattic/Gravatar-SDK-iOS/pull/64

Follow the steps mentioned here: https://github.com/wordpress-mobile/WordPress-iOS/issues/22543#issuecomment-1956744840

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
