### PR TITLE
Offline Mode: Disable context menu when post is not editable

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -13,7 +13,10 @@ struct AbstractPostMenuHelper {
     /// - parameters:
     ///   - presentingView: The view presenting the menu
     ///   - delegate: The delegate that performs post actions
-    func makeMenu(presentingView: UIView, delegate: InteractivePostViewDelegate) -> UIMenu {
+    func makeMenu(presentingView: UIView, delegate: InteractivePostViewDelegate) -> UIMenu? {
+        if RemoteFeatureFlag.syncPublishing.enabled(), !PostSyncStateViewModel(post: post).isEditable {
+            return nil
+        }
         return UIMenu(title: "", options: .displayInline, children: [
             UIDeferredMenuElement.uncached { [weak presentingView, weak delegate] completion in
                 guard let presentingView, let delegate else { return }


### PR DESCRIPTION
Fixes an issue with the context menu available for non-editable posts.

- **Verify** that when the post is updating (moving to trash, moving to draft, etc), the context menu is not available
- **Verify** that the context menu is available otherwise 

To test:

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
