### PR TITLE
Add filesize in media item view controlller

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -98,6 +98,7 @@ final class MediaItemViewController: UITableViewController {
         var rows = [ImmuTableRow]()
         rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename ?? ""))
         rows.append(TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: presenter.fileType ?? ""))
+        rows.append(TextRow(title: NSLocalizedString("File size", comment: "Label for the file size for a media asset"), value: presenter.fileSize ?? ""))
 
         switch media.mediaType {
         case .image, .video:
@@ -425,6 +426,25 @@ private struct MediaMetadataPresenter {
         }
 
         return (filename as NSString).pathExtension.uppercased()
+    }
+
+    var fileSize: String? {
+        guard let fileSizeInBytes = media.filesize as? Int else {
+            return nil
+        }
+
+        let sizeAbbreviations = ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+        var sizeAbbreviationsIndex = 0
+        var capacity = Double(fileSizeInBytes)
+
+        while capacity > 1024 {
+            capacity /= 1024
+            sizeAbbreviationsIndex += 1
+        }
+
+        let formattedCapacity = String(format: "%4.2f", capacity)
+        let sizeAbbreviation = sizeAbbreviations[sizeAbbreviationsIndex]
+        return "\(formattedCapacity) \(sizeAbbreviation)"
     }
 }
 


### PR DESCRIPTION
Fixes #22737 

To test:

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

## Attachments

| Header | Header |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-10 at 17 34 16](https://github.com/wordpress-mobile/WordPress-iOS/assets/48347505/9a635f3e-335e-4f69-b948-eb6f7e03f2ec)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-10 at 17 34 10](https://github.com/wordpress-mobile/WordPress-iOS/assets/48347505/fb5b79aa-ad08-46cc-bdba-04cd9ab8e514) | 


