### PR TITLE
Fix notifications header vertical padding

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsTableHeaderView.swift
@@ -74,7 +74,7 @@ final class NotificationsTableHeaderView: UITableViewHeaderFooterView {
         static let layoutMarginsLeading = NSDirectionalEdgeInsets(
             top: Length.Padding.single,
             leading: Length.Padding.double,
-            bottom: Length.Padding.half,
+            bottom: Length.Padding.single,
             trailing: Length.Padding.double
         )
     }


### PR DESCRIPTION
Follow-up PR for https://github.com/wordpress-mobile/WordPress-iOS/pull/22702

This PR aims to unify vertical padding for a notifications header.

<img width="453" alt="Screenshot 2024-02-26 at 12 25 58" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/21fcb3ab-5b28-4126-9c03-509040f5cd15">

To test:

- Go to the Notifications tab
- Make sure that paddings between headers and notifications are the same

## Regression Notes
1. Potential unintended areas of impact
Notifications screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
