### PR TITLE
Media: Check if blog supports stock photos / tenor

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -197,8 +197,11 @@ extension MediaPickerMenu {
 // MARK: - MediaPickerMenu (Stock Photo)
 
 extension MediaPickerMenu {
-    func makeStockPhotos(blog: Blog, delegate: ExternalMediaPickerViewDelegate) -> UIAction {
-        UIAction(
+    func makeStockPhotos(blog: Blog, delegate: ExternalMediaPickerViewDelegate) -> UIAction? {
+        guard blog.supports(.stockPhotos) else {
+            return nil
+        }
+        return UIAction(
             title: Strings.pickFromStockPhotos,
             image: UIImage(systemName: "photo.on.rectangle"),
             attributes: [],
@@ -229,8 +232,11 @@ extension MediaPickerMenu {
 // MARK: - MediaPickerMenu (Free GIF, Tenor)
 
 extension MediaPickerMenu {
-    func makeFreeGIFAction(blog: Blog, delegate: ExternalMediaPickerViewDelegate) -> UIAction {
-        UIAction(
+    func makeFreeGIFAction(blog: Blog, delegate: ExternalMediaPickerViewDelegate) -> UIAction? {
+        guard blog.supports(.tenor) else {
+            return nil
+        }
+        return UIAction(
             title: Strings.pickFromTenor,
             image: UIImage(systemName: "play.square.stack"),
             attributes: [],

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
@@ -20,12 +20,17 @@ final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDel
             UIMenu(options: [.displayInline], children: [
                 menu.makeCameraAction(delegate: self),
                 makeDocumentPickerAction(from: viewController)
-            ]),
-            UIMenu(options: [.displayInline], children: [
-                menu.makeStockPhotos(blog: blog, delegate: self),
-                menu.makeFreeGIFAction(blog: blog, delegate: self)
             ])
         ]
+        let freeMediaActions: [UIAction] = [
+            menu.makeStockPhotos(blog: blog, delegate: self),
+            menu.makeFreeGIFAction(blog: blog, delegate: self)
+        ].compactMap { $0 }
+        if !freeMediaActions.isEmpty {
+            children += [
+                UIMenu(options: [.displayInline], children: freeMediaActions)
+            ]
+        }
         if let quotaUsageDescription = blog.quotaUsageDescription {
             children += [
                 UIAction(subtitle: quotaUsageDescription, handler: { _ in })


### PR DESCRIPTION
Fixes #22761 

## Description
Updates site media menu to only display the "Free photo library" and the "Free GIF library" options if the blog supports those features.

## How to check
- Create a self-hosted site via the Jurassic Ninja tool
- Don't connect your WP.com account
- Add the self-hosted site on the app
- Go to Media > + button
- **Verify**: the stock photos option isn't displayed
- On web, connect your self-hosted site to your WP.com account
- Go to Media > + button
- **Verify**: the stock photos option is displayed

### JP disconnected
https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/c50fa61c-b416-4d6b-b05f-c8e93f56b056

### JP connected
https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/3d63931d-e6cc-4ae3-b7e8-d10a86368133

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
