### PR TITLE
Offline Mode: Integrate new PostRepository.save method in main publishing flows

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 14.1'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'e0c97bb57938f4637d818e1bc738659b45196c08'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '810b304affac98b1db70c9faf9ed5c9adb173de9'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile
+++ b/Podfile
@@ -49,8 +49,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 14.1'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
+  # pod 'WordPressKit', '~> 14.1'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'e0c97bb57938f4637d818e1bc738659b45196c08'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
     - WordPressKit (~> 14.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (14.1.0):
+  - WordPressKit (14.0.1):
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (>= 9.0.2, ~> 9.0)
-  - WordPressKit (~> 14.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `e0c97bb57938f4637d818e1bc738659b45196c08`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -156,7 +156,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
@@ -175,11 +174,17 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.115.0.podspec
+  WordPressKit:
+    :commit: e0c97bb57938f4637d818e1bc738659b45196c08
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressKit:
+    :commit: e0c97bb57938f4637d818e1bc738659b45196c08
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
@@ -212,7 +217,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: d906a1005febb28de9f5c3a802736ca0850307f6
-  WordPressKit: 324ee6100ad74b72c0c37b81fab8937c437f0773
+  WordPressKit: 689dcd3a65ec76bb7aac03c023c16bc40504736f
   WordPressShared: 04c6d51441bb8fa29651075b3a5536c90ae89c76
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -225,6 +230,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 5b39e8e85fd8101ebfcfef947e6d1d9d4ce7f301
+PODFILE CHECKSUM: 06a674be33b591a014a67f8c88a15604146c40a0
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
     - WordPressKit (~> 14.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (14.0.1):
+  - WordPressKit (14.1.0):
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (>= 9.0.2, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `e0c97bb57938f4637d818e1bc738659b45196c08`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `810b304affac98b1db70c9faf9ed5c9adb173de9`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -175,7 +175,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.115.0.podspec
   WordPressKit:
-    :commit: e0c97bb57938f4637d818e1bc738659b45196c08
+    :commit: 810b304affac98b1db70c9faf9ed5c9adb173de9
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -183,7 +183,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: e0c97bb57938f4637d818e1bc738659b45196c08
+    :commit: 810b304affac98b1db70c9faf9ed5c9adb173de9
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -217,7 +217,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
   WordPressAuthenticator: d906a1005febb28de9f5c3a802736ca0850307f6
-  WordPressKit: 689dcd3a65ec76bb7aac03c023c16bc40504736f
+  WordPressKit: 324ee6100ad74b72c0c37b81fab8937c437f0773
   WordPressShared: 04c6d51441bb8fa29651075b3a5536c90ae89c76
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -230,6 +230,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 06a674be33b591a014a67f8c88a15604146c40a0
+PODFILE CHECKSUM: c09fa5eda847571371a5110b1407f5ff0d4cc7e4
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -2,6 +2,8 @@
 import Foundation
 
 /// Decides what action should happen for post when it is auto-uploaded.
+///
+/// - note: Deprecated (kahu-offline-mode) (along with all related types)
 final class PostAutoUploadInteractor {
     enum AutoUploadAction: String {
         /// Upload the post as is.

--- a/WordPress/Classes/Services/PostCoordinator+Notices.swift
+++ b/WordPress/Classes/Services/PostCoordinator+Notices.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension PostCoordinator {
-    static func makePublishSuccessNotice(for post: AbstractPost) -> Notice {
+    static func makeUploadSuccessNotice(for post: AbstractPost, isExistingPost: Bool = false) -> Notice {
         var message: String {
             let title = post.titleForDisplay() ?? ""
             if !title.isEmpty {
@@ -9,23 +9,25 @@ extension PostCoordinator {
             }
             return post.blog.displayURL as String? ?? ""
         }
-        return Notice(title: Strings.publishSuccessTitle(for: post),
+        let isPublished = post.status == .publish
+        return Notice(title: Strings.publishSuccessTitle(for: post, isExistingPost: isExistingPost),
                       message: message,
                       feedbackType: .success,
-                      notificationInfo: makePublishSuccessNotificationInfo(for: post),
-                      actionTitle: Strings.view,
+                      notificationInfo: makeUploadSuccessNotificationInfo(for: post, isExistingPost: isExistingPost),
+                      actionTitle: isPublished ? Strings.view : nil,
                       actionHandler: { _ in
             PostNoticeNavigationCoordinator.presentPostEpilogue(for: post)
         })
     }
 
-    private static func makePublishSuccessNotificationInfo(for post: AbstractPost) -> NoticeNotificationInfo {
+    private static func makeUploadSuccessNotificationInfo(for post: AbstractPost, isExistingPost: Bool) -> NoticeNotificationInfo {
+        let status = Strings.publishSuccessTitle(for: post, isExistingPost: isExistingPost)
         var title: String {
             let title = post.titleForDisplay() ?? ""
             guard !title.isEmpty else {
-                return Strings.publishSuccessTitle(for: post)
+                return status
             }
-            return "“\(title)” \(Strings.publishSuccessTitle(for: post))"
+            return "“\(title)” \(status)"
         }
         var body: String {
             post.blog.displayURL as String? ?? ""
@@ -39,39 +41,12 @@ extension PostCoordinator {
                 PostNoticeUserInfoKey.postID: post.objectID.uriRepresentation().absoluteString
             ])
     }
-
-    static func makePublishFailureNotice(for post: AbstractPost, error: Error) -> Notice {
-        return Notice(
-            title: Strings.uploadFailed,
-            message: error.localizedDescription,
-            feedbackType: .error,
-            notificationInfo: makePublishFailureNotificationInfo(for: post, error: error)
-        )
-    }
-
-    private static func makePublishFailureNotificationInfo(for post: AbstractPost, error: Error) -> NoticeNotificationInfo {
-        var title: String {
-            let title = post.titleForDisplay() ?? ""
-            guard !title.isEmpty else {
-                return Strings.uploadFailed
-            }
-            return "“\(title)” \(Strings.uploadFailed)"
-        }
-        return NoticeNotificationInfo(
-            identifier: UUID().uuidString,
-            categoryIdentifier: nil,
-            title: title,
-            body: error.localizedDescription
-        )
-    }
 }
 
 private enum Strings {
     static let view = NSLocalizedString("postNotice.view", value: "View", comment: "Button title. Displays a summary / sharing screen for a specific post.")
 
-    static let uploadFailed = NSLocalizedString("postNotice.uploadFailed", value: "Upload failed", comment: "A post upload failed notification.")
-
-    static func publishSuccessTitle(for post: AbstractPost, isFirstTimePublish: Bool = true) -> String {
+    static func publishSuccessTitle(for post: AbstractPost, isExistingPost: Bool = false) -> String {
         switch post {
         case let post as Post:
             switch post.status {
@@ -82,7 +57,7 @@ private enum Strings {
             case .pending:
                 return NSLocalizedString("postNotice.postPendingReview", value: "Post pending review", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
             default:
-                if isFirstTimePublish {
+                if !isExistingPost {
                     return NSLocalizedString("postNotice.postPublished", value: "Post published", comment: "Title of notification displayed when a post has been successfully published.")
                 } else {
                     return NSLocalizedString("postNotice.postUpdated", value: "Post updated", comment: "Title of notification displayed when a post has been successfully updated.")
@@ -97,7 +72,7 @@ private enum Strings {
             case .pending:
                 return NSLocalizedString("postNotice.pagePending", value: "Page pending review", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
             default:
-                if isFirstTimePublish {
+                if !isExistingPost {
                     return NSLocalizedString("postNotice.pagePublished", value: "Page published", comment: "Title of notification displayed when a page has been successfully published.")
                 } else {
                     return NSLocalizedString("postNotice.pageUpdated", value: "Page updated", comment: "Title of notification displayed when a page has been successfully updated.")

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -155,12 +155,12 @@ class PostCoordinator: NSObject {
     ///
     /// - warning: Work-in-progress (kahu-offline-mode)
     @discardableResult @MainActor
-    func _update(_ post: AbstractPost) async throws -> AbstractPost {
+    func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
         let post = post.original ?? post
         do {
             let isExistingPost = post.hasRemote()
             // TODO: Set overwrite to false once conflict resolution support is added
-            try await PostRepository()._save(post, overwrite: true)
+            try await PostRepository()._save(post, changes: changes, overwrite: true)
             show(PostCoordinator.makeUploadSuccessNotice(for: post, isExistingPost: isExistingPost))
             return post
         } catch {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -123,7 +123,6 @@ class PostCoordinator: NSObject {
         var parameters = RemotePostUpdateParameters()
         if post.status == .draft {
             parameters.status = Post.Status.publish.rawValue
-            parameters.date = Date()
         } else {
             // Publish according to the currrent post settings: private, scheduled, etc.
         }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -119,16 +119,17 @@ class PostCoordinator: NSObject {
     /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
     func _publish(_ post: AbstractPost) async throws {
-        let parameters = PostHelper.remotePost(with: post)
+        let post = post.original ?? post
+        var parameters = RemotePostUpdateParameters()
         if post.status == .draft {
-            parameters.status = PostStatusPublish
+            parameters.status = Post.Status.publish.rawValue
             parameters.date = Date()
         } else {
             // Publish according to the currrent post settings: private, scheduled, etc.
         }
         do {
             let repository = PostRepository(coreDataStack: coreDataStack)
-            let post = try await repository._upload(parameters, for: post)
+            try await repository._save(post, changes: parameters)
             didPublish(post)
             show(PostCoordinator.makePublishSuccessNotice(for: post))
         } catch {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -182,7 +182,7 @@ class PostCoordinator: NSObject {
                 break
             case .deleted:
                 alert.addDefaultActionWithTitle(Strings.buttonOK) { _ in
-                    self.didPermanentlyDelete(post)
+                    self.handlePermanentlyDeleted(post)
                 }
             }
         } else {
@@ -191,7 +191,7 @@ class PostCoordinator: NSObject {
         topViewController.present(alert, animated: true)
     }
 
-    private func didPermanentlyDelete(_ post: AbstractPost) {
+    private func handlePermanentlyDeleted(_ post: AbstractPost) {
         let context = coreDataStack.mainContext
         context.deleteObject(post)
         ContextManager.shared.saveContextAndWait(context)

--- a/WordPress/Classes/Services/PostRepository+Helpers.swift
+++ b/WordPress/Classes/Services/PostRepository+Helpers.swift
@@ -39,9 +39,13 @@ private func makeTags(from tags: String) -> [String] {
 }
 
 extension RemotePostUpdateParameters {
+    var isEmpty: Bool {
+        self == RemotePostUpdateParameters()
+    }
+
     /// Returns a diff between the original and the latest revision with the
     /// changes applied on top.
-    static func changes(from original: AbstractPost, to latest: AbstractPost, with changes: RemotePostUpdateParameters?) -> RemotePostUpdateParameters {
+    static func changes(from original: AbstractPost, to latest: AbstractPost, with changes: RemotePostUpdateParameters? = nil) -> RemotePostUpdateParameters {
         let parametersOriginal = RemotePostCreateParameters(post: original)
         var parametersLatest = RemotePostCreateParameters(post: latest)
         if let changes {

--- a/WordPress/Classes/Services/PostRepository+Helpers.swift
+++ b/WordPress/Classes/Services/PostRepository+Helpers.swift
@@ -46,6 +46,9 @@ extension RemotePostUpdateParameters {
     /// Returns a diff between the original and the latest revision with the
     /// changes applied on top.
     static func changes(from original: AbstractPost, to latest: AbstractPost, with changes: RemotePostUpdateParameters? = nil) -> RemotePostUpdateParameters {
+        guard original !== latest else {
+            return changes ?? RemotePostUpdateParameters()
+        }
         let parametersOriginal = RemotePostCreateParameters(post: original)
         var parametersLatest = RemotePostCreateParameters(post: latest)
         if let changes {

--- a/WordPress/Classes/Services/PostRepository+Helpers.swift
+++ b/WordPress/Classes/Services/PostRepository+Helpers.swift
@@ -4,8 +4,10 @@ import WordPressKit
 extension RemotePostCreateParameters {
     /// Initializes the parameters required to create the given post.
     init(post: AbstractPost) {
-        self.init(status: (post.status ?? .draft).rawValue)
-
+        self.init(
+            type: post is Post ? "post" : "page",
+            status: (post.status ?? .draft).rawValue
+        )
         date = post.dateCreated
         authorID = post.authorID?.intValue
         title = post.postTitle

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -63,7 +63,8 @@ final class PostRepository {
                 return NSLocalizedString("postSaveErrorMessage.conflict", value: "The content was modified on another device", comment: "Error message: content was modified on another device")
             case .deleted(let post):
                 let format = NSLocalizedString("postSaveErrorMessage.deleted", value: "\"%@\" was permanently deleted and can no longer be updated", comment: "Error message: item permanently deleted")
-                return String(format: format, post.title ?? "–")
+                let untitled = NSLocalizedString("postSaveErrorMessage.postUntitled", value: "Untitled", comment: "A default value for an post without a title")
+                return String(format: format, post.title ?? untitled)
             }
         }
     }

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -119,6 +119,9 @@ final class PostRepository {
             PostService(managedObjectContext: context)
                 .updateMediaFor(post: original, success: {}, failure: { _ in })
         }
+        /// - warning: Work-in-progress (kahu-offline-mode)
+        // TODO: Remove when it's no longer needed
+        original.remoteStatus = AbstractPostRemoteStatus.sync
         ContextManager.shared.saveContextAndWait(context)
     }
 

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -14,36 +14,4 @@ extension PostServiceRemote {
             })
         }
     }
-
-    /// TODO: Remove it once the new `_save()` method is integrated.
-    ///
-    /// - warning: Work-in-progress (kahu-offline-mode)
-    func _update(_ post: RemotePost) async throws -> RemotePost {
-        try await withUnsafeThrowingContinuation { continuation in
-            update(post, success: {
-                guard let post = $0 else {
-                    return continuation.resume(throwing: URLError(.unknown))
-                }
-                continuation.resume(returning: post)
-            }, failure: {
-                continuation.resume(throwing: $0 ?? URLError(.unknown))
-            })
-        }
-    }
-
-    /// TODO: Remove it once the new `_save()` method is integrated.
-    ///
-    /// - warning: Work-in-progress (kahu-offline-mode)
-    func _create(_ post: RemotePost) async throws -> RemotePost {
-        try await withUnsafeThrowingContinuation { continuation in
-            createPost(post, success: {
-                guard let post = $0 else {
-                    return continuation.resume(throwing: URLError(.unknown))
-                }
-                continuation.resume(returning: post)
-            }, failure: {
-                continuation.resume(throwing: $0 ?? URLError(.unknown))
-            })
-        }
-    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -11,11 +11,11 @@ extension PostEditor {
             settingsViewController = PostSettingsViewController(post: post)
         }
         settingsViewController.featuredImageDelegate = self as? FeaturedImageDelegate
-        let closeButton = UIBarButtonItem(systemItem: .close, primaryAction: .init(handler: { [weak self] _ in
+        let doneButton = UIBarButtonItem(systemItem: .done, primaryAction: .init(handler: { [weak self] _ in
             self?.navigationController?.dismiss(animated: true)
         }))
-        closeButton.accessibilityIdentifier = "close"
-        settingsViewController.navigationItem.leftBarButtonItem = closeButton
+        doneButton.accessibilityIdentifier = "close"
+        settingsViewController.navigationItem.rightBarButtonItem = doneButton
 
         let navigation = UINavigationController(rootViewController: settingsViewController)
         self.navigationController?.present(navigation, animated: true)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -179,7 +179,8 @@ FeaturedImageViewControllerDelegate>
     [super viewWillDisappear:animated];
 
     if (self.isStandalone) {
-        if (!self.isStandaloneEditorDismissingAfterSave) {
+        if ((self.isBeingDismissed || self.parentViewController.isBeingDismissed) && !self.isStandaloneEditorDismissingAfterSave) {
+            // TODO: Implement it using a ViewModel or a child context to eliminate the risk of accidently saving the changes without uploading them
             [self.apost.managedObjectContext refreshObject:self.apost mergeChanges:NO];
         }
     } else {

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -48,7 +48,8 @@ class PostRepositorySaveTests: CoreDataTestCase {
               "content" : "content-1",
               "date" : "2024-03-07T23:00:40+0000",
               "status" : "draft",
-              "title" : "Hello"
+              "title" : "Hello",
+              "type" : "post"
             }
             """)
             return try HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
@@ -117,7 +118,8 @@ class PostRepositorySaveTests: CoreDataTestCase {
                   "tag-2"
                 ]
               },
-              "title" : "Hello"
+              "title" : "Hello",
+              "type" : "post"
             }
             """)
             return try HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
@@ -152,7 +154,8 @@ class PostRepositorySaveTests: CoreDataTestCase {
               "content" : "content-1",
               "date" : "2024-03-07T23:00:40+0000",
               "status" : "publish",
-              "title" : "Hello"
+              "title" : "Hello",
+              "type" : "post"
             }
             """)
             var post = WordPressComPost.mock
@@ -191,7 +194,8 @@ class PostRepositorySaveTests: CoreDataTestCase {
               "content" : "content-1",
               "date" : "2024-03-07T23:00:40+0000",
               "status" : "future",
-              "title" : "Hello"
+              "title" : "Hello",
+              "type" : "post"
             }
             """)
             var post = WordPressComPost.mock
@@ -232,7 +236,8 @@ class PostRepositorySaveTests: CoreDataTestCase {
               "content" : "content-1",
               "date" : "2024-03-07T23:00:40+0000",
               "status" : "publish",
-              "title" : "Hello"
+              "title" : "Hello",
+              "type" : "post"
             }
             """)
             return HTTPStubsResponse(error: URLError(.notConnectedToInternet))


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/pull/22849

Integrates the new `PostRepository._save` method into the main publishing flows.

## To test:

### Publishing

#### Publish New Post

- Create a new post
- Publish the post
- **Verify** that the minimum number of parameters was sent (no password, no date)
- **Verify** that the post got published by checking it on the web

#### Schedule New Post

- Create a new post
- Schedule the post
- **Verify** that the minimum number of parameters was sent
- **Verify** that the post got scheduled by checking it on the web

#### Publishing Existing Draft

- Create a new post
- Save it as a draft
- Re-open the post and publish
- **Verify** that only `"{ "status": "publish" }"` was sent in parameters
- **Verify** that the post got published by checking it on the web

#### Updating Deleted Post

- Create a new post
- Save it as a draft
- Re-open the post 
- Open the same post on the web and delete it permanently
- Return to the app and try publishing a post
- **Verify** that a "post permanently deleted" error is shown
- Tap "OK"
- **Verify** that the editor got dismissed 

### Post Settings

#### Fix for Revert Changes

- Open the post list
- Use the context menu to open Post Settings
- Change "Stick post to the front page"
- Open "Tags"
- Tap "Back"
- **Verify** that "Stick post to the front page" value is still saved

#### Fix for Save Button

- Change one of the values in Post Settings
- **Verify** that "Save" button is enabled
- Change it back to the original value
- **Verify** that "Save" button is disabled

#### Partial Updates

- Open the Post Settings from the Post List
- Open the same post on the web and modify its content and save
- Return to the app Change one of the values in Post Settings
- Tap "Save"
- **Verify** that only the changes fields were sent (use a proxy or breakpoints in `PostServiceRemoteREST+Extended.swift`)
- **Verify** that the changes were applied by using the web interface but the content remained
- Repeat the test for other values and with XMLRPC

#### Updating Deleted Post

- Open Post Settings
- Changes values
- Open the same post on the web and delete it permanently
- Return to the app and tap "Save"
- **Verify** that a "post permanently deleted" error is shown
- Tap "OK"
- **Verify** that the screen got dismissed 


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
