### PR TITLE
Reader: Create a feature flag for the Reader tags feed

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -12,6 +12,7 @@ enum FeatureFlag: Int, CaseIterable {
     case googleDomainsCard
     case newTabIcons
     case readerCustomization
+    case readerTagsFeed
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -39,6 +40,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .newTabIcons:
             return true
         case .readerCustomization:
+            return false
+        case .readerTagsFeed:
             return false
         }
     }
@@ -82,6 +85,8 @@ extension FeatureFlag {
             return "New Tab Icons"
         case .readerCustomization:
             return "Reader Customization"
+        case .readerTagsFeed:
+            return "Reader Tags Feed"
         }
     }
 }


### PR DESCRIPTION
Fixes #22950

> [!WARNING]
> Auto-merge is on.

## Description

Adds a feature flag for the Reader tags feed changes.

## Testing

To test:
- Navigate to the feature flag debug menu
- 🔎 **Verify** the reader tags feed feature flag appears

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
