### PR TITLE
Stats Traffic: Fix a crash on iOS 15 & 16 when expanding rows

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -185,8 +185,7 @@ private extension SiteStatsPeriodTableViewController {
     }
 
     func applyTableUpdates() {
-        tableView.performBatchUpdates({
-        })
+        tableHandler.diffableDataSource.apply(viewModel.tableViewSnapshot(), animatingDifferences: false)
     }
 
     func clearExpandedRows() {


### PR DESCRIPTION
Fixes #22853

Stats Traffic crashes when expanding table view rows (e.g. Clicks, Authors cards) on iOS 15 and iOS 16. The issue is not reproducible on iOS 17:

> UITableView must be updated via the UITableViewDiffableDataSource APIs when acting as the UITableView's dataSource: please do not call mutation APIs directly on UITableView.

The crash is related to recent changes made that introduced diffable data source to Stats Traffic tab (`StatsPeriodTableViewController`). I updated table view reloads that were triggered by view model but haven't updates table view reloads triggered by trying to expand table view cell rows. It incorrectly calls `performBatchUpdates` which shouldn't be called for table views that use diffable data souce. 

We missed this crash since it doesn't happen on iOS 17.

My changes removed the animation when expanding table view rows. However, this is intentional since the animation both on Stats Traffic and Days/Weeks/Months/Years tabs looks broken.

### iOS 16 crash

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/2acdf8e9-cfd4-44fb-972f-3e36467c2aa5

### iOS 16 no crash after the fix

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/eb4b1c3b-b9db-4195-90a5-3dd6992ecb37

### To test:

#### iOS 15 / iOS 16

1. Launch Jetpack app on iOS 15 or iOS 16
2. Log into higher traffic site
3. Open Stats -> Traffic
4. Scroll to Authors / Clicks cards
5. Try to expand the row
6. Confirm that the row expands and no crash happens

#### iOS 17
1. Launch Jetpack app on iOS 117
2. Log into higher traffic site
3. Open Stats -> Traffic
4. Scroll to Authors / Clicks cards
5. Try to expand the row
6. Confirm that the row expands and no crash happens

## Regression Notes
1. Potential unintended areas of impact

Couldn't identify

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
