### PR TITLE
Notifications: Remove reply icon from notifications title

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Ranges/NotificationContentRangeFactory.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Ranges/NotificationContentRangeFactory.swift
@@ -34,10 +34,7 @@ struct NotificationContentRangeFactory: FormattableRangesFactory {
             let commentID = dictionary[RangeKeys.id] as? NSNumber
             return NotificationCommentRange(commentID: commentID, properties: properties)
         case .noticon:
-            guard let value = dictionary[RangeKeys.value] as? String else {
-                fallthrough
-            }
-            return FormattableNoticonRange(value: value, range: properties.range)
+            return nil
         case .post:
             properties.postID = dictionary[RangeKeys.id] as? NSNumber
             return NotificationContentRange(kind: kind, properties: properties)

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -9,10 +9,10 @@ final class NotificationContentRangeFactoryTests: XCTestCase {
         XCTAssertNotNil(subject)
     }
 
-    func testIconRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+    func testIconRangeReturnsNil() throws {
         let subject = NotificationContentRangeFactory.contentRange(from: try mockIconRange()) as? FormattableNoticonRange
 
-        XCTAssertNotNil(subject)
+        XCTAssertNil(subject)
     }
 
     func testPostRangeReturnsExpectedImplementationOfFormattableContentRange() throws {


### PR DESCRIPTION
## Description
This PR removes the reply icon from the notification row in the notifications screen.

| Before | After |
|--------|--------|
|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-01 at 03 05 02](https://github.com/wordpress-mobile/WordPress-iOS/assets/25306722/c8ff8b1f-29f2-435f-ba2e-144292a14ca0)|![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-01 at 03 03 09](https://github.com/wordpress-mobile/WordPress-iOS/assets/25306722/6e66f087-4c29-49f6-be42-5a02cb1c28e3)|



## Testing Instructions

1. Launch the app
2. Navigate to the Notifications list
3. Make sure the comment reply notifications are not showing an arrow icon

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.