### PR TITLE
Reader: Update Reader fetch followed sites to fetch all sites

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -49,8 +49,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 15.0'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
+  # pod 'WordPressKit', '~> 15.0'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'c2a51c232a7c589d3bcf4ade75232d2338582e64'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.2, ~> 9.0)
-  - WordPressKit (~> 15.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `c2a51c232a7c589d3bcf4ade75232d2338582e64`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -130,7 +130,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -175,11 +174,17 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
+  WordPressKit:
+    :commit: c2a51c232a7c589d3bcf4ade75232d2338582e64
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressKit:
+    :commit: c2a51c232a7c589d3bcf4ade75232d2338582e64
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
@@ -212,7 +217,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c
   WordPressAuthenticator: 47ac66428c0a712ced8eb0ab481f64e2f4e80f47
-  WordPressKit: adbefc1caddae6b1a5a1f45d1062d3eb9aa58af6
+  WordPressKit: d4db2fa5861380bd6b71d5574f2bc63cdeee47ba
   WordPressShared: 04c6d51441bb8fa29651075b3a5536c90ae89c76
   WordPressUI: 700e3ec5a9f77b6920c8104c338c85788036ab3c
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -225,6 +230,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: fa9ae5af13b7cf168245f24d1c672a4fb972e37f
 
-PODFILE CHECKSUM: 8798f26f74ffc8f39fbbfa16be38281e942aceaf
+PODFILE CHECKSUM: c908e5faf7735e70d7221f9f6e90806b6c1bbc68
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/Services/ReaderTopicService+FollowedSites.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+FollowedSites.swift
@@ -1,0 +1,66 @@
+
+extension ReaderTopicService {
+
+    enum FollowedSitesError: Error {
+        case unknown
+    }
+
+    @objc func fetchAllFollowedSites(success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
+        let service = ReaderTopicServiceRemote(wordPressComRestApi: apiRequest())
+        let pageSize: UInt = 100
+
+        service.fetchFollowedSites(forPage: 1, number: pageSize) { totalSites, sites in
+            guard let totalSites, let sites else {
+                failure(nil)
+                return
+            }
+            let totalPages = Int(ceil(Double(totalSites.intValue) / Double(pageSize)))
+            WPAnalytics.subscriptionCount = totalSites.intValue
+
+            guard totalPages > 1 else {
+                self.mergeFollowedSites(sites, withSuccess: success)
+                return
+            }
+
+            Task {
+                await withTaskGroup(of: Result<[RemoteReaderSiteInfo], Error>.self) { taskGroup in
+                    for page in 2...totalPages {
+                        taskGroup.addTask {
+                            return await self.fetchFollowedSites(service: service, page: UInt(page), number: pageSize)
+                        }
+                    }
+                    var allSites = sites
+                    for await result in taskGroup {
+                        if case .success(let sites) = result {
+                            allSites.append(contentsOf: sites)
+                        }
+                    }
+                    self.mergeFollowedSites(allSites, withSuccess: success)
+                }
+            }
+        } failure: { error in
+            failure(error)
+        }
+    }
+
+    private func fetchFollowedSites(service: ReaderTopicServiceRemote, page: UInt, number: UInt) async -> Result<[RemoteReaderSiteInfo], Error> {
+        return await withCheckedContinuation { continuation in
+            service.fetchFollowedSites(forPage: page, number: number) { _, sites in
+                continuation.resume(returning: .success(sites ?? []))
+            } failure: { error in
+                DDLogError("Error fetching page \(page) for followed sites: \(String(describing: error))")
+                continuation.resume(returning: .failure(error ?? FollowedSitesError.unknown))
+            }
+        }
+    }
+
+    private func apiRequest() -> WordPressComRestApi {
+        let token = self.coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.authToken
+        }
+
+        return WordPressComRestApi.defaultApi(oAuthToken: token,
+                                              userAgent: WPUserAgent.wordPress())
+    }
+
+}

--- a/WordPress/Classes/Services/ReaderTopicService+FollowedSites.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+FollowedSites.swift
@@ -31,8 +31,14 @@ extension ReaderTopicService {
                     }
                     var allSites = sites
                     for await result in taskGroup {
-                        if case .success(let sites) = result {
+                        switch result {
+                        case .success(let sites):
                             allSites.append(contentsOf: sites)
+                        case .failure(let error):
+                            DispatchQueue.main.async {
+                                failure(error)
+                            }
+                            return
                         }
                     }
                     self.mergeFollowedSites(allSites, withSuccess: success)

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -23,15 +23,6 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 - (void)fetchReaderMenuWithSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure;
 
 /**
- Get a list of ReaderSiteTopics of the sites the user follows.
-
- @param success block called on a successful fetch.
- @param failure block called if there is any error. `error` can be any underlying network error.
- */
-- (void)fetchFollowedSitesWithSuccess:(void(^)(void))success
-                              failure:(void(^)(NSError *error))failure;
-
-/**
  Deletes all search topics from core data and saves the context.
  Use to clean-up searches when they are finished.
  */

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -43,19 +43,6 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     } completion:nil onQueue:dispatch_get_main_queue()];
 }
 
-- (void)fetchFollowedSitesWithSuccess:(void(^)(void))success failure:(void(^)(NSError *error))failure
-{
-    ReaderTopicServiceRemote *service = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
-    [service fetchFollowedSitesWithSuccess:^(NSArray *sites) {
-        [WPAnalytics setSubscriptionCount: sites.count];
-        [self mergeFollowedSites:sites withSuccess:success];
-    } failure:^(NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    }];
-}
-
 - (ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context
 {
     ReaderAbstractTopic *topic;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -122,7 +122,7 @@ class NotificationSettingsViewController: UIViewController {
 
         if AppConfiguration.showsFollowedSitesSettings {
             dispatchGroup.enter()
-            siteService.fetchFollowedSites(success: {
+            siteService.fetchAllFollowedSites(success: {
                 dispatchGroup.leave()
             }, failure: { (error) in
                 dispatchGroup.leave()

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -201,7 +201,7 @@ extension ReaderSiteTopic {
     private static func fetchFollowedSites(completion: @escaping (Result<[ReaderSiteTopic], Error>) -> Void) {
         let siteService = ReaderTopicService(coreDataStack: ContextManager.shared)
 
-        siteService.fetchFollowedSites(success: {
+        siteService.fetchAllFollowedSites(success: {
             let sites = (try? ReaderAbstractTopic.lookupAllSites(in: ContextManager.shared.mainContext)) ?? []
             completion(.success(sites))
         }, failure: { error in

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -170,7 +170,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         }
         isSyncing = true
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
-        service.fetchFollowedSites(success: {[weak self] in
+        service.fetchAllFollowedSites(success: {[weak self] in
             self?.isSyncing = false
             self?.configureNoResultsView()
             self?.refreshControl.endRefreshing()
@@ -179,7 +179,6 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
             self?.isSyncing = false
             self?.configureNoResultsView()
             self?.refreshControl.endRefreshing()
-
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -103,7 +103,7 @@ extension ReaderTabItemsStore {
     }
 
     private func fetchFollowedSites() {
-        service.fetchFollowedSites(success: {
+        service.fetchAllFollowedSites(success: {
         }, failure: { (error) in
             let actualError = error ?? ReaderTopicsConstants.remoteServiceError
             DDLogError("Could not sync sites: \(String(describing: actualError))")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2251,6 +2251,8 @@
 		83E1E5602A5CB8BF000B576F /* PostEditor+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E1E55E2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift */; };
 		83EF3D7B2937D703000AF9BF /* SharedDataIssueSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */; };
 		83EF3D7F2937F08C000AF9BF /* SharedDataIssueSolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */; };
+		83F1BED22BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F1BED12BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift */; };
+		83F1BED32BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F1BED12BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
 		83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */; };
@@ -7619,6 +7621,7 @@
 		83E1E5582A58B5C2000B576F /* JetpackSocialError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialError.swift; sourceTree = "<group>"; };
 		83E1E55E2A5CB8BF000B576F /* PostEditor+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditor+JetpackSocial.swift"; sourceTree = "<group>"; };
 		83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolverTests.swift; sourceTree = "<group>"; };
+		83F1BED12BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicService+FollowedSites.swift"; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		83FB4D3E122C38F700DB9506 /* MediaPlayer.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
@@ -14488,6 +14491,7 @@
 				5DBCD9D318F35D7500B32229 /* ReaderTopicService.h */,
 				5DBCD9D418F35D7500B32229 /* ReaderTopicService.m */,
 				321955C224BF77E400E3F316 /* ReaderTopicService+FollowedInterests.swift */,
+				83F1BED12BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift */,
 				3236F79D24AE75790088E8F3 /* ReaderTopicService+Interests.swift */,
 				3234BB072530D7DC0068DA40 /* ReaderTopicService+SiteInfo.swift */,
 				9F3EFCA0208E305D00268758 /* ReaderTopicService+Subscriptions.swift */,
@@ -21677,6 +21681,7 @@
 				0CA10F6D2ADAE86D00CE75AC /* PostSearchSuggestionsService.swift in Sources */,
 				02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */,
 				984B138E21F65F870004B6A2 /* SiteStatsPeriodTableViewController.swift in Sources */,
+				83F1BED22BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift in Sources */,
 				433ADC1D223B2A7F00ED9DE1 /* TextBundleWrapper.m in Sources */,
 				2F605FAA25145F7200F99544 /* WPCategoryTree.swift in Sources */,
 				5D62BAD718AA88210044E5F7 /* PageSettingsViewController.m in Sources */,
@@ -25928,6 +25933,7 @@
 				FABB25A72602FC2C00C8785C /* ChangeUsernameViewController.swift in Sources */,
 				B0B89DC12A1E882F003D5295 /* DomainResultView.swift in Sources */,
 				173DF292274522A1007C64B5 /* AppAboutScreenConfiguration.swift in Sources */,
+				83F1BED32BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift in Sources */,
 				FABB25A82602FC2C00C8785C /* RichTextView.swift in Sources */,
 				FABB25A92602FC2C00C8785C /* ScenePresenter.swift in Sources */,
 				FABB25AA2602FC2C00C8785C /* AccountSettingsStore.swift in Sources */,


### PR DESCRIPTION
Fixes #15651
WordPressKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/753

## Description

Previously, the API call was only returning the first page of a user's followed sites. This change adds support for a page parameter and uses that to fetch all the pages at the same time.

## Testing
I found the easiest way to test it is by reducing the page size and adding print statements to the new function when it fetches pages. You can copy this code block to make it easier:

<details><summary>Test code</summary>

```swift
    @objc func fetchAllFollowedSites(success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
        let service = ReaderTopicServiceRemote(wordPressComRestApi: apiRequest())
        let pageSize: UInt = 5

        service.fetchFollowedSites(forPage: 1, number: pageSize) { totalSites, sites in
            guard let totalSites, let sites else {
                failure(nil)
                return
            }
            let totalPages = Int(ceil(Double(totalSites.intValue) / Double(pageSize)))
            WPAnalytics.subscriptionCount = totalSites.intValue
            print("🟣 fetchAllFollowedSites - Total pages \(totalPages)")

            guard totalPages > 1 else {
                print("🟣 fetchAllFollowedSites - Merging \(sites.count) sites")
                self.mergeFollowedSites(sites, withSuccess: success)
                return
            }

            Task {
                print("🟣 fetchAllFollowedSites - Fetching additional pages")
                await withTaskGroup(of: Result<[RemoteReaderSiteInfo], Error>.self) { taskGroup in
                    for page in 2...totalPages {
                        taskGroup.addTask {
                            return await self.fetchFollowedSites(service: service, page: UInt(page), number: pageSize)
                        }
                    }
                    var allSites = sites
                    for await result in taskGroup {
                        if case .success(let sites) = result {
                            allSites.append(contentsOf: sites)
                        }
                    }
                    print("🟣 fetchAllFollowedSites - Merging \(sites.count) sites")
                    self.mergeFollowedSites(allSites, withSuccess: success)
                }
            }
        } failure: { error in
            failure(error)
        }
    }

    private func fetchFollowedSites(service: ReaderTopicServiceRemote, page: UInt, number: UInt) async -> Result<[RemoteReaderSiteInfo], Error> {
        return await withCheckedContinuation { continuation in
            service.fetchFollowedSites(forPage: page, number: number) { _, sites in
                print("🟣 fetchFollowedSites - finished fetching page \(page)")
                continuation.resume(returning: .success(sites ?? []))
            } failure: { error in
                DDLogError("Error fetching page \(page) for followed sites: \(String(describing: error))")
                continuation.resume(returning: .failure(error ?? FollowedSitesError.unknown))
            }
        }
    }
```

</details>

To test:
- Login to Jetpack
- Navigate to the dashboard or launch the app to it
- 🔎 **Verify** existing start up fetch site calls fetch all your sites
- Navigate to the `Subscriptions` feed in the Reader
- Tap on the `Blogs` chip
- Tap on `Edit`
- 🔎 **Verify** the fetch call fetches all of your sites


## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
