### PR TITLE
Add count check to safely quit for loop on out of bounds index

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -144,6 +144,12 @@ static CGFloat const DefaultCellHeight = 44.0;
     int i = 0;
     for (NSIndexPath *indexPath in visibleIndexPaths) {
         NSInteger index = [self.fetchedResultsIndexPathsBeforeChange indexOfObject:indexPath];
+        // Fixed a crash that was casued due to index out of bounds.
+        // `index` is calculated from `fetchedResultsIndexPathsBeforeChange` array
+        // but used in `fetchedResultsBeforeChange` array which is a misuse.
+        if (self.fetchedResultsBeforeChange.count <= index) {
+            break;
+        }
         NSManagedObject *obj = self.fetchedResultsBeforeChange[index];
         if (obj.isFault) {
             NSError *error;


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-iOS/issues/22902

## Description

A simple out of bounds crash. Issue was caused by index being calculated on `Array A` and used on `Array B`. Probably they are most of the time in sync but it is of course a bad practice.

I added a safety net to resolve the crash. The fix may not result in expected behavior but it won't crash. Probably the author thought this case was improbable. The code is from 2016 and it hasn't happened so far I think so some other change may have caused this.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
4. N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
