### PR TITLE
Offline Mode: Prototype 2

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+Local.swift
+++ b/WordPress/Classes/Models/AbstractPost+Local.swift
@@ -6,6 +6,7 @@ extension AbstractPost {
         return self.isDraft() && !self.hasRemote()
     }
 
+    /// - warning: deprecated (kahu-offline-mode)
     var isLocalRevision: Bool {
         return self.originalIsDraft() && self.isRevision() && self.remoteStatus == .local
     }

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -14,9 +14,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
     AbstractPostRemoteStatusSync,       // Post uploaded
     AbstractPostRemoteStatusPushingMedia, // Push Media
     AbstractPostRemoteStatusAutoSaved,       // Post remote auto-saved
-
-    // New
-    AbstractPostRemoteStatusSyncNeeded
 };
 
 @interface AbstractPost : BasePost
@@ -30,7 +27,9 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  */
 @property (nonatomic, strong, nullable) NSDate * dateModified;
 @property (nonatomic, strong) NSSet<Media *> *media;
+/// A link to the original post from the revision.
 @property (weak, readonly) AbstractPost *original;
+/// The changes that were saved locally but not yet uploaded to the server.
 @property (weak, readonly) AbstractPost *revision;
 @property (nonatomic, strong) NSSet *comments;
 @property (nonatomic, strong, nullable) Media *featuredImage;
@@ -57,12 +56,19 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, copy, nullable) NSDate *autosaveModifiedDate;
 @property (nonatomic, copy, nullable) NSNumber *autosaveIdentifier;
 
+@property (nonatomic, strong, nullable) NSString *confirmedChangesHash;
+@property (nonatomic, strong, nullable) NSDate *confirmedChangesTimestamp;
+
 // Revision management
 - (AbstractPost *)createRevision;
+/// A new version of `createRevision` that allows you to create revisions based
+/// on other revisions.
+/// 
+/// - warning: Work-in-progress (kahu-offline-mode)
+- (AbstractPost *)_createRevision;
 - (void)deleteRevision;
 - (void)applyRevision;
 - (AbstractPost *)updatePostFrom:(AbstractPost *)revision;
-- (void)updateRevision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;
 
@@ -179,6 +185,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  *
  *  @returns    YES if there ever was an attempt to upload this post, NO otherwise.
  */
+/// - warning: Work-in-progress (kahu-offline-mode)
 - (BOOL)hasNeverAttemptedToUpload;
 
 /**

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -14,6 +14,9 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
     AbstractPostRemoteStatusSync,       // Post uploaded
     AbstractPostRemoteStatusPushingMedia, // Push Media
     AbstractPostRemoteStatusAutoSaved,       // Post remote auto-saved
+
+    // New
+    AbstractPostRemoteStatusSyncNeeded
 };
 
 @interface AbstractPost : BasePost

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -5,21 +5,6 @@
 #import "BasePost.h"
 @import WordPressKit;
 
-@interface AbstractPost ()
-
-/**
- The following pair of properties is used to confirm that the post we'll be trying to automatically retry uploading,
- hasn't changed since user has tapped on "confirm", and that we're not suddenly trying to auto-upload a post that the user
- might have already forgotten about.
-
- The public-facing counterparts of those is the `shouldAttemptAutoUpload` property.
- */
-
-@property (nonatomic, strong, nullable) NSString *confirmedChangesHash;
-@property (nonatomic, strong, nullable) NSDate *confirmedChangesTimestamp;
-
-@end
-
 @implementation AbstractPost
 
 @dynamic blog;
@@ -145,8 +130,13 @@
         return self.revision;
     }
 
+    return [self _createRevision];
+}
+
+- (AbstractPost *)_createRevision {
     AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];
     [post cloneFrom:self];
+    post.isSyncNeeded = NO;
     [post setValue:self forKey:@"original"];
     [post setValue:nil forKey:@"revision"];
     post.isFeaturedImageChanged = self.isFeaturedImageChanged;
@@ -187,14 +177,6 @@
     return self;
 }
 
-- (void)updateRevision
-{
-    if ([self isRevision]) {
-        [self cloneFrom:self.original];
-        self.isFeaturedImageChanged = self.original.isFeaturedImageChanged;
-    }
-}
-
 - (BOOL)isRevision
 {
     return (![self isOriginal]);
@@ -232,7 +214,6 @@
 
     return original;
 }
-
 
 #pragma mark - Helpers
 

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -490,6 +490,7 @@
 
 #pragma mark - Post
 
+/// - note: Deprecated (kahu-offline-mode)
 - (BOOL)canSave
 {
     NSString* titleWithoutSpaces = [self.postTitle stringByReplacingOccurrencesOfString:@" " withString:@""];

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -150,4 +150,14 @@ extension AbstractPost {
     func hasPermanentFailedMedia() -> Bool {
         return media.first(where: { !$0.willAttemptToUploadLater() }) != nil
     }
+
+    /// If there is a revision, returns a list of changes made in the revision.
+    var revisionChanges: RemotePostUpdateParameters {
+        let original = self.original ?? self
+        let latest = self.latest()
+        guard latest.isRevision() else {
+            return RemotePostUpdateParameters() // Empty
+        }
+        return RemotePostUpdateParameters.changes(from: original, to: latest)
+    }
 }

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -160,4 +160,10 @@ extension AbstractPost {
         }
         return RemotePostUpdateParameters.changes(from: original, to: latest)
     }
+
+    var isEmpty: Bool {
+        let title = (postTitle ?? "").trimmingCharacters(in: .whitespaces)
+        let content = (content ?? "").trimmingCharacters(in: .whitespaces)
+        return title.isEmpty && content.isEmpty
+    }
 }

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -6,6 +6,11 @@ extension AbstractPost {
         original?.original() ?? self
     }
 
+    /// - warning: Work-in-progress (kahu-offline-mode)
+    var isNewDraft: Bool {
+        !hasRemote() && remoteStatus != .syncNeeded
+    }
+
     // MARK: - Status
 
     @objc
@@ -153,7 +158,7 @@ extension AbstractPost {
 
     /// If there is a revision, returns a list of changes made in the revision.
     var revisionChanges: RemotePostUpdateParameters {
-        let original = self.original ?? self
+        let original = self.original()
         let latest = self.latest()
         guard latest.isRevision() else {
             return RemotePostUpdateParameters() // Empty

--- a/WordPress/Classes/Models/BasePost.swift
+++ b/WordPress/Classes/Models/BasePost.swift
@@ -35,7 +35,8 @@ extension BasePost {
         case publish = "publish"
         case scheduled = "future"
         case trash = "trash"
-        case deleted = "deleted" // Returned by wpcom REST API when a post is permanently deleted.
+        /// Returned by wpcom REST API when a post is permanently deleted.
+        case deleted = "deleted"
     }
 
     @objc var featuredImageURL: URL? {

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -90,8 +90,7 @@ final class PostRepository {
     /// require special handling or an error from the underlying system.
     ///
     /// - parameters:
-    ///   - post: The post to be synced. It doesn't matter whether you pass
-    ///   the original version of the post or the revision.
+    ///   - post: The post to be synced (original revision) .
     ///   - changes: A set of (optional) changes to be applied on top of the post
     ///   or its latest revision.
     ///   - overwrite: Set to `true` to overwrite the values on the server and
@@ -102,27 +101,62 @@ final class PostRepository {
     /// TODO: update to support XML-RPC (error code, etc)
     @MainActor
     func _save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil, overwrite: Bool = false) async throws {
-        let original = post.original ?? post
+        try await _sync(post, revision: post.latest(), changes: changes, overwrite: overwrite)
+    }
 
-        let uploadedPost: RemotePost
+    /// Syncs revisions that have unsaved changes (see `isSyncNeeded`).
+    ///
+    /// - note: This method is designed to be used with drafts.
+    ///
+    /// - warning: Work-in-progress (kahu-offline-mode)
+    @MainActor
+    func _sync(_ post: AbstractPost) async throws {
+        assert(post.original == nil, "Must be called on an original post")
+        try await _sync(post, revision: post.getLatestRevisionNeedingSync())
+    }
+
+    /// - parameter revision: The revision to upload (doesn't have to
+    /// be the latest revision).
+    @MainActor
+    private func _sync(
+        _ post: AbstractPost,
+        revision: AbstractPost,
+        changes: RemotePostUpdateParameters? = nil,
+        overwrite: Bool = false
+    ) async throws {
+        let post = post.original() // Defensive code
+
+        let remotePost: RemotePost
         var isCreated = false
-        if let postID = original.postID, postID.intValue > 0 {
-            uploadedPost = try await _patch(post, postID: postID, changes: changes, overwrite: overwrite)
+        if let postID = post.postID, postID.intValue > 0 {
+            let changes = RemotePostUpdateParameters.changes(from: post, to: revision, with: changes)
+            if !changes.isEmpty {
+                remotePost = try await _patch(post, postID: postID, changes: changes, overwrite: overwrite)
+            } else {
+                remotePost = try await getRemoteService(for: post.blog).post(withID: postID)
+            }
         } else {
             isCreated = true
-            uploadedPost = try await _create(post, changes: changes)
+            remotePost = try await _create(post, changes: changes)
         }
 
         let context = coreDataStack.mainContext
-        original.deleteRevision()
-        PostHelper.update(original, with: uploadedPost, in: context)
+        if revision.revision == nil {
+            // No more revisions were created during the upload, so it's safe
+            // to fully replace the local version with the remote data
+            PostHelper.update(post, with: remotePost, in: context)
+        } else {
+            // We have to keep the local changes to make sure the delta can
+            // still be computed accurately (a smarter algo could merge the changes)
+            post.clone(from: revision)
+        }
+
+        post.deleteSyncedRevisions(until: revision)
+
         if isCreated {
             PostService(managedObjectContext: context)
-                .updateMediaFor(post: original, success: {}, failure: { _ in })
+                .updateMediaFor(post: post, success: {}, failure: { _ in })
         }
-        /// - warning: Work-in-progress (kahu-offline-mode)
-        // TODO: Remove when it's no longer needed
-        original.remoteStatus = AbstractPostRemoteStatus.sync
         ContextManager.shared.saveContextAndWait(context)
     }
 
@@ -155,13 +189,10 @@ final class PostRepository {
     }
 
     @MainActor
-    private func _patch(_ post: AbstractPost, postID: NSNumber, changes: RemotePostUpdateParameters?, overwrite: Bool) async throws -> RemotePost {
+    private func _patch(_ post: AbstractPost, postID: NSNumber, changes: RemotePostUpdateParameters, overwrite: Bool) async throws -> RemotePost {
         let service = try getRemoteService(for: post.blog)
-        let original = post.original ?? post
-        let latest = post.latest()
-
-        // Create a diff between local revision and the target revision.
-        var changes = RemotePostUpdateParameters.changes(from: original, to: latest, with: changes)
+        let original = post.original()
+        var changes = changes
 
         // Make sure the app never overwrites the content without the user approval.
         if !overwrite, let date = original.dateModified, changes.content != nil {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1064,31 +1064,11 @@ extension AztecPostViewController: AztecNavigationControllerDelegate {
 //
 extension AztecPostViewController {
     @IBAction func publishButtonTapped(sender: UIButton) {
-        handlePublishButtonTap()
+        handlePrimaryActionButtonTap()
     }
 
     @IBAction func secondaryPublishButtonTapped() {
-        guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
-            // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
-            let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
-            WordPressAppDelegate.crashLogging?.logError(error)
-            return
-        }
-
-        let secondaryStat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat
-
-        let publishPostClosure = { [unowned self] in
-            self.publishPost(
-                action: action,
-                dismissWhenDone: action.dismissesEditor,
-                analyticsStat: secondaryStat)
-        }
-
-        if presentedViewController != nil {
-            dismiss(animated: true, completion: publishPostClosure)
-        } else {
-            publishPostClosure()
-        }
+        handleSecondaryActionButtonTap()
     }
 
     @IBAction func closeWasPressed() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditHomepageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditHomepageViewController.swift
@@ -27,7 +27,7 @@ class EditHomepageViewController: GutenbergViewController {
     // If there are changes, offer to save them, otherwise continue will dismiss the editor with no changes.
     override func continueFromHomepageEditing() {
         if editorHasChanges {
-            handlePublishButtonTap()
+            handlePrimaryActionButtonTap()
         } else {
             cancelEditing()
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -27,7 +27,7 @@ extension GutenbergViewController {
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
 
             alert.addDefaultActionWithTitle(buttonTitle) { _ in
-                self.secondaryPublishButtonTapped()
+                self.handleSecondaryActionButtonTap()
                 ActionDispatcher.dispatch(NoticeAction.unlock)
             }
         }
@@ -85,30 +85,6 @@ extension GutenbergViewController {
         }
 
         present(alert, animated: true)
-    }
-
-    func secondaryPublishButtonTapped() {
-        guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
-            // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
-            let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
-            WordPressAppDelegate.crashLogging?.logError(error)
-            return
-        }
-
-        let secondaryStat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat
-
-        let publishPostClosure = { [unowned self] in
-            self.publishPost(
-                action: action,
-                dismissWhenDone: action.dismissesEditor,
-                analyticsStat: secondaryStat)
-        }
-
-        if presentedViewController != nil {
-            dismiss(animated: true, completion: publishPostClosure)
-        } else {
-            publishPostClosure()
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -845,7 +845,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             switch reason {
             case .publish:
                 if editorHasContent(title: title, content: html) {
-                    handlePublishButtonTap()
+                    handlePrimaryActionButtonTap()
                 } else {
                     showAlertForEmptyPostPublish()
                 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -647,7 +647,11 @@ class AbstractPostListViewController: UIViewController,
     @objc func moveToDraft(_ post: AbstractPost) {
         WPAnalytics.track(.postListDraftAction, withProperties: propertiesForAnalytics())
 
-        PostCoordinator.shared.moveToDraft(post)
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            PostCoordinator.shared.moveToDraft(post)
+        } else {
+            PostCoordinator.shared._moveToDraft(post)
+        }
     }
 
     @objc func viewPost(_ post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -149,27 +149,6 @@ class EditPostViewController: UIViewController {
         editor.postIsReblogged = postIsReblogged
         editor.entryPoint = entryPoint
         showEditor(editor)
-
-       showUnsaveChangesDialogIfNeeded(in: editor)
-    }
-
-    private func showUnsaveChangesDialogIfNeeded(in editor: EditorViewController) {
-        guard let post else { return }
-
-        let original = post.original ?? post
-        guard original.status != .draft, !post.revisionChanges.isEmpty else {
-            return
-        }
-        let alert = UIAlertController(title: Strings.dialogUnsavedChangesTitle, message: Strings.dialogUnsavedChangesMessage, preferredStyle: .alert)
-        alert.addAction(.init(title: Strings.dialogUnsavedChangesContinue, style: .default) { _ in
-            // Do nothing
-        })
-        alert.addAction(.init(title: Strings.dialogUnsavedChangesDiscard, style: .destructive) { _ in
-            editor.discardChanges()
-        })
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
-            editor.present(alert, animated: true)
-        }
     }
 
     private func showEditor(_ editor: EditorViewController) {
@@ -274,11 +253,4 @@ extension EditPostViewController: UIViewControllerRestoration {
             coder.encode(post.objectID.uriRepresentation(), forKey: RestorationKey.post.rawValue)
         }
     }
-}
-
-private enum Strings {
-    static let dialogUnsavedChangesTitle = NSLocalizedString("postEditor.unsavedChangesDialog.title", value: "Unsaved changes", comment: "Dialog for applying or discarding unsaved changes to the post")
-    static let dialogUnsavedChangesMessage = NSLocalizedString("postEditor.unsavedChangesDialog.message", value: "The post has unsaved changes. Would you like to continue editing them?", comment: "Dialog for applying or discarding unsaved changes to the post")
-    static let dialogUnsavedChangesContinue = NSLocalizedString("postEditor.unsavedChangesDialog.buttonContinue", value: "Continue Editing", comment: "Dialog for applying or discarding unsaved changes to the post")
-    static let dialogUnsavedChangesDiscard = NSLocalizedString("postEditor.unsavedChangesDialog.buttonDiscard", value: "Discard Changes", comment: "Dialog for applying or discarding unsaved changes to the post")
 }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -27,6 +27,8 @@ class EditPostViewController: UIViewController {
     @objc var onClose: ((_ changesSaved: Bool) -> ())?
     @objc var afterDismiss: (() -> Void)?
 
+    private var originalPostID: NSManagedObjectID?
+
     override var modalPresentationStyle: UIModalPresentationStyle {
         didSet(newValue) {
             // make sure this view is transparent with the previous VC visible
@@ -69,6 +71,7 @@ class EditPostViewController: UIViewController {
     /// - Note: it's preferable to use one of the convenience initializers
     fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: BloggingPrompt? = nil) {
         self.post = post
+        self.originalPostID = (post?.original ?? post)?.objectID
         self.loadAutosaveRevision = loadAutosaveRevision
         if let post = post {
             if !post.originalIsDraft() {
@@ -128,9 +131,9 @@ class EditPostViewController: UIViewController {
     @objc private func didChangeObjects(_ notification: Foundation.Notification) {
         guard let userInfo = notification.userInfo else { return }
 
-        let deletedPosts = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
-        if let post = self.post?.original ?? self.post, deletedPosts.contains(post) {
-            closeEditor(animated: true)
+        let deletedObjects = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
+        if deletedObjects.contains(where: { $0.objectID == originalPostID }) {
+            closeEditor()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -149,6 +149,27 @@ class EditPostViewController: UIViewController {
         editor.postIsReblogged = postIsReblogged
         editor.entryPoint = entryPoint
         showEditor(editor)
+
+       showUnsaveChangesDialogIfNeeded(in: editor)
+    }
+
+    private func showUnsaveChangesDialogIfNeeded(in editor: EditorViewController) {
+        guard let post else { return }
+
+        let original = post.original ?? post
+        guard original.status != .draft, !post.revisionChanges.isEmpty else {
+            return
+        }
+        let alert = UIAlertController(title: Strings.dialogUnsavedChangesTitle, message: Strings.dialogUnsavedChangesMessage, preferredStyle: .alert)
+        alert.addAction(.init(title: Strings.dialogUnsavedChangesContinue, style: .default) { _ in
+            // Do nothing
+        })
+        alert.addAction(.init(title: Strings.dialogUnsavedChangesDiscard, style: .destructive) { _ in
+            editor.discardChanges()
+        })
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
+            editor.present(alert, animated: true)
+        }
     }
 
     private func showEditor(_ editor: EditorViewController) {
@@ -253,4 +274,11 @@ extension EditPostViewController: UIViewControllerRestoration {
             coder.encode(post.objectID.uriRepresentation(), forKey: RestorationKey.post.rawValue)
         }
     }
+}
+
+private enum Strings {
+    static let dialogUnsavedChangesTitle = NSLocalizedString("postEditor.unsavedChangesDialog.title", value: "Unsaved changes", comment: "Dialog for applying or discarding unsaved changes to the post")
+    static let dialogUnsavedChangesMessage = NSLocalizedString("postEditor.unsavedChangesDialog.message", value: "The post has unsaved changes. Would you like to continue editing them?", comment: "Dialog for applying or discarding unsaved changes to the post")
+    static let dialogUnsavedChangesContinue = NSLocalizedString("postEditor.unsavedChangesDialog.buttonContinue", value: "Continue Editing", comment: "Dialog for applying or discarding unsaved changes to the post")
+    static let dialogUnsavedChangesDiscard = NSLocalizedString("postEditor.unsavedChangesDialog.buttonDiscard", value: "Discard Changes", comment: "Dialog for applying or discarding unsaved changes to the post")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -42,6 +42,17 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     var status: String? {
+        guard RemoteFeature.enabled(.syncPublishing) else {
+            return _status
+        }
+        if !post.revisionChanges.isEmpty {
+            return Strings.unsavedChanges
+        }
+        return nil
+    }
+
+    /// - note: Deprecated (kahu-offline-mode)
+    private var _status: String? {
         // TODO Move these string constants to the StatusMessages enum
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")
@@ -264,4 +275,5 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
 private enum Strings {
     static let movingPostToTrash = NSLocalizedString("post.movingToTrashStatusMessage", value: "Moving post to trash...", comment: "Status mesasge for post cells")
     static let deletingPostPermanently = NSLocalizedString("post.deletingPostPermanentlyStatusMessage", value: "Deleting post...", comment: "Status mesasge for post cells")
+    static let unsavedChanges = NSLocalizedString("post.unsavedChanges", value: "Unsaved changes", comment: "Status messsage for post cells when post has unsaved changes")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -45,9 +45,6 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
         guard RemoteFeature.enabled(.syncPublishing) else {
             return _status
         }
-        if !post.revisionChanges.isEmpty {
-            return Strings.unsavedChanges
-        }
         return nil
     }
 
@@ -275,5 +272,4 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
 private enum Strings {
     static let movingPostToTrash = NSLocalizedString("post.movingToTrashStatusMessage", value: "Moving post to trash...", comment: "Status mesasge for post cells")
     static let deletingPostPermanently = NSLocalizedString("post.deletingPostPermanentlyStatusMessage", value: "Deleting post...", comment: "Status mesasge for post cells")
-    static let unsavedChanges = NSLocalizedString("post.unsavedChanges", value: "Unsaved changes", comment: "Status messsage for post cells when post has unsaved changes")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -172,14 +172,16 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
             buttons.append(.share)
         }
 
-        if autoUploadInteractor.canRetryUpload(of: post) ||
-            autoUploadInteractor.autoUploadAttemptState(of: post) == .reachedLimit ||
-            post.isFailed && isInternetReachable {
-            buttons.append(.retry)
-        }
+        if !RemoteFeatureFlag.syncPublishing.enabled() {
+            if autoUploadInteractor.canRetryUpload(of: post) ||
+                autoUploadInteractor.autoUploadAttemptState(of: post) == .reachedLimit ||
+                post.isFailed && isInternetReachable {
+                buttons.append(.retry)
+            }
 
-        if canCancelAutoUpload && !isInternetReachable {
-            buttons.append(.cancelAutoUpload)
+            if canCancelAutoUpload && !isInternetReachable {
+                buttons.append(.cancelAutoUpload)
+            }
         }
 
         if canPublish {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -188,8 +188,8 @@ extension PublishingEditor {
                 dismissOrPopView()
             } catch {
                 postEditorStateContext.updated(isBeingPublished: false)
-                await SVProgressHUD.dismiss()
             }
+            await SVProgressHUD.dismiss()
         }
     }
 
@@ -550,11 +550,8 @@ extension PublishingEditor {
         alert.addDestructiveActionWithTitle(Strings.closeConfirmationAlertDiscardChanges) { _ in
             self.discardAndDismiss()
         }
-        let changes = post.revisionChanges
-        if changes.content != nil { // Only suggest if there is an autosave
-            alert.addActionWithTitle(Strings.closeConfirmationAlertSaveDraftChanges, style: .default) { _ in
-                self.performAutosave()
-            }
+        alert.addActionWithTitle(Strings.closeConfirmationAlertSaveDraftChanges, style: .default) { _ in
+            fatalError("TODO: save changes locally (kahu-offline-mode")
         }
         alert.popoverPresentationController?.barButtonItem = alertBarButtonItem
         present(alert, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -6,6 +6,7 @@ import WordPressShared
 /// None of the associated values should be (nor can be) accessed directly by the UI, only through the `PostEditorStateContext` instance.
 ///
 public enum PostEditorAction {
+    /// - note: Deprecated (kahu-offline-mode)
     case save
     case saveAsDraft
     case schedule

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -15,6 +15,7 @@ public enum PostEditorAction {
     case submitForReview
     case continueFromHomepageEditing
 
+    /// - note: Deprecated (kahu-offline-mode)
     var dismissesEditor: Bool {
         switch self {
         case .publish, .schedule, .submitForReview:
@@ -24,6 +25,7 @@ public enum PostEditorAction {
         }
     }
 
+    /// - note: Deprecated (kahu-offline-mode)
     var isAsync: Bool {
         switch self {
         case .publish, .schedule, .submitForReview:

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -74,6 +74,7 @@ public enum PostEditorAction {
         }
     }
 
+    /// - note: Deprecated (kahu-offline-mode)
     var publishingActionLabel: String {
         switch self {
         case .publish:

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -15,7 +15,6 @@ protocol EditorAnalyticsProperties: AnyObject {
 struct PostListEditorPresenter {
 
     static func handle(post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
-
         // Return early if a post is still uploading when the editor's requested.
         guard !PostCoordinator.shared.isUploading(post: post) else {
             presentAlertForPostBeingUploaded()

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -15,10 +15,18 @@ protocol EditorAnalyticsProperties: AnyObject {
 struct PostListEditorPresenter {
 
     static func handle(post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
-        // Return early if a post is still uploading when the editor's requested.
-        guard !PostCoordinator.shared.isUploading(post: post) else {
-            presentAlertForPostBeingUploaded()
-            return
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            // Return early if a post is still uploading when the editor's requested.
+            guard !PostCoordinator.shared.isUpdating(post) else {
+                presentAlertForPostBeingUploaded()
+                return
+            }
+        } else {
+            // Return early if a post is still uploading when the editor's requested.
+            guard !PostCoordinator.shared.isUploading(post: post) else {
+                presentAlertForPostBeingUploaded()
+                return
+            }
         }
 
         // Autosaves are ignored for posts with local changes.

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -92,9 +92,10 @@ final class PostListHeaderView: UIView {
             return
         }
         NSLayoutConstraint.activate([
-            icon.widthAnchor.constraint(equalToConstant: 24),
-            icon.heightAnchor.constraint(equalToConstant: 24)
+            icon.widthAnchor.constraint(equalToConstant: 22),
+            icon.heightAnchor.constraint(equalToConstant: 22)
         ])
+        icon.contentMode = .scaleAspectFit
     }
 
     private func setupEllipsisButton() {

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -79,6 +79,8 @@ final class PostListHeaderView: UIView {
             stackView = UIStackView(arrangedSubviews: [textLabel, ellipsisButton])
         }
 
+        indicator.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+
         stackView.spacing = 12
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -18,17 +18,8 @@ final class PostListItemViewModel {
         self.imageURL = post.featuredImageURL
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.syncStateViewModel = PostSyncStateViewModel(post: post)
-
-        let displayedRevision: Post
-        let original = (post.original as? Post) ?? post
-        if RemoteFeatureFlag.syncPublishing.enabled(), original.status != .draft {
-            displayedRevision = original
-        } else {
-            displayedRevision = post
-        }
-
-        self.badges = makeBadgesString(for: displayedRevision, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
-        self.content = makeContentString(for: displayedRevision, syncStateViewModel: syncStateViewModel)
+        self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
+        self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -18,8 +18,15 @@ final class PostListItemViewModel {
         self.imageURL = post.featuredImageURL
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.syncStateViewModel = PostSyncStateViewModel(post: post)
-        self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
-        self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
+
+        let original = (post.original as? Post) ?? post
+        if RemoteFeatureFlag.syncPublishing.enabled(), original.status != .draft {
+            self.badges = makeBadgesString(for: original, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
+            self.content = makeContentString(for: original, syncStateViewModel: syncStateViewModel)
+        } else {
+            self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
+            self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -19,14 +19,16 @@ final class PostListItemViewModel {
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.syncStateViewModel = PostSyncStateViewModel(post: post)
 
+        let displayedRevision: Post
         let original = (post.original as? Post) ?? post
         if RemoteFeatureFlag.syncPublishing.enabled(), original.status != .draft {
-            self.badges = makeBadgesString(for: original, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
-            self.content = makeContentString(for: original, syncStateViewModel: syncStateViewModel)
+            displayedRevision = original
         } else {
-            self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
-            self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
+            displayedRevision = post
         }
+
+        self.badges = makeBadgesString(for: displayedRevision, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
+        self.content = makeContentString(for: displayedRevision, syncStateViewModel: syncStateViewModel)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -114,7 +114,7 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
         }
         let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter {
             let post = fetchResultsController.object(at: $0)
-            return updatedObjects.contains(post)
+            return updatedObjects.contains(post) || updatedObjects.contains(post.original())
         }
         if !updatedIndexPaths.isEmpty {
             tableView.beginUpdates()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		0CA10FA52ADB286300CE75AC /* StringRankedSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */; };
 		0CA10FA82ADB7C5200CE75AC /* PostSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */; };
 		0CA10FA92ADB7C5300CE75AC /* PostSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */; };
+		0CA15B4E2BB2128800518D6E /* PostCoordinatorSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA15B4D2BB2128800518D6E /* PostCoordinatorSyncTests.swift */; };
 		0CA1C8C12A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CA1C8C22A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CAE8EF22A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */; };
@@ -6271,6 +6272,7 @@
 		0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRankedSearch.swift; sourceTree = "<group>"; };
 		0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRankedSearchTests.swift; sourceTree = "<group>"; };
 		0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchService.swift; sourceTree = "<group>"; };
+		0CA15B4D2BB2128800518D6E /* PostCoordinatorSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorSyncTests.swift; sourceTree = "<group>"; };
 		0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarMenuController.swift; sourceTree = "<group>"; };
 		0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCell.swift; sourceTree = "<group>"; };
 		0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
@@ -10964,7 +10966,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -15747,6 +15749,7 @@
 				8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */,
 				08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */,
 				8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */,
+				0CA15B4D2BB2128800518D6E /* PostCoordinatorSyncTests.swift */,
 				8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */,
 				8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */,
 				FEFA6AC52A86824A004EE5E6 /* PostHelperJetpackSocialTests.swift */,
@@ -19375,7 +19378,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
@@ -20976,11 +20979,11 @@
 			files = (
 			);
 			inputPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 				"",
@@ -21175,13 +21178,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 			);
@@ -23758,6 +23761,7 @@
 				E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */,
 				0148CC292859127F00CF5D96 /* StatsWidgetsStoreTests.swift in Sources */,
 				7320C8BD2190C9FC0082FED5 /* UITextView+SummaryTests.swift in Sources */,
+				0CA15B4E2BB2128800518D6E /* PostCoordinatorSyncTests.swift in Sources */,
 				24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */,
 				80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */,
 				7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */,

--- a/WordPress/WordPressTest/MediaImageServiceTests.swift
+++ b/WordPress/WordPressTest/MediaImageServiceTests.swift
@@ -242,8 +242,12 @@ class MediaImageServiceTests: CoreDataTestCase {
         return blog
     }
 
-    /// `Media` is hardcoded to work with a specific direcoty URL managed by `MediaFileManager`
     func makeLocalURL(forResource name: String, fileExtension: String) throws -> URL {
+        try MediaImageServiceTests.makeLocalURL(forResource: name, fileExtension: fileExtension)
+    }
+
+    /// `Media` is hardcoded to work with a specific directory URL managed by `MediaFileManager`
+    static func makeLocalURL(forResource name: String, fileExtension: String) throws -> URL {
         let sourceURL = try XCTUnwrap(Bundle.test.url(forResource: name, withExtension: fileExtension))
         let mediaURL = try MediaFileManager.default.makeLocalMediaURL(withFilename: name, fileExtension: fileExtension)
         try FileManager.default.copyItem(at: sourceURL, to: mediaURL)

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+import OHHTTPStubs
+
+@testable import WordPress
+
+@MainActor
+class PostCoordinatorSyncTests: CoreDataTestCase {
+    private var blog: Blog!
+    private var mediaCoordinator: MediaCoordinator!
+    private var coordinator: PostCoordinator!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        blog = BlogBuilder(mainContext)
+            .with(dotComID: 80511)
+            .withAnAccount()
+            .build()
+        try mainContext.save()
+
+        mediaCoordinator = MediaCoordinator(
+            coreDataStack: contextManager)
+        coordinator = PostCoordinator(mediaCoordinator: mediaCoordinator, coreDataStack: contextManager)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        HTTPStubs.removeAllStubs()
+    }
+
+    /// Scenario: user created and saved a new draft post with one image block
+    /// (without waiting for upload to finish).
+    func testHappyPath() async throws {
+        // GIVEN a draft post (synced)
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+        post.postTitle = "title-a"
+
+        // GIVEN a post with a image block with media that needs upload
+        let media = MediaBuilder(mainContext).build()
+        media.remoteStatus = .failed
+        media.blog = post.blog
+        media.mediaType = .image
+        media.filename = "test-image.jpg"
+        media.absoluteLocalURL = try MediaImageServiceTests.makeLocalURL(forResource: "test-image", fileExtension: "jpg")
+
+        // important otherwise MediaService will use temporary objectID and fail
+        try mainContext.save()
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.media = [media]
+        let uploadID = media.gutenbergUploadID
+        revision1.content = "<!-- wp:image {\"id\":\(uploadID),\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"file:///path/thumbnail-15.jpeg\" class=\"wp-image-\(uploadID)\"/></figure>\n<!-- /wp:image -->"
+        revision1.isSyncNeeded = true
+
+        // GIVEN a server where the post was deleted
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+            let content = request.getBodyParameters()?["content"] as? String
+            XCTAssertNotNil(content)
+
+            var mock = WordPressComPost.mock
+            mock.content = content
+            return try! HTTPStubsResponse(value: mock, statusCode: 201)
+        }
+
+        stub(condition: isPath("/rest/v1.1/sites/80511/media/new")) { request in
+            HTTPStubsResponse(data: mediaResponse.data(using: .utf8)!, statusCode: 202, headers: [:])
+        }
+
+        // WHEN saving the post
+        await coordinator.sync(post)
+
+        // THEN image block was updated
+        XCTAssertEqual(post.content, "<!-- wp:image {\"id\":1236,\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://example.files.wordpress.com/2024/03/img_0005-1-1.jpg\" class=\"wp-image-1236\"/></figure>\n<!-- /wp:image -->")
+
+        // THEN revisions were uploaded
+        XCTAssertFalse(post.hasRevision())
+    }
+}
+
+private let mediaResponse = """
+{
+  "media": [
+    {
+      "ID": 1236,
+      "URL": "https://example.files.wordpress.com/2024/03/img_0005-1-1.jpg",
+      "guid": "http://example.files.wordpress.com/2024/03/img_0005-1-1.jpg",
+      "date": "2024-03-25T18:50:12-04:00",
+      "post_ID": 0,
+      "author_ID": 34129043,
+      "file": "img_0005-1-1.jpg",
+      "mime_type": "image/jpeg",
+      "extension": "jpg",
+      "title": "img_0005-1",
+      "caption": "",
+      "description": "",
+      "alt": "",
+      "icon": "https://s1.wp.com/wp-includes/images/media/default.png",
+      "size": "701.54 KB",
+      "height": 1335,
+      "width": 2000
+    }
+  ]
+}
+"""
+
+private extension URLRequest {
+    func getBodyParameters() -> [String: Any]? {
+        guard let data = httpBodyStream?.read(),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let parameters = object as? [String: Any] else {
+            return nil
+        }
+        return parameters
+    }
+}

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -245,7 +245,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
         let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
-        postCoordinator.moveToDraft(post)
+        postCoordinator._moveToDraft(post)
 
         expect(post.status).to(equal(.draft))
     }

--- a/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
+++ b/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
@@ -27,7 +27,7 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true)
 
         // When & Then
-        expect(viewModel.state).to(equal(.syncing))
+        expect(viewModel.state).to(equal(.uploading))
         expect(viewModel.isEditable).to(beFalse())
         expect(viewModel.isShowingEllipsis).to(beFalse())
         expect(viewModel.isShowingIndicator).to(beTrue())


### PR DESCRIPTION
- Rework how "Back" button works in Editor
- Remove status labels from cells
- Fix an issue with how "deleted object" notifications is handled (incorrectly checks for `revision` because at this time all relationships are deleted)

## To test:

> [!WARNING]  
> Don't change post settings. There is an upcoming PR where post settings will be moved out of the revision and to memory.

#### Back (Published)

- Open a published post for editing
- Make some changes
- Tap “Back” without uploading the changes
- **Verify** that the post cell shows no changes
- Open the same post again for editing
- **Verify** that it shows an “Unsaved change” alert with “Continue Editing” and “Dismiss” buttons

The main advantage of this change is that you can now save changes to a published post without publishing them (and it works offline too!).

It also eliminates the scenario where you have unsynced changes to the post: you have to either "Update" and wait or save as this a local revision ("Unsaved change").

**Note**: I'll integrate it with Autosave in the upcoming PRs

#### Back (Draft)

- Open an existing draft for editing
- Make some changes
- Tap “Back” 
- **Verify** that the changes are saved automatically

This helps remove some special-casing (eliminates the "Local changes" scenario). By saving automatically, we add some peace of mind that you can never lose your changes. This is consistent with how Pages, Notes, and most other Apple software works.

#### Back (New Post)

- Start creating a new post
- Add title or content
- Tap "Back"
- **Verify** that the editor shows a confirmation sheet (keep editing/discard)

#### Back (New Post - Empty)

- Start creating a new post
- Don't add any content
- Tap "Back"
- **Verify** that the editor is dismissed and the post got deleted

#### Moving to Trash

- **Verify** that “Moving to trash” status is no longer displayed (spinner is enough)

#### Crash

- Open a published post for editing
- Make some changes
- Crash the app
- Open the same post again for editing
- **Verify** that it shows an “Unsaved change” alert with “Continue Editing” and “Dismiss” buttons

#### Local Changes

- Open a post for editing
- **Verify** that it no longer shows the “Local changes” badge before you even make any changes

#### Permanent Deletion (Regression)

- Run the regression test for permanent deletion (404) and **verify** that the editor gets dismissed if the original post is permanently deleted
- **Verify** that you can interact with the list after the dismissal

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
