### PR TITLE
Offline Mode: Remove Publish button from preview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] [internal] Block editor: Remove code associated to Story block [#22758]
 * [*] Remove "Edit" button from "Post Published" screen [#22762]
+* [*] Remove "Publish" button from "Preview" screen [#22763]
 
 24.4
 -----

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -24,15 +24,6 @@ class PreviewWebKitViewController: WebKitViewController {
         }
     }
 
-    lazy var publishButton: UIBarButtonItem = {
-        let publishButton = UIBarButtonItem(title: Constants.publishButtonTitle,
-                                            style: .plain,
-                                            target: self,
-                                            action: #selector(PreviewWebKitViewController.publishButtonPressed(_:)))
-        publishButton.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .title2), NSAttributedString.Key.foregroundColor: Constants.publishButtonColor], for: .normal)
-        return publishButton
-    }()
-
     lazy var previewButton: UIBarButtonItem = {
         let button = UIBarButtonItem(image: UIImage(named: "icon-devices"), style: .plain, target: self, action: #selector(PreviewWebKitViewController.previewButtonPressed(_:)))
         button.title = NSLocalizedString("Preview Device", comment: "Title for web preview device switching button")
@@ -173,7 +164,7 @@ class PreviewWebKitViewController: WebKitViewController {
             }
         case .urlOnly:
             if canPublish {
-                items = [publishButton, space, previewButton]
+                items = [space, previewButton]
             } else {
                 items = [shareButton, space, safariButton, space, previewButton]
             }
@@ -183,30 +174,6 @@ class PreviewWebKitViewController: WebKitViewController {
     }
 
     // MARK: Button Actions
-
-    @objc private func publishButtonPressed(_ sender: UIBarButtonItem) {
-        let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish in the post list.")
-
-        let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
-        let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
-
-        let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
-        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
-
-        alertController.addCancelActionWithTitle(cancelTitle)
-        alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
-            guard let post = self.post else { return }
-            PostCoordinator.shared.publish(post)
-
-            if let editorVC = (self.presentingViewController?.presentingViewController as? EditPostViewController) {
-                editorVC.closeEditor(true, from: self)
-            } else {
-                self.dismiss(animated: true, completion: nil)
-            }
-        }
-
-        present(alertController, animated: true)
-    }
 
     @objc private func previewButtonPressed(_ sender: UIBarButtonItem) {
         let popoverContentController = PreviewDeviceSelectionViewController()
@@ -263,10 +230,6 @@ class PreviewWebKitViewController: WebKitViewController {
         static let deviceLabelBackgroundColor = UIColor.text.withAlphaComponent(0.8)
 
         static let noPreviewTitle = NSLocalizedString("No Preview URL available", comment: "missing preview URL for blog post preview")
-
-        static let publishButtonTitle = NSLocalizedString("Publish", comment: "Label for the publish (verb) button. Tapping publishes a draft post.")
-
-        static let publishButtonColor = UIColor.primary
 
         static let blankURL = URL(string: "about:blank")
     }

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PreviewWebKitViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PreviewWebKitViewControllerTests.swift
@@ -28,7 +28,6 @@ class PreviewWebKitViewControllerTests: CoreDataTestCase {
         let vc = PreviewWebKitViewController(post: post, previewURL: nil, source: "test_draft_toolbar")
         let items = vc.toolbarItems(linkBehavior: vc.linkBehavior)
 
-        XCTAssertTrue(items.contains(vc.publishButton), "Preview toolbar for draft should contain publish button.")
         XCTAssertFalse(items.contains(vc.safariButton),
                        "Preview toolbar for draft should not contain Safari button.")
         XCTAssertFalse(items.contains(vc.backButton), "Preview toolbar for draft should not contain back button.")
@@ -59,7 +58,6 @@ class PreviewWebKitViewControllerTests: CoreDataTestCase {
         let vc = PreviewWebKitViewController(post: page, previewURL: nil, source: "test_site_page")
         let items = vc.toolbarItems(linkBehavior: vc.linkBehavior)
 
-        XCTAssertFalse(items.contains(vc.publishButton), "Preview toolbar for page should not contain publish button.")
         XCTAssertTrue(items.contains(vc.safariButton), "Preview toolbar for page should contain Safari button.")
         XCTAssertTrue(items.contains(vc.backButton), "Preview toolbar for page should contain back button.")
         XCTAssertTrue(items.contains(vc.forwardButton), "Preview toolbar for page should contain forward button.")
@@ -71,7 +69,6 @@ class PreviewWebKitViewControllerTests: CoreDataTestCase {
         let vc = PreviewWebKitViewController(configuration: config)
         let items = vc.toolbarItems(linkBehavior: vc.linkBehavior)
 
-        XCTAssertFalse(items.contains(vc.publishButton), "Preview toolbar for page should not contain publish button.")
         XCTAssertTrue(items.contains(vc.safariButton), "Preview toolbar for page should contain Safari button.")
         XCTAssertTrue(items.contains(vc.backButton), "Preview toolbar for page should contain back button.")
         XCTAssertTrue(items.contains(vc.forwardButton), "Preview toolbar for page should contain forward button.")


### PR DESCRIPTION
-  Remove "Publish" button from the Preview screen

To test:

- Start a new post
- Open More / Preview
- **Verify** that it has no "Publish" button

## Regression Notes
1. Potential unintended areas of impact: Preview
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
