### PR TITLE
Stats Traffic: Increase number of weeks to fetch for monthly chart

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -743,7 +743,8 @@ private extension SiteStatsPeriodViewModel {
         case .day, .week:
             return 7
         case .month:
-            return 5
+            // 6 to cover all possible weeks that could fall into one month's range
+            return 6
         case .year:
             return 12
         }


### PR DESCRIPTION
More context: p1709642938683799/1709576037.356079-slack-C06BR07TJHK

Long months, such as October 2023 have 6 weeks that fall into one month's range. We should fetch 6 weeks to make sure they are included in the charts. View Model makes sure that the weeks that don't belong to a given month are not shown in a chart.

### To test:

1. Enable Stats Traffic feature flag
2. Open Stats, Traffic
3. Select Month
4. Go through months and confirm that we show all (no more and less) weeks that fall into a provided month's range.

## Regression Notes
1. Potential unintended areas of impact

Couldn't identify any

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)