### PR TITLE
Sync Publishing: Add sync publishing remote feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,7 +11,6 @@ enum FeatureFlag: Int, CaseIterable {
     case compliancePopover
     case googleDomainsCard
     case newTabIcons
-    case offlineMode
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -38,8 +37,6 @@ enum FeatureFlag: Int, CaseIterable {
             return false
         case .newTabIcons:
             return true
-        case .offlineMode:
-            return false
         }
     }
 
@@ -80,8 +77,6 @@ extension FeatureFlag {
             return "Google Domains Promotional Card"
         case .newTabIcons:
             return "New Tab Icons"
-        case .offlineMode:
-            return "Offline Mode (Sync Issues)"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -27,6 +27,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppRating
     case statsTrafficTab
     case siteMonitoring
+    case syncPublishing
 
     var defaultValue: Bool {
         switch self {
@@ -79,6 +80,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .statsTrafficTab:
             return false
         case .siteMonitoring:
+            return false
+        case .syncPublishing:
             return false
         }
     }
@@ -136,6 +139,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "stats_traffic_tab"
         case .siteMonitoring:
             return "site_monitoring"
+        case .syncPublishing:
+            return "sync_publishing"
         }
     }
 
@@ -191,6 +196,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Stats Traffic Tab"
         case .siteMonitoring:
             return "Site Monitoring"
+        case .syncPublishing:
+            return "Synchronous Publishing"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -178,7 +178,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
         updatePublishButtonLabel()
 
-        if FeatureFlag.offlineMode.enabled {
+        if RemoteFeatureFlag.syncPublishing.enabled() {
             updatePublishButtonState()
             mediaPollingTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
                 self?.updatePublishButtonState()


### PR DESCRIPTION
## Description
- Replaces `.offlineMode` local feature flag with `.syncPublishing` remote feature flag

## How to test
- Go to the debug menu
- Verify the `Synchronous Publishing` remote feature flag exists, and enable the flag
- Verify the `Offline Mode (Sync Issue)` local feature flag has been removed

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
