### PR TITLE
Reader: Update `Edit` to `Manage` in Reader filter sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -71,7 +71,7 @@ class FilterSheetViewController: UIViewController {
 
     private lazy var editButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setTitle(Strings.editButtonTitle, for: .normal)
+        button.setTitle(Strings.manageButtonTitle, for: .normal)
         button.tintColor = .label
         button.titleLabel?.adjustsFontForContentSizeCategory = true
 
@@ -169,10 +169,10 @@ private extension FilterSheetViewController {
             value: "Subscribing to new tags...",
             comment: "Label displayed to the user while loading their selected interests"
         )
-        static let editButtonTitle = NSLocalizedString(
-            "reader.filterSheet.button.edit",
-            value: "Edit",
-            comment: "Title for a button that allows user to edit their subscribed list from the filter sheet"
+        static let manageButtonTitle = NSLocalizedString(
+            "reader.filterSheet.button.manage",
+            value: "Manage",
+            comment: "Title for a button that allows user to manage their subscribed list from the filter sheet"
         )
     }
 


### PR DESCRIPTION
Fixes #22825 

## Description

Updates the `Edit` button in the Reader filter sheet to `Manage`.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the `Subscriptions` feed in the Reader
- Tap on `N Tags` chip
- 🔎 **Verify** the `Edit` button is updated to `Manage`
- Dismiss the sheet
- Tap on `N Blogs` chip
- 🔎 **Verify** the `Edit` button is updated to `Manage`

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
