### PR TITLE
Reading Preferences: Enable feature for the Jetpack app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 24.7
 -----
 
+* [**] [Jetpack-only] Reader: Introducing Reading Preferences, an experimental feature that allows users to customize their Reader post content screen with the color, font, and size that they like the most. [#22999]
 * [*] [Jetpack-only] Stats: Optimized the Insights tab to enhance loading and scrolling performance. [#22592]
 
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -89,9 +89,9 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .readerDiscoverEndpoint:
             return true
         case .readingPreferences:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .readingPreferencesFeedback:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -4,7 +4,7 @@ import WordPressShared
 struct ReaderDisplaySetting: Codable, Equatable {
 
     static var customizationEnabled: Bool {
-        RemoteFeatureFlag.readingPreferences.enabled()
+        AppConfiguration.isJetpack && RemoteFeatureFlag.readingPreferences.enabled()
     }
 
     // MARK: Properties

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -236,7 +236,8 @@ extension ReaderDisplaySettingSelectionView {
         }
 
         var feedbackText: Text? {
-            guard RemoteFeatureFlag.readingPreferencesFeedback.enabled() else {
+            guard AppConfiguration.isJetpack,
+                  RemoteFeatureFlag.readingPreferencesFeedback.enabled() else {
                 return nil
             }
 


### PR DESCRIPTION
Part of #22925 
Internal refs: pcdRpT-6bB-p2, pctCYC-1jz-p2

![customisation mocks](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/a4ca71ef-38db-4ef4-b163-50b0b765d68a)

This enables the `reading_preferences` and the `reading_preferences_feedback` feature flag. Note that for this iteration, the customization is only applied on the Reader Post screen.

## To test

- Launch the Jetpack app
- Go to the Reader tab and open any post
- 🔎  Verify that the customization icon is visible
- 🔎  Verify that tapping the customization icon opens the customization sheet

More detailed testing instructions are available in this internal ref: pctCYC-1jz-p2.

## Regression Notes
1. Potential unintended areas of impact
  - `CommentContentTableViewCell` is modified to allow style customization.
  - `ReaderFollowButton` is modified to allow for style customization.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [x] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)