### PR TITLE
Offline Mode: Enable sync publishing for developers

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -82,7 +82,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .siteMonitoring:
             return false
         case .syncPublishing:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -140,7 +140,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .siteMonitoring:
             return "site_monitoring"
         case .syncPublishing:
-            return "sync_publishing"
+            /// - warning: Work-in-progress (kahu-offline-mode)
+            return "_sync_publishing"
         }
     }
 


### PR DESCRIPTION
- Enable the FF for developers

To test:

- **Verify** that sync publishing is enabled by default for local development and branch test builds

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
