### PR TITLE
Hide Reader Details back button when it is the first view controller in the navigation stack

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -195,6 +195,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        updateLeftBarButtonItem()
         setupFeaturedImage()
         updateFollowButtonState()
         toolbar.viewWillAppear()
@@ -1031,21 +1032,28 @@ private extension ReaderDetailViewController {
 private extension ReaderDetailViewController {
 
     func configureNavigationBar() {
-
         // If a Related post fails to load, disable the More and Share buttons as they won't do anything.
         let rightItems = [
             moreButtonItem(enabled: enableRightBarButtons),
             shareButtonItem(enabled: enableRightBarButtons),
             safariButtonItem()
         ]
-
-        if !isModal() {
-            navigationItem.leftBarButtonItem = backButtonItem()
-        } else {
-            navigationItem.leftBarButtonItem = dismissButtonItem()
-        }
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
+    }
+
+    /// Updates the left bar button item based on the current view controller's context in the navigation stack.
+    /// If the view controller is presented modally and does not have a left bar button item, a dismiss button is set.
+    /// If the view controller is not the root of the navigation stack, a back button is set.
+    /// Otherwise, the left bar button item is cleared.
+    func updateLeftBarButtonItem() {
+        if isModal(), navigationItem.leftBarButtonItem == nil {
+            navigationItem.leftBarButtonItem = dismissButtonItem()
+        } else if navigationController?.viewControllers.first !== self {
+            navigationItem.leftBarButtonItem = backButtonItem()
+        } else {
+            navigationItem.leftBarButtonItem = nil
+        }
     }
 
     func backButtonItem() -> UIBarButtonItem {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1049,9 +1049,10 @@ private extension ReaderDetailViewController {
     }
 
     func backButtonItem() -> UIBarButtonItem {
-        let button = barButtonItem(with: .gridicon(.chevronLeft), action: #selector(didTapBackButton(_:)))
+        let config = UIImage.SymbolConfiguration(weight: .semibold)
+        let image = UIImage(systemName: "chevron.backward", withConfiguration: config) ?? .gridicon(.chevronLeft)
+        let button = barButtonItem(with: image, action: #selector(didTapBackButton(_:)))
         button.accessibilityLabel = Strings.backButtonAccessibilityLabel
-
         return button
     }
 


### PR DESCRIPTION
Fixes #22780

## Description

This PR addresses a specific issue on the iPad, where the back button item incorrectly appeared on the Reader Details screen when navigating from the Notifications screen

| Before | After |
| ------ | ----- |
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/8100212f-757e-4b86-a04b-d40bf39fbeb8) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/5a6ce68f-c454-441a-8514-ff966758dcb3) |

## Test Instructions

Using an iPad device:

#### Notifications

1. Navigate to Notifications tab
2. Tap a "New Post" notification
3. **Expect** the back button item not to be visible
4. Navigate to the Comments screen from the Reader Details screen
5. **Expect** the back button to be visible


#### Reader

1. Navigate to Reader
2. Tap any post
3. **Expect** the back button to be visible

## Regression Notes
1. Potential unintended areas of impact
This impacts the visibility of the Reader Details screen back button item. It should be smoke tested for iPhone devices too.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
