### PR TITLE
Fix notification row selection style in landscape mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -89,6 +89,13 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
     ///
     internal var jetpackLoginViewController: JetpackLoginViewController? = nil
 
+    /// Boolean indicating whether the split view controller is collapsed.
+    /// Default is `true` if the view controller isn't embedded inside a split view controller
+    ///
+    override var splitViewControllerIsHorizontallyCompact: Bool {
+        return splitViewController?.isCollapsed ?? true
+    }
+
     /// Timestamp of the most recent note before updates
     /// Used to count notifications to show the second notifications prompt
     ///
@@ -341,11 +348,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
               let note = tableViewHandler.resultsController?.managedObject(atUnsafe: indexPath) as? Notification else {
             return UITableViewCell()
         }
-        if splitViewControllerIsHorizontallyCompact {
-            cell.selectionStyle = .none
-        } else {
-            cell.selectionStyle = .default
-        }
+        cell.selectionStyle = splitViewControllerIsHorizontallyCompact ? .none : .default
         cell.accessibilityHint = Self.accessibilityHint(for: note)
         if let deletionRequest = notificationDeletionRequests[note.objectID] {
             cell.configure(with: note, deletionRequest: deletionRequest, parent: self) { [weak self] in


### PR DESCRIPTION
Fixes #22777 and #22778

## Description

This PR fixes the following issues:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/22778
- https://github.com/wordpress-mobile/WordPress-iOS/issues/22777

## Test Instructions

#### iPhone

1. Navigate to Notifications
2. Tap any notification row
3. Go back to notifications screen
4. **Expect** the selected notification row background color is the same as other rows. It should be either white or black.
5. Rotate the device to landscape mode.
6. **Expect** the app not to automatically navigate to notification details screen.

#### iPad

1. Navigate to Notifications
2. **Expect** the first notification to be selected, and its background is grey.
3. Tap any notification row
4. **Expect** the selected notification row background color is grey.
5. Enable split mode, and resize the Jetpack app window to resemble the one of an iPhone.
6. **Expect** the notification rows selection style is disabled.

## Regression Notes
1. Potential unintended areas of impact
The first notification should be selected automatically when running the app on iPad.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
