### PR TITLE
Stats Insights: Fix Total Comments details shows a different value

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -430,15 +430,17 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
         switch statSection {
         case .insightsViewsVisitors, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
-            segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate)
+            selectedDate = viewModel?.lastRequestedDate
+            let selectedPeriod = viewModel?.lastRequestedPeriod
+            segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate, selectedPeriod: selectedPeriod)
         default:
             segueToDetails(statSection: statSection, selectedDate: selectedDate)
         }
     }
 
-    func segueToInsightsDetails(statSection: StatSection, selectedDate: Date?) {
+    func segueToInsightsDetails(statSection: StatSection, selectedDate: Date?, selectedPeriod: StatsPeriodUnit?) {
         let detailTableViewController = SiteStatsInsightsDetailsTableViewController()
-        detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate)
+        detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate, selectedPeriod: selectedPeriod)
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -22,8 +22,8 @@ class SiteStatsInsightsViewModel: Observable {
     private var insightsReceipt: Receipt?
     private var insightsChangeReceipt: Receipt?
     private var insightsToShow = [InsightType]()
-    private var lastRequestedDate: Date
-    private var lastRequestedPeriod: StatsPeriodUnit
+    private(set) var lastRequestedDate: Date
+    private(set) var lastRequestedPeriod: StatsPeriodUnit
 
     private let pinnedItemStore: SiteStatsPinnedItemStore?
     private let itemToDisplay: SiteStatsPinnable?

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -204,7 +204,7 @@ private extension SiteStatsInsightsDetailsTableViewController {
         case .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals:
             viewModel?.refreshFollowers()
         case .insightsCommentsAuthors, .insightsCommentsPosts:
-            viewModel?.refreshComments()
+            viewModel?.refreshComments(date: selectedDate, period: selectedPeriod ?? .day)
         case .insightsTagsAndCategories:
             viewModel?.refreshTagsAndCategories()
         case .insightsAnnualSiteStats:

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -105,6 +105,13 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                 }
                 insightsReceipt = insightsStore.query(storeQuery)
 
+                if let date = selectedDate, let period = selectedPeriod {
+                    periodChangeReceipt = periodStore.onChange { [weak self] in
+                        self?.emitChange()
+                    }
+                    periodReceipt = periodStore.query(.allCachedPeriodData(date: date, period: period, unit: period))
+                }
+
                 refreshComments()
             default:
                 guard let storeQuery = queryForInsightStatSection(statSection) else {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -100,19 +100,20 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                     return
                 }
 
+                let selectedDate = selectedDate ?? StatsDataHelper.yesterdayDateForSite()
+                let selectedPeriod = selectedPeriod ?? .day
+
                 insightsChangeReceipt = insightsStore.onChange { [weak self] in
                     self?.emitChange()
                 }
                 insightsReceipt = insightsStore.query(storeQuery)
 
-                if let date = selectedDate, let period = selectedPeriod {
-                    periodChangeReceipt = periodStore.onChange { [weak self] in
-                        self?.emitChange()
-                    }
-                    periodReceipt = periodStore.query(.allCachedPeriodData(date: date, period: period, unit: period))
+                periodChangeReceipt = periodStore.onChange { [weak self] in
+                    self?.emitChange()
                 }
+                periodReceipt = periodStore.query(.allCachedPeriodData(date: selectedDate, period: selectedPeriod, unit: selectedPeriod))
 
-                refreshComments()
+                refreshComments(date: selectedDate, period: selectedPeriod)
             default:
                 guard let storeQuery = queryForInsightStatSection(statSection) else {
                     return
@@ -554,7 +555,8 @@ class SiteStatsInsightsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(StatsRevampStoreAction.refreshLikesTotals(date: date))
     }
 
-    func refreshComments() {
+    func refreshComments(date: Date, period: StatsPeriodUnit) {
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriod(query: .timeIntervalsSummary(date: date, period: period)))
         ActionDispatcher.dispatch(InsightAction.refreshComments)
     }
 


### PR DESCRIPTION
Fixes #22824

Total Comments number is not loaded in Stats Insights Details.

Note, there're more product issues with this page that I documented here (https://github.com/wordpress-mobile/WordPress-iOS/issues/22824#issuecomment-2022601320). Since they are shared with Android, we should address them if we make improvements to Insights tab.

### Root Cause

`StatsPeriodStore` is used within `SiteStatsInsightsDetailsViewModel` to get `TimeIntervalSummaryData` which also contains the total comments number. However, the data is not preloaded from the cache or from the API.

### Solution

To be safe, do both things:
1. Preload cached `timeIntervalSummary`  using `.allCachedPeriodData` query for a specified date. In most if not all the cases that should be enough, since a previous Insights view has already loaded and cached this data
2. Refresh `TimeIntervalSummaryData` for a specified date

## To test:

1. Select a higher-traffic site
2. Open Stats
3. Insights
4. Locate Total Comments card and remember the comment number
5. Tap View More
6. Notice Total Comments details card shows the same number

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Existing StatsInsight and StatsInsightDetails tests

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
