### PR TITLE
Offline Mode: Migration

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -14,6 +14,14 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
     AbstractPostRemoteStatusSync,       // Post uploaded
     AbstractPostRemoteStatusPushingMedia, // Push Media
     AbstractPostRemoteStatusAutoSaved,       // Post remote auto-saved
+
+    // All the previous states were deprecated in 24.7 and are no longer used
+    // by the app. To get the status of the uploads, use `PostCoordinator`.
+
+    /// The default state of the newly created local revision.
+    AbstractPostRemoteStatusLocalRevision,
+    /// The user saved the revision, and it needs to be uploaded to a server.
+    AbstractPostRemoteStatusSyncNeeded
 };
 
 @interface AbstractPost : BasePost
@@ -49,6 +57,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, copy, nullable) NSDate *autosaveModifiedDate;
 @property (nonatomic, copy, nullable) NSNumber *autosaveIdentifier;
 
+/// - warning: deprecated (kahu-offline-mode)
 @property (nonatomic, strong, nullable) NSString *confirmedChangesHash;
 @property (nonatomic, strong, nullable) NSDate *confirmedChangesTimestamp;
 

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -153,7 +153,7 @@
 
     AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];
     [post cloneFrom:self];
-    post.isSyncNeeded = NO;
+    post.remoteStatus = AbstractPostRemoteStatusLocalRevision;
     [post setValue:self forKey:@"original"];
     [post setValue:nil forKey:@"revision"];
     return post;

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -19,6 +19,14 @@ extension AbstractPost {
         isRevision() && !isSyncNeeded
     }
 
+    /// Returns `true` if the post object is a revision created by one of the
+    /// versions of the app prior to 24.7.
+    var isLegacyUnsavedRevision: Bool {
+        isRevision() && AbstractPost.deprecatedStatuses.contains(remoteStatus)
+    }
+
+    private static let deprecatedStatuses: Set<AbstractPostRemoteStatus> = [.pushing, .failed, .local, .sync, .pushingMedia, .autoSaved]
+
     // MARK: - Status
 
     /// Returns `true` is the post has one of the given statuses.
@@ -36,7 +44,6 @@ extension AbstractPost {
         return AbstractPost.title(for: status)
     }
 
-    /// - note: deprecated (kahu-offline-mode)
     @objc
     var remoteStatus: AbstractPostRemoteStatus {
         get {
@@ -195,14 +202,9 @@ extension AbstractPost {
         return revisions
     }
 
-    // TODO: Replace with a new flag
-    /// - note: Work-in-progress (kahu-offline-mode)
     @objc var isSyncNeeded: Bool {
-        get { confirmedChangesHash == AbstractPost.syncNeededKey }
-        set { confirmedChangesHash = newValue ? AbstractPost.syncNeededKey : "" }
+        remoteStatus == .syncNeeded
     }
-
-    static let syncNeededKey = "sync-needed"
 
     /// Returns the latest saved revisions that needs to be synced with the server.
     /// Returns `nil` if there are no such revisions.

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -321,7 +321,8 @@ class PostCoordinator: NSObject {
         assert(isSyncAllowed(for: revision.original()), "Sync is not supported for this post")
 
         if !revision.isSyncNeeded {
-            revision.isSyncNeeded = true
+            revision.remoteStatus = .syncNeeded
+            revision.confirmedChangesTimestamp = Date()
             ContextManager.shared.saveContextAndWait(coreDataStack.mainContext)
         }
         startSync(for: revision.original())
@@ -332,7 +333,7 @@ class PostCoordinator: NSObject {
     /// - note: It should typically only be called once during the app launch.
     func initializeSync() {
         let request = NSFetchRequest<AbstractPost>(entityName: NSStringFromClass(AbstractPost.self))
-        request.predicate = NSPredicate(format: "confirmedChangesHash == %@", AbstractPost.syncNeededKey)
+        request.predicate = NSPredicate(format: "remoteStatusNumber == %i", AbstractPostRemoteStatus.syncNeeded.rawValue)
         do {
             let revisions = try coreDataStack.mainContext.fetch(request)
             let originals = Set(revisions.map { $0.original() })
@@ -942,6 +943,9 @@ class PostCoordinator: NSObject {
     }
 
     private func change(post: AbstractPost, status: AbstractPostRemoteStatus, then completion: ((AbstractPost) -> ())? = nil) {
+        guard !isSyncPublishingEnabled else {
+            return
+        }
         guard let context = post.managedObjectContext else {
             return
         }

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -126,7 +126,8 @@ private extension ContentMigrationCoordinator {
                                              NSNumber(value: AbstractPostRemoteStatus.pushing.rawValue),
                                              NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
                                              NSNumber(value: AbstractPostRemoteStatus.local.rawValue),
-                                             NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue))
+                                             NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.syncNeeded.rawValue))
         guard let count = try? coreDataStack.mainContext.count(for: fetchRequest) else {
             return false
         }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -49,6 +49,9 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
         guard isSyncPublishingEnabled else {
             return _status
         }
+        if post.isLegacyUnsavedRevision {
+            return StatusMessages.localChanges
+        }
         return nil
     }
 
@@ -89,6 +92,9 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     var statusColor: UIColor {
         guard isSyncPublishingEnabled else {
             return _statusColor
+        }
+        if post.isLegacyUnsavedRevision {
+            return .warning
         }
         switch post.status ?? .draft {
         case .pending:

--- a/WordPress/WordPressTest/AbstractPostTest.swift
+++ b/WordPress/WordPressTest/AbstractPostTest.swift
@@ -51,7 +51,7 @@ class AbstractPostTest: CoreDataTestCase {
 
         // GIVEN a post with a revision that needs sync
         let revision2 = revision1._createRevision()
-        revision2.isSyncNeeded = true
+        revision2.remoteStatus = .syncNeeded
 
         // THEN
         XCTAssertEqual(post.getLatestRevisionNeedingSync(), revision2)

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -481,15 +481,15 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
 
         let revision1 = post._createRevision()
         revision1.content = "content-b"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         let revision2 = revision1._createRevision()
         revision2.content = "content-c"
-        revision2.isSyncNeeded = true
+        revision2.remoteStatus = .syncNeeded
 
         let revision3 = revision2._createRevision()
         revision3.content = "content-d"
-        revision3.isSyncNeeded = false
+        XCTAssertFalse(revision3.isSyncNeeded)
 
         try mainContext.save()
 
@@ -523,7 +523,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
 
         let revision1 = post._createRevision()
         revision1.content = "content-b"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         let revision2 = revision1._createRevision()
         revision2.content = "content-c"
@@ -559,7 +559,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
 
         let revision1 = post._createRevision()
         revision1.content = "content-b"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         let revision2 = revision1._createRevision()
         revision2.content = "content-c"

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -25,7 +25,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
         let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: .testInstance()))
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock, isSyncPublishingEnabled: false)
 
         postCoordinator.save(post)
 
@@ -122,7 +122,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
         let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: .testInstance()))
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock, isSyncPublishingEnabled: false)
         var returnedError: Error?
 
         postCoordinator.save(post) { result in
@@ -370,8 +370,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock,
-                                              actionDispatcherFacade: actionDispatcherFacadeMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock, actionDispatcherFacade: actionDispatcherFacadeMock, isSyncPublishingEnabled: false)
 
         // Act
         var result: Result<AbstractPost, Error>? = nil
@@ -387,7 +386,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         expect(actionDispatcherFacadeMock.dispatchedActions).toEventuallyNot(beEmpty())
 
         guard case let NoticeAction.post(notice)? = actionDispatcherFacadeMock.dispatchedActions.first else {
-            assertionFailure("The action should be a NoticeAction")
+            XCTFail("The action should be a NoticeAction")
             return
         }
 
@@ -409,7 +408,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
 
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock, isSyncPublishingEnabled: false)
 
         // Act
         var results = [Result<AbstractPost, Error>]()

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -1044,11 +1044,11 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // GIVEN a post that has changes that need to be synced (across two local revision)
         let revision1 = post._createRevision()
         revision1.postTitle = "title-b"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         let revision2 = revision1._createRevision()
         revision2.postTitle = "title-c"
-        revision2.isSyncNeeded = true
+        revision2.remoteStatus = .syncNeeded
 
         // GIVEN a revision created by an editor
         let revision3 = revision2._createRevision()
@@ -1097,7 +1097,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN
-        revision3.isSyncNeeded = true
+        revision3.remoteStatus = .syncNeeded
         try await repository.sync(post)
 
         // THEN it uploads the latest revision
@@ -1126,7 +1126,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // GIVEN a post that has changes that need to be synced (across two local revision)
         let revision1 = post._createRevision()
         revision1.content = "content-b"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         let revision2 = revision1._createRevision()
         revision2.content = "content-c"
@@ -1200,7 +1200,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN syncing remaining changes
-        revision2.isSyncNeeded = true
+        revision2.remoteStatus = .syncNeeded
         try await repository.sync(post)
 
         // THEN it uploads the latest revision and ignores 409 because it's
@@ -1221,7 +1221,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         let revision = post.createRevision()
         revision.postTitle = "title-a"
         revision.content = "content-a"
-        revision.isSyncNeeded = true
+        revision.remoteStatus = .syncNeeded
 
         // GIVEN a server accepting the new post
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { request in
@@ -1262,11 +1262,11 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // GIVEN a change that was reverted in a more recent revision
         let revision1 = post._createRevision()
         revision1.postTitle = "title-b"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         let revision2 = revision1._createRevision()
         revision2.postTitle = "title-a"
-        revision2.isSyncNeeded = true
+        revision2.remoteStatus = .syncNeeded
 
         // GIVEN a server with the an updated content (but not title)
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
@@ -1299,7 +1299,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         let revision1 = post._createRevision()
         revision1.postTitle = "title-a"
         revision1.content = "content-a"
-        revision1.isSyncNeeded = true
+        revision1.remoteStatus = .syncNeeded
 
         // GIVEN a local revision
         let revision2 = revision1._createRevision()


### PR DESCRIPTION
Improves the migration from the previous version. The app will now display the previous "Local changes" status for all old posts that had revisions that never got uploaded.

## Testing

**Test 1.1**

**Precondition**: set breakpoint on `/rest/v1.2/sites/*/posts/*?` and make all requests to create and update posts fail.

- Create a new draft
- Tap "Publish"
- **Verify** that the request was sent (and failed)
- Enable "Syncronous Publishing" and restart the app
- **Verify** that the post was displayed in the "Draft" tab with a "Local changes" status
- Open the post and publish it
- **Verify** that the post got published

**Test 1.2**

**Precondition**: set breakpoint on `/rest/v1.2/sites/*/posts/*?`

- Create a new draft
- Save changes and wait until it syncs (request succeeds)
- Open the draft again and make changes
- Save the changes (request fails)
- Enable "Syncronous Publishing" and restart the app
- **Verify** that the post was displayed in the "Draft" tab with a "Local changes" status
- Open the post and tap "back" and "Save Draft"
- **Verify** that the new spinner got displayed (together with "Local changes") and the post got updated

**Test 1.3**

- **Verify** that for the revisions created using the new system, the "local changes" status isn't displayed


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
