### PR TITLE
Offline Mode: Revisions

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -158,6 +158,7 @@ extension PostEditor {
 
     func displayHistory() {
         guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            _displayHistory()
             return
         }
         let viewController = RevisionsTableViewController(post: post) { _ in }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -2,6 +2,7 @@ class RevisionsTableViewController: UITableViewController {
     typealias RevisionLoadedBlock = (AbstractPost) -> Void
 
     var onRevisionLoaded: RevisionLoadedBlock
+    var onRevisionSelected: ((Revision) -> Void)?
 
     private var post: AbstractPost?
     private var manager: ShowRevisionsListManger?
@@ -146,6 +147,12 @@ private extension RevisionsTableViewController {
     }
 
     private func load(_ revision: Revision) {
+        if let onRevisionSelected {
+            onRevisionSelected(revision)
+            return
+        }
+
+        // - warning: deprecated (kahu-offline-mode_
         guard let blog = post?.blog else {
             return
         }


### PR DESCRIPTION
This PR simplifies the revisions support. It will no longer re-fetch the revision form the server as an instance of an `AbstractPost` and will no longer save it in the database. The behavior now matches that of the web where it simply applies the revision's content to the post. 

I also removed the "Undo" button from the notice because you can simply tap "Back" in the editor if you change your mind.

## Testing

- Open a post with revisions
- Select and load a revision
- **Verify** the the post content got updated
- Tap "Undo"
- **Verify** the the post content got reverted

There is no need to test anything else because loading a revision simply replaces the content in the editor. Any other flows that follow it remain exactly the same.

## Regression Notes
1. Potential unintended areas of impact: Revisions
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
