### PR TITLE
Offline Mode: Prepublishing sheet fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 16.0.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'd25e7f98766c68a7d965b1b72319e88184bae070'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '9ff448f06a413496664aaa8c04e927f561d4cafb'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 16.0.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '9ff448f06a413496664aaa8c04e927f561d4cafb'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '09007896f353820a968b8d03077761c5f540d47c'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.6, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `d25e7f98766c68a7d965b1b72319e88184bae070`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `9ff448f06a413496664aaa8c04e927f561d4cafb`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
   WordPressKit:
-    :commit: d25e7f98766c68a7d965b1b72319e88184bae070
+    :commit: 9ff448f06a413496664aaa8c04e927f561d4cafb
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -186,7 +186,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: d25e7f98766c68a7d965b1b72319e88184bae070
+    :commit: 9ff448f06a413496664aaa8c04e927f561d4cafb
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -234,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: e7d6982103b6de66a5310ec356236f4c8acf784a
+PODFILE CHECKSUM: a343814133c8a3e8203b95b0812201225ba4322e
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.6, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `9ff448f06a413496664aaa8c04e927f561d4cafb`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `09007896f353820a968b8d03077761c5f540d47c`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
   WordPressKit:
-    :commit: 9ff448f06a413496664aaa8c04e927f561d4cafb
+    :commit: 09007896f353820a968b8d03077761c5f540d47c
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -186,7 +186,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: 9ff448f06a413496664aaa8c04e927f561d4cafb
+    :commit: 09007896f353820a968b8d03077761c5f540d47c
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -234,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: a343814133c8a3e8203b95b0812201225ba4322e
+PODFILE CHECKSUM: 8762d86083d78f4f8df8d0850f375f1b46a73c9c
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -409,6 +409,9 @@
 
 - (BOOL)shouldPublishImmediately
 {
+    /// - warning: Yes, this is WordPress logic and it matches the behavior on
+    /// the web. If `dateCreated` is the same as `dateModified`, the system
+    /// uses it to represent a "no publish date selected" scenario.
     return [self originalIsDraft] && [self dateCreatedIsNilOrEqualToDateModified];
 }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -178,7 +178,9 @@ class PostCoordinator: NSObject {
         if (latest.password ?? "") != (options.password ?? "") {
             parameters.password = options.password
         }
-        parameters.date = options.publishDate
+        if let publishDate = options.publishDate {
+            parameters.date = publishDate
+        }
 
         do {
             let repository = PostRepository(coreDataStack: coreDataStack)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -174,7 +174,10 @@ class PostCoordinator: NSObject {
         case .private:
             parameters.status = Post.Status.publishPrivate.rawValue
         }
-        parameters.password = options.password
+        let latest = post.latest()
+        if (latest.password ?? "") != (options.password ?? "") {
+            parameters.password = options.password
+        }
         parameters.date = options.publishDate
 
         do {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -621,7 +621,7 @@ class AbstractPostListViewController: UIViewController,
 
     func publish(_ post: AbstractPost) {
         let action = AbstractPostHelper.editorPublishAction(for: post)
-        PrepublishingViewController.show(for: post, action: action, from: self) { [weak self] result in
+        PrepublishingViewController.show(for: post, action: action, isStandalone: true, from: self) { [weak self] result in
             switch result {
             case .confirmed:
                 self?.didConfirmPublish(for: post)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -37,7 +37,7 @@ extension PostSettingsViewController {
 
         configureDefaultNavigationBarAppearance()
 
-        assert(navigationController?.presentationController != nil)
+        wpAssert(navigationController?.presentationController != nil)
         navigationController?.presentationController?.delegate = self
 
         refreshNavigationBarButtons()

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -698,7 +698,9 @@ FeaturedImageViewControllerDelegate>
         // Publish date
         cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
-        if (self.apost.dateCreated) {
+        // Note: it's safe to remove `shouldPublishImmediately` when
+        // `RemoteFeatureFlagSyncPublishing` is enabled because this cell is not displayed.
+        if (self.apost.dateCreated && ![self.apost shouldPublishImmediately]) {
             cell.detailTextLabel.text = [self.postDateFormatter stringFromDate:self.apost.dateCreated];
         } else {
             cell.detailTextLabel.text = NSLocalizedString(@"Immediately", @"");

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -670,9 +670,8 @@ FeaturedImageViewControllerDelegate>
         [metaRows addObject:@(PostSettingsRowAuthor)];
     }
 
-    [metaRows addObject:@(PostSettingsRowPublishDate)];
-
     if (![RemoteFeature enabled:RemoteFeatureFlagSyncPublishing] || !self.isDraftOrPending) {
+        [metaRows addObject:@(PostSettingsRowPublishDate)];
         [metaRows addObjectsFromArray:@[  @(PostSettingsRowStatus),
                                           @(PostSettingsRowVisibility) ]];
         if (self.apost.password) {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController+JetpackSocial.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// Encapsulates logic related to Jetpack Social in the pre-publishing sheet.
 ///
-extension PrepublishingViewController {
+extension DeprecatedPrepublishingViewController {
 
     /// Determines whether the account and the post's blog is eligible to see the Jetpack Social row.
     func canDisplaySocialRow(isJetpack: Bool = AppConfiguration.isJetpack,
@@ -51,7 +51,7 @@ extension PrepublishingViewController {
 
 // MARK: - Helper Methods
 
-private extension PrepublishingViewController {
+private extension DeprecatedPrepublishingViewController {
 
     /// Convenience variable representing whether the No Connection view has been dismissed.
     /// Note: the value is stored per site.
@@ -171,7 +171,7 @@ private extension PrepublishingViewController {
     func noConnectionDismissTapped() -> () -> Void {
         return { [weak self] in
             guard let self,
-                  let autoSharingRowIndex = options.firstIndex(where: { $0.id == .autoSharing }) else {
+                  let autoSharingRowIndex = filteredIdentifiers.firstIndex(of: .autoSharing) else {
                 return
             }
 
@@ -181,7 +181,7 @@ private extension PrepublishingViewController {
             self.refreshOptions()
 
             // ensure that the `.autoSharing` identifier is truly removed to prevent table updates from crashing.
-            guard options.firstIndex(where: { $0.id == .autoSharing }) == nil else {
+            guard filteredIdentifiers.firstIndex(of: .autoSharing) == nil else {
                 return
             }
 
@@ -242,29 +242,9 @@ private extension PrepublishingViewController {
     }
 }
 
-// MARK: - Auto Sharing Model
-
-/// A value-type representation of `PublicizeService` for the current blog that's simplified for the auto-sharing flow.
-struct PrepublishingAutoSharingModel {
-    let services: [Service]
-    let message: String
-    let sharingLimit: PublicizeInfo.SharingLimit?
-
-    struct Service: Hashable {
-        let name: PublicizeService.ServiceName
-        let connections: [Connection]
-    }
-
-    struct Connection: Hashable {
-        let account: String
-        let keyringID: Int
-        var enabled: Bool
-    }
-}
-
 // MARK: - Sharing View Controller Delegate
 
-extension PrepublishingViewController: SharingViewControllerDelegate {
+extension DeprecatedPrepublishingViewController: SharingViewControllerDelegate {
 
     func didChangePublicizeServices() {
         reloadData()
@@ -274,7 +254,7 @@ extension PrepublishingViewController: SharingViewControllerDelegate {
 
 // MARK: - Prepublishing Social Accounts Delegate
 
-extension PrepublishingViewController: PrepublishingSocialAccountsDelegate {
+extension DeprecatedPrepublishingViewController: PrepublishingSocialAccountsDelegate {
 
     func didUpdateSharingLimit(with newValue: PublicizeInfo.SharingLimit?) {
         reloadData()

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController.swift
@@ -4,25 +4,29 @@ import Combine
 import WordPressUI
 import SwiftUI
 
-enum PrepublishingSheetResult {
-    /// The user confirms that they want to publish (legacy behavior).
-    ///
-    /// - note: Deprecated (kahu-offline-mode)
-    case confirmed
-    /// The sheet published the post (new behavior)
-    case published
-    /// The user cancelled.
-    case cancelled
+/// - warning: deprecated (kahu-offline-mode)
+enum PrepublishingIdentifier {
+    case title
+    case schedule
+    case visibility
+    case tags
+    case categories
+    case autoSharing
+
+    static var defaultIdentifiers: [PrepublishingIdentifier] {
+        if RemoteFeatureFlag.jetpackSocialImprovements.enabled() {
+            return [.visibility, .schedule, .tags, .categories, .autoSharing]
+        }
+        return [.visibility, .schedule, .tags, .categories]
+    }
 }
 
-final class PrepublishingViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-    let post: AbstractPost
+/// - warning: deprecated (kahu-offline-mode)
+final class DeprecatedPrepublishingViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    let post: Post
+    let identifiers: [PrepublishingIdentifier]
     let coreDataStack: CoreDataStackSwift
     let persistentStore: UserPersistentRepository
-
-    private let viewModel: PrepublishingViewModel
-
-    private let coordinator = PostCoordinator.shared
 
     lazy var postBlogID: Int? = {
         coreDataStack.performQuery { [postObjectID = post.objectID] context in
@@ -33,31 +37,43 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         }
     }()
 
+    /// The list of `PrepublishingIdentifier`s that have been filtered for display.
+    var filteredIdentifiers: [PrepublishingIdentifier] {
+        options.map { $0.id }
+    }
+
     private lazy var publishSettingsViewModel = PublishSettingsViewModel(post: post)
 
     private var completion: ((PrepublishingSheetResult) -> ())?
 
     /// The data source for the table rows, based on the filtered `identifiers`.
-    private(set) var options = [PrepublishingOption]()
+    private var options = [PrepublishingOption]()
+
+    private var didTapPublish = false
 
     private let headerView = PrepublishingHeaderView()
     let tableView = UITableView(frame: .zero, style: .plain)
     private let footerSeparator = UIView()
 
+    private weak var titleField: UITextField?
+
     private lazy var publishButtonViewModel = PublishButtonViewModel(title: "Publish") { [weak self] in
         self?.buttonPublishTapped()
     }
 
+    /// Determines whether the text has been first responder already. If it has, don't force it back on the user unless it's been selected by them.
+    private var hasSelectedText: Bool = false
+
     private var cancellables = Set<AnyCancellable>()
+    @Published private var keyboardShown: Bool = false
 
-    private weak var mediaPollingTimer: Timer?
-
-    init(post: AbstractPost,
+    init(post: Post,
+         identifiers: [PrepublishingIdentifier],
          completion: @escaping (PrepublishingSheetResult) -> (),
          coreDataStack: CoreDataStackSwift = ContextManager.shared,
          persistentStore: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         self.post = post
-        self.viewModel = PrepublishingViewModel(post: post)
+        self.identifiers = identifiers
         self.completion = completion
         self.coreDataStack = coreDataStack
         self.persistentStore = persistentStore
@@ -88,24 +104,18 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     func refreshOptions() {
-        switch post {
-        case is Page:
-            options = [
-                PrepublishingOption(identifier: .visibility),
-                PrepublishingOption(identifier: .schedule)
-            ]
-        case is Post:
-            options = [
-                PrepublishingOption(identifier: .visibility),
-                PrepublishingOption(identifier: .schedule),
-                PrepublishingOption(identifier: .tags),
-                PrepublishingOption(identifier: .categories)
-            ]
-            if RemoteFeatureFlag.jetpackSocialImprovements.enabled() && canDisplaySocialRow() {
-                options.append(PrepublishingOption(identifier: .autoSharing))
+        options = identifiers.compactMap { identifier -> PrepublishingOption? in
+            switch identifier {
+            case .autoSharing:
+                // skip the social cell if the post's blog is not eligible for auto-sharing.
+                guard canDisplaySocialRow() else {
+                    return nil
+                }
+                break
+            default:
+                break
             }
-        default:
-            wpAssertionFailure("invalid post type")
+            return .init(identifier: identifier)
         }
     }
 
@@ -118,6 +128,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
         configureHeader()
         configureTableView()
+        configureKeyboardToggle()
         WPStyleGuide.applyBorderStyle(footerSeparator)
 
         title = ""
@@ -161,12 +172,19 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         footerView.pinSubviewToSafeArea(hostingViewController.view, insets: Constants.nuxButtonInsets)
 
         updatePublishButtonLabel()
-        updatePublishButtonState()
-        mediaPollingTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
-            self?.updatePublishButtonState()
-        }
 
         return footerView
+    }
+
+    /// Toggles `keyboardShown` as the keyboard notifications come in
+    private func configureKeyboardToggle() {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)
+            .sink { [weak self] _ in self?.keyboardShown = true }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)
+            .sink { [weak self] _ in self?.keyboardShown = false }
+            .store(in: &cancellables)
     }
 
     override func viewDidLayoutSubviews() {
@@ -183,6 +201,14 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         if let indexPath = tableView.indexPathForSelectedRow {
             tableView.deselectRow(at: indexPath, animated: true)
         }
+
+        // Setting titleField first resonder alongside our transition to avoid layout issues.
+        transitionCoordinator?.animateAlongsideTransition(in: nil, animation: { [weak self] _ in
+            if self?.hasSelectedText == false {
+                self?.titleField?.becomeFirstResponder()
+                self?.hasSelectedText = true
+            }
+        })
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -193,7 +219,10 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             navigationController?.setNavigationBarHidden(false, animated: animated)
         }
 
-        if isBeingDismissed || parent?.isBeingDismissed == true {
+        if (isBeingDismissed || parent?.isBeingDismissed == true) && !didTapPublish {
+            if post.status == .publishPrivate, let originalStatus = post.original?.status {
+                post.status = originalStatus
+            }
             getCompletion()?(.cancelled)
         }
     }
@@ -210,7 +239,9 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
         switch option.type {
         case .textField:
-            wpAssertionFailure("no longer suppored")
+            if let cell = cell as? WPTextFieldTableViewCell {
+                setupTextFieldCell(cell)
+            }
         case .value:
             cell.accessoryType = .disclosureIndicator
             cell.textLabel?.text = option.title
@@ -220,7 +251,9 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
         switch option.id {
         case .title:
-            wpAssertionFailure("no longer suppored")
+            if let cell = cell as? WPTextFieldTableViewCell {
+                configureTitleCell(cell)
+            }
         case .tags:
             configureTagCell(cell)
         case .visibility:
@@ -239,8 +272,10 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     private func dequeueCell(for type: PrepublishingCellType, indexPath: IndexPath) -> WPTableViewCell {
         switch type {
         case .textField:
-            wpAssertionFailure("no longer suppored")
-            return WPTableViewCell()
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.textFieldReuseIdentifier) as? WPTextFieldTableViewCell else {
+                return WPTextFieldTableViewCell.init(style: .default, reuseIdentifier: Constants.textFieldReuseIdentifier)
+            }
+            return cell
         case .value:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.reuseIdentifier) as? WPTableViewCell else {
                 return WPTableViewCell.init(style: .value1, reuseIdentifier: Constants.reuseIdentifier)
@@ -281,6 +316,11 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         tableView.reloadData()
     }
 
+    private func setupTextFieldCell(_ cell: WPTextFieldTableViewCell) {
+        WPStyleGuide.configureTableViewTextCell(cell)
+        cell.delegate = self
+    }
+
     /// Returns the completion closure and sets it to nil to make sure the screen
     /// only calls it once.
     private func getCompletion() -> ((PrepublishingSheetResult) -> Void)? {
@@ -289,38 +329,46 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         return completion
     }
 
-    // MARK: - Tags (Post)
+    // MARK: - Title
+
+    private func configureTitleCell(_ cell: WPTextFieldTableViewCell) {
+        cell.textField.text = post.postTitle
+        cell.textField.adjustsFontForContentSizeCategory = true
+        cell.textField.font = .preferredFont(forTextStyle: .body)
+        cell.textField.textColor = .text
+        cell.textField.placeholder = Strings.postTitle
+        cell.textField.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        cell.textField.autocorrectionType = .yes
+        cell.textField.autocapitalizationType = .sentences
+        titleField = cell.textField
+    }
+
+    // MARK: - Tags
 
     private func configureTagCell(_ cell: WPTableViewCell) {
-        cell.detailTextLabel?.text = (post as! Post).tags
+        cell.detailTextLabel?.text = post.tags
     }
 
     private func didTapTagCell() {
-        let post = post as! Post
         let tagPickerViewController = PostTagPickerViewController(tags: post.tags ?? "", blog: post.blog)
 
         tagPickerViewController.onValueChanged = { [weak self] tags in
-            guard let self else { return }
             WPAnalytics.track(.editorPostTagsChanged, properties: Constants.analyticsDefaultProperty)
 
-            (self.post as! Post).tags = tags
-            self.reloadData()
+            self?.post.tags = tags
+            self?.reloadData()
         }
 
         navigationController?.pushViewController(tagPickerViewController, animated: true)
     }
 
-    // MARK: - Categories (Post)
-
     private func configureCategoriesCell(_ cell: WPTableViewCell) {
-        let post = post as! Post
         cell.detailTextLabel?.text = Array(post.categories ?? [])
             .map { $0.categoryName }
             .joined(separator: ",")
     }
 
     private func didTapCategoriesCell() {
-        let post = post as! Post
         let categoriesViewController = PostCategoriesViewController(blog: post.blog, currentSelection: Array(post.categories ?? []), selectionMode: .post)
         categoriesViewController.delegate = self
         categoriesViewController.onCategoriesChanged = { [weak self] in
@@ -332,44 +380,41 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     // MARK: - Visibility
 
     private func configureVisibilityCell(_ cell: WPTableViewCell) {
-        cell.detailTextLabel?.text = viewModel.visibility.localizedTitle
+        cell.detailTextLabel?.text = post.titleForVisibility
     }
 
     private func didTapVisibilityCell() {
-        let view = PostVisibilityPicker(visibility: viewModel.visibility) { [weak self] selection in
-            guard let self else { return }
-            self.viewModel.visibility = selection.visibility
-            if selection.visibility == .private {
-                self.viewModel.publishDate = nil
-                self.updatePublishButtonLabel()
+        let visbilitySelectorViewController = PostVisibilitySelectorViewController(post)
+
+        visbilitySelectorViewController.completion = { [weak self] option in
+            self?.reloadData()
+            self?.updatePublishButtonLabel()
+
+            WPAnalytics.track(.editorPostVisibilityChanged, properties: Constants.analyticsDefaultProperty)
+
+            // If tue user selects password protected, prompt for a password
+            if option == AbstractPost.passwordProtectedLabel {
+                self?.showPasswordAlert()
+            } else {
+                self?.navigationController?.popViewController(animated: true)
             }
-            self.viewModel.password = selection.password
-            self.reloadData()
-            self.navigationController?.popViewController(animated: true)
         }
-        let viewController = UIHostingController(rootView: view)
-        viewController.title = PostVisibilityPicker.title
-        navigationController?.pushViewController(viewController, animated: true)
+
+        navigationController?.pushViewController(visbilitySelectorViewController, animated: true)
     }
 
     // MARK: - Schedule
 
     func configureScheduleCell(_ cell: WPTableViewCell) {
         cell.textLabel?.text = Strings.publishDate
-        if let publishDate = viewModel.publishDate {
-            let formatter = SiteDateFormatters.dateFormatter(for: post.blog.timeZone ?? TimeZone.current, dateStyle: .medium, timeStyle: .short)
-            cell.detailTextLabel?.text = formatter.string(from: publishDate)
-        } else {
-            cell.detailTextLabel?.text = Strings.immediately
-        }
-        viewModel.visibility == .private ? cell.disable() : cell.enable()
+        cell.detailTextLabel?.text = publishSettingsViewModel.detailString
+        post.status == .publishPrivate ? cell.disable() : cell.enable()
     }
 
     func didTapSchedule(_ indexPath: IndexPath) {
-        let viewController = SchedulingDatePickerViewController()
-        viewController.configuration = SchedulingDatePickerConfiguration(date: viewModel.publishDate, timeZone: post.blog.timeZone ?? TimeZone.current) { [weak self] date in
+        let viewController = SchedulingDatePickerViewController.make(viewModel: publishSettingsViewModel) { [weak self] date in
             WPAnalytics.track(.editorPostScheduledChanged, properties: Constants.analyticsDefaultProperty)
-            self?.viewModel.publishDate = date
+            self?.publishSettingsViewModel.setDate(date)
             self?.reloadData()
             self?.updatePublishButtonLabel()
         }
@@ -391,24 +436,16 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     private func updatePublishButtonLabel() {
-        let isScheduled = viewModel.publishDate.map { $0 > .now } ?? false
-        publishButtonViewModel.title = isScheduled ? Strings.schedule : Strings.publish
+        publishButtonViewModel.title = post.isScheduled() ? Strings.schedule : Strings.publish
     }
 
     private func buttonPublishTapped() {
-        setLoading(true)
-        Task {
-            do {
-                try await PostCoordinator.shared._publish(post.original(), options: .init(
-                    visibility: viewModel.visibility,
-                    password: viewModel.password,
-                    publishDate: viewModel.publishDate
-                ))
-                getCompletion()?(.published)
-            } catch {
-                setLoading(false)
-                publishButtonViewModel.state = .default
-            }
+        didTapPublish = true
+
+        let completion = getCompletion()
+        navigationController?.dismiss(animated: true) {
+            WPAnalytics.track(.editorPostPublishNowTapped)
+            completion?(.confirmed)
         }
     }
 
@@ -423,23 +460,59 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             case let control as UIControl:
                 control.isEnabled = !isLoading
             case let cell as UITableViewCell:
-                cell.textLabel?.textColor = isLoading ? .secondaryLabel : .label
+                isLoading ? cell.disable() : cell.enable()
             default:
                 subviews += view.subviews
             }
         }
     }
 
+    // MARK: - Password Prompt
+
+    private func showPasswordAlert() {
+        let passwordAlertController = PasswordAlertController(onSubmit: { [weak self] password in
+            guard let password = password, !password.isEmpty else {
+                self?.cancelPasswordProtectedPost()
+                return
+            }
+
+            self?.post.password = password
+            self?.navigationController?.popViewController(animated: true)
+        }, onCancel: { [weak self] in
+            self?.cancelPasswordProtectedPost()
+        })
+
+        passwordAlertController.show(from: self)
+    }
+
+    private func cancelPasswordProtectedPost() {
+        post.status = .publish
+        post.password = nil
+        reloadData()
+    }
+
     // MARK: - Accessibility
 
     fileprivate enum Constants {
         static let reuseIdentifier = "wpTableViewCell"
+        static let textFieldReuseIdentifier = "wpTextFieldCell"
         static let nuxButtonInsets = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
         static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]
     }
 }
 
-extension PrepublishingViewController: PostCategoriesViewControllerDelegate {
+extension DeprecatedPrepublishingViewController: WPTextFieldTableViewCellDelegate {
+    func cellWants(toSelectNextField cell: WPTextFieldTableViewCell!) {
+
+    }
+
+    func cellTextDidChange(_ cell: WPTextFieldTableViewCell!) {
+        WPAnalytics.track(.editorPostTitleChanged, properties: Constants.analyticsDefaultProperty)
+        post.postTitle = cell.textField.text
+    }
+}
+
+extension DeprecatedPrepublishingViewController: PostCategoriesViewControllerDelegate {
     func postCategoriesViewController(_ controller: PostCategoriesViewController, didUpdateSelectedCategories categories: NSSet) {
         WPAnalytics.track(.editorPostCategoryChanged, properties: ["via": "prepublishing_nudges"])
 
@@ -447,56 +520,8 @@ extension PrepublishingViewController: PostCategoriesViewControllerDelegate {
         guard let categories = categories as? Set<PostCategory> else {
              return
         }
-        (post as! Post).categories = categories
+        post.categories = categories
         post.save()
-    }
-}
-
-struct PrepublishingOption {
-    let id: PrepublishingIdentifier
-    let title: String
-    let type: PrepublishingCellType
-}
-
-enum PrepublishingCellType {
-    case value
-    case textField
-    case customContainer
-}
-
-extension PrepublishingOption {
-    init(identifier: PrepublishingIdentifier) {
-        switch identifier {
-        case .title:
-            self.init(id: .title, title: Strings.postTitle, type: .textField)
-        case .schedule:
-            self.init(id: .schedule, title: Strings.publishDate, type: .value)
-        case .categories:
-            self.init(id: .categories, title: Strings.categories, type: .value)
-        case .visibility:
-            self.init(id: .visibility, title: Strings.visibility, type: .value)
-        case .tags:
-            self.init(id: .tags, title: Strings.tags, type: .value)
-        case .autoSharing:
-            self.init(id: .autoSharing, title: Strings.jetpackSocial, type: .customContainer)
-        }
-    }
-}
-
-private final class PrepublishingViewModel {
-    private let post: AbstractPost
-
-    var visibility: PostVisibility
-    var password: String?
-    var publishDate: Date?
-
-    init(post: AbstractPost) {
-        self.post = post
-
-        self.visibility = PostVisibility(status: post.status ?? .draft, password: post.password)
-        self.password = post.password
-        // Ask the user to provide the date every time (ignore the obscure WP dateCreated/dateModified logic)
-        self.publishDate = nil
     }
 }
 
@@ -509,5 +534,4 @@ private enum Strings {
     static let categories = NSLocalizedString("prepublishing.categories", value: "Categories", comment: "Label for a cell in the pre-publishing sheet")
     static let tags = NSLocalizedString("prepublishing.tags", value: "Tags", comment: "Label for a cell in the pre-publishing sheet")
     static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
-    static let immediately = NSLocalizedString("prepublishing.publishDateImmediately", value: "Immediately", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -1,18 +1,18 @@
 import UIKit
 
 extension PrepublishingViewController {
-    static func show(for revision: AbstractPost, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+    static func show(for revision: AbstractPost, action: PostEditorAction, isStandalone: Bool = false, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
         guard RemoteFeatureFlag.syncPublishing.enabled() else {
             return _show(for: revision, action: action, from: presentingViewController, completion: completion)
         }
-        show(post: revision, from: presentingViewController, completion: completion)
+        show(post: revision, isStandalone: isStandalone, from: presentingViewController, completion: completion)
     }
 
     /// - warning: deprecated (kahu-offline-mode)
     private static func _show(for revision: AbstractPost, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
         switch revision {
         case let post as Post:
-            show(post: post, from: presentingViewController, completion: completion)
+            showDeprecated(post: post, from: presentingViewController, completion: completion)
         case let page as Page:
             showAlert(for: page, action: action, from: presentingViewController, completion: completion)
         default:
@@ -21,11 +21,11 @@ extension PrepublishingViewController {
         }
     }
 
-    private static func show(post: AbstractPost, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+    private static func show(post: AbstractPost, isStandalone: Bool, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
         // End editing to avoid issues with accessibility
         presentingViewController.view.endEditing(true)
 
-        let viewController = PrepublishingViewController(post: post, completion: completion)
+        let viewController = PrepublishingViewController(post: post, isStandalone: isStandalone, completion: completion)
         viewController.presentAsSheet(from: presentingViewController)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+extension PrepublishingViewController {
+    static func show(for revision: AbstractPost, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            return _show(for: revision, action: action, from: presentingViewController, completion: completion)
+        }
+        show(post: revision, from: presentingViewController, completion: completion)
+    }
+
+    /// - warning: deprecated (kahu-offline-mode)
+    private static func _show(for revision: AbstractPost, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        switch revision {
+        case let post as Post:
+            show(post: post, from: presentingViewController, completion: completion)
+        case let page as Page:
+            showAlert(for: page, action: action, from: presentingViewController, completion: completion)
+        default:
+            assertionFailure("Unsupported post type")
+            break
+        }
+    }
+
+    private static func show(post: AbstractPost, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        // End editing to avoid issues with accessibility
+        presentingViewController.view.endEditing(true)
+
+        let viewController = PrepublishingViewController(post: post, completion: completion)
+        viewController.presentAsSheet(from: presentingViewController)
+    }
+
+    private static func showDeprecated(post: Post, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        // End editing to avoid issues with accessibility
+        presentingViewController.view.endEditing(true)
+
+        let viewController = DeprecatedPrepublishingViewController(post: post, identifiers: PrepublishingIdentifier.defaultIdentifiers, completion: completion)
+        viewController.presentAsSheet(from: presentingViewController)
+    }
+
+    private static func showAlert(for page: Page, action: PostEditorAction, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
+        let title = action.publishingActionQuestionLabel
+        let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
+        let publishTitle = action.publishActionLabel
+        let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
+
+        alertController.addCancelActionWithTitle(keepEditingTitle) { _ in
+            completion(.cancelled)
+        }
+        alertController.addDefaultActionWithTitle(publishTitle) { _ in
+            completion(.confirmed)
+        }
+        presentingViewController.present(alertController, animated: true, completion: nil)
+    }
+}

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -5,8 +5,8 @@ class EditorGutenbergTests: XCTestCase {
 
     @MainActor
     override func setUp() async throws {
-        setUpTestSuite(selectWPComSite: WPUITestCredentials.testWPcomPaidSite)
         try await WireMock.setUpScenario(scenario: "new_post_flow")
+        setUpTestSuite(selectWPComSite: WPUITestCredentials.testWPcomPaidSite)
 
         try TabNavComponent()
             .goToBlockEditorScreen()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -601,6 +601,12 @@
 		0CED95612A460F4B0020F420 /* DebugFeatureFlagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */; };
 		0CF0C4232AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
 		0CF0C4242AE98C13006FFAB4 /* AbstractPostHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */; };
+		0CF22F5C2BC960430005B070 /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF22F5B2BC960430005B070 /* PrepublishingViewController.swift */; };
+		0CF22F5D2BC960430005B070 /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF22F5B2BC960430005B070 /* PrepublishingViewController.swift */; };
+		0CF22F5F2BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF22F5E2BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift */; };
+		0CF22F602BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF22F5E2BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift */; };
+		0CF22F622BC963690005B070 /* PrepublishingViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF22F612BC963690005B070 /* PrepublishingViewController+Helpers.swift */; };
+		0CF22F632BC963690005B070 /* PrepublishingViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF22F612BC963690005B070 /* PrepublishingViewController+Helpers.swift */; };
 		0CF7D6C32ABB753A006D1E89 /* MediaImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */; };
 		0CF7EACF2B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */; };
 		0CF7EAD02B859535003CC558 /* PostServiceRemote+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */; };
@@ -2359,7 +2365,7 @@
 		8BA77BCF2483415400E1EBBF /* ReaderDetailToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */; };
 		8BAC9D9E27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */; };
 		8BAC9D9F27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */; };
-		8BAD272C241FEF3300E9D105 /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */; };
+		8BAD272C241FEF3300E9D105 /* DeprecatedPrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* DeprecatedPrepublishingViewController.swift */; };
 		8BAD53D6241922B900230F4B /* WPAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */; };
 		8BADF16524801BCE005AD038 /* ReaderWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BADF16424801BCE005AD038 /* ReaderWebView.swift */; };
 		8BB185C624B5FB8500A4CCE8 /* ReaderCardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB185C524B5FB8500A4CCE8 /* ReaderCardService.swift */; };
@@ -4700,7 +4706,7 @@
 		FABB22AF2602FC2C00C8785C /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
 		FABB22B12602FC2C00C8785C /* ReaderDetailFeaturedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3223393B24FEC18000BDD4BF /* ReaderDetailFeaturedImageView.swift */; };
 		FABB22B22602FC2C00C8785C /* StatsDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */; };
-		FABB22B32602FC2C00C8785C /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */; };
+		FABB22B32602FC2C00C8785C /* DeprecatedPrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* DeprecatedPrepublishingViewController.swift */; };
 		FABB22B52602FC2C00C8785C /* SearchableItemConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74729CA52056FE6000D1394D /* SearchableItemConvertable.swift */; };
 		FABB22B72602FC2C00C8785C /* SettingsListEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D994E1C0790CC0003D795 /* SettingsListEditorViewController.swift */; };
 		FABB22B82602FC2C00C8785C /* QuickStartChecklistManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4E215B21F75BBE00EFF212 /* QuickStartChecklistManager.swift */; };
@@ -5699,8 +5705,8 @@
 		FED77259298BC5B300C2346E /* PluginJetpackProxyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED77257298BC5B300C2346E /* PluginJetpackProxyService.swift */; };
 		FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
-		FEDA8D9C2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */; };
-		FEDA8D9D2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */; };
+		FEDA8D9C2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift */; };
+		FEDA8D9D2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9B2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift */; };
 		FEDA8D9F2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */; };
 		FEDA8DA02A5B1B1B0081314F /* PrepublishingAutoSharingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
@@ -6337,6 +6343,9 @@
 		0CED200B2B68425A00E6DD52 /* WebKitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebKitView.swift; sourceTree = "<group>"; };
 		0CED955F2A460F4B0020F420 /* DebugFeatureFlagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugFeatureFlagsView.swift; sourceTree = "<group>"; };
 		0CF0C4222AE98C13006FFAB4 /* AbstractPostHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPostHelper.swift; sourceTree = "<group>"; };
+		0CF22F5B2BC960430005B070 /* PrepublishingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingViewController.swift; sourceTree = "<group>"; };
+		0CF22F5E2BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrepublishingViewController+JetpackSocial.swift"; sourceTree = "<group>"; };
+		0CF22F612BC963690005B070 /* PrepublishingViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrepublishingViewController+Helpers.swift"; sourceTree = "<group>"; };
 		0CF7D6C22ABB753A006D1E89 /* MediaImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaImageServiceTests.swift; sourceTree = "<group>"; };
 		0CF7EACE2B859535003CC558 /* PostServiceRemote+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostServiceRemote+Concurrency.swift"; sourceTree = "<group>"; };
 		0CFD6C792A73E703003DD0A0 /* WordPress 152.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 152.xcdatamodel"; sourceTree = "<group>"; };
@@ -7734,7 +7743,7 @@
 		8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderDetailToolbar.xib; sourceTree = "<group>"; };
 		8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailToolbar.swift; sourceTree = "<group>"; };
 		8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardRemoteEntity.swift; sourceTree = "<group>"; };
-		8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingViewController.swift; sourceTree = "<group>"; };
+		8BAD272B241FEF3300E9D105 /* DeprecatedPrepublishingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedPrepublishingViewController.swift; sourceTree = "<group>"; };
 		8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAnalyticsEvent.swift; sourceTree = "<group>"; };
 		8BADF16424801BCE005AD038 /* ReaderWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderWebView.swift; sourceTree = "<group>"; };
 		8BB185C524B5FB8500A4CCE8 /* ReaderCardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCardService.swift; sourceTree = "<group>"; };
@@ -9578,7 +9587,7 @@
 		FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolver.swift; sourceTree = "<group>"; };
 		FED77257298BC5B300C2346E /* PluginJetpackProxyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginJetpackProxyService.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
-		FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrepublishingViewController+JetpackSocial.swift"; sourceTree = "<group>"; };
+		FEDA8D9B2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeprecatedPrepublishingViewController+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingAutoSharingView.swift; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
@@ -18738,8 +18747,11 @@
 		FE7B9A852A6A60EC00488791 /* Prepublishing */ = {
 			isa = PBXGroup;
 			children = (
-				8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */,
-				FEDA8D9B2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift */,
+				0CF22F5B2BC960430005B070 /* PrepublishingViewController.swift */,
+				0CF22F612BC963690005B070 /* PrepublishingViewController+Helpers.swift */,
+				0CF22F5E2BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift */,
+				8BAD272B241FEF3300E9D105 /* DeprecatedPrepublishingViewController.swift */,
+				FEDA8D9B2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift */,
 				FEDA8D9E2A5B1B1B0081314F /* PrepublishingAutoSharingView.swift */,
 				FE7B9A862A6A613000488791 /* PrepublishingSocialAccountsViewController.swift */,
 				FE7B9A892A6BD20200488791 /* PrepublishingSocialAccountsTableFooterView.swift */,
@@ -21709,6 +21721,7 @@
 				FAD951A425B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift in Sources */,
 				C3E2462926277B7700B99EA6 /* PostAuthorSelectorViewController.swift in Sources */,
 				F5E032E62408D537003AF350 /* ActionSheetViewController.swift in Sources */,
+				0CF22F5C2BC960430005B070 /* PrepublishingViewController.swift in Sources */,
 				9A4F8F56218B88E000EEDCCC /* PostService+Revisions.swift in Sources */,
 				FA34AD942B62976100208D65 /* SiteMonitoringView.swift in Sources */,
 				8332D7452ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */,
@@ -22041,7 +22054,7 @@
 				1788106F260E488B00A98BD8 /* UnifiedPrologueNotificationsContentView.swift in Sources */,
 				3223393C24FEC18100BDD4BF /* ReaderDetailFeaturedImageView.swift in Sources */,
 				98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */,
-				8BAD272C241FEF3300E9D105 /* PrepublishingViewController.swift in Sources */,
+				8BAD272C241FEF3300E9D105 /* DeprecatedPrepublishingViewController.swift in Sources */,
 				4A1E77C92988997C006281CC /* PublicizeConnection+Creation.swift in Sources */,
 				01E70EBB2BB5CCCF000BFE45 /* NumberFormatter+Stats.swift in Sources */,
 				F10D634F26F0B78E00E46CC7 /* Blog+Organization.swift in Sources */,
@@ -22072,6 +22085,7 @@
 				98A047722821CEBF001B4E2D /* BloggingPromptsViewController.swift in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				011896A229D5AF0700D34BA9 /* BlogDashboardCardConfigurable.swift in Sources */,
+				0CF22F5F2BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift in Sources */,
 				C81CCD81243BF7A600A83E27 /* TenorService.swift in Sources */,
 				0C749D7A2B0543D0004CB468 /* WPImageViewController+Swift.swift in Sources */,
 				8B51844525893F140085488D /* FilterBarView.swift in Sources */,
@@ -22264,6 +22278,7 @@
 				C3B5545329661F2C00A04753 /* ThemeBrowserViewController+JetpackBannerViewController.swift in Sources */,
 				3FCCAA1523F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift in Sources */,
 				91EABC452BB56EE10098D330 /* UIImageView+Gravatar.swift in Sources */,
+				0CF22F622BC963690005B070 /* PrepublishingViewController+Helpers.swift in Sources */,
 				FFEECFFC2084DE2B009B8CDB /* PostSettingsViewController+FeaturedImageUpload.swift in Sources */,
 				D8212CB120AA64E1008E8AE8 /* ReaderLikeAction.swift in Sources */,
 				01D7EBA42B7A4BBD00F14992 /* HashableImmutableRow.swift in Sources */,
@@ -22501,7 +22516,7 @@
 				F5E032E82408D537003AF350 /* BottomSheetPresentationController.swift in Sources */,
 				FA98A24D2832A5E9003B9233 /* NewQuickStartChecklistView.swift in Sources */,
 				FA98B61929A3BF050071AAE8 /* DashboardBlazePromoCardView.swift in Sources */,
-				FEDA8D9C2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */,
+				FEDA8D9C2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift in Sources */,
 				AB758D9E25EFDF9C00961C0B /* LikesListController.swift in Sources */,
 				E1FD45E01C030B3800750F4C /* AccountSettingsService.swift in Sources */,
 				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
@@ -24908,7 +24923,7 @@
 				FABB22B12602FC2C00C8785C /* ReaderDetailFeaturedImageView.swift in Sources */,
 				FEA7948E26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */,
 				FABB22B22602FC2C00C8785C /* StatsDataHelper.swift in Sources */,
-				FABB22B32602FC2C00C8785C /* PrepublishingViewController.swift in Sources */,
+				FABB22B32602FC2C00C8785C /* DeprecatedPrepublishingViewController.swift in Sources */,
 				FABB22B52602FC2C00C8785C /* SearchableItemConvertable.swift in Sources */,
 				4A9948E5297624EF006282A9 /* Blog+Creation.swift in Sources */,
 				8BBBCE712717651200B277AC /* JetpackModuleHelper.swift in Sources */,
@@ -25209,6 +25224,7 @@
 				175CC17D2723103000622FB4 /* WPAnalytics+Domains.swift in Sources */,
 				FABB237A2602FC2C00C8785C /* LikeComment.swift in Sources */,
 				FABB237B2602FC2C00C8785C /* Page.swift in Sources */,
+				0CF22F5D2BC960430005B070 /* PrepublishingViewController.swift in Sources */,
 				FABB237C2602FC2C00C8785C /* ReaderInterestsCoordinator.swift in Sources */,
 				FABB237D2602FC2C00C8785C /* ReaderSavedPostCellActions.swift in Sources */,
 				C79C308126EA975900E88514 /* ReferrerDetailsHeaderCell.swift in Sources */,
@@ -25592,6 +25608,7 @@
 				FABB248D2602FC2C00C8785C /* PostCoordinator.swift in Sources */,
 				FABB248E2602FC2C00C8785C /* AztecAttachmentDelegate.swift in Sources */,
 				803DE81428FFAE36007D4E9C /* RemoteConfigStore.swift in Sources */,
+				0CF22F602BC9605D0005B070 /* PrepublishingViewController+JetpackSocial.swift in Sources */,
 				086C117D2A2F6451004A3821 /* CompliancePopover.swift in Sources */,
 				FA98A2512833F1DC003B9233 /* QuickStartChecklistConfigurable.swift in Sources */,
 				01E258062ACC373800F09666 /* PlanWizardContent.swift in Sources */,
@@ -25656,7 +25673,7 @@
 				FABB24B82602FC2C00C8785C /* DynamicHeightCollectionView.swift in Sources */,
 				FABB24B92602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowList.swift in Sources */,
 				0C700B872AE1E1300085C2EE /* PageListCell.swift in Sources */,
-				FEDA8D9D2A5AA7050081314F /* PrepublishingViewController+JetpackSocial.swift in Sources */,
+				FEDA8D9D2A5AA7050081314F /* DeprecatedPrepublishingViewController+JetpackSocial.swift in Sources */,
 				FABB24BA2602FC2C00C8785C /* TenorGIF.swift in Sources */,
 				FABB24BB2602FC2C00C8785C /* ThemeBrowserViewController.swift in Sources */,
 				FA73D7ED27987E4500DF24B3 /* SitePickerViewController+QuickStart.swift in Sources */,
@@ -25759,6 +25776,7 @@
 				FABB25022602FC2C00C8785C /* NotificationTextContent.swift in Sources */,
 				FABB25032602FC2C00C8785C /* PostEditor+Publish.swift in Sources */,
 				FABB25042602FC2C00C8785C /* MediaCoordinator.swift in Sources */,
+				0CF22F632BC963690005B070 /* PrepublishingViewController+Helpers.swift in Sources */,
 				834A49D32A0C23A90042ED3D /* TemplatePageTableViewCell.swift in Sources */,
 				FABB25052602FC2C00C8785C /* StatsStackViewCell.swift in Sources */,
 				C79C307E26EA970200E88514 /* ReferrerDetailsHeaderRow.swift in Sources */,

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -557,7 +557,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         XCTAssertTrue(post.isStickyPost)
     }
 
-    // MARK: - Exising Post (404, Not Found)
+    // MARK: - Existing Post (404, Not Found)
 
     /// Scenario: saving a post that was deleted on the remote.
     func testSaveExistingPostDeletedOnRemote() async throws {


### PR DESCRIPTION
- Add `DeprecatedPrepublishingViewController`. There were too many changes required in the screen and it was no longer sustainable to keep adding if statement to the exiting screen. The deprecated version now fully matches the production version to ensure we don't regress the experience for users who don't have this feature flag on.
- Fix an issue with posts being published as "protected" by default
- (Revert) Remove "Publish Date" from the draft Post Settings again (it's unfixable without the switch to the .org API). Related discussion about the publish date: p1712869221226789-slack-C06GRKUGDNX. The republishing sheet will now require you to set the "publish date" right before publishing.
- Fix an issue where a standalone prepublishing sheet would not send the tags and categories when publishing (it required a revision)
- Fix an issue where the changes made in the standalone prepublishing sheet would be saved to the DB and not the server
- Fix an issue with publish button label not updating after changing visibility to .private

Related WPKit PR https://github.com/wordpress-mobile/WordPressKit-iOS/pull/786
 
## To test:

**Test 1.1**

- Create and save a draft post
- Open Post Settings
- **Verify** that the "Publish Date" says "Immediately"
- Change the publish date to a different date
- Return back to Post Settings and verify that the date was displayed
- Save the changes
- Reopen Post Settings and **verify** that is still shows the selected date
- Remove the publish date (in the current branch, tap "Now")
- **Verify** that the "Publish Date" says "Immediately"
- Save 
- Reopend Post Settings and **verify** that the date still says now

**Test 2.1**

- Create and save a draft post
- Open Post Settings and save the publish date in the future
- Tap "Publish" from the list
- Select a future date in the past
- Tap "Publish" to confirm
- **Verify** that the post got published with the selected date

**Test 2.2**

- Create and save a draft post
- Tap "Publish" from the List
- Add a tag
- Tap "Publish" again to confirm
- **Verify** that the post was published with the selected tag

**Test 2.3**

- Create and save a draft post
- Tap "Publish" from the List
- Add a tag
- Tap "Close"
- **Verify** that the revision was deleted and the changes were not saved

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
