### PR TITLE
Reader: Restore the native scroll-to-top behavior

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -155,6 +155,19 @@ extension ReaderTabView {
         self.filteredTabs.append((index: selectedIndex, topic: selectedTopic))
     }
 
+    /// Disables the `scrollsToTop` property for the scroll views created from SwiftUI.
+    /// To preserve the native scroll-to-top behavior when the status bar is tapped, there
+    func disableScrollsToTop() {
+        var viewsToTraverse = navigationMenu.subviews
+        while viewsToTraverse.count > 0 {
+            let subview = viewsToTraverse.removeFirst()
+            if let scrollView = subview as? UIScrollView {
+                scrollView.scrollsToTop = false
+            }
+            viewsToTraverse.append(contentsOf: subview.subviews)
+        }
+    }
+
     private func updateMenuDisplay(hidden: Bool) {
         guard isMenuHidden != hidden else { return }
 
@@ -212,6 +225,7 @@ extension ReaderTabView: ReaderNavigationMenuDelegate {
 
     func scrollViewDidScroll(_ scrollView: UIScrollView, velocity: CGPoint) {
         let isContentOffsetNearTop = scrollView.contentOffset.y < scrollView.frame.height / 2
+        let isContentOffsetAtTop = scrollView.contentOffset.y == .zero
         let isUserScrollingDown = velocity.y < -400
         let isUserScrollingUp = velocity.y > 400
 
@@ -220,6 +234,13 @@ extension ReaderTabView: ReaderNavigationMenuDelegate {
         }
 
         if isMenuHidden && isUserScrollingUp {
+            updateMenuDisplay(hidden: false)
+        }
+
+        // Handles the native scroll-to-top behavior (by tapping the status bar).
+        // Somehow the `scrollViewDidScrollToTop` method is not called in the view controller
+        // containing the scroll view, so we'll need to put a custom logic here instead.
+        if isMenuHidden && isContentOffsetAtTop {
             updateMenuDisplay(hidden: false)
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -156,7 +156,8 @@ extension ReaderTabView {
     }
 
     /// Disables the `scrollsToTop` property for the scroll views created from SwiftUI.
-    /// To preserve the native scroll-to-top behavior when the status bar is tapped, there
+    /// To preserve the native scroll-to-top behavior when the status bar is tapped, there could only be
+    /// one scroll view on screen with the `scrollsToTop` property set to `true`.
     func disableScrollsToTop() {
         var viewsToTraverse = navigationMenu.subviews
         while viewsToTraverse.count > 0 {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -52,6 +52,7 @@ class ReaderTabViewController: UIViewController {
         super.viewDidAppear(animated)
 
         ReaderTracker.shared.start(.main)
+        readerTabView.disableScrollsToTop()
 
         if AppConfiguration.showsWhatIsNew {
             RootViewCoordinator.shared.presentWhatIsNew(on: self)


### PR DESCRIPTION
Refs #22770 

With the new Reader design (internal ref: pcdRpT-506-p2), we unknowingly brought two scroll views on screen having both `scrollsToTop: true`, which breaks the native scroll-to-top behavior when tapping the status bar.

The new scroll view comes from the `ReaderNavigationMenu`, which is written in SwiftUI. There's no direct access to the `scrollsToTop` property, so we need traverse the generated views and update the property manually after the component is rendered.

The native scroll-to-top in theory should trigger [scrollViewDidScrollToTop(_:)](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/1619382-scrollviewdidscrolltotop). In fact, this method is only triggered when scrolling to top from the status bar, but somehow it's not getting called (_you had one job..._ 😅). So I depended on the existing `scrollViewDidScroll` method and added a little logic on the `ReaderTabView` that handles the scroll position calculations. 

I thought this would be a one-liner, but it turned out to be a fun little rabbit hole! 🐰 🪄 

## To test

- Launch the Jetpack app and navigate to the Reader tab.
- Scroll down the stream for a bit.
- Tap on the status bar.
- 🔎 Verify that the stream now scrolls to the top.
- 🔎 Verify that the navigation bar is shown after reaching the top.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
Not applicable

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)