### PR TITLE
Stats Traffic: Avoid initializing Stats Traffic before displaying it

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -96,7 +96,9 @@ class SiteStatsDashboardViewController: UIViewController {
 
         let currentPeriod = SiteStatsDashboardPreferences.getSelectedPeriodUnit() ?? .day
 
-        return SiteStatsPeriodTableViewController(date: date, period: currentPeriod)
+        let viewController = SiteStatsPeriodTableViewController(date: date, period: currentPeriod)
+        viewController.bannerView = jetpackBannerView
+        return viewController
     }()
     private var pageViewController: UIPageViewController?
     private lazy var displayedTabs: [StatsTabType] = StatsTabType.displayedTabs
@@ -118,7 +120,6 @@ class SiteStatsDashboardViewController: UIViewController {
         configureJetpackBanner()
         configureInsightsTableView()
         configurePeriodTableViewControllerDeprecated()
-        configureTrafficTableViewController()
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
         restoreSelectedTabFromUserDefaults()
@@ -139,10 +140,6 @@ class SiteStatsDashboardViewController: UIViewController {
 
     private func configurePeriodTableViewControllerDeprecated() {
         periodTableViewControllerDeprecated.bannerView = jetpackBannerView
-    }
-
-    private func configureTrafficTableViewController() {
-        trafficTableViewController.bannerView = jetpackBannerView
     }
 
     func configureNavBar() {


### PR DESCRIPTION
Fixes #22717

I noticed `stats_period_accessed` event called when opening the Insights tab, both with and without the feature flag enabled. It's caused by a combination of 2 reasons:
- `StatsTrafficDatePickerViewModel` tracks `stats_period_accessed` event when `StatsTrafficDatePickerView` is initialized
- `trafficTableViewController`is initialized whenever `SiteStatsDashboardViewController` loads since `jetpackBanner` is set

## Solution

I'm choosing the easiest solution to avoid initializing `trafficTableViewController` when `SiteStatsDashboardViewController` loads by setting `jetpackBanner` only when
 
## To test:

### Analytics

1. Enable Stats Traffic feature flag
2. Open Stats
3. Select Insights tab
4. Leave Stats
5. Return to Stats
6. Confirm Insights tab is opened
7. Confirm stats_insights_accessed is tracked and stats_period_accessed not tracked
8. Select Traffic tab
9. Confirm stats_period_accessed tracked

### Regression - Jetpack banner works

The easiest way to test is to manually enable `JetpackBrandingVisibility` or just watch the video to confirm that the banner works when needed:

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/7ccce88f-7504-46c3-b5a9-647b3b397bcc

## Regression Notes
1. Potential unintended areas of impact

Breaking Jetpack banner

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
