### PR TITLE
Reading Preferences: Apply display setting to comments and related posts section

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -390,9 +390,6 @@ private extension CommentContentTableViewCell {
         likeButton?.accessibilityIdentifier = .likeButtonAccessibilityId
 
         separatorView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 0).flippedForRightToLeft
-        if style.customizationEnabled {
-            separatorView.backgroundColor = displaySetting.color.border
-        }
     }
 
     private func adjustImageAndTitleEdgeInsets(for button: UIButton) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -137,7 +137,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         didSet {
             style = CellStyle(displaySetting: displaySetting)
             resetRenderedContents()
-            configureViews() // TODO: Re-evaluate calling configure here, as it resets some state.
+            applyStyles()
         }
     }
 
@@ -390,6 +390,17 @@ private extension CommentContentTableViewCell {
         likeButton?.accessibilityIdentifier = .likeButtonAccessibilityId
 
         separatorView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 0).flippedForRightToLeft
+
+        applyStyles()
+    }
+
+    /// Applies the `ReaderDisplaySetting` styles
+    private func applyStyles() {
+        nameLabel?.font = style.nameFont
+        nameLabel?.textColor = style.nameTextColor
+
+        dateLabel?.font = style.dateFont
+        dateLabel?.textColor = style.dateTextColor
     }
 
     private func adjustImageAndTitleEdgeInsets(for button: UIButton) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -136,7 +136,8 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     var displaySetting: ReaderDisplaySetting = .standard {
         didSet {
             style = CellStyle(displaySetting: displaySetting)
-            configureViews() // TODO: Re-evaluate calling configure here.
+            resetRenderedContents()
+            configureViews() // TODO: Re-evaluate calling configure here, as it resets some state.
         }
     }
 
@@ -242,6 +243,8 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isCommentLikesEnabled = false
         isCommentReplyEnabled = false
         isAccessoryButtonEnabled = false
+
+        shouldHideSeparator = true
 
         containerStackLeadingConstraint.constant = 0
         containerStackTrailingConstraint.constant = 0
@@ -386,6 +389,7 @@ private extension CommentContentTableViewCell {
         likeButton?.sizeToFit()
         likeButton?.accessibilityIdentifier = .likeButtonAccessibilityId
 
+        separatorView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 0).flippedForRightToLeft
         if style.customizationEnabled {
             separatorView.backgroundColor = displaySetting.color.border
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -131,9 +131,11 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     private var isLikeButtonAnimating: Bool = false
 
-    private var style: CellStyle = .init(displaySetting: .standard)
+    /// Styling configuration based on `ReaderDisplaySetting`. The parameter is optional so that the styling approach
+    /// can be scoped by using the "legacy" style when the passed parameter is nil.
+    private var style: CellStyle = .init(displaySetting: nil)
 
-    var displaySetting: ReaderDisplaySetting = .standard {
+    var displaySetting: ReaderDisplaySetting? = nil {
         didSet {
             style = CellStyle(displaySetting: displaySetting)
             resetRenderedContents()
@@ -283,7 +285,7 @@ private extension CommentContentTableViewCell {
     /// A structure to override the cell styling based on `ReaderDisplaySetting`.
     /// This doesn't cover all aspects of the cell, and iks currently scoped only for Reader Detail.
     struct CellStyle {
-        let displaySetting: ReaderDisplaySetting
+        let displaySetting: ReaderDisplaySetting?
 
         /// NOTE: Remove when the `readerCustomization` flag is removed.
         var customizationEnabled: Bool {
@@ -293,21 +295,33 @@ private extension CommentContentTableViewCell {
         // Name Label
 
         var nameFont: UIFont {
-            customizationEnabled ? displaySetting.font(with: .subheadline, weight: .semibold) : Style.nameFont
+            guard let displaySetting, customizationEnabled else {
+                return Style.nameFont
+            }
+            return displaySetting.font(with: .subheadline, weight: .semibold)
         }
 
         var nameTextColor: UIColor {
-            customizationEnabled ? displaySetting.color.foreground : Style.nameTextColor
+            guard let displaySetting, customizationEnabled else {
+                return Style.nameTextColor
+            }
+            return displaySetting.color.foreground
         }
 
         // Date Label
 
         var dateFont: UIFont {
-            customizationEnabled ? displaySetting.font(with: .footnote) : Style.dateFont
+            guard let displaySetting, customizationEnabled else {
+                return Style.dateFont
+            }
+            return displaySetting.font(with: .footnote)
         }
 
         var dateTextColor: UIColor {
-            customizationEnabled ? displaySetting.color.secondaryForeground : Style.dateTextColor
+            guard let displaySetting, customizationEnabled else {
+                return Style.dateTextColor
+            }
+            return displaySetting.color.secondaryForeground
         }
     }
 }
@@ -530,7 +544,7 @@ private extension CommentContentTableViewCell {
         var renderer: CommentContentRenderer = {
             switch renderMethod {
             case .web:
-                return WebCommentContentRenderer(comment: comment, displaySetting: displaySetting)
+                return WebCommentContentRenderer(comment: comment, displaySetting: displaySetting ?? .standard)
             case .richContent(let attributedText):
                 let renderer = RichCommentContentRenderer(comment: comment)
                 renderer.richContentDelegate = self.richContentDelegate

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -284,7 +284,7 @@ private extension CommentContentTableViewCell {
 
         /// NOTE: Remove when the `readerCustomization` flag is removed.
         var customizationEnabled: Bool {
-            FeatureFlag.readerCustomization.enabled
+            ReaderDisplaySetting.customizationEnabled
         }
 
         // Name Label

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -28,7 +28,7 @@
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG" userLabel="Container Stack View">
-                        <rect key="frame" x="16" y="0.0" width="288" height="309"/>
+                        <rect key="frame" x="16" y="0.0" width="288" height="330"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="f2E-yC-BJS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="0.0" width="288" height="119"/>
@@ -41,18 +41,18 @@
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="CzL-pe-Tnr" userLabel="Name Stack View">
-                                        <rect key="frame" x="48" y="18" width="208" height="31"/>
+                                        <rect key="frame" x="48" y="18" width="208" height="36"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="po6-3F-ppN" userLabel="Name Container View">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="14.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="208" height="18"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="761" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HpE-B7-6wr" userLabel="Name Label">
-                                                        <rect key="frame" x="0.0" y="0.0" width="169.5" height="14.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="169.5" height="18"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Badge" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDo-cU-sWp" userLabel="Badge Label" customClass="BadgeLabel" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="174.5" y="-2" width="33.5" height="13.5"/>
+                                                        <rect key="frame" x="174.5" y="1" width="33.5" height="13.5"/>
                                                         <color key="backgroundColor" name="Blue50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <color key="textColor" name="White"/>
@@ -82,7 +82,7 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ghT-Xy-q8c" userLabel="Date Label">
-                                                <rect key="frame" x="0.0" y="16.5" width="208" height="14.5"/>
+                                                <rect key="frame" x="0.0" y="20" width="208" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
@@ -127,10 +127,10 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="QT8-DO-J30" userLabel="Reaction Stack View">
-                                <rect key="frame" x="0.0" y="119" width="288" height="190"/>
+                                <rect key="frame" x="0.0" y="119" width="288" height="210"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
-                                        <rect key="frame" x="0.0" y="75" width="184.5" height="40"/>
+                                        <rect key="frame" x="0.0" y="83.5" width="175.5" height="43"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -144,7 +144,7 @@
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="762" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="184.5" y="74.5" width="53.5" height="41"/>
+                                        <rect key="frame" x="175.5" y="83.5" width="62.5" height="43.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -158,7 +158,7 @@
                                         </state>
                                     </button>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8GH-U7-J7H" userLabel="Spacer View">
-                                        <rect key="frame" x="238" y="70" width="50" height="50"/>
+                                        <rect key="frame" x="238" y="80" width="50" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" placeholder="YES" id="4wt-Z8-Xp5"/>
@@ -166,26 +166,23 @@
                                     </view>
                                 </subviews>
                             </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qId-Th-B9r">
+                                <rect key="frame" x="0.0" y="329" width="288" height="1"/>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="HnG-UL-I2f"/>
+                                </constraints>
+                            </view>
                         </subviews>
                     </stackView>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qId-Th-B9r">
-                        <rect key="frame" x="20" y="329" width="300" height="1"/>
-                        <color key="backgroundColor" systemColor="systemGray5Color"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="1" id="HnG-UL-I2f"/>
-                        </constraints>
-                    </view>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="hcN-S7-sLG" secondAttribute="trailing" constant="16" id="2zy-oR-X5O"/>
-                    <constraint firstAttribute="trailing" secondItem="qId-Th-B9r" secondAttribute="trailing" id="3d4-sp-Uyb"/>
-                    <constraint firstItem="qId-Th-B9r" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="I4L-Vv-SIn"/>
+                    <constraint firstAttribute="bottom" secondItem="hcN-S7-sLG" secondAttribute="bottom" constant="10" id="FxL-ee-fbZ"/>
                     <constraint firstItem="mNJ-fg-sKO" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="II8-F0-CBs"/>
                     <constraint firstItem="mNJ-fg-sKO" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eId-Od-5wj"/>
                     <constraint firstItem="hcN-S7-sLG" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="esQ-oB-yxJ"/>
                     <constraint firstAttribute="bottom" secondItem="mNJ-fg-sKO" secondAttribute="bottom" id="izD-cW-YFx"/>
-                    <constraint firstItem="qId-Th-B9r" firstAttribute="top" secondItem="hcN-S7-sLG" secondAttribute="bottom" constant="20" id="pdj-JT-7h5"/>
-                    <constraint firstAttribute="bottom" secondItem="qId-Th-B9r" secondAttribute="bottom" constant="10" id="qZq-8s-UAU"/>
                     <constraint firstItem="hcN-S7-sLG" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="uFL-PF-ffo"/>
                 </constraints>
             </tableViewCellContentView>
@@ -212,7 +209,7 @@
     <resources>
         <image name="gravatar" width="85" height="85"/>
         <image name="icon-reader-comment-reply" width="13" height="12"/>
-        <image name="square.and.arrow.up" catalog="system" width="115" height="128"/>
+        <image name="square.and.arrow.up" catalog="system" width="108" height="128"/>
         <image name="star" catalog="system" width="128" height="116"/>
         <namedColor name="Blue50">
             <color red="0.023529411764705882" green="0.45882352941176469" blue="0.7686274509803922" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -135,15 +135,15 @@ private extension WebCommentContentRenderer {
     }()
 
     var textColor: UIColor {
-        return displaySetting.color.foreground
+        ReaderDisplaySetting.customizationEnabled ? displaySetting.color.foreground : .text
     }
 
     var highlightColor: UIColor {
-        displaySetting.color == .system ? Constants.highlightColor : displaySetting.color.foreground
+        ReaderDisplaySetting.customizationEnabled ? Constants.highlightColor : displaySetting.color.foreground
     }
 
     var mentionBackgroundColor: UIColor {
-        displaySetting.color == .system ? Constants.mentionBackgroundColor : .clear
+        ReaderDisplaySetting.customizationEnabled ? Constants.mentionBackgroundColor : .clear
     }
 
     /// Cache the HTML template format. We only need read the template once.

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -1,4 +1,5 @@
 import WebKit
+import WordPressShared
 
 /// Renders the comment body with a web view. Provides the best visual experience but has the highest performance cost.
 ///
@@ -18,10 +19,17 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     /// Caches the HTML content, to be reused when the orientation changed.
     private var htmlContentCache: String? = nil
 
+    private let displaySetting: ReaderDisplaySetting
+
     // MARK: Methods
 
-    required init(comment: Comment) {
+    required convenience init(comment: Comment) {
+        self.init(comment: comment, displaySetting: .standard)
+    }
+
+    required init(comment: Comment, displaySetting: ReaderDisplaySetting) {
         self.comment = comment
+        self.displaySetting = displaySetting
         super.init()
 
         if #available(iOS 16.4, *) {
@@ -44,7 +52,7 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
             return webView
         }
 
-        webView.loadHTMLString(formattedHTMLString(for: comment.content), baseURL: Self.resourceURL)
+        webView.loadHTMLString(formattedHTMLString(for: comment.content), baseURL: Bundle.wordPressSharedBundle.bundleURL)
 
         return webView
     }
@@ -123,23 +131,79 @@ private extension WebCommentContentRenderer {
 
     /// Used for the web view's `baseURL`, to reference any local files (i.e. CSS) linked from the HTML.
     static let resourceURL: URL? = {
-        Bundle.main.resourceURL
+        Bundle.wordPressSharedBundle.bundleURL
     }()
 
+    var textColor: UIColor {
+        return displaySetting.color.foreground
+    }
+
+    var highlightColor: UIColor {
+        displaySetting.color == .system ? Constants.highlightColor : displaySetting.color.foreground
+    }
+
+    var mentionBackgroundColor: UIColor {
+        displaySetting.color == .system ? Constants.mentionBackgroundColor : .clear
+    }
+
     /// Cache the HTML template format. We only need read the template once.
-    static let htmlTemplateFormat: String? = {
+    var htmlTemplateFormat: String? {
         guard let templatePath = Bundle.main.path(forResource: "richCommentTemplate", ofType: "html"),
               let templateStringFormat = try? String(contentsOfFile: templatePath) else {
             return nil
         }
 
         return String(format: templateStringFormat,
-                      Constants.highlightColor.lightVariant().cssRGBAString(),
-                      Constants.highlightColor.darkVariant().cssRGBAString(),
-                      Constants.mentionBackgroundColor.lightVariant().cssRGBAString(),
-                      Constants.mentionBackgroundColor.darkVariant().cssRGBAString(),
+                      metaContents.joined(separator: ", "),
+                      cssStyles,
                       "%@")
-    }()
+    }
+
+    var metaContents: [String] {
+        [
+            "width=device-width",
+            "initial-scale=\(displaySetting.size.scale)",
+            "maximum-scale=\(displaySetting.size.scale)",
+            "user-scalable=no",
+            "shrink-to-fit=no"
+        ]
+    }
+
+    /// We'll need to load `richCommentStyle.css` from the main bundle and inject it as a string,
+    /// because the web view needs to be loaded with the WordPressShared bundle to gain access to custom fonts.
+    var cssStyles: String {
+        guard let cssURL = Bundle.main.url(forResource: "richCommentStyle", withExtension: "css"),
+              let cssContent = try? String(contentsOf: cssURL) else {
+            return String()
+        }
+        return cssContent.appending(overrideStyles)
+    }
+
+    /// Additional styles based on system or custom theme.
+    var overrideStyles: String {
+        """
+        /* Basic style variables */
+        :root {
+            --text-font: \(displaySetting.font.cssString);
+            --text-color: \(textColor.lightVariant().cssRGBAString());
+            --primary-color: \(highlightColor.lightVariant().cssRGBAString());
+            --mention-background-color: \(mentionBackgroundColor.darkVariant().cssRGBAString());
+        }
+
+        /* Color overrides for dark mode */
+        @media(prefers-color-scheme: dark) {
+            :root {
+                --text-color: \(textColor.darkVariant().cssRGBAString());
+                --primary-color: \(highlightColor.darkVariant().cssRGBAString());
+                --mention-background-color: \(mentionBackgroundColor.darkVariant().cssRGBAString());
+            }
+        }
+
+        a {
+          text-decoration: \(displaySetting.color == .system ? "initial" : "underline");
+        }
+        """
+    }
 
     /// Returns a formatted HTML string by loading the template for rich comment.
     ///
@@ -158,7 +222,7 @@ private extension WebCommentContentRenderer {
         }
 
         // otherwise: sanitize the content, cache it, and then return it.
-        guard let htmlTemplateFormat = Self.htmlTemplateFormat else {
+        guard let htmlTemplateFormat = htmlTemplateFormat else {
             DDLogError("WebCommentContentRenderer: Failed to load HTML template format for comment content.")
             return String()
         }

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -187,7 +187,7 @@ private extension WebCommentContentRenderer {
             --text-font: \(displaySetting.font.cssString);
             --text-color: \(textColor.lightVariant().cssRGBAString());
             --primary-color: \(highlightColor.lightVariant().cssRGBAString());
-            --mention-background-color: \(mentionBackgroundColor.darkVariant().cssRGBAString());
+            --mention-background-color: \(mentionBackgroundColor.lightVariant().cssRGBAString());
         }
 
         /* Color overrides for dark mode */

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -55,6 +55,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// The table view that displays Related Posts
     @IBOutlet weak var relatedPostsTableView: IntrinsicTableView!
 
+    /// Whether the we should load the related posts section.
+    /// Ideally we should only load this section once per post.
+    private var shouldFetchRelatedPosts = true
+
     /// Header container
     @IBOutlet weak var headerContainerView: UIView!
 
@@ -287,6 +291,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) {
+        guard shouldFetchRelatedPosts else {
+            return
+        }
+
+        shouldFetchRelatedPosts = false
+
         let groupedPosts = Dictionary(grouping: posts, by: { $0.postType })
         let sections = groupedPosts.map { RelatedPostsSection(postType: $0.key, posts: $0.value) }
         relatedPosts = sections.sorted { $0.postType.rawValue < $1.postType.rawValue }
@@ -389,6 +399,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         guard let post = post else {
+            return
+        }
+
+        fetchRelatedPostsIfNeeded(for: post)
+    }
+
+    func fetchRelatedPostsIfNeeded(for post: ReaderPost) {
+        guard shouldFetchRelatedPosts else {
             return
         }
 
@@ -571,13 +589,15 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         if let post {
             webView.displaySetting = displaySetting
             webView.loadHTMLString(post.contentForDisplay())
+            // TODO: Fix sizing
         }
 
-        // TODO: Comments table view
+        // Comments table view
         commentsTableViewDelegate.displaySetting = displaySetting
         commentsTableView.reloadData()
 
-        // TODO: Related posts
+        // Related posts table view
+        relatedPostsTableView.reloadData()
 
         // TODO: Toolbar
     }
@@ -953,8 +973,16 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
         let post = relatedPosts[indexPath.section].posts[indexPath.row]
         cell.configure(for: post)
 
-        // TODO: Reader customization: override to transparent background
+        // Additional style overrides
         cell.backgroundColor = .clear
+
+        if ReaderDisplaySetting.customizationEnabled {
+            cell.titleLabel.font = displaySetting.font(with: .body, weight: .semibold)
+            cell.titleLabel.textColor = displaySetting.color.foreground
+
+            cell.excerptLabel.font = displaySetting.font(with: .footnote)
+            cell.excerptLabel.textColor = displaySetting.color.foreground
+        }
 
         return cell
     }
@@ -971,8 +999,13 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
 
         header.titleLabel.text = title
 
-        // TODO: Reader customization: override to transparent background
+        // Additional style overrides
         header.backgroundColorView.backgroundColor = .clear
+
+        if ReaderDisplaySetting.customizationEnabled {
+            header.titleLabel.font = displaySetting.font(with: .footnote, weight: .semibold)
+            header.titleLabel.textColor = displaySetting.color.foreground
+        }
 
         return header
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1165,7 +1165,7 @@ private extension ReaderDetailViewController {
     }
 
     func displaySettingButtonItem() -> UIBarButtonItem? {
-        guard FeatureFlag.readerCustomization.enabled,
+        guard ReaderDisplaySetting.customizationEnabled,
               let symbolImage = UIImage(systemName: "textformat") else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -48,7 +48,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     @IBOutlet weak var commentsTableView: IntrinsicTableView!
 
     // swiftlint:disable:next weak_delegate
-    private let commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
+    private lazy var commentsTableViewDelegate = {
+        ReaderDetailCommentsTableViewDelegate(displaySetting: displaySetting)
+    }()
 
     /// The table view that displays Related Posts
     @IBOutlet weak var relatedPostsTableView: IntrinsicTableView!
@@ -572,6 +574,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         // TODO: Comments table view
+        commentsTableViewDelegate.displaySetting = displaySetting
+        commentsTableView.reloadData()
 
         // TODO: Related posts
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -28,6 +28,8 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
         return post?.isSubscribedComments ?? false
     }
 
+    var displaySetting: ReaderDisplaySetting = .standard
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureView()
@@ -46,6 +48,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
         self.followConversationEnabled = post.commentsOpen && post.canSubscribeComments
         self.followButtonTappedClosure = followButtonTappedClosure
 
+        configureTitle()
         configureButton()
 
         readerCommentsFollowPresenter = ReaderCommentsFollowPresenter.init(
@@ -70,15 +73,14 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
 private extension ReaderDetailCommentsHeader {
 
     func configureView() {
-        contentView.backgroundColor = .basicBackground
-        addBottomBorder(withColor: .divider)
-        configureTitle()
+        contentView.backgroundColor = .clear
+        addBottomBorder(withColor: separatorColor)
 
     }
 
     func configureTitle() {
-        titleLabel.textColor = .text
-        titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .semibold)
+        titleLabel.textColor = titleTextColor
+        titleLabel.font = titleFont
     }
 
     func configureTitleLabel() {
@@ -103,8 +105,8 @@ private extension ReaderDetailCommentsHeader {
             followButton.setTitle(nil, for: .normal)
         } else {
             followButton.setTitle(Titles.followButton, for: .normal)
-            followButton.setTitleColor(.primary, for: .normal)
-            followButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
+            followButton.setTitleColor(followButtonColor, for: .normal)
+            followButton.titleLabel?.font = followButtonFont
             followButton.setImage(nil, for: .normal)
         }
     }
@@ -140,6 +142,33 @@ private extension ReaderDetailCommentsHeader {
         static let followButton = NSLocalizedString("Follow Conversation", comment: "Button title. Follow the comments on a post.")
     }
 
+    // MARK: Customizable Colors
+
+    var titleFont: UIFont {
+        guard ReaderDisplaySetting.customizationEnabled else {
+            return WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .semibold)
+        }
+        return displaySetting.font(with: .title3, weight: .semibold)
+    }
+
+    var titleTextColor: UIColor {
+        ReaderDisplaySetting.customizationEnabled ? displaySetting.color.foreground : .text
+    }
+
+    var followButtonFont: UIFont {
+        guard ReaderDisplaySetting.customizationEnabled else {
+            return WPStyleGuide.fontForTextStyle(.footnote)
+        }
+        return displaySetting.font(with: .footnote)
+    }
+
+    var followButtonColor: UIColor {
+        .primary
+    }
+
+    var separatorColor: UIColor {
+        ReaderDisplaySetting.customizationEnabled ? displaySetting.color.border : .divider
+    }
 }
 
 // MARK: - ReaderCommentsFollowPresenterDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -172,7 +172,19 @@ private extension ReaderDetailCommentsTableViewDelegate {
     func showCommentsButtonCell() -> BorderedButtonTableViewCell {
         let cell = BorderedButtonTableViewCell()
         let title = totalComments == 0 ? Constants.leaveCommentButtonTitle : Constants.viewAllButtonTitle
-        cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
+
+        if ReaderDisplaySetting.customizationEnabled {
+            cell.configure(buttonTitle: title,
+                           titleFont: displaySetting.font(with: .body, weight: .semibold),
+                           normalColor: displaySetting.color.background,
+                           highlightedColor: displaySetting.color.border,
+                           borderColor: displaySetting.color.border,
+                           buttonInsets: Constants.buttonInsets,
+                           backgroundColor: displaySetting.color.foreground)
+        } else {
+            cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
+        }
+
         cell.delegate = buttonDelegate
         cell.backgroundColor = .clear
         cell.contentView.backgroundColor = .clear

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -122,6 +122,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
+        header.displaySetting = displaySetting
         header.contentView.backgroundColor = .clear
         header.configure(
             post: post,
@@ -191,7 +192,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
         static let closedComments = NSLocalizedString("Comments are closed", comment: "Displayed on the post details page when there are no post comments and commenting is closed.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
         static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
-        static let buttonInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
+        static let buttonInsets = UIEdgeInsets.zero
         static let jetpackBadgeBottomPadding: CGFloat = 10
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -112,6 +112,12 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         cell.titleLabel.text = commentsEnabled ? Constants.noComments : Constants.closedComments
         cell.backgroundColor = .clear
         cell.contentView.backgroundColor = .clear
+
+        if ReaderDisplaySetting.customizationEnabled {
+            cell.titleLabel.font = displaySetting.font(with: .body)
+            cell.titleLabel.textColor = displaySetting.color.secondaryForeground
+        }
+
         return cell
     }
 
@@ -179,10 +185,10 @@ private extension ReaderDetailCommentsTableViewDelegate {
                            normalColor: displaySetting.color.foreground,
                            highlightedColor: displaySetting.color.background,
                            borderColor: displaySetting.color.border,
-                           buttonInsets: Constants.buttonInsets,
+                           buttonInsets: showCommentsButtonInsets,
                            backgroundColor: .clear)
         } else {
-            cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
+            cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: showCommentsButtonInsets)
         }
 
         cell.delegate = buttonDelegate
@@ -199,12 +205,17 @@ private extension ReaderDetailCommentsTableViewDelegate {
         JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .readerDetail)
     }
 
+    // The 'No comments' cell doesn't have a bottom padding. When displayed, we need to add top padding to the button.
+    var showCommentsButtonInsets: UIEdgeInsets {
+        comments.count > 0 ? .zero : Constants.buttonInsets
+    }
+
     struct Constants {
         static let noComments = NSLocalizedString("No comments yet", comment: "Displayed on the post details page when there are no post comments.")
         static let closedComments = NSLocalizedString("Comments are closed", comment: "Displayed on the post details page when there are no post comments and commenting is closed.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
         static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
-        static let buttonInsets = UIEdgeInsets.zero
+        static let buttonInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         static let jetpackBadgeBottomPadding: CGFloat = 10
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -15,6 +15,8 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private var totalRows = 0
     private var hideButton = true
 
+    private var displaySetting: ReaderDisplaySetting
+
     private var comments: [Comment] = [] {
         didSet {
             totalRows = {
@@ -39,6 +41,10 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     }
 
     // MARK: - Public Methods
+
+    init(displaySetting: ReaderDisplaySetting = .standard) {
+        self.displaySetting = displaySetting
+    }
 
     func updateWith(post: ReaderPost,
                     comments: [Comment] = [],

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -176,11 +176,11 @@ private extension ReaderDetailCommentsTableViewDelegate {
         if ReaderDisplaySetting.customizationEnabled {
             cell.configure(buttonTitle: title,
                            titleFont: displaySetting.font(with: .body, weight: .semibold),
-                           normalColor: displaySetting.color.background,
-                           highlightedColor: displaySetting.color.border,
+                           normalColor: displaySetting.color.foreground,
+                           highlightedColor: displaySetting.color.background,
                            borderColor: displaySetting.color.border,
                            buttonInsets: Constants.buttonInsets,
-                           backgroundColor: displaySetting.color.foreground)
+                           backgroundColor: .clear)
         } else {
             cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -15,7 +15,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private var totalRows = 0
     private var hideButton = true
 
-    private var displaySetting: ReaderDisplaySetting
+    var displaySetting: ReaderDisplaySetting
 
     private var comments: [Comment] = [] {
         didSet {
@@ -88,6 +88,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
                 return UITableViewCell()
             }
 
+            cell.displaySetting = displaySetting
             cell.configureForPostDetails(with: comment) { _ in
                 do {
                     try WPException.objcTry {
@@ -97,10 +98,6 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
                     WordPressAppDelegate.crashLogging?.logError(error)
                 }
             }
-
-            // TODO: Revisit
-            // Separator is removed because it has a hardcoded background color, which interferes with theming.
-            cell.shouldHideSeparator = true
 
             cell.backgroundColor = .clear
             cell.contentView.backgroundColor = .clear

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -3,6 +3,10 @@ import WordPressShared
 
 struct ReaderDisplaySetting: Codable, Equatable {
 
+    static var customizationEnabled: Bool {
+        FeatureFlag.readerCustomization.enabled
+    }
+
     // MARK: Properties
 
     // The default display setting.
@@ -208,10 +212,10 @@ class ReaderDisplaySettingStore: NSObject {
 
     var setting: ReaderDisplaySetting {
         get {
-            return FeatureFlag.readerCustomization.enabled ? _setting : .standard
+            return ReaderDisplaySetting.customizationEnabled ? _setting : .standard
         }
         set {
-            guard FeatureFlag.readerCustomization.enabled else {
+            guard ReaderDisplaySetting.customizationEnabled else {
                 return
             }
             _setting = newValue

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -141,7 +141,6 @@ struct ReaderDisplaySetting: Codable, Equatable {
         }
     }
 
-    // TODO: Need to import the fonts
     enum Font: String, Codable, CaseIterable {
         case sans
         case serif

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -130,6 +130,15 @@ struct ReaderDisplaySetting: Codable, Equatable {
             }
         }
 
+        var border: UIColor {
+            switch self {
+            case .system:
+                return .separator
+            default:
+                return foreground.withAlphaComponent(0.3)
+            }
+        }
+
         /// Whether the color adjusts between light and dark mode.
         var adaptsToInterfaceStyle: Bool {
             switch self {

--- a/WordPress/Resources/HTML/richCommentStyle.css
+++ b/WordPress/Resources/HTML/richCommentStyle.css
@@ -1,3 +1,27 @@
+@font-face {
+    font-family: 'Noto Serif';
+    src: local('NotoSerif-Regular'), url('NotoSerif-Regular.ttf') format('truetype');
+}
+
+@font-face {
+    font-family: 'Noto Serif';
+    src: local('NotoSerif-Bold'), url('NotoSerif-Bold.ttf') format('truetype');
+    font-weight: bold;
+}
+
+@font-face {
+    font-family: 'Noto Serif';
+    src: local('NotoSerif-Italic'), url('NotoSerif-Italic.ttf') format('truetype');
+    font-style: italic;
+}
+
+@font-face {
+    font-family: 'Noto Serif';
+    src: local('NotoSerif-BoldItalic'), url('NotoSerif-BoldItalic.ttf') format('truetype');
+    font-weight: bold;
+    font-style: italic;
+}
+
 :root {
     /* informs WebKit that this template supports both appearance modes. */
     color-scheme: light dark;
@@ -21,10 +45,11 @@ html {
     -webkit-text-size-adjust: none;
 }
 
-/* use Apple's standard style to match the native look. */
+/* use Apple's standard style to match the native look, while allowing it to be overridden. */
 body {
     font: -apple-system-body;
-    color: -apple-system-label;
+    font-family: var(--text-font);
+    color: var(--text-color);
     background-color: transparent;
 }
 
@@ -97,6 +122,7 @@ p > img:not(.emoji),
 
 figcaption {
     font: -apple-system-caption1;
+    font-family: var(--text-font);
     color: -apple-system-secondary-label;
     text-align: center;
 }
@@ -145,6 +171,7 @@ blockquote > p:first-child {
 blockquote cite {
     display: block;
     font: -apple-system-footnote;
+    font-family: var(--text-font);
     text-align: right;
 }
 
@@ -218,5 +245,5 @@ video {
  some contents apply inline text color styling which may lead to low contrast.
  */
 p, em, strong, b {
-    color: -apple-system-label !important;
+    color: var(--text-color) !important;
 }

--- a/WordPress/Resources/HTML/richCommentTemplate.html
+++ b/WordPress/Resources/HTML/richCommentTemplate.html
@@ -1,24 +1,12 @@
 <html dir="auto">
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=NO" />
-    <link rel="stylesheet" type="text/css" href="richCommentStyle.css">
+    <title>Comment</title>
+    <meta name="viewport" content="%1$@" />
     <style>
-        /* style overrides. */
-        :root {
-            --primary-color: %1$@;
-            --mention-background-color: %3$@;
-        }
-
-        /* overrides for dark color scheme. */
-        @media(prefers-color-scheme: dark) {
-            :root {
-                --primary-color: %2$@;
-                --mention-background-color: %4$@;
-            }
-        }
+        %2$@
     </style>
 </head>
 <body>
-    %5$@
+    %3$@
 </body>
 </html>


### PR DESCRIPTION
Part of #22925 

As titled, this applies the reading preferences to the comments and related posts sections. In addition, this PR also prevents the related posts from re-fetching content when the section is refreshed, preventing the content from changing every time the user tweaks the preferences.

Some previews:

<table>
<tr>
<td><img width="392" alt="comments-default" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b228b23d-1a14-4bce-98d6-94af98b46a7a"></td>
<td><img width="386" alt="comments-oled" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/06e566ec-cb25-4d5a-b62b-9ded54dabf87"></td>
<td><img width="389" alt="comments-soft" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8cc22364-69bb-4482-94b9-e0329c23189a"></td>
</tr>
<tr>
<td><img width="389" alt="comments-evening" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/255e0110-42e2-4b6c-a519-c319611c2d14"></td>
<td><img width="392" alt="comments-sepia" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/e3807711-1dde-4de5-900f-bc8eb7fdffa6"></td>
<td><img width="393" alt="Screenshot 2024-04-01 at 17 40 10" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/f5d86faf-138a-4cee-8459-b28d3c9c4be2"></td>
</tr>
</table>

Related posts:

<table>
<tr>
<td><img width="389" alt="related-default" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/225ecedf-c6f5-4464-aad2-840743bd58d1"></td>
<td><img width="386" alt="related-soft" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c96fe415-407e-47ad-8547-7384a4040e43"></td>
<td><img width="388" alt="related-sepia" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/026656ed-4ff2-4f79-9b8d-f6d60229c469"></td>
</tr>
<tr>
<td><img width="387" alt="related-evening" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b9315f2f-c48c-46b8-8826-49a46daddfaa"></td>
<td><img width="386" alt="related-oled" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/e57e0e8a-25c6-413b-b598-4b53e0fe584e"></td>
</tr>
</table>

## To test

- Launch the Jetpack app.
- Enable the `Reader Customization` feature flag.
- Navigate to the Reader and select any post with comments.
- Scroll down to the comments section.
- Customize the reading preferences.
- 🔎 Verify that the comments section is updated to match the selected preferences.
- Scroll down to the Related Posts section.
- 🔎 Verify that the related posts section is updated to match the selected preferences.

### Posts with no comments

- Navigate back to the Reader stream.
- Select any post that has no comments.
- Scroll down to the comments section.
- 🔎 Verify that the 'No comments yet' text is displayed and styled according to reading preferences. 

## Regression Notes
1. Potential unintended areas of impact
    - This modifies the `CommentContentTableViewCell`, which is used in site comments, notification comments, and comment thread.
    - This modifies the `ReaderDetailViewController` to only fetch the related posts data once. Previously, the related posts data is refreshed every time the web view that displays the post content is loaded.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

4. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
