### PR TITLE
Remove Today card from Insights if Traffic feature flag is enabled

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -36,7 +36,7 @@
     case postStatsRecentWeeks
 
     static var allInsights: [StatSection] {
-        var insights: [StatSection] = [
+        var insights: [StatSection?] = [
             .insightsViewsVisitors,
             .insightsLikesTotals,
             .insightsCommentsTotals,
@@ -45,6 +45,7 @@
             .insightsLatestPostSummary,
             .insightsAllTime,
             .insightsAnnualSiteStats,
+            RemoteFeatureFlag.statsTrafficTab.enabled() ? nil : .insightsTodaysStats,
             .insightsPostingActivity,
             .insightsTagsAndCategories,
             .insightsFollowersWordPress,
@@ -52,11 +53,7 @@
             .insightsPublicize
         ]
 
-        if !RemoteFeatureFlag.statsTrafficTab.enabled() {
-            insights.insert(.insightsTodaysStats, at: 8)
-        }
-
-        return insights
+        return insights.compactMap { $0 }
     }
 
     static let allPeriods: [StatSection] = [

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -35,22 +35,29 @@
     case postStatsAverageViews
     case postStatsRecentWeeks
 
-    static let allInsights: [StatSection] = [
-        .insightsViewsVisitors,
-        .insightsLikesTotals,
-        .insightsCommentsTotals,
-        .insightsFollowerTotals,
-        .insightsMostPopularTime,
-        .insightsLatestPostSummary,
-        .insightsAllTime,
-        .insightsAnnualSiteStats,
-        .insightsTodaysStats,
-        .insightsPostingActivity,
-        .insightsTagsAndCategories,
-        .insightsFollowersWordPress,
-        .insightsFollowersEmail,
-        .insightsPublicize
-    ]
+    static var allInsights: [StatSection] {
+        var insights: [StatSection] = [
+            .insightsViewsVisitors,
+            .insightsLikesTotals,
+            .insightsCommentsTotals,
+            .insightsFollowerTotals,
+            .insightsMostPopularTime,
+            .insightsLatestPostSummary,
+            .insightsAllTime,
+            .insightsAnnualSiteStats,
+            .insightsPostingActivity,
+            .insightsTagsAndCategories,
+            .insightsFollowersWordPress,
+            .insightsFollowersEmail,
+            .insightsPublicize
+        ]
+
+        if !RemoteFeatureFlag.statsTrafficTab.enabled() {
+            insights.insert(.insightsTodaysStats, at: 8)
+        }
+
+        return insights
+    }
 
     static let allPeriods: [StatSection] = [
         .periodOverviewViews,


### PR DESCRIPTION
Fixes #22662

## To test:

1. Disable Stats Traffic feature flag
2. Open Stats -> Insights
3. Open Insight Management on Top Right corner
4. Add Today Stats card
5. Close Stats
6. Disable Stats Traffic feature flag
7. Open Stats -> Insights
8. Confirm Today Stats card is not visible
9. Open Insight Management on Top Right corner
10. Confirm Today Stats card option is not available

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
