### PR TITLE
Reader: Fix blinking navigation bar on dark mode in Reader Post

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -312,6 +312,14 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     private func updateNavigationBar(with offset: CGFloat) {
+        /// Navigation bar is only updated in light interface style, so that the tint color can be reverted
+        /// to the original color after scrolling past the featured image.
+        ///
+        /// In case of dark mode, the navigation bar tint color will always be kept white.
+        guard traitCollection.userInterfaceStyle == .light else {
+            return
+        }
+
         let fullProgress = (offset / heightConstraint.constant)
         let progress = fullProgress.clamp(min: 0, max: 1)
 
@@ -319,12 +327,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
                                             to: Styles.endTintColor,
                                             with: progress)
 
-        if traitCollection.userInterfaceStyle == .light {
-            currentStatusBarStyle = fullProgress >= 2.5 ? .darkContent : .lightContent
-        } else {
-            currentStatusBarStyle = .lightContent
-        }
-
+        currentStatusBarStyle = fullProgress >= 2.5 ? .darkContent : .lightContent
         navBarTintColor = tintColor
     }
 


### PR DESCRIPTION
Internal ref: pcdRpT-675-p2

In dark mode, the navigation bar on the Reader Post screen could blink as the user scrolls through the content. This PR fixes that issue by removing the navigation bar tint modification based on scroll position when in dark mode.

In 🌝 light mode, the intent was to start with a white tint color for the navigation bar, displayed on top of a featured image having a dark tint. As we scroll past the featured image, the tint color should transition to a dark color (`UIColor.text` to be exact) to avoid low contrast with the view background.

In 🌚 dark mode, the transition seems a bit buggy. I'm suspecting something unexpected happened to the custom color interpolation logic since we're transitioning from `.white` to `.text` (which, in dark mode, results to a white color too!) and sometimes this results in the color being black. To solve this, in dark mode, we actually don't need to transition the color. We can just always keep the `.white` color!

Here is a preview:

• | Before | After
-|-|-
Light (should be unchanged) | ![before_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/a215c1b5-8cc5-41bf-86fc-1528f6765886) | ![after_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5eba6b45-d270-4da1-bd1f-f35b4a08c9ef)
Dark | ![before_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c008cf09-c715-4cbc-b0a9-676c6705e936) | ![after_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/00eb8118-d04b-429a-95fd-106924535392)

## To test

### 🌝 Testing light mode

In light mode, the navigation bar should behave as before. 

- Launch the Jetpack app.
- Ensure that the app is in **light mode**, or change via Me > App Settings > Appearance.
- Go to Reader.
- Select a post with a featured image.
- 🔎 Verify that the navigation bar tint color starts off with a white color.
- Start scrolling until you get past the featured image.
- 🔎 Verify that the navigation bar tint color transitions to a dark color.

### 🌚  Testing dark mode

- Launch the Jetpack app.
- Ensure that the app is in **dark mode**, or change via Me > App Settings > Appearance.
- Go to Reader.
- Select a post with a featured image.
- 🔎 Verify that the navigation bar tint color starts off with a white color.
- Start scrolling until you get past the featured image.
- 🔎 Verify that the navigation bar tint color is still white.
- Continue scrolling back and forth.
- 🔎 Verify that the navigation bar tint color stays white and does not "blink" or change colors.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t cisn'tte, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)