### PR TITLE
Offline Mode: Analycs improvements

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -160,6 +160,13 @@ extension AbstractPost {
         return content?.contains("<!-- wp:jetpack/story") ?? false
     }
 
+    var analyticsUserInfo: [String: Any] {
+        [
+            "post_type": analyticsPostType ?? "",
+            "status": status?.rawValue ?? "",
+        ]
+    }
+
     var analyticsPostType: String? {
         switch self {
         case is Post:

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -208,7 +208,7 @@ extension AbstractPost {
     /// Returns the latest saved revisions that needs to be synced with the server.
     /// Returns `nil` if there are no such revisions.
     func getLatestRevisionNeedingSync() -> AbstractPost? {
-        assert(original == nil, "Must be called on an original revision")
+        wpAssert(original == nil, "Must be called on an original revision")
         let revision = allRevisions.last(where: \.isSyncNeeded)
         guard revision != self else {
             return nil
@@ -219,7 +219,7 @@ extension AbstractPost {
     /// Deletes all of the synced revisions until and including the `latest`
     /// one passed as a parameter.
     func deleteSyncedRevisions(until latest: AbstractPost) {
-        assert(original == nil, "Must be called on an original revision")
+        wpAssert(original == nil, "Must be called on an original revision")
         let tail = latest.revision
 
         var current = self

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -287,6 +287,7 @@ class PostCoordinator: NSObject {
     func showResolveConflictView(post: AbstractPost, remoteRevision: RemotePost, source: ResolveConflictView.Source) {
         wpAssert(post.isOriginal())
         guard let topViewController = UIApplication.shared.mainWindow?.topmostPresentedViewController else {
+            wpAssertionFailure("Failed to show conflict resolution view")
             return
         }
         let repository = PostRepository(coreDataStack: coreDataStack)

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -71,7 +71,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         return UploadsManager(uploaders: uploaders)
     }()
 
-    private let loggingStack = WPLoggingStack()
+    private let loggingStack = WPLoggingStack.shared
 
     /// Access the crash logging type
     class var crashLogging: CrashLogging? {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -299,6 +299,12 @@ import Foundation
     case pageListEditHomepageTapped
     case pageListEditHomepageInfoTapped
 
+    // Posts (Techincal)
+    case postRepositoryPostCreated
+    case postRepositoryPostUpdated
+    case postRepositoryPatchStarted
+    case postRepositoryConflictEncountered
+
     // Reader: Filter Sheet
     case readerFilterSheetDisplayed
     case readerFilterSheetDismissed
@@ -1098,6 +1104,16 @@ import Foundation
             return "page_list_edit_homepage_item_pressed"
         case .pageListEditHomepageInfoTapped:
             return "page_list_edit_homepage_info_pressed"
+
+        // Posts (Technical)
+        case .postRepositoryPostCreated:
+            return "post_repository_post_created"
+        case .postRepositoryPostUpdated:
+            return "post_repository_post_updated"
+        case .postRepositoryPatchStarted:
+            return "post_repository_patch_started"
+        case .postRepositoryConflictEncountered:
+            return "post_repository_conflict_encountered"
 
         // Reader: Filter Sheet
         case .readerFilterSheetDisplayed:

--- a/WordPress/Classes/Utility/Logging/CrashLogging+Singleton.swift
+++ b/WordPress/Classes/Utility/Logging/CrashLogging+Singleton.swift
@@ -1,8 +1,11 @@
 import Foundation
 import AutomatticTracks
 
-extension CrashLogging {
+extension WPLoggingStack {
+    static let shared = WPLoggingStack()
+}
 
+extension CrashLogging {
     static let main: CrashLogging = {
         if let crashLogging = WordPressAppDelegate.crashLogging {
             return crashLogging

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -423,7 +423,7 @@ extension PublishingEditor {
         }
 
         guard let context = post.managedObjectContext else {
-            assertionFailure()
+            wpAssertionFailure("Missing managedObjectContext")
             return true
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -16,7 +16,7 @@ extension PrepublishingViewController {
         case let page as Page:
             showAlert(for: page, action: action, from: presentingViewController, completion: completion)
         default:
-            assertionFailure("Unsupported post type")
+            wpAssertionFailure("Unsupported post type")
             break
         }
     }


### PR DESCRIPTION
- Record assertions in Sentry: we expect the assertions to never fire as they have nearly the same severity as crashes, so I think it's OK to track them on Sentry. This way, we'll have more information about the error, including the crash log.
- Add more assertions
- Add tracking for _every_ post update/create
- Add tracking for patch and false positives data conficts

I tested how the assertions looks like in Sentry:

```
wpAssertionFailure("test-error", userInfo: ["user-info-key": 2])
```

You can find it here: [JETPACK-IOS-1AC3](https://a8c.sentry.io/issues/5199998962/?referrer=github_integration)

```
Error Domain=WPAssertionFailure Code=-1 "PostListViewController.swift–63: test-error" UserInfo={NSDebugDescription=PostListViewController.swift–63: test-error}
```

To test: n/a

## Regression Notes
1. Potential unintended areas of impact: Analytics
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
