### PR TITLE
Offline Mode: Setting publish date without changing post.status

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -165,6 +165,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 /**
  Returns YES if the original post is a draft
  */
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)originalIsDraft;
 
 /**
@@ -172,12 +173,14 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  This is different from "isScheduled" in that  a post with a draft, pending, or
  trashed status can also have a date_created_gmt with a future value.
  */
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)hasFuturePublishDate;
 
 /**
  Returns YES if dateCreated is nil, or if dateCreated and dateModified are equal.
  Used when determining if a post should publish immediately.
  */
+/// - note: deprecated (kahu-offline-mode)
 - (BOOL)dateCreatedIsNilOrEqualToDateModified;
 
 /**

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -57,6 +57,8 @@ extension AbstractPost {
     ///
     /// - SeeAlso: PostService
     /// - SeeAlso: PostListFilter
+    ///
+    /// - note: deprecated (kahu-offline-mode)
     var statusAfterSync: Status? {
         get {
             return rawValue(forKey: "statusAfterSync")
@@ -71,6 +73,8 @@ extension AbstractPost {
     /// This should only be used in Objective-C. For Swift, use `statusAfterSync`.
     ///
     /// - SeeAlso: statusAfterSync
+    ///
+    /// - note: deprecated (kahu-offline-mode)
     @objc(statusAfterSync)
     var statusAfterSyncString: String? {
         get {

--- a/WordPress/Classes/Models/BasePost.swift
+++ b/WordPress/Classes/Models/BasePost.swift
@@ -8,6 +8,11 @@ extension BasePost {
     // status to Objc-C since it returns an optional enum.
     // I'd prefer #keyPath over a string constant, but the enum brings way more value.
     static let statusKeyPath = "status"
+
+    /// The status of the post.
+    ///
+    /// - warning: The only component that can change the post status is
+    /// ``PostRepository``. Never change the status of the post directly.
     var status: Status? {
         get {
             return rawValue(forKey: BasePost.statusKeyPath)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -283,7 +283,7 @@ FeaturedImageViewControllerDelegate>
 - (void)setupPostDateFormatter
 {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    dateFormatter.dateStyle = NSDateFormatterLongStyle;
+    dateFormatter.dateStyle = NSDateFormatterMediumStyle;
     dateFormatter.timeStyle = NSDateFormatterShortStyle;
     dateFormatter.timeZone = [self.blog timeZone];
     self.postDateFormatter = dateFormatter;
@@ -691,16 +691,10 @@ FeaturedImageViewControllerDelegate>
     } else if (row == PostSettingsRowPublishDate) {
         // Publish date
         cell = [self getWPTableViewDisclosureCell];
-        if (self.apost.dateCreated && ![self.apost shouldPublishImmediately]) {
-            if ([self.apost hasFuturePublishDate]) {
-                cell.textLabel.text = NSLocalizedString(@"Scheduled for", @"Scheduled for [date]");
-            } else {
-                cell.textLabel.text = NSLocalizedString(@"Published on", @"Published on [date]");
-            }
-
+        cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
+        if (self.apost.dateCreated) {
             cell.detailTextLabel.text = [self.postDateFormatter stringFromDate:self.apost.dateCreated];
         } else {
-            cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
             cell.detailTextLabel.text = NSLocalizedString(@"Immediately", @"");
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -457,7 +457,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     private func updatePublishButtonLabel() {
-        publishButtonViewModel.title = post.isScheduled() ? Strings.schedule : Strings.publish
+        publishButtonViewModel.title = PostEditorStateContext.action(for: post).publishActionLabel
     }
 
     private func buttonPublishTapped() {


### PR DESCRIPTION
This PR simplified "Publish Date" settings. When you change the publish date, it now updates only the publish date (`post.dateCreated`) in the database and nothing else (crucially, not `post.status`). The "Publish" or "Schedule" buttons are now based entirely on `post.dateCreated` whether it's in the future or past.

**Test 1**

1. Create new draft
2. Open Post Settings
3. Select Publish Date in the future
4. Save 
5. **Verify** that the primary button in the editor changed to "Schedule".
6. Tap "Bac" and then "Save Draft"
7. **Verify** that the post was saved as a draft and was NOT published
8. Reopen the post
9. **Verify** that the primary button still says "Schedule"
10. **Verify** that the Publish Date was saved
11. Schedule a post and verify that it was scheduled for a selected date

**Test 2**

1. Create new draft
2. Open Post Settings
3. Select Publish Date in the future
4. Save 
5. **Verify** that the primary button in the editor changed to "Schedule"
6. Open Post Settings
7. Select Publish Date in the past or "Now"
5. **Verify** that the primary button in the editor changed to "Publish"

## Regression Notes
1. Potential unintended areas of impact: Publishing flow
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
