### PR TITLE
Use single feature announcement screen in 24.4

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
@@ -138,7 +138,7 @@ private extension WhatIsNewScenePresenter {
     }
 
     private func shouldUseDashboardCustomView() -> Bool {
-        return self.store.appVersionName == "23.3"
+        return self.store.appVersionName == "24.4"
     }
 
     enum WhatIsNewStrings {


### PR DESCRIPTION
To test, log in with an A8c WP.com account and verify the Stats feature announcement is shown. Use a clean install to avoid caches.

## Regression Notes
1. Potential unintended areas of impact: not applicable
2. What I did to test those areas of impact (or what existing automated tests I relied on): not applicable
3. What automated tests I added (or what prevented me from doing so): not applicable

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: Not applicable