### PR TITLE
Add a missed `completion` call

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackNativeConnectionService.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackNativeConnectionService.swift
@@ -76,6 +76,7 @@ final class JetpackNativeConnectionService: NSObject {
                     }
                     return .failure(.remote(original.localizedDescription))
                 }
+            completion(result)
         }
     }
 }


### PR DESCRIPTION
The call was missed in https://github.com/wordpress-mobile/WordPress-iOS/pull/22612.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: N/A