### PR TITLE
Add a close button to Post Scheduling Date Picker on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -209,10 +209,14 @@ private struct DateAndTimeRow: ImmuTableRow {
 
             if UIDevice.isPad() {
                 let navigation = UINavigationController(rootViewController: viewController)
-                let closeButton = UIBarButtonItem(systemItem: .close, primaryAction: .init(handler: { [weak navigation] _ in
-                    navigation?.dismiss(animated: true)
-                }))
-                viewController.navigationItem.leftBarButtonItem = closeButton
+
+                if UIAccessibility.isVoiceOverRunning {
+                    let closeButton = UIBarButtonItem(systemItem: .close, primaryAction: .init(handler: { [weak navigation] _ in
+                        navigation?.dismiss(animated: true)
+                    }))
+                    viewController.navigationItem.leftBarButtonItem = closeButton
+                }
+
                 navigation.modalPresentationStyle = .popover
                 if let popoverController = navigation.popoverPresentationController {
                     popoverController.sourceView = self?.viewController?.tableView

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -209,6 +209,10 @@ private struct DateAndTimeRow: ImmuTableRow {
 
             if UIDevice.isPad() {
                 let navigation = UINavigationController(rootViewController: viewController)
+                let closeButton = UIBarButtonItem(systemItem: .close, primaryAction: .init(handler: { [weak navigation] _ in
+                    navigation?.dismiss(animated: true)
+                }))
+                viewController.navigationItem.leftBarButtonItem = closeButton
                 navigation.modalPresentationStyle = .popover
                 if let popoverController = navigation.popoverPresentationController {
                     popoverController.sourceView = self?.viewController?.tableView


### PR DESCRIPTION
Fixes #22927

The close button is not displayed on a post-scheduling date picker on iPad making it difficult to close using voiceover. 

### Solution

Add a system close button to a date picker on the iPad. The same close button is used on `Post Settings` as well.

<img width="370" alt="close button date picker" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/35ebb69e-4aa6-4c59-9ef1-373fb30e19ac">

### To test:

1. Open the Jetpack mobile app on an iPad.
2. Enter the post settings.
3. Tap on the publish date to open the date picker.
4. Confirm close button is visible
5. User VoiceOver or use Accessibility Inspector and confirm it's visible and interactive using VoiceOver
6. Confirm tapping on a button closes the picker

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
