### PR TITLE
Reader: Reduce requested amount of followed sites per page

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService+FollowedSites.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+FollowedSites.swift
@@ -7,7 +7,7 @@ extension ReaderTopicService {
 
     @objc func fetchAllFollowedSites(success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
         let service = ReaderTopicServiceRemote(wordPressComRestApi: apiRequest())
-        let pageSize: UInt = 100
+        let pageSize: UInt = 25
 
         service.fetchFollowedSites(forPage: 1, number: pageSize) { totalSites, sites in
             guard let totalSites, let sites else {


### PR DESCRIPTION
> [!WARNING]
> Auto-merge is on.

## Description

Reduces the number of items per page for better performance. I found that by reducing the page size, the overall time for fetching all the sites tends to be reduced by quite a bit.

## Testing

If you want to measure the performance of the requests yourself, you can use this test code:

<details><summary>Test code</summary>

Note: This requires updating the minimum version to `16.0`.

```swift
    @objc func fetchAllFollowedSites(success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
        let service = ReaderTopicServiceRemote(wordPressComRestApi: apiRequest())
        let pageSize: UInt = 25
        print("🟣 Fetching followed sites")
        let clock = ContinuousClock()
        let startTime = clock.now

        service.fetchFollowedSites(forPage: 1, number: pageSize) { totalSites, sites in
            guard let totalSites, let sites else {
                failure(nil)
                return
            }
            let totalPages = Int(ceil(Double(totalSites.intValue) / Double(pageSize)))
            WPAnalytics.subscriptionCount = totalSites.intValue

            guard totalPages > 1 else {
                self.mergeFollowedSites(sites, withSuccess: success)
                return
            }

            Task {
                await withTaskGroup(of: Result<[RemoteReaderSiteInfo], Error>.self) { taskGroup in
                    for page in 2...totalPages {
                        taskGroup.addTask {
                            return await self.fetchFollowedSites(service: service, page: UInt(page), number: pageSize)
                        }
                    }
                    var allSites = sites
                    for await result in taskGroup {
                        switch result {
                        case .success(let sites):
                            allSites.append(contentsOf: sites)
                        case .failure(let error):
                            DispatchQueue.main.async {
                                failure(error)
                            }
                            return
                        }
                    }
                    print("🟣 Finished fetching sites. Total pages: \(totalPages). Site count: \(allSites.count).")
                    print("🟣 Elapsed time: \(startTime.duration(to: clock.now))")
                    self.mergeFollowedSites(allSites, withSuccess: success)
                }
            }
        } failure: { error in
            failure(error)
        }
    }
```




</details>

To test:
- Login to Jetpack
- Navigate to the dashboard or launch the app to it
- 🔎 **Verify** existing start up fetch site calls fetch all your sites
- Navigate to the `Subscriptions` feed in the Reader
- Tap on the `Blogs` chip
- Tap on `Edit`
- 🔎 **Verify** the fetch call fetches all of your sites

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
