### PR TITLE
Reader: Use weak references over unowned

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -406,8 +406,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Scroll the content to a given #hash
     ///
     func scroll(to hash: String) {
-        webView.evaluateJavaScript("document.getElementById('\(hash)').offsetTop", completionHandler: { [unowned self] height, _ in
-            guard let height = height as? CGFloat else {
+        webView.evaluateJavaScript("document.getElementById('\(hash)').offsetTop", completionHandler: { [weak self] height, _ in
+            guard let self, let height = height as? CGFloat else {
                 return
             }
 
@@ -577,7 +577,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         // Load the image
-        featuredImage.load { [unowned self] in
+        featuredImage.load { [weak self] in
+            guard let self else {
+                return
+            }
             self.hideLoading()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -250,7 +250,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 // MARK: - Select Interests Display
 private extension ReaderCardsStreamViewController {
     func displaySelectInterestsIfNeeded() {
-        selectInterestsViewController.userIsFollowingTopics { [unowned self] isFollowing in
+        selectInterestsViewController.userIsFollowingTopics { [weak self] isFollowing in
+            guard let self else {
+                return
+            }
             if isFollowing {
                 self.hideSelectInterestsView()
             } else {
@@ -291,7 +294,10 @@ private extension ReaderCardsStreamViewController {
         selectInterestsViewController.view.frame = self.view.bounds
         self.add(selectInterestsViewController)
 
-        selectInterestsViewController.didSaveInterests = { [unowned self] _ in
+        selectInterestsViewController.didSaveInterests = { [weak self] _ in
+            guard let self else {
+                return
+            }
             self.hideSelectInterestsView()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -59,7 +59,10 @@ import Gridicons
     private lazy var bannerView: JetpackBannerView = {
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.readerSearch)
         let bannerView = JetpackBannerView()
-        bannerView.configure(title: textProvider.brandingText()) { [unowned self] in
+        bannerView.configure(title: textProvider.brandingText()) { [weak self] in
+            guard let self else {
+                return
+            }
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .readerSearch)
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -528,7 +528,10 @@ import WordPressUI
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.reader)
         let bannerView = JetpackBannerView()
-        bannerView.configure(title: textProvider.brandingText()) { [unowned self] in
+        bannerView.configure(title: textProvider.brandingText()) { [weak self] in
+            guard let self else {
+                return
+            }
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .reader)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -27,7 +27,10 @@ extension WPTabBarController {
     }
 
     @objc func makeReaderTabViewController() -> ReaderTabViewController {
-        return ReaderTabViewController(viewModel: readerTabViewModel) { [unowned self] viewModel in
+        return ReaderTabViewController(viewModel: readerTabViewModel) { [weak self] viewModel in
+            guard let self else {
+                return ReaderTabView(viewModel: viewModel)
+            }
             return self.makeReaderTabView(viewModel)
         }
     }
@@ -37,7 +40,10 @@ extension WPTabBarController {
             readerContentFactory: { [unowned self] in
                 self.makeReaderContentViewController(with: $0)
             },
-            searchNavigationFactory: { [unowned self] in
+            searchNavigationFactory: { [weak self] in
+                guard let self else {
+                    return
+                }
                 self.navigateToReaderSearch()
             },
             tabItemsStore: ReaderTabItemsStore(),

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -37,8 +37,16 @@ extension WPTabBarController {
 
     @objc func makeReaderTabViewModel() -> ReaderTabViewModel {
         let viewModel = ReaderTabViewModel(
-            readerContentFactory: { [unowned self] in
-                self.makeReaderContentViewController(with: $0)
+            readerContentFactory: { [weak self] content in
+                if content.topicType == .discover, let topic = content.topic {
+                    let controller = ReaderCardsStreamViewController.controller(topic: topic)
+                    controller.shouldShowCommentSpotlight = self?.readerTabViewModel.shouldShowCommentSpotlight ?? false
+                    return controller
+                } else if let topic = content.topic {
+                    return ReaderStreamViewController.controllerWithTopic(topic)
+                } else {
+                    return ReaderStreamViewController.controllerForContentType(content.type)
+                }
             },
             searchNavigationFactory: { [weak self] in
                 guard let self else {


### PR DESCRIPTION
Fixes #21728

## Description

Replaces the use of `unowned` with `weak` in the Reader.

For the `readerContentFactory`, it is required to return something from that closure. Returning early or `nil` here would not work, so I copied the function body into the closure. The function is still being used in one other place, so I did not delete it.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Perform a basic smoke test, navigating to different screens
- 🔎 **Verify** no crash occurs and everything still works as it previously did
- Delete all followed tags or create a new account
- Navigate to the `Discover` feed
- 🔎 **Verify** no crash occurs with the select interest view controller

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
