### PR TITLE
Reader Preferences: Fix font sizing

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -641,7 +641,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                 /// The display setting's custom size is applied through the HTML's initial-scale property
                 /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
                 /// so we'll need to add the custom scale into account.
-                self.webViewHeight.constant = round(min(webViewHeight, height) * self.displaySetting.size.scale)
+                let scaledWebViewHeight = round(webViewHeight * self.displaySetting.size.scale)
+                self.webViewHeight.constant = min(scaledWebViewHeight, height)
             })
         }
     }


### PR DESCRIPTION
Part of #22925

This PR refactors the font generation method in `ReaderDisplaySetting` so it's safer and more "correct". Mainly:
- This ensures that the custom weight is applied to the generated font. This also updates the default value of the `weight` parameter to nil, to respect the inherent weight from the `UITextStyle`.
- Furthermore, this avoids the use of `UIFontMetrics.scaledFont` because it's a bit prone to error; as in,
fonts cannot go through the `scaledFont` method twice; otherwise, it will raise an exception. Of course, this change also ensures that the generated font scales along with the preferred content size category.

In addition, I fixed a small miscalculation for the Reader Detail post's webview. After more testing, it turns out only the `scrollHeight` value returned from evaluated Javascript ignores the HTML content scaling; https://github.com/wordpress-mobile/WordPress-iOS/commit/3d3675ccd7d98f683c27dbbcf0c5b91d3d055796 fixes that by only applying the scale to the value returned from the Javascript before comparing it with the `height` from the observer.

## To test

Referring to the same test steps from #22939:

- Launch the Jetpack app.
- Ensure that the `Reader Customization` flag is turned on.
- Navigate to the Reader.
- Open any post. Preferably one that has at least 1 comment.
- If you have customized settings, please reset the font and size settings to the default option: `Sans` for font and `Normal` for size (right in the middle).
- Open the customization sheet, select 'Mono' font, and move the slider to the rightmost position. Then tap 'Done'.
- 🔎 Verify that:
  - The header view is correctly resized.
  - The Post webview is correctly resized.
  - The Comment webview is correctly resized.
-  🆕 Open the customization sheet again, and now move the slider to the *leftmost* position. Then tap 'Done'.
- 🔎 Verify that the content is correctly resized.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
