### PR TITLE
Open Traffic By Day tab from Stats dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -114,8 +114,7 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         WPAnalytics.track(.dashboardCardItemTapped,
                           properties: ["type": DashboardCard.todaysStats.rawValue],
                           blog: blog)
-        RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, source: .row, tab: .days, date: nil)
-        WPAppAnalytics.track(.statsAccessed, withProperties: [WPAppAnalyticsKeyTabSource: "dashboard", WPAppAnalyticsKeyTapSource: "todays_stats_card"], with: blog)
+        RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, source: .todayStatsCard, tab: .days, date: nil)
     }
 
     private func showNudgeHint(for blog: Blog, from sourceController: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -114,7 +114,7 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         WPAnalytics.track(.dashboardCardItemTapped,
                           properties: ["type": DashboardCard.todaysStats.rawValue],
                           blog: blog)
-        StatsViewController.show(for: blog, from: sourceController)
+        RootViewCoordinator.sharedPresenter.mySitesCoordinator.showStats(for: blog, source: .row, tab: .days, date: nil)
         WPAppAnalytics.track(.statsAccessed, withProperties: [WPAppAnalyticsKeyTabSource: "dashboard", WPAppAnalyticsKeyTapSource: "todays_stats_card"], with: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -94,6 +94,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
     BlogDetailsNavigationSourceOnboarding = 4,
     BlogDetailsNavigationSourceNotification = 5,
     BlogDetailsNavigationSourceShortcut = 6,
+    BlogDetailsNavigationSourceTodayStatsCard = 7,
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1767,6 +1767,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return @"notification";
         case BlogDetailsNavigationSourceShortcut:
             return @"shortcut";
+        case BlogDetailsNavigationSourceTodayStatsCard:
+            return @"todays_stats_card";
         default:
             return @"";
     }


### PR DESCRIPTION
Opens the older Day tab if Traffic is not enabled by its feature flag.

Thanks to the work in https://github.com/wordpress-mobile/WordPress-iOS/pull/22695, it was straightforward to handle both the scenario where the Traffic tab is enabled and when it's disabled.

Fixes #22716

To test:
1. With the Traffic feature flag enabled, tap the Today's Stats dashboard card and expect to be taken to the Traffic tab with "By day" selected (even if you had previously "By month" or another period or tab selected).
2. With the Traffic feature flag disabled, tap the Today's Stats dashboard card and expect to be taken to the Days tab (even if you had previously "Months" tab or another tab selected).

## Regression Notes
1. Potential unintended areas of impact

The functionality around opening Stats from the Today's Stats card.

3. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

5. What automated tests I added (or what prevented me from doing so)

Navigation isn't suitable for unit testing and we only use UI tests for critical user flows

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: 
- [x] Portrait and landscape orientations.
- [x] iPhone and iPad. 
