### PR TITLE
Reader: Use follow for tag strings instead of subscribe

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -44,7 +44,6 @@ class FilterProvider: Identifiable, Observable, FilterTabBarItem {
     let cellClass: UITableViewCell.Type
     let reuseIdentifier: String
     let emptyTitle: String
-    let emptyActionTitle: String
     let section: ReaderManageScenePresenter.TabbedSection
     let siteType: SiteOrganizationType?
 
@@ -58,7 +57,6 @@ class FilterProvider: Identifiable, Observable, FilterTabBarItem {
          cellClass: UITableViewCell.Type,
          reuseIdentifier: String,
          emptyTitle: String,
-         emptyActionTitle: String,
          section: ReaderManageScenePresenter.TabbedSection,
          provider: @escaping Provider,
          siteType: SiteOrganizationType? = nil) {
@@ -68,7 +66,6 @@ class FilterProvider: Identifiable, Observable, FilterTabBarItem {
         self.cellClass = cellClass
         self.reuseIdentifier = reuseIdentifier
         self.emptyTitle = emptyTitle
-        self.emptyActionTitle = emptyActionTitle
         self.section = section
         self.provider = provider
         self.siteType = siteType
@@ -139,18 +136,12 @@ extension ReaderSiteTopic {
             value: "Add a blog",
             comment: "No Tags View Button Label"
         )
-        let emptyActionTitle = NSLocalizedString(
-            "reader.no.tags.action",
-            value: "You can subscribe to posts on a specific blog by subscribing to it.",
-            comment: "No Sites View Label"
-        )
 
         return FilterProvider(title: titleFunction,
                               accessibilityIdentifier: "SitesFilterTab",
                               cellClass: SiteTableViewCell.self,
                               reuseIdentifier: FilterProvider.ReuseIdentifiers.blogs,
                               emptyTitle: emptyTitle,
-                              emptyActionTitle: emptyActionTitle,
                               section: .sites,
                               provider: tableProvider,
                               siteType: siteType)
@@ -290,18 +281,12 @@ extension ReaderTagTopic {
             value: "Add a tag",
             comment: "No Tags View Button Label"
         )
-        let emptyActionTitle = NSLocalizedString(
-            "reader.no.tags.follow.action",
-            value: "You can follow posts on a specific subject by adding a tag.",
-            comment: "No Topics View Label"
-        )
 
         return FilterProvider(title: titleFunction,
                               accessibilityIdentifier: "TagsFilterTab",
                               cellClass: UITableViewCell.self,
                               reuseIdentifier: FilterProvider.ReuseIdentifiers.tags,
                               emptyTitle: emptyTitle,
-                              emptyActionTitle: emptyActionTitle,
                               section: .tags,
                               provider: tableProvider)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -291,8 +291,8 @@ extension ReaderTagTopic {
             comment: "No Tags View Button Label"
         )
         let emptyActionTitle = NSLocalizedString(
-            "reader.no.tags.action",
-            value: "You can subscribe to posts on a specific subject by adding a tag.",
+            "reader.no.tags.follow.action",
+            value: "You can follow posts on a specific subject by adding a tag.",
             comment: "No Topics View Label"
         )
 

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -165,8 +165,8 @@ private extension FilterSheetViewController {
             comment: "Screen title. Reader select interests title label text."
         )
         static let selectInterestsLoading = NSLocalizedString(
-            "reader.filterSheet.select.tags.loading",
-            value: "Subscribing to new tags...",
+            "reader.filterSheet.select.tags.following",
+            value: "Following new tags...",
             comment: "Label displayed to the user while loading their selected interests"
         )
         static let editButtonTitle = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewController+Cells.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewController+Cells.swift
@@ -10,8 +10,8 @@ extension ReaderTagsTableViewModel {
         let button = UIButton.closeAccessoryButton()
         button.addTarget(self, action: #selector(tappedAccessory(_:)), for: .touchUpInside)
         let unfollowString = NSLocalizedString(
-            "reader.tags.unsubscribe.accessibility.label",
-            value: "Unsubscribe from %@",
+            "reader.tags.unfollow.accessibility.label",
+            value: "Unfollow %@",
             comment: "Accessibility label for unsubscribing from a tag"
         )
         button.accessibilityLabel = String(format: unfollowString, topic.title)

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -140,15 +140,15 @@ extension ReaderTagsTableViewModel {
     private func showSelectInterests() {
         let configuration = ReaderSelectInterestsConfiguration(
             title: NSLocalizedString(
-                "reader.select.interests.title",
-                value: "Subscribe to tags",
+                "reader.select.interests.follow.title",
+                value: "Follow tags",
                 comment: "Screen title. Reader select interests title label text."
             ),
             subtitle: nil,
             buttonTitle: nil,
             loading: NSLocalizedString(
-                "reader.select.interests.loading",
-                value: "Subscribing to new tags...",
+                "reader.select.interests.following",
+                value: "Following new tags...",
                 comment: "Label displayed to the user while loading their selected interests"
             )
         )

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -32,7 +32,7 @@ import WordPressShared
     @objc open func configureHeader(_ topic: ReaderAbstractTopic) {
         titleLabel.text = topic.title.split(separator: "-").map { $0.capitalized }.joined(separator: " ")
         followButton.isSelected = topic.following
-        WPStyleGuide.applyReaderFollowButtonStyle(followButton)
+        WPStyleGuide.applyTagsReaderButtonStyle(followButton)
     }
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -26,8 +26,8 @@ class ReaderSelectInterestsViewController: UIViewController {
 
     private struct Strings {
         static let noSearchResultsTitle = NSLocalizedString(
-            "reader.select.tags.no.results.title",
-            value: "No new tags to subscribe to",
+            "reader.select.tags.no.results.follow.title",
+            value: "No new tags to follow",
             comment: "Message shown when there are no new topics to follow."
         )
         static let tryAgainNoticeTitle = NSLocalizedString("Something went wrong. Please try again.", comment: "Error message shown when the app fails to save user selected interests")

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -244,6 +244,14 @@ extension WPStyleGuide {
         button.setTitleColor(disabledColor, for: .disabled)
     }
 
+    class func applyTagsReaderButtonStyle(_ button: UIButton) {
+        applyReaderFollowButtonStyle(button)
+
+        button.setTitle(FollowButton.Text.tagsFollowString, for: .normal)
+        button.setTitle(FollowButton.Text.tagsFollowingString, for: .selected)
+        button.accessibilityLabel = button.isSelected ? FollowButton.Text.tagsFollowingString : FollowButton.Text.tagsFollowString
+    }
+
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton,
                                                          contentInsets: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 8.0, leading: 24.0, bottom: 8.0, trailing: 24.0)) {
         let font: UIFont = .preferredFont(forTextStyle: .subheadline)
@@ -499,8 +507,8 @@ extension WPStyleGuide {
     public struct FollowButton {
         struct Text {
             static let accessibilityHint = NSLocalizedString(
-                "reader.subscribe.button.accessibility.hint",
-                value: "Subscribes to the tag.",
+                "reader.follow.button.accessibility.hint",
+                value: "Follows the tag.",
                 comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag."
             )
             static let followStringForDisplay =  NSLocalizedString(
@@ -512,6 +520,16 @@ extension WPStyleGuide {
                 "reader.subscribed.button.title",
                 value: "Subscribed",
                 comment: "Verb. Button title. The user is subscribed to a blog."
+            )
+            static let tagsFollowString = NSLocalizedString(
+                "reader.tags.follow.button.title",
+                value: "Follow",
+                comment: "Verb. Button title. Follows a new tag."
+            )
+            static let tagsFollowingString = NSLocalizedString(
+                "reader.tags.following.button.title",
+                value: "Following",
+                comment: "Verb. Button title. The user is following a tag."
             )
         }
     }

--- a/WordPress/UITests/Tests/ReaderTests.swift
+++ b/WordPress/UITests/Tests/ReaderTests.swift
@@ -43,10 +43,10 @@ class ReaderTests: XCTestCase {
     func testFollowNewTopicOnDiscover() throws {
         try ReaderScreen()
             .switchToStream(.discover)
-            .selectTopic()
-            .verifyTopicLoaded()
-            .subscribeToTopic()
-            .verifyTopicSubscribed()
+            .selectTag()
+            .verifyTagLoaded()
+            .followTag()
+            .verifyTagFollowed()
     }
 
     func testSavePost() throws {

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -39,12 +39,12 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Dismiss"]
     }
 
-    private let subscribeButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Subscribe"]
+    private let followButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Follow"]
     }
 
-    private let subscribedButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Subscribed"]
+    private let followingButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Following"]
     }
 
     private let subscriptionsMenuButtonGetter: (XCUIApplication) -> XCUIElement = {
@@ -55,7 +55,7 @@ public class ReaderScreen: ScreenObject {
         $0.buttons["Likes"]
     }
 
-    private let topicCellButtonGetter: (XCUIApplication) -> XCUIElement = {
+    private let tagCellButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["topics-card-cell-button"]
     }
 
@@ -80,8 +80,8 @@ public class ReaderScreen: ScreenObject {
     var discoverButton: XCUIElement { discoverButtonGetter(app) }
     var dismissButton: XCUIElement { dismissButtonGetter(app) }
     var firstPostLikeButton: XCUIElement { firstPostLikeButtonGetter(app) }
-    var subscribeButton: XCUIElement { subscribeButtonGetter(app) }
-    var subscribedButton: XCUIElement { subscribedButtonGetter(app) }
+    var followButton: XCUIElement { followButtonGetter(app) }
+    var followingButton: XCUIElement { followingButtonGetter(app) }
     var subscriptionsMenuButton: XCUIElement { subscriptionsMenuButtonGetter(app) }
     var likesTabButton: XCUIElement { likesTabButtonGetter(app) }
     var noResultsView: XCUIElement { noResultsViewGetter(app) }
@@ -90,7 +90,7 @@ public class ReaderScreen: ScreenObject {
     var moreButton: XCUIElement { moreButtonGetter(app) }
     var savePostButton: XCUIElement { savePostButtonGetter(app) }
     var savedButton: XCUIElement { savedButtonGetter(app) }
-    var topicCellButton: XCUIElement { topicCellButtonGetter(app) }
+    var tagCellButton: XCUIElement { tagCellButtonGetter(app) }
     var visitButton: XCUIElement { visitButtonGetter(app) }
     var ghostLoading: XCUIElement { ghostLoadingGetter(app) }
 
@@ -159,21 +159,21 @@ public class ReaderScreen: ScreenObject {
         (try? ReaderScreen().isLoaded) ?? false
     }
 
-    public func selectTopic() -> Self {
-        topicCellButton.firstMatch.tap()
+    public func selectTag() -> Self {
+        tagCellButton.firstMatch.tap()
 
         return self
     }
 
-    public func verifyTopicLoaded(file: StaticString = #file, line: UInt = #line) -> Self {
+    public func verifyTagLoaded(file: StaticString = #file, line: UInt = #line) -> Self {
         XCTAssertTrue(readerButton.waitForExistence(timeout: 3), file: file, line: line)
-        XCTAssertTrue(subscribeButton.waitForExistence(timeout: 3), file: file, line: line)
+        XCTAssertTrue(followButton.waitForExistence(timeout: 3), file: file, line: line)
 
         return self
     }
 
-    public func subscribeToTopic() -> Self {
-        waitForExistenceAndTap(subscribeButton, timeout: 3)
+    public func followTag() -> Self {
+        waitForExistenceAndTap(followButton, timeout: 3)
 
         return self
     }
@@ -222,9 +222,9 @@ public class ReaderScreen: ScreenObject {
     }
 
     @discardableResult
-    public func verifyTopicSubscribed(file: StaticString = #file, line: UInt = #line) -> Self {
-        XCTAssertTrue(subscribedButton.waitForExistence(timeout: 3), file: file, line: line)
-        XCTAssertTrue(subscribedButton.isSelected, file: file, line: line)
+    public func verifyTagFollowed(file: StaticString = #file, line: UInt = #line) -> Self {
+        XCTAssertTrue(followingButton.waitForExistence(timeout: 3), file: file, line: line)
+        XCTAssertTrue(followingButton.isSelected, file: file, line: line)
 
         return self
     }

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -174,7 +174,6 @@ extension ReaderTabViewModelTests {
                        cellClass: UITableViewCell.self,
                        reuseIdentifier: "Cell",
                        emptyTitle: "Test",
-                       emptyActionTitle: "Test",
                        section: .sites) { completion in
             completion(.success([]))
         }


### PR DESCRIPTION
Fixes #22709 

## Description

Updates the subscribe/subscribed terminology to follow/following for tags.

## Testing

To test:
- Launch Jetpack and login
- Navigate to a Reader stream
- Open a post which has tags
- Tap on one of the tags on the post
- 🔎 **Verify** the tags screen shows `Follow` or `Following`
- Tap on the action button
- 🔎 **Verify** it flips to the opposite one
- Navigate to the `Subscriptions` feed
- Tap on the tags chip
- Tap on `Edit` in the action sheet
- Tap on `Discover more tags` on the manage screen
- 🔎 **Verify** the title of the tag cloud view is `Follow tags`
- Tap on some of the tags on that screen
- Hit `Done`
- 🔎 **Verify** the loading string is `Following new tags...`

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Updated UI tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
