### PR TITLE
Push Notifications: Properly truncate long notifications

### DIFF
--- a/WordPress/Classes/Extensions/String+CondenseWhitespace.swift
+++ b/WordPress/Classes/Extensions/String+CondenseWhitespace.swift
@@ -5,11 +5,12 @@ extension String {
     /// Attempts to remove excessive whitespace in text by replacing multiple new lines with just 2.
     /// This first trims whitespace and newlines from the ends
     /// Then normalizes the newlines by replacing {Space}{Newline} with a single newline char
-    /// Then finally it looks for any newlines that are 3 or more and replaces them with 2 newlines.
+    /// Then it looks for any newlines that are 3 or more and replaces them with 2 newlines.
+    /// Then finally it replaces multiple spaces on the same line with a single space.
     ///
     /// Example:
     /// ```
-    /// This is the first line
+    /// This is the first     line
     ///
     ///
     ///
@@ -27,5 +28,6 @@ extension String {
         return self.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             .replacingOccurrences(of: "\\s\n", with: "\n", options: .regularExpression, range: nil)
             .replacingOccurrences(of: "[\n]{3,}", with: "\n\n", options: .regularExpression, range: nil)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression, range: nil)
     }
 }

--- a/WordPress/Classes/Extensions/String+Truncate.swift
+++ b/WordPress/Classes/Extensions/String+Truncate.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension String {
+
+    /// Trims the trailing characters from the string to ensure the resulting string doesn't exceed the provided limit.
+    /// If the string is shorter than the limit, the string is returned without modifications
+    /// If the string is longer, the trailing characters are trimmed and replaced with an ellipsis character,
+    /// ensuring the length is equal to the limit
+    func truncate(with limit: Int) -> String {
+        guard count > limit else {
+            return self
+        }
+        let prefix = self.prefix(limit - 1)
+        return "\(prefix)…"
+    }
+}

--- a/WordPress/Classes/Extensions/String+Truncate.swift
+++ b/WordPress/Classes/Extensions/String+Truncate.swift
@@ -3,7 +3,7 @@ import Foundation
 extension String {
 
     /// Trims the trailing characters from the string to ensure the resulting string doesn't exceed the provided limit.
-    /// If the string is shorter than the limit, the string is returned without modifications
+    /// If the string is equal to or shorter than the limit, the string is returned without modifications
     /// If the string is longer, the trailing characters are trimmed and replaced with an ellipsis character,
     /// ensuring the length is equal to the limit
     func truncate(with limit: Int) -> String {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1861,6 +1861,10 @@
 		8070EB3E28D807CB005C6513 /* InMemoryUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8070EB3D28D807CB005C6513 /* InMemoryUserDefaults.swift */; };
 		8071390727D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
 		8071390827D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
+		808D102E2B881BE20082E64F /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808D102D2B881BE20082E64F /* String+Truncate.swift */; };
+		808D102F2B881BE20082E64F /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808D102D2B881BE20082E64F /* String+Truncate.swift */; };
+		808D10302B8820920082E64F /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808D102D2B881BE20082E64F /* String+Truncate.swift */; };
+		808D10312B8820950082E64F /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808D102D2B881BE20082E64F /* String+Truncate.swift */; };
 		808DB70C2A710EFE00EA1645 /* NUXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808DB70B2A710EFE00EA1645 /* NUXTests.swift */; };
 		808DB70D2A710EFE00EA1645 /* NUXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808DB70B2A710EFE00EA1645 /* NUXTests.swift */; };
 		8091019329078CFE00FCB4EA /* JetpackFullscreenOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8091019129078CFE00FCB4EA /* JetpackFullscreenOverlayViewController.swift */; };
@@ -7432,6 +7436,7 @@
 		806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModelTests.swift; sourceTree = "<group>"; };
 		8070EB3D28D807CB005C6513 /* InMemoryUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryUserDefaults.swift; sourceTree = "<group>"; };
 		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
+		808D102D2B881BE20082E64F /* String+Truncate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Truncate.swift"; sourceTree = "<group>"; };
 		808DB70B2A710EFE00EA1645 /* NUXTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NUXTests.swift; sourceTree = "<group>"; };
 		8091019129078CFE00FCB4EA /* JetpackFullscreenOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackFullscreenOverlayViewController.swift; sourceTree = "<group>"; };
 		8091019229078CFE00FCB4EA /* JetpackFullscreenOverlayViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackFullscreenOverlayViewController.xib; sourceTree = "<group>"; };
@@ -15494,6 +15499,7 @@
 				FAD1263B2A0CF2F50004E24C /* String+NonbreakingSpace.swift */,
 				B55FFCF91F034F1A0070812C /* String+Ranges.swift */,
 				B54C02231F38F50100574572 /* String+RegEx.swift */,
+				808D102D2B881BE20082E64F /* String+Truncate.swift */,
 				B5969E2120A49E86005E9DF1 /* UIAlertController+Helpers.swift */,
 				1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */,
 				E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */,
@@ -22314,6 +22320,7 @@
 				80EF672527F3D63B0063B138 /* DashboardStatsStackView.swift in Sources */,
 				E1D0D81616D3B86800E33F4C /* SafariActivity.m in Sources */,
 				E603C7701BC94AED00AD49D7 /* WordPress-37-38.xcmappingmodel in Sources */,
+				808D102E2B881BE20082E64F /* String+Truncate.swift in Sources */,
 				01E258022ACC36FA00F09666 /* PlanStep.swift in Sources */,
 				741E22461FC0CC55007967AB /* UploadOperation.swift in Sources */,
 				46C984682527863E00988BB9 /* LayoutPickerAnalyticsEvent.swift in Sources */,
@@ -23201,6 +23208,7 @@
 				09DBEA55281336E10019724E /* AppLocalizedString.swift in Sources */,
 				433ADC1A223B2A7D00ED9DE1 /* TextBundleWrapper.m in Sources */,
 				7335AC6C21220F050012EF2D /* FormattableNoticonRange.swift in Sources */,
+				808D10302B8820920082E64F /* String+Truncate.swift in Sources */,
 				73F6DD42212BA54700CE447D /* RichNotificationContentFormatter.swift in Sources */,
 				73ACDF9C2118AF7000233AD4 /* SFHFKeychainUtils.m in Sources */,
 				7335AC5921220AC40012EF2D /* FormattableContent.swift in Sources */,
@@ -23475,6 +23483,7 @@
 				80F6D03528EE866A00953C1A /* AppLocalizedString.swift in Sources */,
 				80F6D03628EE866A00953C1A /* TextBundleWrapper.m in Sources */,
 				80F6D03728EE866A00953C1A /* FormattableNoticonRange.swift in Sources */,
+				808D10312B8820950082E64F /* String+Truncate.swift in Sources */,
 				80F6D03828EE866A00953C1A /* RichNotificationContentFormatter.swift in Sources */,
 				80F6D03928EE866A00953C1A /* SFHFKeychainUtils.m in Sources */,
 				80F6D03A28EE866A00953C1A /* FormattableContent.swift in Sources */,
@@ -24840,6 +24849,7 @@
 				FABB23112602FC2C00C8785C /* PostingActivityLegend.swift in Sources */,
 				8B92D69727CD51FA001F5371 /* DashboardGhostCardCell.swift in Sources */,
 				FABB23122602FC2C00C8785C /* WPImmuTableRows.swift in Sources */,
+				808D102F2B881BE20082E64F /* String+Truncate.swift in Sources */,
 				FEFA6AC42A83F4BE004EE5E6 /* PostHelper+JetpackSocial.swift in Sources */,
 				086023D52B73AFD0000D084A /* NotificationsTableViewCellContent.swift in Sources */,
 				800035BE291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift in Sources */,

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -141,7 +141,7 @@ class NotificationService: UNNotificationServiceExtension {
                 notificationContent.title = contentFormatter.attributedSubject?.string ?? apsAlert
 
                 // Improve the notification body by trimming whitespace and reducing any multiple blank lines
-                notificationContent.body = contentFormatter.body?.condenseWhitespace() ?? ""
+                notificationContent.body = contentFormatter.attributedBody?.string.condenseWhitespace().truncate(with: 256) ?? ""
             }
 
             notificationContent.userInfo[CodingUserInfoKey.richNotificationViewModel.rawValue] = viewModel.data


### PR DESCRIPTION
Closes #22520
## Description
This PR fixes an issue where notifications with long bodies were getting cut off without indication. The PR properly truncates the body and adds an ellipsis character.

| Before | After |
|--------|--------|
|![5EEC4AA49ADE9CCD45461](https://github.com/wordpress-mobile/WordPress-iOS/assets/25306722/6714580a-acf5-4d79-8542-08876cf1c4d2)|![5EDB72EE2EA141B6DC1C1](https://github.com/wordpress-mobile/WordPress-iOS/assets/25306722/29a8625b-8611-4bbd-ab95-8f9bff0df566)|

## Testing Instructions

1. Install the app
2. Trigger a notification that has a body longer than 256 characters
3. Make sure that the body is properly truncated

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.