### PR TITLE
Offline Mode: Improve Post Settings

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -190,8 +190,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (BOOL)hasRemote;
 // Deletes post locally
 - (void)remove;
-// Save changes to disk
-- (void)save;
 
 // This property is used to indicate whether an app should attempt to automatically retry upload this post
 // the next time a internet connection is available.

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -66,12 +66,6 @@
 
 }
 
-- (void)save
-{
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-}
-
-
 #pragma mark - Getters/Setters
 
 - (void)setRemoteStatusNumber:(NSNumber *)remoteStatusNumber

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -155,7 +155,7 @@ class PostCoordinator: NSObject {
     ///
     /// - warning: Work-in-progress (kahu-offline-mode)
     @discardableResult @MainActor
-    func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
+    func _save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
         let post = post.original ?? post
         do {
             let isExistingPost = post.hasRemote()
@@ -163,6 +163,20 @@ class PostCoordinator: NSObject {
             try await PostRepository()._save(post, changes: changes, overwrite: true)
             show(PostCoordinator.makeUploadSuccessNotice(for: post, isExistingPost: isExistingPost))
             return post
+        } catch {
+            handleError(error, for: post)
+            throw error
+        }
+    }
+
+    /// Patches the post but keeps the local revision if any.
+    ///
+    /// - warning: Work-in-progress (kahu-offline-mode)
+    @MainActor
+    func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
+        let post = post.original ?? post
+        do {
+            try await PostRepository()._update(post, changes: changes)
         } catch {
             handleError(error, for: post)
             throw error

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -4,20 +4,10 @@ import WordPressFlux
 extension PostEditor {
 
     func displayPostSettings() {
-        let settingsViewController: PostSettingsViewController
-        if post is Page {
-            settingsViewController = PageSettingsViewController(post: post)
-        } else {
-            settingsViewController = PostSettingsViewController(post: post)
-        }
-        settingsViewController.featuredImageDelegate = self as? FeaturedImageDelegate
-        let doneButton = UIBarButtonItem(systemItem: .done, primaryAction: .init(handler: { [weak self] _ in
-            self?.navigationController?.dismiss(animated: true)
-        }))
-        doneButton.accessibilityIdentifier = "close"
-        settingsViewController.navigationItem.rightBarButtonItem = doneButton
-
-        let navigation = UINavigationController(rootViewController: settingsViewController)
+        let viewController = PostSettingsViewController.make(for: post)
+        viewController.featuredImageDelegate = self as? FeaturedImageDelegate
+        let navigation = UINavigationController(rootViewController: viewController)
+        navigation.navigationBar.isTranslucent = true // Reset to default
         self.navigationController?.present(navigation, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -469,7 +469,7 @@ extension PublishingEditor {
         if RemoteFeatureFlag.syncPublishing.enabled() {
             Task { @MainActor in
                 do {
-                    self.post = try await PostCoordinator.shared._update(post)
+                    self.post = try await PostCoordinator.shared._save(post)
                     if dismissWhenDone {
                         self.dismissOrPopView()
                     } else {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -73,12 +73,12 @@ extension PostSettingsViewController {
         guard let media = MediaCoordinator.shared.addMedia(from: asset, to: apost) else {
             return
         }
-        self.apost.featuredImage = media
+        self.apost.featuredImage = try? self.apost.managedObjectContext?.existingObject(with: TaggedManagedObjectID(media))
         self.setupObservingOf(media: media)
     }
 
     @objc func setFeaturedImage(media: Media) {
-        apost.featuredImage = media
+        apost.featuredImage = try? self.apost.managedObjectContext?.existingObject(with: TaggedManagedObjectID(media))
         if !media.hasRemote {
             MediaCoordinator.shared.retryMedia(media)
             setupObservingOf(media: media)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
@@ -12,9 +12,12 @@
 - (nonnull instancetype)initWithPost:(nonnull AbstractPost *)aPost;
 - (void)endEditingAction:(nullable id)sender;
 
+/// The post in a temporary context that the screen is working with.
 @property (nonnull, nonatomic, strong, readonly) AbstractPost *apost;
+/// The original post (or revision) from the main context.
+@property (nonnull, nonatomic, strong, readonly) AbstractPost *snapshot;
+
 @property (nonatomic) BOOL isStandalone;
-@property (nonatomic) BOOL isStandaloneEditorDismissingAfterSave;
 @property (nonnull, nonatomic, strong, readonly) NSArray *publicizeConnections;
 @property (nonnull, nonatomic, strong, readonly) NSArray *unsupportedConnections;
 

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -107,9 +107,6 @@ class PostTagPickerViewController: UIViewController {
         textViewContainer.layer.masksToBounds = false
 
         keyboardObserver.tableView = tableView
-
-        let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: "Done button title"), style: .plain, target: self, action: #selector(doneButtonPressed))
-        navigationItem.setRightBarButton(doneButton, animated: false)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -144,10 +141,6 @@ class PostTagPickerViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         textViewContainer.layer.borderColor = UIColor.divider.cgColor
-    }
-
-    @objc func doneButtonPressed() {
-        navigationController?.popViewController(animated: true)
     }
 
     fileprivate func reloadTableData() {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -556,7 +556,6 @@ extension PrepublishingViewController: PostCategoriesViewControllerDelegate {
              return
         }
         post.categories = categories
-        post.save()
     }
 }
 

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -44,7 +44,7 @@ class EditorGutenbergTests: XCTestCase {
             .openPostSettings()
             .selectCategory(name: category)
             .addTag(name: tag)
-            .closePostSettings()
+            .savePostSettings()
             .postAndViewEpilogue(action: .publish)
             .verifyEpilogueDisplays(postTitle: postTitle, siteAddress: WPUITestCredentials.testWPcomPaidSite)
             .tapDone()
@@ -85,7 +85,7 @@ class EditorGutenbergTests: XCTestCase {
             .verifyPostSettings(hasImage: false)
             .setFeaturedImage()
             .verifyPostSettings(hasImage: true)
-            .closePostSettings()
+            .savePostSettings()
     }
 
     func testAddGalleryBlock() throws {

--- a/WordPress/UITests/Tests/PostTests.swift
+++ b/WordPress/UITests/Tests/PostTests.swift
@@ -25,7 +25,7 @@ class PostTests: XCTestCase {
             .openPostSettings()
             .updatePublishDateToFutureDate()
             .closePublishDateSelector()
-            .closePostSettings()
+            .savePostSettings()
             .post(action: .schedule)
 
         try MySiteScreen()

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -47,8 +47,8 @@ public class EditorPostSettings: ScreenObject {
         $0.buttons.containing(.staticText, identifier: "1").element
     }
 
-    private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.navigationBars.buttons["close"]
+    private let saveButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars.buttons["save"]
     }
 
     private let backButtonGetter: (XCUIApplication) -> XCUIElement? = {
@@ -59,7 +59,7 @@ public class EditorPostSettings: ScreenObject {
     var chooseFromMediaButton: XCUIElement { chooseFromMediaButtonGetter(app) }
     var currentFeaturedImage: XCUIElement { currentFeaturedImageGetter(app) }
     var dateSelector: XCUIElement { dateSelectorGetter(app) }
-    var closeButton: XCUIElement { closeButtonGetter(app) }
+    var saveButton: XCUIElement { saveButtonGetter(app) }
     var backButton: XCUIElement? { backButtonGetter(app) }
     var featuredImageButton: XCUIElement { featuredImageButtonGetter(app) }
     var firstCalendarDayButton: XCUIElement { firstCalendarDayButtonGetter(app) }
@@ -135,8 +135,8 @@ public class EditorPostSettings: ScreenObject {
     }
 
     @discardableResult
-    public func closePostSettings() throws -> BlockEditorScreen {
-        closeButton.tap()
+    public func savePostSettings() throws -> BlockEditorScreen {
+        saveButton.tap()
 
         return try BlockEditorScreen()
     }


### PR DESCRIPTION
This PR improves Post Settings in multiple ways by introducing a [child context](https://www.kodeco.com/7586-multiple-managed-object-contexts-with-core-data-tutorial/page/4) as a scratchpad for changes. The only complication is due to the relationships. For example, when you add a category, its added in the `viewContext`, so we have to get the same object in the scratchpad.

## Known Issues

 In this PR, I want to make sure we get the bigger ideas right. There are a couple of known issues:

- `publicizeMessage` and social integration not encoded in the patch parameters
- Assertion when using "password protected" status from the standalone settings screen
- Removing feature image doesn't work (needs to be set to `""` instead of `null`)

I have a list of those and I suggest not focusing on the individual fields for now. We'll do a full test before merging the feature branch.

## Changes 

- Update the navigation bar style in the Post Settings in the Editor
- Add “Cancel” button to allow undoing the changes – extra peace of mind. Thanks to a child context, the app no longer needs to do anything to undo the changes.
- "Save" button will now work based on the diff – same as in the standalone editor
- Fix an issue with “Cancel” button being enable during save (production issue)
- Remove "Done" button from the Tags screen (same behavior as back)

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/a1a0e012-d12b-4a8c-ab30-bb20922a464f


## To test:

- Verify that adding new categories works (important because blog still operates on `viewContext`, so it was a bit tricky to support): you can select new categories, add new categories, and the categories are pre-selected after re-opening the picker
- Verify that passport-protected visibility does not crash in the standalone editor
- Verify that you can cancel any change
- Verify that "Save" is enabled only if there are any changes (undoing a change will disable the button)
- Verify that if you dismiss the editor using a swipe gesture, the changes are not saved
- Verify that if you open Post Settings from the Editor, make changes, and tap "Save", the changes are saved to the database (check by re-opening the settings)
- Disable `.syncPublishing` feature flag and perform regression test of the settings

## Known Issues

- I'm planning to change how `status` updates from the Post Settings are handled in the upcoming PR

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
