### PR TITLE
[WIP] HACK Week: Reader detail customization

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,6 +11,7 @@ enum FeatureFlag: Int, CaseIterable {
     case compliancePopover
     case googleDomainsCard
     case newTabIcons
+    case readerCustomization
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -37,6 +38,8 @@ enum FeatureFlag: Int, CaseIterable {
             return false
         case .newTabIcons:
             return true
+        case .readerCustomization:
+            return false
         }
     }
 
@@ -77,6 +80,8 @@ extension FeatureFlag {
             return "Google Domains Promotional Card"
         case .newTabIcons:
             return "New Tab Icons"
+        case .readerCustomization:
+            return "Reader Customization"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -22,6 +22,20 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
     required init(comment: Comment) {
         self.comment = comment
+        super.init()
+
+        if #available(iOS 16.4, *) {
+            webView.isInspectable = true
+        }
+
+        webView.backgroundColor = .clear
+        webView.isOpaque = false // gets rid of the white flash upon content load in dark mode.
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        webView.scrollView.bounces = false
+        webView.scrollView.showsVerticalScrollIndicator = false
+        webView.scrollView.backgroundColor = .clear
+        webView.configuration.allowsInlineMediaPlayback = true
     }
 
     func render() -> UIView {
@@ -30,12 +44,6 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
             return webView
         }
 
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.navigationDelegate = self
-        webView.scrollView.bounces = false
-        webView.scrollView.showsVerticalScrollIndicator = false
-        webView.isOpaque = false // gets rid of the white flash upon content load in dark mode.
-        webView.configuration.allowsInlineMediaPlayback = true
         webView.loadHTMLString(formattedHTMLString(for: comment.content), baseURL: Self.resourceURL)
 
         return webView
@@ -69,8 +77,10 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
                     return
                 }
 
-                // reset the webview to opaque again so the scroll indicator is visible.
-                webView.isOpaque = true
+                // TODO: Revisit this later.
+                // This is disabled for Reader customization.
+//                // reset the webview to opaque again so the scroll indicator is visible.
+//                webView.isOpaque = true
                 self.delegate?.renderer(self, asyncRenderCompletedWithHeight: height)
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -167,6 +167,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private var tooltipPresenter: TooltipPresenter?
 
+    // Reader customization model
+    private lazy var displaySettingStore: ReaderDisplaySettingStore = {
+        return .init()
+    }()
+
+    // Convenient access to the underlying structure
+    private var displaySetting: ReaderDisplaySetting {
+        displaySettingStore.setting
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -764,6 +764,31 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         coordinator?.openInBrowser()
     }
 
+    @objc func didTapDisplaySettingButton(_ sender: UIBarButtonItem) {
+        let vc = ReaderDisplaySettingViewController()
+        let nav = UINavigationController(rootViewController: vc)
+        if let sheet = nav.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.prefersGrabberVisible = false
+        }
+
+        vc.navigationItem.rightBarButtonItem = .init(systemItem: .close,
+                                                     primaryAction: UIAction { [weak vc] _ in
+            vc?.navigationController?.dismiss(animated: true)
+        })
+
+        nav.navigationBar.isTranslucent = true
+        vc.edgesForExtendedLayout = .top
+
+        let navAppearance = UINavigationBarAppearance()
+        navAppearance.configureWithTransparentBackground()
+        vc.navigationItem.standardAppearance = navAppearance
+        vc.navigationItem.scrollEdgeAppearance = navAppearance
+        vc.navigationItem.compactAppearance = navAppearance
+
+        navigationController?.present(nav, animated: true)
+    }
+
     /// A View Controller that displays a Post content.
     ///
     /// Use this method to present content for the user.
@@ -1061,7 +1086,8 @@ private extension ReaderDetailViewController {
         let rightItems = [
             moreButtonItem(enabled: enableRightBarButtons),
             shareButtonItem(enabled: enableRightBarButtons),
-            safariButtonItem()
+            safariButtonItem(),
+            displaySettingButtonItem()
         ]
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
@@ -1102,6 +1128,15 @@ private extension ReaderDetailViewController {
 
     @objc func didTapDismissButton(_ sender: UIButton) {
         dismiss(animated: true)
+    }
+
+    func displaySettingButtonItem() -> UIBarButtonItem? {
+        guard let symbolImage = UIImage(systemName: "textformat") else {
+            return nil
+        }
+        let button = barButtonItem(with: symbolImage, action: #selector(didTapDisplaySettingButton(_:)))
+
+        return button
     }
 
     func safariButtonItem() -> UIBarButtonItem? {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -765,7 +765,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     @objc func didTapDisplaySettingButton(_ sender: UIBarButtonItem) {
-        let vc = ReaderDisplaySettingViewController()
+        let vc = ReaderDisplaySettingViewController(initialSetting: displaySetting) { [weak self] newSetting in
+            // TODO: Refresh all the views.
+        }
         let nav = UINavigationController(rootViewController: vc)
         if let sheet = nav.sheetPresentationController {
             sheet.detents = [.large()]

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1131,7 +1131,8 @@ private extension ReaderDetailViewController {
     }
 
     func displaySettingButtonItem() -> UIBarButtonItem? {
-        guard let symbolImage = UIImage(systemName: "textformat") else {
+        guard FeatureFlag.readerCustomization.enabled,
+              let symbolImage = UIImage(systemName: "textformat") else {
             return nil
         }
         let button = barButtonItem(with: symbolImage, action: #selector(didTapDisplaySettingButton(_:)))

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -550,9 +550,36 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         view.backgroundColor = displaySetting.color.background
     }
 
+    private func applyDisplaySetting() {
+        UIView.animate(withDuration: 0.3) { [weak self] in
+            guard let self else {
+                return
+            }
+
+            // Main background view
+            view.backgroundColor = displaySetting.color.background
+
+            // Header view
+            header.displaySetting = displaySetting
+        }
+
+        // TODO: Featured image view
+
+        // Update Reader Post web view
+        if let post {
+            webView.displaySetting = displaySetting
+            webView.loadHTMLString(post.contentForDisplay())
+        }
+
+        // TODO: Comments table view
+
+        // TODO: Related posts
+
+        // TODO: Toolbar
+    }
+
     /// Configure the webview
     private func configureWebView() {
-        webView.usesSansSerifStyle = true
         webView.navigationDelegate = self
     }
 
@@ -766,7 +793,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     @objc func didTapDisplaySettingButton(_ sender: UIBarButtonItem) {
         let vc = ReaderDisplaySettingViewController(initialSetting: displaySetting) { [weak self] newSetting in
-            // TODO: Refresh all the views.
+            self?.displaySettingStore.setting = newSetting
+            self?.applyDisplaySetting()
         }
         let nav = UINavigationController(rootViewController: vc)
         if let sheet = nav.sheetPresentationController {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -544,6 +544,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         // Webview is scroll is done by it's superview
         webView.scrollView.isScrollEnabled = false
+
+        webView.displaySetting = displaySetting
+
+        view.backgroundColor = displaySetting.color.background
     }
 
     /// Configure the webview
@@ -567,7 +571,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                 guard let webViewHeight = webViewHeight as? CGFloat else {
                     self?.webViewHeight.constant = height
                     return
-                }
+            }
 
                 self?.webViewHeight.constant = min(height, webViewHeight)
             })
@@ -662,6 +666,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureCommentsTable() {
+        commentsTableView.separatorStyle = .none
+        commentsTableView.backgroundColor = .clear
         commentsTableView.register(ReaderDetailCommentsHeader.defaultNib,
                                    forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID)
         commentsTableView.register(CommentContentTableViewCell.defaultNib,
@@ -673,6 +679,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func configureRelatedPosts() {
         relatedPostsTableView.isScrollEnabled = false
         relatedPostsTableView.separatorStyle = .none
+        relatedPostsTableView.backgroundColor = .clear
 
         relatedPostsTableView.register(ReaderRelatedPostsCell.defaultNib,
                            forCellReuseIdentifier: ReaderRelatedPostsCell.defaultReuseID)
@@ -885,6 +892,10 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
 
         let post = relatedPosts[indexPath.section].posts[indexPath.row]
         cell.configure(for: post)
+
+        // TODO: Reader customization: override to transparent background
+        cell.backgroundColor = .clear
+
         return cell
     }
 
@@ -899,6 +910,9 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
         }
 
         header.titleLabel.text = title
+
+        // TODO: Reader customization: override to transparent background
+        header.backgroundColorView.backgroundColor = .clear
 
         return header
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -77,8 +77,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private let featuredImage: ReaderDetailFeaturedImageView = .loadFromNib()
 
     /// The actual header
-    private lazy var header: UIView & ReaderDetailHeader = {
-        return ReaderDetailNewHeaderViewHost()
+    private lazy var header: ReaderDetailNewHeaderViewHost = {
+        return .init()
     }()
 
     /// Bottom toolbar
@@ -621,6 +621,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureHeader() {
+        header.displaySetting = displaySetting
         header.useCompatibilityMode = useCompatibilityMode
         header.delegate = coordinator
         headerContainerView.addSubview(header)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -92,6 +92,13 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
                 }
             }
 
+            // TODO: Revisit
+            // Separator is removed because it has a hardcoded background color, which interferes with theming.
+            cell.shouldHideSeparator = true
+
+            cell.backgroundColor = .clear
+            cell.contentView.backgroundColor = .clear
+
             return cell
         }
 
@@ -100,6 +107,8 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         }
 
         cell.titleLabel.text = commentsEnabled ? Constants.noComments : Constants.closedComments
+        cell.backgroundColor = .clear
+        cell.contentView.backgroundColor = .clear
         return cell
     }
 
@@ -110,12 +119,14 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
+        header.contentView.backgroundColor = .clear
         header.configure(
             post: post,
             totalComments: totalComments,
             presentingViewController: presentingViewController,
             followButtonTappedClosure: followButtonTappedClosure
         )
+
         headerView = header
         return header
     }
@@ -159,6 +170,8 @@ private extension ReaderDetailCommentsTableViewDelegate {
         let title = totalComments == 0 ? Constants.leaveCommentButtonTitle : Constants.viewAllButtonTitle
         cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
         cell.delegate = buttonDelegate
+        cell.backgroundColor = .clear
+        cell.contentView.backgroundColor = .clear
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -27,7 +27,7 @@ class ReaderDetailNewHeaderViewHost: UIView {
     // TODO: Find out if we still need this.
     var useCompatibilityMode: Bool = false
 
-    var displaySetting: ReaderDisplaySetting = .default {
+    var displaySetting: ReaderDisplaySetting = .standard {
         didSet {
             viewModel.displaySetting = displaySetting
             Task { @MainActor in

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNewHeaderView.swift
@@ -264,7 +264,7 @@ struct ReaderDetailNewHeaderView: View {
             if let postTitle = viewModel.postTitle {
                 Text(postTitle)
                     .font(Font(viewModel.displaySetting.font(with: .title1, weight: .bold)))
-                    .foregroundStyle(Color(viewModel.displaySetting.color.foreground))
+                    .foregroundStyle(Color(primaryTextColor))
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true) // prevents the title from being truncated.
             }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -14,7 +14,7 @@ class ReaderWebView: WKWebView {
 
     var isP2 = false
 
-    var displaySetting: ReaderDisplaySetting = .default
+    var displaySetting: ReaderDisplaySetting = .standard
 
     /// Make the webview transparent
     ///

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -14,9 +14,6 @@ class ReaderWebView: WKWebView {
 
     var isP2 = false
 
-    // TODO: Remove in favor of the display setting.
-    var usesSansSerifStyle = false
-
     var displaySetting: ReaderDisplaySetting = .default
 
     /// Make the webview transparent
@@ -50,7 +47,7 @@ class ReaderWebView: WKWebView {
         return """
         <!DOCTYPE html><html><head><meta charset='UTF-8' />
         <title>Reader Post</title>
-        <meta name='viewport' content='initial-scale=1, maximum-scale=1.0, user-scalable=no'>
+        <meta name='viewport' content='initial-scale=\(displaySetting.size.scale), maximum-scale=\(displaySetting.size.scale), user-scalable=no'>
         <link rel="stylesheet" type="text/css" href="\(ReaderCSS().address)">
         <style>
         \(cssColors())
@@ -184,20 +181,15 @@ class ReaderWebView: WKWebView {
     }
 
     private func overrideStyles() -> String {
-        guard usesSansSerifStyle else {
-            return String()
-        }
-
         /// Some context: We are fetching the CSS file from a remote endpoint, but we store a local `reader.css` file
         /// to override some styles for mobile-specific purposes.
         ///
         /// The `reader.css` forces the text to be displayed in Noto, but this method overrides it back to the
-        /// system font. Later when the `readerImprovements` flag is removed, we should remove this method and
-        /// update the CSS values in `reader.css` instead
+        /// user-preferred font.
         return """
             body.reader-full-post.reader-full-post__story-content {
                 font: -apple-system-body !important;
-                font-family: -apple-system, sans-serif !important;
+                font-family: \(displaySetting.font.cssString) !important;
             }
         """
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -14,7 +14,10 @@ class ReaderWebView: WKWebView {
 
     var isP2 = false
 
+    // TODO: Remove in favor of the display setting.
     var usesSansSerifStyle = false
+
+    var displaySetting: ReaderDisplaySetting = .default
 
     /// Make the webview transparent
     ///
@@ -202,24 +205,27 @@ class ReaderWebView: WKWebView {
     /// Maps app colors to CSS colors to be applied in the webview
     ///
     private func cssColors() -> String {
-        return """
-            @media (prefers-color-scheme: dark) {
-                \(mappedCSSColors(.dark))
-            }
+        if displaySetting.color.adaptsToInterfaceStyle {
+            return """
+                @media (prefers-color-scheme: dark) {
+                    \(mappedCSSColors(.dark))
+                }
 
-            @media (prefers-color-scheme: light) {
-                \(mappedCSSColors(.light))
-            }
-        """
+                @media (prefers-color-scheme: light) {
+                    \(mappedCSSColors(.light))
+                }
+            """
+        }
+
+        // doesn't matter what interface style we pass here because the colors are fixed either way.
+        return mappedCSSColors(.light)
     }
 
     private func mappedCSSColors(_ style: UIUserInterfaceStyle) -> String {
         let trait = UITraitCollection(userInterfaceStyle: style)
-        UIColor(light: .muriel(color: .gray, .shade40),
-                dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString()
         return """
             :root {
-              --color-text: #\(UIColor.text.color(for: trait).hexString() ?? "");
+              --color-text: #\(displaySetting.color.foreground.color(for: trait).hexString() ?? "");
               --color-neutral-0: #\(UIColor.listForegroundUnread.color(for: trait).hexString() ?? "");
               --color-neutral-5: #\(UIColor(light: .muriel(color: .gray, .shade5),
                             dark: .muriel(color: .gray, .shade80)).color(for: trait).hexString() ?? "");

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -9,7 +9,14 @@ html, body {
 }
 
 body {
-  -webkit-text-size-adjust: none !important; font: -apple-system-body !important; font-family: 'Noto Serif', serif !important; font-weight: 400 !important; padding: 0 !important; margin: 0; background-color: transparent;
+  -webkit-text-size-adjust: none !important;
+  font: -apple-system-body !important;
+  font-family: 'Noto Serif', serif !important;
+  font-weight: 400 !important;
+  padding: 0 !important;
+  margin: 0;
+  color: var(--color-text);
+  background-color: transparent;
 }
 
 a { text-decoration: none; color: var(--main-link-color); }
@@ -59,4 +66,9 @@ figure {
   margin-block-end: 0;
   margin-inline-start: 0;
   margin-inline-end: 0;
+}
+
+/* Temporary override for Reader Customization */
+.reader-full-post__story-content blockquote {
+    color: var(--color-text) !important;
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -71,4 +71,6 @@ figure {
 /* Temporary override for Reader Customization */
 .reader-full-post__story-content blockquote {
     color: var(--color-text) !important;
+    border-left: 3px solid var(--color-text) !important;
+    filter: brightness(250%);
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -10,7 +10,7 @@ html, body {
 
 body {
   -webkit-text-size-adjust: none !important;
-  font: -apple-system-body !important;
+  font: -apple-system-body, sans-serif !important;
   font-family: 'Noto Serif', serif !important;
   font-weight: 400 !important;
   padding: 0 !important;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
@@ -5,25 +5,37 @@ struct ReaderFollowButton: View {
     let isFollowing: Bool
     let isEnabled: Bool
     let size: ButtonSize
-    @State var color: ButtonColor = .init()
+    var color: ButtonColor = .init()
+    var displaySetting: ReaderDisplaySetting?
 
     let action: () -> Void
 
     struct ButtonColor {
         let followedText: Color
         let followedBackground: Color
+        let followedStroke: Color
 
         let unfollowedText: Color
         let unfollowedBackground: Color
 
         init(followedText: Color = .secondary,
              followedBackground: Color = .clear,
+             followedStroke: Color = Color(.separator),
              unfollowedText: Color = Color(UIColor.invertedLabel),
              unfollowedBackground: Color = Color(.label)) {
             self.followedText = followedText
             self.followedBackground = followedBackground
+            self.followedStroke = followedStroke
             self.unfollowedText = unfollowedText
             self.unfollowedBackground = unfollowedBackground
+        }
+
+        init(displaySetting: ReaderDisplaySetting) {
+            followedText = Color(displaySetting.color.secondaryForeground)
+            followedBackground = .clear
+            followedStroke = followedText
+            unfollowedText = Color(displaySetting.color.background)
+            unfollowedBackground = Color(displaySetting.color.foreground)
         }
     }
 
@@ -32,11 +44,29 @@ struct ReaderFollowButton: View {
         case regular
     }
 
+    init(isFollowing: Bool,
+         isEnabled: Bool,
+         size: ButtonSize,
+         color: ButtonColor? = nil,
+         displaySetting: ReaderDisplaySetting? = nil,
+         action: @escaping () -> Void) {
+        self.isFollowing = isFollowing
+        self.isEnabled = isEnabled
+        self.size = size
+        self.color = color ?? {
+            if let displaySetting {
+                return .init(displaySetting: displaySetting)
+            }
+            return .init()
+        }()
+        self.action = action
+    }
+
     var body: some View {
         if isFollowing {
             button.overlay(
                 RoundedRectangle(cornerRadius: 5)
-                    .stroke(Color(UIColor.separator), lineWidth: 1)
+                    .stroke(color.followedStroke, lineWidth: 1)
             )
         } else {
             button
@@ -52,12 +82,19 @@ struct ReaderFollowButton: View {
         } label: {
             Text(text)
                 .foregroundColor(textColor)
-                .font(.subheadline)
+                .font(buttonFont)
         }
         .disabled(!isEnabled)
         .padding(.horizontal, size == .compact ? 16.0 : 24.0)
         .padding(.vertical, 8.0)
         .background(backgroundColor)
         .cornerRadius(5.0)
+    }
+
+    var buttonFont: Font {
+        guard let displaySetting else {
+            return .subheadline
+        }
+        return Font(displaySetting.font(with: .subheadline))
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
@@ -5,7 +5,27 @@ struct ReaderFollowButton: View {
     let isFollowing: Bool
     let isEnabled: Bool
     let size: ButtonSize
+    @State var color: ButtonColor = .init()
+
     let action: () -> Void
+
+    struct ButtonColor {
+        let followedText: Color
+        let followedBackground: Color
+
+        let unfollowedText: Color
+        let unfollowedBackground: Color
+
+        init(followedText: Color = .secondary,
+             followedBackground: Color = .clear,
+             unfollowedText: Color = Color(UIColor.invertedLabel),
+             unfollowedBackground: Color = Color(.label)) {
+            self.followedText = followedText
+            self.followedBackground = followedBackground
+            self.unfollowedText = unfollowedText
+            self.unfollowedBackground = unfollowedBackground
+        }
+    }
 
     enum ButtonSize {
         case compact
@@ -25,8 +45,8 @@ struct ReaderFollowButton: View {
 
     private var button: some View {
         let text = isFollowing ? WPStyleGuide.FollowButton.Text.followingStringForDisplay : WPStyleGuide.FollowButton.Text.followStringForDisplay
-        let textColor: Color = isFollowing ? .secondary : Color(UIColor.invertedLabel)
-        let backgroundColor: Color = isFollowing ? .clear : Color(UIColor.label)
+        let textColor: Color = isFollowing ? color.followedText : color.unfollowedText
+        let backgroundColor: Color = isFollowing ? color.followedBackground : color.unfollowedBackground
         return Button {
             action()
         } label: {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
@@ -59,6 +59,7 @@ struct ReaderFollowButton: View {
             }
             return .init()
         }()
+        self.displaySetting = displaySetting
         self.action = action
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -42,6 +42,8 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         }
     }
 
+    var displaySetting: ReaderDisplaySetting? = nil
+
     init(collectionView: UICollectionView, topics: [String]) {
         self.collectionView = collectionView
         self.topics = topics
@@ -117,11 +119,17 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         return size
     }
 
+    // TODO: Stylize
     private func configure(cell: ReaderInterestsCollectionViewCell, with title: String) {
         ReaderInterestsStyleGuide.applyCompactCellLabelStyle(label: cell.label)
 
+        if let displaySetting {
+            cell.label.font = displaySetting.font(with: .footnote)
+            cell.label.textColor = displaySetting.color.foreground
+        }
+
         if metrics.borderWidth > 0 {
-            cell.layer.borderColor = metrics.borderColor.cgColor
+            cell.layer.borderColor = displaySetting?.color.secondaryForeground.cgColor ?? metrics.borderColor.cgColor
             cell.layer.borderWidth = metrics.borderWidth
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -33,6 +33,7 @@ class TopicsCollectionView: DynamicHeightCollectionView {
 
     func commonInit() {
         collectionViewLayout = ReaderInterestsCollectionViewFlowLayout()
+        backgroundColor = .clear
 
         coordinator = ReaderTopicCollectionViewCoordinator(collectionView: self, topics: topics)
         coordinator?.delegate = self

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -128,6 +128,17 @@ struct ReaderDisplaySetting: Codable, Equatable {
         case mono
 //        case olde
 //        case rock
+
+        var cssString: String {
+            switch self {
+            case .sans:
+                return "-apple-system, sans-serif"
+            case .serif:
+                return "'Noto Serif', serif"
+            case .mono:
+                return "'SF Mono', SFMono-Regular, ui-monospace, monospace"
+            }
+        }
     }
 
     // TODO: Determine the magnitude

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -50,9 +50,9 @@ struct ReaderDisplaySetting: Codable, Equatable {
 
     enum Color: String, Codable, CaseIterable {
         case system
-        case paper
+        case soft
         case sepia
-        case charcoal
+        case evening
         case oled
 
         // TODO: Consider localization
@@ -60,12 +60,12 @@ struct ReaderDisplaySetting: Codable, Equatable {
             switch self {
             case .system:
                 return "Default"
-            case .paper:
-                return "Paper"
+            case .soft:
+                return "Soft"
             case .sepia:
                 return "Sepia"
-            case .charcoal:
-                return "Charcoal"
+            case .evening:
+                return "Evening"
             case .oled:
                 return "OLED"
             }
@@ -75,11 +75,11 @@ struct ReaderDisplaySetting: Codable, Equatable {
             switch self {
             case .system:
                 return .text
-            case .paper:
+            case .soft:
                 return .init(fromHex: 0x2d2e2e)
             case .sepia:
                 return .init(fromHex: 0x27201b)
-            case .charcoal:
+            case .evening:
                 return .init(fromHex: 0xabaab2)
             case .oled:
                 return .text.color(for: .init(userInterfaceStyle: .dark))
@@ -99,11 +99,11 @@ struct ReaderDisplaySetting: Codable, Equatable {
             switch self {
             case .system:
                 return .systemBackground
-            case .paper:
+            case .soft:
                 return .init(fromHex: 0xf2f2f2)
             case .sepia:
                 return .init(fromHex: 0xeae0cd)
-            case .charcoal:
+            case .evening:
                 return .init(fromHex: 0x3a3a3c)
             case .oled:
                 return .systemBackground.color(for: .init(userInterfaceStyle: .dark))

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -26,11 +26,11 @@ struct ReaderDisplaySetting: Codable, Equatable {
         let uiFont = {
             switch font {
             case .serif:
-                return WPStyleGuide.serifFontForTextStyle(textStyle).withSize(pointSize)
+                return WPStyleGuide.serifFontForTextStyle(textStyle, fontWeight: weight).withSize(pointSize)
             case .mono:
-                return .monospacedSystemFont(ofSize: pointSize, weight: .regular)
+                return .monospacedSystemFont(ofSize: pointSize, weight: weight)
             default:
-                return .systemFont(ofSize: pointSize)
+                return .systemFont(ofSize: pointSize, weight: weight)
             }
         }()
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -6,7 +6,7 @@ struct ReaderDisplaySetting: Codable, Equatable {
     // MARK: Properties
 
     // The default display setting.
-    static let `default` = ReaderDisplaySetting(color: .system, font: .sans, size: .normal)
+    static let standard = ReaderDisplaySetting(color: .system, font: .sans, size: .normal)
 
     var color: Color
     var font: Font
@@ -200,7 +200,7 @@ class ReaderDisplaySettingStore: NSObject {
 
     var setting: ReaderDisplaySetting {
         get {
-            return FeatureFlag.readerCustomization.enabled ? _setting : .default
+            return FeatureFlag.readerCustomization.enabled ? _setting : .standard
         }
         set {
             guard FeatureFlag.readerCustomization.enabled else {
@@ -210,7 +210,7 @@ class ReaderDisplaySettingStore: NSObject {
         }
     }
 
-    private var _setting: ReaderDisplaySetting = .default {
+    private var _setting: ReaderDisplaySetting = .standard {
         didSet {
             if let dictionary = try? setting.toDictionary() {
                 repository.set(dictionary, forKey: Constants.key)
@@ -224,7 +224,7 @@ class ReaderDisplaySettingStore: NSObject {
             guard let dictionary = repository.dictionary(forKey: Constants.key),
                   let data = try? JSONSerialization.data(withJSONObject: dictionary),
                   let setting = try? JSONDecoder().decode(ReaderDisplaySetting.self, from: data) else {
-                return .default
+                return .standard
             }
             return setting
         }()

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -1,17 +1,45 @@
 import WordPressUI
+import WordPressShared
 
-struct ReaderDisplaySetting: Codable {
+struct ReaderDisplaySetting: Codable, Equatable {
 
     // MARK: Properties
 
     // The default display setting.
-    static let `default` = ReaderDisplaySetting(color: .sepia, font: .sans, size: .normal)
+    static let `default` = ReaderDisplaySetting(color: .system, font: .sans, size: .normal)
 
-    let color: Color
-    let font: Font
-    let size: Size
+    var color: Color
+    var font: Font
+    var size: Size
 
     // MARK: Methods
+
+    static func font(with font: Font,
+                     size: Size = .normal,
+                     textStyle: UIFont.TextStyle,
+                     weight: UIFont.Weight = .regular) -> UIFont {
+        let scale = size.scale
+        let metrics = UIFontMetrics(forTextStyle: textStyle)
+        let descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
+        let pointSize = descriptor.pointSize * scale
+
+        let uiFont = {
+            switch font {
+            case .serif:
+                return WPStyleGuide.serifFontForTextStyle(textStyle).withSize(pointSize)
+            case .mono:
+                return .monospacedSystemFont(ofSize: pointSize, weight: .regular)
+            default:
+                return .systemFont(ofSize: pointSize)
+            }
+        }()
+
+        return metrics.scaledFont(for: uiFont)
+    }
+
+    func font(with textStyle: UIFont.TextStyle, weight: UIFont.Weight = .regular) -> UIFont {
+        return Self.font(with: font, size: size, textStyle: textStyle, weight: weight)
+    }
 
     func toDictionary(_ encoder: JSONEncoder = JSONEncoder()) throws -> NSDictionary? {
         let data = try encoder.encode(self)
@@ -103,12 +131,27 @@ struct ReaderDisplaySetting: Codable {
     }
 
     // TODO: Determine the magnitude
-    enum Size: String, Codable, CaseIterable {
-        case smaller
-        case smallest
+    enum Size: Int, Codable, CaseIterable {
+        case smaller = -2
+        case small
         case normal
         case large
         case larger
+
+        var scale: Double {
+            switch self {
+            case .smaller:
+                return 0.75
+            case .small:
+                return 0.9
+            case .normal:
+                return 1.0
+            case .large:
+                return 1.15
+            case .larger:
+                return 1.25
+            }
+        }
     }
 
     // MARK: Codable

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -170,7 +170,19 @@ class ReaderDisplaySettingStore: NSObject {
 
     private let repository: UserPersistentRepository
 
-    var setting: ReaderDisplaySetting = .default {
+    var setting: ReaderDisplaySetting {
+        get {
+            return FeatureFlag.readerCustomization.enabled ? _setting : .default
+        }
+        set {
+            guard FeatureFlag.readerCustomization.enabled else {
+                return
+            }
+            _setting = newValue
+        }
+    }
+
+    private var _setting: ReaderDisplaySetting = .default {
         didSet {
             if let dictionary = try? setting.toDictionary() {
                 repository.set(dictionary, forKey: Constants.key)
@@ -180,7 +192,7 @@ class ReaderDisplaySettingStore: NSObject {
 
     init(repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.repository = repository
-        self.setting = {
+        self._setting = {
             guard let dictionary = repository.dictionary(forKey: Constants.key),
                   let data = try? JSONSerialization.data(withJSONObject: dictionary),
                   let setting = try? JSONDecoder().decode(ReaderDisplaySetting.self, from: data) else {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -146,8 +146,6 @@ struct ReaderDisplaySetting: Codable, Equatable {
         case sans
         case serif
         case mono
-//        case olde
-//        case rock
 
         var cssString: String {
             switch self {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -126,8 +126,8 @@ struct ReaderDisplaySetting: Codable, Equatable {
         case sans
         case serif
         case mono
-        case olde
-        case rock
+//        case olde
+//        case rock
     }
 
     // TODO: Determine the magnitude

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -1,0 +1,145 @@
+import WordPressUI
+
+struct ReaderDisplaySetting: Codable {
+
+    // MARK: Properties
+
+    // The default display setting.
+    static let `default` = ReaderDisplaySetting(color: .system, font: .sans, size: .normal)
+
+    let color: Color
+    let font: Font
+    let size: Size
+
+    // MARK: Methods
+
+    func toDictionary(_ encoder: JSONEncoder = JSONEncoder()) throws -> NSDictionary? {
+        let data = try encoder.encode(self)
+        return try JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
+    }
+
+    // MARK: Types
+
+    enum Color: String, Codable, CaseIterable {
+        case system
+        case paper
+        case sepia
+        case charcoal
+        case oled
+
+        // TODO: Consider localization
+        var label: String {
+            switch self {
+            case .system:
+                return "Default"
+            case .paper:
+                return "Paper"
+            case .sepia:
+                return "Sepia"
+            case .charcoal:
+                return "Charcoal"
+            case .oled:
+                return "OLED"
+            }
+        }
+
+        var foreground: UIColor {
+            switch self {
+            case .system:
+                return .text
+            case .paper:
+                return .init(fromHex: 0x2d2e2e)
+            case .sepia:
+                return .init(fromHex: 0x27201b)
+            case .charcoal:
+                return .init(fromHex: 0xabaab2)
+            case .oled:
+                return .text.color(for: .init(userInterfaceStyle: .dark))
+            }
+        }
+
+        var background: UIColor {
+            switch self {
+            case .system:
+                return .systemBackground
+            case .paper:
+                return .init(fromHex: 0xf2f2f2)
+            case .sepia:
+                return .init(fromHex: 0xeae0cd)
+            case .charcoal:
+                return .init(fromHex: 0x3a3a3c)
+            case .oled:
+                return .systemBackground.color(for: .init(userInterfaceStyle: .dark))
+            }
+        }
+
+        /// Whether the color adjusts between light and dark mode.
+        var adaptsToInterfaceStyle: Bool {
+            switch self {
+            case .system:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    // TODO: Need to import the fonts
+    enum Font: String, Codable, CaseIterable {
+        case sans
+        case serif
+        case mono
+        case olde
+        case rock
+    }
+
+    // TODO: Determine the magnitude
+    enum Size: String, Codable, CaseIterable {
+        case smaller
+        case smallest
+        case normal
+        case large
+        case larger
+    }
+
+    // MARK: Codable
+
+    private enum CodingKeys: String, CodingKey {
+        case color
+        case font
+        case size
+    }
+}
+
+// MARK: - Controller
+
+/// This should be the object to be strongly retained. Keeps the store up-to-date.
+class ReaderDisplaySettingStore: NSObject {
+
+    private let repository: UserPersistentRepository
+
+    var setting: ReaderDisplaySetting = .default {
+        didSet {
+            if let dictionary = try? setting.toDictionary() {
+                repository.set(dictionary, forKey: Constants.key)
+            }
+        }
+    }
+
+    init(repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+        self.repository = repository
+        self.setting = {
+            guard let dictionary = repository.dictionary(forKey: Constants.key),
+                  let data = try? JSONSerialization.data(withJSONObject: dictionary),
+                  let setting = try? JSONDecoder().decode(ReaderDisplaySetting.self, from: data) else {
+                return .default
+            }
+            return setting
+        }()
+        super.init()
+    }
+
+    private struct Constants {
+        static let key = "readerDisplaySettingKey"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -59,15 +59,35 @@ struct ReaderDisplaySetting: Codable, Equatable {
         var label: String {
             switch self {
             case .system:
-                return "Default"
+                return NSLocalizedString(
+                    "reader.preferences.color.default",
+                    value: "Default",
+                    comment: "Name for the Default color theme, used in the Reader's reading preferences."
+                )
             case .soft:
-                return "Soft"
+                return NSLocalizedString(
+                    "reader.preferences.color.soft",
+                    value: "Soft",
+                    comment: "Name for the Soft color theme, used in the Reader's reading preferences."
+                )
             case .sepia:
-                return "Sepia"
+                return NSLocalizedString(
+                    "reader.preferences.color.sepia",
+                    value: "Sepia",
+                    comment: "Name for the Sepia color theme, used in the Reader's reading preferences."
+                )
             case .evening:
-                return "Evening"
+                return NSLocalizedString(
+                    "reader.preferences.color.evening",
+                    value: "Evening",
+                    comment: "Name for the Evening color theme, used in the Reader's reading preferences."
+                )
             case .oled:
-                return "OLED"
+                return NSLocalizedString(
+                    "reader.preferences.color.oled",
+                    value: "OLED",
+                    comment: "Name for the OLED color theme, used in the Reader's reading preferences."
+                )
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -5,7 +5,7 @@ struct ReaderDisplaySetting: Codable {
     // MARK: Properties
 
     // The default display setting.
-    static let `default` = ReaderDisplaySetting(color: .system, font: .sans, size: .normal)
+    static let `default` = ReaderDisplaySetting(color: .sepia, font: .sans, size: .normal)
 
     let color: Color
     let font: Font
@@ -55,6 +55,15 @@ struct ReaderDisplaySetting: Codable {
                 return .init(fromHex: 0xabaab2)
             case .oled:
                 return .text.color(for: .init(userInterfaceStyle: .dark))
+            }
+        }
+
+        var secondaryForeground: UIColor {
+            switch self {
+            case .system:
+                return .secondaryLabel
+            default:
+                return foreground.withAlphaComponent(0.6)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -159,17 +159,16 @@ struct ReaderDisplaySetting: Codable, Equatable {
         }
     }
 
-    // TODO: Determine the magnitude
     enum Size: Int, Codable, CaseIterable {
-        case smaller = -2
+        case extraSmall = -2
         case small
         case normal
         case large
-        case larger
+        case extraLarge
 
         var scale: Double {
             switch self {
-            case .smaller:
+            case .extraSmall:
                 return 0.75
             case .small:
                 return 0.9
@@ -177,7 +176,7 @@ struct ReaderDisplaySetting: Codable, Equatable {
                 return 1.0
             case .large:
                 return 1.15
-            case .larger:
+            case .extraLarge:
                 return 1.25
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -191,7 +191,12 @@ extension ReaderDisplaySettingSelectionView {
     struct ControlView: View {
         @ObservedObject var viewModel: ReaderDisplaySettingSelectionViewModel
 
-        @State private var sliderValue: Double = 0
+        @State private var sliderValue: Double
+
+        init(viewModel: ReaderDisplaySettingSelectionViewModel) {
+            self.viewModel = viewModel
+            self.sliderValue = Double(viewModel.displaySetting.size.rawValue)
+        }
 
         var body: some View {
             VStack(spacing: .DS.Padding.large) {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -2,6 +2,18 @@ import SwiftUI
 import DesignSystem
 
 class ReaderDisplaySettingViewController: UIViewController {
+    private let initialSetting: ReaderDisplaySetting
+    private let completion: ((ReaderDisplaySetting) -> Void)?
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    init(initialSetting: ReaderDisplaySetting, completion: ((ReaderDisplaySetting) -> Void)?) {
+        self.initialSetting = initialSetting
+        self.completion = completion
+        super.init(nibName: nil, bundle: nil)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -11,7 +23,12 @@ class ReaderDisplaySettingViewController: UIViewController {
     private func setupView() {
         view.backgroundColor = .systemBackground
 
-        let viewModel = ReaderDisplaySettingSelectionViewModel(displaySetting: .default)
+        let viewModel = ReaderDisplaySettingSelectionViewModel(displaySetting: initialSetting) { [weak self] setting in
+            self?.dismiss(animated: true, completion: {
+                self?.completion?(setting)
+            })
+        }
+
         let swiftUIView = UIView.embedSwiftUIView(ReaderDisplaySettingSelectionView(viewModel: viewModel))
         view.addSubview(swiftUIView)
         view.pinSubviewToAllEdges(swiftUIView)
@@ -28,8 +45,15 @@ class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
 
     @Published var displaySetting: ReaderDisplaySetting
 
-    init(displaySetting: ReaderDisplaySetting) {
+    private let completion: ((ReaderDisplaySetting) -> Void)?
+
+    init(displaySetting: ReaderDisplaySetting, completion: ((ReaderDisplaySetting) -> Void)?) {
         self.displaySetting = displaySetting
+        self.completion = completion
+    }
+
+    func doneButtonTapped() {
+        completion?(displaySetting)
     }
 
     // Convenience accessors
@@ -176,7 +200,7 @@ extension ReaderDisplaySettingSelectionView {
                 sizeSelectionView
                     .padding(.horizontal, .DS.Padding.double)
                 DSButton(title: Strings.doneButton, style: DSButtonStyle.init(emphasis: .primary, size: .large)) {
-                    // TODO: Impl
+                    viewModel.doneButtonTapped()
                 }
                 .padding(.horizontal, .DS.Padding.double)
             }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+class ReaderDisplaySettingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+    }
+
+    private func setupView() {
+        view.backgroundColor = .systemBackground
+
+        let viewModel = ReaderDisplaySettingSelectionViewModel(displaySetting: .default)
+        let swiftUIView = UIView.embedSwiftUIView(ReaderDisplaySettingSelectionView(viewModel: viewModel))
+        view.addSubview(swiftUIView)
+        view.pinSubviewToAllEdges(swiftUIView)
+    }
+}
+
+// MARK: - SwiftUI
+
+class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
+
+    @Published var displaySetting: ReaderDisplaySetting
+
+    init(displaySetting: ReaderDisplaySetting) {
+        self.displaySetting = displaySetting
+    }
+}
+
+struct ReaderDisplaySettingSelectionView: View {
+
+    @ObservedObject var viewModel: ReaderDisplaySettingSelectionViewModel
+
+    @State private var sliderValue: Double = 0
+
+    var body: some View {
+        VStack(spacing: 24.0) {
+            previewView
+            colorSelectionView
+            fontSelectionView
+            sizeSelectionView
+
+            // TODO: Add a 'Done' button
+
+            Spacer()
+        }
+    }
+
+    var previewView: some View {
+        VStack(alignment: .leading, spacing: 16.0) {
+            Text("The quick brown fox jumps over the lazy dog")
+                .font(Font(viewModel.displaySetting.font(with: .title1)))
+                .foregroundStyle(foregroundColor)
+
+            HStack(spacing: 8.0) {
+                ForEach(["dogs", "fox", "design", "writing"], id: \.self) { text in
+                    Text(text)
+                        .font(Font(viewModel.displaySetting.font(with: .callout)))
+                        .foregroundStyle(foregroundColor)
+                        .padding(.horizontal, 16.0)
+                        .padding(.vertical, 8.0)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 5.0)
+                                .strokeBorder(foregroundColor, lineWidth: 1.0)
+                        }
+                }
+            }
+
+            Text("Once upon a time, in a quaint little village nestled between rolling hills and lush greenery, there lived a quick brown fox named Jasper.")
+                .font(Font(viewModel.displaySetting.font(with: .callout)))
+                .foregroundStyle(foregroundColor)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 36)
+        .frame(maxWidth: .infinity)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(backgroundColor)
+        .animation(.easeInOut, value: viewModel.displaySetting)
+    }
+
+    var colorSelectionView: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4.0) {
+                ForEach(ReaderDisplaySetting.Color.allCases, id: \.rawValue) { color in
+                    Button {
+                        viewModel.displaySetting.color = color
+                    } label: {
+                        VStack(spacing: 8.0) {
+                            DualColorCircle(primaryColor: Color(color.foreground),
+                                            secondaryColor: Color(color.background))
+                            Text(color.label)
+                                .font(.footnote)
+                                .foregroundStyle(Color(.label))
+                        }
+                        .padding(.horizontal, 10.0)
+                        .padding(.vertical, 8.0)
+                        .clipShape(RoundedRectangle(cornerRadius: 5.0))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 5.0)
+                                .strokeBorder(color == viewModel.displaySetting.color ? .secondary : Color(.secondarySystemBackground), lineWidth: 1.0)
+                        }
+                    }
+                }
+            }
+            .padding(.leading, 16.0) // initial content inset
+        }
+    }
+
+    var fontSelectionView: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4.0) {
+                ForEach(ReaderDisplaySetting.Font.allCases, id: \.rawValue) { font in
+                    Button {
+                        viewModel.displaySetting.font = font
+                    } label: {
+                        VStack(spacing: 4.0) {
+                            Text("Aa")
+                                .font(Font(ReaderDisplaySetting.font(with: font, textStyle: .largeTitle)).bold())
+                                .foregroundStyle(Color(.label))
+                            Text(font.rawValue.capitalized)
+                                .font(.footnote)
+                                .foregroundStyle(Color(.label))
+                        }
+                        .padding(.horizontal, 16.0)
+                        .padding(.vertical, 8.0)
+                        .clipShape(RoundedRectangle(cornerRadius: 5.0))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 5.0)
+                                .strokeBorder(font == viewModel.displaySetting.font ? .secondary : Color(.secondarySystemBackground), lineWidth: 1.0)
+                        }
+                    }
+                }
+            }
+            .padding(.leading, 16.0) // initial content inset
+        }
+    }
+
+    var sizeSelectionView: some View {
+        Slider(value: $sliderValue,
+               in: Double(ReaderDisplaySetting.Size.smaller.rawValue)...Double(ReaderDisplaySetting.Size.larger.rawValue),
+               step: 1) {
+            Text("Size")
+        } minimumValueLabel: {
+            Text("A")
+                .font(Font(ReaderDisplaySetting.font(with: .sans, size: .smaller, textStyle: .body)))
+        } maximumValueLabel: {
+            Text("A")
+                .font(Font(ReaderDisplaySetting.font(with: .sans, size: .larger, textStyle: .body)))
+        } onEditingChanged: { _ in
+            viewModel.displaySetting.size = .init(rawValue: Int(sliderValue)) ?? .normal
+        }
+        .padding(.vertical, 8.0)
+        .padding(.horizontal, 16.0)
+    }
+
+    private var foregroundColor: Color {
+        Color(viewModel.displaySetting.color.foreground)
+    }
+
+    private var backgroundColor: Color {
+        Color(viewModel.displaySetting.color.background)
+    }
+}
+
+fileprivate struct DualColorCircle: View {
+    let primaryColor: Color
+    let secondaryColor: Color
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(primaryColor)
+                .overlay(content: {
+                    Circle().strokeBorder(strokeColor(for: primaryColor), lineWidth: 0.5)
+                })
+                .clipShape(Circle().trim(from: 0.5, to: 1))
+            Circle()
+                .fill(secondaryColor)
+                .overlay(content: {
+                    Circle().strokeBorder(strokeColor(for: secondaryColor), lineWidth: 0.5)
+                })
+                .clipShape(Circle().trim(from: 0, to: 0.5))
+        }
+        .frame(width: 48.0, height: 48.0)
+        .rotationEffect(.degrees(-45.0))
+    }
+
+    func strokeColor(for fillColor: Color) -> Color {
+        guard fillColor == Color(UIColor.systemBackground) else {
+            return .clear
+        }
+        return .secondary
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -131,17 +131,19 @@ extension ReaderDisplaySettingSelectionView {
         }
 
         var tagsView: some View {
-            HStack(spacing: .DS.Padding.single) {
-                ForEach(Strings.Preview.tags, id: \.self) { text in
-                    Text(text)
-                        .font(Font(viewModel.displaySetting.font(with: .callout)))
-                        .foregroundStyle(viewModel.foregroundColor)
-                        .padding(.horizontal, .DS.Padding.double)
-                        .padding(.vertical, .DS.Padding.single)
-                        .overlay {
-                            RoundedRectangle(cornerRadius: .DS.Radius.small)
-                                .strokeBorder(Color(viewModel.displaySetting.color.foreground.withAlphaComponent(0.3)), lineWidth: 1.0)
-                        }
+            ScrollView(.horizontal) {
+                HStack(spacing: .DS.Padding.single) {
+                    ForEach(Strings.Preview.tags, id: \.self) { text in
+                        Text(text)
+                            .font(Font(viewModel.displaySetting.font(with: .callout)))
+                            .foregroundStyle(viewModel.foregroundColor)
+                            .padding(.horizontal, .DS.Padding.double)
+                            .padding(.vertical, .DS.Padding.single)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: .DS.Radius.small)
+                                    .strokeBorder(Color(viewModel.displaySetting.color.foreground.withAlphaComponent(0.3)), lineWidth: 1.0)
+                            }
+                    }
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -176,7 +176,7 @@ extension ReaderDisplaySettingSelectionView {
                 )
 
                 static let bodyNotice = NSLocalizedString(
-                    "reader.customization.preview.body.notice",
+                    "reader.preferences.preview.body.notice",
                     value: "This feature is still in development.",
                     comment: "Footnote to be displayed in the preview section, noticing that the feature is in development."
                 )
@@ -279,7 +279,7 @@ extension ReaderDisplaySettingSelectionView {
             Slider(value: $sliderValue,
                    in: Double(ReaderDisplaySetting.Size.smaller.rawValue)...Double(ReaderDisplaySetting.Size.larger.rawValue),
                    step: 1) {
-                Text("Size")
+                Text(Strings.sizeSliderLabel)
             } minimumValueLabel: {
                 Text("A")
                     .font(Font(ReaderDisplaySetting.font(with: .sans, size: .smaller, textStyle: .body)))
@@ -295,9 +295,15 @@ extension ReaderDisplaySettingSelectionView {
 
     private struct Strings {
         static let doneButton = NSLocalizedString(
-            "reader.customization.control.doneButton",
+            "reader.preferences.control.doneButton",
             value: "Done",
             comment: "Title for a button to save and apply the customized Reader Preferences settings when tapped."
+        )
+
+        static let sizeSliderLabel = NSLocalizedString(
+            "reader.preferences.control.sizeSlider.description",
+            value: "Size",
+            comment: "Describes that the slider is used to customize the text size in the Reader."
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -277,15 +277,15 @@ extension ReaderDisplaySettingSelectionView {
 
         var sizeSelectionView: some View {
             Slider(value: $sliderValue,
-                   in: Double(ReaderDisplaySetting.Size.smaller.rawValue)...Double(ReaderDisplaySetting.Size.larger.rawValue),
+                   in: Double(ReaderDisplaySetting.Size.extraSmall.rawValue)...Double(ReaderDisplaySetting.Size.extraLarge.rawValue),
                    step: 1) {
                 Text(Strings.sizeSliderLabel)
             } minimumValueLabel: {
                 Text("A")
-                    .font(Font(ReaderDisplaySetting.font(with: .sans, size: .smaller, textStyle: .body)))
+                    .font(Font(ReaderDisplaySetting.font(with: .sans, size: .extraSmall, textStyle: .body)))
             } maximumValueLabel: {
                 Text("A")
-                    .font(Font(ReaderDisplaySetting.font(with: .sans, size: .larger, textStyle: .body)))
+                    .font(Font(ReaderDisplaySetting.font(with: .sans, size: .extraLarge, textStyle: .body)))
             } onEditingChanged: { _ in
                 viewModel.displaySetting.size = .init(rawValue: Int(sliderValue)) ?? .normal
             }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DesignSystem
 
 class ReaderDisplaySettingViewController: UIViewController {
 
@@ -19,148 +20,253 @@ class ReaderDisplaySettingViewController: UIViewController {
 
 // MARK: - SwiftUI
 
+// MARK: View Model
+
 class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
+
+    let feedbackLinkString = String() // TODO: Update with actual link
 
     @Published var displaySetting: ReaderDisplaySetting
 
     init(displaySetting: ReaderDisplaySetting) {
         self.displaySetting = displaySetting
     }
+
+    // Convenience accessors
+
+    var foregroundColor: Color {
+        Color(displaySetting.color.foreground)
+    }
+
+    var backgroundColor: Color {
+        Color(displaySetting.color.background)
+    }
 }
+
+// MARK: Container View
 
 struct ReaderDisplaySettingSelectionView: View {
 
     @ObservedObject var viewModel: ReaderDisplaySettingSelectionViewModel
 
-    @State private var sliderValue: Double = 0
-
     var body: some View {
-        VStack(spacing: 24.0) {
-            previewView
-            colorSelectionView
-            fontSelectionView
-            sizeSelectionView
-
-            // TODO: Add a 'Done' button
-
-            Spacer()
+        ZStack {
+            PreviewView(viewModel: viewModel)
+            VStack {
+                Spacer() // stick the control view to the bottom.
+                ControlView(viewModel: viewModel)
+                    .overlay(alignment: .top, content: { // add 1pt top border.
+                        Rectangle()
+                            .frame(width: nil, height: 1.0, alignment: .top)
+                            .foregroundStyle(Color(.tertiaryLabel))
+                    })
+            }
         }
     }
 
-    var previewView: some View {
-        VStack(alignment: .leading, spacing: 16.0) {
-            Text("The quick brown fox jumps over the lazy dog")
-                .font(Font(viewModel.displaySetting.font(with: .title1)))
-                .foregroundStyle(foregroundColor)
+}
 
-            HStack(spacing: 8.0) {
-                ForEach(["dogs", "fox", "design", "writing"], id: \.self) { text in
+// MARK: - Preview View
+
+extension ReaderDisplaySettingSelectionView {
+
+    struct PreviewView: View {
+        @ObservedObject var viewModel: ReaderDisplaySettingSelectionViewModel
+
+        var body: some View {
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: .DS.Padding.double) {
+                    Text(Strings.Preview.title)
+                        .font(Font(viewModel.displaySetting.font(with: .title1)))
+                        .foregroundStyle(Color(viewModel.displaySetting.color.foreground))
+
+                    tagsView
+
+                    // TODO: Add feature flag for feedback collection.
+                    // TODO: Apply link styles.
+                    if let feedbackURL = URL(string: viewModel.feedbackLinkString) {
+                        Link(Strings.Preview.feedbackLinkText, destination: feedbackURL)
+                    }
+
+                    Text(Strings.Preview.bodyDescription)
+                        .font(Font(viewModel.displaySetting.font(with: .callout)))
+                        .foregroundStyle(viewModel.foregroundColor)
+
+                    Text(Strings.Preview.bodyNotice)
+                        .font(Font(viewModel.displaySetting.font(with: .callout)))
+                        .foregroundStyle(viewModel.foregroundColor)
+
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.DS.Padding.double)
+            .background(viewModel.backgroundColor)
+            .animation(.easeInOut, value: viewModel.displaySetting)
+        }
+
+        var tagsView: some View {
+            HStack(spacing: .DS.Padding.single) {
+                ForEach(Strings.Preview.tags, id: \.self) { text in
                     Text(text)
                         .font(Font(viewModel.displaySetting.font(with: .callout)))
-                        .foregroundStyle(foregroundColor)
-                        .padding(.horizontal, 16.0)
-                        .padding(.vertical, 8.0)
+                        .foregroundStyle(viewModel.foregroundColor)
+                        .padding(.horizontal, .DS.Padding.double)
+                        .padding(.vertical, .DS.Padding.single)
                         .overlay {
-                            RoundedRectangle(cornerRadius: 5.0)
-                                .strokeBorder(foregroundColor, lineWidth: 1.0)
+                            RoundedRectangle(cornerRadius: .DS.Radius.small)
+                                .strokeBorder(Color(viewModel.displaySetting.color.foreground.withAlphaComponent(0.3)), lineWidth: 1.0)
                         }
                 }
             }
-
-            Text("Once upon a time, in a quaint little village nestled between rolling hills and lush greenery, there lived a quick brown fox named Jasper.")
-                .font(Font(viewModel.displaySetting.font(with: .callout)))
-                .foregroundStyle(foregroundColor)
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 16)
-        .padding(.bottom, 36)
-        .frame(maxWidth: .infinity)
-        .fixedSize(horizontal: false, vertical: true)
-        .background(backgroundColor)
-        .animation(.easeInOut, value: viewModel.displaySetting)
+
+        private struct Strings {
+            struct Preview {
+                static let title = NSLocalizedString(
+                    "reader.preferences.preview.title",
+                    value: "Choose your Reading Preferences",
+                    comment: "Title text for a preview"
+                )
+
+                static let tags = [
+                    NSLocalizedString("reader.preferences.preview.tags.1", value: "dogs", comment: "Example tag for preview"),
+                    NSLocalizedString("reader.preferences.preview.tags.2", value: "fox", comment: "Example tag for preview"),
+                    NSLocalizedString("reader.preferences.preview.tags.3", value: "design", comment: "Example tag for preview"),
+                    NSLocalizedString("reader.preferences.preview.tags.4", value: "writing", comment: "Example tag for preview"),
+                ]
+
+                static let feedbackLinkText = NSLocalizedString(
+                    "reader.preferences.preview.body.feedbackLink",
+                    value: "Send us a feedback on this feature",
+                    comment: "Text for a feedback link for the Reader Preferences feature"
+                )
+
+                static let bodyDescription = NSLocalizedString(
+                    "reader.preferences.preview.body.description",
+                    value: "Reading is personal, we want you to have control. Choose the styles that suit you.",
+                    comment: "Description text for the preview section of Reader Preferences"
+                )
+
+                static let bodyNotice = NSLocalizedString(
+                    "reader.customization.preview.body.notice",
+                    value: "This feature is still in development.",
+                    comment: "Footnote to be displayed in the preview section, noticing that the feature is in development."
+                )
+            }
+        }
     }
 
-    var colorSelectionView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4.0) {
-                ForEach(ReaderDisplaySetting.Color.allCases, id: \.rawValue) { color in
-                    Button {
-                        viewModel.displaySetting.color = color
-                    } label: {
-                        VStack(spacing: 8.0) {
-                            DualColorCircle(primaryColor: Color(color.foreground),
-                                            secondaryColor: Color(color.background))
-                            Text(color.label)
-                                .font(.footnote)
-                                .foregroundStyle(Color(.label))
-                        }
-                        .padding(.horizontal, 10.0)
-                        .padding(.vertical, 8.0)
-                        .clipShape(RoundedRectangle(cornerRadius: 5.0))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 5.0)
-                                .strokeBorder(color == viewModel.displaySetting.color ? .secondary : Color(.secondarySystemBackground), lineWidth: 1.0)
+}
+
+// MARK: - Control View
+
+extension ReaderDisplaySettingSelectionView {
+
+    struct ControlView: View {
+        @ObservedObject var viewModel: ReaderDisplaySettingSelectionViewModel
+
+        @State private var sliderValue: Double = 0
+
+        var body: some View {
+            VStack(spacing: .DS.Padding.large) {
+                colorSelectionView
+                fontSelectionView
+                sizeSelectionView
+                    .padding(.horizontal, .DS.Padding.double)
+                DSButton(title: Strings.doneButton, style: DSButtonStyle.init(emphasis: .primary, size: .large)) {
+                    // TODO: Impl
+                }
+                .padding(.horizontal, .DS.Padding.double)
+            }
+            .padding(.top, .DS.Padding.medium)
+            .background(Color(.systemBackground))
+        }
+
+        var colorSelectionView: some View {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: .DS.Padding.half) {
+                    ForEach(ReaderDisplaySetting.Color.allCases, id: \.rawValue) { color in
+                        Button {
+                            viewModel.displaySetting.color = color
+                        } label: {
+                            VStack(spacing: .DS.Padding.single) {
+                                DualColorCircle(primaryColor: Color(color.foreground),
+                                                secondaryColor: Color(color.background))
+                                Text(color.label)
+                                    .font(.footnote)
+                                    .foregroundStyle(Color(.label))
+                            }
+                            .padding(.horizontal, .DS.Padding.split)
+                            .padding(.vertical, .DS.Padding.single)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: .DS.Radius.small)
+                                    .strokeBorder(color == viewModel.displaySetting.color
+                                                  ? .primary
+                                                  : Color(UIColor.label.withAlphaComponent(0.1)), lineWidth: 1.0)
+                            }
                         }
                     }
                 }
+                .padding(.leading, .DS.Padding.double) // initial content offset
             }
-            .padding(.leading, 16.0) // initial content inset
         }
-    }
 
-    var fontSelectionView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 4.0) {
-                ForEach(ReaderDisplaySetting.Font.allCases, id: \.rawValue) { font in
-                    Button {
-                        viewModel.displaySetting.font = font
-                    } label: {
-                        VStack(spacing: 4.0) {
-                            Text("Aa")
-                                .font(Font(ReaderDisplaySetting.font(with: font, textStyle: .largeTitle)).bold())
-                                .foregroundStyle(Color(.label))
-                            Text(font.rawValue.capitalized)
-                                .font(.footnote)
-                                .foregroundStyle(Color(.label))
-                        }
-                        .padding(.horizontal, 16.0)
-                        .padding(.vertical, 8.0)
-                        .clipShape(RoundedRectangle(cornerRadius: 5.0))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 5.0)
-                                .strokeBorder(font == viewModel.displaySetting.font ? .secondary : Color(.secondarySystemBackground), lineWidth: 1.0)
+        var fontSelectionView: some View {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: .DS.Padding.half) {
+                    ForEach(ReaderDisplaySetting.Font.allCases, id: \.rawValue) { font in
+                        Button {
+                            viewModel.displaySetting.font = font
+                        } label: {
+                            VStack(spacing: .DS.Padding.half) {
+                                Text("Aa")
+                                    .font(Font(ReaderDisplaySetting.font(with: font, textStyle: .largeTitle)).bold())
+                                    .foregroundStyle(Color(.label))
+                                Text(font.rawValue.capitalized)
+                                    .font(.footnote)
+                                    .foregroundStyle(Color(.label))
+                            }
+                            .padding(.horizontal, .DS.Padding.double)
+                            .padding(.vertical, .DS.Padding.single)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: .DS.Radius.small)
+                                    .strokeBorder(font == viewModel.displaySetting.font
+                                                  ? .primary
+                                                  : Color(UIColor.label.withAlphaComponent(0.1)), lineWidth: 1.0)
+                            }
                         }
                     }
                 }
+                .padding(.leading, .DS.Padding.double) // initial content offset
             }
-            .padding(.leading, 16.0) // initial content inset
+        }
+
+        var sizeSelectionView: some View {
+            Slider(value: $sliderValue,
+                   in: Double(ReaderDisplaySetting.Size.smaller.rawValue)...Double(ReaderDisplaySetting.Size.larger.rawValue),
+                   step: 1) {
+                Text("Size")
+            } minimumValueLabel: {
+                Text("A")
+                    .font(Font(ReaderDisplaySetting.font(with: .sans, size: .smaller, textStyle: .body)))
+            } maximumValueLabel: {
+                Text("A")
+                    .font(Font(ReaderDisplaySetting.font(with: .sans, size: .larger, textStyle: .body)))
+            } onEditingChanged: { _ in
+                viewModel.displaySetting.size = .init(rawValue: Int(sliderValue)) ?? .normal
+            }
+            .padding(.vertical, .DS.Padding.single)
         }
     }
 
-    var sizeSelectionView: some View {
-        Slider(value: $sliderValue,
-               in: Double(ReaderDisplaySetting.Size.smaller.rawValue)...Double(ReaderDisplaySetting.Size.larger.rawValue),
-               step: 1) {
-            Text("Size")
-        } minimumValueLabel: {
-            Text("A")
-                .font(Font(ReaderDisplaySetting.font(with: .sans, size: .smaller, textStyle: .body)))
-        } maximumValueLabel: {
-            Text("A")
-                .font(Font(ReaderDisplaySetting.font(with: .sans, size: .larger, textStyle: .body)))
-        } onEditingChanged: { _ in
-            viewModel.displaySetting.size = .init(rawValue: Int(sliderValue)) ?? .normal
-        }
-        .padding(.vertical, 8.0)
-        .padding(.horizontal, 16.0)
-    }
-
-    private var foregroundColor: Color {
-        Color(viewModel.displaySetting.color.foreground)
-    }
-
-    private var backgroundColor: Color {
-        Color(viewModel.displaySetting.color.background)
+    private struct Strings {
+        static let doneButton = NSLocalizedString(
+            "reader.customization.control.doneButton",
+            value: "Done",
+            comment: "Title for a button to save and apply the customized Reader Preferences settings when tapped."
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -205,6 +205,7 @@ extension ReaderDisplaySettingSelectionView {
                 .padding(.horizontal, .DS.Padding.double)
             }
             .padding(.top, .DS.Padding.medium)
+            .padding(.bottom, .DS.Padding.single)
             .background(Color(.systemBackground))
         }
 

--- a/WordPress/Resources/HTML/richCommentStyle.css
+++ b/WordPress/Resources/HTML/richCommentStyle.css
@@ -25,7 +25,7 @@ html {
 body {
     font: -apple-system-body;
     color: -apple-system-label;
-    background-color: -apple-system-background;
+    background-color: transparent;
 }
 
 /* get rid of the container default margins and paddings. */
@@ -205,7 +205,7 @@ video {
 
 /* override hardcoded background color to system default. */
 .has-background {
-    background-color: -apple-system-background !important;
+    background-color: transparent !important;
 }
 
 /* forcefully remove gaps from custom vertical spacers. */

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5607,6 +5607,8 @@
 		FE34ACDC2B17AA9400108B3C /* BloganuaryOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE34ACD92B17AA6C00108B3C /* BloganuaryOverlayViewController.swift */; };
 		FE39C135269C37C900EFB827 /* ListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE39C133269C37C900EFB827 /* ListTableViewCell.xib */; };
 		FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE39C134269C37C900EFB827 /* ListTableViewCell.swift */; };
+		FE3AB90F2BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3AB90E2BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift */; };
+		FE3AB9102BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3AB90E2BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift */; };
 		FE3D057E26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D057D26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift */; };
 		FE3D058026C3E0F2002A51B0 /* share-app-link-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FE3D057F26C3E0F2002A51B0 /* share-app-link-success.json */; };
 		FE3D058326C419C4002A51B0 /* ShareAppContentPresenter+TableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D058126C40E66002A51B0 /* ShareAppContentPresenter+TableView.swift */; };
@@ -9502,6 +9504,7 @@
 		FE34ACD92B17AA6C00108B3C /* BloganuaryOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloganuaryOverlayViewController.swift; sourceTree = "<group>"; };
 		FE39C133269C37C900EFB827 /* ListTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ListTableViewCell.xib; sourceTree = "<group>"; };
 		FE39C134269C37C900EFB827 /* ListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
+		FE3AB90E2BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDisplaySettingViewController.swift; sourceTree = "<group>"; };
 		FE3D057D26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentPresenterTests.swift; sourceTree = "<group>"; };
 		FE3D057F26C3E0F2002A51B0 /* share-app-link-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "share-app-link-success.json"; sourceTree = "<group>"; };
 		FE3D058126C40E66002A51B0 /* ShareAppContentPresenter+TableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShareAppContentPresenter+TableView.swift"; sourceTree = "<group>"; };
@@ -18688,6 +18691,7 @@
 			isa = PBXGroup;
 			children = (
 				FE6BF4DD2BA5C8760040A190 /* ReaderDisplaySetting.swift */,
+				FE3AB90E2BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -21334,6 +21338,7 @@
 			files = (
 				F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */,
 				0CED20022B6809D600E6DD52 /* FilterCompactDatePicker.swift in Sources */,
+				FE3AB90F2BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift in Sources */,
 				B50C0C621EF42AF200372C65 /* TextList+WordPress.swift in Sources */,
 				B5722E421D51A28100F40C5E /* Notification.swift in Sources */,
 				1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */,
@@ -24401,6 +24406,7 @@
 				0C7762242AAFD39700E07A88 /* SiteMediaAddMediaMenuController.swift in Sources */,
 				C383555A288B02B00062E402 /* JetpackBannerWrapperViewController.swift in Sources */,
 				0CD9CCA42AD831590044A33C /* PostSearchViewModel.swift in Sources */,
+				FE3AB9102BA86E35007ADD36 /* ReaderDisplaySettingViewController.swift in Sources */,
 				FABB21612602FC2C00C8785C /* ReaderShowAttributionAction.swift in Sources */,
 				FABB21622602FC2C00C8785C /* LinkSettingsViewController.swift in Sources */,
 				F46546292AED89790017E3D1 /* AllDomainsListEmptyView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5636,6 +5636,8 @@
 		FE6BB143293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
 		FE6BB144293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
 		FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */; };
+		FE6BF4DE2BA5C8760040A190 /* ReaderDisplaySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BF4DD2BA5C8760040A190 /* ReaderDisplaySetting.swift */; };
+		FE6BF4DF2BA70D810040A190 /* ReaderDisplaySetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BF4DD2BA5C8760040A190 /* ReaderDisplaySetting.swift */; };
 		FE76C5E0293A63A800573C92 /* UIApplication+AppAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */; };
 		FE7B9A872A6A613000488791 /* PrepublishingSocialAccountsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */; };
 		FE7B9A882A6A613000488791 /* PrepublishingSocialAccountsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */; };
@@ -9518,6 +9520,7 @@
 		FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SOTWCardView.swift; sourceTree = "<group>"; };
 		FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinator.swift; sourceTree = "<group>"; };
 		FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinatorTests.swift; sourceTree = "<group>"; };
+		FE6BF4DD2BA5C8760040A190 /* ReaderDisplaySetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDisplaySetting.swift; sourceTree = "<group>"; };
 		FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingSocialAccountsViewController.swift; sourceTree = "<group>"; };
 		FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingSocialAccountsTableFooterView.swift; sourceTree = "<group>"; };
 		FE7FAABA299A36570032A6F2 /* WPComJetpackRemoteInstallViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComJetpackRemoteInstallViewModelTests.swift; sourceTree = "<group>"; };
@@ -16531,6 +16534,7 @@
 		CCB3A03814C8DD5100D43C3F /* Reader */ = {
 			isa = PBXGroup;
 			children = (
+				FE6BF4DC2BA5C86A0040A190 /* Theme */,
 				8B7F51C724EED488008CF5B5 /* Analytics */,
 				5D5A6E901B613C1800DAF819 /* Cards */,
 				9870EF7827866DCE00F3BB54 /* Comments */,
@@ -18678,6 +18682,14 @@
 				FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */,
 			);
 			path = Migration;
+			sourceTree = "<group>";
+		};
+		FE6BF4DC2BA5C86A0040A190 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				FE6BF4DD2BA5C8760040A190 /* ReaderDisplaySetting.swift */,
+			);
+			path = Theme;
 			sourceTree = "<group>";
 		};
 		FE7B9A852A6A60EC00488791 /* Prepublishing */ = {
@@ -21636,6 +21648,7 @@
 				464688D8255C71D200ECA61C /* SiteDesignPreviewViewController.swift in Sources */,
 				3F39C93527A09927001EC300 /* WordPressLibraryLogger.swift in Sources */,
 				3F5B3EB123A851480060FF1F /* ReaderReblogFormatter.swift in Sources */,
+				FE6BF4DE2BA5C8760040A190 /* ReaderDisplaySetting.swift in Sources */,
 				E1AB5A071E0BF17500574B4E /* Array.swift in Sources */,
 				D858F2FD20E1F09F007E8A1C /* NotificationActionParser.swift in Sources */,
 				E66E2A661FE4311300788F22 /* SiteTagsViewController.swift in Sources */,
@@ -25652,6 +25665,7 @@
 				8313B9EF298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */,
 				982DA9A8263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
 				46F583D52624D0BC0010A723 /* Blog+BlockEditorSettings.swift in Sources */,
+				FE6BF4DF2BA70D810040A190 /* ReaderDisplaySetting.swift in Sources */,
 				FABB24E22602FC2C00C8785C /* SharingAccountViewController.swift in Sources */,
 				FABB24E42602FC2C00C8785C /* UIApplication+mainWindow.swift in Sources */,
 				FABB24E52602FC2C00C8785C /* CoreDataIterativeMigrator.swift in Sources */,


### PR DESCRIPTION
Internal refs: zQnohyMpLzBzQ5jzMMKni3-fi-3900_17941, p1710343618122149-slack-C06PGTY5PKK

> [!WARNING]
> Some of the display settings are not fully applied yet, namely:
> - The comments section
> - Related posts
> - Toolbar
> - Navigation bar items
>
> Since the feature is wrapped under a feature flag, I'll plan to address them separately via small-sized PRs. 

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/78271193-24a3-4e9e-b395-5b77ff705c64" width=300>

This covers the proof-of-concept (WIP) of applying custom display settings to the Reader Post screen. The core idea is around the object `ReaderDisplaySetting`, which encapsulates the preferred color, font, and size.

- The main part of customization, the post, is relatively easy. We just need to expose the display setting to the `ReaderWebView`, and allow the colors to be injected to the CSS styles.
- The tricky/arduous part is actually the view components around the web view; like the header view, the comment table, the related posts section, and the navigation bar. Some of them have hardcoded background colors, so I needed to ensure that they are transparent.
- Some definitions (such as secondary text color and font size scaling values) were missing, so I defined the values myself for now. Other details were also replaced with something "easier" to get it done faster—for example, I haven't imported the customization icon yet, so I used one from SF Symbols instead. Slider is another example; I used the "stock" Slider appearance for now, as the one from Figma requires custom implementation.

```[tasklist]
### Todo
- [x] Add a Done button to the customization sheet.
- [x] Save the updated display setting to user defaults.
- [x] Fix the preview section's height so that it remain fixed as the value changes. Internal ref: p1710941720606209/1710938030.708789-slack-C06PGTY5PKK
- [x] Apply the updated display setting to the Reader detail screen.
- [x] Update the view components to apply foreground color based on the display setting.
- [x] Apply font and size settings to the remaining views.
- [x] Add a feature flag
- [ ] Build a custom slider to match the designs.
- [ ] Apply proper accessibility labels to the customization sheet.
```

#### To figure out next

- Consider if the way `ReaderDisplaySetting` is used and/or passed around is the "right" approach.
- Consider somehow merging `ReaderDisplaySetting` to the design system or standard colors.
- How to make the views react when the display setting is updated? In the current PR, I had to painstakingly update each component so that the colors are injectable. 
  - With the display settings integrated to the standard colors, views could automatically use the selected colors.
  - But the problem is, how to make the views react when the selected colors are changed?
- Figure out some other color components for each scheme, such as secondary text colors, secondary background colors, border colors, etc.
- Review if the font generation method is correct, considering the customization variables. Ensure that they respect the preferred content size category, etc.

## To test

Note that the functionality to save the updated preferences hasn't been added yet. For now, you can test bringing up the customization interface and play around with the selections by:

- Going to any Reader post
- Tap the customization icon (next to the "Open in Safari" navigation bar button)

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is hidden behind a feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)