### PR TITLE
[Gravatar] Use new Identifier types

### DIFF
--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -9,7 +9,7 @@ import Gravatar
 
 public protocol GravatarImageUploader {
     @discardableResult
-    func upload(_ image: UIImage, email: String, accessToken: String) async throws -> URLResponse
+    func upload(_ image: UIImage, email: Email, accessToken: String) async throws -> URLResponse
 }
 
 extension AvatarService: GravatarImageUploader { }
@@ -69,7 +69,7 @@ public class GravatarService {
 
         Task {
             do {
-                try await imageUploader.upload(image, email: email, accessToken: accountToken)
+                try await imageUploader.upload(image, email: Email(email), accessToken: accountToken)
                 DDLogInfo("GravatarService.uploadImage Success!")
                 completion?(nil)
             } catch {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -306,7 +306,7 @@ private extension LoginEpilogueTableViewController {
         let service = ProfileService()
         let epilogueInfo = LoginEpilogueUserInfo(profile: profile)
         do {
-            let gravatarProfile = try await service.fetch(withEmail: profile.email)
+            let gravatarProfile = try await service.fetch(with: .email(profile.email))
             let updatedInfo = epilogueInfo.updating(with: gravatarProfile)
             completion(updatedInfo)
         } catch {


### PR DESCRIPTION
Using the new Identifier types in the Gravatar SDK

To test:

- check out: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/154
- check out: https://github.com/Automattic/Gravatar-SDK-iOS/pull/132

- [ ] Smoke test
  - [ ] Upload a new avatar
  - [ ] Verify that your profile loads

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
