### PR TITLE
Add index check to `postCoordinatorDidUpdate` to guard against out of…

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -109,12 +109,22 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
     // MARK: - Notifications
 
     @objc private func postCoordinatorDidUpdate(_ notification: Foundation.Notification) {
+        
         guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
             return
         }
-        let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter {
-            let post = fetchResultsController.object(at: $0)
-            return updatedObjects.contains(post)
+        let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter { indexPath in
+            guard let sections = fetchResultsController.sections, sections.indices.contains(indexPath.section) else {
+                return false
+            }
+
+            let sectionInfo = sections[indexPath.section]
+            if indexPath.row < sectionInfo.numberOfObjects {
+                let post = fetchResultsController.object(at: indexPath)
+                return updatedObjects.contains(post)
+            } else {
+                return false
+            }
         }
         if !updatedIndexPaths.isEmpty {
             tableView.beginUpdates()


### PR DESCRIPTION
## Description
Guards against the out of bounds crash. This file will be refactored soon from what I understood. But the safety net shouldn't hurt in the meantime.

Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/22247

## Testing Steps
1. Install & Login to Jetpack
2. Go to Posts
3. Delete a Published Post
4. ✅  Expect the deletion to function normally.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
