### PR TITLE
Fix dynamic card icons display issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/DynamicDashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/DynamicDashboardCard.swift
@@ -68,9 +68,17 @@ struct DynamicDashboardCard: View {
     var rowsVStack: some View {
         VStack(spacing: Length.Padding.single) {
             ForEach(input.rows) { row in
-                HStack(alignment: .top, spacing: Length.Padding.split) {
+                HStack(alignment: .center, spacing: Length.Padding.split) {
                     if let imageURL = row.imageURL {
-                        AsyncImage(url: imageURL)
+                        AsyncImage(url: imageURL) { phase in
+                            switch phase {
+                            case .success(let image):
+                                image
+                                    .resizable()
+                            default:
+                                Color.DS.Background.secondary
+                            }
+                        }
                             .frame(
                                 width: Constants.rowImageDiameter,
                                 height: Constants.rowImageDiameter
@@ -144,12 +152,12 @@ struct DynamicDashboardCard_Previews: PreviewProvider {
                     .init(
                         title: "Title first",
                         description: "Description first",
-                        imageURL: URL(string: "https://i.pickadummy.com/index.php?imgsize=48x48")!
+                        imageURL: URL(string: "https://mobiledotblog.files.wordpress.com/2024/03/perf-icon.png")!
                     ),
                     .init(
                         title: "Title second",
                         description: "Description second",
-                        imageURL: URL(string: "https://i.pickadummy.com/index.php?imgsize=48x48")!
+                        imageURL: nil
                     )
                 ],
                 action: .init(title: "Action button", callback: {


### PR DESCRIPTION
Ref p1710368771832349/1710273046.671249-slack-C3EA6SMFH

## Description

This PR addresses the issue where dynamic card icons of exactly 48x48 pixels looked blurry on high-resolution displays. The solution implemented allows for uploading icons at 2x or 3x (i.e., 96x96 or 144x144 pixels) the intended display size. These larger icons are then scaled down to fit the 48x48 pixel frame, ensuring they appear sharp and clear across all displays.

| Before | After |
| ------ | ------ | 
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/6933fdb3-8cb1-4b7f-9e65-4463ed02422d) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/e1fc2403-eca2-4e44-b11b-7818ec70e061) |

## Test Instructions

SwiftUI previews don't work when the Jetpack target is selected. My workaround is to copy the SwiftUI file to a different module (e.g. Design System):

1. Copy `DynamicDashboardCard.swift` to Design System module.
2. Xcode will complain that `AppConfiguration.isJetpack` doesn't exist, replacing it with `true` should fix the issue.
3. Wait for the preview to render
4. The card should have 2 rows, the 1st row has an icon, and the 2nd row does not
5. Verify the 1st row icon looks good.

## Regression Notes
1. Potential unintended areas of impact
None.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

6. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.