### PR TITLE
[Design System] Add icon customisability to `DSButton`

### DIFF
--- a/Modules/Sources/DesignSystem/Components/DSButton.swift
+++ b/Modules/Sources/DesignSystem/Components/DSButton.swift
@@ -4,12 +4,14 @@ public struct DSButton: View {
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.colorScheme) private var colorScheme
     private let title: String
+    private let iconName: IconName?
     private let style: DSButtonStyle
     @Binding private var isLoading: Bool
     private let action: (() -> Void)
 
     public init(
         title: String,
+        iconName: IconName? = nil,
         style: DSButtonStyle,
         isLoading: Binding<Bool> = .constant(false),
         action: @escaping () -> Void
@@ -17,6 +19,7 @@ public struct DSButton: View {
         self._isLoading = isLoading
         self.action = action
         self.title = title
+        self.iconName = iconName
         self.style = style
     }
 
@@ -58,7 +61,7 @@ public struct DSButton: View {
                     .tint(Color.white)
             } else {
                 if style.emphasis != .tertiary {
-                    buttonText
+                    buttonLabel
                         .padding(
                             .horizontal,
                             style.size == .small
@@ -66,7 +69,7 @@ public struct DSButton: View {
                             : Length.Padding.medium
                         )
                 } else {
-                    buttonText
+                    buttonLabel
                 }
             }
         }
@@ -75,6 +78,20 @@ public struct DSButton: View {
             ? Length.Padding.large
             : Length.Padding.max
         )
+    }
+
+    @ViewBuilder
+    private var buttonLabel: some View {
+        if let iconName {
+            HStack(alignment: .center, spacing: Length.Padding.half) {
+                Image.DS.icon(named: iconName)
+                    .imageScale(.small)
+                    .foregroundStyle(style.foregroundColor)
+                buttonText
+            }
+        } else {
+            buttonText
+        }
     }
 
     private var buttonText: some View {
@@ -94,6 +111,7 @@ public struct DSButton: View {
         case .tertiary:
             weight = .regular
         }
+
         return Text(title).style(textStyle(weight))
             .foregroundStyle(
                 style.foregroundColor

--- a/Modules/Sources/DesignSystem/Gallery/DSButtonGallery.swift
+++ b/Modules/Sources/DesignSystem/Gallery/DSButtonGallery.swift
@@ -11,6 +11,7 @@ struct DSButtonGallery: View {
                             ForEach(DSButtonStyle.Emphasis.allCases, id: \.title) { emphasis in
                                 DSButton(
                                     title: emphasis.title,
+                                    iconName: .checkmark,
                                     style: .init(
                                         emphasis: emphasis,
                                         size: size,


### PR DESCRIPTION
## Description

The `DSButton` component was not supporting icons before. Now it accepts an `IconName` to follow the LyzJJa6ANKToUswWmRrZee-fi-102_186.

## Testing Steps

Go to Design System Gallery in the Jetpack App.
Components > DSButton

✅ Verify if the icon version matches the designs.

## Screenshot Reference
![Simulator Screenshot - iPhone 15 - 2024-03-19 at 16 36 56](https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/d3e75e50-4e44-4432-a3d6-f4afae4095b3)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)