### PR TITLE
Notifications: Ensure that the section is also within bounds

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -1286,6 +1286,7 @@ private extension NotificationsViewController {
         // ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15370
         guard let indexPath = tableViewHandler.resultsController?.indexPath(forObject: notification),
               indexPath != tableView.indexPathForSelectedRow,
+              0..<tableView.numberOfSections ~= indexPath.section,
               0..<tableView.numberOfRows(inSection: indexPath.section) ~= indexPath.row else {
                   return
               }


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/15368#issuecomment-1982070418, [Sentry](https://a8c.sentry.io/discover/jetpack-ios:07f2de4ba7ce4c3c95d507306b8d3d63/)

As titled, this returns early when the section is out of bounds.

## To test

Referring to the test steps from #17955:

> [!WARNING]
> Note that I've been unable to reproduce the crash, and these steps are based on ad hoc reports and Sentry breadcrumbs. Also, this needs to be tested on a device since it requires interacting with push notifications.

- Open the WordPress app, and minimize it.
- Perform an action (comment, Like, or mention) that triggers a push notification for the Notifications section of the app.
- Tap the push notification.
- 🔍 Verify that the app doesn't crash, and the notification detail is shown correctly.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes are minimal.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Although I couldn't reproduce the crash, I've tried to test the paths that visits the `selectRow` method.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
