### PR TITLE
Post a Slack message after builds have been deployed to TestFlight

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -454,6 +454,22 @@ platform :ios do
     )
   end
 
+  # Send a Slack message to the specified channel
+  #
+  # @param [String] channel The Slack channel to send the message to
+  # @param [String] message The message to send to the channel
+  #
+  def send_slack_message(message:, channel: '#build-and-ship')
+    slack(
+      username: 'WordPress Release Bot',
+      icon_url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',
+      slack_url: get_required_env('SLACK_WEBHOOK'),
+      channel:,
+      message:,
+      default_payloads: []
+    )
+  end
+
   def upload_build_to_app_center(
     name:,
     file:,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -471,8 +471,8 @@ platform :ios do
 
   # Send a Slack message to the specified channel
   #
-  # @param [String] channel The Slack channel to send the message to
   # @param [String] message The message to send to the channel
+  # @param [String] channel The Slack channel to send the message to
   #
   def send_slack_message(message:, channel: '#build-and-ship')
     slack(

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -183,13 +183,22 @@ platform :ios do
     archive_zip_path = File.join(PROJECT_ROOT_FOLDER, 'WordPress.xarchive.zip')
     zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
 
-    version = options[:beta_release] ? build_code_current : release_version_current
-    create_release(
+    build_code = build_code_current
+    release_version = release_version_current
+
+    version = options[:beta_release] ? build_code : release_version
+    release_url = create_release(
       repository: GITHUB_REPO,
       version:,
       release_notes_file_path: WORDPRESS_RELEASE_NOTES_PATH,
       release_assets: archive_zip_path.to_s,
       prerelease: options[:beta_release]
+    )
+
+    send_slack_message(
+      message: <<~MSG
+        :wpicon-blue: :applelogo: WordPress iOS `#{release_version} (#{build_code})` is available for testing and [a GitHub release draft](#{release_url}) has been created.
+      MSG
     )
 
     FileUtils.rm_rf(archive_zip_path)

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -235,6 +235,12 @@ platform :ios do
       project_slug: SENTRY_PROJECT_SLUG_JETPACK,
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
+
+    send_slack_message(
+      message: <<~MSG
+        :jetpack: :applelogo: Jetpack iOS `#{release_version_current} (#{build_code_current})` is available for testing.
+      MSG
+    )
   end
 
   # Builds the "WordPress Internal" app and uploads it to App Center


### PR DESCRIPTION
Example:

<img width="648" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/2671485a-6c5d-4092-a59f-3fa921d9b904">

This will remove the need to manually post messages on every deployment.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.