### PR TITLE
[Gutenberg] Apply workaround in `gutenberg_post_install` to address build failure

### DIFF
--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -124,6 +124,12 @@ def gutenberg_post_install(installer:)
   react_native_path = Pathname.new(react_native_path).relative_path_from(Dir.pwd)
 
   react_native_post_install(installer, react_native_path)
+
+  # The following workaround is needed to avoid the error `typedef redefinition with different types ('uint8_t' (aka 'unsigned char') vs 'enum clockid_t')`.
+  # This solution is referenced in https://github.com/facebook/react-native/issues/39568#issuecomment-1762890606.
+  # It will be needed until RCT-Folly version is bumped in React Native to version v2022.08.29.00 or above.
+  # Referece: https://github.com/facebook/folly/commit/4a2410fae65afb85e1fec6d922005054b05de59f
+  __apply_Xcode_12_5_M1_post_install_workaround(installer)
 end
 
 def gutenberg_post_integrate

--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -125,7 +125,7 @@ def gutenberg_post_install(installer:)
 
   react_native_post_install(installer, react_native_path)
 
-  # The following workaround is needed to avoid the error `typedef redefinition with different types ('uint8_t' (aka 'unsigned char') vs 'enum clockid_t')`.
+  # The following workaround is needed to avoid the error `typedef redefinition with different types ('uint8_t' (aka 'unsigned char') vs 'enum clockid_t')`.
   # This solution is referenced in https://github.com/facebook/react-native/issues/39568#issuecomment-1762890606.
   # It will be needed until RCT-Folly version is bumped in React Native to version v2022.08.29.00 or above.
   # Referece: https://github.com/facebook/folly/commit/4a2410fae65afb85e1fec6d922005054b05de59f


### PR DESCRIPTION
This workaround solves the issue related to redefining `clockid_t` in the pod `RCT-Folly` when using a local bundle. The issue was introduced when upgrading the React Native version to 0.71.15 in [this PR](https://github.com/WordPress/gutenberg/pull/57667), which includes further information about the workaround.

**To test:**
1. Check that you have the Gutenberg Mobile repository in a folder named `gutenberg-mobile` at the same level as the folder where WordPress-iOS repository is located.
2. Quit Xcode if needed.
3. Run `rm -rf build && LOCAL_GUTENBERG=1 bundle exec pod install`
4. Open Xcode.
5. Build the app and observe that no build failures are encountered.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
