### PR TITLE
Offline Mode: Trash, Delete, Restore

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 15.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '8b61680b934ca1bebdbe7f2abb091ff22d08fedf'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'ebaf7d97503a47bde2917d464ac9914c626b1c50'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.2, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `8b61680b934ca1bebdbe7f2abb091ff22d08fedf`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `ebaf7d97503a47bde2917d464ac9914c626b1c50`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.15)
   - ZendeskSupportSDK (= 5.3.0)
@@ -175,7 +175,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
   WordPressKit:
-    :commit: 8b61680b934ca1bebdbe7f2abb091ff22d08fedf
+    :commit: ebaf7d97503a47bde2917d464ac9914c626b1c50
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -183,7 +183,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: 8b61680b934ca1bebdbe7f2abb091ff22d08fedf
+    :commit: ebaf7d97503a47bde2917d464ac9914c626b1c50
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -230,6 +230,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: fa9ae5af13b7cf168245f24d1c672a4fb972e37f
 
-PODFILE CHECKSUM: c86dcd99525fbd017b651da9402b873c51429a52
+PODFILE CHECKSUM: e408b4e6076ddd1bb2f1455312d73afad1eebf11
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -184,7 +184,6 @@ extension AbstractPost {
             current = next
         }
         return revisions
-
     }
 
     // TODO: Replace with a new flag
@@ -223,6 +222,13 @@ extension AbstractPost {
             willChangeValue(forKey: "revision")
             setPrimitiveValue(tail, forKey: "revision")
             didChangeValue(forKey: "revision")
+        }
+    }
+
+    func deleteAllRevisions() {
+        assert(isOriginal())
+        for revision in allRevisions {
+            revision.deleteRevision()
         }
     }
 }

--- a/WordPress/Classes/Models/Post+RefreshStatus.swift
+++ b/WordPress/Classes/Models/Post+RefreshStatus.swift
@@ -6,6 +6,8 @@ extension Post {
     /// - Parameters:
     ///   - onCompletion: block to invoke when status update is finished.
     ///   - onError: block to invoke if any error occurs while the update is being made.
+    ///
+    /// - warning: deprecated (kahu-offline-mode)
     static func refreshStatus(with coreDataStack: CoreDataStack) {
         coreDataStack.performAndSave { context in
             let fetch = NSFetchRequest<Post>(entityName: Post.classNameWithoutNamespaces())

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -254,7 +254,12 @@
 
     if (purge) {
         // Set up predicate for fetching any posts that could be purged for the sync.
-        NSPredicate *predicate  = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];
+        NSPredicate *predicate = nil;
+        if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+            predicate = [NSPredicate predicateWithFormat:@"(postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", blog];
+        } else {
+            predicate = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];
+        }
         if ([statuses count] > 0) {
             NSPredicate *statusPredicate = [NSPredicate predicateWithFormat:@"status IN %@", statuses];
             predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, statusPredicate]];

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -283,6 +283,8 @@ final class PostRepository {
     /// Move the given post to the trash bin. The post will not be deleted from local database, unless it's delete on its WordPress site.
     ///
     /// - Parameter postID: Object ID of the post
+    ///
+    /// - warning: deprecated (kahu-offline-mode)
     func trash<P: AbstractPost>(_ postID: TaggedManagedObjectID<P>) async throws {
         // Trash the original post instead if presents
         let original: TaggedManagedObjectID<AbstractPost>? = try await coreDataStack.performQuery { context in

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -237,6 +237,22 @@ final class PostRepository {
         ContextManager.shared.saveContextAndWait(context)
     }
 
+    /// Permanently delete the given post.
+    @MainActor
+    func _delete(_ post: AbstractPost) async throws {
+        assert(post.isOriginal())
+
+        guard let postID = post.postID, postID.intValue > 0 else {
+            assertionFailure("Trying to patch a non-existent post")
+            return
+        }
+        try await getRemoteService(for: post.blog).deletePost(withID: postID.intValue)
+
+        let context = coreDataStack.mainContext
+        context.deleteObject(post)
+        ContextManager.shared.saveContextAndWait(context)
+    }
+
     /// Permanently delete the given post from local database and the post's WordPress site.
     ///
     /// - Parameter postID: Object ID of the post

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -349,62 +349,6 @@ final class PostRepository {
             }
         }
     }
-
-    /// Move the given post out of the trash bin.
-    ///
-    /// - Parameters:
-    ///   - postID: Object ID of the given post
-    ///   - status: The post's original status before it's moved to the trash bin.
-    func restore<P: AbstractPost>(_ postID: TaggedManagedObjectID<P>, to status: BasePost.Status) async throws {
-        // Restore the original post instead if presents
-        let original: TaggedManagedObjectID<AbstractPost>? = try await coreDataStack.performQuery { context in
-            let post = try context.existingObject(with: postID)
-            if let original = post.original {
-                return TaggedManagedObjectID(original)
-            }
-            return nil
-        }
-        if let original {
-            DDLogInfo("Trash the original post object instead")
-            try await restore(original, to: status)
-            return
-        }
-
-        // Update local database
-        let result: (PostServiceRemote, RemotePost)? = try await coreDataStack.performAndSave { [remoteFactory] context in
-            let post = try context.existingObject(with: postID)
-            post.status = status
-
-            if let remote = remoteFactory.forBlog(post.blog), !post.isRevision() && (post.postID?.int64Value ?? 0) > 0 {
-                return (remote, PostHelper.remotePost(with: post))
-            }
-            return nil
-        }
-
-        // Call WordPress API if needed
-        guard let (remote, remotePost) = result else { return }
-
-        let updatedRemotePost: RemotePost
-        do {
-            updatedRemotePost = try await withCheckedThrowingContinuation { continuation in
-                remote.restore(remotePost, success: { continuation.resume(returning: $0!) }, failure: { continuation.resume(throwing: $0!)} )
-            }
-        } catch {
-            DDLogError("Failed to restore post: \(error)")
-
-            // Put the post back in the trash bin.
-            try? await coreDataStack.performAndSave { context in
-                let post = try context.existingObject(with: postID)
-                post.status = .trash
-            }
-            throw error
-        }
-
-        try? await coreDataStack.performAndSave { context in
-            let post = try context.existingObject(with: postID)
-            PostHelper.update(post, with: updatedRemotePost, in: context)
-        }
-    }
 }
 
 private extension PostRepository {

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -9,11 +9,14 @@ final class PostRepository {
 
     private let coreDataStack: CoreDataStackSwift
     private let remoteFactory: PostServiceRemoteFactory
+    private let isSyncPublishingEnabled: Bool
 
     init(coreDataStack: CoreDataStackSwift = ContextManager.shared,
-         remoteFactory: PostServiceRemoteFactory = PostServiceRemoteFactory()) {
+         remoteFactory: PostServiceRemoteFactory = PostServiceRemoteFactory(),
+         isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
         self.coreDataStack = coreDataStack
         self.remoteFactory = remoteFactory
+        self.isSyncPublishingEnabled = isSyncPublishingEnabled
     }
 
     /// Sync a specific post from the API
@@ -587,7 +590,7 @@ extension PostRepository {
                     // doesn't have local edits
                     NSPredicate(format: "original = NULL AND revision = NULL"),
                     // doesn't have local status changes
-                    NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: AbstractPostRemoteStatus.sync.rawValue)),
+                    self.isSyncPublishingEnabled ? nil : NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: AbstractPostRemoteStatus.sync.rawValue)),
                     // is not included in the fetched page lists (i.e. it has been deleted from the site)
                     NSPredicate(format: "NOT (SELF IN %@)", allPages.map { $0.objectID }),
                     // we only need to deal with pages that match the filters passed to this function.

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 extension PageListViewController: InteractivePostViewDelegate {
-
     func edit(_ apost: AbstractPost) {
         guard let page = apost as? Page else { return }
 
@@ -22,8 +21,11 @@ extension PageListViewController: InteractivePostViewDelegate {
     }
 
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
-        guard let page = post as? Page else { return }
-        trashPage(page, completion: completion)
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            guard let page = post as? Page else { return }
+            return trashPage(page, completion: completion)
+        }
+        return super._trash(post, completion: completion)
     }
 
     func draft(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -193,7 +193,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.moveToDraft],
-            [.trash]
+            [.delete]
         ]
         expect(buttons).to(equal(expectedButtons))
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -96,7 +96,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .duplicate: return UIImage(systemName: "doc.on.doc")
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")
-        case .delete: return UIImage(systemName: "delete")
+        case .delete: return UIImage(systemName: "trash")
         case .cancelAutoUpload: return UIImage(systemName: "xmark.icloud")
         case .share: return UIImage(systemName: "square.and.arrow.up")
         case .blaze: return UIImage(systemName: "flame")
@@ -112,7 +112,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
 
     var attributes: UIMenuElement.Attributes? {
         switch self {
-        case .trash:
+        case .trash, .delete:
             return [UIMenuElement.Attributes.destructive]
         default:
             return nil

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -96,6 +96,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .duplicate: return UIImage(systemName: "doc.on.doc")
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")
+        case .delete: return UIImage(systemName: "delete")
         case .cancelAutoUpload: return UIImage(systemName: "xmark.icloud")
         case .share: return UIImage(systemName: "square.and.arrow.up")
         case .blaze: return UIImage(systemName: "flame")
@@ -126,7 +127,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .stats: return Strings.stats
         case .duplicate: return Strings.duplicate
         case .moveToDraft: return Strings.draft
-        case .trash: return post.status == .trash ? Strings.delete : Strings.trash
+        case .trash: return Strings.trash
+        case .delete: return Strings.delete
         case .cancelAutoUpload: return Strings.cancelAutoUpload
         case .share: return Strings.share
         case .blaze: return Strings.blaze
@@ -156,6 +158,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
             delegate.draft(post)
         case .trash:
             delegate.trash(post)
+        case .delete:
+            delegate.delete(post)
         case .cancelAutoUpload:
             delegate.cancelAutoUpload(post)
         case .share:

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -22,6 +22,7 @@ enum AbstractPostButton: Equatable {
     case duplicate
     case moveToDraft
     case trash
+    case delete
     case cancelAutoUpload
     case share
     case blaze

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -7,6 +7,7 @@ protocol InteractivePostViewDelegate: AnyObject {
     func duplicate(_ post: AbstractPost)
     func publish(_ post: AbstractPost)
     func trash(_ post: AbstractPost, completion: @escaping () -> Void)
+    func delete(_ post: AbstractPost, completion: @escaping () -> Void)
     func draft(_ post: AbstractPost)
     func retry(_ post: AbstractPost)
     func cancelAutoUpload(_ post: AbstractPost)
@@ -28,5 +29,9 @@ extension InteractivePostViewDelegate {
 
     func trash(_ post: AbstractPost) {
         self.trash(post, completion: {})
+    }
+
+    func delete(_ post: AbstractPost) {
+        self.delete(post, completion: {})
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -117,6 +117,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             return AbstractPostButtonSection(buttons: [])
         }
 
-        return AbstractPostButtonSection(buttons: [.trash])
+        let action: AbstractPostButton = page.original().status == .trash ? .delete : .trash
+        return AbstractPostButtonSection(buttons: [action])
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -222,7 +222,8 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     private func createTrashSection() -> AbstractPostButtonSection {
-        return AbstractPostButtonSection(buttons: [.trash])
+        let action: AbstractPostButton = post.original().status == .trash ? .delete : .trash
+        return AbstractPostButtonSection(buttons: [action])
     }
 
     private var canCancelAutoUpload: Bool {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -308,6 +308,13 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
     }
 
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return trashPost(post, completion: completion)
+        }
+        return super._trash(post, completion: completion)
+    }
+
+    private func trashPost(_ post: AbstractPost, completion: @escaping () -> Void) {
         if post.status == .draft ||
             post.status == .scheduled {
             deletePost(post)

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -26,7 +26,9 @@ final class PostSyncStateViewModel {
         guard isSyncPublishingEnabled else {
             return _state
         }
-
+        if PostCoordinator.shared.isDeleting(post) || PostCoordinator.shared.isUpdating(post) {
+            return .uploading
+        }
         if let error = PostCoordinator.shared.syncError(for: post.original()) {
             if let saveError = error as? PostRepository.PostSaveError,
                case .conflict = saveError {
@@ -39,9 +41,6 @@ final class PostSyncStateViewModel {
         }
         if PostCoordinator.shared.isSyncNeeded(for: post) {
             return .unsynced
-        }
-        if PostCoordinator.shared.isDeleting(post) || PostCoordinator.shared.isUpdating(post) {
-            return .uploading
         }
         return .idle
     }

--- a/WordPress/WordPressTest/AbstractPostTest.swift
+++ b/WordPress/WordPressTest/AbstractPostTest.swift
@@ -74,4 +74,19 @@ class AbstractPostTest: CoreDataTestCase {
         XCTAssertTrue(revision2.isDeleted)
         XCTAssertFalse(revision3.isDeleted)
     }
+
+    func testDeleteRevisionDeletsAll() {
+        // GIVEN a post with two revisions
+        let post = PostBuilder(mainContext).build()
+        let revision1 = post._createRevision()
+        let revision2 = revision1._createRevision()
+
+        // WHEN
+        post.deleteAllRevisions()
+
+        // THEN both revision got deleted
+        XCTAssertNil(post.revision)
+        XCTAssertTrue(revision1.isDeleted)
+        XCTAssertTrue(revision2.isDeleted)
+    }
 }

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -121,7 +121,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.moveToDraft],
-            [.trash]
+            [.delete]
         ]
         expect(buttons).to(equal(expectedButtons))
     }


### PR DESCRIPTION
Adds support for trash, delete, and restore (existing move to draft).

When you trash a post, it deletes your local unsynced changes after a confirmation, sends a patch, and moves it to trash. Invariant: all posts in the "Trash" tab have no unsynced changes.

When you delete a post, it uses a new [endpoint](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/776).

## To test:

- **Verify** that when you trash a post, the cells becomes grayed-out (takes precedence over "has unsynced changes" and other states)
- **Verify** that when you trash a post, it sends only `{ "status": "trash" }` in the request
- **Verify** that if you trash a post while the sync request is running, it waits until the request completes
- **Verify** that when you trash a post, it deletes all the local unsynced changes after a confirmatin
- **Verify** that if you trash a post that was permanently deleted, it deletes it form the list (known issue: API returns 403 instead of 404)  (the production version also shows an error; so it's not a regression)
- **Verify** that you can still trash a draft or a pending post without a confirmation (unless they have local changes)
- **Verify**that if you permanently delete and already permanently deleted post, it succeeds (the production version shows an error)

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
