### PR TITLE
UI tests turn on parallelization

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -21,6 +21,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -104,27 +104,28 @@ public class ReaderScreen: ScreenObject {
         )
     }
 
-    public func openLastPost() -> ReaderScreen {
-        getLastPost().tap()
+    public func openLastPost() throws -> ReaderScreen {
+        try getLastPost().tap()
         return self
     }
 
-    public func openLastPostInSafari() -> ReaderScreen {
-        getLastPost().buttons["More"].tap()
+    public func openLastPostInSafari() throws -> ReaderScreen {
+        try getLastPost().buttons["More"].tap()
         visitButton.tap()
         return self
     }
 
     public func openLastPostComments() throws -> CommentsScreen {
-        let commentButton = getLastPost().buttons["Comment"]
-        guard commentButton.waitForIsHittable() else { fatalError("ReaderScreen.Post: Comments button not loaded") }
+        let commentButton = try getLastPost().buttons["Comment"]
+        guard commentButton.waitForIsHittable() else { throw UIElementNotFoundError(message: "ReaderScreen.Post: Comments button not loaded") }
         commentButton.tap()
         return try CommentsScreen()
     }
 
     @discardableResult
-    public func getLastPost() -> XCUIElement {
-        guard let post = app.cells.lastMatch else { fatalError("ReaderScreen: No posts loaded") }
+    public func getLastPost() throws -> XCUIElement {
+        // Crash from testViewPostInSafari
+        guard let post = app.cells.lastMatch else { throw UIElementNotFoundError(message: "ReaderScreen: No posts loaded") }
         scrollDownUntilElementIsFullyVisible(element: post)
         return post
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -124,7 +124,6 @@ public class ReaderScreen: ScreenObject {
 
     @discardableResult
     public func getLastPost() throws -> XCUIElement {
-        // Crash from testViewPostInSafari
         guard let post = app.cells.lastMatch else { throw UIElementNotFoundError(message: "ReaderScreen: No posts loaded") }
         scrollDownUntilElementIsFullyVisible(element: post)
         return post

--- a/WordPress/UITestsFoundation/UIElementNotFoundError.swift
+++ b/WordPress/UITestsFoundation/UIElementNotFoundError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct UIElementNotFoundError: Error {
+    public let message: String
+
+    init(message: String) {
+        self.message = message
+    }
+}

--- a/WordPress/UITestsFoundation/XCTestCase+Utils.swift
+++ b/WordPress/UITestsFoundation/XCTestCase+Utils.swift
@@ -32,11 +32,3 @@ public extension XCTestCase {
     }
 
 }
-
-public struct UIElementNotFoundError: Error {
-    var message: String
-
-    init(message: String) {
-        self.message = message
-    }
-}

--- a/WordPress/UITestsFoundation/XCTestCase+Utils.swift
+++ b/WordPress/UITestsFoundation/XCTestCase+Utils.swift
@@ -32,3 +32,11 @@ public extension XCTestCase {
     }
 
 }
+
+public struct UIElementNotFoundError: Error {
+    var message: String
+
+    init(message: String) {
+        self.message = message
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1350,6 +1350,7 @@
 		4A5598852B05AC180083C220 /* PagesListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5598842B05AC180083C220 /* PagesListTests.swift */; };
 		4A5DE7382B0D511900363171 /* PageTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DE7372B0D511900363171 /* PageTree.swift */; };
 		4A5DE7392B0D511900363171 /* PageTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DE7372B0D511900363171 /* PageTree.swift */; };
+		4A5FC0462B97BB4B0067F525 /* UIElementNotFoundError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5FC0452B97BB4B0067F525 /* UIElementNotFoundError.swift */; };
 		4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */; };
 		4A76A4BD29D43BFD00AABF4B /* CommentService+MorderationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */; };
 		4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */; };
@@ -6994,6 +6995,7 @@
 		4A535E132AF3368B008B87B9 /* MenusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenusViewController.swift; sourceTree = "<group>"; };
 		4A5598842B05AC180083C220 /* PagesListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesListTests.swift; sourceTree = "<group>"; };
 		4A5DE7372B0D511900363171 /* PageTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTree.swift; sourceTree = "<group>"; };
+		4A5FC0452B97BB4B0067F525 /* UIElementNotFoundError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIElementNotFoundError.swift; sourceTree = "<group>"; };
 		4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+LikesTests.swift"; sourceTree = "<group>"; };
 		4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+MorderationTests.swift"; sourceTree = "<group>"; };
 		4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-success.json"; sourceTree = "<group>"; };
@@ -11961,6 +11963,7 @@
 				3F03F2BC2B45041E00A9CE99 /* XCUIElement+TapUntil.swift */,
 				3F762E9A26784D2A0088CD45 /* XCUIElement+Utils.swift */,
 				3F762E9826784CC90088CD45 /* XCUIElementQuery+Utils.swift */,
+				4A5FC0452B97BB4B0067F525 /* UIElementNotFoundError.swift */,
 			);
 			path = UITestsFoundation;
 			sourceTree = "<group>";
@@ -23219,6 +23222,7 @@
 				3FE39A3B26F837FF006E2B3A /* PostsScreen.swift in Sources */,
 				3F2F855C26FAF227000FCDA5 /* LinkOrPasswordScreen.swift in Sources */,
 				3F2F855226FAF227000FCDA5 /* SignupCheckMagicLinkScreen.swift in Sources */,
+				4A5FC0462B97BB4B0067F525 /* UIElementNotFoundError.swift in Sources */,
 				EABE86612A995124004281A8 /* PHPickerScreen.swift in Sources */,
 				3FE39A4026F8386A006E2B3A /* SiteSettingsScreen.swift in Sources */,
 				D8E7529B2A29DC4C00E73B2D /* XCUIApplication+ScrollDownToElement.swift in Sources */,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -101,16 +101,7 @@ platform :ios do
 
     # Only run Jetpack UI tests in parallel.
     # At the time of writing, we need to explicitly set this value despite using test plans that configure parallelism.
-    #
-    # Disabled to test if it makes a difference performance wise in Xcode 15.0.1 in CI as we've seen errors such as this one:
-    # https://github.com/wordpress-mobile/WordPress-iOS/pull/21921#issuecomment-1820707121
-    #
-    # Also, simply disabling at the test plan level doesn't seem to have effect.
-    # In this CI run, it can be seen that there are at least two clones (UI tests logs on iPad, lines 1930 to 1934):
-    # https://buildkite.com/automattic/wpios-macv2-test/builds/14#018bfb60-6b6e-4a31-9acd-d27ee6f053e8/398-1930
-    #
-    # parallel_testing_value = options[:name].include?('Jetpack')
-    parallel_testing_value = false
+    parallel_testing_value = options[:name].include?('Jetpack')
 
     run_tests(
       workspace: WORKSPACE_PATH,


### PR DESCRIPTION
What says in the title. It should be okay to merge this PR if UI tests pass consistently.

During testing, I ran into a `fatalError` crash. I have changed the `fatalError` part to throw an error instead, which means the test would fail instead of crash.

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: N/A