### PR TITLE
Reading Preferences: Add remote flag and tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -568,6 +568,13 @@ import Foundation
     case siteMonitoringTabShown
     case siteMonitoringEntryDetailsShown
 
+    // Reading preferences
+    case readingPreferencesOpened
+    case readingPreferencesFeedbackTapped
+    case readingPreferencesItemTapped
+    case readingPreferencesSaved
+    case readingPreferencesClosed
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1546,6 +1553,18 @@ import Foundation
             return "site_monitoring_tab_shown"
         case .siteMonitoringEntryDetailsShown:
             return "site_monitoring_entry_details_shown"
+
+        // Reading Preferences
+        case .readingPreferencesOpened:
+            return "reader_reading_preferences_opened"
+        case .readingPreferencesFeedbackTapped:
+            return "reader_reading_preferences_feedback_tapped"
+        case .readingPreferencesItemTapped:
+            return "reader_reading_preferences_item_tapped"
+        case .readingPreferencesSaved:
+            return "reader_reading_preferences_saved"
+        case .readingPreferencesClosed:
+            return "reader_reading_preferences_closed"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,7 +11,6 @@ enum FeatureFlag: Int, CaseIterable {
     case compliancePopover
     case googleDomainsCard
     case newTabIcons
-    case readerCustomization
     case readerTagsFeed
 
     /// Returns a boolean indicating if the feature is enabled
@@ -39,8 +38,6 @@ enum FeatureFlag: Int, CaseIterable {
             return false
         case .newTabIcons:
             return true
-        case .readerCustomization:
-            return false
         case .readerTagsFeed:
             return false
         }
@@ -83,8 +80,6 @@ extension FeatureFlag {
             return "Google Domains Promotional Card"
         case .newTabIcons:
             return "New Tab Icons"
-        case .readerCustomization:
-            return "Reader Customization"
         case .readerTagsFeed:
             return "Reader Tags Feed"
         }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -29,6 +29,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case siteMonitoring
     case syncPublishing
     case readerDiscoverEndpoint
+    case readingPreferences
+    case readingPreferencesFeedback
 
     var defaultValue: Bool {
         switch self {
@@ -86,6 +88,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .readerDiscoverEndpoint:
             return true
+        case .readingPreferences:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        case .readingPreferencesFeedback:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -147,6 +153,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "_sync_publishing"
         case .readerDiscoverEndpoint:
             return "reader_discover_new_endpoint"
+        case .readingPreferences:
+            return "reading_preferences"
+        case .readingPreferencesFeedback:
+            return "reading_preferences_feedback"
         }
     }
 
@@ -206,6 +216,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Synchronous Publishing"
         case .readerDiscoverEndpoint:
             return "Reader Discover New Endpoint"
+        case .readingPreferences:
+            return "Reading Preferences"
+        case .readingPreferencesFeedback:
+            return "Reading Preferences Feedback"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -665,6 +665,15 @@ class ReaderDetailCoordinator {
             }
         }
 
+        // Additional properties for Reading Preferences
+        if ReaderDisplaySetting.customizationEnabled {
+            let setting = ReaderDisplaySettingStore().setting
+            properties[DetailAnalyticsConstants.ReadingPreferences.isDefaultKey] = setting.isDefaultSetting
+            properties[DetailAnalyticsConstants.ReadingPreferences.colorSchemeKey] = setting.color.valueForTracks
+            properties[DetailAnalyticsConstants.ReadingPreferences.fontTypeKey] = setting.font.rawValue
+            properties[DetailAnalyticsConstants.ReadingPreferences.fontSizeKey] = setting.size.valueForTracks
+        }
+
         // Track open
         WPAppAnalytics.track(.readerArticleOpened, withProperties: properties)
 
@@ -692,6 +701,13 @@ class ReaderDetailCoordinator {
         static let TypePreviewSite = "preview_site"
         static let OfflineKey = "offline_view"
         static let PixelStatReferrer = "https://wordpress.com/"
+
+        struct ReadingPreferences {
+            static let isDefaultKey = "reading_preferences_is_default"
+            static let colorSchemeKey = "reading_preferences_color_scheme"
+            static let fontTypeKey = "reading_preferences_font"
+            static let fontSizeKey = "reading_preferences_font_size"
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -670,7 +670,7 @@ class ReaderDetailCoordinator {
             let setting = ReaderDisplaySettingStore().setting
             properties[DetailAnalyticsConstants.ReadingPreferences.isDefaultKey] = setting.isDefaultSetting
             properties[DetailAnalyticsConstants.ReadingPreferences.colorSchemeKey] = setting.color.valueForTracks
-            properties[DetailAnalyticsConstants.ReadingPreferences.fontTypeKey] = setting.font.rawValue
+            properties[DetailAnalyticsConstants.ReadingPreferences.fontTypeKey] = setting.font.valueForTracks
             properties[DetailAnalyticsConstants.ReadingPreferences.fontSizeKey] = setting.size.valueForTracks
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -841,7 +841,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     @objc func didTapDisplaySettingButton(_ sender: UIBarButtonItem) {
-        let viewController = ReaderDisplaySettingViewController(initialSetting: displaySetting) { [weak self] newSetting in
+        let viewController = ReaderDisplaySettingViewController(initialSetting: displaySetting,
+                                                                source: .readerPostNavBar) { [weak self] newSetting in
             // no need to refresh if there are no changes to the display setting.
             guard let self,
                   newSetting != self.displaySetting else {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -227,6 +227,10 @@ struct ReaderDisplaySetting: Codable, Equatable {
                 return "'SF Mono', SFMono-Regular, ui-monospace, monospace"
             }
         }
+
+        var valueForTracks: String {
+            rawValue
+        }
     }
 
     enum Size: Int, Codable, CaseIterable {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -4,7 +4,7 @@ import WordPressShared
 struct ReaderDisplaySetting: Codable, Equatable {
 
     static var customizationEnabled: Bool {
-        FeatureFlag.readerCustomization.enabled
+        RemoteFeatureFlag.readingPreferences.enabled()
     }
 
     // MARK: Properties

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -20,6 +20,10 @@ struct ReaderDisplaySetting: Codable, Equatable {
         color.background.brighterThan(0.5)
     }
 
+    var isDefaultSetting: Bool {
+        return self == .standard
+    }
+
     // MARK: Methods
 
     /// Generates a `UIFont` with customizable parameters.
@@ -195,6 +199,17 @@ struct ReaderDisplaySetting: Codable, Equatable {
                 return false
             }
         }
+
+        var valueForTracks: String {
+            switch self {
+            case .system:
+                return "default"
+            case .hacker:
+                return "h4x0r"
+            default:
+                return rawValue
+            }
+        }
     }
 
     enum Font: String, Codable, CaseIterable {
@@ -268,6 +283,21 @@ struct ReaderDisplaySetting: Codable, Equatable {
                     value: "Extra Large",
                     comment: "Accessibility label for the Extra Large size option, used in the Reader's reading preferences."
                 )
+            }
+        }
+
+        var valueForTracks: String {
+            switch self {
+            case .extraSmall:
+                return "extra_small"
+            case .small:
+                return "small"
+            case .normal:
+                return "normal"
+            case .large:
+                return "large"
+            case .extraLarge:
+                return "extra_large"
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -182,7 +182,7 @@ extension ReaderDisplaySettingSelectionView {
                             .tint(Color(linkTintColor))
                             .accessibilityAddTraits(.isLink)
                             .environment(\.openURL, OpenURLAction { url in
-                                // TODO: Add Tracks
+                                WPAnalytics.track(.readingPreferencesFeedbackTapped)
                                 return .systemAction
                             })
                     }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -347,6 +347,9 @@ extension ReaderDisplaySettingSelectionView {
                         Button {
                             viewModel.displaySetting.color = color
                             viewModel.didChangeColor?() // notify the view controller to update.
+                            WPAnalytics.track(.readingPreferencesItemTapped,
+                                              properties: [TrackingKeys.typeKey: TrackingKeys.colorScheme,
+                                                           TrackingKeys.valueKey: color.valueForTracks])
                         } label: {
                             VStack(spacing: .DS.Padding.single) {
                                 DualColorCircle(primaryColor: Color(color.foreground),
@@ -379,6 +382,9 @@ extension ReaderDisplaySettingSelectionView {
                     ForEach(ReaderDisplaySetting.Font.allCases, id: \.rawValue) { font in
                         Button {
                             viewModel.displaySetting.font = font
+                            WPAnalytics.track(.readingPreferencesItemTapped,
+                                              properties: [TrackingKeys.typeKey: TrackingKeys.fontType,
+                                                           TrackingKeys.valueKey: font.rawValue])
                         } label: {
                             VStack(spacing: .DS.Padding.half) {
                                 Text("Aa")
@@ -419,7 +425,11 @@ extension ReaderDisplaySettingSelectionView {
                     .font(Font(ReaderDisplaySetting.font(with: .sans, size: .extraLarge, textStyle: .body)))
                     .accessibilityHidden(true)
             } onEditingChanged: { _ in
-                viewModel.displaySetting.size = .init(rawValue: Int(sliderValue)) ?? .normal
+                let size = ReaderDisplaySetting.Size(rawValue: Int(sliderValue)) ?? .normal
+                viewModel.displaySetting.size = size
+                WPAnalytics.track(.readingPreferencesItemTapped,
+                                  properties: [TrackingKeys.typeKey: TrackingKeys.fontSize,
+                                               TrackingKeys.valueKey: size.valueForTracks])
             }
             .padding(.vertical, .DS.Padding.single)
             .accessibilityValue(Text(viewModel.displaySetting.size.accessibilityLabel))
@@ -481,5 +491,18 @@ fileprivate struct DualColorCircle: View {
             return .clear
         }
         return .secondary
+    }
+}
+
+// MARK: - Tracks
+
+fileprivate extension ReaderDisplaySettingSelectionView {
+
+    struct TrackingKeys {
+        static let typeKey = "type"
+        static let valueKey = "value"
+        static let colorScheme = "color_scheme"
+        static let fontType = "font"
+        static let fontSize = "font_size"
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -1,18 +1,29 @@
 import SwiftUI
 import DesignSystem
 
+/// The tracking source values for the customization sheet.
+/// The values are kept in sync with Android.
+enum ReaderDisplaySettingViewSource: String {
+    case readerPostNavBar = "post_detail_toolbar"
+    case unspecified
+}
+
 class ReaderDisplaySettingViewController: UIViewController {
     private let initialSetting: ReaderDisplaySetting
     private let completion: ((ReaderDisplaySetting) -> Void)?
+    private let trackingSource: ReaderDisplaySettingViewSource
     private var viewModel: ReaderDisplaySettingSelectionViewModel? = nil
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(initialSetting: ReaderDisplaySetting, completion: ((ReaderDisplaySetting) -> Void)?) {
+    init(initialSetting: ReaderDisplaySetting,
+         source: ReaderDisplaySettingViewSource = .unspecified,
+         completion: ((ReaderDisplaySetting) -> Void)?) {
         self.initialSetting = initialSetting
         self.completion = completion
+        self.trackingSource = source
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -21,6 +32,7 @@ class ReaderDisplaySettingViewController: UIViewController {
         super.viewDidLoad()
         setupView()
         setupNavigationItems()
+        trackViewOpened()
     }
 
     private func setupView() {
@@ -63,6 +75,10 @@ class ReaderDisplaySettingViewController: UIViewController {
             WPAnalytics.track(.readingPreferencesClosed)
             self?.navigationController?.dismiss(animated: true)
         })
+    }
+
+    private func trackViewOpened() {
+        WPAnalytics.track(.readingPreferencesOpened, properties: ["source": trackingSource.rawValue])
     }
 
     private func updateNavigationBarStyle(with setting: ReaderDisplaySetting) {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -74,6 +74,8 @@ class ReaderDisplaySettingViewController: UIViewController {
 // MARK: View Model
 
 class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
+    private typealias TrackingKeys = ReaderDisplaySettingSelectionView.TrackingKeys
+
     @Published var displaySetting: ReaderDisplaySetting
 
     /// Called when the user selects a new color.
@@ -87,6 +89,13 @@ class ReaderDisplaySettingSelectionViewModel: NSObject, ObservableObject {
     }
 
     func doneButtonTapped() {
+        WPAnalytics.track(.readingPreferencesSaved, properties: [
+            TrackingKeys.isDefault: displaySetting.isDefaultSetting,
+            TrackingKeys.colorScheme: displaySetting.color.valueForTracks,
+            TrackingKeys.fontType: displaySetting.font.valueForTracks,
+            TrackingKeys.fontSize: displaySetting.size.valueForTracks,
+        ])
+
         completion?(displaySetting)
     }
 
@@ -504,5 +513,6 @@ fileprivate extension ReaderDisplaySettingSelectionView {
         static let colorScheme = "color_scheme"
         static let fontType = "font"
         static let fontSize = "font_size"
+        static let isDefault = "is_default"
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -210,7 +210,9 @@ extension ReaderDisplaySettingSelectionView {
         }
 
         var feedbackText: Text? {
-            // TODO: Check feature flag for feedback collection.
+            guard RemoteFeatureFlag.readingPreferencesFeedback.enabled() else {
+                return nil
+            }
 
             var linkString = "[\(Strings.feedbackLinkCTA)](\(Constants.feedbackLinkString))"
             if viewModel.displaySetting.color != .system {

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -60,6 +60,7 @@ class ReaderDisplaySettingViewController: UIViewController {
 
         updateNavigationBarStyle(with: displaySetting)
         navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .close, primaryAction: UIAction { [weak self] _ in
+            WPAnalytics.track(.readingPreferencesClosed)
             self?.navigationController?.dismiss(animated: true)
         })
     }


### PR DESCRIPTION
Part of #22925 

This PR removes the previous local feature flag, adds the remote feature flags as detailed in p1712003362386389-slack-C06PGTY5PKK, and adds the tracking events as detailed in 1GjE2FLLtZ0OjOK7YmzJ4ZgVWH09JoBTuiRIACsBg0z8-gdoc.

## To test

- Launch the Jetpack app.
- Ensure that the `Reading Preferences` and `Reading Preferences Feedback` remote feature flags are enabled.
- Go to the Reader tab and open any post.
- 🔎  Verify that for the `reader_article_opened` event, these properties were added:
  - `reading_preferences_is_default`
  - `reading_preferences_color_scheme`
  - `reading_preferences_font`
  - `reading_preferences_font_size`
- Tap the customization icon.
- 🔎 Verify that `🔵 Tracked: reader_reading_preferences_opened <source: post_detail_toolbar>` is logged.
- Tap the feedback link.
- 🔎 Verify that `🔵 Tracked: reader_reading_preferences_feedback_tapped <>` is logged.
- Go back to the app.
- Tap any color scheme.
- 🔎 Verify that `🔵 Tracked: reader_reading_preferences_item_tapped <type: color_scheme, value: (value)>` is logged.
- Tap any font.
- 🔎 Verify that `🔵 Tracked: reader_reading_preferences_item_tapped <type: font, value: (value)>` is logged.
- Tap any font size.
- 🔎 Verify that `🔵 Tracked: reader_reading_preferences_item_tapped <type: font_size, value: (value)>` is logged.
- Tap 'Done'.
- 🔎 Verify that `🔵 Tracked: reader_reading_preferences_saved <color_scheme: (value), font: (value), font_size: (value), is_default: (value)>` is logged.
- Open the customization sheet again. Select all the default values: Default scheme, Sans font, and Normal size (the middle), then tap 'Done'.
- 🔎 Verify that the `reader_reading_preferences_saved` event has `is_default` property set to `1`.
- Open the customization sheet again, and tap the close button on the navigation bar.
- 🔎  Verify that `🔵 Tracked: reader_reading_preferences_closed <>` is logged.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A. Not a UI change.

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)