### PR TITLE
Update WordPressKit to address #22891

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 14.1'
+  pod 'WordPressKit', '~> 15.0'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -63,14 +63,14 @@ PODS:
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
     - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (9.0.2):
+  - WordPressAuthenticator (9.0.4):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 14.0)
+    - WordPressKit (~> 15.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (14.1.0):
+  - WordPressKit (15.0.0):
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (>= 9.0.2, ~> 9.0)
-  - WordPressKit (~> 14.1)
+  - WordPressKit (~> 15.0)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -128,6 +128,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -156,7 +157,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - wpxmlrpc
@@ -211,8 +211,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: d906a1005febb28de9f5c3a802736ca0850307f6
-  WordPressKit: 324ee6100ad74b72c0c37b81fab8937c437f0773
+  WordPressAuthenticator: 47ac66428c0a712ced8eb0ab481f64e2f4e80f47
+  WordPressKit: adbefc1caddae6b1a5a1f45d1062d3eb9aa58af6
   WordPressShared: 04c6d51441bb8fa29651075b3a5536c90ae89c76
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -225,6 +225,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 5b39e8e85fd8101ebfcfef947e6d1d9d4ce7f301
+PODFILE CHECKSUM: c46a3c5878876da8bda61f28c86acd78a87ec7e2
 
 COCOAPODS: 1.15.2

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -71,7 +71,7 @@
     blog.isAdmin = YES;
 
     NSString* url = [NSString stringWithFormat:@"rest/v1.1/sites/%@/menus", [blog dotComID]];
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -103,7 +103,7 @@
                 && [[parameters objectForKey:@"name"] isEqualToString:name]);
     };
     
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -152,7 +152,7 @@
     menu.items = items;
 
     NSString* url = [NSString stringWithFormat:@"rest/v1.1/sites/%@/menus/%@", [blog dotComID], menu.menuID];
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -179,7 +179,7 @@
 
     NSString* url = [NSString stringWithFormat:@"rest/v1.1/sites/%@/menus/%@/delete", [blog dotComID], menu.menuID];
     
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -206,7 +206,7 @@
 
     NSString* url = [NSString stringWithFormat:@"rest/v1.1/sites/%@/menus/%@/delete", [blog dotComID], menu.menuID];
     
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -74,7 +74,7 @@
 
     blog.dotComID = blogId;
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg any]
              failure:[OCMArg any]]);
@@ -107,7 +107,7 @@
     blog.dotComID = blogId;
     blog.account.wordPressComRestApi = api;
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]
              success:[OCMArg any]
              failure:[OCMArg any]]);
@@ -147,7 +147,7 @@
     blog.dotComID = blogId;
     blog.account.wordPressComRestApi = api;
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNotNil]
               success:[OCMArg any]
               failure:[OCMArg any]]);


### PR DESCRIPTION
What it says on the title 😅 

As @crazytonyli explained in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/767, it challenging to find a plugin to reproduce the crash. But the code change is unit tested at the library level. 👏 Tony.

---

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.