### PR TITLE
Bump up Gravatar to 1.0.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,8 @@ end
 
 def gravatar
   # pod 'Gravatar', path: '../Gravatar-SDK-iOS'
-  pod 'Gravatar', '1.0.0'
+  pod 'Gravatar', git: 'https://github.com/Automattic/Gravatar-SDK-iOS', commit: '16d650e6fe6825932cfd0acb14ff40a7b63b5a48'
+  # pod 'Gravatar', '1.0.0'
 end
 
 def wordpress_kit

--- a/Podfile
+++ b/Podfile
@@ -50,8 +50,8 @@ end
 
 def gravatar
   # pod 'Gravatar', path: '../Gravatar-SDK-iOS'
-  pod 'Gravatar', git: 'https://github.com/Automattic/Gravatar-SDK-iOS', commit: '16d650e6fe6825932cfd0acb14ff40a7b63b5a48'
-  # pod 'Gravatar', '1.0.0'
+  # pod 'Gravatar', git: 'https://github.com/Automattic/Gravatar-SDK-iOS', commit: ''
+  pod 'Gravatar', '1.0.1'
 end
 
 def wordpress_kit

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - Down (~> 0.6.6)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
-  - Gravatar (from `https://github.com/Automattic/Gravatar-SDK-iOS`, commit `16d650e6fe6825932cfd0acb14ff40a7b63b5a48`)
+  - Gravatar (= 1.0.1)
   - Gridicons (~> 1.2)
   - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec`)
   - JTAppleCalendar (~> 8.0.5)
@@ -142,6 +142,7 @@ SPEC REPOS:
     - CropViewController
     - Down
     - Gifu
+    - Gravatar
     - Gridicons
     - JTAppleCalendar
     - Kanvas
@@ -175,9 +176,6 @@ EXTERNAL SOURCES:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
-  Gravatar:
-    :commit: 16d650e6fe6825932cfd0acb14ff40a7b63b5a48
-    :git: https://github.com/Automattic/Gravatar-SDK-iOS
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
 
@@ -185,9 +183,6 @@ CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
-  Gravatar:
-    :commit: 16d650e6fe6825932cfd0acb14ff40a7b63b5a48
-    :git: https://github.com/Automattic/Gravatar-SDK-iOS
 
 SPEC CHECKSUMS:
   Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
@@ -234,6 +229,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 55ed04898812ee6978265038bdbd34e406589f1a
+PODFILE CHECKSUM: cff152d6fd3b6c78aa23f95c2449c871b1248397
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,7 +25,7 @@ PODS:
   - Down (0.6.6)
   - FSInteractiveMap (0.1.0)
   - Gifu (3.3.1)
-  - Gravatar (1.0.0)
+  - Gravatar (1.0.1)
   - Gridicons (1.2.0)
   - Gutenberg (1.116.0)
   - JTAppleCalendar (8.0.5)
@@ -105,7 +105,7 @@ DEPENDENCIES:
   - Down (~> 0.6.6)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.3.1)
-  - Gravatar (= 1.0.0)
+  - Gravatar (from `https://github.com/Automattic/Gravatar-SDK-iOS`, commit `16d650e6fe6825932cfd0acb14ff40a7b63b5a48`)
   - Gridicons (~> 1.2)
   - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec`)
   - JTAppleCalendar (~> 8.0.5)
@@ -142,7 +142,6 @@ SPEC REPOS:
     - CropViewController
     - Down
     - Gifu
-    - Gravatar
     - Gridicons
     - JTAppleCalendar
     - Kanvas
@@ -176,6 +175,9 @@ EXTERNAL SOURCES:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  Gravatar:
+    :commit: 16d650e6fe6825932cfd0acb14ff40a7b63b5a48
+    :git: https://github.com/Automattic/Gravatar-SDK-iOS
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
 
@@ -183,6 +185,9 @@ CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  Gravatar:
+    :commit: 16d650e6fe6825932cfd0acb14ff40a7b63b5a48
+    :git: https://github.com/Automattic/Gravatar-SDK-iOS
 
 SPEC CHECKSUMS:
   Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
@@ -195,7 +200,7 @@ SPEC CHECKSUMS:
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
-  Gravatar: bdd3950c5128304b51a9e655e4145334f23201d1
+  Gravatar: 51437de6811c1d8d6f60c52985f2ca00a85cfc8e
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   Gutenberg: fda9c1f9d8d5ec0b565d0efb32757a39b046f538
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
@@ -229,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: b361dfc7bcbb688ac4bf5bef27e75c33438c5fb3
+PODFILE CHECKSUM: 55ed04898812ee6978265038bdbd34e406589f1a
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
Fixes https://github.com/Automattic/Gravatar-SDK-iOS/issues/170

Gravatar PR: https://github.com/Automattic/Gravatar-SDK-iOS/pull/174

To test:

Use a network sniffer tool
Try uplading a new avatar
The request should contain a new header
"Client-Type":"ios"

<img width="667" alt="Screenshot 2024-04-04 at 12 42 36" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/5032900/474f100f-44ea-4101-91c0-7da09d672b37">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
