### PR TITLE
Exclude Gutenberg source map file from binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ WordPress/InfoPlist-internal.h
 
 # SwiftLint Remote Config Cache
 .swiftlint/RemoteConfigCache
+
+# Gutenberg extra bundle and source map files
+gutenberg/react-native-bundle-source-map

--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,3 @@ WordPress/InfoPlist-internal.h
 
 # SwiftLint Remote Config Cache
 .swiftlint/RemoteConfigCache
-
-# Gutenberg extra bundle and source map files
-gutenberg/react-native-bundle-source-map

--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -9,6 +9,10 @@ DEFAULT_GUTENBERG_LOCATION = File.join(__dir__, '..', '..', 'gutenberg-mobile')
 
 GUTENBERG_CONFIG_PATH = File.join(__dir__, '..', 'Gutenberg', 'config.yml')
 
+# We skip the simulator architecture as we only need to extract the bundle and source map for installable builds.
+GUTENBERG_FRAMEWORK_FOLDER = File.join(__dir__, '..', 'Pods', 'Gutenberg', 'Frameworks', 'Gutenberg.xcframework', 'ios-arm64', 'Gutenberg.framework')
+GUTENBERG_BUNDLE_SOURCE_MAP_TARGET = File.join(__dir__, '..', 'Gutenberg', 'react-native-bundle-source-map')
+
 LOCAL_GUTENBERG_KEY = 'LOCAL_GUTENBERG'
 
 # Note that the pods in this array might seem unused if you look for
@@ -115,6 +119,8 @@ def apply_rnreanimated_workaround!(dependencies:, gutenberg_path:)
 end
 
 def gutenberg_post_install(installer:)
+  extract_bundle_source_map_files unless should_use_local_gutenberg
+
   return unless should_use_local_gutenberg
 
   raise "[Gutenberg] Could not find local Gutenberg at given path #{local_gutenberg_path}" unless File.exist?(local_gutenberg_path)
@@ -206,4 +212,23 @@ def workaround_broken_search_paths
     end
   end
   project.save
+end
+
+# Copy Gutenberg bundle and source map files so they can be upload it to Sentry during the build process.
+def extract_bundle_source_map_files
+  puts '[Gutenberg] Extracting bundle and source map files'
+
+  FileUtils.mkdir_p(GUTENBERG_BUNDLE_SOURCE_MAP_TARGET)
+  bundle_from_path = File.join(GUTENBERG_FRAMEWORK_FOLDER, 'App.js')
+  bundle_destination_path = File.join(GUTENBERG_BUNDLE_SOURCE_MAP_TARGET, 'main.jsbundle')
+  FileUtils.cp(bundle_from_path, bundle_destination_path)
+
+  # Source map file is moved instead of copied to avoid including it in the binary.
+  source_map_from_path = File.join(GUTENBERG_FRAMEWORK_FOLDER, 'App.composed.js.map')
+  source_map_destination_path = File.join(GUTENBERG_BUNDLE_SOURCE_MAP_TARGET, 'main.jsbundle.map')
+  if File.exist?(source_map_from_path)
+    FileUtils.mv(source_map_from_path, source_map_destination_path)
+  elsif !File.exist?(source_map_destination_path)
+    raise "[Gutenberg] Source map \"#{source_map_from_path}\" could not be found. Please verify that the Gutenberg version includes the file or reinstall the pod."
+  end
 end

--- a/Gutenberg/cocoapods_helpers.rb
+++ b/Gutenberg/cocoapods_helpers.rb
@@ -11,7 +11,7 @@ GUTENBERG_CONFIG_PATH = File.join(__dir__, '..', 'Gutenberg', 'config.yml')
 
 # We skip the simulator architecture as we only need to extract the bundle and source map for installable builds.
 GUTENBERG_FRAMEWORK_FOLDER = File.join(__dir__, '..', 'Pods', 'Gutenberg', 'Frameworks', 'Gutenberg.xcframework', 'ios-arm64', 'Gutenberg.framework')
-GUTENBERG_BUNDLE_SOURCE_MAP_TARGET = File.join(__dir__, '..', 'Gutenberg', 'react-native-bundle-source-map')
+GUTENBERG_BUNDLE_SOURCE_MAP_TARGET = File.join(__dir__, '..', 'Pods', 'Gutenberg', 'react-native-bundle-source-map')
 
 LOCAL_GUTENBERG_KEY = 'LOCAL_GUTENBERG'
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -532,39 +532,31 @@ platform :ios do
   end
 
   def upload_gutenberg_sourcemaps(sentry_project_slug:, release_version:, build_version:, app_identifier:)
-    # The bundle and source map files are the same for all architectures.
-    gutenberg_bundle = File.join(PROJECT_ROOT_FOLDER, 'Pods/Gutenberg/Frameworks/Gutenberg.xcframework/ios-arm64/Gutenberg.framework')
+    gutenberg_bundle_source_map_folder = File.join(PROJECT_ROOT_FOLDER, '..', 'Gutenberg', 'react-native-bundle-source-map')
 
-    Dir.mktmpdir do |sourcemaps_folder|
-      # It's important that the bundle and source map files have specific names, otherwise, Sentry
-      # won't symbolicate the stack traces.
-      FileUtils.cp(File.join(gutenberg_bundle, 'App.js'), File.join(sourcemaps_folder, 'main.jsbundle'))
-      FileUtils.cp(File.join(gutenberg_bundle, 'App.composed.js.map'), File.join(sourcemaps_folder, 'main.jsbundle.map'))
+    # To generate the full release version string to attach the source maps, we need to specify:
+    # - App identifier
+    # - Release version
+    # - Build version
+    # This conforms to the following format: <app_identifier>@<release_version>+<build_version>
+    # Here are a couple of examples:
+    # - Prototype build: com.jetpack.alpha@24.2+pr22654-07765b3
+    # - App Store build: org.wordpress@24.1+24.1.0.3
 
-      # To generate the full release version string to attach the source maps, we need to specify:
-      # - App identifier
-      # - Release version
-      # - Build version
-      # This conforms to the following format: <app_identifier>@<release_version>+<build_version>
-      # Here are a couple of examples:
-      # - Prototype build: com.jetpack.alpha@24.2+pr22654-07765b3
-      # - App Store build: org.wordpress@24.1+24.1.0.3
-
-      sentry_upload_sourcemap(
-        auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
-        org_slug: SENTRY_ORG_SLUG,
-        project_slug: sentry_project_slug,
-        version: release_version,
-        dist: build_version,
-        build: build_version,
-        app_identifier:,
-        # When the React native bundle is generated, the source map file references
-        # include the local machine path, with the `rewrite` and `strip_common_prefix`
-        # options Sentry automatically strips this part.
-        rewrite: true,
-        strip_common_prefix: true,
-        sourcemap: sourcemaps_folder
-      )
-    end
+    sentry_upload_sourcemap(
+      auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
+      org_slug: SENTRY_ORG_SLUG,
+      project_slug: sentry_project_slug,
+      version: release_version,
+      dist: build_version,
+      build: build_version,
+      app_identifier:,
+      # When the React native bundle is generated, the source map file references
+      # include the local machine path, with the `rewrite` and `strip_common_prefix`
+      # options Sentry automatically strips this part.
+      rewrite: true,
+      strip_common_prefix: true,
+      sourcemap: gutenberg_bundle_source_map_folder
+    )
   end
 end

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -532,7 +532,7 @@ platform :ios do
   end
 
   def upload_gutenberg_sourcemaps(sentry_project_slug:, release_version:, build_version:, app_identifier:)
-    gutenberg_bundle_source_map_folder = File.join(PROJECT_ROOT_FOLDER, 'Gutenberg', 'react-native-bundle-source-map')
+    gutenberg_bundle_source_map_folder = File.join(PROJECT_ROOT_FOLDER, 'Pods', 'Gutenberg', 'react-native-bundle-source-map')
 
     # To generate the full release version string to attach the source maps, we need to specify:
     # - App identifier

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -532,7 +532,7 @@ platform :ios do
   end
 
   def upload_gutenberg_sourcemaps(sentry_project_slug:, release_version:, build_version:, app_identifier:)
-    gutenberg_bundle_source_map_folder = File.join(PROJECT_ROOT_FOLDER, '..', 'Gutenberg', 'react-native-bundle-source-map')
+    gutenberg_bundle_source_map_folder = File.join(PROJECT_ROOT_FOLDER, 'Gutenberg', 'react-native-bundle-source-map')
 
     # To generate the full release version string to attach the source maps, we need to specify:
     # - App identifier


### PR DESCRIPTION
_Internal ref:_ pcdRpT-5rI-p2#comment-9518

**To test:**
1. Run command: `bundle exec pod install`.
2. Observe that bundle and source map files are copied to `Pods/Gutenberg/react-native-bundle-source-map` folder.
3. Observe that the source map file (`App.composed.js.map`) is not present in the folder `Pods/Gutenberg/Frameworks/Gutenberg.xcframework/ios-arm64/Gutenberg.framework`.
4. Archive the Xcode project (it can be using the `debug` scheme).
5. Inspect the archive file and observe that the source map file (`App.composed.js.map`) is not present in the folder `<ARCHIVE>.xcarchive/Products/Applications/Jetpack.app/Frameworks/Gutenberg.framework`.
6. Alternatively, the installable build can also be inspected.

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)