### PR TITLE
Reader Comments: Avoid scrolling to an invalid index path

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -877,9 +877,16 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         // This avoids a case where a cell instance could be orphaned and displayed randomly on top of the other cells.
         NSIndexPath *indexPath = [self.tableViewHandler.resultsController indexPathForObject:comment];
         [self.tableView layoutIfNeeded];
-        [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
 
-        self.highlightedIndexPath = indexPath;
+        // Ensure that the indexPath exists before scrolling to it.
+        if (indexPath.section >=0
+            && indexPath.row >=0
+            && indexPath.section < self.tableView.numberOfSections
+            && indexPath.row < [self.tableView numberOfRowsInSection:indexPath.section])
+        {
+            [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
+            self.highlightedIndexPath = indexPath;
+        }
 
         // Reset the commentID so we don't do this again.
         self.navigateToCommentID = nil;


### PR DESCRIPTION
Fixes #20742 

> [!WARNING]
> Auto-merge is turned on.

This mitigates a crash because the table view tries to scroll to an invalid index path in Reader Comments. 

The root cause may be a race condition where the `scrollToRow` method is executed before the table view finishes updating its rows, but there haven't been reliable repro steps for this crash.

## To test

To test this functionality, we need to verify the flows that trigger `scrollToRow`:

### Navigating to a comment via in-app Notifications

- Launch the Jetpack app
- Go to the Notifications tab
- Filter the notifications by Comments
- If possible, select a notification for a comment that's located deep down in the thread.
- From the notification comment screen, tap the header to go to the comment thread and navigate to the comment.
- 🔎 Verify that the comment thread screen scrolls to the comment correctly.

### Navigating to a comment via deeplink

- Prepare a link to comment, e.g. `https://<your-site>/yyyy/mm/dd/post-slug/#comment-id`
- Tap the link
- 🔎 Verify that you are being brought to the comment thread screen and scrolled to the comment correctly.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Instead of crashing, the comment thread will do nothing when trying to process an invalid index path.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A.

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
