### PR TITLE
Fix an issue where the notification inline action causes the notifications view controller to leak

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
@@ -74,8 +74,13 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
     private func postLikeInlineAction(viewModel: NotificationsViewModel,
                                       notification: NewPostNotification,
                                       parent: NotificationsViewController) -> NotificationsTableViewCellContent.InlineAction.Configuration {
-        let action: () -> Void = { [weak self] in
-            guard let self, let content = self.content, case let .regular(style) = content.style, let config = style.inlineAction else {
+        let action: () -> Void = { [weak self, weak parent] in
+            guard let self,
+                  let parent,
+                  let content = self.content,
+                  case let .regular(style) = content.style,
+                  let config = style.inlineAction
+            else {
                 return
             }
             parent.cancelNextUpdateAnimation()
@@ -92,8 +97,12 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
     private func commentLikeInlineAction(viewModel: NotificationsViewModel,
                                          notification: CommentNotification,
                                          parent: NotificationsViewController) -> NotificationsTableViewCellContent.InlineAction.Configuration {
-        let action: () -> Void = { [weak self] in
-            guard let self, let content = self.content, case let .regular(style) = content.style, let config = style.inlineAction else {
+        let action: () -> Void = { [weak self, weak parent] in
+            guard let self,
+                  let parent,
+                  let content = self.content,
+                  case let .regular(style) = content.style,
+                  let config = style.inlineAction else {
                 return
             }
             parent.cancelNextUpdateAnimation()


### PR DESCRIPTION
Fixes #22764

## Description

This PR fixes an issue where the notification inline action causes the notifications view controller to leak.

## Test Instructions
1. Build and run the app in Xcode
2. Navigate to Notifications screen
3. Find a notification with the "Star" Inline Action
4. Tap the Inline Action
5. Sign out
6. Activate the Memory Graph debugger
7. Search for `NotificationsViewController`.
8. Expect the `NotificationsViewController` instance is not found.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
