### PR TITLE
[Gravatar] Implementing Gravatar changes regarding ImageServing protocol naming

### DIFF
--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -68,7 +68,7 @@ open class GravatarService {
 
     /// Overridden by tests for mocking.
     ///
-    func gravatarImageService() -> ImageServing {
+    func gravatarImageService() -> ImageUploader {
         return ImageService()
     }
 

--- a/WordPress/WordPressTest/GravatarServiceTests.swift
+++ b/WordPress/WordPressTest/GravatarServiceTests.swift
@@ -21,7 +21,7 @@ class GravatarServiceTests: CoreDataTestCase {
         }
     }
 
-    class ImageServiceMock: ImageServing {
+    class ImageServiceMock: ImageUploader {
         var capturedAccountToken: String = ""
         var capturedAccountEmail: String = ""
 
@@ -35,28 +35,12 @@ class GravatarServiceTests: CoreDataTestCase {
             capturedAccountEmail = accountEmail
             capturedAccountToken = accountToken
         }
-
-        func fetchImage(with email: String, options: Gravatar.GravatarImageDownloadOptions, completionHandler: Gravatar.ImageDownloadCompletion?) -> Gravatar.CancellableDataTask {
-            fatalError("Not implemented")
-        }
-
-        func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.ImageProcessor, completionHandler: Gravatar.ImageDownloadCompletion?) -> Gravatar.CancellableDataTask? {
-            fatalError("Not implemented")
-        }
-
-        func fetchImage(with email: String, options: Gravatar.GravatarImageDownloadOptions) async throws -> Gravatar.GravatarImageDownloadResult {
-            fatalError("Not implemented")
-        }
-
-        func fetchImage(with url: URL, forceRefresh: Bool, processor: Gravatar.ImageProcessor) async throws -> Gravatar.GravatarImageDownloadResult {
-            fatalError("Not implemented")
-        }
     }
 
     class GravatarServiceTester: GravatarService {
         var gravatarServiceRemoteMock: ImageServiceMock?
 
-        override func gravatarImageService() -> ImageServing {
+        override func gravatarImageService() -> ImageUploader {
             gravatarServiceRemoteMock = ImageServiceMock()
             return gravatarServiceRemoteMock!
         }


### PR DESCRIPTION
This PR implements the changes on the Gravatar SDK

https://github.com/Automattic/Gravatar-SDK-iOS/pull/70

### To test:

- Checkout: https://github.com/Automattic/Gravatar-SDK-iOS/pull/70
- The project should build.
- Follow the steps from:  https://github.com/wordpress-mobile/WordPress-iOS/issues/22543#issuecomment-1956744840

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
