### PR TITLE
[Design System] Replace force-unwrap with `.clear` nil-coalescing

### DIFF
--- a/Modules/Sources/DesignSystem/Foundation/UIColor+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Foundation/UIColor+DesignSystem.swift
@@ -41,7 +41,7 @@ public extension UIColor {
         }
 
         private static func colorWithModuleBundle(colorName: String) -> UIColor {
-            UIColor(named: colorName, in: .module, compatibleWith: .current)!
+            UIColor(named: colorName, in: .module, compatibleWith: .current) ?? .clear
         }
     }
 }


### PR DESCRIPTION
## Description
As the title suggests.
This way the API is kept the same. So we're returning non-optional UIColor but also if something goes really wrong, worst case scenario will be .clear color like SwiftUI.Color's behavior instead of crashing.

## Testing Steps
N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
