### PR TITLE
Offline Mode: Fix an issue with trashing a permanently deleted posts

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 16.0.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '09007896f353820a968b8d03077761c5f540d47c'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'db1aceec23321d11989d86c987bfb34555fcec5b'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
@@ -150,7 +150,7 @@ abstract_target 'Apps' do
 
   pod 'NSURL+IDN', '~> 0.4'
 
-  pod 'WordPressAuthenticator', '~> 9.0', '>= 9.0.6'
+  pod 'WordPressAuthenticator', '~> 9.0', '>= 9.0.8'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -64,14 +64,14 @@ PODS:
   - WordPress-Aztec-iOS (1.19.11)
   - WordPress-Editor-iOS (1.19.11):
     - WordPress-Aztec-iOS (= 1.19.11)
-  - WordPressAuthenticator (9.0.6):
+  - WordPressAuthenticator (9.0.8):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 16.0)
+    - WordPressKit (~> 17.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (16.0.0):
+  - WordPressKit (17.0.0):
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
@@ -120,8 +120,8 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
-  - WordPressAuthenticator (>= 9.0.6, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `09007896f353820a968b8d03077761c5f540d47c`)
+  - WordPressAuthenticator (>= 9.0.8, ~> 9.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `db1aceec23321d11989d86c987bfb34555fcec5b`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.116.0.podspec
   WordPressKit:
-    :commit: 09007896f353820a968b8d03077761c5f540d47c
+    :commit: db1aceec23321d11989d86c987bfb34555fcec5b
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -186,7 +186,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: 09007896f353820a968b8d03077761c5f540d47c
+    :commit: db1aceec23321d11989d86c987bfb34555fcec5b
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -220,8 +220,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c
-  WordPressAuthenticator: 6be121346d4303dd32904a57f6d0e68eaa825152
-  WordPressKit: f6dc2acce37a526ddb59e02388b3d59da50918ed
+  WordPressAuthenticator: 898acaac75c5ade9b900c02622a15b9aef8fde1a
+  WordPressKit: a71cc550f4b525ab5eef057984c8de071462edd5
   WordPressShared: 04c6d51441bb8fa29651075b3a5536c90ae89c76
   WordPressUI: ec5ebcf7e63e797ba51d07513e340c1b14cf45a4
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -234,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 8762d86083d78f4f8df8d0850f375f1b46a73c9c
+PODFILE CHECKSUM: a2b31570f221454ec604c0e7543be13e1127c861
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -1085,6 +1085,7 @@ class PostCoordinator: NSObject {
             MediaCoordinator.shared.cancelUploadOfAllMedia(for: post)
             SearchManager.shared.deleteSearchableItem(post)
         } catch {
+            trackError(error, operation: "post-trash")
             handleError(error, for: post)
         }
     }
@@ -1099,6 +1100,7 @@ class PostCoordinator: NSObject {
         do {
             try await PostRepository(coreDataStack: coreDataStack)._delete(post)
         } catch {
+            trackError(error, operation: "post-delete")
             handleError(error, for: post)
         }
     }

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -2,19 +2,6 @@ import Foundation
 import WordPressKit
 
 extension PostServiceRemote {
-    func post(withID postID: NSNumber) async throws -> RemotePost {
-        try await withCheckedThrowingContinuation { continuation in
-            getPostWithID(postID, success: {
-                guard let post = $0 else {
-                    return continuation.resume(throwing: URLError(.unknown))
-                }
-                continuation.resume(returning: post)
-            }, failure: {
-                continuation.resume(throwing: $0 ?? URLError(.unknown))
-            })
-        }
-    }
-
     func trashPost(_ post: RemotePost) async throws -> RemotePost {
         try await withCheckedThrowingContinuation { continuation in
             trashPost(post) {


### PR DESCRIPTION
Fixes a known issue originally found here https://github.com/wordpress-mobile/WordPress-iOS/pull/22987.

## To test:

For both wp.com and self-hosted sites:

- Open the post list  (Published or Drafts) in the app
- Open the same list on the web and trash and then permanently delete a post
- Trash the same post form the app
- **Verify** that an error alert is shown saying that the post was permanently deleted
- Tap "OK"
- **Verify** that the post was removed from the list

## Regression Notes
1. Potential unintended areas of impact: Post List / Trash
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual and automated
3. What automated tests I added (or what prevented me from doing so): _

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
