### PR TITLE
Compose a user agent instead of using WKWebView

### DIFF
--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -17,10 +17,10 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
         [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:@{WPUserAgentKeyUserAgent: @(0)}];
         
         if ([NSThread isMainThread]){
-            _defaultUserAgent = [WKWebView userAgent];
+            _defaultUserAgent = [self webViewUserAgent];
         } else {
             dispatch_sync(dispatch_get_main_queue(), ^{
-                _defaultUserAgent = [WKWebView userAgent];
+                _defaultUserAgent = [self webViewUserAgent];
             });
         }
         if (storeCurrentUA) {

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -15,14 +15,9 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
         NSDictionary * registrationDomain = [[UserPersistentStoreFactory userDefaultsInstance] volatileDomainForName:NSRegistrationDomain];
         NSString *storeCurrentUA = [registrationDomain objectForKey:WPUserAgentKeyUserAgent];
         [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:@{WPUserAgentKeyUserAgent: @(0)}];
-        
-        if ([NSThread isMainThread]){
-            _defaultUserAgent = [self webViewUserAgent];
-        } else {
-            dispatch_sync(dispatch_get_main_queue(), ^{
-                _defaultUserAgent = [self webViewUserAgent];
-            });
-        }
+
+        _defaultUserAgent = [self webViewUserAgent];
+
         if (storeCurrentUA) {
             [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:@{WPUserAgentKeyUserAgent: storeCurrentUA}];
         }

--- a/WordPress/Classes/Utility/WPUserAgent.swift
+++ b/WordPress/Classes/Utility/WPUserAgent.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension WPUserAgent {
+
+    /// Returns a user agent string similar to (but may not exactly match) the one used in `WKWebView`.
+    @objc static var webViewUserAgent: String {
+        // Examples user agent strings from `WKWebView` in iOS simulators:
+        //
+        // ## iPhone 15 Pro (iOS 17.2)
+        // Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
+        //
+        // ## iPad Pro (iOS 17.0.1)
+        // Mozilla/5.0 (iPad; CPU OS 17_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
+        //
+        // Based on the WebKit implementation[^1], most of the components are hardcoded, and there are only a couple of dynamic components:
+        // 1. Device model. i.e. iPhone/iPad
+        // 2. OS name and version. i.e. iPhone OS 17_2
+        //
+        // Please note the "Mobile/15E148" part is WKWebView's default and hardcoded "application name"[^2].
+        //
+        // [^1]: https://github.com/WebKit/WebKit/blob/5fbb03ee1c6210c79779d6fa1a9e7290daa746d1/Source/WebCore/platform/ios/UserAgentIOS.mm#L88-L113
+        // [^2]: https://github.com/WebKit/WebKit/blob/492140d27dbe/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm#L612
+
+        let device = UIDevice.current
+
+        let deviceModel = device.model // Example: "iPhone"
+        var osName = device.systemName // Example: "iPhone OS"
+        let osVersion = device.systemVersion.replacingOccurrences(of: ".", with: "_") // Example: "17_2"
+
+        // WKWebView on iPad uses a static user agent.
+        // https://github.com/WebKit/WebKit/blob/6a053cfb431bd70d5017ba881a39f004e52effc2/Source/WebCore/platform/ios/UserAgentIOS.mm#L97
+        if device.userInterfaceIdiom == .pad {
+            osName = "OS"
+        }
+
+        // Use "iPhone OS" instead of "iOS", because that's what WKWebView uses.
+        if osName == "iOS" {
+            osName = "iPhone OS"
+        }
+
+        return "Mozilla/5.0 (\(deviceModel); CPU \(osName) \(osVersion) like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1351,6 +1351,8 @@
 		4A5DE7382B0D511900363171 /* PageTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DE7372B0D511900363171 /* PageTree.swift */; };
 		4A5DE7392B0D511900363171 /* PageTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5DE7372B0D511900363171 /* PageTree.swift */; };
 		4A5FC0462B97BB4B0067F525 /* UIElementNotFoundError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5FC0452B97BB4B0067F525 /* UIElementNotFoundError.swift */; };
+		4A690C122BA3F4AD00A8E0C5 /* WPUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A690C112BA3F4AD00A8E0C5 /* WPUserAgent.swift */; };
+		4A690C132BA3F4AD00A8E0C5 /* WPUserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A690C112BA3F4AD00A8E0C5 /* WPUserAgent.swift */; };
 		4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */; };
 		4A76A4BD29D43BFD00AABF4B /* CommentService+MorderationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */; };
 		4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */; };
@@ -6999,6 +7001,7 @@
 		4A5598842B05AC180083C220 /* PagesListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesListTests.swift; sourceTree = "<group>"; };
 		4A5DE7372B0D511900363171 /* PageTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTree.swift; sourceTree = "<group>"; };
 		4A5FC0452B97BB4B0067F525 /* UIElementNotFoundError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIElementNotFoundError.swift; sourceTree = "<group>"; };
+		4A690C112BA3F4AD00A8E0C5 /* WPUserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPUserAgent.swift; sourceTree = "<group>"; };
 		4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+LikesTests.swift"; sourceTree = "<group>"; };
 		4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+MorderationTests.swift"; sourceTree = "<group>"; };
 		4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-success.json"; sourceTree = "<group>"; };
@@ -13932,6 +13935,7 @@
 				5D6C4B071B603E03005E3C43 /* WPTableViewHandler.m */,
 				594DB2931AB891A200E2E456 /* WPUserAgent.h */,
 				594DB2941AB891A200E2E456 /* WPUserAgent.m */,
+				4A690C112BA3F4AD00A8E0C5 /* WPUserAgent.swift */,
 				3F2656A025AF4DFA0073A832 /* AppLocalizedString.swift */,
 				85B125431B02937E008A3D95 /* UIAlertControllerProxy.h */,
 				85B125441B02937E008A3D95 /* UIAlertControllerProxy.m */,
@@ -22255,6 +22259,7 @@
 				F45EB5012B865AF4004E9053 /* NotificationTableViewCell.swift in Sources */,
 				1717139F265FE59700F3A022 /* ButtonStyles.swift in Sources */,
 				C3FF78E828354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */,
+				4A690C122BA3F4AD00A8E0C5 /* WPUserAgent.swift in Sources */,
 				803BB989295B80D300B3F6D6 /* RootViewPresenter+EditorNavigation.swift in Sources */,
 				B58C4ECA207C5E1A00E32E4D /* UIImage+Assets.swift in Sources */,
 				E6158ACA1ECDF518005FA441 /* LoginEpilogueUserInfo.swift in Sources */,
@@ -25608,6 +25613,7 @@
 				FABB24EB2602FC2C00C8785C /* NoResultsViewController.swift in Sources */,
 				FAD7625C29ED780B00C09583 /* JSONDecoderExtension.swift in Sources */,
 				FABB24EC2602FC2C00C8785C /* ActionDispatcherFacade.swift in Sources */,
+				4A690C132BA3F4AD00A8E0C5 /* WPUserAgent.swift in Sources */,
 				FABB24ED2602FC2C00C8785C /* ReaderSavedPostUndoCell.swift in Sources */,
 				FABB24EE2602FC2C00C8785C /* Suggestion.swift in Sources */,
 				FABB24EF2602FC2C00C8785C /* ShareNoticeConstants.swift in Sources */,

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -29,6 +29,31 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     XCTAssertEqualObjects([WPUserAgent wordPressUserAgent], expectedUserAgent);
 }
 
+- (NSRegularExpression *)webkitUserAgentRegex
+{
+    NSError *error = nil;
+    NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:@"^Mozilla/5\\.0 \\([a-zA-Z]+; CPU [\\sa-zA-Z]+ [_0-9]+ like Mac OS X\\) AppleWebKit/605\\.1\\.15 \\(KHTML, like Gecko\\) Mobile/15E148$" options:0 error:&error];
+    XCTAssertNil(error);
+    return regex;
+}
+
+- (void)testUserAgentFormat
+{
+    NSRegularExpression *regex = [self webkitUserAgentRegex];
+    NSString *userAgent = [WPUserAgent webViewUserAgent];
+    XCTAssertEqual([regex numberOfMatchesInString:userAgent options:0 range:NSMakeRange(0, userAgent.length)], 1);
+}
+
+// If this test fails, it may mean `WKWebView` uses a user agent with an unexpected format (see `webkitUserAgentRegex`)
+// and we may need to adjust `UserAgent.webkitUserAgent`'s implementation to match `WKWebView`'s user agent.
+- (void)testWKWebViewUserAgentFormat
+{
+    NSRegularExpression *regex = [self webkitUserAgentRegex];
+    // Please note: WKWebView's user agent may be different on different test device types.
+    NSString *userAgent = [self currentUserAgentFromWebView];
+    XCTAssertEqual([regex numberOfMatchesInString:userAgent options:0 range:NSMakeRange(0, userAgent.length)], 1);
+}
+
 - (void)testUseWordPressUserAgentInWebViews
 {
     NSString *defaultUA = [WPUserAgent defaultUserAgent];


### PR DESCRIPTION
Creating a `WKWebView` to get user agent has a negative impact on app launch performance. The same changes was made to woo a couple of weeks ago in https://github.com/woocommerce/woocommerce-ios/pull/12123.

See the code comment for full implementation details.

## Regression Notes
1. Potential unintended areas of impact
None.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

4. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: N/A