### PR TITLE
Fix: Update static posters flag default value to true

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -47,7 +47,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return false
         case .jetpackFeaturesRemovalStaticPosters:
-            return false
+            return true
         case .blaze:
             return false
         case .blazeManageCampaigns:

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -90,8 +90,9 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
 
     static var currentAppUIType: RootViewCoordinator.AppUIType?
 
-    static func generalPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> GeneralPhase {
-        if AppConfiguration.isJetpack {
+    static func generalPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
+                             isJetpack: Bool = AppConfiguration.isJetpack) -> GeneralPhase {
+        if isJetpack {
             return .normal // Always return normal for Jetpack
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1585,11 +1585,10 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let posts = content.content as? [ReaderPost] else {
+        guard let posts = content.content as? [ReaderPost],
+              let post = posts[safe: indexPath.row] else {
             return UITableViewCell()
         }
-
-        let post = posts[indexPath.row]
 
         return cell(for: post, at: indexPath)
     }
@@ -1648,11 +1647,11 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
             return
         }
 
-        guard let posts = content.content as? [ReaderPost] else {
+        guard let posts = content.content as? [ReaderPost],
+              let post = posts[safe: indexPath.row] else {
             return
         }
 
-        let post = posts[indexPath.row]
         bumpRenderTracker(post)
     }
 
@@ -1697,12 +1696,12 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let posts = content.content as? [ReaderPost] else {
+        guard let posts = content.content as? [ReaderPost],
+              let apost = posts[safe: indexPath.row] else {
             DDLogError("[ReaderStreamViewController tableView:didSelectRowAtIndexPath:] fetchedObjects was nil.")
             return
         }
 
-        let apost = posts[indexPath.row]
         didSelectPost(apost, at: indexPath)
     }
 

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -346,12 +346,45 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertNil(deadline)
     }
 
+    // MARK: Offline Scenarios
+
+    func testWordPressOfflineState() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        // assume that the user fails to request for remote feature flags and we fall back to the default values.
+        let remote = MockFeatureFlagRemote()
+        store.update(using: remote, waitOn: self)
+
+        // When
+        // assume that we're requesting from the WordPress app.
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store, isJetpack: false)
+
+        // Then
+        XCTAssertEqual(phase, .staticScreens)
+    }
+
+    func testJetpackOfflineState() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        // assume that the user fails to request for remote feature flags and we fall back to the default values.
+        let remote = MockFeatureFlagRemote()
+        store.update(using: remote, waitOn: self)
+
+        // When
+        // assume that we're requesting from the Jetpack app.
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store, isJetpack: true)
+
+        // Then
+        XCTAssertEqual(phase, .normal)
+    }
+
     // MARK: Helpers
 
     private func generateFlags(phaseOne: Bool,
                                phaseTwo: Bool,
                                phaseThree: Bool,
                                phaseFour: Bool,
+                               phaseStaticScreens: Bool = false,
                                phaseNewUsers: Bool,
                                phaseSelfHosted: Bool) -> [WordPressKit.FeatureFlag] {
         return [
@@ -359,6 +392,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
             .init(title: RemoteFeatureFlag.jetpackFeaturesRemovalPhaseTwo.remoteKey, value: phaseTwo),
             .init(title: RemoteFeatureFlag.jetpackFeaturesRemovalPhaseThree.remoteKey, value: phaseThree),
             .init(title: RemoteFeatureFlag.jetpackFeaturesRemovalPhaseFour.remoteKey, value: phaseFour),
+            .init(title: RemoteFeatureFlag.jetpackFeaturesRemovalStaticPosters.remoteKey, value: phaseStaticScreens),
             .init(title: RemoteFeatureFlag.jetpackFeaturesRemovalPhaseNewUsers.remoteKey, value: phaseNewUsers),
             .init(title: RemoteFeatureFlag.jetpackFeaturesRemovalPhaseSelfHosted.remoteKey, value: phaseSelfHosted),
         ]


### PR DESCRIPTION
Fixes #22977 
Internal ref p1712651805548069-slack-C012H19SZQ8

This issue affects the WordPress app. Due to the JP feature removal flags' default value set to `false`, when the user fails to fetch the remote feature flag values, [they will get `.normal` value from the JetpackFeaturesRemovalCoordinator](https://github.com/wordpress-mobile/WordPress-iOS/blob/febe218807e1f843691c44ad0dab830f0faa78a3/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift#L93).

This PR solves that by updating the static poster flag's default value to `true`, which should prevent WP app users from unintendedly accessing the Reader (or any other Jetpack feature). The decision on picking which flag's default value to set to `true` is based on which flag has the most recent app version requirement, based on the internal implementation here: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Ssrngher%2Qsyntf%2Spbasvt%2Szbovyr%2Qnccf.cuc%3Se%3Q96953s75%26zb%3Q990%26sv%3Q36%2333%2Q49-og

h/t to @staskus for finding out the root cause! Also, I'm adding @hassaanelgarem as an extra pair of eyes to verify if updating the default value of the static posters phase is the right move here.

---

<details>

<summary>Previous outdated description</summary>

~~This PR adds a workaround for an index out-of-bound exception when the table view tries to get a post object from a collection of posts obtained from a fetched results controller. This particular part of the code remains unchanged, but the Reader hierarchy was [recently changed in 24.2](https://github.com/wordpress-mobile/WordPress-iOS/blob/9fb2da734f2591f2311264217b030665430885e0/RELEASE-NOTES.txt#L44), when we introduced a new UI for the Reader stream. This changes the structure from tabbed view (e.g., load 5 tabs at once) to just a single stream where users could switch streams and trigger content reloads.~~

~~I'm still unsure why this crash first happened in 24.5, since I don't think there are any major changes [between 24.4 and 24.5](https://github.com/wordpress-mobile/WordPress-iOS/compare/24.4...24.5) that would introduce a race condition for the table view.~~

</details>

## To test

**EDIT**: Testing steps updated based on @staskus' findings in https://github.com/wordpress-mobile/WordPress-iOS/pull/22991#discussion_r1560790955:

### WordPress app

- Launch the WordPress app and log in to the app.
- Force close the app, and turn on airplane mode.
- Launch WordPress app again.
- 🔎 Verify that the Reader tab is NOT accessible.

### Jetpack app

- Reader
- Search for `松,`
- Scroll down until more content loads and `reader_infinite_scroll_performed` is logged
- Select input field
- Tap "Done"
- 🔎 Verify that the app does not crash

## Regression Notes
1. Potential unintended areas of impact
Should be none. Out of bound indexes shouldn't crash

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes. Relied on existing tests in `JetpackFeaturesRemovalCoordinatorTests`.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests to cover offline cases for WordPress and Jetpack app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A — not a UI change.

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)