### PR TITLE
[Gravatar] Fetch Gravatar profile using async fetch method

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -302,21 +302,16 @@ private extension LoginEpilogueTableViewController {
         }
     }
 
-    nonisolated
     func fetchGravatarProfile(with profile: UserProfile, completion: @escaping (LoginEpilogueUserInfo?) -> ()) async {
         let service = ProfileService()
         let epilogueInfo = LoginEpilogueUserInfo(profile: profile)
         do {
             let gravatarProfile = try await service.fetch(withEmail: profile.email)
             let updatedInfo = epilogueInfo.updating(with: gravatarProfile)
-            await MainActor.run {
-                completion(updatedInfo)
-            }
+            completion(updatedInfo)
         } catch {
             print("Error: \(error)")
-            await MainActor.run {
-                completion(nil)
-            }
+            completion(nil)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -40,9 +40,11 @@ extension LoginEpilogueUserInfo {
 
     /// Updates the Epilogue properties, given a GravatarProfile instance.
     ///
-    mutating func update(with profile: Gravatar.UserProfile) {
-        gravatarUrl = profile.thumbnailUrl
-        fullName = profile.displayName ?? ""
+    func updating(with profile: Gravatar.UserProfile) -> LoginEpilogueUserInfo {
+        var copy = self
+        copy.gravatarUrl = profile.thumbnailUrl
+        copy.fullName = profile.displayName ?? ""
+        return copy
     }
 
     mutating func update(with socialUser: SocialUser) {


### PR DESCRIPTION
Implementing changes on Gravatar SDK regarding fetching Gravatar profile.

## To test:

To make the code reachable, comment out:

https://github.com/wordpress-mobile/WordPress-iOS/blob/d6978e2f309d65d05559eb6646c63f6c8a2e3b89/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift#L314-L325

Other pre- requisites: 
- Have a self-hosted site with Jetpack.
- If you don't have any, you can create one fast using https://jurassic.ninja/ (the default will install Jetpack connected to your logged-in WPCom account).

After commenting and building the app again:
- Log out of any WPCom account.
- Log in using the self hosted site.
  - Check that you see your information from Gravatar in the epilogue screen.

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9772967/c44da733-5500-4101-a16f-f0827f3dc24a" width="40%">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
