### PR TITLE
Offline Mode: Simplify Queries in Post List

### DIFF
--- a/WordPress/Classes/Models/BasePost.swift
+++ b/WordPress/Classes/Models/BasePost.swift
@@ -77,6 +77,7 @@ extension BasePost {
 }
 
 extension Sequence where Iterator.Element == BasePost.Status {
+    /// - warning: deprecated (kahu-offline-mode)
     var strings: [String] {
         return map({ $0.rawValue })
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -90,6 +90,8 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
             return
         }
 
+        contentView.isUserInteractionEnabled = viewModel.isEditable
+
         titleLabel.alpha = viewModel.isEditable ? 1 : 0.5
         contentStackView.alpha = viewModel.isEditable ? 1 : 0.5
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -13,11 +13,19 @@ final class PageListItemViewModel {
 
     init(page: Page, isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
         self.page = page
-        self.title = makeContentAttributedString(for: page)
-        self.badgeIcon = makeBadgeIcon(for: page)
-        self.badges = makeBadgesString(for: page, isSyncPublishingEnabled: isSyncPublishingEnabled)
-        self.imageURL = page.featuredImageURL
-        self.accessibilityIdentifier = page.slugForDisplay()
+
+        let revision: Page
+        if isSyncPublishingEnabled {
+            revision = (page.isUnsavedRevision ? page.original : page) as! Page
+        } else {
+            revision = page
+        }
+
+        self.badgeIcon = makeBadgeIcon(for: revision)
+        self.badges = makeBadgesString(for: revision, isSyncPublishingEnabled: isSyncPublishingEnabled)
+        self.imageURL = revision.featuredImageURL
+        self.title = makeContentAttributedString(for: revision)
+        self.accessibilityIdentifier = revision.slugForDisplay()
         self.syncStateViewModel = PostSyncStateViewModel(post: page, isSyncPublishingEnabled: isSyncPublishingEnabled)
 
         if isSyncPublishingEnabled {
@@ -29,7 +37,7 @@ final class PageListItemViewModel {
         guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
             return
         }
-        if updatedObjects.contains(page) || updatedObjects.contains(page.original()) {
+        if updatedObjects.contains(page.original()) {
             syncStateViewModel = PostSyncStateViewModel(post: page)
             didUpdateSyncState?(syncStateViewModel)
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -37,7 +37,7 @@ final class PageListItemViewModel {
         guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
             return
         }
-        if updatedObjects.contains(page.original()) {
+        if updatedObjects.contains(page) || updatedObjects.contains(page.original()) {
             syncStateViewModel = PostSyncStateViewModel(post: page)
             didUpdateSyncState?(syncStateViewModel)
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -13,19 +13,11 @@ final class PageListItemViewModel {
 
     init(page: Page, isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
         self.page = page
-
-        let revision: Page
-        if isSyncPublishingEnabled {
-            revision = (page.isUnsavedRevision ? page.original : page) as! Page
-        } else {
-            revision = page
-        }
-
-        self.badgeIcon = makeBadgeIcon(for: revision)
-        self.badges = makeBadgesString(for: revision, isSyncPublishingEnabled: isSyncPublishingEnabled)
-        self.imageURL = revision.featuredImageURL
-        self.title = makeContentAttributedString(for: revision)
-        self.accessibilityIdentifier = revision.slugForDisplay()
+        self.title = makeContentAttributedString(for: page)
+        self.badgeIcon = makeBadgeIcon(for: page)
+        self.badges = makeBadgesString(for: page, isSyncPublishingEnabled: isSyncPublishingEnabled)
+        self.imageURL = page.featuredImageURL
+        self.accessibilityIdentifier = page.slugForDisplay()
         self.syncStateViewModel = PostSyncStateViewModel(post: page, isSyncPublishingEnabled: isSyncPublishingEnabled)
 
         if isSyncPublishingEnabled {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -801,7 +801,7 @@ private enum EditorError: Int {
 }
 
 struct PostEditorDebouncerConstants {
-    static let autoSavingDelay = Double(0.5)
+    static let autoSavingDelay =  RemoteFeatureFlag.syncPublishing.enabled() ? Double(7.0) : Double(0.5)
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -170,6 +170,12 @@ extension PostEditor where Self: UIViewController {
     }
 
     private func appWillTerminate() {
+        // Defensive code to make sure that in rare scenarios where the user changes
+        // status from post settings but doesn't save, and the app gets terminated,
+        // the app doesn't end up saving posts with uncommited status changes.
+        if post.status != post.original().status {
+            post.status = post.original().status
+        }
         guard let context = post.managedObjectContext, post.hasChanges else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -32,30 +32,26 @@ final class PostListHeaderView: UIView {
             configureEllipsisButton(with: viewModel.post, delegate: delegate)
         }
         textLabel.attributedText = viewModel.badges
-
-        if RemoteFeatureFlag.syncPublishing.enabled() {
-            let syncStateViewModel = viewModel.syncStateViewModel
-            configureIcon(with: syncStateViewModel)
-
-            ellipsisButton.isHidden = !syncStateViewModel.isShowingEllipsis
-            icon.isHidden = syncStateViewModel.iconInfo == nil
-            indicator.isHidden = !syncStateViewModel.isShowingIndicator
-
-            if syncStateViewModel.isShowingIndicator {
-                indicator.startAnimating()
-            }
-        }
+        configure(with: viewModel.syncStateViewModel)
     }
 
-    private func configureIcon(with viewModel: PostSyncStateViewModel) {
+    func configure(with viewModel: PostSyncStateViewModel) {
         guard RemoteFeatureFlag.syncPublishing.enabled() else {
             return
         }
-        guard let iconInfo = viewModel.iconInfo else {
-            return
+
+        if let iconInfo = viewModel.iconInfo {
+            icon.image = iconInfo.image
+            icon.tintColor = iconInfo.color
         }
-        icon.image = iconInfo.image
-        icon.tintColor = iconInfo.color
+
+        ellipsisButton.isHidden = !viewModel.isShowingEllipsis
+        icon.isHidden = viewModel.iconInfo == nil
+        indicator.isHidden = !viewModel.isShowingIndicator
+
+        if viewModel.isShowingIndicator {
+            indicator.startAnimating()
+        }
     }
 
     private func configureEllipsisButton(with post: Post, delegate: InteractivePostViewDelegate) {

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -16,19 +16,11 @@ final class PostListItemViewModel {
 
     init(post: Post, shouldHideAuthor: Bool = false, isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
         self.post = post
-
-        let revision: Post
-        if isSyncPublishingEnabled {
-            revision = (post.isUnsavedRevision ? post.original : post) as! Post
-        } else {
-            revision = post
-        }
-
-        self.imageURL = revision.featuredImageURL
+        self.imageURL = post.featuredImageURL
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.syncStateViewModel = PostSyncStateViewModel(post: post)
-        self.badges = makeBadgesString(for: revision, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
-        self.content = makeContentString(for: revision, syncStateViewModel: syncStateViewModel)
+        self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
+        self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
 
         if isSyncPublishingEnabled {
             NotificationCenter.default.addObserver(self, selector: #selector(postCoordinatorDidUpdate), name: .postCoordinatorDidUpdate, object: nil)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -71,7 +71,9 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
             self?.handleRefreshNoResultsViewController($0)
         }
 
-        NotificationCenter.default.addObserver(self, selector: #selector(postCoordinatorDidUpdate), name: .postCoordinatorDidUpdate, object: nil)
+        if !RemoteFeatureFlag.syncPublishing.enabled() {
+            NotificationCenter.default.addObserver(self, selector: #selector(postCoordinatorDidUpdate), name: .postCoordinatorDidUpdate, object: nil)
+        }
     }
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -68,10 +68,12 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
             .sink { [weak self] in self?.reload(with: $0) }
             .store(in: &cancellables)
 
-        NotificationCenter.default
-            .publisher(for: .postCoordinatorDidUpdate, object: nil)
-            .sink { [weak self] in self?.reload(with: $0) }
-            .store(in: &cancellables)
+        if !RemoteFeatureFlag.syncPublishing.enabled() {
+            NotificationCenter.default
+                .publisher(for: .postCoordinatorDidUpdate, object: nil)
+                .sink { [weak self] in self?.reload(with: $0) }
+                .store(in: &cancellables)
+        }
 
         reload()
     }


### PR DESCRIPTION
This PR addresses the crashes in `postCoordinatorDidUpdate` and there are a couple of other improvements with how the list works:

- Update the post/page list cells to listen to `.postCoordinatorDidUpdate`. They will now reload automatically without reloading the list itself.
- Update the cells to display the latest saved revision. So it will no longer keep constantly reloading `makeContentString` (expensive, especially for long posts) during editing.
- Simplify queries in `PostListFilter`
- Reduce the intervals how often the editor saves to, again, reduce the number of reloads in the list

## To test:

- Create a new draft (post and page) and **verify** that the cell state updates during sync
- Make a change to a draft (post and page) and **verify** that the cell state updates during sync
- Publish a draft and **verify** that it gets displayed in the correct tab

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
