### PR TITLE
Reader: Auto-update filter chips when subscriptions are updated

### DIFF
--- a/WordPress/Classes/Models/ReaderTagTopic.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic.swift
@@ -51,4 +51,9 @@ import Foundation
 
         return topic
     }
+
+    @objc func toggleFollowing(_ isFollowing: Bool) {
+        following = isFollowing
+        showInMenu = (following || isRecommended)
+    }
 }

--- a/WordPress/Classes/Models/ReaderTagTopic.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic.swift
@@ -52,6 +52,7 @@ import Foundation
         return topic
     }
 
+    /// Convenience method to update the tag's `following` state and also updates `showInMenu`.
     @objc func toggleFollowing(_ isFollowing: Bool) {
         following = isFollowing
         showInMenu = (following || isRecommended)

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -38,7 +38,12 @@ class FilterProvider: NSObject, Identifiable, Observable, FilterTabBarItem {
         }
     }
 
-    typealias Provider = (Bool, @escaping (Result<[TableDataItem], Error>) -> Void) -> Void
+    /// Closure block that's responsible for populating the items for this `FilterProvider`.
+    ///
+    /// - Parameters:
+    ///     - localOnly: Specifies whether the fetch process should happen locally or remotely.
+    ///     - completion: The closure to be called once the fetching process completes.
+    typealias Provider = (_ localOnly: Bool, _ completion: @escaping (Result<[TableDataItem], Error>) -> Void) -> Void
 
     let accessibilityIdentifier: String
     let cellClass: UITableViewCell.Type

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -40,6 +40,9 @@ class FilterProvider: NSObject, Identifiable, Observable, FilterTabBarItem {
 
     /// Closure block that's responsible for populating the items for this `FilterProvider`.
     ///
+    /// The `localOnly` parameter provides information for the closure on whether the fetch should happen
+    /// locally or remotely, but whether this parameter is honored or not depends on the actual implementation.
+    ///
     /// - Parameters:
     ///     - localOnly: Specifies whether the fetch process should happen locally or remotely.
     ///     - completion: The closure to be called once the fetching process completes.
@@ -104,8 +107,9 @@ class FilterProvider: NSObject, Identifiable, Observable, FilterTabBarItem {
 
 extension FilterProvider: ReaderTopicObserverDelegate {
     func readerTopicDidChange() {
-        // Important: We should ensure that the data is only refreshed from local store.
-        // Pulling the data from remote will cause the observer to react and trigger another refresh.
+        // TODO: Revisit and think of better approach.
+        // IMPORTANT — This is a workaround. At this stage, we need to ensure that the data is *only* refreshed
+        // from the local store, because pulling from remote will trigger the observer again and causing a loop!
         refresh(localOnly: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/ReaderTopicChangeObserver.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/ReaderTopicChangeObserver.swift
@@ -1,0 +1,42 @@
+import CoreData
+
+// MARK: - Protocols
+
+protocol ReaderTopicObserverDelegate: NSObjectProtocol {
+    func readerTopicDidChange()
+}
+
+protocol ReaderTopicObserving: NSObjectProtocol {
+    var delegate: ReaderTopicObserverDelegate? { get set }
+}
+
+// MARK: - Concrete Class
+
+/// Observes model changes to `Topic` and notifies the delegate.
+/// The type `Topic` is restricted to `ReaderAbstractTopic` and its subclasses.
+///
+class ReaderTopicChangeObserver<Topic: ReaderAbstractTopic>: NSObject, ReaderTopicObserving {
+    weak var delegate: ReaderTopicObserverDelegate?
+
+    init(delegate: ReaderTopicObserverDelegate? = nil) {
+        self.delegate = delegate
+        super.init()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleObjectsChange),
+                                               name: .NSManagedObjectContextObjectsDidChange,
+                                               object: nil)
+    }
+
+    @objc private func handleObjectsChange(_ notification: Foundation.Notification) {
+        // Skip if `Topic` is not included in the notification payload.
+        guard let updated = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>,
+              updated.firstIndex(where: { $0 is Topic }) != nil else {
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            self?.delegate?.readerTopicDidChange()
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Filter/ReaderTopicChangeObserver.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/ReaderTopicChangeObserver.swift
@@ -29,9 +29,14 @@ class ReaderTopicChangeObserver<Topic: ReaderAbstractTopic>: NSObject, ReaderTop
     }
 
     @objc private func handleObjectsChange(_ notification: Foundation.Notification) {
-        // Skip if `Topic` is not included in the notification payload.
-        guard let updated = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>,
-              updated.firstIndex(where: { $0 is Topic }) != nil else {
+        // Check for objects with type `Topic` within the Notification.
+        let notificationContainsTopic = [notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>,
+                                         notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject>]
+                                     .compactMap { set in set?.firstIndex(where: { $0 is Topic }) }
+                                     .count > 0
+
+        // Skip if `Topic` is not included at all in the notification payload.
+        guard notificationContainsTopic else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -66,7 +66,7 @@ class ReaderManageScenePresenter {
         }
 
         self.selectedSection = selectedSection
-        let navigationController = UINavigationController(rootViewController: makeViewController(onDismiss: completion))
+        let navigationController = UINavigationController(rootViewController: makeViewController())
         presentedViewController = navigationController
         viewController.present(navigationController, animated: true, completion: nil)
 
@@ -85,7 +85,7 @@ extension ReaderManageScenePresenter: ScenePresenter {
 // MARK: - Private helpers
 
 private extension ReaderManageScenePresenter {
-    func makeViewController(onDismiss: (() -> Void)? = nil) -> TabbedViewController {
+    func makeViewController() -> TabbedViewController {
         let tabbedItems = sections.map({ item in
             return item.tabbedItem
         })
@@ -95,7 +95,6 @@ private extension ReaderManageScenePresenter {
                 return
             }
 
-            onDismiss?()
             self.delegate?.didDismiss(presenter: self)
             NotificationCenter.default.post(name: .readerManageControllerWasDismissed, object: self)
             WPAnalytics.track(.readerManageViewDismissed)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -226,15 +226,11 @@ extension ReaderTabViewModel {
 
     func presentManage(filter: FilterProvider, from: UIViewController) {
         guard let managePresenter = settingsPresenter as? ReaderManageScenePresenter else {
-            settingsPresenter.present(on: from, animated: true, completion: nil)
+          settingsPresenter.present(on: from, animated: true, completion: nil)
             return
         }
 
-        managePresenter.present(on: from, selectedSection: filter.section, animated: true) {
-            // on completion, ensure that the FilterProvider is refreshed so the latest changes
-            // can be reflected on the UI.
-            filter.refresh()
-        }
+        managePresenter.present(on: from, selectedSection: filter.section, animated: true, completion: nil)
     }
 
     func didTapStreamFilterButton(with filter: FilterProvider) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5692,6 +5692,8 @@
 		FEF4DC5528439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEF4DC5628439357003806BE /* ReminderScheduleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */; };
 		FEF7F3402AFEA0C200F793FC /* blogging-prompts-bloganuary.json in Resources */ = {isa = PBXBuildFile; fileRef = FEF7F33F2AFEA0C200F793FC /* blogging-prompts-bloganuary.json */; };
+		FEF9A74B2BA1CF370014045E /* ReaderTopicChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF9A74A2BA1CF370014045E /* ReaderTopicChangeObserver.swift */; };
+		FEF9A74C2BA1CF370014045E /* ReaderTopicChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF9A74A2BA1CF370014045E /* ReaderTopicChangeObserver.swift */; };
 		FEFA263E26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */; };
 		FEFA263F26C5AE9A009CCB7E /* ShareAppContentPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8226C3BD0900B69DE4 /* ShareAppContentPresenter.swift */; };
 		FEFA264026C5AE9E009CCB7E /* ShareAppTextActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8426C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift */; };
@@ -9551,6 +9553,7 @@
 		FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailNewHeaderView.swift; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
 		FEF7F33F2AFEA0C200F793FC /* blogging-prompts-bloganuary.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blogging-prompts-bloganuary.json"; sourceTree = "<group>"; };
+		FEF9A74A2BA1CF370014045E /* ReaderTopicChangeObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopicChangeObserver.swift; sourceTree = "<group>"; };
 		FEFA263D26C58427009CCB7E /* ShareAppTextActivityItemSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSourceTests.swift; sourceTree = "<group>"; };
 		FEFA6AC22A83F4BE004EE5E6 /* PostHelper+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostHelper+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEFA6AC52A86824A004EE5E6 /* PostHelperJetpackSocialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHelperJetpackSocialTests.swift; sourceTree = "<group>"; };
@@ -18126,6 +18129,7 @@
 				F5E29037243FAB0300C19CA5 /* FilterTableData.swift */,
 				837779B02B55D44B00FDA1AC /* EmptyFilterView.swift */,
 				837779B32B55E93800FDA1AC /* EmptyFilterViewModel.swift */,
+				FEF9A74A2BA1CF370014045E /* ReaderTopicChangeObserver.swift */,
 			);
 			path = Filter;
 			sourceTree = "<group>";
@@ -23140,6 +23144,7 @@
 				E1B912831BB01047003C25B9 /* PeopleRoleBadgeLabel.swift in Sources */,
 				40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */,
 				E16FB7E11F8B5D7D0004DD9F /* WebViewControllerConfiguration.swift in Sources */,
+				FEF9A74B2BA1CF370014045E /* ReaderTopicChangeObserver.swift in Sources */,
 				98B3FA8421C05BDC00148DD4 /* ViewMoreRow.swift in Sources */,
 				8BADF16524801BCE005AD038 /* ReaderWebView.swift in Sources */,
 				8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */,
@@ -24826,6 +24831,7 @@
 				FABB22A12602FC2C00C8785C /* MediaHost+Blog.swift in Sources */,
 				FABB22A22602FC2C00C8785C /* PlanListRow.swift in Sources */,
 				FABB22A32602FC2C00C8785C /* SiteCreationWizard.swift in Sources */,
+				FEF9A74C2BA1CF370014045E /* ReaderTopicChangeObserver.swift in Sources */,
 				FA4B203029A619130089FE68 /* BlazeFlowCoordinator.swift in Sources */,
 				C7AFF875283C0ADC000E01DF /* UIApplication+Helpers.swift in Sources */,
 				FABB22A52602FC2C00C8785C /* SignupEpilogueViewController.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -170,11 +170,12 @@ extension ReaderTabViewModelTests {
 
     private func makeFilterProvider() -> FilterProvider {
         return FilterProvider(title: { _ in "Test" },
-                       accessibilityIdentifier: "Test",
-                       cellClass: UITableViewCell.self,
-                       reuseIdentifier: "Cell",
-                       emptyTitle: "Test",
-                       section: .sites) { completion in
+                              accessibilityIdentifier: "Test",
+                              cellClass: UITableViewCell.self,
+                              reuseIdentifier: "Cell",
+                              emptyTitle: "Test",
+                              emptyActionTitle: "Test",
+                              section: .sites) { _, completion in
             completion(.success([]))
         }
     }

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -174,7 +174,6 @@ extension ReaderTabViewModelTests {
                               cellClass: UITableViewCell.self,
                               reuseIdentifier: "Cell",
                               emptyTitle: "Test",
-                              emptyActionTitle: "Test",
                               section: .sites) { _, completion in
             completion(.success([]))
         }


### PR DESCRIPTION
Refs #22601

This adds an observer class, `ReaderTopicChangeObserver,` to the `FilterProvider`, which will notify the provider whenever Core Data updates the related model (such as `ReaderTagTopic` or `ReaderSiteTopic`). However, with this, I'd need to differentiate the data fetching method (i.e., locally or remotely) because fetching the data remotely will cause the observer to react and, in turn, trigger the fetching process again—causing an infinite loop!

It's not ideal since the `Provider` implementation needs to respect the `localOnly` parameter, which makes it a bit prone to error. Still, I'll note this down for future improvement since we will need to keep `FilterProvider` as context-free as possible. 

In addition, through https://github.com/wordpress-mobile/WordPress-iOS/commit/0887244a717648a3269d13ddaf612b47b8c33ccd, this also resolves a bug(?) where the tag's `following` property is not set to `true` after subscribing to it from the Manage flow. This little issue made it look like the observer was not working properly... 😅 

## To test

### Case 1: Manage flow

- Launch the Jetpack app and move to the Reader tab.
- Switch to the Subscriptions stream.
- Tap the `Tags` filter chip, and then Edit.
- Add a new tag, and tap Done.
- 🔎 Verify that the new tag appears on the filter sheet.
- 🔎 Verify that the number on the tag filter chip is updated.
- Tap Edit again.
- Remove the tag that was added previously, and tap Done.
- 🔎 Verify that the tag is removed from the filter sheet.
- 🔎 Verify that the number on the tag filter chip is updated.
- 🔁 Repeat the steps above for the `Blogs` filter chip.

### Case 2: Search flow

- Launch the Jetpack app and move to the Reader tab.
- Switch to the Subscriptions stream.
- Tap on the Search icon, and search for a site (e.g., "Matt Mullenweg")
- Select the site on the `Blogs` tab, and tap Subscribe.
- Return to the Reader stream.
- 🔎 Verify that the number on the filter chip is updated.

### Case 3: Universal Link

- Launch the Jetpack app and move to the Reader tab.
- Switch to the Subscriptions stream.
- Tap a universal link to a post detail from an unsubscribed blog.
  - 💡 **Tip:** If you're on a simulator, from the terminal you can simulate a deeplink by entering:
    ```
    xcrun simctl openurl booted '<universal-link-post-here>'
    ```
- Tap `Subscribe` on the top right of Post Detail.
- Tap back to return to the Reader stream.
- 🔎 Verify that the number on the filter chip is updated.

## Regression Notes
1. Potential unintended areas of impact
The change is isolated to the `FilterProvider` which is only used in the Reader navigation bar, but may have risk since it now subscribes to Core Data changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
