### PR TITLE
Reader: Fix navigation button animation issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
@@ -39,24 +39,29 @@ struct ReaderNavigationButton: View {
     }
 
     private func menuLabel(for item: ReaderTabItem) -> some View {
-        HStack(spacing: 4.0) {
-            item.image
-                .frame(width: 24.0, height: 24.0)
-                .foregroundColor(Colors.primary)
-            Text(item.title)
-                .foregroundStyle(Colors.primary)
-                .font(.subheadline.weight(.semibold))
-                .minimumScaleFactor(0.1) // prevents the text from truncating while in transition.
-                .frame(minHeight: 24.0)
-            Image("reader-menu-chevron-down")
-                .frame(width: 16.0, height: 16.0)
-                .foregroundColor(Colors.primary)
+        /// There's a bug/unexpected behavior with how `SwiftUI.Menu`'s label "twitches" when it's animated.
+        /// Using `ZStack` is a hack to prevent the "container" view from twitching during animation.
+        ZStack {
+            // This is used for the background component.
+            Capsule().fill(Colors.background)
+
+            HStack(spacing: 4.0) {
+                item.image
+                    .frame(width: 24.0, height: 24.0)
+                    .foregroundColor(Colors.primary)
+                Text(item.title)
+                    .foregroundStyle(Colors.primary)
+                    .font(.subheadline.weight(.semibold))
+                    .minimumScaleFactor(0.1) // prevents the text from truncating while in transition.
+                    .frame(minHeight: 24.0)
+                Image("reader-menu-chevron-down")
+                    .frame(width: 16.0, height: 16.0)
+                    .foregroundColor(Colors.primary)
+            }
+            .padding(.vertical, 6.0)
+            .padding(.leading, item.image == nil ? 16.0 : 8.0)
+            .padding(.trailing, 12.0)
         }
-        .padding(.vertical, 6.0)
-        .padding(.leading, item.image == nil ? 16.0 : 8.0)
-        .padding(.trailing, 12.0)
-        .background(Colors.background)
-        .clipShape(Capsule())
     }
 
     private func menuButton(for item: ReaderTabItem) -> some View {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -30,6 +30,7 @@ struct ReaderNavigationMenu: View {
                 HStack {
                     ReaderNavigationButton(viewModel: viewModel)
                         .frame(maxHeight: .infinity)
+                        .zIndex(1)
                         .animation(.easeInOut, value: viewModel.selectedItem)
                     streamFilterView
                     // add some empty space so that the last filter chip doesn't get covered by the gradient mask.


### PR DESCRIPTION
Refs #22770 

This addresses two issues:

- When transitioning to "Subscriptions", the navigation button starts from a shifted position.
- The filter chip buttons should animate from below the navigation button.

The first one is particularly tricky. It turned out that animating the label component of `SwiftUI.Menu` makes it twitch. The workaround is to separate the container capsule view and its contents with a `ZStack` container.

• | Before | After
-|-|-
Filter chip animates from below the navigation button | <img width="487" alt="before-navbar" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/51954591-45fb-40d9-bb3f-00fcebae44da"> | <img width="490" alt="after-navbar" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/dd7633e1-5838-42fc-978b-a8f1c62c8c79">
Navigation button shouldn't twitch during transition | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/7d682d34-2195-4a22-9e38-61e66fac1e1b"> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/78f46392-e0ec-4278-b4da-3a6434ad07d5">

## To test

- Launch the Jetpack app and navigate to the Reader tab.
- Change streams and observe the transition between chips, especially when transitioning to/from "Subscriptions".
- 🔎 Verify that the transitions work as described.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
