### PR TITLE
[Gravatar] Rename types to `ImageCache` and `ImageCaching`

### DIFF
--- a/WordPress/Classes/Utility/Media/MemoryCache.swift
+++ b/WordPress/Classes/Utility/Media/MemoryCache.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AlamofireImage
 import WordPressUI
+import protocol Gravatar.ImageCaching
 
 protocol MemoryCacheProtocol: AnyObject {
     subscript(key: String) -> UIImage? { get set }
@@ -88,7 +89,7 @@ extension MemoryCache {
     }
 }
 
-private struct WordpressUICacheAdapter: WordPressUI.ImageCaching {
+private struct WordpressUICacheAdapter: ImageCaching {
     let cache: MemoryCache
 
     func setImage(_ image: UIImage, forKey key: String) {


### PR DESCRIPTION
Fixes part of #22543 

# To test:

## Regression Notes
Checkout Gravatar branch: https://github.com/Automattic/Gravatar-SDK-iOS/pull/50
Checkout WordPressUI branch: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/146

Follow the steps mentioned here: https://github.com/wordpress-mobile/WordPress-iOS/issues/22543#issuecomment-1956744840

1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
