### PR TITLE
Offline Mode: Sync Publishing

### DIFF
--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -35,6 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  BOOL flag set to true if the post is first time published.
+
+ - note: Deprecated (kahu-offline-mode)
  */
 @property (nonatomic, assign) BOOL isFirstTimePublish;
 

--- a/WordPress/Classes/Services/PostCoordinator+Notices.swift
+++ b/WordPress/Classes/Services/PostCoordinator+Notices.swift
@@ -1,0 +1,111 @@
+import UIKit
+
+extension PostCoordinator {
+    static func makePublishSuccessNotice(for post: AbstractPost) -> Notice {
+        var message: String {
+            let title = post.titleForDisplay() ?? ""
+            if !title.isEmpty {
+                return title
+            }
+            return post.blog.displayURL as String? ?? ""
+        }
+        return Notice(title: Strings.publishSuccessTitle(for: post),
+                      message: message,
+                      feedbackType: .success,
+                      notificationInfo: makePublishSuccessNotificationInfo(for: post),
+                      actionTitle: Strings.view,
+                      actionHandler: { _ in
+            PostNoticeNavigationCoordinator.presentPostEpilogue(for: post)
+        })
+    }
+
+    private static func makePublishSuccessNotificationInfo(for post: AbstractPost) -> NoticeNotificationInfo {
+        var title: String {
+            let title = post.titleForDisplay() ?? ""
+            guard !title.isEmpty else {
+                return Strings.publishSuccessTitle(for: post)
+            }
+            return "“\(title)” \(Strings.publishSuccessTitle(for: post))"
+        }
+        var body: String {
+            post.blog.displayURL as String? ?? ""
+        }
+        return NoticeNotificationInfo(
+            identifier: UUID().uuidString,
+            categoryIdentifier: InteractiveNotificationsManager.NoteCategoryDefinition.postUploadSuccess.rawValue,
+            title: title,
+            body: body,
+            userInfo: [
+                PostNoticeUserInfoKey.postID: post.objectID.uriRepresentation().absoluteString
+            ])
+    }
+
+    static func makePublishFailureNotice(for post: AbstractPost, error: Error) -> Notice {
+        return Notice(
+            title: Strings.uploadFailed,
+            message: error.localizedDescription,
+            feedbackType: .error,
+            notificationInfo: makePublishFailureNotificationInfo(for: post, error: error)
+        )
+    }
+
+    private static func makePublishFailureNotificationInfo(for post: AbstractPost, error: Error) -> NoticeNotificationInfo {
+        var title: String {
+            let title = post.titleForDisplay() ?? ""
+            guard !title.isEmpty else {
+                return Strings.uploadFailed
+            }
+            return "“\(title)” \(Strings.uploadFailed)"
+        }
+        return NoticeNotificationInfo(
+            identifier: UUID().uuidString,
+            categoryIdentifier: nil,
+            title: title,
+            body: error.localizedDescription
+        )
+    }
+}
+
+private enum Strings {
+    static let view = NSLocalizedString("postNotice.view", value: "View", comment: "Button title. Displays a summary / sharing screen for a specific post.")
+
+    static let uploadFailed = NSLocalizedString("postNotice.uploadFailed", value: "Upload failed", comment: "A post upload failed notification.")
+
+    static func publishSuccessTitle(for post: AbstractPost, isFirstTimePublish: Bool = true) -> String {
+        switch post {
+        case let post as Post:
+            switch post.status {
+            case .draft:
+                return NSLocalizedString("postNotice.postDraftCreated", value: "Post draft uploaded", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
+            case .scheduled:
+                return NSLocalizedString("postNotice.postScheduled", value: "Post scheduled", comment: "Title of notification displayed when a post has been successfully scheduled.")
+            case .pending:
+                return NSLocalizedString("postNotice.postPendingReview", value: "Post pending review", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
+            default:
+                if isFirstTimePublish {
+                    return NSLocalizedString("postNotice.postPublished", value: "Post published", comment: "Title of notification displayed when a post has been successfully published.")
+                } else {
+                    return NSLocalizedString("postNotice.postUpdated", value: "Post updated", comment: "Title of notification displayed when a post has been successfully updated.")
+                }
+            }
+        case let page as Page:
+            switch page.status {
+            case .draft:
+                return NSLocalizedString("postNotice.pageDraftCreated", value: "Page draft uploaded", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
+            case .scheduled:
+                return NSLocalizedString("postNotice.pageScheduled", value: "Page scheduled", comment: "Title of notification displayed when a page has been successfully scheduled.")
+            case .pending:
+                return NSLocalizedString("postNotice.pagePending", value: "Page pending review", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
+            default:
+                if isFirstTimePublish {
+                    return NSLocalizedString("postNotice.pagePublished", value: "Page published", comment: "Title of notification displayed when a page has been successfully published.")
+                } else {
+                    return NSLocalizedString("postNotice.pageUpdated", value: "Page updated", comment: "Title of notification displayed when a page has been successfully updated.")
+                }
+            }
+        default:
+            assertionFailure("Unexpected post type: \(post)")
+            return ""
+        }
+    }
+}

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -124,7 +124,7 @@ class PostCoordinator: NSObject {
             parameters.status = PostStatusPublish
             parameters.date = Date()
         } else {
-            // Pulbish according to the currrent post settings: private, scheduled, etc.
+            // Publish according to the currrent post settings: private, scheduled, etc.
         }
         do {
             let repository = PostRepository(coreDataStack: coreDataStack)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -131,8 +131,9 @@ class PostCoordinator: NSObject {
             try await repository._upload(parameters, for: post)
             didPublish(post)
 
-            let notice = PostNoticeViewModel.makeSuccessNotice(for: post, isFirstTimePublish: true)
-            actionDispatcherFacade.dispatch(NoticeAction.post(notice))
+            // TODO: The post is not updated by the time this method is called. Refactor this to ensure _upload returns something we could work with immediatelly (kahu-offline-mode)
+            // let notice = PostNoticeViewModel.makeSuccessNotice(for: post, isFirstTimePublish: true)
+            // actionDispatcherFacade.dispatch(NoticeAction.post(notice))
         } catch {
             let notice = PostNoticeViewModel.makeFailureNotice(for: post, error: error)
             actionDispatcherFacade.dispatch(NoticeAction.post(notice))

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -76,7 +76,7 @@ final class PostRepository {
     }
 
     /// Uploads the changes to the given post to the server and deletes the
-    /// uploaded local revision afterward. If the post has an associated
+    /// uploaded local revision afterward. If the post doesn't have an associated
     /// remote ID, creates a new post.
     ///
     /// - note: This method is a low-level primitive for syncing the latest

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -97,8 +97,6 @@ final class PostRepository {
             uploadedPost = try await service.create(parameters)
         }
 
-        PostHelper.update(post, with: uploadedPost, in: context)
-
         let postID = TaggedManagedObjectID(post)
         try await coreDataStack.performAndSave { context in
             var post = try context.existingObject(with: postID)

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -97,6 +97,8 @@ final class PostRepository {
             uploadedPost = try await service.create(parameters)
         }
 
+        PostHelper.update(post, with: uploadedPost, in: context)
+
         let postID = TaggedManagedObjectID(post)
         try await coreDataStack.performAndSave { context in
             var post = try context.existingObject(with: postID)

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -59,7 +59,7 @@ final class PostRepository {
     }
 
     /// Uploads the changes to the given post to the server and deletes the
-    /// uploaded local revision afterward. If the post has an associated
+    /// uploaded local revision afterward. If the post doesn't have an associated
     /// remote ID, creates a new post.
     ///
     /// - note: This method is a low-level primitive for syncing the latest

--- a/WordPress/Classes/Services/PostService+UnattachedMedia.swift
+++ b/WordPress/Classes/Services/PostService+UnattachedMedia.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension PostService {
+    /// - note: Deprecated (kahu-offline-mode)
     @objc func updateMediaFor(post: AbstractPost,
                               success: @escaping () -> Void,
                               failure: @escaping (Error?) -> Void) {

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -90,6 +90,8 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
         parameter, since if the input post was a revision, it will no longer exist once the upload
         succeeds.
  @param failure A failure block
+
+ - note: Deprecated (kahu-offline-mode) (see PostRepository.upload)
  */
 - (void)uploadPost:(AbstractPost *)post
            success:(nullable void (^)(AbstractPost *post))success
@@ -105,6 +107,8 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
 
  Another use case of `forceDraftIfCreating` is to create the post in the background so we can
  periodically auto-save it. Again, we'd still want to create it as a `.draft` status.
+
+ - note: Deprecated (kahu-offline-mode) (see PostRepository.upload)
  */
 - (void)uploadPost:(AbstractPost *)post
 forceDraftIfCreating:(BOOL)forceDraftIfCreating

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -13,7 +13,6 @@ extension PostServiceRemote {
         }
     }
 
-    // TODO: Check if we need special logic like in `PostService` to update the post status to scheduled if needed
     func create(_ post: RemotePost) async throws -> RemotePost {
         try await withUnsafeThrowingContinuation { continuation in
             createPost(post, success: {

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -1,0 +1,27 @@
+import Foundation
+import WordPressKit
+
+extension PostServiceRemote {
+    func update(_ post: RemotePost) async throws -> RemotePost {
+        try await withUnsafeThrowingContinuation { continuation in
+            update(post, success: {
+                assert($0 != nil)
+                continuation.resume(returning: $0 ?? post)
+            }, failure: { error in
+                continuation.resume(throwing: error ?? URLError(.unknown))
+            })
+        }
+    }
+
+    // TODO: Check if we need special logic like in `PostService` to update the post status to scheduled if needed
+    func create(_ post: RemotePost) async throws -> RemotePost {
+        try await withUnsafeThrowingContinuation { continuation in
+            createPost(post, success: {
+                assert($0 != nil)
+                continuation.resume(returning: $0 ?? post)
+            }, failure: { error in
+                continuation.resume(throwing: error ?? URLError(.unknown))
+            })
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -605,6 +605,8 @@ class AbstractPostListViewController: UIViewController,
                 switch result {
                 case .completed(let post):
                     self?.didConfirmPublish(for: post)
+                case .published:
+                    self?.dismiss(animated: true)
                 case .dismissed:
                     break
                 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -603,11 +603,11 @@ class AbstractPostListViewController: UIViewController,
         func showPrepublishingFlow(for post: Post) {
             let viewController = PrepublishingViewController(post: post, identifiers: PrepublishingIdentifier.defaultIdentifiers) { [weak self] result in
                 switch result {
-                case .completed(let post):
+                case .confirmed:
                     self?.didConfirmPublish(for: post)
                 case .published:
                     self?.dismiss(animated: true)
-                case .dismissed:
+                case .cancelled:
                     break
                 }
             }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -236,6 +236,9 @@ extension PublishingEditor {
             case .completed(let post):
                 self?.post = post
                 publishAction()
+            case .published:
+                // TODO: verify if we need anything else from here
+                self?.dismissOrPopView()
             case .dismissed:
                 dismissAction()
             }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -8,12 +8,24 @@ struct PostNoticeViewModel {
     private let post: AbstractPost
     private let postCoordinator: PostCoordinator
     private let autoUploadInteractor = PostAutoUploadInteractor()
+    private let isFirstTimePublish: Bool
     private let isInternetReachable: Bool
 
-    init(post: AbstractPost, postCoordinator: PostCoordinator = PostCoordinator.shared, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
+    init(post: AbstractPost, postCoordinator: PostCoordinator = PostCoordinator.shared, isFirstTimePublish: Bool? = nil, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
         self.post = post
         self.postCoordinator = postCoordinator
+        self.isFirstTimePublish = isFirstTimePublish ?? post.isFirstTimePublish
         self.isInternetReachable = isInternetReachable
+    }
+
+    static func makeSuccessNotice(for post: AbstractPost, isFirstTimePublish: Bool) -> Notice {
+        let model = PostNoticeViewModel(post: post, isFirstTimePublish: isFirstTimePublish)
+        return model.successNotice
+    }
+
+    static func makeFailureNotice(for post: AbstractPost, error: Error) -> Notice {
+        let model = PostNoticeViewModel(post: post, isInternetReachable: (error as? URLError)?.code == .notConnectedToInternet)
+        return model.failureNotice
     }
 
     /// Returns the Notice represented by this view model.
@@ -87,7 +99,7 @@ struct PostNoticeViewModel {
         case .pending:
             return NSLocalizedString("Page pending review", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
         default:
-            if page.isFirstTimePublish {
+            if isFirstTimePublish {
                 return NSLocalizedString("Page published", comment: "Title of notification displayed when a page has been successfully published.")
             } else {
                 return NSLocalizedString("Page updated", comment: "Title of notification displayed when a page has been successfully updated.")
@@ -106,7 +118,7 @@ struct PostNoticeViewModel {
         case .pending:
             return NSLocalizedString("Post pending review", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
         default:
-            if post.isFirstTimePublish {
+            if isFirstTimePublish {
                 return NSLocalizedString("Post published", comment: "Title of notification displayed when a post has been successfully published.")
             } else {
                 return NSLocalizedString("Post updated", comment: "Title of notification displayed when a post has been successfully updated.")

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -18,11 +18,6 @@ struct PostNoticeViewModel {
         self.isInternetReachable = isInternetReachable
     }
 
-    static func makeSuccessNotice(for post: AbstractPost, isFirstTimePublish: Bool) -> Notice {
-        let model = PostNoticeViewModel(post: post, isFirstTimePublish: isFirstTimePublish)
-        return model.successNotice
-    }
-
     static func makeFailureNotice(for post: AbstractPost, error: Error) -> Notice {
         let model = PostNoticeViewModel(post: post, isInternetReachable: (error as? URLError)?.code == .notConnectedToInternet)
         return model.failureNotice

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -472,13 +472,32 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     private func publishPost() {
-        publishButtonViewModel.state = .loading
+        setLoading(true)
         Task {
             do {
                 try await PostCoordinator.shared._publish(post)
                 getCompletion()?(.published)
             } catch {
+                setLoading(false)
                 publishButtonViewModel.state = .default
+            }
+        }
+    }
+
+    private func setLoading(_ isLoading: Bool) {
+        publishButtonViewModel.state = isLoading ? .loading : .default
+        isModalInPresentation = isLoading
+        view.isUserInteractionEnabled = !isLoading
+
+        var subviews: [UIView] = [view]
+        while let view = subviews.popLast() {
+            switch view {
+            case let control as UIControl:
+                control.isEnabled = !isLoading
+            case let cell as UITableViewCell:
+                isLoading ? cell.disable() : cell.enable()
+            default:
+                subviews += view.subviews
             }
         }
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -579,6 +579,8 @@
 		0CF0C4232AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
 		0CF0C4242AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
 		0CF7D6C32ABB753A006D1E89 /* MediaImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */; };
+		0CF7EACF2B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */; };
+		0CF7EAD02B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */; };
 		0CFE9AC62AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
 		0CFE9AC72AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
 		0CFE9AC92AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC82AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift */; };
@@ -6253,6 +6255,7 @@
 		0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFeatureFlagsView.swift; sourceTree = "<group>"; };
 		0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostHelper.swift; sourceTree = "<group>"; };
 		0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageServiceTests.swift; sourceTree = "<group>"; };
+		0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostServiceRemote+Concurrency.swift"; sourceTree = "<group>"; };
 		0CFD6C792A73E703003DD0A0 /* WordPress 152.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 152.xcdatamodel"; sourceTree = "<group>"; };
 		0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPostHelper+Actions.swift"; sourceTree = "<group>"; };
 		0CFE9AC82AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSettingsViewController+Swift.swift"; sourceTree = "<group>"; };
@@ -14353,6 +14356,7 @@
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
 				8B5E1DD727EA5929002EBEE3 /* PostCoordinator+Dashboard.swift */,
 				4A2C73F32A95856000ACE79E /* PostRepository.swift */,
+				0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */,
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
 				98E0829E2637545C00537BF1 /* PostService+Likes.swift */,
@@ -22559,6 +22563,7 @@
 				4A9B81E32921AE03007A05D1 /* ContextManager.swift in Sources */,
 				F5D0A64923C8FA1500B20D27 /* LinkBehavior.swift in Sources */,
 				08E6E07B2A4C3E3A00B807B0 /* CompliancePopoverViewController.swift in Sources */,
+				0CF7EACF2B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */,
 				0C75E26E2A9F63CB00B784E5 /* MediaImageService.swift in Sources */,
 				80C523A429959DE000B1C14B /* BlazeWebViewController.swift in Sources */,
 				E6DE44671B90D251000FA7EF /* ReaderHelpers.swift in Sources */,
@@ -25812,6 +25817,7 @@
 				FABB25EE2602FC2C00C8785C /* ViewMoreRow.swift in Sources */,
 				FABB25EF2602FC2C00C8785C /* ReaderWebView.swift in Sources */,
 				FABB25F02602FC2C00C8785C /* PostVisibilitySelectorViewController.swift in Sources */,
+				0CF7EAD02B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */,
 				FABB25F12602FC2C00C8785C /* UIApplication+Helpers.m in Sources */,
 				FA141F2B2AEC23E300C9A653 /* PageListViewController+Menu.swift in Sources */,
 				FABB25F22602FC2C00C8785C /* ErrorStateView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -535,6 +535,8 @@
 		0CB424F72AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */; };
 		0CB54F572AEC320700582080 /* WordPressAppDelegate+PostCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB54F562AEC320700582080 /* WordPressAppDelegate+PostCoordinatorDelegate.swift */; };
 		0CB54F582AEC320700582080 /* WordPressAppDelegate+PostCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB54F562AEC320700582080 /* WordPressAppDelegate+PostCoordinatorDelegate.swift */; };
+		0CC21C6C2B95220E003BDB4A /* PostCoordinator+Notices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC21C6B2B95220E003BDB4A /* PostCoordinator+Notices.swift */; };
+		0CC21C6D2B95220E003BDB4A /* PostCoordinator+Notices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC21C6B2B95220E003BDB4A /* PostCoordinator+Notices.swift */; };
 		0CD223DF2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */; };
 		0CD223E02AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */; };
 		0CD382832A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */; };
@@ -6233,6 +6235,7 @@
 		0CB424F32ADF3CBE0080B807 /* PostSearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchViewModelTests.swift; sourceTree = "<group>"; };
 		0CB424F52AE0416D0080B807 /* SolidColorActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidColorActivityIndicator.swift; sourceTree = "<group>"; };
 		0CB54F562AEC320700582080 /* WordPressAppDelegate+PostCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAppDelegate+PostCoordinatorDelegate.swift"; sourceTree = "<group>"; };
+		0CC21C6B2B95220E003BDB4A /* PostCoordinator+Notices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostCoordinator+Notices.swift"; sourceTree = "<group>"; };
 		0CD223DE2AA8ADFD002BD761 /* DashboardQuickActionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickActionsViewModel.swift; sourceTree = "<group>"; };
 		0CD382822A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModel.swift; sourceTree = "<group>"; };
 		0CD382852A4B6FCE00612173 /* DashboardBlazeCardCellViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCardCellViewModelTest.swift; sourceTree = "<group>"; };
@@ -14354,6 +14357,7 @@
 				93FA59DB18D88C1C001446BC /* PostCategoryService.h */,
 				93FA59DC18D88C1C001446BC /* PostCategoryService.m */,
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
+				0CC21C6B2B95220E003BDB4A /* PostCoordinator+Notices.swift */,
 				8B5E1DD727EA5929002EBEE3 /* PostCoordinator+Dashboard.swift */,
 				4A2C73F32A95856000ACE79E /* PostRepository.swift */,
 				0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */,
@@ -22939,6 +22943,7 @@
 				FACF66CA2ADD4703008C3E13 /* PostListCell.swift in Sources */,
 				F5E032DB24088F44003AF350 /* UIView+SpringAnimations.swift in Sources */,
 				E6A338501BB0A70F00371587 /* ReaderGapMarkerCell.swift in Sources */,
+				0CC21C6C2B95220E003BDB4A /* PostCoordinator+Notices.swift in Sources */,
 				98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */,
 				82FFBF4D1F434BDA00F4573F /* ThemeIdHelper.swift in Sources */,
 				730D290F22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift in Sources */,
@@ -25601,6 +25606,7 @@
 				016231512B3B3CAD0010E377 /* PrimaryDomainView.swift in Sources */,
 				FABB25582602FC2C00C8785C /* PostCategoriesViewController.swift in Sources */,
 				FABB25592602FC2C00C8785C /* NSManagedObject+Lookup.swift in Sources */,
+				0CC21C6D2B95220E003BDB4A /* PostCoordinator+Notices.swift in Sources */,
 				FABB255A2602FC2C00C8785C /* StatsPeriodHelper.swift in Sources */,
 				FABB255B2602FC2C00C8785C /* FooterContentStyles.swift in Sources */,
 				FABB255C2602FC2C00C8785C /* TenorMedia.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/22579

To test:

> [!IMPORTANT]  
> Make sure to enable the `.offlineMode` feature flag.

- Tap "+" to create a new post
- Add content and tap "Publish"
- **Verify** that the pre-publishing sheet is shown
- Tap "Publish"
- **Verify** that that sheet is disabled and can't be dismissed during publishing
- **Verify** that if request fails, a snackbar is shown (note: it should not have a "Retry" button)
- **Verify** that if request succeed, the editor is dismissed

This is the only scenario that is now officially supported. We'll need more tests, including automated test in the future PRs.

## Regression Notes
1. Potential unintended areas of impact: Publishing
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
