### PR TITLE
[Unit Tests] Increase testGetAuthCookie timeout to cope with execution time in CI 

### DIFF
--- a/WordPress/WordPressTest/AtomicAuthenticationServiceTests.swift
+++ b/WordPress/WordPressTest/AtomicAuthenticationServiceTests.swift
@@ -51,6 +51,6 @@ class AtomicAuthenticationServiceTests: CoreDataTestCase {
             XCTFail("Can't get the requested auth cookie.")
         }
 
-        waitForExpectations(timeout: TimeInterval(0.2))
+        waitForExpectations(timeout: TimeInterval(5))
     }
 }


### PR DESCRIPTION
This is a follow up PR to #22822.

While a typical test execution time in local stays under 0.2 seconds (0.148s for the first run, averaging 0.002 in subsequent runs), on CI the numbers are a bit worse.

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/42008628/01cc7ef1-d47f-40ac-9a43-a6c979b2575e)

In the last 28 days, the failed runs were generaly over 1s, 95% under 2.63s, but we still got a singe 3.75s run. 

This PR sets the timeout to 5s for this test, which is not too high to compromise the Unit Tests performance.
