### PR TITLE
Fix pre-publishing sheet analytics

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -224,10 +224,8 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             navigationController?.setNavigationBarHidden(false, animated: animated)
         }
 
-        if isBeingDismissed || parent?.isBeingDismissed == true {
-            if !didTapPublish,
-               post.status == .publishPrivate,
-               let originalStatus = post.original?.status {
+        if (isBeingDismissed || parent?.isBeingDismissed == true) && !didTapPublish {
+            if post.status == .publishPrivate, let originalStatus = post.original?.status {
                 post.status = originalStatus
             }
             completion(.dismissed)


### PR DESCRIPTION
Fixes a regression in 24.3 where the pre-publishing sheet would sometimes call the "dismissed" callback together with "completed". It doesn't introduce any functional issues, so it was unnoticed, but there is an issue with analytics.

To test:

- Set debugger PostEditor+Publish on `publishBlock` and the dismiss closure below
- Tap "Publish"
- Tap "Close" and **verify** that only dismiss closure is called
- Tap "Publish"
- Tap outside of the sheet and **verify** that only dismiss closure is called
- Tap "Publish"
- Add a tag and **verify** that the dismiss close is not called
- Tap "Publish" 
- Confirm publishing and **verify** that only `publishBlock` closure is called

## Regression Notes
1. Potential unintended areas of impact: Pre-publishing Sheet
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
