### PR TITLE
Enhance error handling for notifications from private blogs

### DIFF
--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -191,21 +191,15 @@ class LikesListController: NSObject {
             self.isFirstLoad = false
             self.isLoadingContent = false
             self.trackUsersToExclude()
-        }, failure: { [weak self] error in
-            guard let self = self else {
-                return
-            }
-
+        }, failure: { error in
             let errorMessage: String? = {
-                // Get error message from API response if provided.
-                if let error = error,
-                   let message = (error as NSError).userInfo[WordPressComRestApi.ErrorKeyErrorMessage] as? String,
-                   !message.isEmpty {
-                    return message
+                guard let error = error as? NSError,
+                      error.domain == WordPressComRestApiEndpointError.errorDomain,
+                      error.code == WordPressComRestApiErrorCode.authorizationRequired.rawValue else {
+                    return nil
                 }
-                return nil
+                return Strings.fetchLikesFromPrivateBlogErrorMessage
             }()
-
             self.isLoadingContent = false
             self.delegate?.showErrorView(title: self.errorTitle, subtitle: errorMessage)
         })
@@ -419,6 +413,14 @@ private extension LikesListController {
         static let headerSectionIndex = 0
         static let headerRowIndex = 0
         static let numberOfHeaderRows = 1
+    }
+
+    struct Strings {
+        static let fetchLikesFromPrivateBlogErrorMessage = NSLocalizedString(
+            "likesListViewController.likesList.privateBlogErrorMessage",
+            value: "You have no access to the private blog.",
+            comment: "Error message that informs likes from a private blog cannot be fetched."
+        )
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -418,7 +418,7 @@ private extension LikesListController {
     struct Strings {
         static let fetchLikesFromPrivateBlogErrorMessage = NSLocalizedString(
             "likesListViewController.likesList.privateBlogErrorMessage",
-            value: "You have no access to the private blog.",
+            value: "You don't have permission to view this private blog.",
             comment: "Error message that informs likes from a private blog cannot be fetched."
         )
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -402,7 +402,7 @@ private extension NotificationCommentDetailViewController {
     struct Strings {
         static let fetchCommentDetailsFromPrivateBlogErrorMessage = NSLocalizedString(
             "notificationCommentDetailViewController.commentDetails.privateBlogErrorMessage",
-            value: "You have no access to the private blog.",
+            value: "You don't have permission to view this private blog.",
             comment: "Error message that informs comment details from a private blog cannot be fetched."
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -796,9 +796,11 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     NSString *subtitle = nil;
     if (self.fetchCommentsError != nil) {
         image = @"wp-illustration-reader-empty";
-        NSString *message = self.fetchCommentsError.userInfo[@"WordPressComRestApiErrorMessageKey"];
-        if (message != nil && ![message isEqualToString:@""]) {
-            subtitle = message;
+        NSError *error = self.fetchCommentsError;
+        if (error && [error.domain isEqualToString:WordPressComRestApiErrorDomain] && error.code == WordPressComRestApiErrorCodeAuthorizationRequired) {
+            subtitle = NSLocalizedString(@"You have no access to the private blog.",
+                                          @"Error message that informs reader comments from a private blog cannot be fetched.");
+
         }
     }
     [self.noResultsViewController configureWithTitle:self.noResultsTitleText

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -798,7 +798,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         image = @"wp-illustration-reader-empty";
         NSError *error = self.fetchCommentsError;
         if (error && [error.domain isEqualToString:WordPressComRestApiErrorDomain] && error.code == WordPressComRestApiErrorCodeAuthorizationRequired) {
-            subtitle = NSLocalizedString(@"You have no access to the private blog.",
+            subtitle = NSLocalizedString(@"You don't have permission to view this private blog.",
                                           @"Error message that informs reader comments from a private blog cannot be fetched.");
 
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -357,13 +357,12 @@ class ReaderDetailCoordinator {
 
     private func showError(error: Error?) {
         let errorMessage: String? = {
-            // Get error message from API response if provided.
-            if let error = error,
-               let message = (error as NSError).userInfo[WordPressComRestApi.ErrorKeyErrorMessage] as? String,
-               !message.isEmpty {
-                return message
+            guard let error = error as? NSError,
+                  error.domain == WordPressComRestApiEndpointError.errorDomain,
+                  error.code == WordPressComRestApiErrorCode.authorizationRequired.rawValue else {
+                return nil
             }
-            return nil
+            return Strings.fetchDetailFromPrivateBlogErrorMessage
         }()
         self.view?.showError(subtitle: errorMessage)
     }
@@ -790,4 +789,18 @@ extension ReaderDetailCoordinator {
             coder.encode(post.objectID.uriRepresentation().absoluteString, forKey: type(of: self).restorablePostObjectURLKey)
         }
     }
+}
+
+// MARK: - Private Definitions
+
+private extension ReaderDetailCoordinator {
+
+    struct Strings {
+        static let fetchDetailFromPrivateBlogErrorMessage = NSLocalizedString(
+            "readerDetailCoordinator.readerDetail.privateBlogErrorMessage",
+            value: "You have no access to the private blog.",
+            comment: "Error message that informs reader detail from a private blog cannot be fetched."
+        )
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -333,8 +333,8 @@ class ReaderDetailCoordinator {
                                     success: { [weak self] post in
                                         self?.post = post
                                         self?.renderPostAndBumpStats()
-                                    }, failure: { [weak self] _ in
-                                        self?.postURL == nil ? self?.view?.showError() : self?.view?.showErrorWithWebAction()
+                                    }, failure: { [weak self] error in
+                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction()
                                         self?.reportPostLoadFailure()
                                     })
     }
@@ -350,9 +350,22 @@ class ReaderDetailCoordinator {
                                         self?.renderPostAndBumpStats()
                                     }, failure: { [weak self] error in
                                         DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
-                                        self?.postURL == nil ? self?.view?.showError() : self?.view?.showErrorWithWebAction()
+                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction()
                                         self?.reportPostLoadFailure()
                                     })
+    }
+
+    private func showError(error: Error?) {
+        let errorMessage: String? = {
+            // Get error message from API response if provided.
+            if let error = error,
+               let message = (error as NSError).userInfo[WordPressComRestApi.ErrorKeyErrorMessage] as? String,
+               !message.isEmpty {
+                return message
+            }
+            return nil
+        }()
+        self.view?.showError(subtitle: errorMessage)
     }
 
     private func renderPostAndBumpStats() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -798,7 +798,7 @@ private extension ReaderDetailCoordinator {
     struct Strings {
         static let fetchDetailFromPrivateBlogErrorMessage = NSLocalizedString(
             "readerDetailCoordinator.readerDetail.privateBlogErrorMessage",
-            value: "You have no access to the private blog.",
+            value: "You don't have permission to view this private blog.",
             comment: "Error message that informs reader detail from a private blog cannot be fetched."
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -7,7 +7,7 @@ protocol ReaderDetailView: AnyObject {
     func render(_ post: ReaderPost)
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost])
     func showLoading()
-    func showError()
+    func showError(subtitle: String?)
     func showErrorWithWebAction()
     func scroll(to: String)
     func updateHeader()
@@ -384,11 +384,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     /// Shown an error
-    func showError() {
+    func showError(subtitle: String?) {
         isLoadingWebView = false
         hideLoading()
 
-        displayLoadingView(title: LoadingText.errorLoadingTitle)
+        displayLoadingView(title: LoadingText.errorLoadingTitle, subtitle: subtitle)
     }
 
     /// Shown an error with a button to open the post on the browser
@@ -995,8 +995,8 @@ extension ReaderDetailViewController: WKNavigationDelegate {
 // MARK: - Error View Handling (NoResultsViewController)
 
 private extension ReaderDetailViewController {
-    func displayLoadingView(title: String, accessoryView: UIView? = nil) {
-        noResultsViewController.configure(title: title, accessoryView: accessoryView)
+    func displayLoadingView(title: String, subtitle: String? = nil, accessoryView: UIView? = nil) {
+        noResultsViewController.configure(title: title, subtitle: subtitle, accessoryView: accessoryView)
         showLoadingView()
     }
 

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -325,7 +325,7 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
         didCallRenderWithPost = post
     }
 
-    func showError() {
+    func showError(subtitle: String?) {
         didCallShowError = true
     }
 


### PR DESCRIPTION
Fixes #17127 

This PR handles errors for two types of notifications related to private blogs to which the user does not have access: comments and mentions. Mentions are split into mentions either in a comment or a post.

Moreover, the Reader's comments screen displayed an infinite loading progress bar, so it's been fixed too.

**To test:**

First, please temporarily leave a P2 from which you have tons of notifications to make it private for you. I assume it's cdRpT-p2.
Go to Notifications screen and test the following cases
- Open a "mention in/reply to a comment" notification that you've already seen (it has to be cached). You should see the comment on a Mention notification details screen
- Go to the comments screen from the details (tap on the "Comment on >" section on the top of the screen)
- [ ] Make sure you see an error message stating that you cannot access the private blog instead of an infinite loading state.
- [ ] Go back to the notifications screen and open a "mention in/reply to a comment" notification that is not cached yet. Make sure you can see a similar error without seeing the comment.
- Go back to the notifications and find a notification mentioning you **in a post**.
- [ ] Tap on it and ensure you see an error message stating you cannot access the private blog.
- [ ] Smoke test other notifications
- [ ] Subscribe back to the P2 and test the cases again to ensure you have access to all the notifications' details

## Regression Notes
1. Potential unintended areas of impact
Reader comments, Notification details screens

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
There were no initial tests to the legacy code this PR touches

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)