### PR TITLE
Remove unsupported reblog notification type

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
@@ -44,7 +44,7 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
         case .newPost(let notification):
             return postLikeInlineAction(viewModel: viewModel, notification: notification, parent: parent)
         case .other(let notification):
-            guard notification.kind == .like || notification.kind == .reblog else {
+            guard notification.kind == .like else {
                 return nil
             }
             return shareInlineAction(viewModel: viewModel, notification: notification, parent: parent)

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
@@ -18,7 +18,6 @@ enum NotificationKind: String {
     case login          = "push_auth"
     case viewMilestone  = "view_milestone"
     case unknown        = "unknown"
-    case reblog         = "reblog"
 }
 
 extension NotificationKind {


### PR DESCRIPTION
Fixes #22676

This PR removes unsupported unused reblog notification type.

To test:
Smoke test the notifications. Make sure everything works as usual and reblogging does not trigger any notification.

## Regression Notes
1. Potential unintended areas of impact
Notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Code removal. There are no tests for this class.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
