### PR TITLE
Reading Preferences: Fix sizing issues for post detail and web-based comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -80,16 +80,17 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
 
             // To capture the content height, the methods to use is either `document.body.scrollHeight` or `document.documentElement.scrollHeight`.
             // `document.body` does not capture margins on <body> tag, so we'll use `document.documentElement` instead.
-            webView.evaluateJavaScript("document.documentElement.scrollHeight") { height, _ in
-                guard let height = height as? CGFloat else {
+            webView.evaluateJavaScript("document.documentElement.scrollHeight") { [weak self] height, _ in
+                guard let self,
+                      let height = height as? CGFloat else {
                     return
                 }
 
-                // TODO: Revisit this later.
-                // This is disabled for Reader customization.
-//                // reset the webview to opaque again so the scroll indicator is visible.
-//                webView.isOpaque = true
-                self.delegate?.renderer(self, asyncRenderCompletedWithHeight: height)
+                /// The display setting's custom size is applied through the HTML's initial-scale property
+                /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
+                /// so we'll need to add the custom scale into account.
+                let actualHeight = round(height * self.displaySetting.size.scale)
+                self.delegate?.renderer(self, asyncRenderCompletedWithHeight: actualHeight)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -623,7 +623,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Updates the webview height constraint with it's height
     private func observeWebViewHeight() {
         scrollObserver = webView.scrollView.observe(\.contentSize, options: .new) { [weak self] _, change in
-            guard let height = change.newValue?.height else {
+            guard let self,
+                  let height = change.newValue?.height else {
                 return
             }
 
@@ -631,13 +632,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             /// (except for a few times when it returns a very big weird number)
             /// We use that value so the content is not displayed with weird empty space at the bottom
             ///
-            self?.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { (webViewHeight, error) in
+            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { (webViewHeight, error) in
                 guard let webViewHeight = webViewHeight as? CGFloat else {
-                    self?.webViewHeight.constant = height
+                    self.webViewHeight.constant = height
                     return
-            }
+                }
 
-                self?.webViewHeight.constant = min(height, webViewHeight)
+                /// The display setting's custom size is applied through the HTML's initial-scale property
+                /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
+                /// so we'll need to add the custom scale into account.
+                self.webViewHeight.constant = round(min(webViewHeight, height) * self.displaySetting.size.scale)
             })
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -42,6 +42,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         }
     }
 
+    /// For custom styling. When nil, the cell will be configured with default styling.
     var displaySetting: ReaderDisplaySetting? = nil
 
     init(collectionView: UICollectionView, topics: [String]) {
@@ -104,7 +105,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
     private func sizeForCell(title: String, of collectionView: UICollectionView) -> CGSize {
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: ReaderInterestsStyleGuide.compactCellLabelTitleFont
+            .font: displaySetting?.font(with: .footnote) ?? ReaderInterestsStyleGuide.compactCellLabelTitleFont
         ]
 
         let title: NSString = title as NSString
@@ -119,7 +120,6 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         return size
     }
 
-    // TODO: Stylize
     private func configure(cell: ReaderInterestsCollectionViewCell, with title: String) {
         ReaderInterestsStyleGuide.applyCompactCellLabelStyle(label: cell.label)
 


### PR DESCRIPTION
Part of #22925 
Depends on #22938 

This PR fixes the sizing issue for the header view, post webview, and comment webview in Reader Detail. This should also resolve sizing issues raised in https://github.com/wordpress-mobile/WordPress-iOS/pull/22851#pullrequestreview-1968656823 and potentially #21797.

- For the header view in Reader Detail, since it's built-in SwiftUI, I've found that there aren't any reliable "hooks" to detect the correct content size. Therefore, I've added a `GeometryReader` to report for content size changes.
- For the Post and Comment webviews, since `ReaderDisplaySetting` makes use of the web view's [zoom level](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale) to increase the content scale, we'd also need to manually calculate the scale after getting the web view's height since it looks like the `scrollHeight` property does not take zoom level into account.

## To test

- Launch the Jetpack app.
- Ensure that the `Reader Customization` flag is turned on.
- Navigate to the Reader.
- Open any post. Preferably one that has at least 1 comment.
- If you have customized settings, please reset the font and size settings to the default option: `Sans` for font and `Normal` for size (right in the middle).
- Open the customization sheet, select 'Mono' font, and move the slider to the rightmost position. Then tap 'Done'.
- 🔎 Verify that:
  - The header view is correctly resized.
  - The Post webview is correctly resized.
  - The Comment webview is correctly resized.

## Regression Notes
1. Potential unintended areas of impact
Should be none. While the web view calculations take `ReaderDisplaySetting`'s scale into account, when the flag is off, the display setting is set to `.standard`, which has a scale value of `1.0`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
