### PR TITLE
Reading Preferences: Polish Post web view + handle change updates

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -604,8 +604,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         if let post {
             webView.displaySetting = displaySetting
             webView.loadHTMLString(post.contentForDisplay())
-            // TODO: Fix sizing
         }
+
+        // Likes view
+        likesSummary.displaySetting = displaySetting
 
         // Comments table view
         commentsTableViewDelegate.displaySetting = displaySetting
@@ -712,6 +714,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private func configureLikesSummary() {
         likesSummary.delegate = coordinator
+        likesSummary.displaySetting = displaySetting
         likesContainerView.addSubview(likesSummary)
         likesContainerView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -185,7 +185,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     // Reader customization model
     private lazy var displaySettingStore: ReaderDisplaySettingStore = {
-        return .init()
+        let store = ReaderDisplaySettingStore()
+        store.delegate = self
+        return store
     }()
 
     // Convenient access to the underlying structure
@@ -560,7 +562,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     /// Apply view styles
-    private func applyStyles() {
+    @MainActor private func applyStyles() {
         guard let readableGuide = webView.superview?.readableContentGuide else {
             return
         }
@@ -1067,6 +1069,14 @@ extension ReaderDetailViewController: UITableViewDataSource, UITableViewDelegate
         default:
             return nil
         }
+    }
+}
+
+// MARK: - ReaderDisplaySettingStoreDelegate
+
+extension ReaderDetailViewController: ReaderDisplaySettingStoreDelegate {
+    func displaySettingDidChange() {
+        applyDisplaySetting()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -175,6 +175,13 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
+        // Re-apply the styles after a potential orientation change.
+        // This fixes a case where the navbar tint would revert after changing orientation.
+        if ReaderDisplaySetting.customizationEnabled {
+            resetNavigationBarTintColor()
+            resetStatusBarStyle()
+        }
+
         updateIfNotLoading()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -191,6 +191,12 @@ class ReaderWebView: WKWebView {
                 font: -apple-system-body !important;
                 font-family: \(displaySetting.font.cssString) !important;
             }
+
+            /* link styling */
+            a {
+                font-weight: \(displaySetting.color == .system ? "inherit" : "600");
+                text-decoration: underline;
+            }
         """
     }
 
@@ -218,18 +224,62 @@ class ReaderWebView: WKWebView {
         return """
             :root {
               --color-text: #\(displaySetting.color.foreground.color(for: trait).hexString() ?? "");
-              --color-neutral-0: #\(UIColor.listForegroundUnread.color(for: trait).hexString() ?? "");
-              --color-neutral-5: #\(UIColor(light: .muriel(color: .gray, .shade5),
-                            dark: .muriel(color: .gray, .shade80)).color(for: trait).hexString() ?? "");
-              --color-neutral-10: #\(UIColor(light: .muriel(color: .gray, .shade10),
-                            dark: .muriel(color: .gray, .shade30)).color(for: trait).hexString() ?? "");
-              --color-neutral-40: #\(UIColor(light: .muriel(color: .gray, .shade40),
-              dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString() ?? "");
-              --color-neutral-50: #\(UIColor.textSubtle.color(for: trait).hexString() ?? "");
-              --color-neutral-70: #\(UIColor.text.color(for: trait).hexString() ?? "");
-              --main-link-color: #\(UIColor.muriel(color: .init(name: .blue)).color(for: trait).hexString() ?? "");
-              --main-link-active-color: #\(UIColor.muriel(name: .blue, .shade30).color(for: trait).hexString() ?? "");
+              --color-neutral-0: #\(neutralColor(shade: .shade0, trait: trait).hexString() ?? "");
+              --color-neutral-5: #\(neutralColor(shade: .shade5, trait: trait).hexString() ?? "");
+              --color-neutral-10: #\(neutralColor(shade: .shade10, trait: trait).hexString() ?? "");
+              --color-neutral-40: #\(neutralColor(shade: .shade40, trait: trait).hexString() ?? "");
+              --color-neutral-50: #\(neutralColor(shade: .shade50, trait: trait).hexString() ?? "");
+              --color-neutral-70: #\(neutralColor(shade: .shade70, trait: trait).hexString() ?? "");
+              --main-link-color: #\(linkColor(for: trait).hexString() ?? "");
+              --main-link-active-color: #\(activeLinkColor(for: trait).hexString() ?? "");
             }
         """
+    }
+
+    /// Returns the requested neutral color based on the current color theme.
+    /// Note that the previous color values were preserved for the `.system` color theme.
+    ///
+    /// - Parameters:
+    ///   - shade: `MurielColorShade` enum.
+    ///   - trait: The trait collection for the color.
+    /// - Returns: `UIColor`
+    func neutralColor(shade: MurielColorShade, trait: UITraitCollection) -> UIColor {
+        let color: UIColor = {
+            switch shade {
+            case .shade0:
+                return .listForegroundUnread
+            case .shade5:
+                if displaySetting.color == .system {
+                    return .init(light: .muriel(color: .gray, .shade5), dark: .muriel(color: .gray, .shade80))
+                }
+                return displaySetting.color.border
+            case .shade10:
+                if displaySetting.color == .system {
+                    return .init(light: .muriel(color: .gray, .shade10), dark: .muriel(color: .gray, .shade30))
+                }
+                return displaySetting.color.border
+            case .shade40:
+                if displaySetting.color == .system {
+                    return .init(light: .muriel(color: .gray, .shade40), dark: .muriel(color: .gray, .shade20))
+                }
+                return displaySetting.color.secondaryForeground
+            case .shade50:
+                return displaySetting.color.secondaryForeground
+            default:
+                return displaySetting.color.foreground
+            }
+        }()
+
+        return color.color(for: trait)
+    }
+
+    func linkColor(for trait: UITraitCollection) -> UIColor {
+        let color = displaySetting.color == .system ? UIColor.muriel(color: .init(name: .blue)) : displaySetting.color.foreground
+        return color.color(for: trait)
+    }
+
+    func activeLinkColor(for trait: UITraitCollection) -> UIColor {
+        let color = displaySetting.color == .system ? UIColor.muriel(name: .blue, .shade30) : displaySetting.color.secondaryForeground
+        return color.color(for: trait)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -68,6 +68,11 @@ figure {
   margin-inline-end: 0;
 }
 
+/* Workaround: limit the maximum width so that the right border is not cut off */
+figure.wp-block-embed.is-type-video {
+    max-width: 99vw;
+}
+
 /* Temporary override for Reader Customization */
 .reader-full-post__story-content blockquote {
     color: var(--color-text) !important;

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -65,7 +65,6 @@ struct ReaderDisplaySetting: Codable, Equatable {
         case hacker
         case candy
 
-        // TODO: Consider localization
         var label: String {
             switch self {
             case .system:
@@ -266,11 +265,21 @@ struct ReaderDisplaySetting: Codable, Equatable {
 
 // MARK: - Controller
 
+protocol ReaderDisplaySettingStoreDelegate: NSObjectProtocol {
+    func displaySettingDidChange()
+}
+
 /// This should be the object to be strongly retained. Keeps the store up-to-date.
 class ReaderDisplaySettingStore: NSObject {
 
     private let repository: UserPersistentRepository
 
+    private let notificationCenter: NotificationCenter
+
+    weak var delegate: ReaderDisplaySettingStoreDelegate?
+
+    /// A public facade to simplify the flag checking dance for the `ReaderDisplaySetting` object.
+    /// When the flag is disabled, this will always return the `standard` object, and the setter does nothing.
     var setting: ReaderDisplaySetting {
         get {
             return ReaderDisplaySetting.customizationEnabled ? _setting : .standard
@@ -283,16 +292,23 @@ class ReaderDisplaySettingStore: NSObject {
         }
     }
 
+    /// The actual instance variable that holds the setting object.
+    /// This is intentionally set to private so that it's only controllable by `ReaderDisplaySettingStore`.
     private var _setting: ReaderDisplaySetting = .standard {
         didSet {
-            if let dictionary = try? setting.toDictionary() {
-                repository.set(dictionary, forKey: Constants.key)
+            guard oldValue != _setting,
+                  let dictionary = try? setting.toDictionary() else {
+                return
             }
+            repository.set(dictionary, forKey: Constants.key)
+            broadcastChangeNotification()
         }
     }
 
-    init(repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+    init(repository: UserPersistentRepository = UserPersistentStoreFactory.instance(),
+         notificationCenter: NotificationCenter = .default) {
         self.repository = repository
+        self.notificationCenter = notificationCenter
         self._setting = {
             guard let dictionary = repository.dictionary(forKey: Constants.key),
                   let data = try? JSONSerialization.data(withJSONObject: dictionary),
@@ -302,9 +318,56 @@ class ReaderDisplaySettingStore: NSObject {
             return setting
         }()
         super.init()
+        registerNotifications()
+    }
+
+    private func registerNotifications() {
+        notificationCenter.addObserver(self,
+                                       selector: #selector(handleChangeNotification),
+                                       name: .readerDisplaySettingStoreDidChange,
+                                       object: nil)
+    }
+
+    private func broadcastChangeNotification() {
+        notificationCenter.post(name: .readerDisplaySettingStoreDidChange, object: self)
+    }
+
+    @objc
+    private func handleChangeNotification(_ notification: NSNotification) {
+        // ignore self broadcasts.
+        if let broadcaster = notification.object as? ReaderDisplaySettingStore,
+           broadcaster == self {
+            return
+        }
+
+        // since we're handling change notifications, a stored setting object *should* exist.
+        guard let updatedSetting = try? fetchSetting() else {
+            DDLogError("ReaderDisplaySettingStore: Received a didChange notification with a nil stored value")
+            return
+        }
+
+        _setting = updatedSetting
+        delegate?.displaySettingDidChange()
+    }
+
+    /// Fetches the stored value of `ReaderDisplaySetting`.
+    ///
+    /// - Returns: `ReaderDisplaySetting`
+    private func fetchSetting() throws -> ReaderDisplaySetting? {
+        guard let dictionary = repository.dictionary(forKey: Constants.key) else {
+            return nil
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: dictionary)
+        let setting = try JSONDecoder().decode(ReaderDisplaySetting.self, from: data)
+        return setting
     }
 
     private struct Constants {
         static let key = "readerDisplaySettingKey"
     }
+}
+
+fileprivate extension NSNotification.Name {
+    static let readerDisplaySettingStoreDidChange = NSNotification.Name("ReaderDisplaySettingDidChange")
 }

--- a/WordPress/Resources/HTML/richCommentStyle.css
+++ b/WordPress/Resources/HTML/richCommentStyle.css
@@ -93,7 +93,9 @@ figure {
 /** LINKS **/
 
 a {
-    color: var(--primary-color);
+    color: var(--link-color);
+    font-weight: var(--link-font-weight);
+    text-decoration: var(--link-text-decoration);
 }
 
 a.mention {
@@ -123,7 +125,7 @@ p > img:not(.emoji),
 figcaption {
     font: -apple-system-caption1;
     font-family: var(--text-font);
-    color: -apple-system-secondary-label;
+    color: var(--text-secondary-color);
     text-align: center;
 }
 
@@ -159,7 +161,7 @@ blockquote {
     font-size: 1rem;
     margin: 15pt 0;
     padding: 10pt;
-    background-color: -apple-system-secondary-background;
+    background-color: var(--background-secondary-color);
     -webkit-border-radius: 3pt;
 }
 
@@ -186,7 +188,7 @@ pre {
     font-family: var(--monospace-font);
     font-size: 0.85rem;
     -webkit-border-radius: 3pt;
-    background-color: -apple-system-secondary-background;
+    background-color: var(--background-secondary-color);
 }
 
 code {
@@ -213,7 +215,7 @@ table {
 }
 
 table, tr, td {
-    border: 1px solid -apple-system-separator;
+    border: 1px solid var(--border-color);
 }
 
 td {


### PR DESCRIPTION
Part of #22925 

This PR includes several improvements and fixes:

- Further styling fixes for the ReaderWebView.
- Re-apply style on orientation changes.
- When a setting is set, it now broadcasts an `NSNotification` so that observers can receive and apply timely updates. This handles the case of "stacked" Reader posts (e.g., clicking a link to another Reader Post.)
- Apply proper customization to the likes view in the Reader Detail.

## To test

- Launch the Jetpack app.
- Go to the Reader tab and open any post.
- Rotate the device/simulator to landscape orientation.
- 🔎 Verify that the navigation bar tint color stays in sync with the current color theme and doesn't reset.
- Select a different post, preferably those that contain links that lead to another Reader Post. Here's an internal example: pLZE4-szF-p2
- Tap on the link to nest another Reader Post.
- Change the preferences from the second post, and go back to the first post.
- 🔎 Verify that the changes are applied to the first post.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is hidden behind a feature flag. Some changes are made in the Reader web view, but old values are maintained for cases where the feature flag is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)