### PR TITLE
Offline Mode: Fix cell reload on postCoordinatorDidUpdate

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -999,11 +999,11 @@ class PostCoordinator: NSObject {
 
     @MainActor
     private func setUpdating(_ isUpdating: Bool, for post: AbstractPost) {
-        let objectID = post.original().objectID
+        let post = post.original()
         if isUpdating {
-            pendingPostIDs.insert(objectID)
+            pendingPostIDs.insert(post.objectID)
         } else {
-            pendingPostIDs.remove(objectID)
+            pendingPostIDs.remove(post.objectID)
         }
         NotificationCenter.default.post(name: .postCoordinatorDidUpdate, object: self, userInfo: [
             NSUpdatedObjectsKey: Set([post])

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import Combine
 
-final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
+final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResultCell, Reusable {
 
     // MARK: - Views
 
@@ -28,6 +28,10 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         set { titleLabel.attributedText = newValue }
     }
 
+    // MARK: AbstractPostListCell
+
+    var post: AbstractPost? { viewModel?.page }
+
     // MARK: - Initializers
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -45,7 +49,7 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         super.prepareForReuse()
 
         imageLoader.prepareForReuse()
-        viewModel?.didUpdateSyncState = nil
+        viewModel = nil
     }
 
     func configure(with viewModel: PageListItemViewModel, indentation: Int = 0, isFirstSubdirectory: Bool = false, delegate: InteractivePostViewDelegate? = nil) {
@@ -78,11 +82,7 @@ final class PageListCell: UITableViewCell, PostSearchResultCell, Reusable {
         indentationIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
 
         configure(with: viewModel.syncStateViewModel)
-        viewModel.didUpdateSyncState = { [weak self] in
-            self?.configure(with: $0)
-        }
-
-        self.viewModel = viewModel // Important to retain it
+        self.viewModel = viewModel
     }
 
     private func configure(with viewModel: PostSyncStateViewModel) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -7,9 +7,7 @@ final class PageListItemViewModel {
     let badges: NSAttributedString
     let imageURL: URL?
     let accessibilityIdentifier: String?
-    private(set) var syncStateViewModel: PostSyncStateViewModel
-
-    var didUpdateSyncState: ((PostSyncStateViewModel) -> Void)?
+    let syncStateViewModel: PostSyncStateViewModel
 
     init(page: Page, isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
         self.page = page
@@ -19,20 +17,6 @@ final class PageListItemViewModel {
         self.imageURL = page.featuredImageURL
         self.accessibilityIdentifier = page.slugForDisplay()
         self.syncStateViewModel = PostSyncStateViewModel(post: page, isSyncPublishingEnabled: isSyncPublishingEnabled)
-
-        if isSyncPublishingEnabled {
-            NotificationCenter.default.addObserver(self, selector: #selector(postCoordinatorDidUpdate), name: .postCoordinatorDidUpdate, object: nil)
-        }
-    }
-
-    @objc private func postCoordinatorDidUpdate(_ notification: Foundation.Notification) {
-        guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
-            return
-        }
-        if updatedObjects.contains(page) || updatedObjects.contains(page.original()) {
-            syncStateViewModel = PostSyncStateViewModel(post: page)
-            didUpdateSyncState?(syncStateViewModel)
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -1,7 +1,12 @@
 import Foundation
 import UIKit
 
-final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
+protocol AbstractPostListCell {
+    /// A post displayed by the cell.
+    var post: AbstractPost? { get }
+}
+
+final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResultCell, Reusable {
     var isEnabled = true
 
     // MARK: - Views
@@ -35,6 +40,10 @@ final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
         set { contentLabel.attributedText = newValue }
     }
 
+    // MARK: AbstractPostListCell
+
+    var post: AbstractPost? { viewModel?.post }
+
     // MARK: - Initializers
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -52,7 +61,7 @@ final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
         super.prepareForReuse()
 
         imageLoader.prepareForReuse()
-        viewModel?.didUpdateSyncState = nil
+        viewModel = nil
     }
 
     func configure(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate? = nil) {
@@ -74,11 +83,7 @@ final class PostListCell: UITableViewCell, PostSearchResultCell, Reusable {
         accessibilityLabel = viewModel.accessibilityLabel
 
         configure(with: viewModel.syncStateViewModel)
-        viewModel.didUpdateSyncState = { [weak self] in
-            self?.headerView.configure(with: $0)
-        }
-
-        self.viewModel = viewModel // Important to retain it
+        self.viewModel = viewModel
     }
 
     private func configure(with viewModel: PostSyncStateViewModel) {

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -5,36 +5,20 @@ final class PostListItemViewModel {
     let content: NSAttributedString
     let imageURL: URL?
     let badges: NSAttributedString
-    private(set) var syncStateViewModel: PostSyncStateViewModel
+    let syncStateViewModel: PostSyncStateViewModel
     private let statusViewModel: PostCardStatusViewModel
 
     var status: String { statusViewModel.statusAndBadges(separatedBy: " · ")}
     var statusColor: UIColor { statusViewModel.statusColor }
     var accessibilityLabel: String? { makeAccessibilityLabel(for: post, statusViewModel: statusViewModel) }
 
-    var didUpdateSyncState: ((PostSyncStateViewModel) -> Void)?
-
-    init(post: Post, shouldHideAuthor: Bool = false, isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+    init(post: Post, shouldHideAuthor: Bool = false) {
         self.post = post
         self.imageURL = post.featuredImageURL
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.syncStateViewModel = PostSyncStateViewModel(post: post)
         self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
         self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
-
-        if isSyncPublishingEnabled {
-            NotificationCenter.default.addObserver(self, selector: #selector(postCoordinatorDidUpdate), name: .postCoordinatorDidUpdate, object: nil)
-        }
-    }
-
-    @objc private func postCoordinatorDidUpdate(_ notification: Foundation.Notification) {
-        guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
-            return
-        }
-        if updatedObjects.contains(post.original()) {
-            syncStateViewModel = PostSyncStateViewModel(post: post)
-            didUpdateSyncState?(syncStateViewModel)
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -70,10 +70,6 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
         refreshNoResultsViewController = { [weak self] in
             self?.handleRefreshNoResultsViewController($0)
         }
-
-        if !RemoteFeatureFlag.syncPublishing.enabled() {
-            NotificationCenter.default.addObserver(self, selector: #selector(postCoordinatorDidUpdate), name: .postCoordinatorDidUpdate, object: nil)
-        }
     }
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {
@@ -105,23 +101,6 @@ final class PostListViewController: AbstractPostListViewController, UIViewContro
             createButtonCoordinator.showCreateButton(for: blog)
         } else {
             createButtonCoordinator.hideCreateButton()
-        }
-    }
-
-    // MARK: - Notifications
-
-    @objc private func postCoordinatorDidUpdate(_ notification: Foundation.Notification) {
-        guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
-            return
-        }
-        let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter {
-            let post = fetchResultsController.object(at: $0)
-            return updatedObjects.contains(post) || updatedObjects.contains(post.original())
-        }
-        if !updatedIndexPaths.isEmpty {
-            tableView.beginUpdates()
-            tableView.reloadRows(at: updatedIndexPaths, with: .automatic)
-            tableView.endUpdates()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -68,12 +68,10 @@ final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
             .sink { [weak self] in self?.reload(with: $0) }
             .store(in: &cancellables)
 
-        if !RemoteFeatureFlag.syncPublishing.enabled() {
-            NotificationCenter.default
-                .publisher(for: .postCoordinatorDidUpdate, object: nil)
-                .sink { [weak self] in self?.reload(with: $0) }
-                .store(in: &cancellables)
-        }
+        NotificationCenter.default
+            .publisher(for: .postCoordinatorDidUpdate, object: nil)
+            .sink { [weak self] in self?.reload(with: $0) }
+            .store(in: &cancellables)
 
         reload()
     }


### PR DESCRIPTION
Fixes reload of cells by reverting the previous changes.

## To test

The issue is easy to reproduce on self-hosted sites that use XMLRPC where "Move to Trash" currently fails.

- Open a context menu for a post cell
- Tap "Move to Trash"
- **Verify** that the cell briefly changes state to "Updating" and back to the original state
- Repeat for Post List, Page List, Search

## Regression Notes
1. Potential unintended areas of impact: manual
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
