### PR TITLE
Improve Unit Tests reliability

### DIFF
--- a/WordPress/WordPressTest/AtomicAuthenticationServiceTests.swift
+++ b/WordPress/WordPressTest/AtomicAuthenticationServiceTests.swift
@@ -51,6 +51,6 @@ class AtomicAuthenticationServiceTests: CoreDataTestCase {
             XCTFail("Can't get the requested auth cookie.")
         }
 
-        waitForExpectations(timeout: TimeInterval(0.1))
+        waitForExpectations(timeout: TimeInterval(0.2))
     }
 }


### PR DESCRIPTION
### The problem

It's been a while since `testGetAuthCookie` started failing some times, requiring Unit Tests retries. At some point, automatic retries was enabled for Unit Tests, what definitely reduced the need to manually hit the retry button on CI but obviously didn't solve the issue. The test started failing more often, though, for the last 28 days, according to Buildkite,[ it has basically failed every run and passing on the automatic retry](https://buildkite.com/organizations/automattic/analytics/suites/wordpress-ios/tests/01862e49-35c7-7051-8b10-0ee22fc9246e?branch=trunk#failed). [This brings the WPiOS Unit Tests suite to 0% reliability](https://buildkite.com/organizations/automattic/analytics/suites/wordpress-ios?branch=trunk).

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/4e213c7c-2459-4444-94eb-35ab228f6fd0)

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/172cf393-16d2-4641-8449-56cf3a81a0d0)

The failure is always the same:
```
Assertion Failure: Asynchronous wait failed: Exceeded timeout of 0.1 seconds, with unfulfilled expectations: "We expect the cookie to be retrieved and decoded fine.".
```

I tried running the test in repetition (100 times) and it didn't have a clean pass. Most times it failed right in the first execution, which makes sense with the CI results.

### The solution

I tried increasing a bit the assertion timeout, from 0.1s to 0.2s, as it didn't look like critical for the test. Interestingly, the test could now pass `100,000` in repetition.

```
Test Case '-[WordPressTest.AtomicAuthenticationServiceTests testGetAuthCookie]' passed (0.002 seconds).
Test Suite 'AtomicAuthenticationServiceTests' passed at 2024-03-12 23:52:20.200.
	 Executed 100000 tests, with 0 failures (0 unexpected) in 182.958 (196.440) seconds
Test Suite 'WordPressTest.xctest' passed at 2024-03-12 23:52:20.209.
	 Executed 100000 tests, with 0 failures (0 unexpected) in 182.958 (196.449) seconds
Test Suite 'Selected tests' passed at 2024-03-12 23:52:20.218.
	 Executed 100000 tests, with 0 failures (0 unexpected) in 182.958 (196.458) seconds
```

Not sure if it will be enough for clean CI execution, but it looks like a good start.

### Testing

Local:
1. Checkout this branch
2. Run `testGetAuthCookie` in repetition mode.

CI:
1. Check a build in Buildkite, [like this one](https://buildkite.com/automattic/wordpress-ios/builds/21014#_). (Ok, we can leave UI  Tests failing out of the scope of this PR, right? 😅 )
2. Unit Tests step should be 🟢 .
3. There shouldn't be a Test annotaion mentioning a `testGetAuthCookie` failure, [like this one from another build](https://buildkite.com/automattic/wordpress-ios/builds/21007#018e3313-ec6a-4a60-9a61-eedcd053af56).


