### PR TITLE
Offline Mode: Fix discard changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -432,13 +432,7 @@ extension PublishingEditor {
         // TODO: this is incorrect because there might still be media in the previous revision
         cancelUploadOfAllMedia(for: post)
 
-        let original = post.original()
-
-        // Original can be either an unsynced revision or an original post at this post
-        original.deleteRevision()
-        if original.isNewDraft {
-            context.delete(original)
-        }
+        AbstractPost.deleteLatestRevision(post, in: context)
         ContextManager.shared.saveContextAndWait(context)
         return true
     }


### PR DESCRIPTION
I messed up the discard logic in one of the previous PRs where I blindly replaced `.original` with `original()` (poor naming too).

## To test:

**Test 1.1**

- Create a new draft
- Tap "Back"
- **Verify** that the post was deleted

**Test 1.2**

- Create a new draft
- Make some changes
- Tap "Back" and tap "Discard changes"
- **Verify** that the post was deleted

**Test 1.3**

- Create and save a draft
- Open the draft
- Tap "Back"
- **Verify** that the post is intact

**Test 1.4**

- Create and save a new draft
- Set a breakpoint on `/rest/v1.2/sites/*/posts/*`
- Open the draft and save a change
- **Verify** that the breakpoint was hit
- Open the draft again and tap "Back"
- **Verify** that the previously saved changes was NOT deleted
- Release the breakpoint
- **Verify** that the change was saved on the remote

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
