### PR TITLE
Offline Mode: Instrumentation

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -569,6 +569,10 @@ import Foundation
     // Widgets
     case widgetsLoadedOnApplicationOpened
 
+    // Assertions & Errors
+    case assertionFailure
+    case postCoordinatorErrorEncountered
+
     // Site monitoring
     case siteMonitoringTabShown
     case siteMonitoringEntryDetailsShown
@@ -1551,6 +1555,12 @@ import Foundation
         // Widgets
         case .widgetsLoadedOnApplicationOpened:
             return "widgets_loaded_on_application_opened"
+
+        // Assertions & Errors
+        case .assertionFailure:
+            return "assertion_failure"
+        case .postCoordinatorErrorEncountered:
+            return "post-coordinator-eerror-encountered"
 
         // Site Monitoring
         case .siteMonitoringTabShown:

--- a/WordPress/Classes/Utility/WPInstrumentation.swift
+++ b/WordPress/Classes/Utility/WPInstrumentation.swift
@@ -37,33 +37,33 @@ extension WordPressAPIError: TrackableErrorProtocol {
     func getTrackingUserInfo() -> [String: String]? {
         switch self {
         case .requestEncodingFailure(let underlyingError):
-            return getUserInfo(for: underlyingError, category: "request-encoding-failure")
+            return getUserInfo(for: underlyingError, category: "request_encoding_failure")
         case .connection(let error):
             return getUserInfo(for: error, category: "connection")
         case .endpointError(let endpointError):
             switch endpointError {
             case let error as WordPressComRestApiEndpointError:
                 return [
-                    "category": "wpcom-endpoint-error",
-                    "wpcom-endpoint-error-api-error-code": error.apiErrorCode?.description ?? "–",
-                    "wpcom-endpoint-error-api-error-message": error.apiErrorMessage ?? "–"
+                    "category": "wpcom_endpoint_error",
+                    "wpcom_endpoint_error_api_error_code": error.apiErrorCode?.description ?? "–",
+                    "wpcom_endpoint_error_api_error_message": error.apiErrorMessage ?? "–"
                 ]
             case let error as WordPressOrgXMLRPCApiFault:
                 return [
-                    "category": "xmlrpc-endpoint-error",
-                    "xmlrpc-endpoint-error-api-error-code": error.code?.description ?? "–",
-                    "xmlrpc-endpoint-error-api-error-message": error.message ?? "–"
+                    "category": "xmlrpc_endpoint_error",
+                    "xmlrpc_endpoint_error_api_error_code": error.code?.description ?? "–",
+                    "xmlrpc_endpoint_error_api_error_message": error.message ?? "–"
                 ]
             default:
-                return ["category": "unexpected-endpoint-error"]
+                return ["category": "unexpected_endpoint_error"]
             }
         case let .unacceptableStatusCode(response, _):
             return [
-                "category": "unacceptable-status-code",
-                "status-code": response.statusCode.description
+                "category": "unacceptable_status_code",
+                "status_code": response.statusCode.description
             ]
         case let .unparsableResponse(_, _, error):
-            return getUserInfo(for: error, category: "unparsable-response")
+            return getUserInfo(for: error, category: "unparsable_response")
         case .unknown(let error):
             return getUserInfo(for: error, category: "unknown")
         }
@@ -73,7 +73,7 @@ extension WordPressAPIError: TrackableErrorProtocol {
 private func getUserInfo(for error: Error, category: String) -> [String: String] {
     return [
         "category": category,
-        "\(category)-error-domain": (error as NSError).domain,
-        "\(category)-error-code": (error as NSError).code.description
+        "\(category)_error_domain": (error as NSError).domain,
+        "\(category)_error_code": (error as NSError).code.description
     ]
 }

--- a/WordPress/Classes/Utility/WPInstrumentation.swift
+++ b/WordPress/Classes/Utility/WPInstrumentation.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Sentry
+
+// MARK: - Assertions
+
+func wpAssert(_ closure: @autoclosure () -> Bool, _ message: StaticString = "–", file: StaticString = #file, line: UInt = #line) {
+    guard !closure() else {
+        return
+    }
+
+    let filename = (file.description as NSString).lastPathComponent
+    DDLogError("WPAssertionFailure in \(filename)–\(line): \(message)")
+
+    WPAnalytics.track(.assertionFailure, properties: [
+        "file": filename,
+        "line": line,
+        "message": "\(filename)–\(line): \(message)"
+    ])
+
+#if DEBUG
+    assertionFailure(message.description, file: file, line: line)
+#endif
+}
+
+func wpAssertionFailure(_ message: StaticString, file: StaticString = #file, line: UInt = #line) {
+    wpAssert(false, message, file: file, line: line)
+}
+
+// MARK: - Error Tracking
+
+protocol TrackableErrorProtocol {
+    func getTrackingUserInfo() -> [String: String]?
+}
+
+extension WordPressAPIError: TrackableErrorProtocol {
+    /// Returns a Tracks-compatible user info.
+    func getTrackingUserInfo() -> [String: String]? {
+        switch self {
+        case .requestEncodingFailure(let underlyingError):
+            return getUserInfo(for: underlyingError, category: "request-encoding-failure")
+        case .connection(let error):
+            return getUserInfo(for: error, category: "connection")
+        case .endpointError(let endpointError):
+            switch endpointError {
+            case let error as WordPressComRestApiEndpointError:
+                return [
+                    "category": "wpcom-endpoint-error",
+                    "wpcom-endpoint-error-api-error-code": error.apiErrorCode?.description ?? "–",
+                    "wpcom-endpoint-error-api-error-message": error.apiErrorMessage ?? "–"
+                ]
+            case let error as WordPressOrgXMLRPCApiFault:
+                return [
+                    "category": "xmlrpc-endpoint-error",
+                    "xmlrpc-endpoint-error-api-error-code": error.code?.description ?? "–",
+                    "xmlrpc-endpoint-error-api-error-message": error.message ?? "–"
+                ]
+            default:
+                return ["category": "unexpected-endpoint-error"]
+            }
+        case let .unacceptableStatusCode(response, _):
+            return [
+                "category": "unacceptable-status-code",
+                "status-code": response.statusCode.description
+            ]
+        case let .unparsableResponse(_, _, error):
+            return getUserInfo(for: error, category: "unparsable-response")
+        case .unknown(let error):
+            return getUserInfo(for: error, category: "unknown")
+        }
+    }
+}
+
+private func getUserInfo(for error: Error, category: String) -> [String: String] {
+    return [
+        "category": category,
+        "\(category)-error-domain": (error as NSError).domain,
+        "\(category)-error-code": (error as NSError).code.description
+    ]
+}

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -144,7 +144,7 @@ extension PublishingEditor {
             changes.status = Post.Status.pending.rawValue
             performUpdateAction(changes: changes)
         case .save, .saveAsDraft, .continueFromHomepageEditing:
-            assertionFailure("No longer used and supported")
+            wpAssertionFailure("No longer used and supported")
             break
         }
     }
@@ -154,7 +154,7 @@ extension PublishingEditor {
             guard let self else { return }
             switch result {
             case .confirmed:
-                assertionFailure("Not used when .syncPublishing is enabled")
+                wpAssertionFailure("Not used when .syncPublishing is enabled")
                 break
             case .published:
                 self.emitPostSaveEvent()
@@ -711,10 +711,10 @@ extension PublishingEditor {
             return _createRevisionOfPost(loadAutosaveRevision: loadAutosaveRevision)
         }
         guard let managedObjectContext = post.managedObjectContext else {
-            return assertionFailure()
+            return wpAssertionFailure("managedObjectContext is missing")
         }
 
-        assert(post.latest() == post, "Must be opened with the latest verison of the post")
+        wpAssert(post.latest() == post, "Must be opened with the latest verison of the post")
 
         if !post.isUnsavedRevision {
             DDLogDebug("Creating new revision")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -583,6 +583,8 @@
 		0CE7833E2B08F3C300B114EB /* ExternalMediaPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */; };
 		0CE783412B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
 		0CE783422B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
+		0CEA55522BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
+		0CEA55532BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
 		0CED1FED2B61AAF600E6DD52 /* AtomicSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */; };
 		0CED1FEE2B61AAF600E6DD52 /* AtomicSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */; };
 		0CED20002B6809CB00E6DD52 /* FilterCompactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */; };
@@ -6326,6 +6328,7 @@
 		0CE58A2C2B35C91900E87D1E /* SiteMediaPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPreviewViewController.swift; sourceTree = "<group>"; };
 		0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerViewController.swift; sourceTree = "<group>"; };
 		0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerCollectionCell.swift; sourceTree = "<group>"; };
+		0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPInstrumentation.swift; sourceTree = "<group>"; };
 		0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicSiteService.swift; sourceTree = "<group>"; };
 		0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactButton.swift; sourceTree = "<group>"; };
 		0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactDatePicker.swift; sourceTree = "<group>"; };
@@ -13988,6 +13991,7 @@
 				E114D798153D85A800984182 /* WPError.h */,
 				E114D799153D85A800984182 /* WPError.m */,
 				57D5812C2228526C002BAAD7 /* WPError+Swift.swift */,
+				0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */,
 				8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */,
 				5D6C4B061B603E03005E3C43 /* WPTableViewHandler.h */,
 				5D6C4B071B603E03005E3C43 /* WPTableViewHandler.m */,
@@ -22320,6 +22324,7 @@
 				2FA6511721F26A24009AA935 /* ChangePasswordViewController.swift in Sources */,
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
 				982DA9A7263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
+				0CEA55522BC55940008D0FE5 /* WPInstrumentation.swift in Sources */,
 				80F8DAC1282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */,
 				FAFF7A1C2B693D8B006A7CB2 /* PHPLogsView.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
@@ -25432,6 +25437,7 @@
 				FABB24262602FC2C00C8785C /* SiteAssemblyStep.swift in Sources */,
 				FABB24272602FC2C00C8785C /* SiteSettingsViewController+Swift.swift in Sources */,
 				3FFDEF8F29187F1200B625CE /* MigrationHeaderConfiguration.swift in Sources */,
+				0CEA55532BC55940008D0FE5 /* WPInstrumentation.swift in Sources */,
 				FABB24282602FC2C00C8785C /* FilterTableData.swift in Sources */,
 				FABB24292602FC2C00C8785C /* ReaderGapMarker.m in Sources */,
 				FABB242A2602FC2C00C8785C /* Pattern.swift in Sources */,


### PR DESCRIPTION
This PR adds some basic instrumentation:

- Add `WPAssert` to capture assertions in production
- Add tracking for post sync errors (also using Tracks)

To test: n/a

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
