### PR TITLE
Reader: Update tags recommendation card position

### DIFF
--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -37,60 +37,59 @@ class ReaderCardService {
             self.service.fetchCards(for: slugs,
                                     page: self.pageHandle(isFirstPage: isFirstPage),
                                     refreshCount: refreshCount,
-                               success: { [weak self] cards, pageHandle in
+                                    success: { [weak self] cards, pageHandle in
+                guard let self = self else {
+                    return
+                }
 
-                                guard let self = self else {
-                                    return
+                self.pageHandle = pageHandle
+
+                self.coreDataStack.performAndSave({ context in
+                    if isFirstPage {
+                        self.pageNumber = 1
+                        self.removeAllCards(in: context)
+                    } else {
+                        self.pageNumber += 1
+                    }
+
+                    cards.enumerated().forEach { index, remoteCard in
+                        if isFirstPage && index == 0 && remoteCard.type == .interests {
+                            // Removes displaying the tags recommendation card
+                            // first in the Discover feed
+                            return
+                        }
+
+                        let card = ReaderCard(context: context, from: remoteCard)
+
+                        // Assign each interest an endpoint
+                        card?
+                            .topics?
+                            .array
+                            .compactMap { $0 as? ReaderTagTopic }
+                            .forEach { $0.path = self.followedInterestsService.path(slug: $0.slug) }
+
+                        // Assign each site an endpoint URL if needed
+                        card?
+                            .sites?
+                            .array
+                            .compactMap { $0 as? ReaderSiteTopic }
+                            .forEach {
+                                let path = $0.path
+                                // Sites coming from the cards API only have a path and not a full url
+                                // Once we save the model locally it will be a full URL, so we don't
+                                // want to reapply this logic
+                                if !path.hasPrefix("http") {
+                                    $0.path = self.siteInfoService.endpointURLString(path: path)
                                 }
+                            }
 
-                                self.pageHandle = pageHandle
-
-                                self.coreDataStack.performAndSave({ context in
-                                    if isFirstPage {
-                                        self.pageNumber = 1
-                                        self.removeAllCards(in: context)
-                                    } else {
-                                        self.pageNumber += 1
-                                    }
-
-                                    cards.enumerated().forEach { index, remoteCard in
-                                        if isFirstPage && index == 0 && remoteCard.type == .interests {
-                                            // Removes displaying the tags recommendation card
-                                            // first in the Discover feed
-                                            return
-                                        }
-
-                                        let card = ReaderCard(context: context, from: remoteCard)
-
-                                        // Assign each interest an endpoint
-                                        card?
-                                            .topics?
-                                            .array
-                                            .compactMap { $0 as? ReaderTagTopic }
-                                            .forEach { $0.path = self.followedInterestsService.path(slug: $0.slug) }
-
-                                        // Assign each site an endpoint URL if needed
-                                        card?
-                                            .sites?
-                                            .array
-                                            .compactMap { $0 as? ReaderSiteTopic }
-                                            .forEach {
-                                                let path = $0.path
-                                                // Sites coming from the cards API only have a path and not a full url
-                                                // Once we save the model locally it will be a full URL, so we don't
-                                                // want to reapply this logic
-                                                if !path.hasPrefix("http") {
-                                                    $0.path = self.siteInfoService.endpointURLString(path: path)
-                                                }
-                                            }
-
-                                        // To keep the API order
-                                        card?.sortRank = Double((self.pageNumber * Constants.paginationMultiplier) + index)
-                                    }
-                                }, completion: {
-                                    let hasMore = pageHandle != nil
-                                    success(cards.count, hasMore)
-                                }, on: .main)
+                        // To keep the API order
+                        card?.sortRank = Double((self.pageNumber * Constants.paginationMultiplier) + index)
+                    }
+                }, completion: {
+                    let hasMore = pageHandle != nil
+                    success(cards.count, hasMore)
+                }, on: .main)
             }, failure: { error in
                 failure(error)
             })

--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -38,8 +38,13 @@ class ReaderCardService {
                                     page: self.pageHandle(isFirstPage: isFirstPage),
                                     refreshCount: refreshCount,
                                     success: { [weak self] cards, pageHandle in
-                guard let self = self else {
+                guard let self else {
                     return
+                }
+                var updatedCards = cards
+                if isFirstPage && updatedCards.first?.type == .interests && updatedCards.count > 2 {
+                    // Move the first tags recommendation card to a lower position
+                    updatedCards.move(fromOffsets: IndexSet(integer: 0), toOffset: 3)
                 }
 
                 self.pageHandle = pageHandle
@@ -52,13 +57,7 @@ class ReaderCardService {
                         self.pageNumber += 1
                     }
 
-                    cards.enumerated().forEach { index, remoteCard in
-                        if isFirstPage && index == 0 && remoteCard.type == .interests {
-                            // Removes displaying the tags recommendation card
-                            // first in the Discover feed
-                            return
-                        }
-
+                    updatedCards.enumerated().forEach { index, remoteCard in
                         let card = ReaderCard(context: context, from: remoteCard)
 
                         // Assign each interest an endpoint

--- a/WordPress/WordPressTest/ReaderCardServiceTests.swift
+++ b/WordPress/WordPressTest/ReaderCardServiceTests.swift
@@ -77,7 +77,7 @@ class ReaderCardServiceTests: CoreDataTestCase {
 
         service.fetch(isFirstPage: true, success: { _, _ in
             let cards = try? self.mainContext.fetch(NSFetchRequest(entityName: ReaderCard.classNameWithoutNamespaces()))
-            expect(cards?.count).to(equal(9))
+            expect(cards?.count).to(equal(10))
             expectation.fulfill()
         }, failure: { _ in })
 
@@ -129,7 +129,7 @@ class ReaderCardServiceTests: CoreDataTestCase {
             // Fetch again, this time the 1st page
             service.fetch(isFirstPage: true, success: { _, _ in
                 let cards = try? self.mainContext.fetch(NSFetchRequest(entityName: ReaderCard.classNameWithoutNamespaces())) as? [ReaderCard]
-                expect(cards?.count).to(equal(9))
+                expect(cards?.count).to(equal(10))
                 expectation.fulfill()
             }, failure: { _ in })
         }, failure: {_ in })


### PR DESCRIPTION
Fixes #22725

## Description

Re-adds the first tags recommendation card and puts it in the third position of the initial cards list.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader `Discover` feed
- Scroll until the third card is visible
- 🔎 **Verify** the third card is the tags recommendation card

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
