### PR TITLE
[Tooling] Improve the "internal pods not on stable version" annotation

### DIFF
--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -15,5 +15,8 @@ bundle exec fastlane run configure_apply
 echo "--- :swift: Setting up Swift Packages"
 install_swiftpm_dependencies
 
+echo "--- Test unstable internal pods annotation"
+bundle exec fastlane test_check_pods_references
+
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_wordpress_prototype_build

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -15,8 +15,5 @@ bundle exec fastlane run configure_apply
 echo "--- :swift: Setting up Swift Packages"
 install_swiftpm_dependencies
 
-echo "--- Test unstable internal pods annotation"
-bundle exec fastlane test_check_pods_references
-
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_wordpress_prototype_build

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -598,8 +598,7 @@ end
 def check_pods_references
   result = ios_check_beta_deps(lockfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile.lock'))
 
-  # Will fail if :pods doesn't exist in the result.
-  # Seems fair, given the shape of the result Hash should not change unless via a major version bump.
-  style = result[:pods].empty? ? 'success' : 'warning'
-  buildkite_annotate(context: 'pods-check', style:, message: result[:message]) if is_ci
+  style = result[:pods].nil? || result[:pods].empty? ? 'success' : 'warning'
+  message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
+  buildkite_annotate(context: 'pods-check', style:, message:) if is_ci
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -602,7 +602,3 @@ def check_pods_references
   message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
   buildkite_annotate(context: 'pods-check', style:, message:) if is_ci
 end
-
-lane :test_check_pods_references do
-  check_pods_references
-end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -602,3 +602,7 @@ def check_pods_references
   message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
   buildkite_annotate(context: 'pods-check', style:, message:) if is_ci
 end
+
+lane :test_check_pods_references do
+  check_pods_references
+end


### PR DESCRIPTION
## What

From feedback and discussions in Slack (p1713196666919479/1713193106.071799-slack-C06CKSPHYA1), it seems that adding some h3 title in the annotation about the `ios_check_beta_pods` result would help make it clearer which annotation to look at when going through the release scenario.

## Testing

In https://github.com/wordpress-mobile/WordPress-iOS/pull/23009/commits/0b3b8090b09f6b2b8117406c651bccc13fc0b0d4 I've made the `check_pods_references` helper method be called during Prototype builds, just to validate that the annotation would look good (commit then reverted via https://github.com/wordpress-mobile/WordPress-iOS/pull/23009/commits/b04033200d77d3e60dc742229d61b99c2db28347)

This resulted in the annotation looking as expected:
<img width="1155" alt="image" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/216089/d6b65145-448c-445c-aa75-5c0b3ebf71ff">

Note: the case for when there are no pods to be updated has been tested as part of the similar change made on https://github.com/woocommerce/woocommerce-ios/pull/12484