### PR TITLE
Stats: Limit date to current site date when fetching Stats totals from stats/visits endpoint

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -535,7 +535,11 @@ private extension StatsPeriodStore {
             return
         }
 
-        let totalsOperation = PeriodOperation(service: service, for: params.period, unit: params.period, date: params.date, limit: params.chartTotalsLimit) { [weak self] (totalsSummary: StatsSummaryTimeIntervalData?, error: Error?) in
+        // Backend doesn't accept a future date when fetching totals in some cases
+        // https://github.com/Automattic/jetpack/issues/36117
+        let totalsOperationDate = min(params.date, StatsDataHelper.currentDateForSite())
+
+        let totalsOperation = PeriodOperation(service: service, for: params.period, unit: params.period, date: totalsOperationDate, limit: params.chartTotalsLimit) { [weak self] (totalsSummary: StatsSummaryTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("Stats Traffic: Error fetching totals summary: \(String(describing: error?.localizedDescription))")
             }


### PR DESCRIPTION
Fixes #22749

This is a workaround in case https://github.com/Automattic/jetpack/issues/36117 cannot be fixed from the backend side. This issue didn't appear in February and now appears in March. More context p1709296332936439-slack-C06BR07TJHK. 

## To test

1. Enable Stats traffic feature flag
2. Select Stats
3. Open Traffic tab
4. Select month
5. Confirm Views and Visitors show correct totals

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)