### PR TITLE
Fix crash when uploading images from the share extension

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,8 +51,8 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 13.1'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '40d6a9f4928b470d73a5ade7ff1842a29e80cef8'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
+  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '40d6a9f4928b470d73a5ade7ff1842a29e80cef8'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'fix-crash-in-background-url-session'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `000cbf2b3b1644b224eb46f14f1cfc609103f686`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `40d6a9f4928b470d73a5ade7ff1842a29e80cef8`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix-crash-in-background-url-session`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `0a14bc96e22f097eca99eeccf37b5de11fa62612`)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -175,7 +175,7 @@ EXTERNAL SOURCES:
     :commit: 000cbf2b3b1644b224eb46f14f1cfc609103f686
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: 40d6a9f4928b470d73a5ade7ff1842a29e80cef8
+    :branch: fix-crash-in-background-url-session
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 0a14bc96e22f097eca99eeccf37b5de11fa62612
@@ -189,7 +189,7 @@ CHECKOUT OPTIONS:
     :commit: 000cbf2b3b1644b224eb46f14f1cfc609103f686
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: 40d6a9f4928b470d73a5ade7ff1842a29e80cef8
+    :commit: 11a6e5880e7a6bd30da52cef82238b5679f40397
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 0a14bc96e22f097eca99eeccf37b5de11fa62612
@@ -239,6 +239,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 70c703d9dea1af3e9a7d9dd82484925dcab05711
+PODFILE CHECKSUM: e42393e4efe24d59365f62716628ceaedea2476a
 
 COCOAPODS: 1.14.2

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -21,7 +21,8 @@ import WordPressFlux
     fileprivate lazy var backgroundSession: URLSession = {
         let configuration = URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier)
         configuration.sharedContainerIdentifier = self.appGroup
-        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        // Using the `main` queue because main context is used in the `URLSessionDelegate` implemention.
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: .main)
         return session
     }()
 


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPressKit-iOS/pull/739 for context.

## Test Instructions

Open Photos app, selected mutliple images, tap the Share button, select the "Jetpack" action, publish a post with the selected images. Go to the site from a web browser and verify the post is created successfully. Open the app and verify the post is available from the app.

Repeat the above steps with and without the app opening in the background.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See the "Test Instructions" section.

3. What automated tests I added (or what prevented me from doing so)
See the WordPressKit PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: N/A