### PR TITLE
Include year in Traffic date picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
@@ -41,7 +41,9 @@ class StatsTrafficDatePickerViewModel: ObservableObject {
     func formattedCurrentPeriod() -> String {
         let dateFormatter = period.dateFormatter
         if period == .week, let week = StatsPeriodHelper().weekIncludingDate(date) {
-            return "\(dateFormatter.string(from: week.weekStart)) - \(dateFormatter.string(from: week.weekEnd))"
+            let weekEndFormatter = DateFormatter()
+            weekEndFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+            return "\(dateFormatter.string(from: week.weekStart)) - \(weekEndFormatter.string(from: week.weekEnd))"
         } else {
             return dateFormatter.string(from: date)
         }
@@ -60,11 +62,11 @@ private extension StatsPeriodUnit {
         let format: String
         switch self {
         case .day:
-            format = "MMMM d"
+            format = "MMMM d, yyyy"
         case .week:
             format = "MMM d"
         case .month:
-            format = "MMMM"
+            format = "MMMM, yyyy"
         case .year:
             format = "yyyy"
         }

--- a/WordPress/WordPressTest/StatsTrafficDatePickerViewModelTests.swift
+++ b/WordPress/WordPressTest/StatsTrafficDatePickerViewModelTests.swift
@@ -44,6 +44,27 @@ final class StatsTrafficDatePickerViewModelTests: XCTestCase {
         viewModel.goToNextPeriod()
         XCTAssertEqual(date, viewModel.date, "Date shouldn't go beyond the current site date")
     }
+
+    func testFormattedCurrentPeriod_yearIsIncludedInDayPeriod() {
+        let date = Date("2024-01-20")
+        let currentDateGetter: SiteCurrentDateGetter = { date }
+        viewModel = StatsTrafficDatePickerViewModel(period: .day, date: date, currentDateGetter: currentDateGetter)
+        XCTAssertEqual(viewModel.formattedCurrentPeriod(), "January 20, 2024")
+    }
+
+    func testFormattedCurrentPeriod_yearIsIncludedInWeekPeriod() {
+        let date = Date("2024-01-20")
+        let currentDateGetter: SiteCurrentDateGetter = { date }
+        viewModel = StatsTrafficDatePickerViewModel(period: .week, date: date, currentDateGetter: currentDateGetter)
+        XCTAssertEqual(viewModel.formattedCurrentPeriod(), "Jan 15 - Jan 21, 2024")
+    }
+
+    func testFormattedCurrentPeriod_yearIsIncludedInMonthPeriod() {
+        let date = Date("2024-01-20")
+        let currentDateGetter: SiteCurrentDateGetter = { date }
+        viewModel = StatsTrafficDatePickerViewModel(period: .month, date: date, currentDateGetter: currentDateGetter)
+        XCTAssertEqual(viewModel.formattedCurrentPeriod(), "January 2024")
+    }
 }
 
 private extension Date {


### PR DESCRIPTION
Adds the year to the date picker's display date to avoid confusion about which year is being displayed.

Fixes #22767

## Screenshots
| Before | After | 
| - | - | 
| <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/a8f16f19-6f17-44e7-a99f-58b66c3bce11" /> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/77f1d4e4-ff67-4461-86ed-f83b72a6e04c" /> |


## To test
1. Open Stats
2. Go to the Traffic tab
3. Switch "By day" to different periods and notice the dates include the year (the exact formatting depends on the device locale):
    - By day: `January 20, 2024`
    - By week: `Jan 15 - Jan 21, 2024`
    - By year: `January 2024`

## Regression Notes
1. Potential unintended areas of impact

The Traffic tab is the only screen that might be affected

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing and existing unit tests.

3. What automated tests I added (or what prevented me from doing so)

I added unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] iPhone and iPad. 
