### PR TITLE
Add a workaround for an issue with RN not rendering local files without a file extension

### DIFF
--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -70,6 +70,8 @@ typedef NS_ENUM(NSUInteger, MediaType) {
 /**
  Local file URL for a preprocessed **large** thumbnail that can be used for
  a full-screen presentation.
+
+ - warning: Deprecated! Use ``MediaImageService`` to access the thumbnails.
  */
 @property (nonatomic, strong, nullable) NSURL *absoluteThumbnailLocalURL;
 


### PR DESCRIPTION
To test:

- Add an image to the Gutenberg editor
- Verify that the thumbnail got displayed _before_ image got fully uploaded

## Regression Notes
1. Potential unintended areas of impact: Gutenberg Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
