### PR TITLE
Offline Mode: Sync Engine

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+HashHelpers.h
+++ b/WordPress/Classes/Models/AbstractPost+HashHelpers.h
@@ -7,14 +7,19 @@ NS_ASSUME_NONNULL_BEGIN
 // This value is used in Offline Posting — to calculate whether the post that the user _wanted_ to publish,
 // hasn't changed in the meantime and still is the same post.
 // It works by calculating a SHA256 hash for a subset of properties of a Post and then combining them together (including the hashes returned by the `additionalContentHashes` method, to let subclasses provide additional sources of truthfulness).
+/// - note: deprecated (kahu-offline-mode)
 - (NSString *)calculateConfirmedChangesContentHash;
 
 // This is an extension point for the subclasses to add additional sources of truthfulness.
+/// - note: deprecated (kahu-offline-mode)
 - (NSArray<NSData *> *)additionalContentHashes;
 
 
+/// - note: deprecated (kahu-offline-mode)
 - (NSData *)hashForString:(NSString *)string;
+/// - note: deprecated (kahu-offline-mode)
 - (NSData *)hashForNSInteger:(NSInteger)integer;
+/// - note: deprecated (kahu-offline-mode)
 - (NSData *)hashForDouble:(double)dbl;
 
 @end

--- a/WordPress/Classes/Models/AbstractPost+Local.swift
+++ b/WordPress/Classes/Models/AbstractPost+Local.swift
@@ -2,10 +2,12 @@ import Foundation
 
 extension AbstractPost {
     /// Returns true if the post is a draft and has never been uploaded to the server.
+    /// - note: deprecated (kahu-offline-mode)
     var isLocalDraft: Bool {
         return self.isDraft() && !self.hasRemote()
     }
 
+    /// - warning: deprecated (kahu-offline-mode)
     var isLocalRevision: Bool {
         return self.originalIsDraft() && self.isRevision() && self.remoteStatus == .local
     }

--- a/WordPress/Classes/Models/AbstractPost+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Models/AbstractPost+MarkAsFailedAndDraftIfNeeded.swift
@@ -21,6 +21,7 @@
     ///     eventually be made private.
     /// - SeeAlso: PostCoordinator.resume
     ///
+    /// - note: deprecated (kahu-offline-mode)
     func markAsFailedAndDraftIfNeeded() {
         guard self.remoteStatus != .failed else {
             return

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -54,12 +54,19 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, copy, nullable) NSDate *autosaveModifiedDate;
 @property (nonatomic, copy, nullable) NSNumber *autosaveIdentifier;
 
+@property (nonatomic, strong, nullable) NSString *confirmedChangesHash;
+@property (nonatomic, strong, nullable) NSDate *confirmedChangesTimestamp;
+
 // Revision management
 - (AbstractPost *)createRevision;
+/// A new version of `createRevision` that allows you to create revisions based
+/// on other revisions.
+/// 
+/// - warning: Work-in-progress (kahu-offline-mode)
+- (AbstractPost *)_createRevision;
 - (void)deleteRevision;
 - (void)applyRevision;
 - (AbstractPost *)updatePostFrom:(AbstractPost *)revision;
-- (void)updateRevision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;
 
@@ -73,7 +80,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (BOOL)hasCategories;
 - (BOOL)hasTags;
 
-/// True if either the post failed to upload, or the post has media that failed to upload.
+/// - note: deprecated (kahu-offline-mode)
 @property (nonatomic, assign, readonly) BOOL isFailed;
 
 @property (nonatomic, assign, readonly) BOOL hasFailedMedia;
@@ -86,7 +93,9 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (BOOL)hasRevision;
 
 #pragma mark - Conveniece Methods
+/// - note: deprecated (kahu-offline-mode)
 - (void)publishImmediately;
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)shouldPublishImmediately;
 - (NSString *)authorNameForDisplay;
 - (NSString *)blavatarForDisplay;
@@ -176,6 +185,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  *
  *  @returns    YES if there ever was an attempt to upload this post, NO otherwise.
  */
+/// - warning: deprecated (kahu-offline-mode)
 - (BOOL)hasNeverAttemptedToUpload;
 
 /**

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -55,39 +55,10 @@ class Post: AbstractPost {
         }
     }
 
-    // MARK: - Properties
-
-    fileprivate var storedContentPreviewForDisplay = ""
-
     // MARK: - NSManagedObject
 
     override class func entityName() -> String {
         return "Post"
-    }
-
-    override func awakeFromFetch() {
-        super.awakeFromFetch()
-        buildContentPreview()
-    }
-
-    override func willSave() {
-        super.willSave()
-
-        if isDeleted {
-            return
-        }
-
-        storedContentPreviewForDisplay = ""
-    }
-
-    // MARK: - Content Preview
-
-    fileprivate func buildContentPreview() {
-        if let excerpt = mt_excerpt, excerpt.count > 0 {
-            storedContentPreviewForDisplay = excerpt.makePlainText()
-        } else if let content = content {
-            storedContentPreviewForDisplay = content.summarized()
-        }
     }
 
     // MARK: - Format
@@ -301,11 +272,23 @@ class Post: AbstractPost {
     // MARK: - BasePost
 
     override func contentPreviewForDisplay() -> String {
-        if storedContentPreviewForDisplay.count == 0 {
-            buildContentPreview()
+        if let excerpt = mt_excerpt, excerpt.count > 0 {
+            if let preview = PostPreviewCache.shared.excerpt[excerpt] {
+                return preview
+            }
+            let preview = excerpt.makePlainText()
+            PostPreviewCache.shared.excerpt[excerpt] = preview
+            return preview
+        } else if let content = content {
+            if let preview = PostPreviewCache.shared.content[content] {
+                return preview
+            }
+            let preview = content.summarized()
+            PostPreviewCache.shared.content[content] = preview
+            return preview
+        } else {
+            return ""
         }
-
-        return storedContentPreviewForDisplay
     }
 
     override func hasLocalChanges() -> Bool {
@@ -385,5 +368,22 @@ class Post: AbstractPost {
                 hash(for: postFormat ?? ""),
                 hash(for: stringifiedCategories),
                 hash(for: isStickyPost ? 1 : 0)]
+    }
+}
+
+private final class PostPreviewCache {
+    static let shared = PostPreviewCache()
+
+    let excerpt = Cache<String, String>()
+    let content = Cache<String, String>()
+}
+
+private final class Cache<Key: Hashable, Value> {
+    private let lock = NSLock()
+    private var dictionary: [Key: Value] = [:]
+
+    subscript(key: Key) -> Value? {
+        get { lock.withLock { dictionary[key] } }
+        set { lock.withLock { dictionary[key] = newValue } }
     }
 }

--- a/WordPress/Classes/Services/PostHelper.h
+++ b/WordPress/Classes/Services/PostHelper.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PostHelper: NSObject
 
 + (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext;
++ (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext overwrite:(BOOL)overwrite;
 
 /**
  Creates a RemotePost from an AbstractPost to be used for API calls.

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -8,6 +8,14 @@
 @implementation PostHelper
 
 + (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext {
+    [self updatePost:post withRemotePost:remotePost inContext:managedObjectContext overwrite:NO];
+}
+
++ (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext overwrite:(BOOL)overwrite {
+    if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing] && (post.revision != nil && !overwrite)) {
+        return;
+    }
+
     NSNumber *previousPostID = post.postID;
     post.postID = remotePost.postID;
     // Used to populate author information for self-hosted sites.

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -328,6 +328,10 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             self?.uploadsManager.resume()
         }
 
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            PostCoordinator.shared.scheduleSync()
+        }
+
         setupWordPressExtensions()
 
         shortcutCreator.createShortcutsIf3DTouchAvailable(AccountHelper.isLoggedIn)
@@ -427,14 +431,16 @@ extension WordPressAppDelegate {
                 return
             }
 
-            let wifi = reachability.isReachableViaWiFi() ? "Y" : "N"
-            let wwan = reachability.isReachableViaWWAN() ? "Y" : "N"
+            DispatchQueue.main.async {
+                let wifi = reachability.isReachableViaWiFi() ? "Y" : "N"
+                let wwan = reachability.isReachableViaWWAN() ? "Y" : "N"
 
-            DDLogInfo("Reachability - Internet - WiFi: \(wifi) WWAN: \(wwan)")
-            let newValue = reachability.isReachable()
-            self?.connectionAvailable = newValue
+                DDLogInfo("Reachability - Internet - WiFi: \(wifi) WWAN: \(wwan)")
+                let newValue = reachability.isReachable()
+                self?.connectionAvailable = newValue
 
-            NotificationCenter.default.post(name: .reachabilityChanged, object: self, userInfo: [Foundation.Notification.reachabilityKey: newValue])
+                NotificationCenter.default.post(name: .reachabilityChanged, object: self, userInfo: [Foundation.Notification.reachabilityKey: newValue])
+            }
         }
 
         internetReachability?.reachableBlock = reachabilityBlock

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1064,31 +1064,11 @@ extension AztecPostViewController: AztecNavigationControllerDelegate {
 //
 extension AztecPostViewController {
     @IBAction func publishButtonTapped(sender: UIButton) {
-        handlePublishButtonTap()
+        handlePrimaryActionButtonTap()
     }
 
     @IBAction func secondaryPublishButtonTapped() {
-        guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
-            // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
-            let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
-            WordPressAppDelegate.crashLogging?.logError(error)
-            return
-        }
-
-        let secondaryStat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat
-
-        let publishPostClosure = { [unowned self] in
-            self.publishPost(
-                action: action,
-                dismissWhenDone: action.dismissesEditor,
-                analyticsStat: secondaryStat)
-        }
-
-        if presentedViewController != nil {
-            dismiss(animated: true, completion: publishPostClosure)
-        } else {
-            publishPostClosure()
-        }
+        handleSecondaryActionButtonTap()
     }
 
     @IBAction func closeWasPressed() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditHomepageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditHomepageViewController.swift
@@ -27,7 +27,7 @@ class EditHomepageViewController: GutenbergViewController {
     // If there are changes, offer to save them, otherwise continue will dismiss the editor with no changes.
     override func continueFromHomepageEditing() {
         if editorHasChanges {
-            handlePublishButtonTap()
+            handlePrimaryActionButtonTap()
         } else {
             cancelEditing()
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -27,7 +27,7 @@ extension GutenbergViewController {
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
 
             alert.addDefaultActionWithTitle(buttonTitle) { _ in
-                self.secondaryPublishButtonTapped()
+                self.handleSecondaryActionButtonTap()
                 ActionDispatcher.dispatch(NoticeAction.unlock)
             }
         }
@@ -85,30 +85,6 @@ extension GutenbergViewController {
         }
 
         present(alert, animated: true)
-    }
-
-    func secondaryPublishButtonTapped() {
-        guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
-            // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
-            let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
-            WordPressAppDelegate.crashLogging?.logError(error)
-            return
-        }
-
-        let secondaryStat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat
-
-        let publishPostClosure = { [unowned self] in
-            self.publishPost(
-                action: action,
-                dismissWhenDone: action.dismissesEditor,
-                analyticsStat: secondaryStat)
-        }
-
-        if presentedViewController != nil {
-            dismiss(animated: true, completion: publishPostClosure)
-        } else {
-            publishPostClosure()
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -845,7 +845,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             switch reason {
             case .publish:
                 if editorHasContent(title: title, content: html) {
-                    handlePublishButtonTap()
+                    handlePrimaryActionButtonTap()
                 } else {
                     showAlertForEmptyPostPublish()
                 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -646,7 +646,6 @@ class AbstractPostListViewController: UIViewController,
 
     @objc func moveToDraft(_ post: AbstractPost) {
         WPAnalytics.track(.postListDraftAction, withProperties: propertiesForAnalytics())
-
         PostCoordinator.shared.moveToDraft(post)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -27,6 +27,8 @@ class EditPostViewController: UIViewController {
     @objc var onClose: ((_ changesSaved: Bool) -> ())?
     @objc var afterDismiss: (() -> Void)?
 
+    private var originalPostID: NSManagedObjectID?
+
     override var modalPresentationStyle: UIModalPresentationStyle {
         didSet(newValue) {
             // make sure this view is transparent with the previous VC visible
@@ -69,6 +71,7 @@ class EditPostViewController: UIViewController {
     /// - Note: it's preferable to use one of the convenience initializers
     fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: BloggingPrompt? = nil) {
         self.post = post
+        self.originalPostID = (post?.original ?? post)?.objectID
         self.loadAutosaveRevision = loadAutosaveRevision
         if let post = post {
             if !post.originalIsDraft() {
@@ -128,9 +131,9 @@ class EditPostViewController: UIViewController {
     @objc private func didChangeObjects(_ notification: Foundation.Notification) {
         guard let userInfo = notification.userInfo else { return }
 
-        let deletedPosts = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
-        if let post = self.post?.original ?? self.post, deletedPosts.contains(post) {
-            closeEditor(animated: true)
+        let deletedObjects = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
+        if deletedObjects.contains(where: { $0.objectID == originalPostID }) {
+            closeEditor()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -6,6 +6,7 @@ import WordPressShared
 /// None of the associated values should be (nor can be) accessed directly by the UI, only through the `PostEditorStateContext` instance.
 ///
 public enum PostEditorAction {
+    /// - note: Deprecated (kahu-offline-mode)
     case save
     case saveAsDraft
     case schedule
@@ -14,6 +15,7 @@ public enum PostEditorAction {
     case submitForReview
     case continueFromHomepageEditing
 
+    /// - note: Deprecated (kahu-offline-mode)
     var dismissesEditor: Bool {
         switch self {
         case .publish, .schedule, .submitForReview:
@@ -23,6 +25,7 @@ public enum PostEditorAction {
         }
     }
 
+    /// - note: Deprecated (kahu-offline-mode)
     var isAsync: Bool {
         switch self {
         case .publish, .schedule, .submitForReview:
@@ -71,6 +74,7 @@ public enum PostEditorAction {
         }
     }
 
+    /// - note: Deprecated (kahu-offline-mode)
     var publishingActionLabel: String {
         switch self {
         case .publish:

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -15,11 +15,18 @@ protocol EditorAnalyticsProperties: AnyObject {
 struct PostListEditorPresenter {
 
     static func handle(post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
-
-        // Return early if a post is still uploading when the editor's requested.
-        guard !PostCoordinator.shared.isUploading(post: post) else {
-            presentAlertForPostBeingUploaded()
-            return
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            // Return early if a post is still uploading when the editor's requested.
+            guard !PostCoordinator.shared.isUpdating(post) else {
+                presentAlertForPostBeingUploaded()
+                return
+            }
+        } else {
+            // Return early if a post is still uploading when the editor's requested.
+            guard !PostCoordinator.shared.isUploading(post: post) else {
+                presentAlertForPostBeingUploaded()
+                return
+            }
         }
 
         // Autosaves are ignored for posts with local changes.

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -79,6 +79,8 @@ final class PostListHeaderView: UIView {
             stackView = UIStackView(arrangedSubviews: [textLabel, ellipsisButton])
         }
 
+        indicator.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
+
         stackView.spacing = 12
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -90,9 +92,10 @@ final class PostListHeaderView: UIView {
             return
         }
         NSLayoutConstraint.activate([
-            icon.widthAnchor.constraint(equalToConstant: 24),
-            icon.heightAnchor.constraint(equalToConstant: 24)
+            icon.widthAnchor.constraint(equalToConstant: 22),
+            icon.heightAnchor.constraint(equalToConstant: 22)
         ])
+        icon.contentMode = .scaleAspectFit
     }
 
     private func setupEllipsisButton() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -114,7 +114,7 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
         }
         let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter {
             let post = fetchResultsController.object(at: $0)
-            return updatedObjects.contains(post)
+            return updatedObjects.contains(post) || updatedObjects.contains(post.original())
         }
         if !updatedIndexPaths.isEmpty {
             tableView.beginUpdates()

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -26,11 +26,18 @@ extension PostSettingsViewController {
         apost.objectWillChange.sink { [weak self] in
             self?.didUpdateSettings()
         }.store(in: &cancellables)
-        objc_setAssociatedObject(self, &PostSettingsViewController.cancellablesKey, cancellables, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
         if RemoteFeatureFlag.syncPublishing.enabled() {
-            NotificationCenter.default.addObserver(self, selector: #selector(didChangeObjects), name: NSManagedObjectContext.didChangeObjectsNotification, object: apost.managedObjectContext)
+            let originalPostID = (apost.original ?? apost).objectID
+
+            NotificationCenter.default
+                .publisher(for: NSManagedObjectContext.didChangeObjectsNotification, object: apost.managedObjectContext)
+                .sink { [weak self] notification in
+                    self?.didChangeObjects(notification, originalPostID: originalPostID)
+                }.store(in: &cancellables)
         }
+
+        objc_setAssociatedObject(self, &PostSettingsViewController.cancellablesKey, cancellables, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 
     private func didUpdateSettings() {
@@ -83,12 +90,11 @@ extension PostSettingsViewController {
         }
     }
 
-    @objc private func didChangeObjects(_ notification: Foundation.Notification) {
+    private func didChangeObjects(_ notification: Foundation.Notification, originalPostID: NSManagedObjectID) {
         guard let userInfo = notification.userInfo else { return }
 
-        let deletedPosts = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
-        let original = self.apost.original ?? self.apost
-        if deletedPosts.contains(original) {
+        let deletedObjects = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
+        if deletedObjects.contains(where: { $0.objectID == originalPostID }) {
             presentingViewController?.dismiss(animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -3,17 +3,53 @@ import Foundation
 final class PostSyncStateViewModel {
     enum State {
         case idle
-        case syncing
+        // Has unsynced changes
+        case unsynced
+        case uploading
         case offlineChanges
         case failed
     }
 
     private let post: Post
     private let isInternetReachable: Bool
+    private let isSyncPublishingEnabled: Bool
+
+    init(post: Post,
+         isInternetReachable: Bool = ReachabilityUtils.isInternetReachable(),
+         isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+        self.post = post
+        self.isInternetReachable = isInternetReachable
+        self.isSyncPublishingEnabled = isSyncPublishingEnabled
+    }
 
     var state: State {
+        guard isSyncPublishingEnabled else {
+            return _state
+        }
+
+        if let error = PostCoordinator.shared.syncError(for: post.original()) {
+            if let saveError = error as? PostRepository.PostSaveError,
+               case .conflict = saveError {
+                return .failed // Terminal error
+            }
+            if let urlError = (error as NSError).underlyingErrors.first as? URLError,
+               urlError.code == .notConnectedToInternet {
+                return .offlineChanges // A better indicator on what's going on
+            }
+        }
+        if PostCoordinator.isSyncNeeded(for: post) {
+            return .unsynced
+        }
+        if PostCoordinator.shared.isDeleting(post) || PostCoordinator.shared.isUpdating(post) {
+            return .uploading
+        }
+        return .idle
+    }
+
+    /// - note: Deprecated (kahu-offline-mode)
+    private var _state: State {
         if post.remoteStatus == .pushing || PostCoordinator.shared.isDeleting(post) || PostCoordinator.shared.isUpdating(post) {
-            return .syncing
+            return .uploading
         }
         if post.isFailed {
             return isInternetReachable ? .failed : .offlineChanges
@@ -22,7 +58,7 @@ final class PostSyncStateViewModel {
     }
 
     var isEditable: Bool {
-        state == .idle || state == .offlineChanges || state == .failed
+        state != .uploading
     }
 
     var isShowingEllipsis: Bool {
@@ -30,7 +66,7 @@ final class PostSyncStateViewModel {
     }
 
     var isShowingIndicator: Bool {
-        state == .syncing
+        state == .uploading || state == .unsynced
     }
 
     var iconInfo: (image: UIImage?, color: UIColor)? {
@@ -39,33 +75,24 @@ final class PostSyncStateViewModel {
             return (UIImage(systemName: "wifi.slash"), UIColor.listIcon)
         case .failed:
             return (UIImage.gridicon(.notice), UIColor.error)
-        case .idle, .syncing:
+        case .idle, .uploading, .unsynced:
             return nil
         }
     }
 
     var statusMessage: String? {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard isSyncPublishingEnabled else {
             return nil
         }
         switch state {
         case .offlineChanges:
             return Strings.offlineChanges
-        case .failed, .idle, .syncing:
+        case .failed, .idle, .uploading, .unsynced:
             return nil
         }
-    }
-
-    init(post: Post, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
-        self.post = post
-        self.isInternetReachable = isInternetReachable
     }
 }
 
 private enum Strings {
-    static let offlineChanges = NSLocalizedString(
-        "postList.offlineChanges",
-        value: "Offline changes",
-        comment: "Label for a post in the post list. Indicates that the post has offline changes."
-    )
+    static let offlineChanges = NSLocalizedString("postList.offlineChanges", value: "Offline changes", comment: "Label for a post in the post list. Indicates that the post has offline changes.")
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		0CA10FA52ADB286300CE75AC /* StringRankedSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */; };
 		0CA10FA82ADB7C5200CE75AC /* PostSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */; };
 		0CA10FA92ADB7C5300CE75AC /* PostSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */; };
+		0CA15B4E2BB2128800518D6E /* PostCoordinatorSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA15B4D2BB2128800518D6E /* PostCoordinatorSyncTests.swift */; };
 		0CA1C8C12A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CA1C8C22A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CAE8EF22A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */; };
@@ -6281,6 +6282,7 @@
 		0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRankedSearch.swift; sourceTree = "<group>"; };
 		0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRankedSearchTests.swift; sourceTree = "<group>"; };
 		0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchService.swift; sourceTree = "<group>"; };
+		0CA15B4D2BB2128800518D6E /* PostCoordinatorSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorSyncTests.swift; sourceTree = "<group>"; };
 		0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarMenuController.swift; sourceTree = "<group>"; };
 		0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCell.swift; sourceTree = "<group>"; };
 		0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
@@ -15764,6 +15766,7 @@
 				8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */,
 				08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */,
 				8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */,
+				0CA15B4D2BB2128800518D6E /* PostCoordinatorSyncTests.swift */,
 				8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */,
 				8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */,
 				FEFA6AC52A86824A004EE5E6 /* PostHelperJetpackSocialTests.swift */,
@@ -23791,6 +23794,7 @@
 				E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */,
 				0148CC292859127F00CF5D96 /* StatsWidgetsStoreTests.swift in Sources */,
 				7320C8BD2190C9FC0082FED5 /* UITextView+SummaryTests.swift in Sources */,
+				0CA15B4E2BB2128800518D6E /* PostCoordinatorSyncTests.swift in Sources */,
 				24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */,
 				80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */,
 				7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */,

--- a/WordPress/WordPressTest/MediaImageServiceTests.swift
+++ b/WordPress/WordPressTest/MediaImageServiceTests.swift
@@ -242,8 +242,12 @@ class MediaImageServiceTests: CoreDataTestCase {
         return blog
     }
 
-    /// `Media` is hardcoded to work with a specific direcoty URL managed by `MediaFileManager`
     func makeLocalURL(forResource name: String, fileExtension: String) throws -> URL {
+        try MediaImageServiceTests.makeLocalURL(forResource: name, fileExtension: fileExtension)
+    }
+
+    /// `Media` is hardcoded to work with a specific directory URL managed by `MediaFileManager`
+    static func makeLocalURL(forResource name: String, fileExtension: String) throws -> URL {
         let sourceURL = try XCTUnwrap(Bundle.test.url(forResource: name, withExtension: fileExtension))
         let mediaURL = try MediaFileManager.default.makeLocalMediaURL(withFilename: name, fileExtension: fileExtension)
         try FileManager.default.copyItem(at: sourceURL, to: mediaURL)

--- a/WordPress/WordPressTest/PostCompactCellGhostableTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellGhostableTests.swift
@@ -37,14 +37,6 @@ class PostCompactCellGhostableTests: CoreDataTestCase {
         XCTAssertTrue(postCell.isUserInteractionEnabled)
     }
 
-    func testShowBadgesLabelAfterConfigure() {
-        let post = PostBuilder(mainContext).build()
-
-        postCell.configure(with: post)
-
-        XCTAssertFalse(postCell.badgesLabel.isHidden)
-    }
-
     func testHideGhostAfterConfigure() {
         let post = PostBuilder(mainContext).build()
 
@@ -52,22 +44,6 @@ class PostCompactCellGhostableTests: CoreDataTestCase {
 
         XCTAssertTrue(postCell.ghostView.isHidden)
         XCTAssertFalse(postCell.contentStackView.isHidden)
-    }
-
-    func testMenuButtonOpacityAfterConfigure() {
-        let post = PostBuilder(mainContext).with(remoteStatus: .sync).build()
-
-        postCell.configure(with: post)
-
-        XCTAssertEqual(postCell.menuButton.layer.opacity, 1)
-    }
-
-    func testMenuButtonOpacityAfterConfigureWithPushingStatus() {
-        let post = PostBuilder(mainContext).with(remoteStatus: .pushing).build()
-
-        postCell.configure(with: post)
-
-        XCTAssertEqual(postCell.menuButton.layer.opacity, 0.3)
     }
 
     private func postCellFromNib() -> PostCompactCell {

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -53,15 +53,6 @@ class PostCompactCellTests: CoreDataTestCase {
         XCTAssertEqual(postCell.badgesLabel.text, "Sticky")
     }
 
-    func testHideBadgesWhenEmpty() {
-        let post = PostBuilder(mainContext).build()
-
-        postCell.configure(with: post)
-
-        XCTAssertEqual(postCell.badgesLabel.text, "Uploading post...")
-        XCTAssertFalse(postCell.badgesLabel.isHidden)
-    }
-
     func testShowBadgesWhenNotEmpty() {
         let post = PostBuilder(mainContext)
             .with(remoteStatus: .sync)
@@ -73,16 +64,6 @@ class PostCompactCellTests: CoreDataTestCase {
         XCTAssertTrue(postCell.badgesLabel.isHidden)
     }
 
-    func testShowProgressView() {
-        let post = PostBuilder(mainContext)
-            .with(remoteStatus: .pushing)
-            .published().build()
-
-        postCell.configure(with: post)
-
-        XCTAssertFalse(postCell.progressView.isHidden)
-    }
-
     func testHideProgressView() {
         let post = PostBuilder(mainContext)
             .with(remoteStatus: .sync)
@@ -91,18 +72,6 @@ class PostCompactCellTests: CoreDataTestCase {
         postCell.configure(with: post)
 
         XCTAssertTrue(postCell.progressView.isHidden)
-    }
-
-    func testShowsWarningMessageForFailedPublishedPosts() {
-        // Given
-        let post = PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
-
-        // When
-        postCell.configure(with: post)
-
-        // Then
-        XCTAssertEqual(postCell.badgesLabel.text, i18n("We'll publish the post when your device is back online."))
-        XCTAssertEqual(postCell.badgesLabel.textColor, UIColor.warning)
     }
 
     private func postCellFromNib() -> PostCompactCell {

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -1,0 +1,421 @@
+import Combine
+import XCTest
+import OHHTTPStubs
+
+@testable import WordPress
+
+@MainActor
+class PostCoordinatorSyncTests: CoreDataTestCase {
+    private var blog: Blog!
+    private var mediaCoordinator: MediaCoordinator!
+    private var coordinator: PostCoordinator!
+    private var cancellables: [AnyCancellable] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        blog = BlogBuilder(mainContext)
+            .with(dotComID: 80511)
+            .withAnAccount()
+            .build()
+        try mainContext.save()
+
+        mediaCoordinator = MediaCoordinator(coreDataStack: contextManager)
+        coordinator = PostCoordinator(mediaCoordinator: mediaCoordinator, coreDataStack: contextManager, isSyncPublishingEnabled: true)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        HTTPStubs.removeAllStubs()
+    }
+
+    /// Scenario: save a single revision, it successfully syncs.
+    func testSyncSingleSimpleRevision() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.content = "content-a"
+
+        // GIVEN
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+            try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+        }
+
+        // WHEN
+        coordinator.setNeedsSync(for: revision1)
+        try await coordinator.waitForSync(post, to: revision1)
+
+        // THEN post got synced
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: first request fails, second one succeedes.
+    func testSyncSingleSimpleRevisionAfterRetry() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.content = "content-a"
+
+        // GIVEN
+        var requestCount = 0
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
+            requestCount += 1
+            switch requestCount {
+            case 1:
+                return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+            case 2:
+                return try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+            default:
+                XCTFail("Unexpected number of requests")
+                return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+            }
+        }
+
+        // GIVEN
+        coordinator.syncRetryDelay = 0.01
+
+        // WHEN
+        coordinator.setNeedsSync(for: revision1)
+        try await coordinator.waitForSync(post, to: revision1, ignoreErrors: true)
+
+        // THEN post got synced after the retry
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: user saves changes to the post while sync is in progress.
+    func testSyncRevisionAddedDuringSync() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-a"
+        revision1.content = "content-a"
+
+        // GIVEN
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
+            XCTAssertFalse(Thread.isMainThread)
+            DispatchQueue.main.sync {
+                let revision2 = revision1._createRevision()
+                revision2.postTitle = "title-b"
+                self.coordinator.setNeedsSync(for: revision2)
+            }
+
+            let response = try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+            response.responseTime = 0.01
+            return response
+        }
+
+        var isPartialRequestSent = false
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            XCTAssertEqual(request.getBodyParameters()?["title"] as? String, "title-b")
+            isPartialRequestSent = true
+
+            var post = WordPressComPost.mock
+            post.title = "title-b"
+            post.content = "content-a"
+            return try! HTTPStubsResponse(value: post, statusCode: 202)
+        }
+
+        // WHEN
+        coordinator.setNeedsSync(for: revision1)
+
+        try await coordinator.waitForSync(post) { operation in
+            operation.revision != revision1 // Must be revision2
+        }
+
+        // THEN post got synced after the retry
+        XCTAssertTrue(isPartialRequestSent)
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertEqual(post.postTitle, "title-b")
+        XCTAssertEqual(post.content, "content-a")
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: user created and saved a new draft post with one image block
+    /// (without waiting for upload to finish).
+    func testSyncNewDraftWithImageBlock() async throws {
+        // GIVEN a draft post
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+        post.postTitle = "title-a"
+
+        // GIVEN a post with a image block with media that needs upload
+        let media = MediaBuilder(mainContext).build()
+        media.remoteStatus = .failed
+        media.blog = post.blog
+        media.mediaType = .image
+        media.filename = "test-image.jpg"
+        media.absoluteLocalURL = try MediaImageServiceTests.makeLocalURL(forResource: "test-image", fileExtension: "jpg")
+
+        // important otherwise MediaService will use temporary objectID and fail
+        try mainContext.save()
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.media = [media]
+        let uploadID = media.gutenbergUploadID
+        revision1.content = "<!-- wp:image {\"id\":\(uploadID),\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"file:///path/thumbnail-15.jpeg\" class=\"wp-image-\(uploadID)\"/></figure>\n<!-- /wp:image -->"
+
+        // GIVEN
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+            let content = request.getBodyParameters()?["content"] as? String
+            XCTAssertNotNil(content)
+
+            var mock = WordPressComPost.mock
+            mock.content = content
+            return try! HTTPStubsResponse(value: mock, statusCode: 201)
+        }
+
+        stub(condition: isPath("/rest/v1.1/sites/80511/media/new")) { request in
+            HTTPStubsResponse(data: mediaResponse.data(using: .utf8)!, statusCode: 202, headers: [:])
+        }
+
+        // WHEN
+        coordinator.setNeedsSync(for: revision1)
+        try await coordinator.waitForSync(post, to: revision1)
+
+        // THEN image block was updated
+        XCTAssertEqual(post.content, "<!-- wp:image {\"id\":1236,\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"https://example.files.wordpress.com/2024/03/img_0005-1-1.jpg\" class=\"wp-image-1236\"/></figure>\n<!-- /wp:image -->")
+
+        // THEN revisions were uploaded
+        XCTAssertFalse(post.hasRevision())
+    }
+
+    /// Scenario: sync fails with a "not connected to internet" error and the
+    /// app quickly re-establishes the connection.
+    func testSyncFastRetryOnReachabilityChange() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.content = "content-a"
+
+        try mainContext.save()
+
+        // GIVEN a first request that fails with a `.notConnectedToInternet`
+        // error and the second one that succedes
+        var requestCount = 0
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+            requestCount += 1
+            switch requestCount {
+            case 1:
+                return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+            case 2:
+                return try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+            default:
+                XCTFail("Unexpected number of requests: \(requestCount)")
+                return HTTPStubsResponse(error: URLError(.unknown))
+            }
+        }
+
+        // GIVEN a long default retry
+        coordinator.syncRetryDelay = 10
+
+        // GIVEN the app quickly restoring connectivity after the first failure
+        coordinator.syncEvents.sink {
+            if case .finished(_, let result) = $0, case .failure = result {
+                NotificationCenter.default.post(name: .reachabilityChanged, object: nil, userInfo: [Foundation.Notification.reachabilityKey: true])
+            }
+        }.store(in: &cancellables)
+
+        coordinator.setNeedsSync(for: revision1)
+        try await coordinator.waitForSync(post, to: revision1, ignoreErrors: true)
+
+        // THEN post got synced
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: create and save a revision with a failing image upload. Re-open
+    /// the editor, delete the image, and try to sync.
+    func testSyncRevisionAfterDeletingFailingImageUpload() async throws {
+        // GIVEN a draft post
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+        post.postTitle = "title-a"
+
+        // GIVEN a post with a image block with media that needs upload
+        let media = MediaBuilder(mainContext).build()
+        media.remoteStatus = .failed
+        media.blog = post.blog
+        media.mediaType = .image
+        media.filename = "test-image.jpg"
+        media.absoluteLocalURL = try MediaImageServiceTests.makeLocalURL(forResource: "test-image", fileExtension: "jpg")
+
+        // important otherwise MediaService will use temporary objectID and fail
+        try mainContext.save()
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.media = [media]
+        let uploadID = media.gutenbergUploadID
+        revision1.content = "<!-- wp:image {\"id\":\(uploadID),\"sizeSlug\":\"large\"} -->\n<figure class=\"wp-block-image size-large\"><img src=\"file:///path/thumbnail-15.jpeg\" class=\"wp-image-\(uploadID)\"/></figure>\n<!-- /wp:image -->"
+
+        // GIVEN
+        let expectation = self.expectation(description: "started-media-request")
+        stub(condition: isPath("/rest/v1.1/sites/80511/media/new")) { _ in
+            let response = HTTPStubsResponse(error: URLError(.unknown))
+            expectation.fulfill()
+            response.responseTime = 10
+            return response
+        }
+
+        // WHEN the app sends the request to upload the image
+        coordinator.setNeedsSync(for: revision1)
+        await fulfillment(of: [expectation], timeout: 2)
+
+        let revision2 = post._createRevision()
+        revision2.media = []
+        revision2.content = "empty"
+
+        // GIVEN
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
+            try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+        }
+
+        coordinator.setNeedsSync(for: revision2)
+        try await coordinator.waitForSync(post, to: revision2)
+
+        // THEN post got synced without waiting for the image to be uploaded
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: syncing changes to an existing draft that was permanently deleted.
+    func testSyncPermanentlyDeletedPost() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.postID = 974
+        post.status = .draft
+        post.authorID = 29043
+        post.postTitle = "title-b"
+        post.content = "content-a"
+
+        let revision1 = post._createRevision()
+        revision1.content = "content-b"
+
+        // GIVEN a server where the post was deleted
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { _ in
+            return try! HTTPStubsResponse(value: [
+                "error": "unknown_post",
+                "message": "Unknown post"
+            ], statusCode: 404)
+        }
+
+        // WHEN
+        coordinator.setNeedsSync(for: revision1)
+        do {
+            try await coordinator.waitForSync(post, to: revision1)
+            XCTFail("Expected sync to fail")
+        } catch {
+            guard let error = error as? PostRepository.PostSaveError,
+                  case .deleted = error else {
+                return XCTFail("Unexpected error")
+            }
+        }
+
+        // THEN post got deleted from the database
+        XCTAssertNil(post.managedObjectContext)
+    }
+}
+
+private let mediaResponse = """
+{
+  "media": [
+    {
+      "ID": 1236,
+      "URL": "https://example.files.wordpress.com/2024/03/img_0005-1-1.jpg",
+      "guid": "http://example.files.wordpress.com/2024/03/img_0005-1-1.jpg",
+      "date": "2024-03-25T18:50:12-04:00",
+      "post_ID": 0,
+      "author_ID": 34129043,
+      "file": "img_0005-1-1.jpg",
+      "mime_type": "image/jpeg",
+      "extension": "jpg",
+      "title": "img_0005-1",
+      "caption": "",
+      "description": "",
+      "alt": "",
+      "icon": "https://s1.wp.com/wp-includes/images/media/default.png",
+      "size": "701.54 KB",
+      "height": 1335,
+      "width": 2000
+    }
+  ]
+}
+"""
+
+private extension URLRequest {
+    func getBodyParameters() -> [String: Any]? {
+        guard let data = httpBodyStream?.read(),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let parameters = object as? [String: Any] else {
+            return nil
+        }
+        return parameters
+    }
+}
+
+private extension PostCoordinator {
+    func waitForSync(_ post: AbstractPost, to revision: AbstractPost, ignoreErrors: Bool = false, timeout: TimeInterval = 5) async throws {
+        var olderRevisionIDs = Set(post.allRevisions.filter(\.isSyncNeeded).map(\.objectID))
+        olderRevisionIDs.remove(revision.objectID)
+        return try await waitForSync(post, ignoreErrors: ignoreErrors, timeout: timeout) { operation in
+            guard !olderRevisionIDs.contains(operation.revision.objectID) else {
+                return false // Skip operation for older revisions
+            }
+            return true
+        }
+    }
+
+    /// Taps into the coordinator events and waits until the post syncs to the
+    /// given revision.
+    ///
+    /// - warning: If more revisions are added during after the call is made,
+    /// it'll still finish.
+    ///
+    /// - parameter timeout: The default value is 10 seconds.
+    /// - parameter handler: Return `true` if the revision matches the one you expected.
+    func waitForSync(_ post: AbstractPost, ignoreErrors: Bool = false, timeout: TimeInterval = 5, handler: @escaping (PostCoordinator.SyncOperation) -> Bool) async throws {
+        let result = await syncEvents
+            .compactMap { event -> Result<Void, Error>? in
+                guard case .finished(let operation, let result) = event else {
+                    return nil
+                }
+                if ignoreErrors, case .failure = result {
+                    return nil // Ignore intermitent errors
+                }
+                guard handler(operation) else {
+                    return nil
+                }
+                return result
+            }
+            .first()
+            .timeout(.seconds(timeout), scheduler: DispatchQueue.main)
+            .values
+            .first { _ in true }
+
+        guard let result else {
+            throw URLError(.unknown) // Should never happen
+        }
+        try result.get()
+    }
+}

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -317,7 +317,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
 
         XCTAssertNotNil(post.revision, "Revision is missing")
 
-        // GIVEN a server where the post
+        // GIVEN
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
             // THEN the app sends a partial update
             try assertRequestBody(request, expected: """
@@ -939,6 +939,319 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // THEN the post is still in the database until the user taps OK and confirms
         XCTAssertNotNil(post.managedObjectContext)
     }
+
+    // MARK: - Sync (Drafts)
+
+    /// Scenarios: the app syncs drafts post while the editor is opened.
+    func testSyncExistingDraftPostWithUnsavedChangesDuringEditing() async throws {
+        // GIVEN a draft post (synced)
+        let post = makePost {
+            $0.status = .draft
+            $0.postID = 974
+            $0.authorID = 29043
+            $0.dateCreated = Date(timeIntervalSince1970: 1709852440)
+            $0.dateModified = Date(timeIntervalSince1970: 1709852440)
+            $0.postTitle = "title-a"
+            $0.content = "content-a"
+        }
+
+        // GIVEN a post that has changes that need to be synced (across two local revision)
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.isSyncNeeded = true
+
+        let revision2 = revision1._createRevision()
+        revision2.postTitle = "title-c"
+        revision2.isSyncNeeded = true
+
+        // GIVEN a revision created by an editor
+        let revision3 = revision2._createRevision()
+        revision3.postTitle = "title-d"
+
+        // GIVEN a server where the post was deleted
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            // THEN the app sends a partial update
+            try assertRequestBody(request, expected: """
+            {
+              "title" : "title-c"
+            }
+            """)
+
+            var post = WordPressComPost.mock
+            post.title = "title-c"
+            post.sticky = true
+            return try HTTPStubsResponse(value: post, statusCode: 202)
+        }
+
+        // WHEN saving the post
+        try await repository.sync(post)
+
+        // THEN it uploads the latest revision and applies the revision1 to the post
+        XCTAssertEqual(post.postTitle, "title-c")
+        XCTAssertTrue(post.revision == revision3)
+
+        // THEN but doesn't apply the remote changes to make sure the app could
+        // still correctly track local changes (revision0 vs revision2)
+        XCTAssertFalse(post.isStickyPost)
+
+        // GIVEN
+        HTTPStubs.removeAllStubs()
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            // THEN the app sends a partial update
+            try assertRequestBody(request, expected: """
+            {
+              "title" : "title-d"
+            }
+            """)
+
+            var post = WordPressComPost.mock
+            post.title = "title-d"
+            post.sticky = true
+            return try HTTPStubsResponse(value: post, statusCode: 202)
+        }
+
+        // WHEN
+        revision3.isSyncNeeded = true
+        try await repository.sync(post)
+
+        // THEN it uploads the latest revision
+        XCTAssertEqual(post.postTitle, "title-d")
+        XCTAssertNil(post.revision)
+
+        // THEN and can now safely apply the changes from the remote
+        XCTAssertTrue(post.isStickyPost)
+    }
+
+    /// Scenarios: the app syncs drafts post while the editor is open. The changes
+    /// include changes to the `content` that might lead to a conflict.
+    func testSyncExistingDraftPostWithContentChangesDuringEditing() async throws {
+        // GIVEN a draft post (synced)
+        let dateModified = Date(timeIntervalSince1970: 1709852440)
+        let post = makePost {
+            $0.status = .draft
+            $0.postID = 974
+            $0.authorID = 29043
+            $0.dateCreated = dateModified
+            $0.dateModified = dateModified
+            $0.postTitle = "title-a"
+            $0.content = "content-a"
+        }
+
+        // GIVEN a post that has changes that need to be synced (across two local revision)
+        let revision1 = post._createRevision()
+        revision1.content = "content-b"
+        revision1.isSyncNeeded = true
+
+        let revision2 = revision1._createRevision()
+        revision2.content = "content-c"
+
+        // GIVEN a server where the post was deleted
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            // THEN the app sends a partial update
+            try assertRequestBody(request, expected: """
+            {
+              "content" : "content-b",
+              "if_not_modified_since" : "2024-03-07T23:00:40+0000"
+            }
+            """)
+
+            var post = WordPressComPost.mock
+            post.content = "content-b"
+            post.modified = dateModified.addingTimeInterval(5)
+            return try HTTPStubsResponse(value: post, statusCode: 202)
+        }
+
+        // WHEN saving the post
+        try await repository.sync(post)
+
+        // THEN it uploads the latest revision and applies the revision1 to the post
+        XCTAssertEqual(post.content, "content-b")
+        XCTAssertTrue(post.revision == revision2)
+
+        // GIVEN the app hits 409 but it's a false positive, so we are good
+        HTTPStubs.removeAllStubs()
+
+        var requestCount = 0
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            // THEN the app sends a partial update but still has the old
+            // original revision of the post
+            requestCount += 1
+
+            if requestCount == 1 {
+                // THEN the first request contains an `if_not_modified_since` parameter
+                try assertRequestBody(request, expected: """
+                {
+                  "content" : "content-c",
+                  "if_not_modified_since" : "2024-03-07T23:00:40+0000"
+                }
+                """)
+                return HTTPStubsResponse(jsonObject: [
+                    "error": "old-revision",
+                    "message": "There is a revision of this post that is more recent."
+                ], statusCode: 409, headers: nil)
+            }
+            if requestCount == 2 {
+                // THEN the second request contains only the delta
+                try assertRequestBody(request, expected: """
+                {
+                  "content" : "content-c"
+                }
+                """)
+                var post = WordPressComPost.mock
+                post.content = "content-c"
+                post.modified = dateModified.addingTimeInterval(10)
+                return try HTTPStubsResponse(value: post, statusCode: 200)
+            }
+
+            throw URLError(.unknown)
+        }
+
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+            var post = WordPressComPost.mock
+            post.content = "content-b"
+            post.modified = dateModified.addingTimeInterval(5)
+            return try HTTPStubsResponse(value: post, statusCode: 200)
+        }
+
+        // WHEN syncing remaining changes
+        revision2.isSyncNeeded = true
+        try await repository.sync(post)
+
+        // THEN it uploads the latest revision and ignores 409 because it's
+        // false positive – the app made changes based on the latest content
+        XCTAssertEqual(post.content, "content-c")
+        XCTAssertEqual(post.dateModified, dateModified.addingTimeInterval(10))
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: created and saved a new draft.
+    func testSyncNewDraftPost() async throws {
+        // GIVEN a draft post (new)
+        let post = makePost {
+            $0.status = .draft
+            $0.authorID = 29043
+        }
+
+        let revision = post.createRevision()
+        revision.postTitle = "title-a"
+        revision.content = "content-a"
+        revision.isSyncNeeded = true
+
+        // GIVEN a server accepting the new post
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+            // THEN the app sends only the required parameters
+            try assertRequestBody(request, expected: """
+            {
+              "author" : 29043,
+              "content" : "content-a",
+              "status" : "draft",
+              "title" : "title-a",
+              "type" : "post"
+            }
+            """)
+            return try HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+        }
+
+        // WHEN
+        try await repository.sync(post)
+
+        // THEN the post was created
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertEqual(post.status, .draft)
+    }
+
+    /// Scenario: made an offline change and then reverted it.
+    func testSyncRevertedChangesAreSkipped() async throws {
+        // GIVEN a draft post (synced)
+        let post = makePost {
+            $0.status = .draft
+            $0.postID = 974
+            $0.authorID = 29043
+            $0.dateCreated = Date(timeIntervalSince1970: 1709852440)
+            $0.dateModified = Date(timeIntervalSince1970: 1709852440)
+            $0.postTitle = "title-a"
+            $0.content = "content-a"
+        }
+
+        // GIVEN a change that was reverted in a more recent revision
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.isSyncNeeded = true
+
+        let revision2 = revision1._createRevision()
+        revision2.postTitle = "title-a"
+        revision2.isSyncNeeded = true
+
+        // GIVEN a server with the an updated content (but not title)
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            XCTFail("No POST requests should be made")
+            return try HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 202)
+        }
+
+        stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
+            var post = WordPressComPost.mock
+            post.title = "title-a"
+            post.content = "content-b"
+            return try HTTPStubsResponse(value: post, statusCode: 200)
+        }
+
+        // WHEN saving the post
+        try await repository.sync(post)
+
+        // THEN is gets the latest revision from the server but sends no changes
+        XCTAssertEqual(post.postTitle, "title-a")
+        XCTAssertEqual(post.content, "content-b")
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: saved a new draft and opened an editor before it syncs.
+    func testSyncCreatedPostWithLocalRevision() async throws {
+        // GIVEN a new draft post (not synced)
+        let post = makePost {
+            $0.status = .draft
+            $0.authorID = 29043
+        }
+
+        // GIVEN a saved revision
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-a"
+        revision1.content = "content-a"
+        revision1.isSyncNeeded = true
+
+        // GIVEN a local revision
+        let revision2 = revision1._createRevision()
+        revision2.postTitle = "title-b"
+
+        // GIVEN a server accepting the new post
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
+            // THEN the app sends only the required parameters
+            try assertRequestBody(request, expected: """
+            {
+              "author" : 29043,
+              "content" : "content-a",
+              "status" : "draft",
+              "title" : "title-a",
+              "type" : "post"
+            }
+            """)
+            var post = WordPressComPost.mock
+            post.excerpt = "hello"
+            return try HTTPStubsResponse(value: post, statusCode: 201)
+        }
+
+        // WHEN saving the post
+        try await repository.sync(post)
+
+        // THEN `postID` is saved to make sure new changes are saved using partial updates
+        XCTAssertEqual(post.postID, 974)
+
+        // THEN local revision is presereved
+        XCTAssertNotNil(post.revision)
+        XCTAssertEqual(post.revision?.postTitle, "title-b")
+
+        // THEN the rest of the post content is retained because we have a local revision
+        XCTAssertNil(post.mt_excerpt)
+    }
 }
 
 // MARK: - Helpers
@@ -1009,7 +1322,7 @@ private enum PostRepositorySaveTestsError: Error {
     case unexpectedRequestBody(_ lhs: Any, _ rhs: Any)
 }
 
-private extension HTTPStubsResponse {
+extension HTTPStubsResponse {
     convenience init<T: Encodable>(value: T, statusCode: Int) throws {
         let data = try encoder.encode(value)
         self.init(data: data, statusCode: Int32(statusCode), headers: nil)
@@ -1018,7 +1331,7 @@ private extension HTTPStubsResponse {
 
 // MARK: - Server
 
-private struct WordPressComPost: Hashable, Codable {
+struct WordPressComPost: Hashable, Codable {
     var id: Int
     var siteID: Int
     var date: Date
@@ -1063,7 +1376,7 @@ private struct WordPressComPost: Hashable, Codable {
     }()
 }
 
-private struct WordPressComAuthor: Hashable, Codable {
+struct WordPressComAuthor: Hashable, Codable {
     var id: Int
     var login: String?
     var email: Bool?

--- a/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
+++ b/WordPress/WordPressTest/PostSyncStateViewModelTests.swift
@@ -24,10 +24,10 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         let post = PostBuilder(mainContext)
             .with(remoteStatus: .pushing)
             .build()
-        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true)
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true, isSyncPublishingEnabled: false)
 
         // When & Then
-        expect(viewModel.state).to(equal(.syncing))
+        expect(viewModel.state).to(equal(.uploading))
         expect(viewModel.isEditable).to(beFalse())
         expect(viewModel.isShowingEllipsis).to(beFalse())
         expect(viewModel.isShowingIndicator).to(beTrue())
@@ -39,7 +39,7 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         let post = PostBuilder(mainContext)
             .with(remoteStatus: .failed)
             .build()
-        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: false)
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: false, isSyncPublishingEnabled: false)
 
         // When & Then
         expect(viewModel.state).to(equal(.offlineChanges))
@@ -54,7 +54,7 @@ final class PostSyncStateViewModelTests: CoreDataTestCase {
         let post = PostBuilder(mainContext)
             .with(remoteStatus: .failed)
             .build()
-        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true)
+        let viewModel = PostSyncStateViewModel(post: post, isInternetReachable: true, isSyncPublishingEnabled: false)
 
         // When & Then
         expect(viewModel.state).to(equal(.failed))

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -131,7 +131,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
     func testReturnFailedMessageIfPostFailedAndThereIsConnectivity() {
         let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
-        let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: true)
+        let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: true, isSyncPublishingEnabled: false)
 
         expect(viewModel.status).to(equal(i18n("Upload failed")))
         expect(viewModel.statusColor).to(equal(.error))
@@ -142,7 +142,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
     func testReturnWillUploadLaterMessageIfPostFailedAndThereIsConnectivity() {
         let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
-        let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: false)
+        let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: false, isSyncPublishingEnabled: false)
 
         expect(viewModel.status).to(equal(i18n("We'll publish the post when your device is back online.")))
         expect(viewModel.statusColor).to(equal(.warning))


### PR DESCRIPTION
This PR introduces a new sync engine for draft posts (see `PostCoordinator.setNeedsSync(for:)` and the related methods).

There are a lot of additions, but it's mostly unit tests.

The unit test target has some unrelated failures due to the WordPressKit update. I'll need to merge `trunk` in order to fix it and `trunk` needs this change to be merged https://github.com/wordpress-mobile/WordPress-iOS/pull/22900 first.

## Architecture

### Data

When you open an editor, it now always creates a new revision. For example:

```
// Before open
R0 → R1 (sync-needed)

// Editor opened
R0 → R1 (sync-needed) → R2
```

The editor works with `R2`. The previous revisions are immutable.

The app not longer uses the existing `remoteStatus` property. Instead, it uses a simple `isSyncNeeded` boolean to determine which revisions to sync.

This amount of data is just enough to implement nearly any sync algorithm and to also fix issues like #21940.

### Sync

`PostCoordinator` periodically syncs the revisions that have a `isSyncNeeded` flag set to `true`. It uses the new `PostRepository.sync` method introduces in the previous PRs. It creates a diff between the original and the most recent revision that needs sync, and uploads the changes using partial updates.

## Known Issues

- [ ] If media fails with a `.notConnectedToInternet`, the app doesn't display the "offline changes" label and doesn't perform quick retries

## Testing

The changes were tested **only** using REST APIs and **only** using a simplest scenarios where you edit a post and then tap "back" to save or discard changes. The remaining flows will be updated in the future PRs.

### Discard changes (new draft)

- Create a new draft
- **Verify** that if you tap back, the post is deleted without a confirmation dialog
- **Verify** that if you make any changes to the post and tap "back", it shows a confirmation dialog where you can discard or save the draft

### Discard changes (existing draft)

- Edit an existing draft
- **Verify** that if you tap back, the editor closes right away
- **Verify** that if you make any changes to the post and tap "back", it shows a confirmation dialog where you can discard or save the changes

### Discard changes (fix #21940)

Follow the steps from the issue https://github.com/wordpress-mobile/WordPress-iOS/issues/21940 and verify that it no longer reproduces.

### Create new post with image

- Create a new draft
- Add an image 
- Tap back and tap "Save Draft" before the image gets fully uploaded
- **Verify** that the image get uploaded
- **Verify** that the post is created on the server with an image
- **Verify** that no alerts or snackbars are shown at any point during sync

### Creating and updating unsynced a draft

- Set a breakpoint on `/post/new`
- Create and save a draft
- **Verify** that it hits the breakpoint
- Edit the draft (e.g. change the tilte) and save the changes
- Execute the original request
- **Verify** that the post was created
- **Verify** that app sends a follow-up request to save the changes on the server using partial updates
- **Verify** that the post got updated and these is only one post on the server

### Offline mode

Precondition: you are offline.

- Create and save a new draft
- **Verify** that the cell shows "Offline changes"
- **Verify** that you can open the post for editing and make more changes
- Enable connectivity
- **Verify** that the app uploads the post nearly instantaneously (you can look for "connection is reachable – retrying now" in the logs)

### Offline mode and restart

- Create and save a new draft
- **Verify** that the cell shows "Offline changes"
- Terminate the app
- Enable connectivity
- Re-open the app
- **Verify** that the post gets uploaded

### Sync failure and retry

Precondition: request fails for any reason other than "404"

- Create a new or update an existing draft
- Save draft
- **Verify** that the post gets synced with a progressively long delay (5, 7.5, 11.25...) until it reaches the maximum of 60 seconds

### Discarded images

- Create a new draft
- Create a revision with a new image
- Save the changes by tapping "Back" and "Save Changes"
- Create another revision and delete the image
- Save the changes
- Enable connectity
- **Verify** that the image does no get uploaded and does not block the app from uploading the changes

## Regression Notes
1. Potential unintended areas of impact: Draft Posts
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual and automated integration tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
