### PR TITLE
Enlarge Traffic date picker tap targets

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerView.swift
@@ -13,23 +13,26 @@ struct StatsTrafficDatePickerView: View {
                     })
                 }
             } label: {
-                Text(viewModel.period.label)
-                    .style(TextStyle.bodySmall(.emphasized))
-                    .foregroundColor(Color.DS.Foreground.primary)
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 8))
-                    .foregroundColor(Color.DS.Foreground.secondary)
-
+                HStack {
+                    Text(viewModel.period.label)
+                        .style(TextStyle.bodySmall(.emphasized))
+                        .foregroundColor(Color.DS.Foreground.primary)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8))
+                        .foregroundColor(Color.DS.Foreground.secondary)
+                }
+                .padding(.vertical, Length.Padding.single)
+                .padding(.horizontal, Length.Padding.double)
+                .background(Color.DS.Background.secondary)
+                .clipShape(RoundedRectangle(cornerRadius: Length.Radius.max))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Length.Radius.max)
+                        .strokeBorder(.clear, lineWidth: 0)
+                )
+                .padding(.vertical, Length.Padding.single)
+                .padding(.horizontal, Length.Padding.double)
             }
             .menuStyle(.borderlessButton)
-            .padding(.vertical, Length.Padding.single)
-            .padding(.horizontal, Length.Padding.double)
-            .background(Color.DS.Background.secondary)
-            .clipShape(RoundedRectangle(cornerRadius: Length.Radius.max))
-            .overlay(
-                RoundedRectangle(cornerRadius: Length.Radius.max)
-                    .strokeBorder(.clear, lineWidth: 0)
-            )
 
             Spacer()
 
@@ -40,32 +43,36 @@ struct StatsTrafficDatePickerView: View {
 
             Spacer().frame(width: Length.Padding.split)
 
-            Button(action: {
-                viewModel.goToPreviousPeriod()
-            }) {
-                Image(systemName: "chevron.left")
-                    .imageScale(.small)
-                    .foregroundColor(Color.DS.Foreground.secondary)
-                    .flipsForRightToLeftLayoutDirection(true)
-            }
-            .padding(.trailing, Length.Padding.single)
+            HStack {
+                Button(action: {
+                    viewModel.goToPreviousPeriod()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .imageScale(.small)
+                        .foregroundColor(Color.DS.Foreground.secondary)
+                        .flipsForRightToLeftLayoutDirection(true)
+                        .padding(.vertical, Length.Padding.double)
+                        .contentShape(Rectangle())
+                }
+                .padding(.trailing, Length.Padding.single)
 
-            let isNextDisabled = !viewModel.isNextPeriodAvailable
-            let enabledColor = Color.DS.Foreground.secondary
-            let disabledColor = enabledColor.opacity(0.5)
+                let isNextDisabled = !viewModel.isNextPeriodAvailable
+                let enabledColor = Color.DS.Foreground.secondary
+                let disabledColor = enabledColor.opacity(0.5)
 
-            Button(action: {
-                viewModel.goToNextPeriod()
-            }) {
-                Image(systemName: "chevron.right")
-                    .imageScale(.small)
-                    .foregroundColor(isNextDisabled ? disabledColor : enabledColor)
-                    .flipsForRightToLeftLayoutDirection(true)
-            }
-            .disabled(isNextDisabled)
-        }.padding(.vertical, Length.Padding.single)
-            .padding(.horizontal, Length.Padding.double)
-            .background(Color.DS.Background.primary)
+                Button(action: {
+                    viewModel.goToNextPeriod()
+                }) {
+                    Image(systemName: "chevron.right")
+                        .imageScale(.small)
+                        .foregroundColor(isNextDisabled ? disabledColor : enabledColor)
+                        .flipsForRightToLeftLayoutDirection(true)
+                        .padding(.vertical, Length.Padding.double)
+                        .contentShape(Rectangle())
+                }.disabled(isNextDisabled)
+            }.padding(.trailing, Length.Padding.medium)
+
+        }.background(Color.DS.Background.primary)
             .overlay(
                 Rectangle()
                     .frame(height: Length.Border.thin)


### PR DESCRIPTION
Fixes #22728

The goal here is to make the buttons in the date picker easier to tap while maintaining the same design and layout.

- The period drop-down was made more easily tappable by increasing its dimensions (via padding) while keeping the visible part (grey oval-shaped button) the same size.
- The arrows were made more easily tappable by increasing their height (via padding)while keeping the arrows themselves the same size.

The date picker should still match the designs, while the invisible touch areas have increased in size.

### To test
1. Navigate to the Traffic tab
2. Use the date picker (drop-down and left and right arrows) and verify that they are easier to tap than before.

## Regression Notes
1. Potential unintended areas of impact

The Traffic screen's date picker

3. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing using the below testing checklist

4. What automated tests I added (or what prevented me from doing so)

This is a layout fix, not suitable for UI tests or unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)