### PR TITLE
Update WP.com dashboard path to /home

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -49,12 +49,7 @@ NSString * const HideWPAdminDate = @"2015-09-07T00:00:00Z";
 CGFloat const BlogDetailReminderSectionHeaderHeight = 8.0;
 CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
 
-// NOTE: Currently "stats" acts as the calypso dashboard with a redirect to
-// stats/insights. Per @mtias, if the dashboard should change at some point the
-// redirect will be updated to point to new content, eventhough the path is still
-// "stats/".
-// aerych, 2016-06-14
-NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
+NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 
 #pragma mark - Helper Classes for Blog Details view model.
 


### PR DESCRIPTION
Context: pcdRpT-6gD-p2#comment-9672

WP/JP app shows "Dashboard" row in My Sites if the site is hosted at wp.com (https://github.com/wordpress-mobile/WordPress-iOS/blob/a80e96ea95f3df5f3569cfabee8a54f50caa246c/WordPress/Classes/ViewRelated/Blog/Blog%20Details/BlogDetailsViewController.m#L1517).

For at least the last 8 years, it was opening /stats as a dashboard entry point, although /home entry point exists now. 

🐛  Opening /stats also has a corner-case issue that results in WP app opening if both JP and WP apps are installed.

### Solution

Open /home path for a dashboard option.

### To test:

### WPcom site

1. Install both WordPress and Jetpack apps
2. Open Jetpack app
3. Select WP.com site
3. Open My Site (Dashboard -> More)
4. Select Dashboard
5. Confirm Safari opens WP.com dashboard

### Self-hosted site

1. Install both WordPress and Jetpack apps
2. Open Jetpack app
3. Select self-hosted site
3. Open My Site (Dashboard -> More)
4. Select WP-Admin
5. Confirm Safari opens wp-admin

## Regression Notes
1. Potential unintended areas of impact

Couldn't identify any

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)