### PR TITLE
[Hack Week] Publishing flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostNoticePublishSuccessView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticePublishSuccessView.swift
@@ -1,0 +1,93 @@
+import Foundation
+import SwiftUI
+import DesignSystem
+
+// TODO: add l10n
+struct PostNoticePublishSuccessView: View {
+    let post: AbstractPost
+    let onDoneTapped: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 33) {
+            Spacer()
+
+            HStack(alignment: .center, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Post published!")
+                        .font(.subheadline)
+
+                    Text(post.titleForDisplay())
+                        .font(.title3.weight(.semibold))
+
+                    Button(action: {
+                        // TODO: action for viewing
+                    }, label: {
+                        HStack {
+                            // TODO: cut in the middle
+                            let domain = post.blog.primaryDomainAddress
+                            if !domain.isEmpty {
+                                Text("View on \(domain)")
+                            } else {
+                                Text("View")
+                            }
+                            Image("icon-post-actionbar-view")
+                        }
+                        .font(.subheadline)
+                        .lineLimit(1)
+                    })
+                    .tint(.secondary)
+                }
+
+                Spacer()
+
+                Image("post-published")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 90)
+            }
+
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Get more traffic:")
+                HStack {
+                    Button(action: {}, label: {
+                        HStack(alignment: .center, spacing: 4) {
+                            Image(systemName: "square.and.arrow.up")
+                            Text("Share post")
+                        }
+                    })
+                    Button(action: {}, label: {
+                        HStack(alignment: .center) {
+                            Image("icon-blaze").renderingMode(.template)
+                            Text("Promote with Blaze")
+                        }
+                    })
+                }
+            }
+            .buttonStyle(PublishSuccessSecondaryButtonStyle())
+
+            Spacer()
+
+            // TOOD: repalce isJetpack
+            DSButton(title: "Done", style: .init(emphasis: .primary, size: .large, isJetpack: true), action: onDoneTapped)
+        }
+        .dynamicTypeSize(.medium ... .accessibility3)
+        .padding()
+        .navigationBarBackButtonHidden()
+    }
+}
+
+private struct PublishSuccessSecondaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(minHeight: 24)
+            .lineLimit(1)
+            .font(.subheadline.weight(.medium))
+            .tint(configuration.isPressed ? .secondary : .primary)
+            .padding(EdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10))
+            .foregroundStyle(.tint)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(.tertiary, lineWidth: 1)
+            )
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -475,8 +475,16 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         setLoading(true)
         Task {
             do {
+                // TODO: check that we are sending correct post instance
+                let original = post.original ?? post
                 try await PostCoordinator.shared._publish(post)
-                getCompletion()?(.published)
+                // TODO: remove alerts & cleanup
+                // TODO: hide navigation button
+                let view = PostNoticePublishSuccessView(post: original) {
+                    self.getCompletion()?(.published)
+                }
+                let host = UIHostingController(rootView: view)
+                navigationController?.pushViewController(host, animated: true)
             } catch {
                 setLoading(false)
                 publishButtonViewModel.state = .default

--- a/WordPress/Resources/AppImages.xcassets/post-published.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/post-published.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "post-publihsed.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WordPress/Resources/AppImages.xcassets/post-published.imageset/post-publihsed.svg
+++ b/WordPress/Resources/AppImages.xcassets/post-published.imageset/post-publihsed.svg
@@ -1,0 +1,24 @@
+<svg fill="none" height="266" viewBox="0 0 214 266" width="214" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<linearGradient id="a" gradientUnits="userSpaceOnUse" x1="181.5" x2="20.5" y1="210.5" y2="271">
+		<stop offset="0" stop-color="#c4c4c5"/>
+		<stop offset=".62652" stop-color="#dedede"/>
+	</linearGradient>
+	<linearGradient id="b" gradientUnits="userSpaceOnUse" x1="186" x2="189" y1="12" y2="212">
+		<stop offset="0" stop-color="#4b4f52"/><stop offset="1" stop-opacity="0"/>
+	</linearGradient>
+	<path d="m115.221 3.99979 85.844 42.70981-19.922 4.185-7.913 19.4894-.408-18.4514-26.419 1.5475z" stroke="#4b4f52" stroke-linecap="round" stroke-width="2.8"/>
+	<g stroke-linecap="square">
+		<g stroke="#4b4f52">
+			<path d="m128.804 15.1743 43.696 35.5544" stroke-width="2.4"/>
+			<path d="m159.057 53.3097 13.394 15.4395" stroke-linejoin="bevel" stroke-width="2.6"/>
+			<path d="m177.169 47.4566-25.566-17.3041" stroke-width="2.2"/>
+		</g>
+		<path d="m185.762 88.2423c24.238 55.7577 14 138.4997-24.5 141.9997-23.85 3.692-43.329-39.323-57.733-37.094-14.4041 2.23-14.2834 44.944-35.3068 34.252-21.0234-10.691-28.0841 33.788-45.4862 36.481" stroke="url(#a)" stroke-width="3"/>
+		<path d="m185.762 88.2423c24.238 55.7577 14 138.4997-24.5 141.9997-23.85 3.692-43.329-39.323-57.733-37.094-14.4041 2.23-14.2834 44.944-35.3068 34.252-21.0234-10.691-28.0841 33.788-45.4862 36.481" stroke="url(#b)" stroke-opacity=".5" stroke-width="3"/>
+	</g>
+	<circle cx="49.2617" cy="232.742" fill="#7f858a" r="2" stroke="#7f858a" stroke-width="3"/>
+	<g fill="#fffffe">
+		<circle cx="118.762" cy="201.242" r="3.75" stroke="#6e7378" stroke-width="2.5"/>
+		<circle cx="199" cy="160.742" r="6" stroke="#4b4f52" stroke-width="3"/>
+	</g>
+</svg>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -465,6 +465,8 @@
 		0C391E612A3002950040EA91 /* BlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* BlazeCampaignStatusView.swift */; };
 		0C391E622A3002950040EA91 /* BlazeCampaignStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E602A3002950040EA91 /* BlazeCampaignStatusView.swift */; };
 		0C391E642A312DB20040EA91 /* BlazeCampaignViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C391E632A312DB20040EA91 /* BlazeCampaignViewModelTests.swift */; };
+		0C3C50422BA3A024002A37B4 /* PostNoticePublishSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3C50412BA3A024002A37B4 /* PostNoticePublishSuccessView.swift */; };
+		0C3C50432BA3A024002A37B4 /* PostNoticePublishSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C3C50412BA3A024002A37B4 /* PostNoticePublishSuccessView.swift */; };
 		0C5751102B011468001074E5 /* RemoteConfigDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */; };
 		0C5751112B011468001074E5 /* RemoteConfigDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */; };
 		0C63266F2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */; };
@@ -6229,6 +6231,7 @@
 		0C391E5D2A2FE5350040EA91 /* DashboardBlazeCampaignView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignView.swift; sourceTree = "<group>"; };
 		0C391E602A3002950040EA91 /* BlazeCampaignStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignStatusView.swift; sourceTree = "<group>"; };
 		0C391E632A312DB20040EA91 /* BlazeCampaignViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignViewModelTests.swift; sourceTree = "<group>"; };
+		0C3C50412BA3A024002A37B4 /* PostNoticePublishSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticePublishSuccessView.swift; sourceTree = "<group>"; };
 		0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDebugView.swift; sourceTree = "<group>"; };
 		0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergFilesAppMediaSourceTests.swift; sourceTree = "<group>"; };
 		0C6C4CCF2A4F0A000049E762 /* BlazeCampaignsStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStreamTests.swift; sourceTree = "<group>"; };
@@ -12598,6 +12601,7 @@
 				43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */,
 				174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */,
 				170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */,
+				0C3C50412BA3A024002A37B4 /* PostNoticePublishSuccessView.swift */,
 				F16C35DB23F3F78E00C81331 /* AutoUploadMessageProvider.swift */,
 				F16C35D923F3F76C00C81331 /* PostAutoUploadMessageProvider.swift */,
 				8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */,
@@ -21756,6 +21760,7 @@
 				177074851FB209F100951A4A /* CircularProgressView.swift in Sources */,
 				3F8B45A9292C1F2C00730FA4 /* DashboardMigrationSuccessCell.swift in Sources */,
 				8B5E1DD827EA5929002EBEE3 /* PostCoordinator+Dashboard.swift in Sources */,
+				0C3C50422BA3A024002A37B4 /* PostNoticePublishSuccessView.swift in Sources */,
 				98458CB821A39D350025D232 /* StatsNoDataRow.swift in Sources */,
 				FE1E20152A47042500CE7C90 /* PublicizeInfo+CoreDataProperties.swift in Sources */,
 				3234BB172530DFCA0068DA40 /* ReaderTableCardCell.swift in Sources */,
@@ -25359,6 +25364,7 @@
 				08A250F928D9E87600F50420 /* CommentDetailInfoViewController.swift in Sources */,
 				FABB243E2602FC2C00C8785C /* ReaderStreamViewController+Helper.swift in Sources */,
 				FABB243F2602FC2C00C8785C /* ReaderAbstractTopic.swift in Sources */,
+				0C3C50432BA3A024002A37B4 /* PostNoticePublishSuccessView.swift in Sources */,
 				FABB24402602FC2C00C8785C /* PostService+UnattachedMedia.swift in Sources */,
 				FABB24412602FC2C00C8785C /* ReaderDefaultTopic.swift in Sources */,
 				FABB24422602FC2C00C8785C /* ReaderCard+CoreDataClass.swift in Sources */,


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/21509.

I've been going through the maintenance board, noticed the linked defect, and decided to resurrect this PR from the last Hack Week, which I didn't get to complete then. This is based on the designed we worked on with Chris.

## To test:

- Publish a new post
- Tap "View" on a snackbar
- ✅ Verify that the updated success screen is shown
- ✅ Verify that all buttons are working
- ✅ Verify that for Blaze-enabled blogs, "Promote with Blaze" button is visible.

<img width="320" alt="Screenshot 2024-04-30 at 3 23 10 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/7824f4e2-76cc-4b9d-8ef3-9a5d2af6c2e0">
<img width="450" alt="Screenshot 2024-04-30 at 3 54 10 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/46dc7d3e-947b-434b-a4ca-1f8fe58ee1b0">


## Regression Notes
1. Potential unintended areas of impact: Post Publish Success Notice View
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
