### PR TITLE
Offline Mode: Create copes of deprecated classes

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - Alamofire (5.8.1)
+  - Alamofire (5.9.0)
   - AlamofireImage (4.3.0):
     - Alamofire (~> 5.8)
   - AlamofireNetworkActivityIndicator (3.1.0):
     - Alamofire (~> 5.1)
-  - AppCenter (5.0.3):
-    - AppCenter/Analytics (= 5.0.3)
-    - AppCenter/Crashes (= 5.0.3)
-  - AppCenter/Analytics (5.0.3):
+  - AppCenter (5.0.4):
+    - AppCenter/Analytics (= 5.0.4)
+    - AppCenter/Crashes (= 5.0.4)
+  - AppCenter/Analytics (5.0.4):
     - AppCenter/Core
-  - AppCenter/Core (5.0.3)
-  - AppCenter/Crashes (5.0.3):
+  - AppCenter/Core (5.0.4)
+  - AppCenter/Crashes (5.0.4):
     - AppCenter/Core
-  - AppCenter/Distribute (5.0.3):
+  - AppCenter/Distribute (5.0.4):
     - AppCenter/Core
   - Automattic-Tracks-iOS (3.3.0):
     - Sentry (~> 8.0)
@@ -32,7 +32,7 @@ PODS:
     - CropViewController
   - MediaEditor (1.2.2):
     - CropViewController (~> 2.5.3)
-  - NSObject-SafeExpectations (0.0.4)
+  - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
   - OCMock (3.4.3)
   - OHHTTPStubs/Core (9.1.0)
@@ -56,14 +56,14 @@ PODS:
     - SentryPrivate (= 8.21.0)
   - SentryPrivate (8.21.0)
   - Sodium (0.9.1)
-  - Starscream (4.0.6)
+  - Starscream (4.0.8)
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
-  - WordPress-Aztec-iOS (1.19.9)
-  - WordPress-Editor-iOS (1.19.9):
-    - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (9.0.2):
+  - WordPress-Aztec-iOS (1.19.10)
+  - WordPress-Editor-iOS (1.19.10):
+    - WordPress-Aztec-iOS (= 1.19.10)
+  - WordPressAuthenticator (9.0.3):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
@@ -76,22 +76,22 @@ PODS:
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.3.1)
-  - WordPressUI (1.15.0)
+  - WordPressUI (1.15.1)
   - wpxmlrpc (0.10.0)
-  - ZendeskCommonUISDK (6.1.2)
+  - ZendeskCommonUISDK (6.1.4)
   - ZendeskCoreSDK (2.5.1)
-  - ZendeskMessagingAPISDK (3.8.3):
-    - ZendeskSDKConfigurationsSDK (= 1.1.9)
-  - ZendeskMessagingSDK (3.8.3):
-    - ZendeskCommonUISDK (= 6.1.2)
-    - ZendeskMessagingAPISDK (= 3.8.3)
-  - ZendeskSDKConfigurationsSDK (1.1.9)
+  - ZendeskMessagingAPISDK (3.8.5):
+    - ZendeskSDKConfigurationsSDK (= 1.1.11)
+  - ZendeskMessagingSDK (3.8.5):
+    - ZendeskCommonUISDK (= 6.1.4)
+    - ZendeskMessagingAPISDK (= 3.8.5)
+  - ZendeskSDKConfigurationsSDK (1.1.11)
   - ZendeskSupportProvidersSDK (5.3.0):
     - ZendeskCoreSDK (~> 2.5.1)
   - ZendeskSupportSDK (5.3.0):
     - ZendeskMessagingSDK (~> 3.8.2)
     - ZendeskSupportProvidersSDK (~> 5.3.0)
-  - ZIPFoundation (0.9.16)
+  - ZIPFoundation (0.9.18)
 
 DEPENDENCIES:
   - AlamofireImage (~> 4.0)
@@ -182,10 +182,10 @@ CHECKOUT OPTIONS:
     :tag: 0.2.0
 
 SPEC CHECKSUMS:
-  Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
+  Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
   AlamofireImage: 843953fa97bee5f561cf05d83abd759e590b068d
   AlamofireNetworkActivityIndicator: 6564782bd7b9e6c430ae67d9277af01907b01ca4
-  AppCenter: a4070ec3d4418b5539067a51f57155012e486ebd
+  AppCenter: 85c92db0759d2792a65eb61d6842d2e86611a49a
   Automattic-Tracks-iOS: fc307762052ec20b733ae76363d1387a9d93d6a5
   CocoaLumberjack: 78abfb691154e2a9df8ded4350d504ee19d90732
   CropViewController: a5c143548a0fabcd6cc25f2d26e40460cfb8c78c
@@ -197,7 +197,7 @@ SPEC CHECKSUMS:
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae
-  NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
+  NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
@@ -205,25 +205,25 @@ SPEC CHECKSUMS:
   Sentry: ebc12276bd17613a114ab359074096b6b3725203
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
-  Starscream: fb2c4510bebf908c62bd383bcf05e673720e91fd
+  Starscream: 19b5533ddb925208db698f0ac508a100b884a1b9
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
-  WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
-  WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: d906a1005febb28de9f5c3a802736ca0850307f6
+  WordPress-Aztec-iOS: 8eaa928fb3a5694924ed3befac64beaae5656e12
+  WordPress-Editor-iOS: 98ce1fc542c3a09e48ddc9423405b1d1e48240f1
+  WordPressAuthenticator: 20c962dc116473337be1a3825bd16c321ee865cb
   WordPressKit: 324ee6100ad74b72c0c37b81fab8937c437f0773
   WordPressShared: 04c6d51441bb8fa29651075b3a5536c90ae89c76
-  WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
+  WordPressUI: 700e3ec5a9f77b6920c8104c338c85788036ab3c
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
-  ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5
+  ZendeskCommonUISDK: ba160fe413b491af9e7bfcb9808afcd494dc83a5
   ZendeskCoreSDK: 19a18e5ef2edcb18f4dbc0ea0d12bd31f515712a
-  ZendeskMessagingAPISDK: db91be0c5cb88229d22f0e560ed99ba6e1dce02e
-  ZendeskMessagingSDK: ce2750c0a3dbd40918ea2e2d44dd0dbe34d21bc8
-  ZendeskSDKConfigurationsSDK: f91f54f3b41aa36ffbc43a37af9956752a062055
+  ZendeskMessagingAPISDK: 410f9bcf07c79fe98d6f251da102368d6b356c54
+  ZendeskMessagingSDK: 95d396c981dacfab83cc7b9736e8561d51a3052b
+  ZendeskSDKConfigurationsSDK: ebced171fd1f4eb57760e8537d8cfa6a450122be
   ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
-  ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
+  ZIPFoundation: fa9ae5af13b7cf168245f24d1c672a4fb972e37f
 
 PODFILE CHECKSUM: 5b39e8e85fd8101ebfcfef947e6d1d9d4ce7f301
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -83,7 +83,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .siteMonitoring:
             return false
         case .syncPublishing:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return false
         case .readerDiscoverEndpoint:
             return true
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1848,7 +1848,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showPostListFromSource:(BlogDetailsNavigationSource)source
 {
     [self trackEvent:WPAnalyticsStatOpenedPosts fromSource:source];
-    PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
+    UIViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 
@@ -1858,7 +1858,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showPageListFromSource:(BlogDetailsNavigationSource)source
 {
     [self trackEvent:WPAnalyticsStatOpenedPages fromSource:source];
-    PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
+    UIViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 
@@ -2221,7 +2221,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         statsView.blog = self.blog;
         return statsView;
     } else {
-        PostListViewController *postsView = [PostListViewController controllerWithBlog:self.blog];
+        UIViewController *postsView = [PostListViewController controllerWithBlog:self.blog];
         postsView.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
         return postsView;
     }

--- a/WordPress/Classes/ViewRelated/Pages/DeprecatedPageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/DeprecatedPageListViewController+Menu.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+extension DeprecatedPageListViewController: InteractivePostViewDelegate {
+
+    func edit(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+
+        PageEditorPresenter.handle(page: page, in: self, entryPoint: .pagesList)
+    }
+
+    func view(_ apost: AbstractPost) {
+        viewPost(apost)
+    }
+
+    func stats(for apost: AbstractPost) {
+        // Not available for pages
+    }
+
+    func duplicate(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        copyPage(page)
+    }
+
+    func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
+        guard let page = post as? Page else { return }
+        trashPage(page, completion: completion)
+    }
+
+    func draft(_ apost: AbstractPost) {
+        moveToDraft(apost)
+    }
+
+    func retry(_ apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        PostCoordinator.shared.save(page)
+    }
+
+    func cancelAutoUpload(_ apost: AbstractPost) {
+        // Not available for pages
+    }
+
+    func share(_ apost: AbstractPost, fromView view: UIView) {
+        guard let page = apost as? Page else { return }
+
+        WPAnalytics.track(.postListShareAction, properties: propertiesForAnalytics())
+
+        let shareController = PostSharingController()
+        shareController.sharePage(page, fromView: view, inViewController: self)
+    }
+
+    func blaze(_ apost: AbstractPost) {
+        BlazeEventsTracker.trackEntryPointTapped(for: .pagesList)
+        BlazeFlowCoordinator.presentBlaze(in: self, source: .pagesList, blog: blog, post: apost)
+    }
+
+    func comments(_ apost: AbstractPost) {
+        // Not available for pages
+    }
+
+    func showSettings(for post: AbstractPost) {
+        WPAnalytics.track(.postListSettingsAction, properties: propertiesForAnalytics())
+        PostSettingsViewController.showStandaloneEditor(for: post, from: self)
+    }
+
+    func setParent(for apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        Task {
+            await setParentPage(for: page)
+        }
+    }
+
+    func setHomepage(for apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        WPAnalytics.track(.postListSetAsPostsPageAction)
+        setPageAsHomepage(page)
+    }
+
+    func setPostsPage(for apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        WPAnalytics.track(.postListSetHomePageAction)
+        togglePageAsPostsPage(page)
+    }
+
+    func setRegularPage(for apost: AbstractPost) {
+        guard let page = apost as? Page else { return }
+        WPAnalytics.track(.postListSetAsRegularPageAction)
+        togglePageAsPostsPage(page)
+    }
+
+    // MARK: - Helpers
+
+    private func copyPage(_ page: Page) {
+        // Analytics
+        WPAnalytics.track(.postListDuplicateAction, withProperties: propertiesForAnalytics())
+        // Copy Page
+        let newPage = page.blog.createDraftPage()
+        newPage.postTitle = page.postTitle
+        newPage.content = page.content
+        // Open Editor
+        let editorViewController = EditPageViewController(page: newPage)
+        present(editorViewController, animated: false)
+    }
+
+    private func trashPage(_ page: Page, completion: @escaping () -> Void) {
+        if page.status == .draft ||
+            page.status == .scheduled {
+            deletePost(page)
+            completion()
+            return
+        }
+
+        let isPageTrashed = page.status == .trash
+        let actionText = isPageTrashed ? Strings.DeletePermanently.actionText : Strings.Trash.actionText
+        let titleText = isPageTrashed ? Strings.DeletePermanently.titleText : Strings.Trash.titleText
+        let messageText = isPageTrashed ? Strings.DeletePermanently.messageText : Strings.Trash.messageText
+
+        let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(Strings.cancelText) { _ in
+            completion()
+        }
+        alertController.addDestructiveActionWithTitle(actionText) { [weak self] _ in
+            self?.deletePost(page)
+            completion()
+        }
+        alertController.presentFromRootViewController()
+    }
+}
+
+private enum Strings {
+
+    static let cancelText = NSLocalizedString("pagesList.trash.cancel", value: "Cancel", comment: "Cancels an Action")
+
+    enum DeletePermanently {
+        static let actionText = NSLocalizedString("pagesList.deletePermanently.actionTitle", value: "Delete Permanently", comment: "Delete option in the confirmation alert when deleting a page from the trash.")
+        static let titleText = NSLocalizedString("pagesList.deletePermanently.alertTitle", value: "Delete Permanently?", comment: "Title of the confirmation alert when deleting a page from the trash.")
+        static let messageText = NSLocalizedString("pagesList.deletePermanently.alertMessage", value: "Are you sure you want to permanently delete this page?", comment: "Message of the confirmation alert when deleting a page from the trash.")
+    }
+
+    enum Trash {
+        static let actionText = NSLocalizedString("pagesList.trash.actionTitle", value: "Move to Trash", comment: "Trash option in the trash page confirmation alert.")
+        static let titleText = NSLocalizedString("pagesList.trash.alertTitle", value: "Trash this page?", comment: "Title of the trash page confirmation alert.")
+        static let messageText = NSLocalizedString("pagesList.trash.alertMessage", value: "Are you sure you want to trash this page?", comment: "Message of the trash page confirmation alert.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Pages/DeprecatedPageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/DeprecatedPageListViewController.swift
@@ -5,7 +5,7 @@ import WordPressFlux
 import UIKit
 
 /// - note: Deprecated (kahu-offline-mode)
-final class DeprecatedPageListViewController: DeprecatedAbstractPostListViewController, UIViewControllerRestoration {
+final class DeprecatedPageListViewController: DeprecatedAbstractPostListViewController {
     private struct Constant {
         struct Size {
             static let pageCellEstimatedRowHeight = CGFloat(44.0)
@@ -59,7 +59,6 @@ final class DeprecatedPageListViewController: DeprecatedAbstractPostListViewCont
     @objc class func controllerWithBlog(_ blog: Blog) -> PageListViewController {
         let vc = PageListViewController()
         vc.blog = blog
-        vc.restorationClass = self
         if QuickStartTourGuide.shared.isCurrentElement(.pages) {
             vc.filterSettings.setFilterWithPostStatus(BasePost.Status.publish)
         }
@@ -72,35 +71,6 @@ final class DeprecatedPageListViewController: DeprecatedAbstractPostListViewCont
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
         QuickStartTourGuide.shared.visited(.pages)
-    }
-
-    // MARK: - UIViewControllerRestoration
-
-    class func viewController(withRestorationIdentifierPath identifierComponents: [String],
-                              coder: NSCoder) -> UIViewController? {
-
-        let context = ContextManager.sharedInstance().mainContext
-
-        guard let blogID = coder.decodeObject(forKey: Constant.Identifiers.pagesViewControllerRestorationKey) as? String,
-            let objectURL = URL(string: blogID),
-            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: objectURL),
-            let restoredBlog = try? context.existingObject(with: objectID) as? Blog else {
-
-                return nil
-        }
-
-        return controllerWithBlog(restoredBlog)
-    }
-
-    // MARK: - UIStateRestoring
-
-    override func encodeRestorableState(with coder: NSCoder) {
-
-        let objectString = blog?.objectID.uriRepresentation().absoluteString
-
-        coder.encode(objectString, forKey: Constant.Identifiers.pagesViewControllerRestorationKey)
-
-        super.encodeRestorableState(with: coder)
     }
 
     // MARK: - UIViewController

--- a/WordPress/Classes/ViewRelated/Pages/DeprecatedPageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/DeprecatedPageListViewController.swift
@@ -4,7 +4,8 @@ import WordPressShared
 import WordPressFlux
 import UIKit
 
-final class PageListViewController: AbstractPostListViewController, UIViewControllerRestoration {
+/// - note: Deprecated (kahu-offline-mode)
+final class DeprecatedPageListViewController: DeprecatedAbstractPostListViewController, UIViewControllerRestoration {
     private struct Constant {
         struct Size {
             static let pageCellEstimatedRowHeight = CGFloat(44.0)
@@ -55,14 +56,7 @@ final class PageListViewController: AbstractPostListViewController, UIViewContro
 
     // MARK: - Convenience constructors
 
-    @objc class func controllerWithBlog(_ blog: Blog) -> UIViewController {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
-            return DeprecatedPageListViewController.controllerWithBlog(blog)
-        }
-        return PageListViewController._controllerWithBlog(blog)
-    }
-
-    @objc private class func _controllerWithBlog(_ blog: Blog) -> PageListViewController {
+    @objc class func controllerWithBlog(_ blog: Blog) -> PageListViewController {
         let vc = PageListViewController()
         vc.blog = blog
         vc.restorationClass = self
@@ -73,11 +67,7 @@ final class PageListViewController: AbstractPostListViewController, UIViewContro
     }
 
     static func showForBlog(_ blog: Blog, from sourceController: UIViewController) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
-            return DeprecatedPageListViewController.showForBlog(blog, from: sourceController)
-        }
-
-        let controller = PageListViewController._controllerWithBlog(blog)
+        let controller = PageListViewController.controllerWithBlog(blog)
         controller.navigationItem.largeTitleDisplayMode = .never
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
@@ -564,7 +554,7 @@ final class PageListViewController: AbstractPostListViewController, UIViewContro
 
 // MARK: - No Results Handling
 
-private extension PageListViewController {
+private extension DeprecatedPageListViewController {
 
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -4,7 +4,7 @@ import WordPressShared
 import WordPressFlux
 import UIKit
 
-final class PageListViewController: AbstractPostListViewController, UIViewControllerRestoration {
+final class PageListViewController: AbstractPostListViewController {
     private struct Constant {
         struct Size {
             static let pageCellEstimatedRowHeight = CGFloat(44.0)
@@ -65,7 +65,6 @@ final class PageListViewController: AbstractPostListViewController, UIViewContro
     @objc private class func _controllerWithBlog(_ blog: Blog) -> PageListViewController {
         let vc = PageListViewController()
         vc.blog = blog
-        vc.restorationClass = self
         if QuickStartTourGuide.shared.isCurrentElement(.pages) {
             vc.filterSettings.setFilterWithPostStatus(BasePost.Status.publish)
         }
@@ -82,35 +81,6 @@ final class PageListViewController: AbstractPostListViewController, UIViewContro
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
         QuickStartTourGuide.shared.visited(.pages)
-    }
-
-    // MARK: - UIViewControllerRestoration
-
-    class func viewController(withRestorationIdentifierPath identifierComponents: [String],
-                              coder: NSCoder) -> UIViewController? {
-
-        let context = ContextManager.sharedInstance().mainContext
-
-        guard let blogID = coder.decodeObject(forKey: Constant.Identifiers.pagesViewControllerRestorationKey) as? String,
-            let objectURL = URL(string: blogID),
-            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: objectURL),
-            let restoredBlog = try? context.existingObject(with: objectID) as? Blog else {
-
-                return nil
-        }
-
-        return controllerWithBlog(restoredBlog)
-    }
-
-    // MARK: - UIStateRestoring
-
-    override func encodeRestorableState(with coder: NSCoder) {
-
-        let objectString = blog?.objectID.uriRepresentation().absoluteString
-
-        coder.encode(objectString, forKey: Constant.Identifiers.pagesViewControllerRestorationKey)
-
-        super.encodeRestorableState(with: coder)
     }
 
     // MARK: - UIViewController

--- a/WordPress/Classes/ViewRelated/Post/DeprecatedAbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/DeprecatedAbstractPostListViewController.swift
@@ -1,0 +1,783 @@
+import Foundation
+import CoreData
+import Gridicons
+import CocoaLumberjack
+import WordPressShared
+import wpxmlrpc
+import WordPressFlux
+import WordPressUI
+
+/// - note: Deprecated (kahu-offline-mode)
+class DeprecatedAbstractPostListViewController: UIViewController,
+                                                WPContentSyncHelperDelegate,
+                                                NSFetchedResultsControllerDelegate,
+                                                UITableViewDelegate,
+                                                UITableViewDataSource,
+                                                NetworkAwareUI // This protocol is not in an extension so that subclasses can override noConnectionMessage()
+{
+    typealias SyncPostResult = (posts: [AbstractPost], hasMore: Bool)
+
+    private static let httpErrorCodeForbidden = 403
+    private static let postsFetchRequestBatchSize = 10
+    private static let pagesNumberOfLoadedElement = 100
+    private static let postsLoadMoreThreshold = 4
+
+    private var fetchBatchSize: Int {
+        return postTypeToSync() == .page ? 0 : type(of: self).postsFetchRequestBatchSize
+    }
+
+    private var fetchLimit: Int {
+        return postTypeToSync() == .page ? 0 : Int(numberOfPostsPerSync())
+    }
+
+    private var numberOfLoadedElement: NSNumber {
+        return postTypeToSync() == .page ? NSNumber(value: type(of: self).pagesNumberOfLoadedElement) : NSNumber(value: numberOfPostsPerSync())
+    }
+
+    var blog: Blog!
+
+    /// This closure will be executed whenever the noResultsView must be visually refreshed.  It's up
+    /// to the subclass to define this property.
+    ///
+    var refreshNoResultsViewController: ((NoResultsViewController) -> ())!
+    private var reloadTableViewBeforeAppearing = false
+
+    let tableView = UITableView(frame: .zero, style: .plain)
+
+    var shouldHideAuthor: Bool {
+        guard filterSettings.canFilterByAuthor() else {
+            return true
+        }
+        return filterSettings.currentPostAuthorFilter() == .mine
+    }
+
+    private let buttonAuthorFilter = AuthorFilterButton()
+
+    let refreshControl = UIRefreshControl()
+
+    private(set) var fetchResultsController: NSFetchedResultsController<AbstractPost>!
+
+    lazy var syncHelper: WPContentSyncHelper = {
+        let syncHelper = WPContentSyncHelper()
+        syncHelper.delegate = self
+        return syncHelper
+    }()
+
+    lazy var noResultsViewController: NoResultsViewController = {
+        let noResultsViewController = NoResultsViewController.controller()
+        noResultsViewController.delegate = self
+        return noResultsViewController
+    }()
+
+    lazy var filterSettings: PostListFilterSettings = {
+        return PostListFilterSettings(blog: self.blog, postType: self.postTypeToSync())
+    }()
+
+    let filterTabBar = FilterTabBar()
+
+    private lazy var searchResultsViewController = PostSearchViewController(viewModel: PostSearchViewModel(blog: blog, filters: filterSettings))
+
+    private lazy var searchController = UISearchController(searchResultsController: searchResultsViewController)
+
+    private var emptyResults: Bool {
+        fetchResultsController?.fetchedObjects?.count == 0
+    }
+
+    private var atLeastSyncedOnce = false
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+        edgesForExtendedLayout = .all
+        extendedLayoutIncludesOpaqueBars = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureFetchResultsController()
+        configureTableView()
+        configureFilterBar()
+        configureTableView()
+        configureSearchController()
+        configureAuthorFilter()
+        configureDefaultNavigationBarAppearance()
+
+        updateAndPerformFetchRequest()
+
+        observeNetworkStatus()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if reloadTableViewBeforeAppearing {
+            reloadTableViewBeforeAppearing = false
+            tableView.reloadData()
+        }
+
+        updateSelectedFilter()
+
+        refreshResults()
+
+        // Show it initially but allow the user to dismiss it by scrolling
+        navigationItem.hidesSearchBarWhenScrolling = false
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        automaticallySyncIfAppropriate()
+
+        navigationItem.hidesSearchBarWhenScrolling = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        dismissAllNetworkErrorNotices()
+
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    // MARK: - Configuration
+
+    private func configureFetchResultsController() {
+        fetchResultsController = NSFetchedResultsController<AbstractPost>(fetchRequest: fetchRequest(), managedObjectContext: managedObjectContext(), sectionNameKeyPath: nil, cacheName: nil)
+        fetchResultsController.delegate = self
+    }
+
+    func configureTableView() {
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(tableView)
+
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = .systemBackground
+        tableView.sectionHeaderTopPadding = 0
+        tableView.estimatedRowHeight = 110
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.refreshControl = refreshControl
+        refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
+    }
+
+    private func configureFilterBar() {
+        WPStyleGuide.configureFilterTabBar(filterTabBar)
+        filterTabBar.backgroundColor = .clear
+        filterTabBar.items = filterSettings.availablePostListFilters()
+        filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
+
+        filterTabBar.translatesAutoresizingMaskIntoConstraints = true
+        filterTabBar.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: 40)
+        tableView.tableHeaderView = filterTabBar
+    }
+
+    func refreshResults() {
+        guard isViewLoaded == true else {
+            return
+        }
+
+        let _ = DispatchDelayedAction(delay: .milliseconds(500)) { [weak self] in
+            self?.refreshControl.endRefreshing()
+        }
+
+        hideNoResultsView()
+        if emptyResults {
+            showNoResultsView()
+        }
+    }
+
+    private func configureSearchController() {
+        assert(self is InteractivePostViewDelegate, "The subclass has to implement InteractivePostViewDelegate protocol")
+
+        searchResultsViewController.configure(searchController, self as? InteractivePostViewDelegate)
+
+        definesPresentationContext = true
+        navigationItem.searchController = searchController
+        if #available(iOS 16.0, *) {
+            navigationItem.preferredSearchBarPlacement = .stacked
+        }
+    }
+
+    func propertiesForAnalytics() -> [String: AnyObject] {
+        var properties = [String: AnyObject]()
+
+        properties["type"] = postTypeToSync().rawValue as AnyObject?
+        properties["filter"] = filterSettings.currentPostListFilter().title as AnyObject?
+
+        if let dotComID = blog.dotComID {
+            properties[WPAppAnalyticsKeyBlogID] = dotComID
+        }
+
+        return properties
+    }
+
+    // MARK: - Author Filter
+
+    private func configureAuthorFilter() {
+        guard filterSettings.canFilterByAuthor() else {
+            return
+        }
+        buttonAuthorFilter.sizeToFit()
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttonAuthorFilter)
+
+        buttonAuthorFilter.addTarget(self, action: #selector(showAuthorSelectionPopover(_:)), for: .touchUpInside)
+        updateAuthorFilter()
+    }
+
+    private func updateAuthorFilter() {
+        if filterSettings.currentPostAuthorFilter() == .everyone {
+            buttonAuthorFilter.filterType = .everyone
+        } else {
+            buttonAuthorFilter.filterType = .user(gravatarEmail: blog.account?.email)
+        }
+    }
+
+    @objc private func showAuthorSelectionPopover(_ sender: UIView) {
+        let filterController = AuthorFilterViewController(initialSelection: filterSettings.currentPostAuthorFilter(), gravatarEmail: blog.account?.email, postType: postTypeToSync()) { [weak self] filter in
+            if filter != self?.filterSettings.currentPostAuthorFilter() {
+                UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: sender)
+            }
+
+            self?.filterSettings.setCurrentPostAuthorFilter(filter)
+            self?.updateAuthorFilter()
+            self?.refreshAndReload()
+            self?.syncItemsWithUserInteraction(false)
+            self?.dismiss(animated: true)
+        }
+
+        ForcePopoverPresenter.configurePresentationControllerForViewController(filterController, presentingFromView: sender)
+        filterController.popoverPresentationController?.permittedArrowDirections = .up
+
+        present(filterController, animated: true)
+    }
+
+    // MARK: - GUI: No results view logic
+
+    func hideNoResultsView() {
+        noResultsViewController.removeFromView()
+    }
+
+    func showNoResultsView() {
+        guard refreshNoResultsViewController != nil, atLeastSyncedOnce else {
+            return
+        }
+        refreshNoResultsViewController(noResultsViewController)
+
+        // Only add no results view if it isn't already in the table view
+        if noResultsViewController.view.isDescendant(of: tableView) == false {
+            self.addChild(noResultsViewController)
+            tableView.addSubview(noResultsViewController.view)
+            noResultsViewController.view.frame = tableView.frame.offsetBy(dx: 0, dy: -view.safeAreaInsets.top + 40)
+            noResultsViewController.didMove(toParent: self)
+        }
+
+        tableView.sendSubviewToBack(noResultsViewController.view)
+    }
+
+    // MARK: - Core Data
+
+    func entityName() -> String {
+        fatalError("You should implement this method in the subclass")
+    }
+
+    func managedObjectContext() -> NSManagedObjectContext {
+        return ContextManager.sharedInstance().mainContext
+    }
+
+    func fetchRequest() -> NSFetchRequest<AbstractPost> {
+        let fetchRequest = NSFetchRequest<AbstractPost>(entityName: entityName())
+        fetchRequest.predicate = predicateForFetchRequest()
+        fetchRequest.sortDescriptors = sortDescriptorsForFetchRequest()
+        fetchRequest.fetchBatchSize = fetchBatchSize
+        fetchRequest.fetchLimit = fetchLimit
+        return fetchRequest
+    }
+
+    func sortDescriptorsForFetchRequest() -> [NSSortDescriptor] {
+        return filterSettings.currentPostListFilter().sortDescriptors
+    }
+
+    func updateAndPerformFetchRequest() {
+        assert(Thread.isMainThread, "AbstractPostListViewController Error: NSFetchedResultsController accessed in BG")
+
+        var predicate = predicateForFetchRequest()
+        let sortDescriptors = sortDescriptorsForFetchRequest()
+        let fetchRequest = fetchResultsController.fetchRequest
+
+        let filter = filterSettings.currentPostListFilter()
+
+        if let oldestPostDate = filter.oldestPostDate {
+
+            // Filter posts by any posts newer than the filter's oldestPostDate.
+            // Also include any posts that don't have a date set, such as local posts created without a connection.
+            let datePredicate = NSPredicate(format: "(date_created_gmt = NULL) OR (date_created_gmt >= %@)", oldestPostDate as CVarArg)
+
+            predicate = NSCompoundPredicate.init(andPredicateWithSubpredicates: [predicate, datePredicate])
+        }
+
+        // Set up the fetchLimit based on filtering
+        if filter.oldestPostDate != nil {
+            // If filtering by the oldestPostDate, the fetchLimit should be disabled.
+            fetchRequest.fetchLimit = 0
+        } else {
+            // If not filtering by the oldestPostDate, set the fetchLimit to the default number of posts.
+            fetchRequest.fetchLimit = fetchLimit
+        }
+
+        fetchRequest.predicate = predicate
+        fetchRequest.sortDescriptors = sortDescriptors
+
+        do {
+            try fetchResultsController.performFetch()
+        } catch {
+            DDLogError("Error fetching posts after updating the fetch request predicate: \(error)")
+        }
+    }
+
+    func updateAndPerformFetchRequestRefreshingResults() {
+        updateAndPerformFetchRequest()
+        tableView.reloadData()
+        refreshResults()
+    }
+
+    func predicateForFetchRequest() -> NSPredicate {
+        fatalError("You should implement this method in the subclass")
+    }
+
+    // MARK: - NSFetchedResultsControllerDelegate
+
+    func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        tableView.beginUpdates()
+    }
+
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        switch type {
+        case .insert:
+            guard let newIndexPath else { return }
+            tableView.insertRows(at: [newIndexPath], with: .none)
+        case .delete:
+            guard let indexPath else { return }
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        case .update:
+            guard let indexPath else { return }
+            tableView.reloadRows(at: [indexPath], with: .none)
+        case .move:
+            guard let indexPath, let newIndexPath else { return }
+            tableView.moveRow(at: indexPath, to: newIndexPath)
+        @unknown default:
+            break
+        }
+    }
+
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        do { // Some defensive code, just in case
+            try WPException.objcTry {
+                self.tableView.endUpdates()
+            }
+        } catch {
+            tableView.reloadData()
+        }
+        refreshResults()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        fetchResultsController.fetchedObjects?.count ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        fatalError("Not implemented")
+    }
+
+    // MARK: - UITableViewDelegate
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard isViewOnScreen() else {
+            return
+        }
+
+        // Are we approaching the end of the table?
+        if indexPath.section + 1 == tableView.numberOfSections
+            && indexPath.row + type(of: self).postsLoadMoreThreshold >= tableView.numberOfRows(inSection: indexPath.section)
+            && postTypeToSync() == .post {
+            // Only 3 rows till the end of table
+            if filterSettings.currentPostListFilter().hasMore {
+                syncHelper.syncMoreContent()
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func refresh(_ sender: AnyObject) {
+        syncItemsWithUserInteraction(true)
+
+        WPAnalytics.track(.postListPullToRefresh, withProperties: propertiesForAnalytics())
+    }
+
+    // MARK: - Syncing
+
+    private func automaticallySyncIfAppropriate() {
+        // Only automatically refresh if the view is loaded and visible on the screen
+        if !isViewLoaded || view.window == nil {
+            DDLogVerbose("View is not visible and will not check for auto refresh.")
+            return
+        }
+
+        // Do not start auto-sync if connection is down
+        let appDelegate = WordPressAppDelegate.shared
+
+        if appDelegate?.connectionAvailable == false {
+            refreshResults()
+            dismissAllNetworkErrorNotices()
+            handleConnectionError()
+            return
+        }
+
+        // Update in the background
+        syncItemsWithUserInteraction(false)
+    }
+
+    @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
+        syncHelper.syncContentWithUserInteraction(userInteraction)
+        refreshResults()
+    }
+
+    @objc func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], hasMore: Bool) {
+        guard posts.count > 0 else {
+            assertionFailure("This method should not be called with no posts.")
+            return
+        }
+        // Reset the filter to only show the latest sync point, based on the oldest post date in the posts just synced.
+        // Note: Getting oldest date manually as the API may return results out of order if there are
+        // differing time offsets in the created dates.
+        let oldestPost = posts.min { ($0.date_created_gmt ?? .distantPast) < ($1.date_created_gmt ?? .distantPast) }
+        filter.oldestPostDate = oldestPost?.date_created_gmt
+        filter.hasMore = hasMore
+
+        updateAndPerformFetchRequestRefreshingResults()
+    }
+
+    @objc func numberOfPostsPerSync() -> UInt {
+        return PostServiceDefaultNumberToSync
+    }
+
+    // MARK: - WPContentSyncHelperDelegate
+
+    @objc internal func postTypeToSync() -> PostServiceType {
+        // Subclasses should override.
+        return .any
+    }
+
+    @MainActor
+    func syncPosts(isFirstPage: Bool) async throws -> SyncPostResult {
+        let postType = postTypeToSync()
+        let filter = filterSettings.currentPostListFilter()
+        let author = filterSettings.shouldShowOnlyMyPosts() ? blogUserID() : nil
+
+        let coreDataStack = ContextManager.shared
+        let blogID = TaggedManagedObjectID(blog)
+        let number = numberOfLoadedElement.intValue
+
+        let repository = PostRepository(coreDataStack: coreDataStack)
+        let result = try await repository.paginate(
+            type: postType == .post ? Post.self : Page.self,
+            statuses: filter.statuses,
+            authorUserID: author,
+            offset: isFirstPage ? 0 : fetchResultsController.fetchedObjects?.count ?? 0,
+            number: number,
+            in: blogID
+        )
+
+        let posts = try result.map { try coreDataStack.mainContext.existingObject(with: $0) }
+        let hasMore = result.count >= number
+
+        return (posts, hasMore)
+    }
+
+    func syncHelper(_ syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((_ hasMore: Bool) -> ())?, failure: ((_ error: NSError) -> ())?) {
+        let filter = filterSettings.currentPostListFilter()
+        Task { @MainActor [weak self] in
+            do {
+                guard let (posts, hasMore) = try await self?.syncPosts(isFirstPage: true) else { return }
+
+                guard let self else { return }
+
+                if posts.count > 0 {
+                    self.updateFilter(filter, withSyncedPosts: posts, hasMore: hasMore)
+                    SearchManager.shared.indexItems(posts)
+                }
+
+                success?(filter.hasMore)
+            } catch {
+                guard let self else { return }
+
+                failure?(error as NSError)
+
+                if userInteraction == true {
+                    self.handleSyncFailure(error as NSError)
+                }
+            }
+        }
+    }
+
+    func syncHelper(_ syncHelper: WPContentSyncHelper, syncMoreWithSuccess success: ((_ hasMore: Bool) -> Void)?, failure: ((_ error: NSError) -> Void)?) {
+
+        setFooterHidden(false)
+
+        let filter = filterSettings.currentPostListFilter()
+
+        Task { @MainActor [weak self] in
+            do {
+                guard let (posts, hasMore) = try await self?.syncPosts(isFirstPage: false) else { return }
+
+                // User may have exit the screen when the "syncPosts" call above completes.
+                guard let self else { return }
+
+                if posts.count > 0 {
+                    self.updateFilter(filter, withSyncedPosts: posts, hasMore: hasMore)
+                    SearchManager.shared.indexItems(posts)
+                }
+
+                success?(filter.hasMore)
+            } catch {
+                failure?(error as NSError)
+            }
+        }
+    }
+
+    func syncContentStart(_ syncHelper: WPContentSyncHelper) {
+        atLeastSyncedOnce = true
+    }
+
+    func syncContentEnded(_ syncHelper: WPContentSyncHelper) {
+        refreshControl.endRefreshing()
+        setFooterHidden(true)
+        noResultsViewController.removeFromView()
+
+        if emptyResults {
+            // This is a special case.  Core data can be a bit slow about notifying
+            // NSFetchedResultsController delegates about changes to the fetched results.
+            // To compensate, call configureNoResultsView after a short delay.
+            // It will be redisplayed if necessary.
+
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(100 * NSEC_PER_MSEC)) / Double(NSEC_PER_SEC), execute: { [weak self] in
+                self?.refreshResults()
+            })
+        }
+    }
+
+    @objc func handleSyncFailure(_ error: NSError) {
+        if error.domain == WPXMLRPCFaultErrorDomain
+            && error.code == type(of: self).httpErrorCodeForbidden {
+            WordPressAppDelegate.shared?.showPasswordInvalidPrompt(for: blog)
+            return
+        }
+
+        dismissAllNetworkErrorNotices()
+
+        // If there is no internet connection, we'll show the specific error message defined in
+        // `noConnectionMessage()` (overridden by subclasses). For everything else, we let
+        // `WPError.showNetworkingNotice` determine the user-friendly error message.
+        if !connectionAvailable() {
+            handleConnectionError()
+        } else {
+            let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
+            WPError.showNetworkingNotice(title: title, error: error)
+        }
+    }
+
+    // MARK: - Actions
+
+    func publish(_ post: AbstractPost) {
+        let action = AbstractPostHelper.editorPublishAction(for: post)
+
+        func showPrepublishingFlow(for post: Post) {
+            let viewController = PrepublishingViewController(post: post, identifiers: PrepublishingIdentifier.defaultIdentifiers) { [weak self] result in
+                switch result {
+                case .confirmed:
+                    self?.didConfirmPublish(for: post)
+                case .published:
+                    self?.dismiss(animated: true)
+                case .cancelled:
+                    break
+                }
+            }
+            viewController.presentAsSheet(from: self)
+        }
+
+        func showPublishingConfirmation() {
+            let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
+
+            let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
+            let alertController = UIAlertController(title: action.publishingActionQuestionLabel, message: nil, preferredStyle: style)
+
+            alertController.addCancelActionWithTitle(cancelTitle)
+            alertController.addDefaultActionWithTitle(action.publishingActionQuestionLabel) { [unowned self] _ in
+                self.didConfirmPublish(for: post)
+            }
+
+            present(alertController, animated: true)
+        }
+
+        if let post = post as? Post {
+            showPrepublishingFlow(for: post)
+        } else {
+            showPublishingConfirmation()
+        }
+    }
+
+    private func didConfirmPublish(for post: AbstractPost) {
+        WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
+        PostCoordinator.shared.publish(post)
+
+        if post is Post {
+            BloggingRemindersFlow.present(from: self, for: post.blog, source: .publishFlow, alwaysShow: false)
+        }
+    }
+
+    @objc func moveToDraft(_ post: AbstractPost) {
+        WPAnalytics.track(.postListDraftAction, withProperties: propertiesForAnalytics())
+
+        PostCoordinator.shared.moveToDraft(post)
+    }
+
+    @objc func viewPost(_ post: AbstractPost) {
+        WPAnalytics.track(.postListViewAction, withProperties: propertiesForAnalytics())
+
+        let post = post.hasRevision() ? post.revision! : post
+
+        let controller = PreviewWebKitViewController(post: post, source: "posts_pages_view_post")
+        controller.trackOpenEvent()
+        // NOTE: We'll set the title to match the title of the View action button.
+        // If the button title changes we should also update the title here.
+        controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
+        let navWrapper = LightNavigationController(rootViewController: controller)
+        if navigationController?.traitCollection.userInterfaceIdiom == .pad {
+            navWrapper.modalPresentationStyle = .fullScreen
+        }
+        navigationController?.present(navWrapper, animated: true)
+    }
+
+    func deletePost(_ post: AbstractPost) {
+        Task {
+            await PostCoordinator.shared.delete(post)
+        }
+    }
+
+    @objc func copyPostLink(_ post: AbstractPost) {
+        let pasteboard = UIPasteboard.general
+        guard let link = post.permaLink else { return }
+        pasteboard.string = link as String
+        let noticeTitle = NSLocalizedString("Link Copied to Clipboard", comment: "Link copied to clipboard notice title")
+        let notice = Notice(title: noticeTitle, feedbackType: .success)
+        ActionDispatcher.dispatch(NoticeAction.dismiss) // Dismiss any old notices
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+
+    private func dismissAllNetworkErrorNotices() {
+        dismissNoNetworkAlert()
+        WPError.dismissNetworkingNotice()
+    }
+
+    // MARK: - Post Actions
+
+    @objc func createPost() {
+        assert(false, "You should implement this method in the subclass")
+    }
+
+    // MARK: - Data Sources
+
+    /// Retrieves the userID for the user of the current blog.
+    ///
+    /// - Returns: the userID for the user of the current WPCom blog.  If the blog is not hosted at
+    ///     WordPress.com, `nil` is returned instead.
+    ///
+    @objc func blogUserID() -> NSNumber? {
+        return blog.userID
+    }
+
+    // MARK: - Filtering
+
+    @objc func refreshAndReload() {
+        updateSelectedFilter()
+        updateAndPerformFetchRequestRefreshingResults()
+    }
+
+    func updateFilterWithPostStatus(_ status: BasePost.Status) {
+        filterSettings.setFilterWithPostStatus(status)
+        refreshAndReload()
+        WPAnalytics.track(.postListStatusFilterChanged, withProperties: propertiesForAnalytics())
+    }
+
+    private func updateSelectedFilter() {
+        if filterTabBar.selectedIndex != filterSettings.currentFilterIndex() {
+            filterTabBar.setSelectedIndex(filterSettings.currentFilterIndex(), animated: false)
+        }
+    }
+
+    @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+        filterSettings.setCurrentFilterIndex(filterBar.selectedIndex)
+
+        refreshAndReload()
+
+        syncItemsWithUserInteraction(false)
+
+        WPAnalytics.track(.postListStatusFilterChanged, withProperties: propertiesForAnalytics())
+    }
+
+    // MARK: - NetworkAwareUI
+
+    func contentIsEmpty() -> Bool {
+        fetchResultsController.isEmpty()
+    }
+
+    func noConnectionMessage() -> String {
+        return ReachabilityUtils.noConnectionMessage()
+    }
+
+    // MARK: - Misc
+
+    private func setFooterHidden(_ isHidden: Bool) {
+        if isHidden {
+            tableView.tableFooterView = nil
+        } else {
+            tableView.tableFooterView = PagingFooterView(state: .loading)
+            tableView.sizeToFitFooterView()
+        }
+    }
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        // We override this method to dismiss any Notice that is currently being shown. If we
+        // don't do this, the present Notice will be shown on top of the ViewController we are
+        // presenting.
+        dismissAllNetworkErrorNotices()
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+}
+
+extension DeprecatedAbstractPostListViewController: NetworkStatusDelegate {
+    func networkStatusDidChange(active: Bool) {
+        automaticallySyncIfAppropriate()
+    }
+}
+
+extension DeprecatedAbstractPostListViewController: EditorAnalyticsProperties { }
+
+// MARK: - NoResultsViewControllerDelegate
+
+extension DeprecatedAbstractPostListViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
+        WPAnalytics.track(.postListNoResultsButtonPressed, withProperties: propertiesForAnalytics())
+        createPost()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/DeprecatedPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/DeprecatedPostListViewController.swift
@@ -5,9 +5,7 @@ import Gridicons
 import UIKit
 
 /// - note: Deprecated (kahu-offline-mode)
-final class DeprecatedPostListViewController: DeprecatedAbstractPostListViewController, UIViewControllerRestoration, InteractivePostViewDelegate {
-    static private let postsViewControllerRestorationKey = "PostsViewControllerRestorationKey"
-
+final class DeprecatedPostListViewController: DeprecatedAbstractPostListViewController, InteractivePostViewDelegate {
     /// If set, when the post list appear it will show the tab for this status
     private var initialFilterWithPostStatus: BasePost.Status?
 
@@ -16,7 +14,6 @@ final class DeprecatedPostListViewController: DeprecatedAbstractPostListViewCont
     @objc class func controllerWithBlog(_ blog: Blog) -> DeprecatedPostListViewController {
         let vc = DeprecatedPostListViewController()
         vc.blog = blog
-        vc.restorationClass = self
         return vc
     }
 
@@ -27,33 +24,6 @@ final class DeprecatedPostListViewController: DeprecatedAbstractPostListViewCont
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
         QuickStartTourGuide.shared.visited(.blogDetailNavigation)
-    }
-
-    // MARK: - UIViewControllerRestoration
-
-    class func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
-        let context = ContextManager.sharedInstance().mainContext
-
-        guard let blogID = coder.decodeObject(forKey: postsViewControllerRestorationKey) as? String,
-              let objectURL = URL(string: blogID),
-              let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: objectURL),
-              let restoredBlog = (try? context.existingObject(with: objectID)) as? Blog else {
-
-            return nil
-        }
-
-        return self.controllerWithBlog(restoredBlog)
-    }
-
-    // MARK: - UIStateRestoring
-
-    override func encodeRestorableState(with coder: NSCoder) {
-
-        let objectString = blog?.objectID.uriRepresentation().absoluteString
-
-        coder.encode(objectString, forKey: type(of: self).postsViewControllerRestorationKey)
-
-        super.encodeRestorableState(with: coder)
     }
 
     // MARK: - UIViewController

--- a/WordPress/Classes/ViewRelated/Post/DeprecatedPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/DeprecatedPostListViewController.swift
@@ -4,7 +4,8 @@ import WordPressShared
 import Gridicons
 import UIKit
 
-final class PostListViewController: AbstractPostListViewController, UIViewControllerRestoration, InteractivePostViewDelegate {
+/// - note: Deprecated (kahu-offline-mode)
+final class DeprecatedPostListViewController: DeprecatedAbstractPostListViewController, UIViewControllerRestoration, InteractivePostViewDelegate {
     static private let postsViewControllerRestorationKey = "PostsViewControllerRestorationKey"
 
     /// If set, when the post list appear it will show the tab for this status
@@ -12,26 +13,15 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
 
     // MARK: - Convenience constructors
 
-    @objc class func controllerWithBlog(_ blog: Blog) -> UIViewController {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
-            return DeprecatedPostListViewController.controllerWithBlog(blog)
-        }
-        return PostListViewController._controllerWithBlog(blog)
-    }
-
-    @objc private class func _controllerWithBlog(_ blog: Blog) -> PostListViewController {
-        let vc = PostListViewController()
+    @objc class func controllerWithBlog(_ blog: Blog) -> DeprecatedPostListViewController {
+        let vc = DeprecatedPostListViewController()
         vc.blog = blog
         vc.restorationClass = self
         return vc
     }
 
     static func showForBlog(_ blog: Blog, from sourceController: UIViewController, withPostStatus postStatus: BasePost.Status? = nil) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
-            return DeprecatedPostListViewController.showForBlog(blog, from: sourceController, withPostStatus: postStatus)
-        }
-
-        let controller = PostListViewController._controllerWithBlog(blog)
+        let controller = DeprecatedPostListViewController.controllerWithBlog(blog)
         controller.navigationItem.largeTitleDisplayMode = .never
         controller.initialFilterWithPostStatus = postStatus
         sourceController.navigationController?.pushViewController(controller, animated: true)
@@ -409,7 +399,7 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
 
 // MARK: - No Results Handling
 
-private extension PostListViewController {
+private extension DeprecatedPostListViewController {
 
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -4,8 +4,7 @@ import WordPressShared
 import Gridicons
 import UIKit
 
-final class PostListViewController: AbstractPostListViewController, UIViewControllerRestoration, InteractivePostViewDelegate {
-    static private let postsViewControllerRestorationKey = "PostsViewControllerRestorationKey"
+final class PostListViewController: AbstractPostListViewController, InteractivePostViewDelegate {
 
     /// If set, when the post list appear it will show the tab for this status
     private var initialFilterWithPostStatus: BasePost.Status?
@@ -22,7 +21,6 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
     @objc private class func _controllerWithBlog(_ blog: Blog) -> PostListViewController {
         let vc = PostListViewController()
         vc.blog = blog
-        vc.restorationClass = self
         return vc
     }
 
@@ -37,33 +35,6 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
         QuickStartTourGuide.shared.visited(.blogDetailNavigation)
-    }
-
-    // MARK: - UIViewControllerRestoration
-
-    class func viewController(withRestorationIdentifierPath identifierComponents: [String], coder: NSCoder) -> UIViewController? {
-        let context = ContextManager.sharedInstance().mainContext
-
-        guard let blogID = coder.decodeObject(forKey: postsViewControllerRestorationKey) as? String,
-              let objectURL = URL(string: blogID),
-              let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: objectURL),
-              let restoredBlog = (try? context.existingObject(with: objectID)) as? Blog else {
-
-            return nil
-        }
-
-        return self.controllerWithBlog(restoredBlog)
-    }
-
-    // MARK: - UIStateRestoring
-
-    override func encodeRestorableState(with coder: NSCoder) {
-
-        let objectString = blog?.objectID.uriRepresentation().absoluteString
-
-        coder.encode(objectString, forKey: type(of: self).postsViewControllerRestorationKey)
-
-        super.encodeRestorableState(with: coder)
     }
 
     // MARK: - UIViewController

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -312,6 +312,14 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     private func updateNavigationBar(with offset: CGFloat) {
+        /// Navigation bar is only updated in light interface style, so that the tint color can be reverted
+        /// to the original color after scrolling past the featured image.
+        ///
+        /// In case of dark mode, the navigation bar tint color will always be kept white.
+        guard traitCollection.userInterfaceStyle == .light else {
+            return
+        }
+
         let fullProgress = (offset / heightConstraint.constant)
         let progress = fullProgress.clamp(min: 0, max: 1)
 
@@ -319,12 +327,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
                                             to: Styles.endTintColor,
                                             with: progress)
 
-        if traitCollection.userInterfaceStyle == .light {
-            currentStatusBarStyle = fullProgress >= 2.5 ? .darkContent : .lightContent
-        } else {
-            currentStatusBarStyle = .lightContent
-        }
-
+        currentStatusBarStyle = fullProgress >= 2.5 ? .darkContent : .lightContent
         navBarTintColor = tintColor
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -743,7 +743,8 @@ private extension SiteStatsPeriodViewModel {
         case .day, .week:
             return 7
         case .month:
-            return 5
+            // 6 to cover all possible weeks that could fall into one month's range
+            return 6
         case .year:
             return 12
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10947,7 +10947,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+		29B97314FDCFA39411CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -19354,7 +19354,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			mainGroup = 29B97314FDCFA39411CA2CEA;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
@@ -20589,6 +20589,7 @@
 				"${PODS_ROOT}/WordPress-Editor-iOS/WordPressEditor/WordPressEditor/Assets/aztec.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
+				"${PODS_ROOT}/ZIPFoundation/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -20598,6 +20599,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/aztec.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -20747,6 +20749,7 @@
 				"${PODS_ROOT}/WordPress-Editor-iOS/WordPressEditor/WordPressEditor/Assets/aztec.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
+				"${PODS_ROOT}/ZIPFoundation/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -20756,6 +20759,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/aztec.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -20769,6 +20773,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Automattic-Tracks-iOS/DataModel.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/CropViewController/TOCropViewControllerBundle.bundle",
 				"${PODS_ROOT}/Down/Resources/DownView.bundle",
@@ -20779,15 +20784,18 @@
 				"${BUILT_PRODUCTS_DIR}/MediaEditor/MediaEditor.framework/MediaEditorHub.storyboardc",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MediaEditor/MediaEditor.bundle",
 				"${PODS_ROOT}/SVProgressHUD/SVProgressHUD/SVProgressHUD.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Starscream/Starscream_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPress-Aztec-iOS/WordPress-Aztec-iOS.bundle",
 				"${PODS_ROOT}/WordPress-Editor-iOS/WordPressEditor/WordPressEditor/Assets/aztec.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressAuthenticator/WordPressAuthenticatorResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
+				"${PODS_ROOT}/ZIPFoundation/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy",
 				"${PODS_CONFIGURATION_BUILD_DIR}/AppCenter/AppCenterDistributeResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Alamofire.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DataModel.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DownView.bundle",
@@ -20798,11 +20806,13 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditorHub.storyboardc",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditor.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SVProgressHUD.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Starscream_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPress-Aztec-iOS.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/aztec.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressAuthenticatorResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AppCenterDistributeResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -20823,6 +20833,7 @@
 				"${PODS_ROOT}/WordPress-Editor-iOS/WordPressEditor/WordPressEditor/Assets/aztec.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
+				"${PODS_ROOT}/ZIPFoundation/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -20832,6 +20843,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/aztec.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -20883,6 +20895,7 @@
 				"${PODS_ROOT}/WordPress-Editor-iOS/WordPressEditor/WordPressEditor/Assets/aztec.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
+				"${PODS_ROOT}/ZIPFoundation/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -20892,6 +20905,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/aztec.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -20940,11 +20954,11 @@
 			files = (
 			);
 			inputPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
 			);
 			outputPaths = (
 				"",
@@ -21086,6 +21100,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Automattic-Tracks-iOS/DataModel.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/CropViewController/TOCropViewControllerBundle.bundle",
 				"${PODS_ROOT}/Down/Resources/DownView.bundle",
@@ -21096,15 +21111,18 @@
 				"${BUILT_PRODUCTS_DIR}/MediaEditor/MediaEditor.framework/MediaEditorHub.storyboardc",
 				"${PODS_CONFIGURATION_BUILD_DIR}/MediaEditor/MediaEditor.bundle",
 				"${PODS_ROOT}/SVProgressHUD/SVProgressHUD/SVProgressHUD.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Starscream/Starscream_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPress-Aztec-iOS/WordPress-Aztec-iOS.bundle",
 				"${PODS_ROOT}/WordPress-Editor-iOS/WordPressEditor/WordPressEditor/Assets/aztec.png",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressAuthenticator/WordPressAuthenticatorResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressShared/WordPressShared.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressUI/WordPressUIResources.bundle",
+				"${PODS_ROOT}/ZIPFoundation/Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy",
 				"${PODS_CONFIGURATION_BUILD_DIR}/AppCenter/AppCenterDistributeResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Alamofire.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DataModel.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DownView.bundle",
@@ -21115,11 +21133,13 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditorHub.storyboardc",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditor.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SVProgressHUD.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Starscream_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPress-Aztec-iOS.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/aztec.png",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressAuthenticatorResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressShared.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/WordPressUIResources.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/PrivacyInfo.xcprivacy",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AppCenterDistributeResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -21133,13 +21153,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
+				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
 			);
 			outputPaths = (
 			);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -435,6 +435,14 @@
 		0C0D3B0E2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C1531FE2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */; };
 		0C1531FF2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */; };
+		0C168EA62BAB100A00253DB7 /* DeprecatedPostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EA52BAB100A00253DB7 /* DeprecatedPostListViewController.swift */; };
+		0C168EA72BAB100A00253DB7 /* DeprecatedPostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EA52BAB100A00253DB7 /* DeprecatedPostListViewController.swift */; };
+		0C168EA92BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EA82BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift */; };
+		0C168EAA2BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EA82BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift */; };
+		0C168EAC2BAB107200253DB7 /* DeprecatedPageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EAB2BAB107200253DB7 /* DeprecatedPageListViewController.swift */; };
+		0C168EAD2BAB107200253DB7 /* DeprecatedPageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EAB2BAB107200253DB7 /* DeprecatedPageListViewController.swift */; };
+		0C168EAF2BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EAE2BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift */; };
+		0C168EB02BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C168EAE2BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift */; };
 		0C1C083E2B9BF9A000E52F8C /* PostRepository+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1C083D2B9BF9A000E52F8C /* PostRepository+Helpers.swift */; };
 		0C1C083F2B9BF9A000E52F8C /* PostRepository+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1C083D2B9BF9A000E52F8C /* PostRepository+Helpers.swift */; };
 		0C1DB5FF2B095DA50028F200 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1DB5FE2B095DA50028F200 /* ImageView.swift */; };
@@ -6217,6 +6225,10 @@
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSearchViewModel+Highlighter.swift"; sourceTree = "<group>"; };
+		0C168EA52BAB100A00253DB7 /* DeprecatedPostListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedPostListViewController.swift; sourceTree = "<group>"; };
+		0C168EA82BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedAbstractPostListViewController.swift; sourceTree = "<group>"; };
+		0C168EAB2BAB107200253DB7 /* DeprecatedPageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedPageListViewController.swift; sourceTree = "<group>"; };
+		0C168EAE2BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeprecatedPageListViewController+Menu.swift"; sourceTree = "<group>"; };
 		0C1C083D2B9BF9A000E52F8C /* PostRepository+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostRepository+Helpers.swift"; sourceTree = "<group>"; };
 		0C1DB5FE2B095DA50028F200 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
 		0C1DB6072B0A419B0028F200 /* ImageDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDecoder.swift; sourceTree = "<group>"; };
@@ -12772,6 +12784,8 @@
 			children = (
 				591232681CCEAA5100B86207 /* AbstractPostListViewController.swift */,
 				590E873A1CB8205700D1B734 /* PostListViewController.swift */,
+				0C168EA82BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift */,
+				0C168EA52BAB100A00253DB7 /* DeprecatedPostListViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -12825,9 +12839,11 @@
 			isa = PBXGroup;
 			children = (
 				59DCA5201CC68AF3000F245F /* PageListViewController.swift */,
+				0C168EAB2BAB107200253DB7 /* DeprecatedPageListViewController.swift */,
 				9AF724EE2146813C00F63A61 /* ParentPageSettingsViewController.swift */,
 				7D21280C251CF0850086DD2C /* EditPageViewController.swift */,
 				FA141F292AEC23E300C9A653 /* PageListViewController+Menu.swift */,
+				0C168EAE2BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -21313,6 +21329,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */,
+				0C168EA62BAB100A00253DB7 /* DeprecatedPostListViewController.swift in Sources */,
 				0CED20022B6809D600E6DD52 /* FilterCompactDatePicker.swift in Sources */,
 				B50C0C621EF42AF200372C65 /* TextList+WordPress.swift in Sources */,
 				B5722E421D51A28100F40C5E /* Notification.swift in Sources */,
@@ -21401,8 +21418,10 @@
 				594399931B45091000539E21 /* WPAuthTokenIssueSolver.m in Sources */,
 				837779B12B55D44B00FDA1AC /* EmptyFilterView.swift in Sources */,
 				F16C35D623F33DE400C81331 /* PageAutoUploadMessageProvider.swift in Sources */,
+				0C168EAC2BAB107200253DB7 /* DeprecatedPageListViewController.swift in Sources */,
 				0CB4057929C8DDEC008EED0A /* BlogDashboardPersonalizationViewModel.swift in Sources */,
 				8BDA5A6B247C2EAF00AB124C /* ReaderDetailViewController.swift in Sources */,
+				0C168EAF2BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift in Sources */,
 				3F8B313025D1D652005A2903 /* HomeWidgetThisWeekData.swift in Sources */,
 				17ABD3522811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */,
 				7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */,
@@ -22242,6 +22261,7 @@
 				983002A822FA05D600F03DBB /* InsightsManagementViewController.swift in Sources */,
 				98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */,
 				4A878550290F2C7D0083AB78 /* Media+Sync.swift in Sources */,
+				0C168EA92BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift in Sources */,
 				931F312C2714302A0075433B /* PublicizeServicesState.swift in Sources */,
 				8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */,
 				FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */,
@@ -24685,6 +24705,7 @@
 				FAA9084D27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */,
 				FABB223C2602FC2C00C8785C /* EditCommentViewController.m in Sources */,
 				FABB223E2602FC2C00C8785C /* PostAutoUploadMessageProvider.swift in Sources */,
+				0C168EA72BAB100A00253DB7 /* DeprecatedPostListViewController.swift in Sources */,
 				F42A9C672B7111BB0035CBCE /* NotificationsViewController+Strings.swift in Sources */,
 				FABB223F2602FC2C00C8785C /* GutenbergMediaPickerHelper.swift in Sources */,
 				0CB424EF2ADEE3CD0080B807 /* PostSearchTokenTableCell.swift in Sources */,
@@ -24771,6 +24792,7 @@
 				FABB22792602FC2C00C8785C /* WPCrashLoggingProvider.swift in Sources */,
 				FA332AD529C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */,
 				0CA10F742ADB014C00CE75AC /* StringRankedSearch.swift in Sources */,
+				0C168EAD2BAB107200253DB7 /* DeprecatedPageListViewController.swift in Sources */,
 				FABB227A2602FC2C00C8785C /* StockPhotosMedia.swift in Sources */,
 				FABB227B2602FC2C00C8785C /* FancyAlertViewController+SavedPosts.swift in Sources */,
 				FABB227C2602FC2C00C8785C /* WPRichTextMediaAttachment.swift in Sources */,
@@ -25031,6 +25053,7 @@
 				FABB232D2602FC2C00C8785C /* TenorPageable.swift in Sources */,
 				83204EDD2ACE098B000C3229 /* ReaderPostCardCellViewModel.swift in Sources */,
 				FABB232E2602FC2C00C8785C /* AccountService+MergeDuplicates.swift in Sources */,
+				0C168EB02BAB125700253DB7 /* DeprecatedPageListViewController+Menu.swift in Sources */,
 				FABB232F2602FC2C00C8785C /* URL+Helpers.swift in Sources */,
 				FABB23302602FC2C00C8785C /* WPStyleGuide+Aztec.swift in Sources */,
 				FABB23312602FC2C00C8785C /* SettingsCommon.swift in Sources */,
@@ -25296,6 +25319,7 @@
 				F4141EEC2AE945C7000D2AAE /* AllDomainsListItemViewModel.swift in Sources */,
 				9895401226C1F39300EDEB5A /* EditCommentTableViewController.swift in Sources */,
 				FABB23F42602FC2C00C8785C /* MediaSettings.swift in Sources */,
+				0C168EAA2BAB104F00253DB7 /* DeprecatedAbstractPostListViewController.swift in Sources */,
 				FABB23F52602FC2C00C8785C /* DomainCreditRedemptionSuccessViewController.swift in Sources */,
 				FABB23F62602FC2C00C8785C /* ActivityLogDetailViewController.m in Sources */,
 				FABB23F72602FC2C00C8785C /* NSObject+Helpers.m in Sources */,


### PR DESCRIPTION
- Create copes of deprecated classes to make it easier to make changes.
- Remove state restoration support just in case. My understanding is that it never worked, and relying on Apple's state restoration is a bad idea ™  

To test:

- Enable `.syncPublishing` and verify that new classes are used
- Disable `.syncPublishing` and verify that old classes are used

## Regression Notes
1. Potential unintended areas of impact: Post & Page lists
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
