### PR TITLE
Updates Jetpack banners and badges copy

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,9 +5,9 @@
 24.3
 -----
 * [***] [internal] Refactored websocket connections to Pinghub. [#22611]
-
 * [**] Multiple pre-publishing sheet fixes and improvements [#22606]
 * [*] Gravatar: Adds informative new view about Gravatar to the profile editing page. [#22615]
+* [*] [internal][WordPress-only] Updates Jetpack banners and badges copy for consistency [#20123]
 
 24.2
 -----

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -118,11 +118,7 @@ private extension JetpackBrandingTextProvider {
         static let phaseThreeSingularMovingInText = NSLocalizedString("jetpack.branding.badge_banner.moving_in.singular",
                                                                       value: "%@ is moving in %@",
                                                                       comment: "Title of a badge indicating when a feature in singular form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Reader is moving in 2 weeks")
-        static let phaseStaticScreensText = NSLocalizedString(
-            "jetpack.branding.badge_banner.moving_in_days.plural",
-            value: "Moving to the Jetpack app in a few days.",
-            comment: "Title of a badge or banner indicating that this feature will be moved in a few days."
-        )
+        static let phaseStaticScreensText = defaultText
     }
 
     private var isPlural: Bool {


### PR DESCRIPTION
## Description
Updates Jetpack banners and badges copy for consistency (internal ref pcdRpT-5EP-p2)

## To Test:
1. Open the WordPress app from this PR
2. Verify that the copy `Jetpack powered` is displayed in the following screens:
- Activity logs
- Themes
- Menu
- Social

|Activity logs|Themes|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-02-22 at 12 16 18](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/4cdf750b-fcb9-45b4-890d-9f742914b03a)|![Simulator Screenshot - iPhone 15 - 2024-02-22 at 12 16 33](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/fc85642a-8e4b-4806-88e2-9a7b2c93c564)|

|Menu|Social|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-02-22 at 12 16 46](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/4a800169-7e62-43d6-a9cc-a3f6069183f9)|![Simulator Screenshot - iPhone 15 - 2024-02-22 at 12 17 01](https://github.com/wordpress-mobile/WordPress-iOS/assets/304044/3454ce37-bc42-47bc-b697-fae7b8ea81e6)|


## Regression Notes
1. Potential unintended areas of impact
Jetpack banners/badges copy

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
