### PR TITLE
Fix flaky testCreateBlankPage

### DIFF
--- a/WordPress/UITests/Tests/PagesTests.swift
+++ b/WordPress/UITests/Tests/PagesTests.swift
@@ -5,8 +5,8 @@ class PageTests: XCTestCase {
 
     @MainActor
     override func setUp() async throws {
-        setUpTestSuite(selectWPComSite: WPUITestCredentials.testWPcomFreeSite)
         try await WireMock.setUpScenario(scenario: "new_page_flow")
+        setUpTestSuite(selectWPComSite: WPUITestCredentials.testWPcomFreeSite)
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
Fixes `testCreateBlankPage()`.


To test:

## RCA

- `setUpTestSuite(selectWPComSite: WPUITestCredentials.testWPcomFreeSite)` launches the app and nearly instantly logs the user in (which is awesome – thank you!)
- The app fetches the list of pages and transition the test scenario to the `initial_pages_list` state
- The app calls `try await WireMock.setUpScenario(scenario: "new_page_flow")` and reset the scenario state back to "Started"

As a result, the mock server returns the following error when you try to upload a post:

```
                                               Request was not matched
                                               =======================

-----------------------------------------------------------------------------------------------------------------------
| Closest stub                                             | Request                                                  |
-----------------------------------------------------------------------------------------------------------------------
                                                           |
POST                                                       | POST
[path] /rest/v1.2/sites/181851495/posts/new                | /rest/v1.2/sites/181851495/posts/new?context=edit&locale=
                                                           | en
                                                           |
Query: context = edit                                      | context: edit
Query: locale = en                                         | locale: en
                                                           |
[Scenario 'new_page_flow' state: initial_pages_list]       | [Scenario 'new_page_flow' state: Started]           <<<<< Scenario does not match
            
```

It's a race condition and it depends on whether the pages are fetched before or after the reset happens.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
