### PR TITLE
Offline Mode: Update Post Settings to use the new APIs

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -179,6 +179,9 @@ FeaturedImageViewControllerDelegate>
     [super viewWillDisappear:animated];
 
     if (self.isStandalone) {
+        if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+            return; // No longer needed
+        }
         if ((self.isBeingDismissed || self.parentViewController.isBeingDismissed) && !self.isStandaloneEditorDismissingAfterSave) {
             // TODO: Implement it using a ViewModel or a child context to eliminate the risk of accidently saving the changes without uploading them
             [self.apost.managedObjectContext refreshObject:self.apost mergeChanges:NO];


### PR DESCRIPTION
## To test:

- **Verify** that you can cancel the changes by tapping "Cancel", using a swipe-to-dismiss gesture or terminating the app
- **Verify** that "Save" is enabled only if there are any changes (undoing a change will disable the button)
- **Verify** that when you make changes to drafts to posts, the changes are sent using partial updates

## Regression Notes
1. Potential unintended areas of impact: Post Settings
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
