### PR TITLE
Make new feature announcement UI the default

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
@@ -138,7 +138,7 @@ private extension WhatIsNewScenePresenter {
     }
 
     private func shouldUseDashboardCustomView() -> Bool {
-        return self.store.appVersionName == "24.4"
+        return true
     }
 
     enum WhatIsNewStrings {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22868

To test:
1. Install a previous version (or just update Jetpack target > General > Identity > Version to 24.4 and run the app)
2. Install this version and verify the new feature announcement layout is shown (the new one uses larger images; see https://github.com/wordpress-mobile/WordPress-iOS/issues/22868)


## Regression Notes
1. Potential unintended areas of impact: Not applicable
3. What I did to test those areas of impact (or what existing automated tests I relied on): Not applicable
4. What automated tests I added (or what prevented me from doing so): Not applicable

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist: Not applicable