### PR TITLE
Offline Mode: Fix trashing (XMLRPC)

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -1033,7 +1033,7 @@ class PostCoordinator: NSObject {
 
     /// Moves the given post to trash.
     @MainActor
-    func trash(_ post: AbstractPost) async throws {
+    func trash(_ post: AbstractPost) async {
         wpAssert(post.isOriginal())
 
         setUpdating(true, for: post)
@@ -1054,7 +1054,7 @@ class PostCoordinator: NSObject {
     }
 
     @MainActor
-    func _delete(_ post: AbstractPost) async throws {
+    func _delete(_ post: AbstractPost) async {
         wpAssert(post.isOriginal())
 
         setUpdating(true, for: post)

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -257,14 +257,44 @@ final class PostRepository {
         ContextManager.shared.saveContextAndWait(context)
     }
 
+    /// Trashes the given post.
+    ///
+    /// - warning: This method delets all local revision of the post.
+    @MainActor
+    func _trash(_ post: AbstractPost) async throws {
+        assert(post.isOriginal())
+
+        let context = coreDataStack.mainContext
+
+        guard let postID = post.postID, postID.intValue > 0 else {
+            context.deleteObject(post) // Delete all the local data
+            ContextManager.shared.saveContextAndWait(context)
+            return
+        }
+
+        post.deleteAllRevisions()
+        ContextManager.shared.saveContextAndWait(context)
+
+        let remote = try getRemoteService(for: post.blog)
+        var remotePost = try await remote.post(withID: postID)
+
+        // If the post is already in trash, do nothing. If the app were to
+        // proceed with `/delete`, it would permanently delete the post.
+        if remotePost.status != BasePost.Status.trash.rawValue {
+            remotePost = try await remote.trashPost(PostHelper.remotePost(with: post))
+        }
+
+        PostHelper.update(post, with: remotePost, in: context)
+        ContextManager.shared.saveContextAndWait(context)
+    }
+
     /// Permanently delete the given post.
     @MainActor
     func _delete(_ post: AbstractPost) async throws {
         wpAssert(post.isOriginal())
 
         guard let postID = post.postID, postID.intValue > 0 else {
-            wpAssertionFailure("Trying to patch a non-existent post")
-            return
+            return wpAssertionFailure("Trying to patch a non-existent post")
         }
         try await getRemoteService(for: post.blog).deletePost(withID: postID.intValue)
 

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -262,7 +262,7 @@ final class PostRepository {
     /// - warning: This method delets all local revision of the post.
     @MainActor
     func _trash(_ post: AbstractPost) async throws {
-        assert(post.isOriginal())
+        wpAssert(post.isOriginal())
 
         let context = coreDataStack.mainContext
 

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -14,6 +14,19 @@ extension PostServiceRemote {
             })
         }
     }
+
+    func trashPost(_ post: RemotePost) async throws -> RemotePost {
+        try await withCheckedThrowingContinuation { continuation in
+            trashPost(post) {
+                guard let post = $0 else {
+                    return continuation.resume(throwing: URLError(.unknown))
+                }
+                continuation.resume(returning: post)
+            } failure: {
+                continuation.resume(throwing: $0 ?? URLError(.unknown))
+            }
+        }
+    }
 }
 
 extension PostServiceRemoteREST {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -669,7 +669,7 @@ class AbstractPostListViewController: UIViewController,
 
         func performAction() {
             Task {
-                try? await PostCoordinator.shared.trash(post)
+                await PostCoordinator.shared.trash(post)
             }
         }
 
@@ -698,7 +698,7 @@ class AbstractPostListViewController: UIViewController,
         alert.addDestructiveActionWithTitle(Strings.Delete.actionTitle) { _ in
             completion()
             Task {
-                try? await PostCoordinator.shared._delete(post)
+                await PostCoordinator.shared._delete(post)
             }
         }
         alert.presentFromRootViewController()

--- a/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorSyncTests.swift
@@ -568,7 +568,7 @@ class PostCoordinatorSyncTests: CoreDataTestCase {
 
         // GIVEN
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
-            try! HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+            HTTPStubsResponse(error: URLError(.notConnectedToInternet))
         }
 
         // WHEN


### PR DESCRIPTION
Fixes trashing of posts.

## Known Issues

- I ended up using the existing `/trashPost` and `getPosts` methods but there is no good way to capture 404 anymore, so it'll still show an error on 404 – I think we can leave with it for now and keep it in the backlog (it's a production issue).

## To test

Re-run the testes from https://github.com/wordpress-mobile/WordPress-iOS/pull/22947

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
