### PR TITLE
Stats Period: Optimize table view updates by integrating diffable data source

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -45,9 +45,10 @@ struct StatsGhostTopImmutableRow: StatsRowGhostable {
         return ImmuTableCell.nib(StatsGhostTopCell.defaultNib, StatsGhostTopCell.self)
     }()
 
+    var statSection: StatSection? = nil
     var hideTopBorder = false
     var hideBottomBorder = false
-    var statSection: StatSection? = nil
+    var hideTitle = false
 
     // MARK: - Hashable
 
@@ -65,7 +66,9 @@ struct StatsGhostTopImmutableRow: StatsRowGhostable {
         if let detailCell = cell as? StatsGhostTopCell {
             detailCell.topBorder?.isHidden = hideTopBorder
             detailCell.bottomBorder?.isHidden = hideBottomBorder
-            detailCell.statSection = statSection
+            if !hideTitle {
+                detailCell.statSection = statSection
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -5,7 +5,7 @@ import DGCharts
 // MARK: - Shared Rows
 
 // TODO: Remove with SiteStatsPeriodViewModelDeprecated
-struct OverviewRow: ImmuTableRow {
+struct OverviewRow: StatsHashableImmuTableRow {
 
     typealias CellType = OverviewCell
 
@@ -24,11 +24,6 @@ struct OverviewRow: ImmuTableRow {
 
     // MARK: - Hashable
 
-    static func == (lhs: OverviewRow, rhs: OverviewRow) -> Bool {
-        return lhs.tabsData == rhs.tabsData &&
-            lhs.chartHighlightIndex == rhs.chartHighlightIndex
-    }
-
     func configureCell(_ cell: UITableViewCell) {
 
         guard let cell = cell as? CellType else {
@@ -36,6 +31,10 @@ struct OverviewRow: ImmuTableRow {
         }
 
         cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period, statsBarChartViewDelegate: statsBarChartViewDelegate, barChartHighlightIndex: chartHighlightIndex)
+    }
+
+    static func == (lhs: OverviewRow, rhs: OverviewRow) -> Bool {
+        return lhs.tabsData == rhs.tabsData && lhs.period == rhs.period && lhs.chartHighlightIndex == rhs.chartHighlightIndex
     }
 }
 struct StatsTrafficBarChartRow: StatsHashableImmuTableRow {
@@ -110,6 +109,7 @@ struct CellHeaderRow: StatsHashableImmuTableRow {
     }()
 
     let statSection: StatSection?
+    var displayTitle: Bool = true
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -118,7 +118,11 @@ struct CellHeaderRow: StatsHashableImmuTableRow {
             return
         }
 
-        cell.configure(statSection: statSection)
+        if displayTitle {
+            cell.configure(statSection: statSection)
+        } else {
+            cell.configure()
+        }
     }
 
     // MARK: - Hashable
@@ -128,7 +132,7 @@ struct CellHeaderRow: StatsHashableImmuTableRow {
     }
 }
 
-struct TableFooterRow: ImmuTableRow {
+struct TableFooterRow: StatsHashableImmuTableRow {
 
     typealias CellType = StatsTableFooter
 
@@ -137,10 +141,15 @@ struct TableFooterRow: ImmuTableRow {
     }()
 
     let action: ImmuTableAction? = nil
+    let statSection: StatSection? = nil
 
     func configureCell(_ cell: UITableViewCell) {
         // No configuration needed.
         // This method is needed to satisfy ImmuTableRow protocol requirements.
+    }
+
+    static func == (lhs: TableFooterRow, rhs: TableFooterRow) -> Bool {
+        return true
     }
 }
 
@@ -461,8 +470,7 @@ struct AddInsightStatRow: ImmuTableRow {
 
 // MARK: - Period Rows
 
-struct PeriodEmptyCellHeaderRow: ImmuTableRow {
-
+struct PeriodEmptyCellHeaderRow: StatsHashableImmuTableRow {
     typealias CellType = StatsCellHeader
 
     static let cell: ImmuTableCell = {
@@ -470,6 +478,7 @@ struct PeriodEmptyCellHeaderRow: ImmuTableRow {
     }()
 
     let action: ImmuTableAction? = nil
+    let statSection: StatSection?
 
     func configureCell(_ cell: UITableViewCell) {
 
@@ -478,6 +487,10 @@ struct PeriodEmptyCellHeaderRow: ImmuTableRow {
         }
 
         cell.configure()
+    }
+
+    static func == (lhs: PeriodEmptyCellHeaderRow, rhs: PeriodEmptyCellHeaderRow) -> Bool {
+        return lhs.statSection == rhs.statSection
     }
 }
 
@@ -899,6 +912,7 @@ struct StatsErrorRow: StatsHashableImmuTableRow {
     let rowStatus: StoreFetchingStatus
     let statType: StatType
     let statSection: StatSection?
+    var hideTitle: Bool = false
 
     private let noDataRow = StatsNoDataRow.loadFromNib()
 
@@ -918,7 +932,7 @@ struct StatsErrorRow: StatsHashableImmuTableRow {
         noDataRow.configure(forType: statType, rowStatus: rowStatus)
         cell.insert(view: noDataRow)
 
-        if let statSection = statSection {
+        if let statSection = statSection, !hideTitle {
            cell.statSection = statSection
         }
     }


### PR DESCRIPTION
Related PRs:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22542
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22592
- https://github.com/wordpress-mobile/WordPress-iOS/pull/22823

### Description

Introduce diffable data source into Days/Weeks/Months/Years tab since we continue using these tabs and the functionality requires only a couple of changes. It avoids annoying flickering and unnecessary reloads of the view.

### To test

### Happy Path
1. Select a high traffic site
2. Open `Days/Weeks/Months/Years` tab
3. Confirm data loads without flickering

### Error Path

1. Turn-off internet connection
2. Open `Days/Weeks/Months/Years` tab
3. Confirm error states appear correctly

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
