### PR TITLE
Update Lottie class in a nib file

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
@@ -42,7 +42,7 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bUe-f2-zzc" userLabel="Icon Super View">
                                             <rect key="frame" x="0.0" y="0.0" width="317" height="75"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" placeholderIntrinsicWidth="120" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="v3d-AD-Jsf" customClass="AnimationView" customModule="Lottie">
+                                                <view contentMode="scaleToFill" placeholderIntrinsicWidth="120" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="v3d-AD-Jsf" customClass="LottieAnimationView" customModule="Lottie">
                                                     <rect key="frame" x="0.0" y="0.0" width="120" height="65"/>
                                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>


### PR DESCRIPTION
`AnimationView` is renamed to `LottieAnimationView` in Lottie v4. I forgot to check xib files in [my updating Lottie changes][PR].

[PR]: https://github.com/wordpress-mobile/WordPress-iOS/pull/22605

## Test Instructions

Here is how to reproduce the crash:

1. On your device, install Jetpack app, uninstall WordPress app
2. Prepare a self-hosted test site, and connect it to Jetpack
3. Install WordPress app and log in to the self-hosted site
4. The app crashes. The expected behaviour is showing this screen with a WordPress+Jetpack animation.
<img width="556" alt="Screenshot 2024-02-23 at 9 46 47 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1101828/e9ca8d2b-a7c8-4926-9d28-6d75a15f6882">



## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verify the crash no longer happens.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: N/A