### PR TITLE
Reader: Remove returning a cached `ReaderSiteTopic`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 24.6
 -----
 * [**] Block editor: Highlight text fixes [https://github.com/WordPress/gutenberg/pull/57650]
+* [*] [Jetpack-only] Reader: Fix displaying stale site information [#22885]
 
 24.5
 -----


### PR DESCRIPTION
Fixes #22883
Ref: p4a5px-2UT-p2

## Description

Returning a cached version of the site topic results in stale data and causes the displayed values to be inaccurate. This change removes showing the cached site info and fetches it each time instead.

## Testing

### Stale data
- Launch Jetpack and login
- Navigate to the Reader
- Find a blog you control and view the site details
- Make some posts on that blog
- Navigate back to the site details in the Reader
- 🔎 **Verify** the post count is updated

### Cached info on error
- Launch Jetpack and login
- Navigate to the Reader
- View the site details of a blog post
- Navigate back to the Reader feed
- Disable your internet
- Open the site details again for the same site
- 🔎 **Verify** the cached version of the site is returned

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)