### PR TITLE
Let Xcode decided how many test runners to spawn

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -116,9 +116,7 @@ platform :ios do
       result_bundle: true,
       output_types: '',
       fail_build: false,
-      parallel_testing: parallel_testing_value,
-      concurrent_workers: CONCURRENT_SIMULATORS,
-      max_concurrent_simulators: CONCURRENT_SIMULATORS
+      parallel_testing: parallel_testing_value
     )
 
     trainer(path: lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH], fail_build: true)

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -5,7 +5,7 @@ SENTRY_PROJECT_SLUG_WORDPRESS = 'wordpress-ios'
 SENTRY_PROJECT_SLUG_JETPACK = 'jetpack-ios'
 APPCENTER_OWNER_NAME = 'automattic'
 APPCENTER_OWNER_TYPE = 'organization'
-CONCURRENT_SIMULATORS = 2
+CONCURRENT_SIMULATORS = 3
 
 # Shared options to use when invoking `gym` / `build_app`.
 #

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -116,7 +116,9 @@ platform :ios do
       result_bundle: true,
       output_types: '',
       fail_build: false,
-      parallel_testing: parallel_testing_value
+      parallel_testing: parallel_testing_value,
+      concurrent_workers: CONCURRENT_SIMULATORS,
+      max_concurrent_simulators: CONCURRENT_SIMULATORS
     )
 
     trainer(path: lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH], fail_build: true)


### PR DESCRIPTION
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
