### PR TITLE
[Share Action] Set provider to only url for Copy action

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -5,11 +5,11 @@ import SVProgressHUD
 
     @objc func shareController(_ title: String?, summary: String?, link: String?) -> UIActivityViewController {
         let url = link.flatMap(URL.init(string:))
-        let allItems: [Any?] = [title, summary, url]
-        let nonNilActivityItems = allItems.compactMap({ $0 })
+        let provider = CustomActivityItemProvider(title: title, summary: summary, url: url)
 
         let activities = WPActivityDefaults.defaultActivities() as! [UIActivity]
-        let controller = UIActivityViewController(activityItems: nonNilActivityItems, applicationActivities: activities)
+        let controller = UIActivityViewController(activityItems: [provider], applicationActivities: activities)
+
         if let str = title {
             controller.setValue(str, forKey: "subject")
         }
@@ -144,4 +144,27 @@ import SVProgressHUD
     }
 
     typealias PopoverAnchor = UIPopoverPresentationController.PopoverAnchor
+}
+
+private class CustomActivityItemProvider: UIActivityItemProvider {
+    private let title: String?
+    private let summary: String?
+    private let url: URL?
+
+    init(title: String?, summary: String?, url: URL?) {
+        self.title = title
+        self.summary = summary
+        self.url = url
+        super.init(placeholderItem: url ?? "")
+    }
+
+    override var item: Any {
+        guard let activityType = self.activityType else { return url ?? "" }
+
+        if activityType == .copyToPasteboard {
+            return url ?? ""
+        } else {
+            return [title as Any, summary as Any, url as Any].compactMap { $0 }
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -164,7 +164,8 @@ private class CustomActivityItemProvider: UIActivityItemProvider {
         if activityType == .copyToPasteboard {
             return url ?? ""
         } else {
-            return [title as Any, summary as Any, url as Any].compactMap { $0 }
+            let formattedText = "\(title ?? "")\n\(summary ?? "")\n\(url?.absoluteString ?? "")"
+            return formattedText
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -161,7 +161,7 @@ private class CopyLinkActivity: UIActivity {
     }
 
     override var activityImage: UIImage? {
-        return UIImage(systemName: "doc.on.doc")
+        return UIImage(systemName: "link")
     }
 
     override var activityType: UIActivity.ActivityType? {
@@ -191,7 +191,10 @@ private class CopyLinkActivity: UIActivity {
    }
 
    override func perform() {
-    UIPasteboard.general.string = url?.absoluteString
-    activityDidFinish(true)
+       guard let url else {
+           return
+       }
+       UIPasteboard.general.string = url.absoluteString
+       activityDidFinish(true)
    }
 }


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/22988

## Description
Due to a regression, "Copy" action for sharing posts was copying the "title + url" to the clipboard. Now only for copy action, only url will be copied. The rest of the actions will keep behaving as they were. This change affects all share entry points that use `PostSharingController`. 

## Testing Steps

### Copy Message
1. Install and Login to Jetpack
2. Go to Posts
3. Tap on Context Menu > Share > Copy
4. ✅ Verify that the text only contains the URL for the post.

### Regression
1. Go to Posts
2. Tap on Context Menu > Share then any share action.
3. ✅ Verify that the text contains the title as well as the url like before.

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
