### PR TITLE
Reader: Use escaped pattern when fetching search suggestion

### DIFF
--- a/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
+++ b/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
@@ -41,6 +41,7 @@ import CocoaLumberjack
     /// - Returns: A matching search phrase or nil.
     ///
     private func findSuggestion(forPhrase phrase: String, in context: NSManagedObjectContext) -> ReaderSearchSuggestion? {
+        let phrase = NSRegularExpression.escapedPattern(for: phrase)
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
         fetchRequest.predicate = NSPredicate(format: "searchPhrase MATCHES[cd] %@", phrase)
 


### PR DESCRIPTION
Fixes: #19241

## Description

Fixes a crash due to trying to use an invalid regular expression.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the Reader search
- Type in a phrase which contains a `\` such as `test\` and search
- 🔎 **Verify** the app does not crash

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
