### PR TITLE
Reader: Update tags filter to be before blogs filter

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -206,7 +206,7 @@ extension ReaderTabViewModel {
         var filters = [ReaderSiteTopic.filterProvider(for: siteType)]
 
         if !selectedStream.shouldHideTagFilter {
-            filters.append(ReaderTagTopic.filterProvider())
+            filters.insert(ReaderTagTopic.filterProvider(), at: 0)
         }
 
         streamFilters = filters


### PR DESCRIPTION
Fixes #22789 

> [!WARNING]
> Auto-merge is on.

## Description

Swaps the order the blogs and tags pill appear.

![Screenshot 2024-03-07 at 1 44 57 PM](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/723f67ba-4181-4012-b8b6-d142b27b2342)

## Testing

To test:
- Launch Jetpack and login
- Navigate to the `Subscriptions` Reader feed
- 🔎 **Verify** the tags pill appears before the blogs pill

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
