### PR TITLE
Offline Mode: Previews

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -207,6 +207,10 @@ class PostCoordinator: NSObject {
     @discardableResult @MainActor
     func _save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
         let post = post.original()
+
+        await pauseSyncing(for: post)
+        defer { resumeSyncing(for: post) }
+
         do {
             let isExistingPost = post.hasRemote()
             // TODO: Set overwrite to false once conflict resolution support is added

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -272,6 +272,17 @@ final class PostRepository {
         ContextManager.shared.saveContextAndWait(context)
     }
 
+    /// Creates an autosave with the changes in the given revision.
+    @MainActor
+    func autosave(_ revision: AbstractPost) async throws -> PostServiceRemoteREST.AutosaveResponse {
+        assert(revision.isRevision())
+        guard let remote = try getRemoteService(for: revision.blog) as? PostServiceRemoteREST else {
+            throw Error.remoteAPIUnavailable
+        }
+        let post = PostHelper.remotePost(with: revision)
+        return try await remote.createAutosave(with: post)
+    }
+
     /// Permanently delete the given post from local database and the post's WordPress site.
     ///
     /// - Parameter postID: Object ID of the post

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -15,3 +15,23 @@ extension PostServiceRemote {
         }
     }
 }
+
+extension PostServiceRemoteREST {
+    struct AutosaveResponse {
+        var previewURL: URL
+    }
+
+    func createAutosave(with post: RemotePost) async throws -> AutosaveResponse {
+        try await withCheckedThrowingContinuation { continuation in
+            self.autoSave(post, success: { _, previewURL in
+                guard let previewURL = previewURL.flatMap(URL.init) else {
+                    return continuation.resume(throwing: URLError(.unknown))
+                }
+                let response = AutosaveResponse(previewURL: previewURL)
+                continuation.resume(returning: response)
+            }, failure: {
+                continuation.resume(throwing: $0 ?? URLError(.unknown))
+            })
+        }
+    }
+}

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -496,7 +496,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
 
     /// Scenario: the app needs to upload the most recent revision to the server
     /// to generate a preview.
-    func testSaveDraftPostChangesImmediatellyFailure() async throws {
+    func testSaveDraftPostChangesImmediatelyFailure() async throws {
         // GIVEN a draft post with an unsynced revision and a local revision
         // that wasn't commited yet
         let post = PostBuilder(mainContext, blog: blog).build()

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -460,7 +460,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
 
     /// Scenario: the app needs to upload the most recent revision to the server
     /// to generate a preview.
-    func testSaveDraftPostChangesImmediatelly() async throws {
+    func testSaveDraftPostChangesImmediately() async throws {
         // GIVEN a draft post with an unsynced revision and a local revision
         // that wasn't commited yet
         let post = PostBuilder(mainContext, blog: blog).build()

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -1271,22 +1271,19 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // GIVEN a server with the an updated content (but not title)
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
             XCTFail("No POST requests should be made")
-            return try HTTPStubsResponse(value: WordPressComPost.mock, statusCode: 202)
+            return HTTPStubsResponse(error: URLError(.unknown))
         }
 
         stub(condition: isPath("/rest/v1.1/sites/80511/posts/974")) { request in
-            var post = WordPressComPost.mock
-            post.title = "title-a"
-            post.content = "content-b"
-            return try HTTPStubsResponse(value: post, statusCode: 200)
+            XCTFail("No GET requests should be made")
+            return HTTPStubsResponse(error: URLError(.unknown))
         }
 
         // WHEN saving the post
         try await repository.sync(post)
 
-        // THEN is gets the latest revision from the server but sends no changes
+        // THEN the local revisions are deleted
         XCTAssertEqual(post.postTitle, "title-a")
-        XCTAssertEqual(post.content, "content-b")
         XCTAssertNil(post.revision)
     }
 


### PR DESCRIPTION
Update "Preview" button to use the new services.

## To test:

### Previews

**Test 1.1**

- Open an existing post (publish|publishPrivate|scheduled)
- Make a change 
- Tap "Preview"
- **Verify** that the preview was generated
- Open the same post on the web
- **Verify** that the "View autosave" panel is shown 

> Note: not ideal, but it matches the existing behavior in production

**Test 1.2**

- Open an existing draft post
- Make a change
- Tap "Preview"
- **Verify** that the preview was generated
- **Verify** that the post was synced

**Test 1.3**

- Create a new draft post
- Tap "Preview"
- **Verify** that the preview was generated
- **Verify** that the post was synced

### Misc

**Test 2.1**

**Precondition**: app is offline.

- Open an existing draft post with content A
- Change the content to B
- Save draft
- Change the content back to A
- Save draft
- **Verify** that the spinner was dismissed; not network requests made

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
