### PR TITLE
Offline Mode: Integrate new APIs in moveToDraft

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -2,6 +2,10 @@ import Foundation
 
 extension AbstractPost {
 
+    func original() -> AbstractPost {
+        original?.original() ?? self
+    }
+
     // MARK: - Status
 
     @objc

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -12,7 +12,7 @@ final class PostSyncStateViewModel {
     private let isInternetReachable: Bool
 
     var state: State {
-        if post.remoteStatus == .pushing || PostCoordinator.shared.isDeleting(post) {
+        if post.remoteStatus == .pushing || PostCoordinator.shared.isDeleting(post) || PostCoordinator.shared.isUpdating(post) {
             return .syncing
         }
         if post.isFailed {

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -243,7 +243,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testChangePostToDraftWhenMovingToDraft() {
         let post = PostBuilder(mainContext).published().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, isSyncPublishingEnabled: false)
 
         postCoordinator.moveToDraft(post)
 


### PR DESCRIPTION
## To test

### Happy Path

- Publish a new post
- Tap "Move to Draft" from the context menu
- **Verify** that the activity indicator is displayed and you can't interact with the post
- **Verify** that after a slight delay post got moved to drafts
- **Verify** that the app sent only `{ "status": "draft" }` in the request body (aka partial updates)

### Negative Scenarios

- **Verify** that if you try to move to draft a permanently deleted posts, the alert error is shown and the post is deleted from the list after you tap "OK"
- **Verify** that if you are offline, an alert with an error message is shown 

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
