### PR TITLE
Stats Traffic: Add or update analytics

### DIFF
--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -30,7 +30,7 @@ open class WP3DTouchShortcutHandler: NSObject {
                 WPAnalytics.track(.shortcutStats)
                 clearCurrentViewController()
                 if let mainBlog = Blog.lastUsedOrFirst(in: ContextManager.sharedInstance().mainContext) {
-                    rootViewPresenter.mySitesCoordinator.showStats(for: mainBlog)
+                    rootViewPresenter.mySitesCoordinator.showStats(for: mainBlog, source: .shortcut)
                 }
                 return true
             case ShortcutIdentifier.Notifications.type:

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -227,7 +227,7 @@ final class InteractiveNotificationsManager: NSObject {
 
                     RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(
                         for: targetBlog,
-                        source: BlogDetailsNavigationSource,
+                        source: .notification,
                         timePeriod: .weeks,
                         date: targetDate)
                 }

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -227,6 +227,7 @@ final class InteractiveNotificationsManager: NSObject {
 
                     RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(
                         for: targetBlog,
+                        source: BlogDetailsNavigationSource,
                         timePeriod: .weeks,
                         date: targetDate)
                 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -113,6 +113,7 @@ extension StatsRoute: NavigationAction {
                                   using coordinator: MySitesCoordinator) {
         if let blog = blog(from: values) {
             coordinator.showStats(for: blog,
+                                  source: source(from: values),
                                   timePeriod: timePeriod)
         } else {
             showMySitesAndFailureNotice(using: coordinator,
@@ -143,6 +144,14 @@ extension StatsRoute: NavigationAction {
             return
         }
 
-        coordinator.showStats(for: blog, timePeriod: timePeriod)
+        coordinator.showStats(for: blog, source: source(from: values), timePeriod: timePeriod)
+    }
+
+    private func source(from values: [String: String]) -> BlogDetailsNavigationSource {
+        if values["matched-route-source"] != nil {
+            return .widget
+        } else {
+            return .link
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -93,6 +93,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
     BlogDetailsNavigationSourceWidget = 3,
     BlogDetailsNavigationSourceOnboarding = 4,
     BlogDetailsNavigationSourceNotification = 5,
+    BlogDetailsNavigationSourceShortcut = 6,
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -89,7 +89,8 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
     BlogDetailsNavigationSourceButton = 0,
     BlogDetailsNavigationSourceRow = 1,
-    BlogDetailsNavigationSourceLink = 2
+    BlogDetailsNavigationSourceLink = 2,
+    BlogDetailsNavigationSourceWidget = 3,    
 };
 
 
@@ -189,5 +190,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 + (nonnull NSString *)userInfoShowPickerKey;
 + (nonnull NSString *)userInfoSiteMonitoringTabKey;
++ (nonnull NSString *)userInfoSourceKey;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -90,7 +90,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
     BlogDetailsNavigationSourceButton = 0,
     BlogDetailsNavigationSourceRow = 1,
     BlogDetailsNavigationSourceLink = 2,
-    BlogDetailsNavigationSourceWidget = 3,    
+    BlogDetailsNavigationSourceWidget = 3,
+    BlogDetailsNavigationSourceOnboarding = 4,
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -92,6 +92,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
     BlogDetailsNavigationSourceLink = 2,
     BlogDetailsNavigationSourceWidget = 3,
     BlogDetailsNavigationSourceOnboarding = 4,
+    BlogDetailsNavigationSourceNotification = 5,
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1765,6 +1765,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return @"onboarding";
         case BlogDetailsNavigationSourceNotification:
             return @"notification";
+        case BlogDetailsNavigationSourceShortcut:
+            return @"shortcut";
         default:
             return @"";
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -500,13 +500,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
             break;
-        case BlogDetailsSubsectionStats:
+        case BlogDetailsSubsectionStats: {
             self.restorableSelectedIndexPath = indexPath;
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showStatsFromSource:BlogDetailsNavigationSourceLink];
+            NSNumber *sourceValue = userInfo[[BlogDetailsViewController userInfoSourceKey]];
+            BlogDetailsNavigationSource source = sourceValue ? sourceValue.unsignedIntegerValue : BlogDetailsNavigationSourceLink;
+            [self showStatsFromSource:source];
             break;
+        }
         case BlogDetailsSubsectionPosts:
             self.restorableSelectedIndexPath = indexPath;
             [self.tableView selectRowAtIndexPath:indexPath
@@ -1756,6 +1759,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return @"link";
         case BlogDetailsNavigationSourceButton:
             return @"button";
+        case BlogDetailsNavigationSourceWidget:
+            return @"widget";
+        case BlogDetailsNavigationSourceOnboarding:
+            return @"onboarding";
+        case BlogDetailsNavigationSourceNotification:
+            return @"notification";
         default:
             return @"";
     }
@@ -2275,6 +2284,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 + (NSString *)userInfoSiteMonitoringTabKey {
     return @"site-monitoring-tab";
+}
+
++ (NSString *)userInfoSourceKey {
+    return @"source";
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+OnboardingPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+OnboardingPrompt.swift
@@ -17,7 +17,7 @@ extension MySiteViewController {
         case .stats:
             // Show the stats view for the current blog
             if let blog = blog {
-                RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, timePeriod: .insights)
+                RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, source: .onboarding, timePeriod: .insights)
             }
         case .writing:
             // Open the editor

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -895,11 +895,7 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
     /// - Parameters:
     ///         - subsection: The specific subsection to show.
     ///
-    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {
-        blogDetailsViewController?.showDetailView(for: subsection)
-    }
-
-    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection, userInfo: [AnyHashable: Any]) {
+    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection, userInfo: [AnyHashable: Any] =  [:]) {
         blogDetailsViewController?.showDetailView(for: subsection, userInfo: userInfo)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -93,6 +93,7 @@ struct NotificationContentRouter {
             if url.absoluteString.matches(regex: "\\/backup\\/").count > 0 {
                 try coordinator.displayBackupWithSiteID(range.siteID)
             } else {
+                trackStatsRoute()
                 try coordinator.displayStatsWithSiteID(range.siteID, url: url)
             }
         case .follow:
@@ -109,5 +110,10 @@ struct NotificationContentRouter {
 
     private func getRange(with url: URL) -> FormattableContentRange? {
         return notification.contentRange(with: url)
+    }
+
+    private func trackStatsRoute() {
+        let properties: [AnyHashable: Any] = [WPAppAnalyticsKeyTapSource: "notification"]
+        WPAppAnalytics.track(.statsAccessed, withProperties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -28,9 +28,11 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
     var selectedPeriod: StatsPeriodUnit? {
         didSet {
 
-            guard selectedPeriod != nil else {
+            guard let selectedPeriod else {
                 return
             }
+
+            trackPeriodAccessEvent(selectedPeriod)
 
             clearExpandedRows()
 
@@ -345,5 +347,26 @@ private extension SiteStatsPeriodTableViewController {
         if let bannerView = bannerView {
             analyticsTracker.addTranslationObserver(bannerView)
         }
+    }
+}
+
+// MARK: - Tracking
+
+private extension SiteStatsPeriodTableViewController {
+    func trackPeriodAccessEvent(_ period: StatsPeriodUnit) {
+        let event: WPAnalyticsStat = {
+            switch period {
+            case .day:
+                return .statsPeriodDaysAccessed
+            case .week:
+                return .statsPeriodWeeksAccessed
+            case .month:
+                return .statsPeriodMonthsAccessed
+            case .year:
+                return .statsPeriodYearsAccessed
+            }
+        }()
+
+        WPAppAnalytics.track(event)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -7,6 +7,7 @@ import WordPressFlux
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
+    @objc optional func barChartTabSelected(_ tabIndex: StatsTrafficBarChartTabIndex)
 }
 
 protocol SiteStatsReferrerDelegate: AnyObject {
@@ -314,6 +315,12 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
                                                                                             postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
+
+    func barChartTabSelected(_ tabIndex: StatsTrafficBarChartTabIndex) {
+        if let tab = StatsTrafficBarChartTabs(rawValue: tabIndex), let period = selectedPeriod {
+            trackBarChartTabSelectionEvent(tab: tab, period: period)
+        }
+    }
 }
 
 // MARK: - SiteStatsReferrerDelegate
@@ -368,5 +375,11 @@ private extension SiteStatsPeriodTableViewController {
         }()
 
         WPAppAnalytics.track(event)
+    }
+
+    func trackBarChartTabSelectionEvent(tab: StatsTrafficBarChartTabs, period: StatsPeriodUnit) {
+        let properties: [AnyHashable: Any] = [StatsPeriodUnit.analyticsPeriodKey: period.description as Any]
+        WPAppAnalytics.track(tab.analyticsEvent, withProperties: properties)
+
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -306,7 +306,8 @@ private extension SiteStatsPeriodViewModel {
             chartData: barChartData,
             chartStyling: barChartStyling,
             period: lastRequestedPeriod,
-            unit: chartBarsUnit(from: lastRequestedPeriod)
+            unit: chartBarsUnit(from: lastRequestedPeriod),
+            siteStatsPeriodDelegate: periodDelegate
         )
 
         tableRows.append(row)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -120,6 +120,8 @@ private extension PostStatsTableViewController {
     func trackAccessEvent() {
         var properties = [AnyHashable: Any]()
 
+        properties[WPAppAnalyticsKeyTapSource] = "posts"
+
         if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
             properties["blog_id"] = blogIdentifier
         }
@@ -128,7 +130,7 @@ private extension PostStatsTableViewController {
             properties["post_id"] = postIdentifier
         }
 
-        WPAppAnalytics.track(.statsSinglePostAccessed, withProperties: properties)
+        WPAppAnalytics.track(.statsAccessed, withProperties: properties)
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -49,14 +49,14 @@ fileprivate extension StatsPeriodType {
         }
     }
 
-    var analyticsAccessEvent: WPAnalyticsStat {
+    var analyticsAccessEvent: WPAnalyticsStat? {
         switch self {
         case .insights: return .statsInsightsAccessed
         case .days:     return .statsPeriodDaysAccessed
         case .weeks:    return .statsPeriodWeeksAccessed
         case .months:   return .statsPeriodMonthsAccessed
         case .years:    return .statsPeriodYearsAccessed
-        case .traffic:  return .noStat // TODO
+        case .traffic:  return nil
         }
     }
 }
@@ -318,7 +318,8 @@ private extension SiteStatsDashboardViewController {
     }
 
     func trackAccessEvent() {
-        let event = currentSelectedPeriod.analyticsAccessEvent
-        captureAnalyticsEvent(event)
+        if let event = currentSelectedPeriod.analyticsAccessEvent {
+            captureAnalyticsEvent(event)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -38,6 +38,7 @@ struct StatsTrafficBarChartRow: ImmuTableRow {
     let chartStyling: [StatsTrafficBarChartStyling]
     let period: StatsPeriodUnit
     let unit: StatsPeriodUnit
+    weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
 
     static let cell: ImmuTableCell = {
         return ImmuTableCell.class(CellType.self)
@@ -46,7 +47,7 @@ struct StatsTrafficBarChartRow: ImmuTableRow {
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else { return }
 
-        cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period, unit: unit)
+        cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period, unit: unit, siteStatsPeriodDelegate: siteStatsPeriodDelegate)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
@@ -25,6 +25,7 @@ final class StatsTrafficBarChartCell: UITableViewCell {
     private var period: StatsPeriodUnit?
     private var unit: StatsPeriodUnit?
     private var chartView: StatsTrafficBarChartView?
+    private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
 
     // MARK: - Configure
 
@@ -47,12 +48,14 @@ final class StatsTrafficBarChartCell: UITableViewCell {
                    barChartData: [BarChartDataConvertible] = [],
                    barChartStyling: [StatsTrafficBarChartStyling] = [],
                    period: StatsPeriodUnit,
-                   unit: StatsPeriodUnit) {
+                   unit: StatsPeriodUnit,
+                   siteStatsPeriodDelegate: SiteStatsPeriodDelegate?) {
         self.tabsData = tabsData
         self.chartData = barChartData
         self.chartStyling = barChartStyling
         self.period = period
         self.unit = unit
+        self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
 
         updateLabels()
         updateButtons()
@@ -64,6 +67,7 @@ private extension StatsTrafficBarChartCell {
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         updateLabels()
         updateChartView()
+        siteStatsPeriodDelegate?.barChartTabSelected?(filterBar.selectedIndex)
     }
 
     func updateLabels() {

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartTabs.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartTabs.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressKit
 
+typealias StatsTrafficBarChartTabIndex = Int
 enum StatsTrafficBarChartTabs: Int, CaseIterable {
     case views = 0, visitors, likes, comments
 
@@ -16,6 +17,19 @@ enum StatsTrafficBarChartTabs: Int, CaseIterable {
             return \.likesCount
         case .comments:
             return \.commentsCount
+        }
+    }
+
+    var analyticsEvent: WPAnalyticsStat {
+        switch self {
+        case .views:
+            return .statsOverviewTypeTappedViews
+        case .visitors:
+            return .statsOverviewTypeTappedVisitors
+        case .likes:
+            return .statsOverviewTypeTappedLikes
+        case .comments:
+            return .statsOverviewTypeTappedComments
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -139,7 +139,7 @@ class MySitesCoordinator: NSObject {
         showBlogDetails(for: blog, then: .stats)
     }
 
-    func showStats(for blog: Blog, source: BlogDetailsNavigationSource, timePeriod: StatsPeriodType, date: Date? = nil) {
+    func showStats(for blog: Blog, source: BlogDetailsNavigationSource, timePeriod: StatsPeriodType? = nil, date: Date? = nil) {
         guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             unsupportedFeatureFallback()
             return
@@ -151,7 +151,7 @@ class MySitesCoordinator: NSObject {
             UserPersistentStoreFactory.instance().set(date, forKey: SiteStatsDashboardViewController.lastSelectedStatsDateKey)
         }
 
-        if let siteID = blog.dotComID?.intValue {
+        if let siteID = blog.dotComID?.intValue, let timePeriod = timePeriod {
             let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
             UserPersistentStoreFactory.instance().set(timePeriod.rawValue, forKey: key)
         }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -156,7 +156,7 @@ class MySitesCoordinator: NSObject {
             UserPersistentStoreFactory.instance().set(timePeriod.rawValue, forKey: key)
         }
 
-        let userInfo: [AnyHashable: Any] = [BlogDetailsViewController.userInfoSourceKey(): source]
+        let userInfo: [AnyHashable: Any] = [BlogDetailsViewController.userInfoSourceKey(): NSNumber(value: source.rawValue)]
         mySiteViewController.showBlogDetailsSubsection(.stats, userInfo: userInfo)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -139,7 +139,7 @@ class MySitesCoordinator: NSObject {
         showBlogDetails(for: blog, then: .stats)
     }
 
-    func showStats(for blog: Blog, timePeriod: StatsPeriodType, date: Date? = nil) {
+    func showStats(for blog: Blog, source: BlogDetailsNavigationSource, timePeriod: StatsPeriodType, date: Date? = nil) {
         guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             unsupportedFeatureFallback()
             return
@@ -156,7 +156,8 @@ class MySitesCoordinator: NSObject {
             UserPersistentStoreFactory.instance().set(timePeriod.rawValue, forKey: key)
         }
 
-        mySiteViewController.showBlogDetailsSubsection(.stats)
+        let userInfo: [AnyHashable: Any] = [BlogDetailsViewController.userInfoSourceKey(): source]
+        mySiteViewController.showBlogDetailsSubsection(.stats, userInfo: userInfo)
     }
 
     func showActivityLog(for blog: Blog) {


### PR DESCRIPTION
Fixes #22594
https://github.com/wordpress-mobile/jetpack-issue-repo/issues/4

## To test:

### stats_accesed

|`tap_source` property that has been added to `stats_accesed` event|Description|
|-|-|
|`quick_actions`|Opening stats from My Site|
|`row`|Opening stats from My Site → More|
|`posts`|Opening stats from My Site → Posts|
|`today_stats_card`|Opening stats from "Today's Stats" card on "My Site"|
|`notification`|Opening stats from a notification (for example, "Congratulations! Your site passed * all-time views") |
|`link`|Opening stats from a deeplink (WordPress.com/stats and tap "Open Jetpack" banner |
|`widget`|Opening stats from widgets|
|`onboarding`|Opening stats from onboarding prompt|
|`shortcut`|Opening stats from long-press app icon shortcut|

### stats_period_accessed

1. Open Stats Traffic
2. Confirm `stats_period_accessed` called with the correct `period`
3. Changing `period` in the view controller should also call the event but it cannot be tested yet

### stats_overview_type_tapped_

1. From the code, preselect week, month, year tab in dashboard `trafficTableViewController.selectedPeriod = .month`
2. Open Stats Traffic
3. Change between Views/Visitors/Comments/Likes tabs
4. Confirm `stats_overview_type_tapped_` event is called with the selected period

### stats_date_tapped_backward, stats_date_tapped_forward

1. Open Stats Traffic
2. Change dates back and forward
3. Confirm `stats_date_tapped_backward` and `stats_date_tapped_forward` called

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
