### PR TITLE
Offline Mode: Publishing Drafts

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+TitleForVisibility.swift
+++ b/WordPress/Classes/Models/AbstractPost+TitleForVisibility.swift
@@ -6,6 +6,8 @@ extension AbstractPost {
     static let publicLabel = NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP.")
 
     /// A title describing the status. Ie.: "Public" or "Private" or "Password protected"
+    ///
+    /// - warning: deprecated (kahu-offline-mode) (use ``PostVisibility``)
     @objc var titleForVisibility: String {
         if password != nil {
             return AbstractPost.passwordProtectedLabel

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -20,11 +20,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 // Relationships
 @property (nonatomic, strong) Blog *blog;
-/**
- The dateModified field is used in tandem with date_created_gmt to determine if
- a draft post should be published immediately. A draft post will "publish immediately"
- when the date_created_gmt and the modified date match.
- */
 @property (nonatomic, strong, nullable) NSDate * dateModified;
 @property (nonatomic, strong) NSSet<Media *> *media;
 @property (weak, readonly) AbstractPost *original;
@@ -165,6 +160,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 /**
  Returns YES if the original post is a draft
  */
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)originalIsDraft;
 
 /**
@@ -172,12 +168,14 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  This is different from "isScheduled" in that  a post with a draft, pending, or
  trashed status can also have a date_created_gmt with a future value.
  */
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)hasFuturePublishDate;
 
 /**
  Returns YES if dateCreated is nil, or if dateCreated and dateModified are equal.
  Used when determining if a post should publish immediately.
  */
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)dateCreatedIsNilOrEqualToDateModified;
 
 /**

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -81,6 +81,10 @@
 {
     self.date_created_gmt = localDate;
 
+    if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+        return;
+    }
+
     /*
      If the date is nil it means publish immediately so set the status to publish.
      If the date is in the future set the status to scheduled if current status is published.

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -136,10 +136,17 @@
         return self.revision;
     }
 
-    return [self _createRevision];
+    AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];
+    [post cloneFrom:self];
+    [post setValue:self forKey:@"original"];
+    [post setValue:nil forKey:@"revision"];
+    post.isFeaturedImageChanged = self.isFeaturedImageChanged;
+    return post;
 }
 
 - (AbstractPost *)_createRevision {
+    NSParameterAssert(self.revision == nil);
+
     AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];
     [post cloneFrom:self];
     post.isSyncNeeded = NO;

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -2,6 +2,8 @@ import Foundation
 
 extension AbstractPost {
 
+    /// Returns the original post by navigating the entire list of revisions
+    /// until it reaches the head.
     func original() -> AbstractPost {
         original?.original() ?? self
     }

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -57,6 +57,8 @@ extension AbstractPost {
     ///
     /// - SeeAlso: PostService
     /// - SeeAlso: PostListFilter
+    ///
+    /// - note: deprecated (kahu-offline-mode)
     var statusAfterSync: Status? {
         get {
             return rawValue(forKey: "statusAfterSync")
@@ -71,6 +73,8 @@ extension AbstractPost {
     /// This should only be used in Objective-C. For Swift, use `statusAfterSync`.
     ///
     /// - SeeAlso: statusAfterSync
+    ///
+    /// - note: deprecated (kahu-offline-mode)
     @objc(statusAfterSync)
     var statusAfterSyncString: String? {
         get {

--- a/WordPress/Classes/Models/BasePost.swift
+++ b/WordPress/Classes/Models/BasePost.swift
@@ -8,6 +8,11 @@ extension BasePost {
     // status to Objc-C since it returns an optional enum.
     // I'd prefer #keyPath over a string constant, but the enum brings way more value.
     static let statusKeyPath = "status"
+
+    /// The status of the post.
+    ///
+    /// - warning: The only component that can change the post status is
+    /// ``PostRepository``. Never change the status of the post directly.
     var status: Status? {
         get {
             return rawValue(forKey: BasePost.statusKeyPath)

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -87,7 +87,7 @@ class MediaCoordinator: NSObject {
         }
 
         // Use the original post so we don't create new coordinators for post revisions
-        let original = post.original ?? post
+        let original = post.original()
 
         let coordinator = MediaProgressCoordinator()
         coordinator.delegate = self
@@ -103,7 +103,7 @@ class MediaCoordinator: NSObject {
     ///            if one does not exist.
     private func cachedCoordinator(for post: AbstractPost) -> MediaProgressCoordinator? {
         // Use the original post so we don't create new coordinators for post revisions
-        let original = post.original ?? post
+        let original = post.original()
 
         return progressCoordinatorQueue.sync {
             return postMediaProgressCoordinators[original]
@@ -558,7 +558,7 @@ class MediaCoordinator: NSObject {
     func addObserver(_ onUpdate: @escaping ObserverBlock, forMediaFor post: AbstractPost) -> UUID {
         let uuid = UUID()
 
-        let original = post.original ?? post
+        let original = post.original()
         let observer = MediaObserver(subject: .post(id: original.objectID), onUpdate: onUpdate)
 
         queue.async {
@@ -689,7 +689,7 @@ class MediaCoordinator: NSObject {
                 guard let post = object as? AbstractPost else {
                     return nil
                 }
-                return (post.original ?? post).objectID
+                return post.original().objectID
             } ?? []
         }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -140,7 +140,11 @@ class PostCoordinator: NSObject {
     /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
     func _publish(_ post: AbstractPost) async throws {
-        let post = post.original ?? post
+        let post = post.original()
+
+        await pauseSyncing(for: post)
+        defer { resumeSyncing(for: post) }
+
         var parameters = RemotePostUpdateParameters()
         if post.status == .draft {
             parameters.status = Post.Status.publish.rawValue
@@ -177,7 +181,7 @@ class PostCoordinator: NSObject {
     /// - warning: Work-in-progress (kahu-offline-mode)
     @discardableResult @MainActor
     func _save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
-        let post = post.original ?? post
+        let post = post.original()
         do {
             let isExistingPost = post.hasRemote()
             // TODO: Set overwrite to false once conflict resolution support is added
@@ -195,7 +199,7 @@ class PostCoordinator: NSObject {
     /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
     func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
-        let post = post.original ?? post
+        let post = post.original()
         do {
             try await PostRepository(coreDataStack: coreDataStack)._update(post, changes: changes)
         } catch {
@@ -266,8 +270,13 @@ class PostCoordinator: NSObject {
 
     // MARK: - Sync
 
+    /// Returns `true` if the post is eligible for syncing.
+    func isSyncAllowed(for post: AbstractPost) -> Bool {
+        post.status == .draft
+    }
+
     /// Returns `true` if post has any revisions that need to be synced.
-    static func isSyncNeeded(for post: AbstractPost) -> Bool {
+    func isSyncNeeded(for post: AbstractPost) -> Bool {
         post.original().getLatestRevisionNeedingSync() != nil
     }
 
@@ -278,7 +287,7 @@ class PostCoordinator: NSObject {
     /// - warning: Work-in-progress (kahu-offline-mode)
     func setNeedsSync(for revision: AbstractPost) {
         assert(revision.isRevision(), "Must be used only on revisions")
-        assert(revision.original().status == .draft, "Must be used only with draft posts")
+        assert(isSyncAllowed(for: revision.original()), "Sync is not supported for this post")
 
         if !revision.isSyncNeeded {
             revision.isSyncNeeded = true
@@ -304,9 +313,52 @@ class PostCoordinator: NSObject {
         }
     }
 
+    /// Safely pauses sync for the post. If there are any outstanding operations
+    /// that can't be canceled, allowing them to finish. When the method returns,
+    /// it's guaranteed that no requests will be sent until resumed.
+    @MainActor
+    func pauseSyncing(for post: AbstractPost) async {
+        assert(post.isOriginal())
+        guard isSyncAllowed(for: post) else { return }
+
+        guard let worker = workers[post.objectID] else {
+            return
+        }
+        worker.isPaused = true
+        worker.log("paused")
+        guard let operation = worker.operation else {
+            return
+        }
+        tryCancelSyncOperation(operation)
+        if operation.isCancelled {
+            return // Cancelled immediatelly
+        }
+        _ = await syncEvents.first(where: { [expected = operation] event in
+            if case .finished(let operation, _) = event, operation === expected {
+                return true
+            }
+            return false
+        }).values.first(where: { _ in true })
+    }
+
+    /// Resumes sync for the given post.
+    @MainActor
+    func resumeSyncing(for post: AbstractPost) {
+        assert(post.isOriginal())
+        guard isSyncAllowed(for: post) else { return }
+
+        guard let worker = workers[post.objectID] else {
+            return
+        }
+        worker.isPaused = false
+        worker.log("resumed")
+        startSync(for: post)
+    }
+
     /// A manages sync for the given post. Every post has its own worker.
     private final class SyncWorker {
         let post: AbstractPost
+        var isPaused = false
         var operation: SyncOperation? // The sync operation that's currently running
         var error: Error? // The previous sync error
 
@@ -383,11 +435,16 @@ class PostCoordinator: NSObject {
         assert(!post.objectID.isTemporaryID)
 
         let worker = getWorker(for: post)
+
+        guard !worker.isPaused else {
+            return worker.log("start failed: worker is paused")
+        }
+
         if let operation = worker.operation {
             guard operation.revision != revision else {
                 return worker.log("already syncing to the latest revision")
             }
-            tryCancelSyncOperation(operation, latest: revision)
+            tryCancelSyncOperation(operation)
             guard operation.isCancelled else {
                 return worker.log("waiting until the current operation finishes")
             }
@@ -408,21 +465,9 @@ class PostCoordinator: NSObject {
     }
 
     /// Try to cancel the current sync operation, which is not always possible.
-    private func tryCancelSyncOperation(_ operation: SyncOperation, latest: AbstractPost) {
-        // If there is a current sync operation running and it doesn't target
-        // the latest revision, then try to cancel it.
+    private func tryCancelSyncOperation(_ operation: SyncOperation) {
         switch operation.state {
         case .uploadingMedia:
-            // Cancel the upload for media, but keep the tasks scheduled
-            // for the media still present in the revision.
-            let deleted = Set(operation.revision.media).subtracting(Set(latest.media))
-            for media in deleted {
-                mediaCoordinator.cancelUpload(of: media)
-            }
-            if !deleted.isEmpty {
-                operation.log("cancel upload for deleted media: \(deleted.map(\.filename))")
-            }
-            operation.log("cancel media upload")
             operation.isCancelled = true
             syncOperation(operation, didFinishWithResult: .failure(CancellationError())) // Finish immediatelly
         case .syncing:

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -599,39 +599,15 @@ class AbstractPostListViewController: UIViewController,
 
     func publish(_ post: AbstractPost) {
         let action = AbstractPostHelper.editorPublishAction(for: post)
-
-        func showPrepublishingFlow(for post: Post) {
-            let viewController = PrepublishingViewController(post: post, identifiers: PrepublishingIdentifier.defaultIdentifiers) { [weak self] result in
-                switch result {
-                case .confirmed:
-                    self?.didConfirmPublish(for: post)
-                case .published:
-                    self?.dismiss(animated: true)
-                case .cancelled:
-                    break
-                }
+        PrepublishingViewController.show(for: post, action: action, from: self) { [weak self] result in
+            switch result {
+            case .confirmed:
+                self?.didConfirmPublish(for: post)
+            case .published:
+                self?.dismiss(animated: true)
+            case .cancelled:
+                break
             }
-            viewController.presentAsSheet(from: self)
-        }
-
-        func showPublishingConfirmation() {
-            let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
-
-            let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
-            let alertController = UIAlertController(title: action.publishingActionQuestionLabel, message: nil, preferredStyle: style)
-
-            alertController.addCancelActionWithTitle(cancelTitle)
-            alertController.addDefaultActionWithTitle(action.publishingActionQuestionLabel) { [unowned self] _ in
-                self.didConfirmPublish(for: post)
-            }
-
-            present(alertController, animated: true)
-        }
-
-        if let post = post as? Post {
-            showPrepublishingFlow(for: post)
-        } else {
-            showPublishingConfirmation()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -71,7 +71,7 @@ class EditPostViewController: UIViewController {
     /// - Note: it's preferable to use one of the convenience initializers
     fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: BloggingPrompt? = nil) {
         self.post = post
-        self.originalPostID = (post?.original ?? post)?.objectID
+        self.originalPostID = post?.original().objectID
         self.loadAutosaveRevision = loadAutosaveRevision
         if let post = post {
             if !post.originalIsDraft() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -130,7 +130,7 @@ extension PostEditor {
                     return
                 }
                 DispatchQueue.main.async {
-                    guard let original = self?.post.original,
+                    guard let original = self?.post.original(),
                         let clone = self?.post.clone(from: original) else {
                         return
                     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -46,6 +46,7 @@ protocol PublishingEditor where Self: UIViewController {
     /// Debouncer used to save the post locally with a delay
     var debouncer: Debouncer { get }
 
+    /// - warning: deprecated (kahu-offline-mode)
     var prepublishingIdentifiers: [PrepublishingIdentifier] { get }
 
     func emitPostSaveEvent()
@@ -317,52 +318,8 @@ extension PublishingEditor {
         present(alertController, animated: true, completion: nil)
     }
 
-    /// If the user is publishing a post, displays the Prepublishing Nudges
-    /// Otherwise, shows a confirmation Action Sheet.
-    ///
-    /// - Parameters:
-    ///     - action: Publishing action being performed
-    ///
     fileprivate func displayPublishConfirmationAlert(for action: PostEditorAction, completion: @escaping (PrepublishingSheetResult) -> Void) {
-        if let post = post as? Post {
-            displayPrepublishingNudges(post: post, completion: completion)
-        } else {
-            displayPublishConfirmationAlertForPage(for: action, completion: completion)
-        }
-    }
-
-    /// Displays the Prepublishing Nudges Bottom Sheet
-    ///
-    /// - Parameters:
-    ///     - action: Publishing action being performed
-    ///
-    fileprivate func displayPrepublishingNudges(post: Post, completion: @escaping (PrepublishingSheetResult) -> Void) {
-        // End editing to avoid issues with accessibility
-        view.endEditing(true)
-
-        let viewController = PrepublishingViewController(post: post, identifiers: prepublishingIdentifiers, completion: completion)
-        viewController.presentAsSheet(from: topmostPresentedViewController)
-    }
-
-    /// Displays a publish confirmation alert with two options: "Keep Editing" and String for Action.
-    ///
-    /// - Parameters:
-    ///     - action: Publishing action being performed
-    ///
-    fileprivate func displayPublishConfirmationAlertForPage(for action: PostEditorAction, completion: @escaping (PrepublishingSheetResult) -> Void) {
-        let title = action.publishingActionQuestionLabel
-        let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
-        let publishTitle = action.publishActionLabel
-        let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
-        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
-
-        alertController.addCancelActionWithTitle(keepEditingTitle) { _ in
-            completion(.cancelled)
-        }
-        alertController.addDefaultActionWithTitle(publishTitle) { _ in
-            completion(.confirmed)
-        }
-        present(alertController, animated: true, completion: nil)
+        PrepublishingViewController.show(for: post, action: action, from: self, completion: completion)
     }
 
     private func trackPostSave(stat: WPAnalyticsStat) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -468,10 +468,8 @@ extension PublishingEditor {
         // TODO: this is incorrect because there might still be media in the previous revision
         cancelUploadOfAllMedia(for: post)
 
-        guard let original = post.original else {
-            assertionFailure("Editor works with revisions")
-            return true
-        }
+        let original = post.original()
+
         // Original can be either an unsynced revision or an original post at this post
         original.deleteRevision()
         if original.isNewDraft {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -240,21 +240,61 @@ public class PostEditorStateContext {
         self.userCanPublish = userCanPublish
         self.currentPublishDate = publishDate
         self.delegate = delegate
-        self.action = PostEditorStateContext.initialAction(for: originalPostStatus, userCanPublish: userCanPublish)
+        self.action = PostEditorStateContext.initialAction(for: originalPostStatus, publishDate: publishDate, userCanPublish: userCanPublish)
     }
 
-    private static func initialAction(for originalPostStatus: BasePost.Status?, userCanPublish: Bool) -> PostEditorAction {
+    private static func initialAction(for originalPostStatus: BasePost.Status?, publishDate: Date?, userCanPublish: Bool) -> PostEditorAction {
         // We assume an initial status of draft if none is set
         let newPostStatus = originalPostStatus ?? .draft
 
-        return action(for: originalPostStatus, newPostStatus: newPostStatus, userCanPublish: userCanPublish)
+        return action(for: originalPostStatus, newPostStatus: newPostStatus, publishDate: publishDate, userCanPublish: userCanPublish)
     }
 
     private static func action(
         for originalPostStatus: BasePost.Status?,
         newPostStatus: BasePost.Status,
-        userCanPublish: Bool) -> PostEditorAction {
+        publishDate: Date?,
+        userCanPublish: Bool
+    ) -> PostEditorAction {
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            return action(status: originalPostStatus ?? .draft, publishDate: publishDate, userCanPublish: userCanPublish)
+        } else {
+            return _action(for: originalPostStatus, newPostStatus: newPostStatus, userCanPublish: userCanPublish)
+        }
+    }
 
+    static func action(
+        status: BasePost.Status,
+        publishDate: Date?,
+        userCanPublish: Bool
+    ) -> PostEditorAction {
+        func makePublishAction() -> PostEditorAction {
+            guard userCanPublish else {
+                return .submitForReview
+            }
+            guard let publishDate else {
+                return .publish
+            }
+            return publishDate > .now ? .schedule : .publish
+        }
+        switch status {
+        case .draft:
+            return makePublishAction()
+        case .pending:
+            return .update
+        case .publishPrivate, .publish, .scheduled:
+            return .update
+        case .trash, .deleted:
+            return .update // Should never happen (trashed posts are not be editable)
+        }
+    }
+
+    /// - note: deprecated (kahu-offline-mode)
+    private static func _action(
+        for originalPostStatus: BasePost.Status?,
+        newPostStatus: BasePost.Status,
+        userCanPublish: Bool
+    ) -> PostEditorAction {
         let isNewOrDraft = { (status: BasePost.Status?) -> Bool in
             return status == nil || status == .draft
         }
@@ -263,11 +303,7 @@ public class PostEditorStateContext {
         case .draft where originalPostStatus == nil:
             return publishAction(userCanPublish: userCanPublish)
         case .draft:
-            if RemoteFeatureFlag.syncPublishing.enabled() {
-                return publishAction(userCanPublish: userCanPublish)
-            } else {
-                return .update
-            }
+            return .update
         case .pending:
             return .save
         case .publish where isNewOrDraft(originalPostStatus):
@@ -290,7 +326,7 @@ public class PostEditorStateContext {
     }
 
     private func action(for newPostStatus: BasePost.Status) -> PostEditorAction {
-        return PostEditorStateContext.action(for: originalPostStatus, newPostStatus: newPostStatus, userCanPublish: userCanPublish)
+        return PostEditorStateContext.action(for: originalPostStatus, newPostStatus: newPostStatus, publishDate: currentPublishDate, userCanPublish: userCanPublish)
     }
 
     private static func publishAction(userCanPublish: Bool) -> PostEditorAction {
@@ -320,6 +356,9 @@ public class PostEditorStateContext {
     ///
     func updated(publishDate: Date?) {
         currentPublishDate = publishDate
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            action = action(for: currentPostStatus ?? .draft)
+        }
     }
 
     /// Call whenever the post content is not empty - title or content body
@@ -367,6 +406,10 @@ public class PostEditorStateContext {
 
     /// - note: deprecated (kahu-offline-mode)
     var isSecondaryPublishButtonShown: Bool {
+        guard !RemoteFeatureFlag.syncPublishing.enabled() else {
+            return false
+        }
+
         guard hasContent else {
             return false
         }
@@ -379,10 +422,6 @@ public class PostEditorStateContext {
 
         // Don't show Publish Now for a draft with a future date
         guard !(currentPostStatus == .draft && isFutureDated(currentPublishDate)) else {
-            return false
-        }
-
-        guard !RemoteFeatureFlag.syncPublishing.enabled() else {
             return false
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -206,7 +206,8 @@ public class PostEditorStateContext {
                      action: PostEditorAction? = nil) {
         var originalPostStatus: BasePost.Status? = nil
 
-        if let originalPost = post.original, let postStatus = originalPost.status, originalPost.hasRemote() {
+        let originalPost = post.original()
+        if let postStatus = originalPost.status, originalPost.hasRemote() {
             originalPostStatus = postStatus
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -12,9 +12,12 @@ extension PostSettingsViewController {
         presentingViewController.present(navigation, animated: true)
     }
 
+    @objc var isDraftOrPending: Bool {
+        [Post.Status.draft, Post.Status.draft].contains(apost.original().status)
+    }
+
     @objc func setupStandaloneEditor() {
         guard isStandalone else { return }
-
         configureDefaultNavigationBarAppearance()
 
         refreshNavigationBarButtons()
@@ -49,7 +52,9 @@ extension PostSettingsViewController {
     private func refreshNavigationBarButtons() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(buttonCancelTapped))
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(buttonSaveTapped))
+        let buttonSave = UIBarButtonItem(barButtonSystemItem: isStandalone ? .save : .done, target: self, action: #selector(buttonSaveTapped))
+        buttonSave.accessibilityLabel = "save"
+        navigationItem.rightBarButtonItem = buttonSave
     }
 
     @objc private func buttonCancelTapped() {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -285,7 +285,7 @@ FeaturedImageViewControllerDelegate>
 - (void)setupPostDateFormatter
 {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    dateFormatter.dateStyle = NSDateFormatterLongStyle;
+    dateFormatter.dateStyle = NSDateFormatterMediumStyle;
     dateFormatter.timeStyle = NSDateFormatterShortStyle;
     dateFormatter.timeZone = [self.apost.blog timeZone];
     self.postDateFormatter = dateFormatter;
@@ -667,12 +667,14 @@ FeaturedImageViewControllerDelegate>
         [metaRows addObject:@(PostSettingsRowAuthor)];
     }
 
-    [metaRows addObjectsFromArray:@[ @(PostSettingsRowPublishDate),
-                                      @(PostSettingsRowStatus),
-                                      @(PostSettingsRowVisibility) ]];
+    [metaRows addObject:@(PostSettingsRowPublishDate)];
 
-    if (self.apost.password) {
-        [metaRows addObject:@(PostSettingsRowPassword)];
+    if (![RemoteFeature enabled:RemoteFeatureFlagSyncPublishing] || !self.isDraftOrPending) {
+        [metaRows addObjectsFromArray:@[  @(PostSettingsRowStatus),
+                                          @(PostSettingsRowVisibility) ]];
+        if (self.apost.password) {
+            [metaRows addObject:@(PostSettingsRowPassword)];
+        }
     }
 
     self.postMetaSectionRows = [metaRows copy];
@@ -693,16 +695,10 @@ FeaturedImageViewControllerDelegate>
     } else if (row == PostSettingsRowPublishDate) {
         // Publish date
         cell = [self getWPTableViewDisclosureCell];
-        if (self.apost.dateCreated && ![self.apost shouldPublishImmediately]) {
-            if ([self.apost hasFuturePublishDate]) {
-                cell.textLabel.text = NSLocalizedString(@"Scheduled for", @"Scheduled for [date]");
-            } else {
-                cell.textLabel.text = NSLocalizedString(@"Published on", @"Published on [date]");
-            }
-
+        cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
+        if (self.apost.dateCreated) {
             cell.detailTextLabel.text = [self.postDateFormatter stringFromDate:self.apost.dateCreated];
         } else {
-            cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
             cell.detailTextLabel.text = NSLocalizedString(@"Immediately", @"");
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -37,7 +37,7 @@ final class PostSyncStateViewModel {
                 return .offlineChanges // A better indicator on what's going on
             }
         }
-        if PostCoordinator.isSyncNeeded(for: post) {
+        if PostCoordinator.shared.isSyncNeeded(for: post) {
             return .unsynced
         }
         if PostCoordinator.shared.isDeleting(post) || PostCoordinator.shared.isUpdating(post) {

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+struct PostVisibilityPicker: View {
+    @State private var selection: PostVisibility = .public
+    @State private var password = ""
+    @State private var isEnteringPassword = false
+    @State private var isDismissing = false
+
+    struct Selection {
+        var visibility: PostVisibility
+        var password: String?
+    }
+
+    private let onSubmit: (Selection) -> Void
+
+    static var title: String { Strings.title }
+
+    init(visibility: PostVisibility, onSubmit: @escaping (Selection) -> Void) {
+        self._selection = State(initialValue: visibility)
+        self.onSubmit = onSubmit
+    }
+
+    var body: some View {
+        Form {
+            ForEach(PostVisibility.allCases, content: makeRow)
+        }
+        .disabled(isDismissing)
+        .navigationTitle(Strings.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func makeRow(for visibility: PostVisibility) -> some View {
+        Button(action: {
+            withAnimation {
+                if visibility == .protected {
+                    isEnteringPassword = true
+                } else {
+                    selection = visibility
+                    onSubmit(Selection(visibility: visibility, password: nil))
+                }
+            }
+        }, label: {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(visibility.localizedTitle)
+                    Text(visibility.localizedDetails)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .opacity(isEnteringPassword ? 0.5 : 1)
+                }
+                Spacer()
+                Image(systemName: "checkmark.circle.fill")
+                    .opacity((selection == visibility && !isEnteringPassword) ? 1 : 0)
+            }
+        })
+        .tint(.primary)
+        .disabled(isEnteringPassword && visibility != .protected)
+
+        if visibility == .protected, isEnteringPassword {
+            enterPasswordRows
+        }
+    }
+
+    @ViewBuilder
+    private var enterPasswordRows: some View {
+        PasswordField(password: $password)
+            .onSubmit(savePassword)
+
+        HStack {
+            Button(Strings.cancel) {
+                withAnimation {
+                    password = ""
+                    isEnteringPassword = false
+                }
+            }
+            .keyboardShortcut(.cancelAction)
+            Spacer()
+            Button(Strings.save, action: savePassword)
+                .font(.body.weight(.medium))
+                .disabled(password.isEmpty)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(Color(uiColor: .brand))
+    }
+
+    private func savePassword() {
+        withAnimation {
+            selection = .protected
+            isEnteringPassword = false
+            isDismissing = true
+            // Let the keyboard dismiss first to avoid janky animation
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(550)) {
+                onSubmit(Selection(visibility: .protected, password: password))
+            }
+        }
+    }
+}
+
+private struct PasswordField: View {
+    @Binding var password: String
+    @State var isSecure = true
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        HStack {
+            textField
+                .focused($isFocused)
+            if !password.isEmpty {
+                Button(action: { password = "" }) {
+                    Image(systemName: "xmark.circle")
+                        .foregroundStyle(.secondary)
+                }.padding(.trailing, 4)
+            }
+            Button(action: { isSecure.toggle() }) {
+                Image(systemName: isSecure ? "eye" : "eye.slash")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .buttonStyle(.plain)
+        .onAppear { isFocused = true }
+    }
+    @ViewBuilder
+    private var textField: some View {
+        if isSecure {
+            SecureField(Strings.password, text: $password)
+        } else {
+            TextField(Strings.password, text: $password)
+        }
+    }
+}
+
+enum PostVisibility: Identifiable, CaseIterable {
+    case `public`
+    case `private`
+    case protected
+
+    init(status: AbstractPost.Status, password: String?) {
+        if password != nil {
+            self = .protected
+        } else if status == .publishPrivate {
+            self = .private
+        } else {
+            self = .public
+        }
+    }
+
+    var id: PostVisibility { self }
+
+    var localizedTitle: String {
+        switch self {
+        case .public: NSLocalizedString("postVisibility.public.title", value: "Public", comment: "Title for a 'Public' (default) privacy setting")
+        case .protected: NSLocalizedString("postVisibility.protected.title", value: "Password protected", comment: "Title for a 'Password Protected' privacy setting")
+        case .private: NSLocalizedString("postVisibility.private.title", value: "Private", comment: "Title for a 'Private' privacy setting")
+        }
+    }
+
+    var localizedDetails: String {
+        switch self {
+        case .public: NSLocalizedString("postVisibility.public.details", value: "Visible to everyone", comment: "Details for a 'Public' (default) privacy setting")
+        case .protected: NSLocalizedString("postVisibility.protected.details", value: "Visibile to everyone but requires a password", comment: "Details for a 'Password Protected' privacy setting")
+        case .private: NSLocalizedString("postVisibility.private.details", value: "Only visible to site admins and editors", comment: "Details for a 'Private' privacy setting")
+        }
+    }
+
+}
+
+private enum Strings {
+    static let title = NSLocalizedString("postVisibilityPicker.navigationTitle", value: "Visibility", comment: "Navigation bar title for the Post Visibility picker")
+    static let cancel = NSLocalizedString("postVisibilityPicker.cancel", value: "Cancel", comment: "Button cancel")
+    static let save = NSLocalizedString("postVisibilityPicker.save", value: "Save", comment: "Button save")
+    static let password = NSLocalizedString("postVisibilityPicker.password", value: "Password", comment: "Password placeholder text")
+}

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
@@ -50,7 +50,8 @@ struct PostVisibilityPicker: View {
                         .opacity(isEnteringPassword ? 0.5 : 1)
                 }
                 Spacer()
-                Image(systemName: "checkmark.circle.fill")
+                Image(systemName: "checkmark")
+                    .tint(Color(uiColor: .primary))
                     .opacity((selection == visibility && !isEnteringPassword) ? 1 : 0)
             }
         })

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+/// - warning: deprecated (kahu-offline-mode)
 @objc class PostVisibilitySelectorViewController: SettingsSelectionViewController {
     /// The post to change the visibility
     private var post: AbstractPost!

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PasswordAlertController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PasswordAlertController.swift
@@ -2,6 +2,8 @@ import UIKit
 import Gridicons
 
 /// Display an Alert Controller that prompts for a password
+///
+/// - warning: deprecated (kahu-offline-mode)
 class PasswordAlertController {
 
     var passwordField: UITextField!

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -32,10 +32,12 @@ enum PrepublishingSheetResult {
 }
 
 final class PrepublishingViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    private let original: AbstractPost
     let post: Post
     let identifiers: [PrepublishingIdentifier]
     let coreDataStack: CoreDataStackSwift
     let persistentStore: UserPersistentRepository
+    private let coordinator = PostCoordinator.shared
 
     lazy var postBlogID: Int? = {
         coreDataStack.performQuery { [postObjectID = post.objectID] context in
@@ -83,6 +85,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
          completion: @escaping (PrepublishingSheetResult) -> (),
          coreDataStack: CoreDataStackSwift = ContextManager.shared,
          persistentStore: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+        self.original = post.original() // Important to keep track of in case revision is deleted
         self.post = post
         self.identifiers = identifiers
         self.completion = completion

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -32,12 +32,15 @@ enum PrepublishingSheetResult {
 }
 
 final class PrepublishingViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-    private let original: AbstractPost
     let post: Post
     let identifiers: [PrepublishingIdentifier]
     let coreDataStack: CoreDataStackSwift
     let persistentStore: UserPersistentRepository
     private let coordinator = PostCoordinator.shared
+
+    private var visibility: PostVisibility
+    private var password: String?
+    private var publishDate: Date?
 
     lazy var postBlogID: Int? = {
         coreDataStack.performQuery { [postObjectID = post.objectID] context in
@@ -85,8 +88,10 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
          completion: @escaping (PrepublishingSheetResult) -> (),
          coreDataStack: CoreDataStackSwift = ContextManager.shared,
          persistentStore: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
-        self.original = post.original() // Important to keep track of in case revision is deleted
         self.post = post
+        self.visibility = PostVisibility(status: post.status ?? .draft, password: post.password)
+        self.password = post.password
+        self.publishDate = post.dateCreated
         self.identifiers = identifiers
         self.completion = completion
         self.coreDataStack = coreDataStack
@@ -241,8 +246,10 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         }
 
         if (isBeingDismissed || parent?.isBeingDismissed == true) && !didTapPublish {
-            if post.status == .publishPrivate, let originalStatus = post.original?.status {
-                post.status = originalStatus
+            if !RemoteFeatureFlag.syncPublishing.enabled() {
+                if post.status == .publishPrivate, let originalStatus = post.original?.status {
+                    post.status = originalStatus
+                }
             }
             getCompletion()?(.cancelled)
         }
@@ -401,10 +408,34 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     // MARK: - Visibility
 
     private func configureVisibilityCell(_ cell: WPTableViewCell) {
-        cell.detailTextLabel?.text = post.titleForVisibility
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            cell.detailTextLabel?.text = visibility.localizedTitle
+        } else {
+            cell.detailTextLabel?.text = post.titleForVisibility
+        }
     }
 
     private func didTapVisibilityCell() {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return _didTapVisibilityCell()
+        }
+        let view = PostVisibilityPicker(visibility: visibility) { [weak self] selection in
+            guard let self else { return }
+            self.visibility = selection.visibility
+            if selection.visibility == .private {
+                self.publishDate = nil
+            }
+            self.password = selection.password
+            self.reloadData()
+            self.navigationController?.popViewController(animated: true)
+        }
+        let viewController = UIHostingController(rootView: view)
+        viewController.title = PostVisibilityPicker.title
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    /// - note: deprecated (kahu-offline-mode)
+    private func _didTapVisibilityCell() {
         let visbilitySelectorViewController = PostVisibilitySelectorViewController(post)
 
         visbilitySelectorViewController.completion = { [weak self] option in
@@ -427,12 +458,42 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     // MARK: - Schedule
 
     func configureScheduleCell(_ cell: WPTableViewCell) {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return _configureScheduleCell(cell)
+        }
+        cell.textLabel?.text = Strings.publishDate
+        if let publishDate {
+            let formatter = SiteDateFormatters.dateFormatter(for: post.blog.timeZone ?? TimeZone.current, dateStyle: .medium, timeStyle: .short)
+            cell.detailTextLabel?.text = formatter.string(from: publishDate)
+        } else {
+            cell.detailTextLabel?.text = Strings.immediatelly
+        }
+        visibility == .private ? cell.disable() : cell.enable()
+    }
+
+    func didTapSchedule(_ indexPath: IndexPath) {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return _didTapSchedule(indexPath)
+        }
+        let viewController = SchedulingDatePickerViewController()
+        viewController.configuration = SchedulingDatePickerConfiguration(date: publishDate, timeZone: post.blog.timeZone ?? TimeZone.current) { [weak self] date in
+            WPAnalytics.track(.editorPostScheduledChanged, properties: Constants.analyticsDefaultProperty)
+            self?.publishDate = date
+            self?.reloadData()
+            self?.updatePublishButtonLabel()
+        }
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    /// - note: deprecated (kahu-offline-mode)
+    func _configureScheduleCell(_ cell: WPTableViewCell) {
         cell.textLabel?.text = Strings.publishDate
         cell.detailTextLabel?.text = publishSettingsViewModel.detailString
         post.status == .publishPrivate ? cell.disable() : cell.enable()
     }
 
-    func didTapSchedule(_ indexPath: IndexPath) {
+    /// - note: deprecated (kahu-offline-mode)
+    func _didTapSchedule(_ indexPath: IndexPath) {
         let viewController = SchedulingDatePickerViewController.make(viewModel: publishSettingsViewModel) { [weak self] date in
             WPAnalytics.track(.editorPostScheduledChanged, properties: Constants.analyticsDefaultProperty)
             self?.publishSettingsViewModel.setDate(date)
@@ -457,7 +518,13 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     private func updatePublishButtonLabel() {
-        publishButtonViewModel.title = post.isScheduled() ? Strings.schedule : Strings.publish
+        let isScheduled: Bool
+        if RemoteFeatureFlag.syncPublishing.enabled() {
+            isScheduled = publishDate.map { $0 > .now } ?? false
+        } else {
+            isScheduled = post.isScheduled()
+        }
+        publishButtonViewModel.title = isScheduled ? Strings.schedule : Strings.publish
     }
 
     private func buttonPublishTapped() {
@@ -478,7 +545,11 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         setLoading(true)
         Task {
             do {
-                try await PostCoordinator.shared._publish(post)
+                try await PostCoordinator.shared._publish(post.original(), options: .init(
+                    visibility: visibility,
+                    password: password,
+                    publishDate: publishDate
+                ))
                 getCompletion()?(.published)
             } catch {
                 setLoading(false)
@@ -498,7 +569,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             case let control as UIControl:
                 control.isEnabled = !isLoading
             case let cell as UITableViewCell:
-                isLoading ? cell.disable() : cell.enable()
+                cell.textLabel?.textColor = isLoading ? .secondaryLabel : .label
             default:
                 subviews += view.subviews
             }
@@ -507,6 +578,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
     // MARK: - Password Prompt
 
+    /// - note: deprecated (kahu-offline-mode)
     private func showPasswordAlert() {
         let passwordAlertController = PasswordAlertController(onSubmit: { [weak self] password in
             guard let password = password, !password.isEmpty else {
@@ -523,6 +595,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         passwordAlertController.show(from: self)
     }
 
+    /// - note: deprecated (kahu-offline-mode)
     private func cancelPasswordProtectedPost() {
         post.status = .publish
         post.password = nil
@@ -594,6 +667,44 @@ private extension PrepublishingOption {
     }
 }
 
+extension PrepublishingViewController {
+    static func show(for revision: AbstractPost, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        switch revision {
+        case let post as Post:
+            show(post: post, from: presentingViewController, completion: completion)
+        case let page as Page:
+            show(for: page, action: action, from: presentingViewController, completion: completion)
+        default:
+            assertionFailure("Unsupported post type")
+            break
+        }
+    }
+
+    private static func show(post: Post, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        // End editing to avoid issues with accessibility
+        presentingViewController.view.endEditing(true)
+
+        let viewController = PrepublishingViewController(post: post, identifiers: PrepublishingIdentifier.defaultIdentifiers, completion: completion)
+        viewController.presentAsSheet(from: presentingViewController)
+    }
+
+    private static func show(for page: Page, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        let title = action.publishingActionQuestionLabel
+        let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
+        let publishTitle = action.publishActionLabel
+        let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
+
+        alertController.addCancelActionWithTitle(keepEditingTitle) { _ in
+            completion(.cancelled)
+        }
+        alertController.addDefaultActionWithTitle(publishTitle) { _ in
+            completion(.confirmed)
+        }
+        presentingViewController.present(alertController, animated: true, completion: nil)
+    }
+}
+
 private enum Strings {
     static let publish = NSLocalizedString("prepublishing.publish", value: "Publish", comment: "Primary button label in the pre-publishing sheet")
     static let schedule = NSLocalizedString("prepublishing.schedule", value: "Schedule", comment: "Primary button label in the pre-publishing shee")
@@ -603,4 +714,5 @@ private enum Strings {
     static let categories = NSLocalizedString("prepublishing.categories", value: "Categories", comment: "Label for a cell in the pre-publishing sheet")
     static let tags = NSLocalizedString("prepublishing.tags", value: "Tags", comment: "Label for a cell in the pre-publishing sheet")
     static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
+    static let immediatelly = NSLocalizedString("prepublishing.publishDateImmediatelly", value: "Immediatelly", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -466,7 +466,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             let formatter = SiteDateFormatters.dateFormatter(for: post.blog.timeZone ?? TimeZone.current, dateStyle: .medium, timeStyle: .short)
             cell.detailTextLabel?.text = formatter.string(from: publishDate)
         } else {
-            cell.detailTextLabel?.text = Strings.immediatelly
+            cell.detailTextLabel?.text = Strings.immediately
         }
         visibility == .private ? cell.disable() : cell.enable()
     }
@@ -714,5 +714,5 @@ private enum Strings {
     static let categories = NSLocalizedString("prepublishing.categories", value: "Categories", comment: "Label for a cell in the pre-publishing sheet")
     static let tags = NSLocalizedString("prepublishing.tags", value: "Tags", comment: "Label for a cell in the pre-publishing sheet")
     static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
-    static let immediatelly = NSLocalizedString("prepublishing.publishDateImmediatelly", value: "Immediatelly", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
+    static let immediately = NSLocalizedString("prepublishing.publishDateImmediately", value: "Immediately", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
 }

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingDatePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingDatePickerViewController.swift
@@ -5,8 +5,6 @@ import UIKit
 struct SchedulingDatePickerConfiguration {
     var date: Date?
     var timeZone: TimeZone
-    var dateFormatter: DateFormatter
-    var dateTimeFormatter: DateFormatter
     var updated: (Date?) -> Void
 }
 
@@ -74,8 +72,6 @@ extension SchedulingDatePickerViewController {
         viewController.configuration = SchedulingDatePickerConfiguration(
             date: viewModel.date,
             timeZone: viewModel.timeZone,
-            dateFormatter: viewModel.dateFormatter,
-            dateTimeFormatter: viewModel.dateTimeFormatter,
             updated: onDateUpdated
         )
         return viewController

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -599,6 +599,8 @@
 		0CF7D6C32ABB753A006D1E89 /* MediaImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */; };
 		0CF7EACF2B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */; };
 		0CF7EAD02B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */; };
+		0CFDEE802BB8729000FA3EE0 /* PostVisibilityPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFDEE7F2BB8729000FA3EE0 /* PostVisibilityPicker.swift */; };
+		0CFDEE812BB8729000FA3EE0 /* PostVisibilityPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFDEE7F2BB8729000FA3EE0 /* PostVisibilityPicker.swift */; };
 		0CFE9AC62AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
 		0CFE9AC72AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */; };
 		0CFE9AC92AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFE9AC82AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift */; };
@@ -6321,6 +6323,7 @@
 		0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageServiceTests.swift; sourceTree = "<group>"; };
 		0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostServiceRemote+Concurrency.swift"; sourceTree = "<group>"; };
 		0CFD6C792A73E703003DD0A0 /* WordPress 152.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 152.xcdatamodel"; sourceTree = "<group>"; };
+		0CFDEE7F2BB8729000FA3EE0 /* PostVisibilityPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostVisibilityPicker.swift; sourceTree = "<group>"; };
 		0CFE9AC52AF44A9F00B8F659 /* AbstractPostHelper+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPostHelper+Actions.swift"; sourceTree = "<group>"; };
 		0CFE9AC82AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSettingsViewController+Swift.swift"; sourceTree = "<group>"; };
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -15135,6 +15138,7 @@
 				0CFE9AC82AF52D3B00B8F659 /* PostSettingsViewController+Swift.swift */,
 				FFEECFFB2084DE2B009B8CDB /* PostSettingsViewController+FeaturedImageUpload.swift */,
 				83914BD32A2EA03A0017A588 /* PostSettingsViewController+JetpackSocial.swift */,
+				0CFDEE7F2BB8729000FA3EE0 /* PostVisibilityPicker.swift */,
 				8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */,
 				593F26601CAB00CA00F14073 /* PostSharingController.swift */,
 				E155EC711E9B7DCE009D7F63 /* PostTagPickerViewController.swift */,
@@ -21964,6 +21968,7 @@
 				8B05D29123A9417E0063B9AA /* WPMediaEditor.swift in Sources */,
 				987E79CB261F8858000192B7 /* UserProfileSheetViewController.swift in Sources */,
 				D816C1EC20E0887C00C4D82F /* ApproveComment.swift in Sources */,
+				0CFDEE802BB8729000FA3EE0 /* PostVisibilityPicker.swift in Sources */,
 				74AF4D741FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,
 				981C986E21B9D71400A7C0C8 /* PostingActivityCollectionViewCell.swift in Sources */,
 				FADC40A82A8BC2A200C19997 /* UIImage+Gravatar.swift in Sources */,
@@ -24522,6 +24527,7 @@
 				FABB21AA2602FC2C00C8785C /* WPStyleGuide+Activity.swift in Sources */,
 				77DFF08A2B68386B00FA561D /* BooleanUserDefaultsDebugView.swift in Sources */,
 				F4141EE42AE7152F000D2AAE /* AllDomainsListViewController+Strings.swift in Sources */,
+				0CFDEE812BB8729000FA3EE0 /* PostVisibilityPicker.swift in Sources */,
 				FABB21AB2602FC2C00C8785C /* AllTimeWidgetStats.swift in Sources */,
 				F1A75B9C2732EF3700784A70 /* AboutScreenTracker.swift in Sources */,
 				FABB21AC2602FC2C00C8785C /* GutenbergFilesAppMediaSource.swift in Sources */,

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -62,11 +62,6 @@ class PostBuilder {
         return self
     }
 
-    func revision() -> PostBuilder {
-        post.setPrimitiveValue(post, forKey: "original")
-        return self
-    }
-
     func autosaved() -> PostBuilder {
         post.autosaveTitle = "a"
         post.autosaveExcerpt = "b"

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -404,7 +404,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
         await fulfillment(of: [expectation], timeout: 2)
 
         // WHEN
-        try await coordinator._publish(post)
+        try await coordinator._publish(post, options: .init(visibility: .public, password: nil, publishDate: nil))
 
         // THEN the coordinator wait for the sync to complete and the post to
         // be created and only then sends a parial update to get it published

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -282,7 +282,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
         coordinator.setNeedsSync(for: revision1)
         await fulfillment(of: [expectation], timeout: 2)
 
-        let revision2 = post._createRevision()
+        let revision2 = revision1._createRevision()
         revision2.media = []
         revision2.content = "empty"
 
@@ -335,6 +335,88 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
         // THEN post got deleted from the database
         XCTAssertNil(post.managedObjectContext)
     }
+
+    func testPauseSyncing() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-b"
+        revision1.content = "content-a"
+
+        // GIVEN
+        let expectation = self.expectation(description: "request-sent")
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
+            expectation.fulfill()
+            let response = try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+            response.responseTime = 0.05
+            return response
+        }
+        coordinator.setNeedsSync(for: revision1)
+        await fulfillment(of: [expectation], timeout: 2)
+
+        // WHEN
+        await coordinator.pauseSyncing(for: post)
+
+        // THEN post got synced
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertNil(post.revision)
+    }
+
+    /// Scenario: publish a draft post that has unsynced revisions.
+    func testPublishDraftPostThatNeedsSyncing() async throws {
+        // GIVEN a draft post that needs sync
+        let post = PostBuilder(mainContext, blog: blog).build()
+        post.status = .draft
+        post.authorID = 29043
+
+        let revision1 = post._createRevision()
+        revision1.postTitle = "title-a"
+        revision1.content = "content-a"
+
+        // WHEN a slug was changes during the current editor session
+        let revision2 = revision1._createRevision()
+        revision2.wp_slug = "hello"
+
+        // GIVEN
+        let expectation = self.expectation(description: "request-sent")
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
+            expectation.fulfill()
+            let response = try! HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 201)
+            response.responseTime = 0.05
+            return response
+        }
+        stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
+            XCTAssertEqual(request.getBodyParameters(), [
+                "slug": "hello",
+                "status": "publish"
+            ])
+            var post = WordPressComPost.mock
+            post.status = AbstractPost.Status.publish.rawValue
+            post.title = "title-a"
+            post.content = "content-a"
+            post.slug = "hello"
+            return try! HTTPStubsResponse(value: post, statusCode: 202)
+        }
+        coordinator.setNeedsSync(for: revision1)
+        await fulfillment(of: [expectation], timeout: 2)
+
+        // WHEN
+        try await coordinator._publish(post)
+
+        // THEN the coordinator wait for the sync to complete and the post to
+        // be created and only then sends a parial update to get it published
+        XCTAssertEqual(post.postID, 974)
+        XCTAssertEqual(post.status, .publish)
+        XCTAssertEqual(post.postTitle, "title-a")
+        XCTAssertEqual(post.content, "content-a")
+        XCTAssertEqual(post.wp_slug, "hello")
+        XCTAssertNil(post.revision)
+        XCTAssertNil(revision1.managedObjectContext)
+        XCTAssertNil(revision2.managedObjectContext)
+    }
 }
 
 private let mediaResponse = """
@@ -364,10 +446,10 @@ private let mediaResponse = """
 """
 
 private extension URLRequest {
-    func getBodyParameters() -> [String: Any]? {
+    func getBodyParameters() -> [String: AnyHashable]? {
         guard let data = httpBodyStream?.read(),
               let object = try? JSONSerialization.jsonObject(with: data),
-              let parameters = object as? [String: Any] else {
+              let parameters = object as? [String: AnyHashable] else {
             return nil
         }
         return parameters

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -129,7 +129,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
     /// If the post fails to upload and there is internet connectivity, show "Upload failed" message
     ///
     func testReturnFailedMessageIfPostFailedAndThereIsConnectivity() {
-        let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: true, isSyncPublishingEnabled: false)
 
@@ -140,7 +140,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
     /// If the post fails to upload and there is NO internet connectivity, show a message that we'll publish when the user is back online
     ///
     func testReturnWillUploadLaterMessageIfPostFailedAndThereIsConnectivity() {
-        let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: false, isSyncPublishingEnabled: false)
 


### PR DESCRIPTION
It was always possible to publish drafts, but with this change, the service now makes sure there are no outstanding sync operations for the post before publishing.

## To test:

### Simple Post

1. Set a network breakpoint on `/rest/v1.2/sites/*/posts/new`
2. Create and save a new draft
3. **Verify** that the breakpoint was hit and that the cell with the post shows a spinner
4. Open the post
5. Tap "Publish" and confirm publishing
6. **Verify** that the prepublishing sheet shows a spinner but no new requests were made
7. Execute the request
8. **Verify** that the app sent two request: `/posts/new` to sync the post and the a follow-up request to publish the synced post

**Request 1:**

```json
{
  "type": "post",
  "author": 34129043,
  "format": "standard",
  "title": "Test-1308",
  "content": "<!-- wp:paragraph -->\n<p>A</p>\n<!-- /wp:paragraph -->",
  "status": "draft"
}
```

9. Make some more changes and save them
10. **Verify** that the sync engine is resumed and is syncing them

**Request 2:**

```json
{
  "status": "publish"
}
```

### Post with Media (Deleted)

1. Set a network breakpoint on `/rest/v1.1/sites/*/media/new`
2. Create a new draft
3. Add an image
4. **Verify** that the breakpoint was hit
5. Tap "Back" and save the draft
6. Re-open the draft
7. Delete the image
8. Tap "Publish" and confirm publishing
11. **Verify** that the post got published (**without** executing the media/new request) 
12. **Verify** that the app sent one request: `/posts/new`

**Request 1:**

```json
{
  "type": "post",
  "author": 34129043,
  "format": "standard",
  "title": "Test-1308",
  "content": "<!-- wp:paragraph -->\n<p>A</p>\n<!-- /wp:paragraph -->",
  "status": "publish"
}
```

### Post with Media (Kept)

1. Set a network breakpoint on `/rest/v1.1/sites/80511/media/new`
2. Create a new draft
3. Add an image
4. **Verify** that the breakpoint was hit
5. Tap "Back" and save the draft
6. Re-open the draft
8. Tap "Publish" and confirm publishing
9. Execute the request for media
11. **Verify** that the post got published
13. **Verify** that the app sent one request: `/posts/new`

## Regression Notes
1. Potential unintended areas of impact: Post Publishing
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual + unit tests
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
