### PR TITLE
Update UI testing instructions

### DIFF
--- a/WordPress/UITests/README.md
+++ b/WordPress/UITests/README.md
@@ -78,7 +78,7 @@ Note that due to the mock server setup, tests cannot be run on physical devices 
 
 1. Follow the [build instructions](https://github.com/wordpress-mobile/WordPress-iOS#build-instructions) (steps 1-5) to clone the project, install the dependencies, and open the project in Xcode.
 2. `rake mocks` to start a local mock server.
-3. With the `WordPress` scheme selected in Xcode, open the Test Navigator and select the `WordPressUITests` test plan.
+3. With the `Jetpack` scheme selected in Xcode, open the Test Navigator and select the `JetpackUITests` test plan.
 4. Run the tests on a simulator.
 
 ## Adding tests


### PR DESCRIPTION
As @staskus pointed out in https://github.com/wordpress-mobile/WordPress-iOS/pull/22703#issuecomment-1968347841, UI tests are run on the Jetpack app. 

Given this, it makes sense for the UI testing docs to suggest running Jetpack tests, as this is most likely what most contributors will want to run.

To test: Check if the above makes sense. 

## Regression Notes
1. Potential unintended areas of impact: Not applicable
2. What I did to test those areas of impact (or what existing automated tests I relied on): Not applicable
3. What automated tests I added (or what prevented me from doing so): Not applicable

PR submission checklist: Not applicable

Testing checklist: Not applicable