### PR TITLE
build: Enable Gutenberg WebView inspection

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -40,6 +40,9 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
         addProgressView()
         startObservingWebView()
         waitForGutenbergToLoad(fallback: showTroubleshootingInstructions)
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
     }
 
     deinit {


### PR DESCRIPTION
Allow debugging issues within the WebView used for the unsupported block
editor (UBE). Similar configuration was applied to the Reader WebView in
https://github.com/wordpress-mobile/WordPress-iOS/pull/22022.


To test: Verify the [UBE](https://github.com/wordpress-mobile/test-cases/blob/698996af2bb0216fd95c5f65fea43d0f2075640a/test-cases/gutenberg/unsupported-block-editing.md#editing-unsupported-blocks-is-enabled-on-self-hosted-sites-accessed-via-jetpack) continues to load without crashing.

## Regression Notes
1. Potential unintended areas of impact
    The UBE could cease to function.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested the UBE.
3. What automated tests I added (or what prevented me from doing so)
    I deemed it not relevant to automate tests for development debugging
features.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
