### PR TITLE
Fix Reader interest selection index out of bounds

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsDataSource.swift
@@ -102,8 +102,8 @@ class ReaderInterestsDataSource {
 
     /// Returns a reader interest for the specified row
     /// - Parameter row: The index of the item you want to return
-    /// - Returns: A reader interest model
-    public func interest(for row: Int) -> ReaderInterestViewModel {
-        return interests[row]
+    /// - Returns: A reader interest model if exists; or nil otherwise.
+    public func interest(for row: Int) -> ReaderInterestViewModel? {
+        return interests[safe: row]
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import AutomatticTracks
 import WordPressUI
 
 protocol ReaderDiscoverFlowDelegate: AnyObject {
@@ -322,7 +323,8 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
         }
 
         guard let interest = dataSource.interest(for: indexPath.row) else {
-            DDLogError("ReaderSelectInterestsViewController: Requested for data at invalid row \(indexPath.row)")
+            CrashLogging.main.logMessage("ReaderSelectInterestsViewController: Requested for data at invalid row",
+                                         properties: ["row": indexPath.row], level: .warning)
             return .init(frame: .zero)
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -321,7 +321,10 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
             fatalError("Expected a ReaderInterestsCollectionViewCell for identifier: \(Constants.reuseIdentifier)")
         }
 
-        let interest: ReaderInterestViewModel = dataSource.interest(for: indexPath.row)
+        guard let interest = dataSource.interest(for: indexPath.row) else {
+            DDLogError("ReaderSelectInterestsViewController: Requested for data at invalid row \(indexPath.row)")
+            return .init(frame: .zero)
+        }
 
         ReaderInterestsStyleGuide.applyCellLabelStyle(label: cell.label,
                                                       isSelected: interest.isSelected)
@@ -339,12 +342,15 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegate
 extension ReaderSelectInterestsViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let interest = dataSource.interest(for: indexPath.row) else {
+            return
+        }
 
         if spotlightIsShown {
             spotlightIsShown = false
         }
 
-        dataSource.interest(for: indexPath.row).toggleSelected()
+        interest.toggleSelected()
         updateNextButtonState()
 
         UIView.animate(withDuration: 0) {
@@ -356,7 +362,9 @@ extension ReaderSelectInterestsViewController: UICollectionViewDelegate {
 // MARK: - UICollectionViewFlowLayout
 extension ReaderSelectInterestsViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let interest: ReaderInterestViewModel = dataSource.interest(for: indexPath.row)
+        guard let interest = dataSource.interest(for: indexPath.row) else {
+            return .zero
+        }
 
         let attributes: [NSAttributedString.Key: Any] = [
             .font: ReaderInterestsStyleGuide.cellLabelTitleFont


### PR DESCRIPTION
Fixes #22677

> [!WARNING]
> This targets the current beta branch `release/24.5`.

This PR fixes the out-of-bounds issue by updating the `interests(for:)` method to return an optional object when the provided index is invalid. No recent changes have been made to this component, but my assumption is that the crash rate has been rising since we enabled the Select Interests or tag discovery screen.

Previously, the crash rate remained low because we only showed the Select Interests screen for users with 0 tags... Since new users automatically get subscribed to the `dailyprompt` tag, almost no one visited the Select Interests screen. However, recently we've changed the logic to also show the Select Interests logic to users that *only* follow the `dailyprompt` tag.

Since the error rate is rising, I think it's worth targeting the current 24.5-beta.

## To test

I haven't been able to reproduce the issue, but you could test several entry points:

### Select Interests in Discover

- Launch the Jetpack app.
- Log in to a new account, or one that only follows the `dailyprompt` tag.
- Go to Reader > Discover.
- 🔎 Verify that the Select Interests screen is shown and the app doesn't crash.

### Select Interests from the Tags manage flow

- Launch the Jetpack app.
- Log in to any existing account.
- Go to Reader > Subscriptions.
- Tap the `N Tags` filter chip > Edit.
- Tap `Discover more tags`.
- 🔎 Verify that the Select Interests screen is shown and the app doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes and made sure the existing unit tests were passing.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests to cover an out-of-bounds scenario.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:

- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
