### PR TITLE
Reading Preferences: Fix customization sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -841,8 +841,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     @objc func didTapDisplaySettingButton(_ sender: UIBarButtonItem) {
         let viewController = ReaderDisplaySettingViewController(initialSetting: displaySetting) { [weak self] newSetting in
-            self?.displaySettingStore.setting = newSetting
-            self?.applyDisplaySetting()
+            // no need to refresh if there are no changes to the display setting.
+            guard let self,
+                  newSetting != self.displaySetting else {
+                return
+            }
+
+            self.displaySettingStore.setting = newSetting
+            self.applyDisplaySetting()
         }
 
         let navController = UINavigationController(rootViewController: viewController)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -840,31 +840,20 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     @objc func didTapDisplaySettingButton(_ sender: UIBarButtonItem) {
-        let vc = ReaderDisplaySettingViewController(initialSetting: displaySetting) { [weak self] newSetting in
+        let viewController = ReaderDisplaySettingViewController(initialSetting: displaySetting) { [weak self] newSetting in
             self?.displaySettingStore.setting = newSetting
             self?.applyDisplaySetting()
         }
-        let nav = UINavigationController(rootViewController: vc)
-        if let sheet = nav.sheetPresentationController {
+
+        let navController = UINavigationController(rootViewController: viewController)
+        navController.navigationBar.isTranslucent = true
+
+        if let sheet = navController.sheetPresentationController {
             sheet.detents = [.large()]
             sheet.prefersGrabberVisible = false
         }
 
-        vc.navigationItem.rightBarButtonItem = .init(systemItem: .close,
-                                                     primaryAction: UIAction { [weak vc] _ in
-            vc?.navigationController?.dismiss(animated: true)
-        })
-
-        nav.navigationBar.isTranslucent = true
-        vc.edgesForExtendedLayout = .top
-
-        let navAppearance = UINavigationBarAppearance()
-        navAppearance.configureWithTransparentBackground()
-        vc.navigationItem.standardAppearance = navAppearance
-        vc.navigationItem.scrollEdgeAppearance = navAppearance
-        vc.navigationItem.compactAppearance = navAppearance
-
-        navigationController?.present(nav, animated: true)
+        navigationController?.present(navController, animated: true)
     }
 
     /// A View Controller that displays a Post content.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1222,6 +1222,7 @@ private extension ReaderDetailViewController {
             return nil
         }
         let button = barButtonItem(with: icon, action: #selector(didTapDisplaySettingButton(_:)))
+        button.accessibilityLabel = Strings.displaySettingAccessibilityLabel
 
         return button
     }
@@ -1312,6 +1313,10 @@ extension ReaderDetailViewController {
             value: "Dismiss",
             comment: "Spoken accessibility label"
         )
+        static let displaySettingAccessibilityLabel = NSLocalizedString(
+            "readerDetail.displaySettingButton.accessibilityLabel",
+            value: "Reading Preferences",
+            comment: "Spoken accessibility label for the Reading Preferences menu.")
         static let safariButtonAccessibilityLabel = NSLocalizedString(
             "readerDetail.safariButton.accessibilityLabel",
             value: "Open in Safari",

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -147,9 +147,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     private func applyStyles() {
         backgroundColor = displaySetting == .standard ? .listForeground : displaySetting.color.background
         dividerView.backgroundColor = displaySetting == .standard ? .divider : displaySetting.color.border
-
-//        WPStyleGuide.applyReaderCardActionButtonStyle(commentButton)
-//        WPStyleGuide.applyReaderCardActionButtonStyle(likeButton)
     }
 
     // MARK: - Configuration

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -62,6 +62,8 @@ struct ReaderDisplaySetting: Codable, Equatable {
         case sepia
         case evening
         case oled
+        case hacker
+        case candy
 
         // TODO: Consider localization
         var label: String {
@@ -96,6 +98,18 @@ struct ReaderDisplaySetting: Codable, Equatable {
                     value: "OLED",
                     comment: "Name for the OLED color theme, used in the Reader's reading preferences."
                 )
+            case .hacker:
+                return NSLocalizedString(
+                    "reader.preferences.color.h4x0r",
+                    value: "h4x0r",
+                    comment: "Name for the h4x0r color theme, used in the Reader's reading preferences."
+                )
+            case .candy:
+                return NSLocalizedString(
+                    "reader.preferences.color.candy",
+                    value: "Candy",
+                    comment: "Name for the Candy color theme, used in the Reader's reading preferences."
+                )
             }
         }
 
@@ -111,6 +125,10 @@ struct ReaderDisplaySetting: Codable, Equatable {
                 return .init(fromHex: 0xabaab2)
             case .oled:
                 return .text.color(for: .init(userInterfaceStyle: .dark))
+            case .hacker:
+                return .green
+            case .candy:
+                return .init(fromHex: 0x0066ff)
             }
         }
 
@@ -135,6 +153,10 @@ struct ReaderDisplaySetting: Codable, Equatable {
                 return .init(fromHex: 0x3a3a3c)
             case .oled:
                 return .systemBackground.color(for: .init(userInterfaceStyle: .dark))
+            case .hacker:
+                return .systemBackground.color(for: .init(userInterfaceStyle: .dark))
+            case .candy:
+                return .init(fromHex: 0xffe8fd)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -196,6 +196,41 @@ struct ReaderDisplaySetting: Codable, Equatable {
                 return 1.25
             }
         }
+
+        var accessibilityLabel: String {
+            switch self {
+            case .extraSmall:
+                return NSLocalizedString(
+                    "reader.preferences.size.extraSmall",
+                    value: "Extra Small",
+                    comment: "Accessibility label for the Extra Small size option, used in the Reader's reading preferences."
+                )
+            case .small:
+                return NSLocalizedString(
+                    "reader.preferences.size.small",
+                    value: "Small",
+                    comment: "Accessibility label for the Small size option, used in the Reader's reading preferences."
+                )
+            case .normal:
+                return NSLocalizedString(
+                    "reader.preferences.size.normal",
+                    value: "Normal",
+                    comment: "Accessibility label for the Normal size option, used in the Reader's reading preferences."
+                )
+            case .large:
+                return NSLocalizedString(
+                    "reader.preferences.size.large",
+                    value: "Large",
+                    comment: "Accessibility label for the Large size option, used in the Reader's reading preferences."
+                )
+            case .extraLarge:
+                return NSLocalizedString(
+                    "reader.preferences.size.extraLarge",
+                    value: "Extra Large",
+                    comment: "Accessibility label for the Extra Large size option, used in the Reader's reading preferences."
+                )
+            }
+        }
     }
 
     // MARK: Codable

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -127,6 +127,7 @@ struct ReaderDisplaySettingSelectionView: View {
             }
             .overlay(alignment: .top, content: { // add a thin top border.
                 Rectangle()
+                    .ignoresSafeArea()
                     .frame(width: nil, height: .hairlineBorderWidth, alignment: .top)
                     .foregroundStyle(Color(.tertiaryLabel))
             })

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -41,7 +41,7 @@ class ReaderDisplaySettingViewController: UIViewController {
 
 class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
 
-    let feedbackLinkString = String() // TODO: Update with actual link
+    let feedbackLinkString = "https://wordpress.com/about"
 
     @Published var displaySetting: ReaderDisplaySetting
 
@@ -100,25 +100,22 @@ extension ReaderDisplaySettingSelectionView {
         var body: some View {
             ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: .DS.Padding.double) {
-                    Text(Strings.Preview.title)
+                    Text(Strings.title)
                         .font(Font(viewModel.displaySetting.font(with: .title1)))
                         .foregroundStyle(Color(viewModel.displaySetting.color.foreground))
 
-                    tagsView
+                    Text(Strings.bodyText)
+                        .font(Font(viewModel.displaySetting.font(with: .callout)))
+                        .foregroundStyle(viewModel.foregroundColor)
 
-                    // TODO: Add feature flag for feedback collection.
-                    // TODO: Apply link styles.
-                    if let feedbackURL = URL(string: viewModel.feedbackLinkString) {
-                        Link(Strings.Preview.feedbackLinkText, destination: feedbackURL)
+                    if let feedbackText {
+                        feedbackText
+                            .font(Font(viewModel.displaySetting.font(with: .callout)))
+                            .foregroundStyle(viewModel.foregroundColor)
+                            .tint(Color(linkTintColor))
                     }
 
-                    Text(Strings.Preview.bodyDescription)
-                        .font(Font(viewModel.displaySetting.font(with: .callout)))
-                        .foregroundStyle(viewModel.foregroundColor)
-
-                    Text(Strings.Preview.bodyNotice)
-                        .font(Font(viewModel.displaySetting.font(with: .callout)))
-                        .foregroundStyle(viewModel.foregroundColor)
+                    tagsView
 
                     Spacer()
                 }
@@ -130,10 +127,31 @@ extension ReaderDisplaySettingSelectionView {
             .animation(.easeInOut, value: viewModel.displaySetting)
         }
 
+        var feedbackText: Text? {
+            // TODO: Check feature flag for feedback collection.
+            let linkMarkdownString = "[\(Strings.feedbackLinkCTA)](\(viewModel.feedbackLinkString))"
+            let string = String(format: Strings.feedbackLineFormat, linkMarkdownString)
+
+            guard var attributedString = try? AttributedString(markdown: string) else {
+                return nil
+            }
+
+            if viewModel.displaySetting.color != .system,
+               let rangeOfLink = attributedString.range(of: Strings.feedbackLinkCTA) {
+                attributedString[rangeOfLink].underlineStyle = .single
+            }
+
+            return Text(attributedString)
+        }
+
+        var linkTintColor: UIColor {
+            viewModel.displaySetting.color == .system ? UIColor.tintColor : viewModel.displaySetting.color.foreground
+        }
+
         var tagsView: some View {
             ScrollView(.horizontal) {
                 HStack(spacing: .DS.Padding.single) {
-                    ForEach(Strings.Preview.tags, id: \.self) { text in
+                    ForEach(Strings.tags, id: \.self) { text in
                         Text(text)
                             .font(Font(viewModel.displaySetting.font(with: .callout)))
                             .foregroundStyle(viewModel.foregroundColor)
@@ -149,38 +167,43 @@ extension ReaderDisplaySettingSelectionView {
         }
 
         private struct Strings {
-            struct Preview {
-                static let title = NSLocalizedString(
-                    "reader.preferences.preview.title",
-                    value: "Choose your Reading Preferences",
-                    comment: "Title text for a preview"
-                )
+            static let title = NSLocalizedString(
+                "reader.preferences.preview.header",
+                value: "Reading Preferences",
+                comment: "Title text for a preview"
+            )
 
-                static let tags = [
-                    NSLocalizedString("reader.preferences.preview.tags.1", value: "dogs", comment: "Example tag for preview"),
-                    NSLocalizedString("reader.preferences.preview.tags.2", value: "fox", comment: "Example tag for preview"),
-                    NSLocalizedString("reader.preferences.preview.tags.3", value: "design", comment: "Example tag for preview"),
-                    NSLocalizedString("reader.preferences.preview.tags.4", value: "writing", comment: "Example tag for preview"),
-                ]
+            static let bodyText = NSLocalizedString(
+                "reader.preferences.preview.body.text",
+                value: "Choose your colors, fonts, and sizes. Preview your selection here, and read posts with your styles once you're done.",
+                comment: "Description text for the preview section of Reader Preferences"
+            )
 
-                static let feedbackLinkText = NSLocalizedString(
-                    "reader.preferences.preview.body.feedbackLink",
-                    value: "Send us a feedback on this feature",
-                    comment: "Text for a feedback link for the Reader Preferences feature"
-                )
+            static let feedbackLineFormat = NSLocalizedString(
+                "reader.preferences.preview.body.feedback.format",
+                value: "This is a new feature still in development. To help us improve it %1$@.",
+                comment: """
+                Text format for the feedback line text, to be displayed in the preview section.
+                %1$@ is a placeholder for a call-to-action that completes the line, which will be filled programmatically.
+                Example: 'This is a new feature still in development. To help us improve it send your feedback.'
+                """
+            )
 
-                static let bodyDescription = NSLocalizedString(
-                    "reader.preferences.preview.body.description",
-                    value: "Reading is personal, we want you to have control. Choose the styles that suit you.",
-                    comment: "Description text for the preview section of Reader Preferences"
-                )
+            static let feedbackLinkCTA = NSLocalizedString(
+                "reader.preferences.preview.body.feedback.link",
+                value: "send your feedback",
+                comment: """
+                A call-to-action text fragment to ask the user provide feedback for the Reading Preferences feature.
+                Note that the lowercase format is intended, as this will be injected to form a full paragraph.
+                Refer to: `reader.preferences.preview.body.feedback.format`
+                """
+            )
 
-                static let bodyNotice = NSLocalizedString(
-                    "reader.preferences.preview.body.notice",
-                    value: "This feature is still in development.",
-                    comment: "Footnote to be displayed in the preview section, noticing that the feature is in development."
-                )
-            }
+            static let tags = [
+                NSLocalizedString("reader.preferences.preview.tags.reading", value: "reading", comment: "Example tag for preview"),
+                NSLocalizedString("reader.preferences.preview.tags.colors", value: "colors", comment: "Example tag for preview"),
+                NSLocalizedString("reader.preferences.preview.tags.fonts", value: "fonts", comment: "Example tag for preview"),
+            ]
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -41,7 +41,7 @@ class ReaderDisplaySettingViewController: UIViewController {
 
 class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
 
-    let feedbackLinkString = "https://wordpress.com/about"
+    let feedbackLinkString = String() // TODO: Update with the actual feedback link.
 
     @Published var displaySetting: ReaderDisplaySetting
 
@@ -97,6 +97,8 @@ extension ReaderDisplaySettingSelectionView {
     struct PreviewView: View {
         @ObservedObject var viewModel: ReaderDisplaySettingSelectionViewModel
 
+        @Environment(\.openURL) private var openURL
+
         var body: some View {
             ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: .DS.Padding.double) {
@@ -113,6 +115,10 @@ extension ReaderDisplaySettingSelectionView {
                             .font(Font(viewModel.displaySetting.font(with: .callout)))
                             .foregroundStyle(viewModel.foregroundColor)
                             .tint(Color(linkTintColor))
+                            .environment(\.openURL, OpenURLAction { url in
+                                // TODO: Add Tracks
+                                return .systemAction
+                            })
                     }
 
                     tagsView

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -130,7 +130,7 @@ extension ReaderDisplaySettingSelectionView {
         @Environment(\.openURL) private var openURL
 
         var body: some View {
-            ScrollView(.vertical) {
+            ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: .DS.Padding.double) {
                     Text(Strings.title)
                         .font(Font(viewModel.displaySetting.font(with: .title1)))
@@ -159,6 +159,16 @@ extension ReaderDisplaySettingSelectionView {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
             }
+            .mask({
+                // adds a soft gradient mask that hints that there are more content to scroll.
+                VStack(spacing: .zero) {
+                    Rectangle().fill(.black)
+                    LinearGradient(gradient: Gradient(colors: [.black, .clear]),
+                                   startPoint: .top,
+                                   endPoint: .bottom)
+                    .frame(height: Constants.gradientMaskHeight)
+                }
+            })
             .background(viewModel.backgroundColor)
             .animation(.easeInOut, value: viewModel.displaySetting)
         }
@@ -201,6 +211,10 @@ extension ReaderDisplaySettingSelectionView {
                     }
                 }
             }
+        }
+
+        private struct Constants {
+            static let gradientMaskHeight = 32.0
         }
 
         private struct Strings {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -74,9 +74,6 @@ class ReaderDisplaySettingViewController: UIViewController {
 // MARK: View Model
 
 class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
-
-    let feedbackLinkString = String() // TODO: Update with the actual feedback link.
-
     @Published var displaySetting: ReaderDisplaySetting
 
     /// Called when the user selects a new color.
@@ -213,7 +210,7 @@ extension ReaderDisplaySettingSelectionView {
         var feedbackText: Text? {
             // TODO: Check feature flag for feedback collection.
 
-            let linkMarkdownString = "[\(Strings.feedbackLinkCTA)](\(viewModel.feedbackLinkString))"
+            let linkMarkdownString = "[\(Strings.feedbackLinkCTA)](\(Constants.feedbackLinkString))"
             let string = String(format: Strings.feedbackLineFormat, linkMarkdownString)
 
             guard var attributedString = try? AttributedString(markdown: string) else {
@@ -252,6 +249,8 @@ extension ReaderDisplaySettingSelectionView {
 
         private struct Constants {
             static let gradientMaskHeight = 32.0
+
+            static let feedbackLinkString = "https://automattic.survey.fm/reader-customization-survey"
         }
 
         private struct Strings {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -168,7 +168,7 @@ extension ReaderDisplaySettingSelectionView {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: .DS.Padding.double) {
                     Text(Strings.title)
-                        .font(Font(viewModel.displaySetting.font(with: .title1)))
+                        .font(Font(viewModel.displaySetting.font(with: .title1, weight: .semibold)))
                         .foregroundStyle(viewModel.foregroundColor)
 
                     Text(Strings.bodyText)
@@ -212,14 +212,18 @@ extension ReaderDisplaySettingSelectionView {
         var feedbackText: Text? {
             // TODO: Check feature flag for feedback collection.
 
-            let linkString = "[\(Strings.feedbackLinkCTA)](\(Constants.feedbackLinkString))"
+            var linkString = "[\(Strings.feedbackLinkCTA)](\(Constants.feedbackLinkString))"
+            if viewModel.displaySetting.color != .system {
+                // for color themes other than the default, we'll mark it bold.
+                linkString = "**\(linkString)**"
+            }
+
             let string = String(format: Strings.feedbackLineFormat, linkString)
             guard var attributedString = try? AttributedString(markdown: string) else {
                 return nil
             }
 
-            if viewModel.displaySetting.color != .system,
-               let rangeOfLink = attributedString.range(of: Strings.feedbackLinkCTA) {
+            if let rangeOfLink = attributedString.range(of: Strings.feedbackLinkCTA) {
                 attributedString[rangeOfLink].underlineStyle = .single
             }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -231,7 +231,7 @@ extension ReaderDisplaySettingSelectionView {
         }
 
         var linkTintColor: UIColor {
-            viewModel.displaySetting.color == .system ? UIColor.tintColor : viewModel.displaySetting.color.foreground
+            viewModel.displaySetting.color == .system ? .muriel(color: .init(name: .blue)) : viewModel.displaySetting.color.foreground
         }
 
         var tagsView: some View {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -179,6 +179,7 @@ extension ReaderDisplaySettingSelectionView {
                             .font(Font(viewModel.displaySetting.font(with: .callout)))
                             .foregroundStyle(viewModel.foregroundColor)
                             .tint(Color(linkTintColor))
+                            .accessibilityAddTraits(.isLink)
                             .environment(\.openURL, OpenURLAction { url in
                                 // TODO: Add Tracks
                                 return .systemAction
@@ -210,9 +211,8 @@ extension ReaderDisplaySettingSelectionView {
         var feedbackText: Text? {
             // TODO: Check feature flag for feedback collection.
 
-            let linkMarkdownString = "[\(Strings.feedbackLinkCTA)](\(Constants.feedbackLinkString))"
-            let string = String(format: Strings.feedbackLineFormat, linkMarkdownString)
-
+            let linkString = "[\(Strings.feedbackLinkCTA)](\(Constants.feedbackLinkString))"
+            let string = String(format: Strings.feedbackLineFormat, linkString)
             guard var attributedString = try? AttributedString(markdown: string) else {
                 return nil
             }
@@ -244,12 +244,13 @@ extension ReaderDisplaySettingSelectionView {
                             }
                     }
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Strings.tagsListAccessibilityLabel)
             }
         }
 
         private struct Constants {
             static let gradientMaskHeight = 32.0
-
             static let feedbackLinkString = "https://automattic.survey.fm/reader-customization-survey"
         }
 
@@ -291,6 +292,12 @@ extension ReaderDisplaySettingSelectionView {
                 NSLocalizedString("reader.preferences.preview.tags.colors", value: "colors", comment: "Example tag for preview"),
                 NSLocalizedString("reader.preferences.preview.tags.fonts", value: "fonts", comment: "Example tag for preview"),
             ]
+
+            static let tagsListAccessibilityLabel = NSLocalizedString(
+                "reader.preferences.preview.tagsList.a11y",
+                value: "Example tags",
+                comment: "Accessibility label for a list of tags in the preview section."
+            )
         }
     }
 
@@ -350,9 +357,12 @@ extension ReaderDisplaySettingSelectionView {
                                                   : Color(UIColor.label.withAlphaComponent(0.1)), lineWidth: 1.0)
                             }
                         }
+                        .accessibilityAddTraits(color == viewModel.displaySetting.color ? .isSelected : [])
                     }
                 }
                 .padding(.leading, .DS.Padding.double) // initial content offset
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel(Strings.colorListAccessibilityLabel)
             }
         }
 
@@ -380,6 +390,8 @@ extension ReaderDisplaySettingSelectionView {
                                                   : Color(UIColor.label.withAlphaComponent(0.1)), lineWidth: 1.0)
                             }
                         }
+                        .accessibilityAddTraits(font == viewModel.displaySetting.font ? .isSelected : [])
+                        .accessibilityLabel(font.rawValue.capitalized)
                     }
                 }
                 .padding(.leading, .DS.Padding.double) // initial content offset
@@ -394,13 +406,16 @@ extension ReaderDisplaySettingSelectionView {
             } minimumValueLabel: {
                 Text("A")
                     .font(Font(ReaderDisplaySetting.font(with: .sans, size: .extraSmall, textStyle: .body)))
+                    .accessibilityHidden(true)
             } maximumValueLabel: {
                 Text("A")
                     .font(Font(ReaderDisplaySetting.font(with: .sans, size: .extraLarge, textStyle: .body)))
+                    .accessibilityHidden(true)
             } onEditingChanged: { _ in
                 viewModel.displaySetting.size = .init(rawValue: Int(sliderValue)) ?? .normal
             }
             .padding(.vertical, .DS.Padding.single)
+            .accessibilityValue(Text(viewModel.displaySetting.size.accessibilityLabel))
         }
     }
 
@@ -415,6 +430,18 @@ extension ReaderDisplaySettingSelectionView {
             "reader.preferences.control.sizeSlider.description",
             value: "Size",
             comment: "Describes that the slider is used to customize the text size in the Reader."
+        )
+
+        static let colorListAccessibilityLabel = NSLocalizedString(
+            "reader.preferences.control.colors.a11y",
+            value: "Colors",
+            comment: "Accessibility label describing the list of colors to be selected from."
+        )
+
+        static let fontListAccessibilityLabel = NSLocalizedString(
+            "reader.preferences.control.fonts.a11y",
+            value: "Fonts",
+            comment: "Accessibility label describing the list of fonts to be selected from."
         )
     }
 }


### PR DESCRIPTION
Part of #22925 

In this PR, several improvements are included for the customization sheet, which should also address the issues raised in https://github.com/wordpress-mobile/WordPress-iOS/pull/22851#pullrequestreview-1967363382:

- The navigation bar button now adapts to the currently highlighted color theme.
- Added decent/passable support for landscape mode.
- Added accessibility support.
- Added `h4x0r` and `Candy` themes. 🎨  
- Added a soft gradient at the bottom of the Preview section to indicate that there are more contents to scroll.
- Added the actual feedback survey link.

| Portrait | Landscape |
-|-
![Simulator Screenshot - iPhone 15 - 2024-04-05 at 03 08 45](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/8fd8f306-831f-4495-8ad7-538001cc6f37) |  ![Simulator Screenshot - iPhone 15 - 2024-04-05 at 03 28 38](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/d7b9b527-3552-409e-ac3e-b65da28d5206)

## To test

- Launch the Jetpack app.
- Ensure that the `Reader Customization` flag is enabled.
- Go to the Reader tab and open any post.
- Tap the reading preferences button.
- 🔎 Test the screen with various configurations. Verify that the contents are all reachable, both in portrait and landscape mode.
- 🔎 Test with VoiceOver, and verify that the hierarchy of the customization sheet makes sense.

## Regression Notes
1. Potential unintended areas of impact
Should be none. This change is isolated to the customization sheet, which is a new component that's hidden behind a disabled feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
