### PR TITLE
Stats Traffic: Ensure deep links and widget routing work

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -78,9 +78,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
         if let match = matches.first,
            let action = match.action as? StatsRoute,
            let timePeriod = action.timePeriod {
-            // Initializing a StatsPeriodType to ensure we have a valid period
-            let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
-            UserPersistentStoreFactory.instance().set(timePeriod.rawValue, forKey: key)
+            SiteStatsDashboardPreferences.setSelected(periodType: timePeriod, siteID: siteID)
         }
     }
 

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -77,8 +77,8 @@ struct DefaultContentCoordinator: ContentCoordinator {
         let matches = matcher.routesMatching(url)
         if let match = matches.first,
            let action = match.action as? StatsRoute,
-           let timePeriod = action.timePeriod {
-            SiteStatsDashboardPreferences.setSelected(periodType: timePeriod, siteID: siteID)
+           let tab = action.tab {
+            SiteStatsDashboardPreferences.setSelected(tabType: tab, siteID: siteID)
         }
     }
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -228,7 +228,7 @@ final class InteractiveNotificationsManager: NSObject {
                     RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(
                         for: targetBlog,
                         source: .notification,
-                        timePeriod: .weeks,
+                        tab: .weeks,
                         date: targetDate)
                 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -12,7 +12,7 @@ enum StatsRoute {
     case annualStats
     case activityLog
 
-    var timePeriod: StatsPeriodType? {
+    var tab: StatsTabType? {
         switch self {
         case .daySite:
             return .days
@@ -85,19 +85,19 @@ extension StatsRoute: NavigationAction {
                 showStatsForDefaultBlog(from: values, with: coordinator)
             }
         case .daySite:
-            showStatsForBlog(from: values, timePeriod: .days, using: coordinator)
+            showStatsForBlog(from: values, tab: .days, using: coordinator)
         case .weekSite:
-            showStatsForBlog(from: values, timePeriod: .weeks, using: coordinator)
+            showStatsForBlog(from: values, tab: .weeks, using: coordinator)
         case .monthSite:
-            showStatsForBlog(from: values, timePeriod: .months, using: coordinator)
+            showStatsForBlog(from: values, tab: .months, using: coordinator)
         case .yearSite:
-            showStatsForBlog(from: values, timePeriod: .years, using: coordinator)
+            showStatsForBlog(from: values, tab: .years, using: coordinator)
         case .insights:
-            showStatsForBlog(from: values, timePeriod: .insights, using: coordinator)
+            showStatsForBlog(from: values, tab: .insights, using: coordinator)
         case .dayCategory:
-            showStatsForBlog(from: values, timePeriod: .days, using: coordinator)
+            showStatsForBlog(from: values, tab: .days, using: coordinator)
         case .annualStats:
-            showStatsForBlog(from: values, timePeriod: .years, using: coordinator)
+            showStatsForBlog(from: values, tab: .years, using: coordinator)
         case .activityLog:
             if let blog = blog(from: values) {
                 coordinator.showActivityLog(for: blog)
@@ -109,12 +109,12 @@ extension StatsRoute: NavigationAction {
     }
 
     private func showStatsForBlog(from values: [String: String],
-                                  timePeriod: StatsPeriodType,
+                                  tab: StatsTabType,
                                   using coordinator: MySitesCoordinator) {
         if let blog = blog(from: values) {
             coordinator.showStats(for: blog,
                                   source: source(from: values),
-                                  timePeriod: timePeriod)
+                                  tab: tab)
         } else {
             showMySitesAndFailureNotice(using: coordinator,
                                         values: values)
@@ -139,12 +139,12 @@ extension StatsRoute: NavigationAction {
         // In this case, we'll check whether the last component is actually a
         // time period, and if so we'll show that time period for the default site.
         guard let component = values["domain"],
-              let timePeriod = StatsPeriodType(from: component),
+              let timePeriod = StatsTabType(from: component),
               let blog = defaultBlog() else {
             return
         }
 
-        coordinator.showStats(for: blog, source: source(from: values), timePeriod: timePeriod)
+        coordinator.showStats(for: blog, source: source(from: values), tab: timePeriod)
     }
 
     private func source(from values: [String: String]) -> BlogDetailsNavigationSource {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+OnboardingPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+OnboardingPrompt.swift
@@ -17,7 +17,7 @@ extension MySiteViewController {
         case .stats:
             // Show the stats view for the current blog
             if let blog = blog {
-                RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, source: .onboarding, timePeriod: .insights)
+                RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, source: .onboarding, tab: .insights)
             }
         case .writing:
             // Open the editor

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -11,7 +11,11 @@ final class SiteStatsPeriodViewModel: Observable {
     private weak var referrerDelegate: SiteStatsReferrerDelegate?
     private let store: any StatsPeriodStoreProtocol
     private var lastRequestedDate: Date
-    private var lastRequestedPeriod: StatsPeriodUnit
+    private var lastRequestedPeriod: StatsPeriodUnit {
+        didSet {
+            SiteStatsDashboardPreferences.setSelected(periodUnit: lastRequestedPeriod)
+        }
+    }
     private var periodReceipt: Receipt?
     private var changeReceipt: Receipt?
     private typealias Style = WPStyleGuide.Stats

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -341,7 +341,7 @@ struct SiteStatsDashboardPreferences {
     static func setSelected(periodUnit: StatsPeriodUnit) {
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else { return }
 
-        let unitKey = lastSelectedStatsTabTypeKey(forSiteID: siteID)
+        let unitKey = lastSelectedStatsUnitTypeKey(forSiteID: siteID)
         UserPersistentStoreFactory.instance().set(periodUnit.rawValue, forKey: unitKey)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -339,11 +339,11 @@ struct SiteStatsDashboardPreferences {
         }
     }
 
-    static func setSelected(unit: StatsPeriodUnit) {
+    static func setSelected(periodUnit: StatsPeriodUnit) {
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else { return }
 
         let unitKey = lastSelectedStatsTabTypeKey(forSiteID: siteID)
-        UserPersistentStoreFactory.instance().set(unit.rawValue, forKey: unitKey)
+        UserPersistentStoreFactory.instance().set(periodUnit.rawValue, forKey: unitKey)
     }
 
     static func getSelectedTabType() -> StatsTabType? {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SwiftUI
 
-enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
+enum StatsTabType: Int, FilterTabBarItem, CaseIterable {
     case insights = 0
     case days
     case weeks
@@ -56,8 +56,8 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
     }
 }
 
-fileprivate extension StatsPeriodType {
-    static var displayedPeriods: [StatsPeriodType] {
+fileprivate extension StatsTabType {
+    static var displayedTabs: [StatsTabType] {
         if RemoteFeatureFlag.statsTrafficTab.enabled() {
             return [.traffic, .insights]
         } else {
@@ -100,7 +100,7 @@ class SiteStatsDashboardViewController: UIViewController {
         return SiteStatsPeriodTableViewController(selectedDate: selectedDate, selectedPeriod: selectedPeriodUnit)
     }()
     private var pageViewController: UIPageViewController?
-    private lazy var displayedPeriods: [StatsPeriodType] = StatsPeriodType.displayedPeriods
+    private lazy var displayedTabs: [StatsTabType] = StatsTabType.displayedTabs
 
     @objc lazy var manageInsightsButton: UIBarButtonItem = {
         let button = UIBarButtonItem(
@@ -122,7 +122,7 @@ class SiteStatsDashboardViewController: UIViewController {
         configureTrafficTableViewController()
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
-        restoreSelectedPeriodFromUserDefaults()
+        restoreSelectedTabFromUserDefaults()
         addWillEnterForegroundObserver()
         configureNavBar()
         view.accessibilityIdentifier = "stats-dashboard"
@@ -147,7 +147,7 @@ class SiteStatsDashboardViewController: UIViewController {
     }
 
     func configureNavBar() {
-        parent?.navigationItem.rightBarButtonItem = currentSelectedPeriod == .insights ? manageInsightsButton : nil
+        parent?.navigationItem.rightBarButtonItem = currentSelectedTab == .insights ? manageInsightsButton : nil
     }
 
     func configureJetpackBanner() {
@@ -182,30 +182,30 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         if traitCollection.verticalSizeClass == .regular, traitCollection.horizontalSizeClass == .compact {
-            updatePeriodView(oldSelectedPeriod: currentSelectedPeriod)
+            updatePeriodView(oldSelectedTab: currentSelectedTab)
         }
     }
 }
 
 extension SiteStatsDashboardViewController: StatsForegroundObservable {
     func reloadStatsData() {
-        updatePeriodView(oldSelectedPeriod: currentSelectedPeriod)
+        updatePeriodView(oldSelectedTab: currentSelectedTab)
     }
 }
 
 // MARK: - Private Extension
 
 private extension SiteStatsDashboardViewController {
-    var currentSelectedPeriod: StatsPeriodType {
+    var currentSelectedTab: StatsTabType {
         get {
             let selectedIndex = filterTabBar?.selectedIndex ?? 0
-            return displayedPeriods[selectedIndex]
+            return displayedTabs[selectedIndex]
         }
         set {
-            let index = displayedPeriods.firstIndex(of: newValue) ?? 0
+            let index = displayedTabs.firstIndex(of: newValue) ?? 0
             filterTabBar?.setSelectedIndex(index)
-            let oldSelectedPeriod = getSelectedPeriodFromUserDefaults()
-            updatePeriodView(oldSelectedPeriod: oldSelectedPeriod)
+            let oldSelectedPeriod = getSelectedTabFromUserDefaults()
+            updatePeriodView(oldSelectedTab: oldSelectedPeriod)
             saveSelectedPeriodToUserDefaults()
             trackAccessEvent()
         }
@@ -218,13 +218,13 @@ private extension SiteStatsDashboardViewController {
 
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
-        filterTabBar.items = displayedPeriods
+        filterTabBar.items = displayedTabs
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         filterTabBar.accessibilityIdentifier = "site-stats-dashboard-filter-bar"
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
-        currentSelectedPeriod = displayedPeriods[filterBar.selectedIndex]
+        currentSelectedTab = displayedTabs[filterBar.selectedIndex]
 
         configureNavBar()
     }
@@ -241,19 +241,19 @@ private extension SiteStatsDashboardViewController {
         }
 
         guard !insightsTableViewController.isGrowAudienceShowing else {
-            SiteStatsDashboardPreferences.setSelected(periodType: .insights, siteID: siteID)
+            SiteStatsDashboardPreferences.setSelected(tabType: .insights, siteID: siteID)
             return
         }
 
-        SiteStatsDashboardPreferences.setSelected(periodType: currentSelectedPeriod, siteID: siteID)
+        SiteStatsDashboardPreferences.setSelected(tabType: currentSelectedTab, siteID: siteID)
     }
 
-    func getSelectedPeriodFromUserDefaults() -> StatsPeriodType {
-        guard let periodType = SiteStatsDashboardPreferences.getSelectedPeriodType() else {
-            return displayedPeriods[0]
+    func getSelectedTabFromUserDefaults() -> StatsTabType {
+        guard let tabType = SiteStatsDashboardPreferences.getSelectedTabType() else {
+            return displayedTabs[0]
         }
 
-        return periodType
+        return tabType
     }
 
     func restoreSelectedDateFromUserDefaults() {
@@ -261,17 +261,17 @@ private extension SiteStatsDashboardViewController {
         SiteStatsDashboardPreferences.removeLastSelectedDateFromUserDefaults()
     }
 
-    func restoreSelectedPeriodFromUserDefaults() {
-        currentSelectedPeriod = getSelectedPeriodFromUserDefaults()
+    func restoreSelectedTabFromUserDefaults() {
+        currentSelectedTab = getSelectedTabFromUserDefaults()
     }
 
-    func updatePeriodView(oldSelectedPeriod: StatsPeriodType) {
-        let selectedPeriodChanged = currentSelectedPeriod != oldSelectedPeriod
-        let previousSelectedPeriodWasInsights = oldSelectedPeriod == .insights
+    func updatePeriodView(oldSelectedTab: StatsTabType) {
+        let selectedPeriodChanged = currentSelectedTab != oldSelectedTab
+        let previousSelectedPeriodWasInsights = oldSelectedTab == .insights
         let pageViewControllerIsEmpty = pageViewController?.viewControllers?.isEmpty ?? true
         let isGrowAudienceShowingOnInsights = insightsTableViewController.isGrowAudienceShowing
 
-        switch currentSelectedPeriod {
+        switch currentSelectedTab {
         case .insights:
             if selectedPeriodChanged || pageViewControllerIsEmpty || isGrowAudienceShowingOnInsights {
                 pageViewController?.setViewControllers([insightsTableViewController],
@@ -298,7 +298,7 @@ private extension SiteStatsDashboardViewController {
                 periodTableViewControllerDeprecated.selectedDate = StatsDataHelper.currentDateForSite()
             }
 
-            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedTab.rawValue - 1) ?? .day
             periodTableViewControllerDeprecated.selectedPeriod = selectedPeriod
         }
     }
@@ -318,7 +318,7 @@ private extension SiteStatsDashboardViewController {
     }
 
     func trackAccessEvent() {
-        if let event = currentSelectedPeriod.analyticsAccessEvent {
+        if let event = currentSelectedTab.analyticsAccessEvent {
             captureAnalyticsEvent(event)
         }
     }
@@ -327,14 +327,14 @@ private extension SiteStatsDashboardViewController {
 // MARK: - Preferences
 
 struct SiteStatsDashboardPreferences {
-    static func setSelected(periodType: StatsPeriodType, siteID: Int? = nil) {
+    static func setSelected(tabType: StatsTabType, siteID: Int? = nil) {
         guard let siteID = siteID ?? SiteStatsInformation.sharedInstance.siteID?.intValue else { return }
 
-        let periodKey = lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
-        UserPersistentStoreFactory.instance().set(periodType.rawValue, forKey: periodKey)
+        let periodKey = lastSelectedStatsTabTypeKey(forSiteID: siteID)
+        UserPersistentStoreFactory.instance().set(tabType.rawValue, forKey: periodKey)
 
         let unitKey = lastSelectedStatsUnitTypeKey(forSiteID: siteID)
-        if let unit = periodType.unit {
+        if let unit = tabType.unit {
             UserPersistentStoreFactory.instance().set(unit.rawValue, forKey: unitKey)
         }
     }
@@ -342,15 +342,15 @@ struct SiteStatsDashboardPreferences {
     static func setSelected(unit: StatsPeriodUnit) {
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else { return }
 
-        let unitKey = lastSelectedStatsUnitTypeKey(forSiteID: siteID)
+        let unitKey = lastSelectedStatsTabTypeKey(forSiteID: siteID)
         UserPersistentStoreFactory.instance().set(unit.rawValue, forKey: unitKey)
     }
 
-    static func getSelectedPeriodType() -> StatsPeriodType? {
+    static func getSelectedTabType() -> StatsTabType? {
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else { return nil }
 
-        let key = Self.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
-        return StatsPeriodType(rawValue: UserPersistentStoreFactory.instance().integer(forKey: key))
+        let key = Self.lastSelectedStatsTabTypeKey(forSiteID: siteID)
+        return StatsTabType(rawValue: UserPersistentStoreFactory.instance().integer(forKey: key))
     }
 
     static func getSelectedPeriodUnit() -> StatsPeriodUnit? {
@@ -370,8 +370,8 @@ struct SiteStatsDashboardPreferences {
 
     // MARK: - Keys
 
-    private static func lastSelectedStatsPeriodTypeKey(forSiteID siteID: Int) -> String {
-        return "LastSelectedStatsPeriodType-\(siteID)"
+    private static func lastSelectedStatsTabTypeKey(forSiteID siteID: Int) -> String {
+        return "LastSelectedStatsTabType-\(siteID)"
     }
 
     private static func lastSelectedStatsUnitTypeKey(forSiteID siteID: Int) -> String {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -152,8 +152,7 @@ class MySitesCoordinator: NSObject {
         }
 
         if let siteID = blog.dotComID?.intValue, let timePeriod = timePeriod {
-            let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
-            UserPersistentStoreFactory.instance().set(timePeriod.rawValue, forKey: key)
+            SiteStatsDashboardPreferences.setSelected(periodType: timePeriod, siteID: siteID)
         }
 
         let userInfo: [AnyHashable: Any] = [BlogDetailsViewController.userInfoSourceKey(): NSNumber(value: source.rawValue)]

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -139,7 +139,7 @@ class MySitesCoordinator: NSObject {
         showBlogDetails(for: blog, then: .stats)
     }
 
-    func showStats(for blog: Blog, source: BlogDetailsNavigationSource, timePeriod: StatsPeriodType? = nil, date: Date? = nil) {
+    func showStats(for blog: Blog, source: BlogDetailsNavigationSource, tab: StatsTabType? = nil, date: Date? = nil) {
         guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             unsupportedFeatureFallback()
             return
@@ -151,8 +151,8 @@ class MySitesCoordinator: NSObject {
             UserPersistentStoreFactory.instance().set(date, forKey: SiteStatsDashboardViewController.lastSelectedStatsDateKey)
         }
 
-        if let siteID = blog.dotComID?.intValue, let timePeriod = timePeriod {
-            SiteStatsDashboardPreferences.setSelected(periodType: timePeriod, siteID: siteID)
+        if let siteID = blog.dotComID?.intValue, let tab = tab {
+            SiteStatsDashboardPreferences.setSelected(tabType: tab, siteID: siteID)
         }
 
         let userInfo: [AnyHashable: Any] = [BlogDetailsViewController.userInfoSourceKey(): NSNumber(value: source.rawValue)]


### PR DESCRIPTION
Ensure deep links and widget routing work

https://github.com/wordpress-mobile/jetpack-issue-repo/issues/16
https://github.com/wordpress-mobile/jetpack-issue-repo/issues/17

## Problem

Routing is supported by setting `StatsPeriodType` in user preferences and then reading from it when determining which tab to display when opening Stats.

This solution worked well when `/days` `/months` `/years` `/insights` routes mapped well to tabs displayed on the Stats Dashboard.

However, with the introduction of `Traffic` tab, we need to separate the concept of the selected tab (Insights / Traffic), and the selected period unit (Days/Weeks/Months/Years) while at the same time keep supporting the previous configuration with feature flag disabled.

## Solution

1. Rename `StatsPeriodType` to `StatsTabType` to correctly reflect that this `enum` is used to represent tabs displayed on Stats Dashboard
2. Aggregate all user preferences code in `SiteStatsDashboardPreferences`
3. When setting `StatsTabType` during the routing process, also set `StatsPeriodUnit`, mapping `/days to .day`, `/months to .month`...
4. When opening Stats Traffic, set the selected period unit to Traffic VC (`getSelectedPeriodUnit`) which was preselected during the routing process. When the feature flag is disabled, `getSelectedPeriodUnit` is not used since the selected tab is equal to the selected unit as well.

## To test:

### Widgets
1. Enable the Stats Traffic feature flag
2. Add all types of widgets for different sites
3. Confirm that correct tab is opened with a correct period type

### Links
1. Enable the Stats Traffic feature flag
2. Open WordPress.com/stats
3. Switch between Traffic/Insights, and Day/Week/Month/Year data range
4. Select Open Jetpack banner
6. Confirm that correct tab is opened with a correct period type

### Tab Switching regression

1. Enable the Stats Traffic feature flag
2. Open Stats
3. Select Insights tab
4. Leave Stats
5. Re-enter Stats, confirm Insights tab is shown
6. Change to Traffic
7. Leave/come back to Stats
8. Confirm Traffic tab is shown
9. Add "This week" widget
10. Tap on widget
11. Confirm Traffic tab with Weekly chart is shown
12. Leave/come back to Stats
13. Confirm Traffic tab with Weekly chart is shown

### Videos

#### Stats Traffic feature flag enabled

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/11bbc3a2-27fe-4c51-91eb-d23a26cecd1a

#### Stats Traffic feature flag disabled

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/65703dbc-ae6c-4950-acf9-56616c3c1459

## Regression Notes
1. Potential unintended areas of impact

Breaking existing routing functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I tried to make the solution that doesn't change anything how routing or tab selection works
- Did manual testing (see video)

14. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x]  I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)