### PR TITLE
Reader: Update Reader details like view to match web

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -96,11 +96,9 @@ private extension ReaderDetailLikesView {
     func updateSummaryLabel() {
         switch (displaysSelfAvatar, totalLikes) {
         case (true, 0):
-            summaryLabel.attributedText = highlightedText(SummaryLabelFormats.onlySelf)
+            summaryLabel.attributedText = NSAttributedString(string: SummaryLabelFormats.onlySelf)
         case (true, 1):
-            summaryLabel.attributedText = highlightedText(SummaryLabelFormats.singularWithSelf)
-        case (true, _) where totalLikes > 1:
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.pluralWithSelf, totalLikes))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.plural, 2))
         case (false, 1):
             summaryLabel.attributedText = highlightedText(SummaryLabelFormats.singular)
         default:
@@ -147,6 +145,10 @@ private extension ReaderDetailLikesView {
         guard gesture.state == .ended else {
             return
         }
+        if displaysSelfAvatar && totalLikes == 0 {
+            // Only the current user liked the post
+            return
+        }
 
         delegate?.didTapLikesView()
     }
@@ -157,22 +159,23 @@ private extension ReaderDetailLikesView {
     }
 
     struct SummaryLabelFormats {
-        static let onlySelf = NSLocalizedString("_You_ like this.",
-                                                comment: "Describes that the current user is the only one liking a post."
-                                                    + " The underscores denote underline and is not displayed.")
-        static let singularWithSelf = NSLocalizedString("_You and another blogger_ like this.",
-                                                        comment: "Describes that the current user and one other user like a post."
-                                                            + " The underscores denote underline and is not displayed.")
-        static let pluralWithSelf = NSLocalizedString("_You and %1$d bloggers_ like this.",
-                                                      comment: "Plural format string for displaying the number of post likes, including the like from the current user."
-                                                        + " %1$d is the number of likes, excluding the like by current user."
-                                                        + " The underscores denote underline and is not displayed.")
-        static let singular = NSLocalizedString("_One blogger_ likes this.",
-                                                comment: "Describes that only one user likes a post. "
-                                                    + " The underscores denote underline and is not displayed.")
-        static let plural = NSLocalizedString("_%1$d bloggers_ like this.",
-                                              comment: "Plural format string for displaying the number of post likes."
-                                                + " %1$d is the number of likes. The underscores denote underline and is not displayed.")
+        static let onlySelf = NSLocalizedString(
+            "reader.detail.likes.self",
+            value: "You like this.",
+            comment: "Describes that the current user is the only one liking a post."
+        )
+        static let singular = NSLocalizedString(
+            "reader.detail.likes.single",
+            value: "_1 like_",
+            comment: "Describes that only one user likes a post. "
+            + " The underscores denote underline and is not displayed."
+        )
+        static let plural = NSLocalizedString(
+            "reader.detail.likes.plural",
+            value: "_%1$d likes_",
+            comment: "Plural format string for displaying the number of post likes."
+            + " %1$d is the number of likes. The underscores denote underline and is not displayed."
+        )
     }
 
     func highlightedText(_ text: String) -> NSAttributedString {
@@ -183,11 +186,10 @@ private extension ReaderDetailLikesView {
         let lastPart = labelParts.last ?? ""
 
         let foregroundAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.secondaryLabel]
-        let underlineAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary,
-                                                                  .underlineStyle: NSUnderlineStyle.single.rawValue]
+        let highlightedAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary]
 
         let attributedString = NSMutableAttributedString(string: firstPart, attributes: foregroundAttributes)
-        attributedString.append(NSAttributedString(string: countPart, attributes: underlineAttributes))
+        attributedString.append(NSAttributedString(string: countPart, attributes: highlightedAttributes))
         attributedString.append(NSAttributedString(string: lastPart, attributes: foregroundAttributes))
 
         return attributedString


### PR DESCRIPTION
Fixes #22710

## Description

Updates the text and behavior of the likes on the Reader details screen to match what the web is currently doing.

## Screenshots

> [!NOTE]
> The links on web change color based on the theme of the blog.

| | Web | Mobile after changes |
|---|:---:|:---:|
| Single like by user | ![Screenshot 2024-03-05 at 3 58 19 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/ce633b1c-2d90-4f22-ad48-a7727677907f) | ![Screenshot 2024-03-05 at 4 25 51 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/ba15a3ca-bfd4-46b3-81df-d836092c147d) |
| Single like by another user | ![Screenshot 2024-03-05 at 4 30 38 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/fc77bdd4-0f61-4519-bd37-3ab04188cf14) | ![Screenshot 2024-03-05 at 4 31 18 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/aa79a3bc-0f3f-419d-8063-12d501484a63) |
| Multiple likes including user | ![Screenshot 2024-03-05 at 4 12 41 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/9b10c191-00fa-4a04-b752-04803463a889) | ![Screenshot 2024-03-05 at 4 18 02 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/9ed888ff-0308-47aa-80d4-8a1430f7d947) | 

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader
- Tap on a post with multiple likes
- Scroll down until the likes section
- 🔎 **Verify**:
  - A plural format of `N likes`
  - The label is tappable
- Navigate back to the Reader feed
- Tap on a post with a single like
- Scroll down until the likes section
- 🔎 **Verify**:
  - A singular format of `1 like`
  - The label is tappable
- Navigate back to the Reader feed
- Tap on a post with no likes
- Like the post
- Scroll down until the likes section
- 🔎 **Verify**:
  - A singular format of `You like this post.`
  - The label is not tappable

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
