### PR TITLE
Stats Traffic: Prevent selection of date periods in the future

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
@@ -33,7 +33,7 @@ class StatsTrafficDatePickerViewModel: ObservableObject {
     }
 
     func goToNextPeriod() {
-        let nextDate = StatsDataHelper.calendar.date(byAdding: .year, value: 1, to: date) ?? date
+        let nextDate = StatsDataHelper.calendar.date(byAdding: .period.calendarComponent, value: 1, to: date) ?? date
         date = min(nextDate, getCurrentDateForSite())
         track(isNext: true)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+typealias SiteCurrentDateGetter = () -> Date
+
 class StatsTrafficDatePickerViewModel: ObservableObject {
 
     @Published var period: StatsPeriodUnit {
@@ -9,9 +11,15 @@ class StatsTrafficDatePickerViewModel: ObservableObject {
     }
     @Published var date: Date
 
-    init(period: StatsPeriodUnit, date: Date) {
+    private let getCurrentDateForSite: SiteCurrentDateGetter
+
+    init(period: StatsPeriodUnit,
+         date: Date,
+         currentDateGetter: @escaping SiteCurrentDateGetter = StatsDataHelper.currentDateForSite
+    ) {
         self.period = period
         self.date = date
+        self.getCurrentDateForSite = currentDateGetter
         period.track()
     }
 
@@ -25,7 +33,8 @@ class StatsTrafficDatePickerViewModel: ObservableObject {
     }
 
     func goToNextPeriod() {
-        date = StatsDataHelper.calendar.date(byAdding: period.calendarComponent, value: 1, to: date) ?? date
+        let nextDate = StatsDataHelper.calendar.date(byAdding: .year, value: 1, to: date) ?? date
+        date = min(nextDate, getCurrentDateForSite())
         track(isNext: true)
     }
 

--- a/WordPress/WordPressTest/StatsTrafficDatePickerViewModelTests.swift
+++ b/WordPress/WordPressTest/StatsTrafficDatePickerViewModelTests.swift
@@ -30,6 +30,20 @@ final class StatsTrafficDatePickerViewModelTests: XCTestCase {
         viewModel.goToPreviousPeriod()
         XCTAssertEqual(aMonthEarlier, viewModel.date)
     }
+
+    func testGoToNextPeriod_nextDateAfterCurrentDate() {
+        let date = Date("2024-01-20")
+        let currentDateGetter: SiteCurrentDateGetter = { date }
+        viewModel = StatsTrafficDatePickerViewModel(period: .day, date: date, currentDateGetter: currentDateGetter)
+
+        viewModel.period = .month
+        viewModel.goToPreviousPeriod()
+        XCTAssertEqual(Date("2023-12-20"), viewModel.date)
+
+        viewModel.period = .year
+        viewModel.goToNextPeriod()
+        XCTAssertEqual(date, viewModel.date, "Date shouldn't go beyond the current site date")
+    }
 }
 
 private extension Date {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/jetpack-issue-repo/issues/19

1. Select By month
2. Come back a couple of months to November, 2023
3. Select By Year
4. Confirm 2023 is shown
5. Go forward to 2024
6. Select by month
7. Confirm current month is shown

## Regression Notes
1. Potential unintended areas of impact

Couldn't identify any

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual & automated testing

3. What automated tests I added (or what prevented me from doing so)

I added unit test to automate the manual repro steps

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
