### PR TITLE
Use shared env vars in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,5 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - $CI_TOOLKIT_PLUGIN
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
@@ -19,7 +16,7 @@ steps:
       - label: "🛠 WordPress Prototype Build"
         command: ".buildkite/commands/prototype-build-wordpress.sh"
         env: *common_env
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         if: "build.pull_request.id != null || build.pull_request.draft"
         notify:
           - github_commit_status:
@@ -28,7 +25,7 @@ steps:
       - label: "🛠 Jetpack Prototype Build"
         command: ".buildkite/commands/prototype-build-jetpack.sh"
         env: *common_env
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         if: "build.pull_request.id != null || build.pull_request.draft"
         notify:
           - github_commit_status:
@@ -43,7 +40,7 @@ steps:
         key: "build_wordpress"
         command: ".buildkite/commands/build-for-testing.sh wordpress"
         env: *common_env
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         notify:
           - github_commit_status:
               context: "WordPress Build for Testing"
@@ -52,7 +49,7 @@ steps:
         key: "build_jetpack"
         command: ".buildkite/commands/build-for-testing.sh jetpack"
         env: *common_env
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         notify:
           - github_commit_status:
               context: "Jetpack Build for Testing"
@@ -64,7 +61,7 @@ steps:
     command: ".buildkite/commands/run-unit-tests.sh"
     depends_on: "build_wordpress"
     env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN]
     artifact_paths:
       - "build/results/*"
     notify:
@@ -80,7 +77,7 @@ steps:
         command: .buildkite/commands/run-ui-tests.sh 'iPhone 15'
         depends_on: "build_jetpack"
         env: *common_env
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"
           - "build/results/crashes/*"
@@ -92,7 +89,7 @@ steps:
         command: .buildkite/commands/run-ui-tests.sh 'iPad Pro (12.9-inch) (6th generation)'
         depends_on: "build_jetpack"
         env: *common_env
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"
           - "build/results/crashes/*"
@@ -107,7 +104,7 @@ steps:
     steps:
       - label: ":swift: SwiftLint"
         command: run_swiftlint --strict
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         notify:
           - github_commit_status:
               context: "SwiftLint"
@@ -127,5 +124,5 @@ steps:
 
       - label: ":sleuth_or_spy: Lint Localized Strings Format"
         command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN]
         env: *common_env

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,5 @@
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common environment values to use with the `env` key.
-  - &common_env
-    # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: $IMAGE_ID
+env:
+  IMAGE_ID: $IMAGE_ID
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -15,7 +11,6 @@ steps:
     steps:
       - label: "🛠 WordPress Prototype Build"
         command: ".buildkite/commands/prototype-build-wordpress.sh"
-        env: *common_env
         plugins: [$CI_TOOLKIT_PLUGIN]
         if: "build.pull_request.id != null || build.pull_request.draft"
         notify:
@@ -24,7 +19,6 @@ steps:
 
       - label: "🛠 Jetpack Prototype Build"
         command: ".buildkite/commands/prototype-build-jetpack.sh"
-        env: *common_env
         plugins: [$CI_TOOLKIT_PLUGIN]
         if: "build.pull_request.id != null || build.pull_request.draft"
         notify:
@@ -39,7 +33,6 @@ steps:
       - label: "🛠 :wordpress: Build for Testing"
         key: "build_wordpress"
         command: ".buildkite/commands/build-for-testing.sh wordpress"
-        env: *common_env
         plugins: [$CI_TOOLKIT_PLUGIN]
         notify:
           - github_commit_status:
@@ -48,7 +41,6 @@ steps:
       - label: "🛠 :jetpack: Build for Testing"
         key: "build_jetpack"
         command: ".buildkite/commands/build-for-testing.sh jetpack"
-        env: *common_env
         plugins: [$CI_TOOLKIT_PLUGIN]
         notify:
           - github_commit_status:
@@ -60,7 +52,6 @@ steps:
   - label: "🔬 :wordpress: Unit Tests"
     command: ".buildkite/commands/run-unit-tests.sh"
     depends_on: "build_wordpress"
-    env: *common_env
     plugins: [$CI_TOOLKIT_PLUGIN]
     artifact_paths:
       - "build/results/*"
@@ -76,7 +67,6 @@ steps:
       - label: "🔬 :jetpack: UI Tests (iPhone)"
         command: .buildkite/commands/run-ui-tests.sh 'iPhone 15'
         depends_on: "build_jetpack"
-        env: *common_env
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"
@@ -88,7 +78,6 @@ steps:
       - label: "🔬 :jetpack: UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh 'iPad Pro (12.9-inch) (6th generation)'
         depends_on: "build_jetpack"
-        env: *common_env
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"
@@ -125,4 +114,3 @@ steps:
       - label: ":sleuth_or_spy: Lint Localized Strings Format"
         command: .buildkite/commands/lint-localized-strings-format.sh
         plugins: [$CI_TOOLKIT_PLUGIN]
-        env: *common_env

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,11 +2,11 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#3.1.0
+    - $CI_TOOLKIT_PLUGIN
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.1
+    IMAGE_ID: $IMAGE_ID
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,10 +4,10 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#3.1.0
+    - $CI_TOOLKIT_PLUGIN
 
 env:
-  IMAGE_ID: xcode-15.1
+  IMAGE_ID: $IMAGE_ID
 
 steps:
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,11 +1,5 @@
 # This pipeline is meant to be run via the Buildkite API, and is only used for release builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - $CI_TOOLKIT_PLUGIN
-
 env:
   IMAGE_ID: $IMAGE_ID
 
@@ -13,12 +7,12 @@ steps:
 
   - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN]
     notify:
     - slack: "#build-and-ship"
 
   - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN]
     notify:
     - slack: "#build-and-ship"

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -1,7 +1,7 @@
 steps:
   - label: Code Freeze
     plugins:
-      - automattic/a8c-ci-toolkit#3.1.0
+      - $CI_TOOLKIT_PLUGIN
     # The first client to implement releases in CI was Android so the automation works in that queue.
     # We might want to move it to a leaner one in the future.
     agents:

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -1,8 +1,3 @@
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - $CI_TOOLKIT_PLUGIN
-
 env:
   IMAGE_ID: $IMAGE_ID
 
@@ -13,10 +8,10 @@ agents:
 steps:
   - label: Complete Code Freeze
     key: complete_code_freeze
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN]
     command: ".buildkite/commands/complete-code-freeze.sh $RELEASE_VERSION"
 
   - label: Log Outdated Pods
     depends_on: complete_code_freeze
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN]
     command: ".buildkite/commands/log-outdated-pods.sh $RELEASE_VERSION"

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -1,11 +1,11 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#3.1.0
+    - $CI_TOOLKIT_PLUGIN
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.1
+    IMAGE_ID: $IMAGE_ID
 
 steps:
   - label: Complete Code Freeze

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -2,25 +2,21 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - $CI_TOOLKIT_PLUGIN
-  # Common environment values to use with the `env` key.
-  - &common_env
-    # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: $IMAGE_ID
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
+# The code freeze completion needs to run on macOS because it uses genstrings under the hood
+agents:
+    queue: mac
 
 steps:
   - label: Complete Code Freeze
     key: complete_code_freeze
     plugins: *common_plugins
-    env: *common_env
-    # The code freeze completion needs to run on macOS because it uses genstrings under the hood
-    agents:
-        queue: mac
     command: ".buildkite/commands/complete-code-freeze.sh $RELEASE_VERSION"
 
   - label: Log Outdated Pods
     depends_on: complete_code_freeze
     plugins: *common_plugins
-    env: *common_env
-    agents:
-        queue: mac
     command: ".buildkite/commands/log-outdated-pods.sh $RELEASE_VERSION"

--- a/.buildkite/release-pipelines/finalize-hotfix.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix.yml
@@ -1,10 +1,10 @@
 steps:
   - label: Finalize Release
     plugins:
-      - automattic/a8c-ci-toolkit#3.1.0
+      - $CI_TOOLKIT_PLUGIN
     # The finalization needs to run on macOS because of localization linting
     agents:
         queue: mac
     env:
-      IMAGE_ID: xcode-15.1
+      IMAGE_ID: $IMAGE_ID
     command: ".buildkite/commands/finalize-hotfix.sh $VERSION"

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -1,10 +1,10 @@
 steps:
   - label: Finalize Release
     plugins:
-      - automattic/a8c-ci-toolkit#3.1.0
+      - $CI_TOOLKIT_PLUGIN
     # The finalization needs to run on macOS because of localization linting
     agents:
         queue: mac
     env:
-      IMAGE_ID: xcode-15.1
+      IMAGE_ID: $IMAGE_ID
     command: ".buildkite/commands/finalize-release.sh $RELEASE_VERSION"

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -1,12 +1,12 @@
 steps:
   - label: New Beta Deployment
     plugins:
-      - automattic/a8c-ci-toolkit#3.1.0
+      - $CI_TOOLKIT_PLUGIN
     # The beta needs to run on macOS because it uses genstrings under the hood
     agents:
         queue: mac
     env:
-      IMAGE_ID: xcode-15.1
+      IMAGE_ID: $IMAGE_ID
     command: |
       echo '--- :git: Configure Git for release management'
       .buildkite/commands/configure-git-for-release-management.sh

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -2,7 +2,7 @@ steps:
   - label: New Hotfix Deployment
     plugins:
       - $CI_TOOLKIT_PLUGIN
-    # The beta needs to run on macOS because it uses genstrings under the hood
+    # The hotfix needs to run on macOS because it uses genstrings under the hood
     agents:
         queue: mac
     env:

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -1,12 +1,12 @@
 steps:
   - label: New Hotfix Deployment
     plugins:
-      - automattic/a8c-ci-toolkit#3.1.0
+      - $CI_TOOLKIT_PLUGIN
     # The beta needs to run on macOS because it uses genstrings under the hood
     agents:
         queue: mac
     env:
-      IMAGE_ID: xcode-15.1
+      IMAGE_ID: $IMAGE_ID
     command: |
       echo '--- :git: Configure Git for release management'
       .buildkite/commands/configure-git-for-release-management.sh

--- a/.buildkite/release-pipelines/update-app-store-strings.yml
+++ b/.buildkite/release-pipelines/update-app-store-strings.yml
@@ -1,7 +1,7 @@
 steps:
   - label: Update App Store Strings
     plugins:
-      - automattic/a8c-ci-toolkit#3.1.0
+      - $CI_TOOLKIT_PLUGIN
     # The first client to implement releases in CI was Android so the automation works in that queue.
     # We might want to move it to a leaner one in the future.
     agents:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+# The ~> modifier is not currently used, but we check for it just in case
+XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
+export IMAGE_ID="$XCODE_VERSION"
+
+export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#3.1.0"


### PR DESCRIPTION
Centralizes Xcode version for CI and CI-toolkit plugin version in `shared-env-var`, which CI is already configured to source if present.

See how CI resolves them to verify the changes are correct:

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/1218433/b330aac2-9162-4c5e-9f66-79abf39bd21a)

Note: I only tested them via the main pipeline scenario, under the assumption that all other pipelines will behave the same.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.