### PR TITLE
Stats: Localize percentage strings - update method signature

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -172,7 +172,7 @@ extension Float {
         return Double(self).abbreviatedString(forHeroNumber: forHeroNumber)
     }
 
-    func percentageString(forHeroNumber: Bool = false) -> String {
+    func percentageString() -> String {
         return Double(self).percentageString()
     }
 }
@@ -182,7 +182,7 @@ extension Int {
         return Double(self).abbreviatedString(forHeroNumber: forHeroNumber)
     }
 
-    func percentageString(forHeroNumber: Bool = false) -> String {
+    func percentageString() -> String {
         return Double(self).percentageString()
     }
 }


### PR DESCRIPTION
Continuation of https://github.com/wordpress-mobile/WordPress-iOS/pull/22918

Remove `forHeroNumber: Bool = false` from `func percentageString(forHeroNumber: Bool = false)` as asked in code review (https://github.com/wordpress-mobile/WordPress-iOS/pull/22918#discussion_r1549953659)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
