### PR TITLE
Reader: Hide "Tags" chip on the Reader subscriptions feed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
@@ -17,7 +17,7 @@ struct ReaderTabItem: FilterTabBarItem, Hashable {
         let filterableTopicTypes = [ReaderTopicType.following, .organization]
         shouldHideStreamFilters = !filterableTopicTypes.contains(content.topicType) && content.type != .selfHostedFollowing
         shouldHideSettingsButton = content.type == .selfHostedFollowing
-        shouldHideTagFilter = content.topicType == .organization
+        shouldHideTagFilter = content.topicType == .organization || FeatureFlag.readerTagsFeed.enabled
     }
 
     static func == (lhs: ReaderTabItem, rhs: ReaderTabItem) -> Bool {


### PR DESCRIPTION
Fixes #22952 

## Description

Hides the "Tags" chip in the Reader Subscriptions feed.

## Testing

To test:
- Launch Jetpack and login
- Enable the Reader tags feed feature flag
- Navigate to the Reader Subscriptions feed
- 🔎 **Verify** the "Tags" chip is no longer shown (Note: may need to restart after changing feature flag)

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
