### PR TITLE
Stats: Fix data shown or for incorrect period issues

### DIFF
--- a/WordPress/Classes/Stores/StoreContainer.swift
+++ b/WordPress/Classes/Stores/StoreContainer.swift
@@ -15,9 +15,6 @@ class StoreContainer {
     let notice = NoticeStore()
     let timezone = TimeZoneStore()
     let activity = ActivityStore()
-    let statsInsights = StatsInsightsStore()
-    let statsPeriod = StatsPeriodStore()
     let jetpackInstall = JetpackInstallStore()
     let statsWidgets = StatsWidgetsStore()
-    let statsRevamp = StatsRevampStore()
 }

--- a/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodTableViewControllerDeprecated.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodTableViewControllerDeprecated.swift
@@ -36,7 +36,7 @@ class SiteStatsPeriodTableViewControllerDeprecated: UITableViewController, Story
         }
     }
 
-    private let store = StoreContainer.shared.statsPeriod
+    private let store = StatsPeriodStore()
     private var changeReceipt: Receipt?
 
     private var viewModel: SiteStatsPeriodViewModelDeprecated?

--- a/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodViewModelDeprecated.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Deprecated/SiteStatsPeriodViewModelDeprecated.swift
@@ -48,7 +48,7 @@ class SiteStatsPeriodViewModelDeprecated: Observable {
 
     // MARK: - Constructor
 
-    init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod,
+    init(store: StatsPeriodStore = StatsPeriodStore(),
          selectedDate: Date,
          selectedPeriod: StatsPeriodUnit,
          periodDelegate: SiteStatsPeriodDelegate,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -34,7 +34,7 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
         return SiteStatsPinnedItemStore(siteId: siteID)
     }()
 
-    private let insightsStore = StoreContainer.shared.statsInsights
+    private let insightsStore = StatsInsightsStore()
 
     private var viewNeedsUpdating = false
     private var displayingEmptyView = false

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -74,8 +74,23 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
         displayEmptyViewIfNecessary()
     }
 
-    func refreshInsights(forceRefresh: Bool = false) {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
         addViewModelListeners()
+        viewModel?.addListeners()
+
+        refreshInsights()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        removeViewModelListeners()
+        viewModel?.removeListeners()
+    }
+
+    private func refreshInsights(forceRefresh: Bool = false) {
         viewModel?.refreshInsights(forceRefresh: forceRefresh)
     }
 
@@ -116,9 +131,6 @@ private extension SiteStatsInsightsTableViewController {
                                                viewsAndVisitorsDelegate: self,
                                                insightsStore: insightsStore,
                                                pinnedItemStore: pinnedItemStore)
-        addViewModelListeners()
-        viewModel?.fetchInsights()
-        viewModel?.startFetchingPeriodOverview()
     }
 
     func addViewModelListeners() {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -52,7 +52,7 @@ class SiteStatsInsightsViewModel: Observable {
          viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?,
          insightsStore: StatsInsightsStore,
          pinnedItemStore: SiteStatsPinnedItemStore?,
-         periodStore: StatsPeriodStore = StoreContainer.shared.statsPeriod) {
+         periodStore: StatsPeriodStore = StatsPeriodStore()) {
         self.siteStatsInsightsDelegate = insightsDelegate
         self.viewsAndVisitorsDelegate = viewsAndVisitorsDelegate
         self.insightsToShow = insightsToShow

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -34,14 +34,15 @@ class SiteStatsInsightsViewModel: Observable {
         return !pinnedItemStore.shouldShow(item)
     }
 
-    private var periodReceipt: Receipt?
     private var periodChangeReceipt: Receipt?
 
     private typealias Style = WPStyleGuide.Stats
 
     weak var statsLineChartViewDelegate: StatsLineChartViewDelegate?
 
-    private var mostRecentChartData: StatsSummaryTimeIntervalData?
+    private var mostRecentChartData: StatsSummaryTimeIntervalData? {
+        periodStore.getSummary()
+    }
 
     private var selectedViewsVisitorsSegment: StatsSegmentedControlData.Segment = .views
 
@@ -65,29 +66,7 @@ class SiteStatsInsightsViewModel: Observable {
         // Exclude today's data for weekly insights
         self.lastRequestedDate = StatsDataHelper.yesterdayDateForSite()
         self.lastRequestedPeriod = StatsPeriodUnit.day
-
-        insightsChangeReceipt = self.insightsStore.onChange { [weak self] in
-            self?.emitChange()
-        }
-
-        periodChangeReceipt = self.periodStore.onChange { [weak self] in
-            self?.updateMostRecentChartData(self?.periodStore.getSummary())
-            self?.emitChange()
-        }
     }
-
-    func fetchInsights() {
-        insightsReceipt = insightsStore.query(.insights)
-    }
-
-    func startFetchingPeriodOverview() {
-        periodReceipt = periodStore.query(.allCachedPeriodData(date: lastRequestedDate, period: lastRequestedPeriod, unit: lastRequestedPeriod))
-        periodStore.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: lastRequestedDate,
-                period: lastRequestedPeriod,
-                forceRefresh: true))
-    }
-
-    // MARK: - Refresh Data
 
     /// This method will trigger a refresh of insights data, provided that we're not already
     /// performing a refresh and that we haven't refreshed within the last 5 minutes.
@@ -95,8 +74,41 @@ class SiteStatsInsightsViewModel: Observable {
     /// of a pull to refresh action), you can pass a `forceRefresh` value of `true` here.
     ///
     func refreshInsights(forceRefresh: Bool = false) {
+        loadCachedInsights()
+
+        /// Refresh Insights data if needed
         ActionDispatcher.dispatch(InsightAction.refreshInsights(forceRefresh: forceRefresh))
+
         startFetchingPeriodOverview()
+    }
+
+    private func loadCachedInsights() {
+        insightsReceipt = nil
+        insightsReceipt = insightsStore.query(.insights)
+    }
+
+    private func startFetchingPeriodOverview() {
+        periodStore.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: lastRequestedDate,
+                period: lastRequestedPeriod,
+                forceRefresh: true))
+    }
+
+    // MARK: - Listeners
+
+    func addListeners() {
+        insightsChangeReceipt = self.insightsStore.onChange { [weak self] in
+            self?.emitChange()
+        }
+
+        periodChangeReceipt = self.periodStore.onChange { [weak self] in
+            self?.emitChange()
+        }
+    }
+
+    func removeListeners() {
+        periodChangeReceipt = nil
+        insightsChangeReceipt = nil
+        insightsReceipt = nil
     }
 
     // MARK: - Table Model
@@ -766,20 +778,6 @@ private extension SiteStatsInsightsViewModel {
                        dataSubtitle: "",
                        totalCount: totalCount,
                        dataRows: followersData ?? [])
-    }
-
-    func updateMostRecentChartData(_ periodSummary: StatsSummaryTimeIntervalData?) {
-        if mostRecentChartData == nil,
-           let periodSummary = periodSummary,
-           periodSummary.periodEndDate >= lastRequestedDate.normalizedDate() {
-            mostRecentChartData = periodSummary
-        } else if let mostRecentChartData = mostRecentChartData,
-                  let periodSummary = periodSummary,
-                  mostRecentChartData.periodEndDate == periodSummary.periodEndDate {
-            self.mostRecentChartData = periodSummary
-        } else if let periodSummary = periodSummary, let chartData = mostRecentChartData, periodSummary.periodEndDate > chartData.periodEndDate {
-            mostRecentChartData = chartData
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -69,9 +69,6 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
                                              selectedPeriod: datePickerViewModel.period,
                                              periodDelegate: self,
                                              referrerDelegate: self)
-        addViewModelListeners()
-        viewModel.startFetchingOverview()
-
         Publishers.CombineLatest(datePickerViewModel.$date, datePickerViewModel.$period)
             .sink(receiveValue: { [weak self] _, _ in
                 DispatchQueue.main.async {
@@ -83,10 +80,17 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if !isMovingToParent {
-            addViewModelListeners()
-            viewModel.refreshTrafficOverviewData(withDate: datePickerViewModel.date, forPeriod: datePickerViewModel.period)
-        }
+
+        addViewModelListeners()
+        viewModel.addListeners()
+        viewModel.refreshTrafficOverviewData(withDate: datePickerViewModel.date, forPeriod: datePickerViewModel.period)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        removeViewModelListeners()
+        viewModel.removeListeners()
     }
 
     override func initTableView() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -26,7 +26,7 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
         return ContextManager.sharedInstance().mainContext
     }()
 
-    private let store = StoreContainer.shared.statsPeriod
+    private let store = StatsPeriodStore()
     private var changeReceipt: Receipt?
 
     private var viewModel: SiteStatsPeriodViewModel!

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -22,7 +22,7 @@ final class SiteStatsPeriodViewModel: Observable {
 
     // MARK: - Constructor
 
-    init(store: any StatsPeriodStoreProtocol = StoreContainer.shared.statsPeriod,
+    init(store: any StatsPeriodStoreProtocol = StatsPeriodStore(),
          selectedDate: Date,
          selectedPeriod: StatsPeriodUnit,
          periodDelegate: SiteStatsPeriodDelegate,

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -32,13 +32,13 @@ final class SiteStatsPeriodViewModel: Observable {
         self.store = store
         self.lastRequestedDate = StatsPeriodHelper().endDate(from: selectedDate, period: selectedPeriod)
         self.lastRequestedPeriod = selectedPeriod
-
-        changeReceipt = store.onChange { [weak self] in
-            self?.emitChange()
-        }
     }
 
-    func startFetchingOverview() {
+    func refreshTrafficOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
+        lastRequestedDate = StatsPeriodHelper().endDate(from: date, period: period)
+        lastRequestedPeriod = period
+
+        periodReceipt = nil
         periodReceipt = store.query(
             .trafficOverviewData(
                 .init(
@@ -51,6 +51,21 @@ final class SiteStatsPeriodViewModel: Observable {
             )
         )
     }
+
+    // MARK: - Listeners
+
+    func addListeners() {
+        changeReceipt = store.onChange { [weak self] in
+            self?.emitChange()
+        }
+    }
+
+    func removeListeners() {
+        changeReceipt = nil
+        periodReceipt = nil
+    }
+
+    // MARK: - Loading
 
     func isFetchingChart() -> Bool {
         return store.isFetchingSummary
@@ -264,25 +279,6 @@ final class SiteStatsPeriodViewModel: Observable {
         default:
             return .idle
         }
-    }
-
-    // MARK: - Refresh Data
-
-    func refreshTrafficOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
-        lastRequestedDate = StatsPeriodHelper().endDate(from: date, period: period)
-        lastRequestedPeriod = period
-        periodReceipt = nil
-        periodReceipt = store.query(
-            .trafficOverviewData(
-                .init (
-                    date: lastRequestedDate,
-                    period: lastRequestedPeriod,
-                    chartBarsUnit: chartBarsUnit(from: lastRequestedPeriod),
-                    chartBarsLimit: chartBarsLimit(for: lastRequestedPeriod),
-                    chartTotalsLimit: chartTotalsLimit()
-                )
-            )
-        )
     }
 
     // MARK: - Chart Date

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -4,7 +4,7 @@ final class ReferrerDetailsTableViewController: UITableViewController {
     private var data: StatsTotalRowData
     private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
     private lazy var viewModel = ReferrerDetailsViewModel(data: data, delegate: self, referrersDelegate: self)
-    private let periodStore = StoreContainer.shared.statsPeriod
+    private let periodStore = StatsPeriodStore()
 
     init(data: StatsTotalRowData) {
         self.data = data

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -22,7 +22,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
     private var tableHeaderView: SiteStatsTableHeaderView?
     private typealias Style = WPStyleGuide.Stats
     private var viewModel: PostStatsViewModel?
-    private let store = StoreContainer.shared.statsPeriod
+    private let store = StatsPeriodStore()
     private var changeReceipt: Receipt?
 
     private lazy var tableHandler: ImmuTableViewHandler = {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -16,7 +16,7 @@ class PostStatsViewModel: Observable {
     private var postURL: URL?
     private weak var postStatsDelegate: PostStatsDelegate?
 
-    private let store = StoreContainer.shared.statsPeriod
+    private let store = StatsPeriodStore()
     private var receipt: Receipt?
     private var changeReceipt: Receipt?
     private var postStats: StatsPostDetails?

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -28,8 +28,8 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
 
     private var receipt: Receipt?
 
-    private let insightsStore = StoreContainer.shared.statsInsights
-    private let periodStore = StoreContainer.shared.statsPeriod
+    private let insightsStore = StatsInsightsStore()
+    private let periodStore = StatsPeriodStore()
 
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -16,11 +16,11 @@ class SiteStatsDetailsViewModel: Observable {
     private weak var detailsDelegate: SiteStatsDetailsDelegate?
     private weak var referrerDelegate: SiteStatsReferrerDelegate?
 
-    private let insightsStore = StoreContainer.shared.statsInsights
+    private let insightsStore = StatsInsightsStore()
     private var insightsReceipt: Receipt?
     private var insightsChangeReceipt: Receipt?
 
-    private let periodStore = StoreContainer.shared.statsPeriod
+    private let periodStore = StatsPeriodStore()
     private var periodReceipt: Receipt?
     private var periodChangeReceipt: Receipt?
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -16,8 +16,8 @@ class SiteStatsInsightsDetailsTableViewController: SiteStatsBaseTableViewControl
 
     private var receipt: Receipt?
 
-    private let insightsStore = StoreContainer.shared.statsInsights
-    private let periodStore = StoreContainer.shared.statsPeriod
+    private let insightsStore = StatsInsightsStore()
+    private let periodStore = StatsPeriodStore()
 
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -19,15 +19,15 @@ class SiteStatsInsightsDetailsViewModel: Observable {
     private weak var referrerDelegate: SiteStatsReferrerDelegate?
     private weak var viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?
 
-    private let insightsStore = StoreContainer.shared.statsInsights
+    private let insightsStore = StatsInsightsStore()
     private var insightsReceipt: Receipt?
     private var insightsChangeReceipt: Receipt?
 
-    private let periodStore = StoreContainer.shared.statsPeriod
+    private let periodStore = StatsPeriodStore()
     private var periodReceipt: Receipt?
     private var periodChangeReceipt: Receipt?
 
-    private let revampStore = StoreContainer.shared.statsRevamp
+    private let revampStore = StatsRevampStore()
     private var revampChangeReceipt: Receipt?
 
     private(set) var selectedDate: Date?

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -274,7 +274,6 @@ private extension SiteStatsDashboardViewController {
                                                        direction: .forward,
                                                        animated: false)
             }
-            insightsTableViewController.refreshInsights()
         case .traffic:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([trafficTableViewController],

--- a/WordPress/WordPressTest/ViewRelated/Stats/Traffic/SiteStatsPeriodViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Traffic/SiteStatsPeriodViewModelTests.swift
@@ -22,6 +22,7 @@ final class SiteStatsPeriodViewModelTests: XCTestCase {
             periodDelegate: SiteStatsPeriodDelegateMock(),
             referrerDelegate: SiteStatsReferrerDelegateMock()
         )
+        sut.addListeners()
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
Fixes #21099

There are multiple ways to reproduce issues with incorrect data shown, different data continuously blinking, or not loading when switching between Stats periods and tabs. Examples:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/21099#issuecomment-1635122443
- https://github.com/wordpress-mobile/WordPress-iOS/issues/21099#issuecomment-1649726255
- https://github.com/wordpress-mobile/WordPress-iOS/issues/21099#issuecomment-1870794228
- https://github.com/wordpress-mobile/WordPress-iOS/issues/21099#issuecomment-1966550044
- https://github.com/wordpress-mobile/WordPress-iOS/issues/21099#issuecomment-1972719972

Issues affect both the new Stats Traffic tab and Days/Weeks/Months/Years tabs with the feature flag disabled

## Root Cause

As explained well in this comment (https://github.com/wordpress-mobile/WordPress-iOS/issues/21099#issuecomment-1635122443), Stats stores process queries for previously requested periods and then loads unexpected data. It happens because queries are maintained globally and we're not removing existing queries when switching between different tabs.

Moreover, we keep our stores themselves as singletons in `StoreContainer`. Since our stores contain `state` variables, sometimes incorrect data is shown because another view accesses `state` that was loaded by another view. 

## Solution

### Queries

This issue is solved by adding listeners (receipts) when the view appears and removing them when the view disappears. So far I applied it to the Traffic and Insights tab. It's not necessary for the Details views since multiple Details views cannot be opened at once, and receipts are removed when we tap back from the Details view. However, Traffic and Insights views remain active while StatsDashboardVC is presented.

### Outdated State

There's no need for Stats stores to be kept within `StoreContainer`. It made sense when we used `CoreData` for caching and wanted to optimize state loading. However, now each view can access a fresh `Store` and `loadCache` for requested periods and dates. It avoids any issues for the state being accidentally shared.

## To test

### Case 1
1. Open Stats
2. Open Insights
3. Confirm the data is displayed as expected
4. Open Traffic
5. Switch to By Year -> By Month -> By Year
6. Exit Stats
7. Open Stats
8. Open Insights
9. Confirm data is loaded

### Case 2
1. Open Stats
2. Open Traffic
3. Switch to month, switch to week
4. Open Insights
5. Open Traffic
6. Confirm data is loaded

### Case 3
1. Open Stats
2. Open Traffic
3. Switch to month
4. Open into any details page
5. Confirm data is loaded
6. Come back to Traffic
7. Confirm correct data is shown

### Case 4: Regression

1. Disable Feature flag
2. Switch between Days/Weeks/Months/Years tabs
3. Confirm correct data is loaded
4. Go into any details page
5. Confirm data is loaded
6. Go back, go to Insights
7. Confirm data is loaded
8. Go into Insights details
9. Confirm data is loaded
10. Come back
11. Confirm data is loaded
12. Come back to home
13. Come back to Insights
14. Confirm cached data is loaded

## Regression Notes
1. Potential unintended areas of impact

Breaking Stats data loading even more but I think these changes are worth the risk

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

Relying on existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
