### PR TITLE
Fix Stats information fails to load when date cannot be parsed when returned from API

### DIFF
--- a/WordPressKit/Sources/CoreAPI/RFC339NoTimeDateFormatter.swift
+++ b/WordPressKit/Sources/CoreAPI/RFC339NoTimeDateFormatter.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// RFC339NoTimeDateFormatter works with yyyy-MM-dd dates with no time
+/// RFC-3339 format requires to use UTC time zone to avoid unexpected issues during conversions
+/// However, when we turn yyyy-MM-dd string into date using UTC time zone, it may appear as a different date
+/// for other time zones.
+/// RFC339NoTimeDateFormatter ensures that the date is converted to local time zone before returning.
+///
+final class RFC339NoTimeDateFormatter: DateFormatter {
+    private let currentTimeZone: TimeZone
+
+    init(currentTimeZone: TimeZone = .current) {
+        self.currentTimeZone = currentTimeZone
+        super.init()
+
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// RFC-3339 standard requires to have
+    /// en_US_POSIX locale
+    /// and UTC time `one
+    /// otherwise there can be problems with date conversions
+    private func commonInit() {
+        locale = Locale(identifier: "en_US_POSIX")
+        dateFormat = "yyyy-MM-dd"
+        timeZone = .init(secondsFromGMT: 0)
+    }
+
+    /// Returns a date which is shifted based on local time zone
+    override func date(from string: String) -> Date? {
+        guard let dateInUTC = super.date(from: string) else {
+            return nil
+        }
+
+        let secondsFromGMT = TimeInterval(currentTimeZone.secondsFromGMT(for: dateInUTC))
+        let localDate = dateInUTC.addingTimeInterval(-secondsFromGMT)
+
+        return localDate
+    }
+
+    override func string(from date: Date) -> String {
+        let secondsFromGMT = TimeInterval(currentTimeZone.secondsFromGMT(for: date))
+        let utcDate = date.addingTimeInterval(secondsFromGMT)
+
+        return super.string(from: utcDate)
+    }
+}

--- a/WordPressKit/Sources/WordPressKit/Models/Stats/Insights/StatsAllTimesInsight.swift
+++ b/WordPressKit/Sources/WordPressKit/Models/Stats/Insights/StatsAllTimesInsight.swift
@@ -46,8 +46,6 @@ extension StatsAllTimesInsight: StatsInsightData {
 
     // MARK: -
     private static var dateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
+        RFC339NoTimeDateFormatter()
     }
 }

--- a/WordPressKit/Sources/WordPressKit/Models/Stats/Insights/StatsPostingStreakInsight.swift
+++ b/WordPressKit/Sources/WordPressKit/Models/Stats/Insights/StatsPostingStreakInsight.swift
@@ -141,8 +141,6 @@ extension StatsPostingStreakInsight: StatsInsightData {
     }
 
     fileprivate static var dateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
+        return RFC339NoTimeDateFormatter()
     }
 }

--- a/WordPressKit/Sources/WordPressKit/Models/Stats/Time Interval/StatsSummaryTimeIntervalData.swift
+++ b/WordPressKit/Sources/WordPressKit/Models/Stats/Time Interval/StatsSummaryTimeIntervalData.swift
@@ -185,10 +185,7 @@ private extension StatsSummaryData {
     }
 
     static var regularDateFormatter: DateFormatter {
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POS")
-        df.dateFormat = "yyyy-MM-dd"
-        return df
+        RFC339NoTimeDateFormatter()
     }
 
     // We have our own handrolled date format for data broken up on week basis.
@@ -201,8 +198,7 @@ private extension StatsSummaryData {
     // represent the _beginning_ of the period they're applying to, e.g.
     // data set for `2019W02W18` is containing data for the period of Feb 18 - Feb 24 2019.
     private static var weeksDateFormatter: DateFormatter {
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POS")
+        let df = RFC339NoTimeDateFormatter()
         df.dateFormat = "yyyy'W'MM'W'dd"
         return df
     }

--- a/WordPressKit/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
+++ b/WordPressKit/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
@@ -18,10 +18,7 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
     private let siteTimezone: TimeZone
 
     private var periodDataQueryDateFormatter: DateFormatter {
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POSIX")
-        df.dateFormat = "yyyy-MM-dd"
-        return df
+        RFC339NoTimeDateFormatter()
     }
 
     private lazy var calendarForSite: Calendar = {

--- a/WordPressKit/Tests/WordPressKitTests/Tests/RFC339NoTimeDateFormatterTests.swift
+++ b/WordPressKit/Tests/WordPressKitTests/Tests/RFC339NoTimeDateFormatterTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import WordPressKit
+
+final class RFC339NoTimeDateFormatterTests: XCTestCase {
+    func testDateFromString_DTS() {
+        // Given we pass a time zone and date string that has a
+        // daylight saving time shift happening
+        let timeZone = TimeZone(identifier: "America/Asuncion")!
+        let sut = RFC339NoTimeDateFormatter(currentTimeZone: timeZone)
+        let ordinaryFormatter = ordinaryFormatter(currentTimeZone: timeZone)
+        let dateString = "2023-10-01"
+
+        // When we turn dateString to date
+        // Then ordinary formatter fails to convert DST dateString to string
+        XCTAssertNil(ordinaryFormatter.date(from: dateString))
+
+        // and SUT formatter converts DST dateString to string
+        XCTAssertNotNil(sut.date(from: dateString))
+    }
+
+    func testDateFromString() {
+        // Given we pass an ordinary date
+        let timeZone = TimeZone(identifier: "Europe/Vilnius")!
+        let sut = RFC339NoTimeDateFormatter(currentTimeZone: timeZone)
+        let ordinaryFormatter = ordinaryFormatter(currentTimeZone: timeZone)
+        let dateString = "2024-01-03"
+
+        // When we turn dateString to date
+        // Then ordinary formatter and SUT formatter should return the same date
+        XCTAssertEqual(
+            sut.date(from: dateString),
+            ordinaryFormatter.date(from: dateString)
+        )
+    }
+
+    func testStringFromDate_DTS() {
+        let timeZone = TimeZone(identifier: "America/Asuncion")!
+        let sut = RFC339NoTimeDateFormatter(currentTimeZone: timeZone)
+        let ordinaryFormatter = ordinaryFormatter(currentTimeZone: timeZone)
+
+        let date = date(year: 2023, month: 10, day: 01, timeZone: timeZone)
+
+        XCTAssertEqual(sut.string(from: date), "2023-10-01")
+        XCTAssertEqual(ordinaryFormatter.string(from: date), "2023-10-01")
+    }
+
+    func testStringFromDate() {
+        let timeZone = TimeZone(identifier: "Australia/Adelaide")!
+        let sut = RFC339NoTimeDateFormatter(currentTimeZone: timeZone)
+
+        let date1 = date(year: 2023, month: 02, day: 02, hour: 23, timeZone: timeZone)
+        XCTAssertEqual(sut.string(from: date1), "2023-02-02")
+
+        let date2 = date(year: 2023, month: 02, day: 02, hour: 01, timeZone: timeZone)
+        XCTAssertEqual(sut.string(from: date2), "2023-02-02")
+    }
+}
+
+extension RFC339NoTimeDateFormatterTests {
+    private func ordinaryFormatter(currentTimeZone: TimeZone) -> DateFormatter {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.dateFormat = "yyyy-MM-dd"
+        df.timeZone = currentTimeZone
+        return df
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int? = nil, timeZone: TimeZone) -> Date {
+        let calendar = Calendar(identifier: .iso8601)
+        let dateComponents = DateComponents(calendar: calendar, timeZone: timeZone, year: year, month: month, day: day, hour: hour)
+        return dateComponents.date!
+    }
+}

--- a/WordPressKit/Tests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
+++ b/WordPressKit/Tests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
@@ -76,9 +76,9 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             let calendar = Calendar.autoupdatingCurrent
 
-            let march28 = DateComponents(year: 2018, month: 3, day: 28)
-            let march29 = DateComponents(year: 2018, month: 3, day: 29)
-            let feb7 = DateComponents(year: 2019, month: 2, day: 7)
+            let march28 = DateComponents(timeZone: .current, year: 2018, month: 3, day: 28)
+            let march29 = DateComponents(timeZone: .current, year: 2018, month: 3, day: 29)
+            let feb7 = DateComponents(timeZone: .current, year: 2019, month: 2, day: 7)
 
             XCTAssertEqual(insight?.longestStreakStart, calendar.date(from: march28))
             XCTAssertEqual(insight?.longestStreakEnd, calendar.date(from: march29))
@@ -407,7 +407,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteVisitsDataEndpoint, filename: getVisitsDayMockFilename, contentType: .ApplicationJSON)
 
-        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let feb21 = DateComponents(timeZone: .current, year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
         remote.getData(for: .day, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
@@ -516,7 +516,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteVisitsDataEndpoint, filename: getVisitsWeekMockFilename, contentType: .ApplicationJSON)
 
-        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let feb21 = DateComponents(timeZone: .current, year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
         remote.getData(for: .week, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
@@ -530,7 +530,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[0].likesCount, 855)
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 44)
 
-            let dec17 = DateComponents(year: 2018, month: 12, day: 17)
+            let dec17 = DateComponents(timeZone: .current, year: 2018, month: 12, day: 17)
             let dec17Date = Calendar.autoupdatingCurrent.date(from: dec17)!
             XCTAssertEqual(summary?.summaryData[0].periodStartDate, dec17Date)
 
@@ -554,7 +554,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteVisitsDataEndpoint, filename: getVisitsMonthMockFilename, contentType: .ApplicationJSON)
 
-        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let feb21 = DateComponents(timeZone: .current, year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
         remote.getData(for: .month, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
@@ -568,7 +568,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[0].likesCount, 72)
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 0)
 
-            let may1 = DateComponents(year: 2018, month: 5, day: 1)
+            let may1 = DateComponents(timeZone: .current, year: 2018, month: 5, day: 1)
             let may1Date = Calendar.autoupdatingCurrent.date(from: may1)!
             XCTAssertEqual(summary?.summaryData[0].periodStartDate, may1Date)
 
@@ -577,7 +577,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[9].likesCount, 116)
             XCTAssertEqual(summary?.summaryData[9].commentsCount, 0)
 
-            let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(byAdding: .month, value: 9, to: may1Date)!
+            let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(from: DateComponents(timeZone: .current, year: 2019, month: 2, day: 1))!
 
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, nineMonthsFromMay1)
 
@@ -592,7 +592,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteVisitsDataEndpoint, filename: getVisitsMonthWithWeekUnitMockFilename, contentType: .ApplicationJSON)
 
-        let jan31 = DateComponents(year: 2024, month: 1, day: 31)
+        let jan31 = DateComponents(timeZone: .current, year: 2024, month: 1, day: 31)
         let date = Calendar.autoupdatingCurrent.date(from: jan31)!
 
         remote.getData(for: .month, unit: .week, endingOn: date, limit: 5) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
@@ -609,7 +609,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 50)
             XCTAssertEqual(summary?.summaryData[0].period, .week)
 
-            let jan1 = DateComponents(year: 2024, month: 1, day: 1)
+            let jan1 = DateComponents(timeZone: .current, year: 2024, month: 1, day: 1)
             let jan1Date = Calendar.autoupdatingCurrent.date(from: jan1)!
             XCTAssertEqual(summary?.summaryData[0].periodStartDate, jan1Date)
 
@@ -628,7 +628,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteVisitsDataEndpoint, filename: getVisitsMonthMockFilename, contentType: .ApplicationJSON)
 
-        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let feb21 = DateComponents(timeZone: .current, year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
         remote.getData(for: .month, endingOn: date) { (summary: StatsLikesSummaryTimeIntervalData?, error: Error?) in
@@ -642,7 +642,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[0].likesCount, 72)
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 0)
 
-            let may1 = DateComponents(year: 2018, month: 5, day: 1)
+            let may1 = DateComponents(timeZone: .current, year: 2018, month: 5, day: 1)
             let may1Date = Calendar.autoupdatingCurrent.date(from: may1)!
             XCTAssertEqual(summary?.summaryData[0].periodStartDate, may1Date)
 
@@ -651,7 +651,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[9].likesCount, 116)
             XCTAssertEqual(summary?.summaryData[9].commentsCount, 0)
 
-            let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(byAdding: .month, value: 9, to: may1Date)!
+            let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(from: DateComponents(timeZone: .current, year: 2019, month: 2, day: 1))!
 
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, nineMonthsFromMay1)
 

--- a/WordPressKit/WordPressKit.podspec
+++ b/WordPressKit/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '17.2.0'
+  s.version       = '17.2.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes #22859

- [ ] Make sure WPKit Podspec is correctly updated

We need to pass `yyyy-MM-dd` date to `API` when fetching `stats/visits` and other similar endpoints. However, in some cases, date conversions to date string fails. 

The bug is related to TimeZone and DTS. For example, Paraguay has a DTS change at midnight 2023-10-01 which is ambiguous to `DateFormatter` and `nil` is returned.

Date formatter we use:

```
private var periodDataQueryDateFormatter: DateFormatter {
    let df = DateFormatter()
    df.locale = Locale(identifier: "en_US_POSIX")
    df.dateFormat = "yyyy-MM-dd"
    return df
}
```

Result for "America/Asuncion" time zone:

```
df.timeZone = TimeZone(identifier: "America/Asuncion")
df.date(from: "2023-10-01") // result nil
```

Result for "Europe/Vilnius" time zone:

```
po df.timeZone = TimeZone(identifier: "Europe/Vilnius")
po df.date(from: "2023-10-01") // result <Date> 2023-09-30 21:00:00 +0000
 ```

[In documentation](https://developer.apple.com/documentation/foundation/dateformatter) Apple suggests to set the timezone to UTC:

> When working with fixed format dates, such as RFC 3339, you set the [dateFormat](https://developer.apple.com/documentation/foundation/dateformatter/1413514-dateformat) property to specify a format string. For most fixed formats, you should also set the [locale](https://developer.apple.com/documentation/foundation/dateformatter/1411973-locale) property to a POSIX locale ("en_US_POSIX"), and set the [timeZone](https://developer.apple.com/documentation/foundation/dateformatter/1411406-timezone) property to UTC.

> RFC3339DateFormatter.timeZone = TimeZone(secondsFromGMT: 0)

However, this is not a straightforward solution, since in Stats we're working with dates that are in a different time zone.

### Solution

Created `RFC339NoTimeDateFormatter` that sets:

```
df.locale = Locale(identifier: "en_US_POSIX")
df.dateFormat = "yyyy-MM-dd"
df.timeZone = TimeZone(secondsFromGMT: 0)
```

but also recalculates the data to the current time zone after conversion. Therefore, the dates remain unchanged but conversions also succeed. I added `RFC339NoTimeDateFormatterTests` as an example.

### To test:

The easiest way to reproduce and confirm that the issue is fixed is to follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/issues/22859

1. Set defaultPeriodCount from 14 to 50 in `SiteStatsTableHeaderView` view so we can go back further back in dates
1. Switch the time zone to Paraguay/Asuncion
2. Open Stats Traffic tab
3. Select weeks
4. Come back to Sep 25 - Oct 1, 2023 week
5. Confirm data loads

## Video before the fix

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/8fd8e053-5fad-4525-9726-df274ad06b76

## Video after the fix

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/582f7075-8bee-45d4-b4a3-54e491ad9a67

## Regression Notes
1. Potential unintended areas of impact

There shouldn't be any. WPKit-PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/771 adds unit tests to make sure that a new date formatter behaves in exact same way but additionally doesn't fail during DST changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Unit tests, manual tests

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
