### PR TITLE
Offline Mode: Add support for pending posts

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -17,6 +17,11 @@ extension AbstractPost {
 
     // MARK: - Status
 
+    /// Returns `true` is the post has one of the given statuses.
+    func isStatus(in statuses: Set<Status>) -> Bool {
+        statuses.contains(status ?? .draft)
+    }
+
     /// - note: deprecated (kahu-offline-mode)
     @objc
     var statusTitle: String? {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -12,17 +12,11 @@ protocol PostCoordinatorDelegate: AnyObject {
 class PostCoordinator: NSObject {
 
     enum SavingError: Error, LocalizedError {
-        /// If the action can only be performs
-        case hasUnsyncedChanges
         case mediaFailure(AbstractPost)
         case unknown
 
         var errorDescription: String? {
-            switch self {
-            case .hasUnsyncedChanges: return Strings.errorUnsyncedChangesMessage
-            case .mediaFailure: return Strings.genericErrorTitle
-            case .unknown: return Strings.genericErrorTitle
-            }
+            Strings.genericErrorTitle
         }
     }
 
@@ -234,9 +228,6 @@ class PostCoordinator: NSObject {
 
         let post = post.original()
         do {
-            guard post.revision == nil else {
-                throw SavingError.hasUnsyncedChanges
-            }
             try await PostRepository(coreDataStack: coreDataStack)._update(post, changes: changes)
         } catch {
             handleError(error, for: post)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -11,9 +11,19 @@ protocol PostCoordinatorDelegate: AnyObject {
 
 class PostCoordinator: NSObject {
 
-    enum SavingError: Error {
+    enum SavingError: Error, LocalizedError {
+        /// If the action can only be performs
+        case hasUnsyncedChanges
         case mediaFailure(AbstractPost)
         case unknown
+
+        var errorDescription: String? {
+            switch self {
+            case .hasUnsyncedChanges: return Strings.errorUnsyncedChangesMessage
+            case .mediaFailure: return Strings.genericErrorTitle
+            case .unknown: return Strings.genericErrorTitle
+            }
+        }
     }
 
     @objc static let shared = PostCoordinator()
@@ -153,7 +163,7 @@ class PostCoordinator: NSObject {
     @MainActor
     func _publish(_ post: AbstractPost, options: PublishingOptions) async throws {
         assert(post.isOriginal())
-        assert(post.status == .draft)
+        assert(post.isStatus(in: [.draft, .pending]))
 
         await pauseSyncing(for: post)
         defer { resumeSyncing(for: post) }
@@ -217,16 +227,16 @@ class PostCoordinator: NSObject {
 
     /// Patches the post.
     ///
-    /// - warning: Can only be used on posts with no unsynced revisions.
-    ///
     /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
     func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
         assert(post.isOriginal())
-        assert(post.revision == nil, "Can only be used on posts with no unsynced changes")
 
         let post = post.original()
         do {
+            guard post.revision == nil else {
+                throw SavingError.hasUnsyncedChanges
+            }
             try await PostRepository(coreDataStack: coreDataStack)._update(post, changes: changes)
         } catch {
             handleError(error, for: post)
@@ -238,7 +248,7 @@ class PostCoordinator: NSObject {
         guard let topViewController = UIApplication.shared.mainWindow?.topmostPresentedViewController else {
             return
         }
-        let alert = UIAlertController(title: Strings.errorTitle, message: error.localizedDescription, preferredStyle: .alert)
+        let alert = UIAlertController(title: Strings.genericErrorTitle, message: error.localizedDescription, preferredStyle: .alert)
         if let error = error as? PostRepository.PostSaveError {
             switch error {
             case .conflict:
@@ -298,7 +308,7 @@ class PostCoordinator: NSObject {
 
     /// Returns `true` if the post is eligible for syncing.
     func isSyncAllowed(for post: AbstractPost) -> Bool {
-        post.status == .draft
+        post.status == .draft || post.status == .pending
     }
 
     /// Returns `true` if post has any revisions that need to be synced.
@@ -1215,6 +1225,7 @@ private enum Strings {
     static let deletePost = NSLocalizedString("postsList.deletePost.message", value: "Post deleted permanently", comment: "A short message explaining that a post was deleted permanently.")
     static let movePageToTrash = NSLocalizedString("postsList.movePageToTrash.message", value: "Page moved to trash", comment: "A short message explaining that a page was moved to the trash bin.")
     static let deletePage = NSLocalizedString("postsList.deletePage.message", value: "Page deleted permanently", comment: "A short message explaining that a page was deleted permanently.")
-    static let errorTitle = NSLocalizedString("postNotice.errorTitle", value: "An error occured", comment: "A generic error message title")
+    static let genericErrorTitle = NSLocalizedString("postNotice.errorTitle", value: "An error occured", comment: "A generic error message title")
     static let buttonOK = NSLocalizedString("postNotice.ok", value: "OK", comment: "Button OK")
+    static let errorUnsyncedChangesMessage = NSLocalizedString("postNotice.errorUnsyncedChangesMessage", value: "The app is uploading previously made changes to the server. Please try again later.", comment: "An error message")
 }

--- a/WordPress/Classes/Services/PostRepository+Helpers.swift
+++ b/WordPress/Classes/Services/PostRepository+Helpers.swift
@@ -9,7 +9,10 @@ extension RemotePostCreateParameters {
             status: (post.status ?? .draft).rawValue
         )
         date = post.dateCreated
-        authorID = post.authorID?.intValue
+        // - warning: the currnet Core Data model defaults to `0`
+        if let authorID = post.authorID?.intValue, authorID > 0 {
+            self.authorID = authorID
+        }
         title = post.postTitle
         content = post.content
         password = post.password

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -3,8 +3,18 @@ import WordPressKit
 
 final class PostRepository {
 
-    enum Error: Swift.Error {
+    enum Error: Swift.Error, LocalizedError {
         case remoteAPIUnavailable
+        case hasUnsyncedChanges
+        case patchingUnsyncedPost // Should never happen
+
+        var errorDescription: String? {
+            switch self {
+            case .remoteAPIUnavailable: return Strings.genericErrorMessage
+            case .hasUnsyncedChanges: return Strings.errorUnsyncedChangesMessage
+            case .patchingUnsyncedPost: return Strings.genericErrorMessage
+            }
+        }
     }
 
     private let coreDataStack: CoreDataStackSwift
@@ -170,15 +180,19 @@ final class PostRepository {
     /// revisions are used only for content.
     @MainActor
     func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
-        let original = post.original ?? post
-        guard let postID = original.postID, postID.intValue > 0 else {
+        assert(post.isOriginal())
+
+        guard post.revision == nil else {
+            throw PostRepository.Error.hasUnsyncedChanges
+        }
+        guard let postID = post.postID, postID.intValue > 0 else {
             assertionFailure("Trying to patch a non-existent post")
-            return
+            throw PostRepository.Error.patchingUnsyncedPost
         }
         let uploadedPost = try await _patch(post, postID: postID, changes: changes, overwrite: true)
 
         let context = coreDataStack.mainContext
-        PostHelper.update(original, with: uploadedPost, in: context, overwrite: true)
+        PostHelper.update(post, with: uploadedPost, in: context, overwrite: true)
         ContextManager.shared.saveContextAndWait(context)
     }
 
@@ -670,4 +684,9 @@ extension PostRepository {
         return updatedPosts
     }
 
+}
+
+private enum Strings {
+    static let genericErrorMessage = NSLocalizedString("postList.genericErrorMessage", value: "Something went wrong", comment: "A generic error message title")
+    static let errorUnsyncedChangesMessage = NSLocalizedString("postList.errorUnsyncedChangesMessage", value: "The app is uploading previously made changes to the server. Please try again later.", comment: "An error message")
 }

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -213,7 +213,8 @@ final class PostRepository {
             case .conflict:
                 // Fetch the latest post to consolidate the changes
                 let remotePost = try await service.post(withID: postID)
-                if changes.content != nil && remotePost.content != original.content {
+                // Check for false positives
+                if changes.content != nil && remotePost.content != changes.content && remotePost.content != original.content {
                     // The conflict in content can be resolved only manually
                     throw PostSaveError.conflict(latest: remotePost)
                 }

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -154,7 +154,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.duplicate, .publish],
+            [.publish, .duplicate],
             [.setParent],
             [.trash]
         ]
@@ -174,7 +174,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.moveToDraft, .publish],
+            [.moveToDraft],
             [.setParent],
             [.trash]
         ]

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum AbstractPostHelper {
+    /// - warning: deprecated (kahu-offline-mode)
     static func editorPublishAction(for post: AbstractPost) -> PostEditorAction {
         post.blog.isPublishingPostsAllowed() ? .publish : .submitForReview
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -123,7 +123,11 @@ extension AbstractPostButton: AbstractPostMenuAction {
         switch self {
         case .retry: return Strings.retry
         case .view: return post.status == .publish ? Strings.view : Strings.preview
-        case .publish: return AbstractPostHelper.editorPublishAction(for: post).publishActionLabel
+        case .publish:
+            guard RemoteFeatureFlag.syncPublishing.enabled() else {
+                return AbstractPostHelper.editorPublishAction(for: post).publishActionLabel
+            }
+            return Strings.publish
         case .stats: return Strings.stats
         case .duplicate: return Strings.duplicate
         case .moveToDraft: return Strings.draft
@@ -194,6 +198,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to trash", comment: "Label for a option that moves a post to the trash folder")
         static let view = NSLocalizedString("posts.view.actionTitle", value: "View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let preview = NSLocalizedString("posts.preview.actionTitle", value: "Preview", comment: "Label for the preview post button. Tapping displays the post as it appears on the web.")
+        static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish", comment: "Label for the publish post button.")
         static let retry = NSLocalizedString("posts.retry.actionTitle", value: "Retry", comment: "Retry uploading the post.")
         static let share = NSLocalizedString("posts.share.actionTitle", value: "Share", comment: "Share the post.")
         static let blaze = NSLocalizedString("posts.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the post with Blaze.")

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -52,7 +52,11 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
     private func createSecondarySection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        if !page.isStatus(in: [.draft, .pending]) && !isSiteHomepage {
+        if canPublish {
+            buttons.append(.publish)
+        }
+
+        if page.status != .draft && !isSiteHomepage {
             buttons.append(.moveToDraft)
         }
 
@@ -64,12 +68,10 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             buttons.append(.share)
         }
 
-        if page.status != .trash && page.isFailed {
-            buttons.append(.retry)
-        }
-
-        if canPublish {
-            buttons.append(.publish)
+        if !isSyncPublishingEnabled {
+            if page.status != .trash && page.isFailed {
+                buttons.append(.retry)
+            }
         }
 
         return AbstractPostButtonSection(buttons: buttons)

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -52,7 +52,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
     private func createSecondarySection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        if (page.status != .draft  || page.status != .pending) && !isSiteHomepage {
+        if !page.isStatus(in: [.draft, .pending]) && !isSiteHomepage {
             buttons.append(.moveToDraft)
         }
 
@@ -80,7 +80,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             return !page.isFailed && page.status != .publish && page.status != .trash
         }
         let userCanPublish = page.blog.capabilities != nil ? page.blog.isPublishingPostsAllowed() : true
-        return (page.status == .draft || page.status == .pending) && userCanPublish
+        return page.isStatus(in: [.draft, .pending]) && userCanPublish
     }
 
     private func createBlazeSection() -> AbstractPostButtonSection {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -241,10 +241,11 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     func statusAndBadges(separatedBy separator: String) -> String {
-        let sticky = post.isStickyPost && !isUploadingOrFailed ? Constants.stickyLabel : ""
+        let sticky = post.isStickyPost ? Constants.stickyLabel : ""
+        let pending = (post.status == .pending && isSyncPublishingEnabled) ? Constants.pendingReview : ""
         let status = self.status ?? ""
 
-        return [status, sticky].filter { !$0.isEmpty }.joined(separator: separator)
+        return [status, pending, sticky].filter { !$0.isEmpty }.joined(separator: separator)
     }
 
     /// Determine what the failed status message should be and return it.
@@ -266,6 +267,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
 
     private enum Constants {
         static let stickyLabel = NSLocalizedString("Sticky", comment: "Label text that defines a post marked as sticky")
+        static let pendingReview = NSLocalizedString("postList.badgePendingReview", value: "Pending review", comment: "Badge for post cells")
     }
 
     enum StatusMessages {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -86,6 +86,23 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     var statusColor: UIColor {
+        guard isSyncPublishingEnabled else {
+            return _statusColor
+        }
+        switch post.status ?? .draft {
+        case .pending:
+            return .success
+        case .scheduled:
+            return .primary(.shade40)
+        case .trash:
+            return .error
+        default:
+            return .neutral(.shade70)
+        }
+    }
+
+    /// - warning: deprecated (kahu-offline-mode)
+    var _statusColor: UIColor {
         guard let status = postStatus else {
             return .neutral(.shade70)
         }
@@ -166,7 +183,11 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     private func createSecondarySection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        if post.status != .draft && post.status != .pending {
+        if canPublish {
+            buttons.append(.publish)
+        }
+
+        if post.status != .draft {
             buttons.append(.moveToDraft)
         }
 
@@ -188,10 +209,6 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
             if canCancelAutoUpload && !isInternetReachable {
                 buttons.append(.cancelAutoUpload)
             }
-        }
-
-        if canPublish {
-            buttons.append(.publish)
         }
 
         return AbstractPostButtonSection(buttons: buttons)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -15,6 +15,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     private let isBlazeFlagEnabled: Bool
     private let isSyncPublishingEnabled: Bool
 
+    /// - warning: deprecated (kahu-offline-mode)
     var progressBlock: ((Float) -> Void)? = nil {
         didSet {
             if let _ = oldValue, let uuid = progressObserverUUID {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -166,7 +166,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     private func createSecondarySection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        if post.status != .draft {
+        if post.status != .draft && post.status != .pending {
             buttons.append(.moveToDraft)
         }
 
@@ -230,12 +230,16 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
         return autoUploadInteractor.canCancelAutoUpload(of: post)
     }
 
-    /// Returns true if any of the following conditions are true:
-    ///
-    /// * The post is a draft.
-    /// * The post failed to upload and has local changes but the user canceled auto-uploading
-    /// * The upload failed and the user cannot Cancel it anymore. This happens when we reached the maximum number of retries.
     private var canPublish: Bool {
+        guard isSyncPublishingEnabled else {
+            return _canPublish
+        }
+        let userCanPublish = post.blog.capabilities != nil ? post.blog.isPublishingPostsAllowed() : true
+        return (post.status == .draft || post.status == .pending) && userCanPublish
+    }
+
+    /// - warning: deprecated (kahu-offline-mode)
+    private var _canPublish: Bool {
         let isNotCancelableWithFailedToUploadChanges: Bool = post.isFailed && post.hasLocalChanges() && !autoUploadInteractor.canCancelAutoUpload(of: post)
         return post.isDraft() || isNotCancelableWithFailedToUploadChanges
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -371,7 +371,7 @@ extension PublishingEditor {
             return discardAndDismiss()
         }
 
-        if post.original().status == .draft {
+        if post.original().isStatus(in: [.draft, .pending]) {
             showCloseDraftConfirmationAlert()
         } else {
             showClosePublishedPostConfirmationAlert()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -133,10 +133,17 @@ extension PublishingEditor {
         case .schedule, .publish:
             showPrepublishingSheet(for: action, analyticsStat: analyticsStat)
         case .update:
-            performUpdatePostAction()
+            guard !isUploadingMedia else {
+                return displayMediaIsUploadingAlert()
+            }
+            performUpdateAction()
         case .submitForReview:
-            // TODO: Show Prepublishing VC
-            fatalError("Not implemented (kahu-offline-mode)")
+            guard !isUploadingMedia else {
+                return displayMediaIsUploadingAlert()
+            }
+            var changes = RemotePostUpdateParameters()
+            changes.status = Post.Status.pending.rawValue
+            performUpdateAction(changes: changes)
         case .save, .saveAsDraft, .continueFromHomepageEditing:
             assertionFailure("No longer used and supported")
             break
@@ -171,15 +178,16 @@ extension PublishingEditor {
         dismissOrPopView()
     }
 
-    private func performUpdatePostAction() {
+    private func performUpdateAction(changes: RemotePostUpdateParameters? = nil) {
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.show()
         postEditorStateContext.updated(isBeingPublished: true)
 
         Task { @MainActor in
             do {
-                try await PostCoordinator.shared._save(post)
-                dismissOrPopView()
+                let post = try await PostCoordinator.shared._save(post, changes: changes)
+                self.post = post
+                self.createRevisionOfPost()
             } catch {
                 postEditorStateContext.updated(isBeingPublished: false)
             }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -281,7 +281,7 @@ public class PostEditorStateContext {
         case .draft:
             return makePublishAction()
         case .pending:
-            return .update
+            return userCanPublish ? .publish : .update
         case .publishPrivate, .publish, .scheduled:
             return .update
         case .trash, .deleted:

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -105,6 +105,9 @@ private func makeBadgesString(for post: Post, syncStateViewModel: PostSyncStateV
     if !shouldHideAuthor, let author = post.authorForDisplay() {
         badges.append((author, nil))
     }
+    if !syncStateViewModel.isEditable {
+        badges = badges.map { ($0.0, UIColor.textTertiary) }
+    }
     return AbstractPostHelper.makeBadgesString(with: badges)
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -25,7 +25,7 @@ extension PostSettingsViewController {
     }
 
     @objc var isDraftOrPending: Bool {
-        [Post.Status.draft, Post.Status.draft].contains(apost.original().status)
+        apost.original().isStatus(in: [.draft, .pending])
     }
 
     @objc func setupStandaloneEditor() {

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -81,7 +81,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
             .map { $0.buttons }
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
-            [.duplicate, .publish],
+            [.publish, .duplicate],
             [.settings],
             [.trash]
         ]


### PR DESCRIPTION
## Changes

- Add "Submit for Review" support
- When you "Update" the post, stay in the editor
- Show "Publish" as a primary action for admin
- Remove the "Submit for Review" from the list context menu (too many entry-points; low usage; rarely gets tested → let's keep it simple)
- Fix an issue where you couldn't save changes to a pending draft by tapping "Back"
- Fix an issue where the "Status" and "Visibility" sections were still visible in "Post Settings" for pending posts for admins
- Fix a false positive for data conflicts (see test 3.1)

## Tests

**Submit for Review (Contributor)**

**Test 1.1**

- Login as a contributor
- Create a new draft
- Set a breakpoint on `/rest/v1.1/sites/*/media/new`
- Add a media asset
- Tap "Submit for Review"
- **Verify** that the the wait-until-media-is-uploaded alert is shown
- Delete the asset

**Test 1.2**

- Login as a contributor
- Create a new draft
- Tap "Submit for Review"
- **Verify** that the spinner is shown
- **Verify** that editor was dismissed and the snackbar confirming submission was shown
- **Verify** that the post was submitted for review
- **Verify** that the cell in the post list has a "Pending review" label

**Test 1.3**

- Open an exisitng "pending" post as a contributor
- Make changes
- **Verify** that the primary button is "Update"
- Tap "Update"
- **Verify** that the changes were saved
- **Verify** that the editor is still opened and a new revision got created: you can add more changes, discard them, etc
- **Verify** that if you don't make any additional changes, you can tap "Back" to dismiss the editor without needed to confirm the action

**Test 1.4**

- Open an existing "pending" post as a contributor
- Make changes
- Tap "Back"
- Tap "Save Draft Changes"
- **Verify** that the changes were saved (asyncronously)

**Test 1.5.1**

Moving a pending post back to the `.draft` state.

- Create and submit a pending draft as a contributor
- Return to the list and open the context menu for the post
- Tap "Move to Draft"
- **Verify** that after a spinner, the post was moved back to draft

**Test 1.5.2**

Moving a pending post with unsaved changes back to the `.draft` state.

- Create and submit a pending draft as a contributor
- Return to the list and open the context menu for the post
- Set the breakpoint on `/rest/v1.2/sites/*/posts/*`
- Make and save some change to the draft by tapping "Back" and "Save Draft"
- Return to the list and open the context menu for the post
- Tap "Move to Draft"
- **Verify** that the post-is-being-uploaded-retry-later error is shown
- Release the breakpoint, retry and **verify** that the action was successful

> Note: this is maybe not the most elegant solution, but you are unlikely to hit it, and I think it's easy enough to understand what's going on.

**Submit for Review (Admin)**

**Test 2.1**

- Open a blog that has pending posts from other user as **an admin**
- **Verify** that you can publish a pending post using the context menu in the list

**Test 2.2**

- Open a pending post in the editor
- **Verify** that the primary action is "Publish"
- Tap "Publish" and **verify** that you can publish the post

**Test 2.3**

- Open a pending post in the editor
- Open "Post Settings"
- **Verify** that "Status" and "Visibility" rows are **not** available

**Test 2.4**

- Repeat tests 1.5.1 and 1.5.2 but as an admin.

**Data Conflicts**

**Test 3.1**

- Create a new draft with content "A" and save it
- Set the breakpoint on `/rest/v1.2/sites/*/posts/*`
- Change the content to "B" and save
- Release the request breakpoint (but **not** the response breakpoint)
- **Verify** that the content got updated on the server to "B"
- Terminate and re-start the app
- **Verify** that the app tries the upload again
- **Verify** that it hits 409 (release the breakpoints) but the upload succeeds (false positive data conflict)

> The reason why this happens is that the content on the remote get updated to "B" and the post gets assigned a new modified app, but the app still thinks that the upload didn't go through. When it tries again, it sends the old modified date.

## Regression Notes
1. Potential unintended areas of impact: Pending Posts
2. What I did to test those areas of impact (or what existing automated tests I relied on): Yes
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
