### PR TITLE
[Notifications P1] Section header spacing change

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
@@ -61,10 +61,10 @@ final class NotificationsTableHeaderView: UITableViewHeaderFooterView {
 
     private enum Appearance {
         static let backgroundColor = UIColor.systemBackground
-        static let textColor = UIColor.DS.Foreground.primary ?? .text
+        static let textColor = UIColor.DS.Foreground.primary
         static let textFont = UIFont.DS.font(.bodyLarge(.emphasized))
         static let layoutMargins = NSDirectionalEdgeInsets(
-            top: Length.Padding.double,
+            top: Length.Padding.single,
             leading: Length.Padding.double,
             bottom: Length.Padding.double,
             trailing: Length.Padding.double

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -342,6 +342,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
         cell.selectionStyle = .none
         cell.accessibilityHint = Self.accessibilityHint(for: note)
         cell.host(content, parent: self)
+        cell.backgroundColor = .systemBackground
         return cell
     }
 
@@ -709,6 +710,7 @@ private extension NotificationsViewController {
     func setupFilterBar() {
         WPStyleGuide.configureFilterTabBar(filterTabBar)
         filterTabBar.superview?.backgroundColor = .systemBackground
+        filterTabBar.backgroundColor = .systemBackground
 
         filterTabBar.items = Filter.allCases
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -96,12 +96,12 @@ struct AvatarsView: View {
         secondaryURL: URL?,
         tertiaryURL: URL?
     ) -> some View {
-        ZStack(alignment: .bottom) {
+        ZStack(alignment: .center) {
             avatar(url: tertiaryURL)
                 .padding(.trailing, Length.Padding.medium * scale)
             avatar(url: secondaryURL)
                 .avatarBorderOverlay()
-                .offset(x: 0, y: -Length.Padding.split * scale)
+                .padding(.bottom, Length.Padding.medium * scale)
             avatar(url: primaryURL)
                 .avatarBorderOverlay()
                 .padding(.leading, Length.Padding.medium * scale)

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -76,14 +76,8 @@ fileprivate extension NotificationsTableViewCellContent {
                     .saveSize(in: $textsSize)
                 Spacer()
                 if let inlineAction = info.inlineAction {
-                    Button {
-                        inlineAction.action()
-                    } label: {
-                        inlineAction.icon
-                            .imageScale(.small)
-                            .foregroundStyle(Color.DS.Foreground.secondary)
-                            .frame(width: Length.Padding.medium, height: Length.Padding.medium)
-                    }
+                    actionIcon(inlineAction: inlineAction)
+                        .padding(.top, actionIconTopPadding(inlineAction: inlineAction))
                 }
             }
             .padding(.trailing, Length.Padding.double)
@@ -129,6 +123,21 @@ fileprivate extension NotificationsTableViewCellContent {
                         .padding(.top, Length.Padding.half)
                 }
             }
+        }
+
+        private func actionIcon(inlineAction: InlineAction) -> some View {
+            Button {
+                inlineAction.action()
+            } label: {
+                inlineAction.icon
+                    .imageScale(.small)
+                    .foregroundStyle(Color.DS.Foreground.secondary)
+                    .frame(width: Length.Padding.medium, height: Length.Padding.medium)
+            }
+        }
+
+        private func actionIconTopPadding(inlineAction: InlineAction) -> CGFloat {
+            rootStackAlignment == .center ? 0 : ((info.avatarStyle.diameter * textScale - Length.Padding.medium) / 2)
         }
     }
 }


### PR DESCRIPTION
Fixes #22671

## Description
Update the header top spacing as 8.
Also updates the background color of the rows.

## Testing Steps
1. Install & Login Jetpack
2. Navigate to Notifications tab.
3. ✅ Verify that the top spacing is now 8 instead of 16 (Length.Padding.double -> Length.Padding.single)
4. ✅ Verify that on dark mode, only the navigation bar is elevated. The rest of the screen should have black background.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
