### PR TITLE
Stats Traffic: Make Views, Visitors, Likes, and Comments visible on the Traffic tab 

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
@@ -7,10 +7,6 @@ final class StatsTrafficBarChartCell: UITableViewCell {
 
     private let contentStackView = UIStackView()
 
-    private let labelsStackView = UIStackView()
-    private let titleStackView = UIStackView()
-    private let numberLabel = UILabel()
-    private let titleLabel = UILabel()
     private let differenceLabel = UILabel()
 
     private let chartContainerView = UIView()
@@ -68,8 +64,6 @@ private extension StatsTrafficBarChartCell {
 
     func updateLabels() {
         let tabData = tabsData[filterTabBar.selectedIndex]
-        titleLabel.text = tabData.tabTitle
-        numberLabel.text = tabData.tabData.abbreviatedString()
         differenceLabel.attributedText = differenceAttributedString(tabData)
     }
 
@@ -97,7 +91,7 @@ private extension StatsTrafficBarChartCell {
             chartView.translatesAutoresizingMaskIntoConstraints = false
             chartContainerView.addSubview(chartView)
             chartContainerView.accessibilityElements = [chartView]
-            chartContainerView.pinSubviewToAllEdges(chartView)
+            chartContainerView.pinSubviewToAllEdges(chartView, insets: UIEdgeInsets(top: Length.Padding.split, left: 0, bottom: 0, right: 0))
             self.chartView = chartView
         } else {
             self.chartView?.update(barChartData: chartData, styling: styling)
@@ -117,7 +111,6 @@ private extension StatsTrafficBarChartCell {
     func setupViews() {
         setupContentView()
         setupContentStackView()
-        setupLabels()
         setupChart()
         setupButtons()
     }
@@ -133,26 +126,6 @@ private extension StatsTrafficBarChartCell {
         contentStackView.spacing = Length.Padding.split
         contentView.addSubview(contentStackView)
         contentView.pinSubviewToAllEdges(contentStackView)
-    }
-
-    func setupLabels() {
-        labelsStackView.axis = .vertical
-        labelsStackView.alignment = .leading
-        labelsStackView.spacing = 0
-        labelsStackView.isLayoutMarginsRelativeArrangement = true
-        labelsStackView.layoutMargins = .init(top: Length.Padding.single, left: Length.Padding.double, bottom: 0, right: Length.Padding.double)
-        contentStackView.addArrangedSubview(labelsStackView)
-
-        titleStackView.axis = .horizontal
-        titleStackView.alignment = .firstBaseline
-        titleStackView.spacing = Length.Padding.single
-        contentStackView.addArrangedSubview(titleStackView)
-        titleStackView.addArrangedSubviews([numberLabel, titleLabel])
-
-        titleLabel.font = .preferredFont(forTextStyle: .body)
-        numberLabel.font = .preferredFont(forTextStyle: .largeTitle).semibold()
-
-        labelsStackView.addArrangedSubviews([titleStackView, differenceLabel])
     }
 
     func setupChart() {

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
@@ -309,18 +309,15 @@ struct StatsTrafficBarChartTabData: FilterTabBarItem, Equatable {
     var attributedTitle: NSAttributedString? {
         let attributedTitle = NSMutableAttributedString(string: tabTitle)
         attributedTitle.addAttributes([.font: TextStyle.footnote.uiFont],
-                                      range: NSMakeRange(0, attributedTitle.string.count))
+                                      range: NSMakeRange(0, attributedTitle.length))
 
         let dataString: String = {
-            if let tabDataStub = tabDataStub {
-                return tabDataStub
-            }
-            return tabData.abbreviatedString()
+            return tabDataStub ?? tabData.abbreviatedString()
         }()
 
         let attributedData = NSMutableAttributedString(string: dataString)
         attributedData.addAttributes([.font: TextStyle.bodyLarge(.emphasized).uiFont],
-                                     range: NSMakeRange(0, attributedData.string.count))
+                                     range: NSMakeRange(0, attributedData.length))
 
         attributedTitle.append(NSAttributedString(string: "\n"))
         attributedTitle.append(attributedData)

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
@@ -340,4 +340,8 @@ struct StatsTrafficBarChartTabData: FilterTabBarItem, Equatable {
     var accessibilityLabel: String? {
         tabTitle
     }
+
+    var accessibilityValue: String? {
+        return tabDataStub != nil ? "" : "\(tabData)"
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/Chart/StatsTrafficBarChartCell.swift
@@ -164,7 +164,7 @@ private extension StatsTrafficBarChartCell {
     func setupButtons() {
         contentStackView.addArrangedSubview(filterTabBar)
         filterTabBar.widthAnchor.constraint(equalTo: contentStackView.widthAnchor).isActive = true
-        filterTabBar.tabBarHeight = 40
+        filterTabBar.tabBarHeight = 56
         filterTabBar.equalWidthFill = .fillEqually
         filterTabBar.equalWidthSpacing = Length.Padding.single
         filterTabBar.tabSizingStyle = .equalWidths
@@ -174,7 +174,7 @@ private extension StatsTrafficBarChartCell {
         filterTabBar.tabSeparatorPlacement = .top
         filterTabBar.tabsFont = tabsFont()
         filterTabBar.tabsSelectedFont = tabsFont()
-        filterTabBar.tabButtonInsets = UIEdgeInsets(top: Length.Padding.single, left: Length.Padding.half, bottom: Length.Padding.single, right: Length.Padding.half)
+        filterTabBar.tabAttributedButtonInsets = UIEdgeInsets(top: Length.Padding.single, left: Length.Padding.half, bottom: Length.Padding.single, right: Length.Padding.half)
         filterTabBar.tabSeparatorPadding = Length.Padding.single
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
@@ -331,6 +331,33 @@ struct StatsTrafficBarChartTabData: FilterTabBarItem, Equatable {
 
     var title: String {
         return self.tabTitle
+    }
+
+    var attributedTitle: NSAttributedString? {
+        let attributedTitle = NSMutableAttributedString(string: tabTitle)
+        attributedTitle.addAttributes([.font: TextStyle.footnote.uiFont],
+                                      range: NSMakeRange(0, attributedTitle.string.count))
+
+        let dataString: String = {
+            if let tabDataStub = tabDataStub {
+                return tabDataStub
+            }
+            return tabData.abbreviatedString()
+        }()
+
+        let attributedData = NSMutableAttributedString(string: dataString)
+        attributedData.addAttributes([.font: TextStyle.bodyLarge(.emphasized).uiFont],
+                                     range: NSMakeRange(0, attributedData.string.count))
+
+        attributedTitle.append(NSAttributedString(string: "\n"))
+        attributedTitle.append(attributedData)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 0.9
+        paragraphStyle.alignment = .center
+        attributedTitle.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: attributedTitle.length))
+
+        return attributedTitle
     }
 
     var accessibilityIdentifier: String {

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -216,6 +216,7 @@ class FilterTabBar: UIControl {
     }
 
     var tabButtonInsets: UIEdgeInsets = AppearanceMetrics.buttonInsets
+    var tabAttributedButtonInsets: UIEdgeInsets = AppearanceMetrics.buttonInsetsAttributedTitle
     var tabSeparatorPadding: CGFloat = AppearanceMetrics.buttonPadding
 
     // MARK: - Initialization
@@ -301,6 +302,7 @@ class FilterTabBar: UIControl {
         tab.setAttributedTitle(item.attributedTitle, for: .normal)
         tab.titleLabel?.lineBreakMode = .byWordWrapping
         tab.titleLabel?.textAlignment = .center
+        tab.titleLabel?.numberOfLines = 0
         tab.setAttributedTitle(addColor(titleColorForSelected, toAttributedString: item.attributedTitle), for: .selected)
         tab.setAttributedTitle(addColor(deselectedTabColor, toAttributedString: item.attributedTitle), for: .normal)
 
@@ -310,7 +312,7 @@ class FilterTabBar: UIControl {
         tab.accessibilityHint = item.accessibilityHint
 
         tab.contentEdgeInsets = item.attributedTitle != nil ?
-            AppearanceMetrics.buttonInsetsAttributedTitle :
+            tabAttributedButtonInsets :
             tabButtonInsets
 
         tab.sizeToFit()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/jetpack-issue-repo/issues/14
Figma IqhXWz3Iir7RMb5XH5gGfZ-fi-660_538

## To test:

1. In the code set selected period `trafficTableViewController.selectedPeriod = .week` or `.month`, or `.year`
2. Enable Stats Traffic Feature Flag
3. Open Stats Traffic Tab
4. Confirm that bar chart cell tabs now display numbers
5. Confirm title is no longer visible

<img height="382" alt="Stats Traffic 2" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/40c78cb0-6119-49d7-9930-95ecd12381de">
<img height="382" alt="Stats Traffic 1" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/da55ebfd-4fd4-448c-b3df-2ef21f89a223">

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)