### PR TITLE
Reader: Only animate the navigation menu when the titles changed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationMenu.swift
@@ -20,6 +20,10 @@ struct ReaderNavigationMenu: View {
         return viewModel.streamFilters
     }
 
+    private var filterTitles: [String] {
+        filters.map { $0.title }
+    }
+
     private var hasActiveFilter: Bool {
         return viewModel.activeStreamFilter != nil
     }
@@ -38,7 +42,7 @@ struct ReaderNavigationMenu: View {
                 }
                 .fixedSize(horizontal: false, vertical: true)
             }
-            .animation(.easeInOut, value: filters)
+            .animation(.easeInOut, value: filterTitles)
             .mask({
                 HStack(spacing: .zero) {
                     Rectangle().fill(.black)


### PR DESCRIPTION
This fixes an issue where the filter chips animate needlessly, even when there are no changes to the title. This is probably because of the recent addition of `ReaderTopicChangeObserver`, which could cause the navigation menu to refresh a bit too much.

You can observe this issue sometimes when having the `Subscriptions` filter saved as the last opened stream; the filter chips would bounce/animate immediately after tapping the Reader tab. Or when switching from Subscriptions to Subscriptions.

## To test

- Launch the Jetpack app.
- Go to Reader > Subscriptions.
- Tap the navigation button > Subscriptions again.
- 🔎 Verify that the filter chips do not animate.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
