### PR TITLE
Reader: Add UI for the Reader tags feed

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -598,6 +598,10 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (NSFetchedResultsController *)resultsController
 {
+    if (_resultsController != nil && ![_resultsController.fetchRequest.entityName isEqualToString:[self fetchRequest].entityName]) {
+        _resultsController = nil;
+    }
+
     if (_resultsController != nil) {
         return _resultsController;
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
@@ -1,0 +1,63 @@
+
+extension ReaderPost {
+
+    var isCommentsEnabled: Bool {
+        let usesWPComAPI = isWPCom() || isJetpack()
+        let commentCount = commentCount()?.intValue ?? 0
+        let hasComments = commentCount > 0
+
+        return usesWPComAPI && (commentsOpen() || hasComments)
+    }
+
+    func isLikesEnabled(isLoggedIn: Bool) -> Bool {
+        let likeCount = likeCount()?.intValue ?? 0
+        return !isExternal() && (likeCount > 0 || isLoggedIn)
+    }
+
+    func shortDateForDisplay() -> String? {
+        let isRTL = UIView.userInterfaceLayoutDirection(for: .unspecified) == .rightToLeft
+        guard let date = dateForDisplay()?.toShortString() else {
+            return nil
+        }
+        let postDateFormat = isRTL ? "%@ •" : "• %@"
+        return blogNameForDisplay() != nil ? String(format: postDateFormat, date) : date
+    }
+
+    func summaryForDisplay(isPad: Bool = false) -> String? {
+        if featuredImageURLForDisplay() == nil || isPad {
+            let content = contentForDisplay()?
+                .stringByDecodingXMLCharacters()
+                .replacingOccurrences(of: "<br>", with: "\n")
+                .strippingHTML()
+                .replacingOccurrences(of: "^\n+", with: "", options: .regularExpression)
+                .replacingOccurrences(of: "\n{2,}", with: "\n\n", options: .regularExpression)
+                .trim()
+            return content ?? contentPreviewForDisplay()
+        } else {
+            return contentPreviewForDisplay()
+        }
+    }
+
+    func countsForDisplay(isLoggedIn: Bool) -> String? {
+        let likes: String? = {
+            guard isLikesEnabled(isLoggedIn: isLoggedIn),
+                  let count = likeCount()?.intValue,
+                  count > 0 else {
+                return nil
+            }
+            return WPStyleGuide.likeCountForDisplay(count)
+        }()
+        let comments: String? = {
+            guard isCommentsEnabled,
+                  let count = commentCount()?.intValue,
+                  count > 0 else {
+                return nil
+            }
+            return WPStyleGuide.commentCountForDisplay(count)
+        }()
+
+        let countStrings = [likes, comments].compactMap { $0 }
+        return countStrings.count > 0 ? countStrings.joined(separator: " • ") : nil
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
@@ -10,6 +10,8 @@ final class ReaderTableConfiguration {
     private let readerGapMarkerCellReuseIdentifier = "ReaderGapMarkerCellReuseIdentifier"
     private let readerCrossPostCellNibName = "ReaderCrossPostCell"
     private let readerCrossPostCellReuseIdentifier = "ReaderCrossPostCellReuseIdentifier"
+    private let readerTagCardCellNibName = "ReaderTagCardCell"
+    private let readerTagCardCellReuseIdentifier = "ReaderTagCellReuseIdentifier"
 
     private let rowHeight = CGFloat(415.0)
 
@@ -20,6 +22,7 @@ final class ReaderTableConfiguration {
         setUpBlockerCell(tableView)
         setUpGapMarkerCell(tableView)
         setUpCrossPostCell(tableView)
+        setUpTagCell(tableView)
     }
 
     private func setupAccessibility(_ tableView: UITableView) {
@@ -53,6 +56,11 @@ final class ReaderTableConfiguration {
         tableView.register(nib, forCellReuseIdentifier: readerCrossPostCellReuseIdentifier)
     }
 
+    private func setUpTagCell(_ tableView: UITableView) {
+        let nib = UINib(nibName: readerTagCardCellNibName, bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: readerTagCardCellReuseIdentifier)
+    }
+
     func footer() -> PostListFooterView {
         guard let footer = Bundle.main.loadNibNamed(footerViewNibName, owner: nil, options: nil)?.first as? PostListFooterView else {
             assertionFailure("Failed to load view from nib named \(footerViewNibName)")
@@ -80,4 +88,9 @@ final class ReaderTableConfiguration {
     func blockedSiteCell(_ tableView: UITableView) -> ReaderBlockedSiteCell {
         return tableView.dequeueReusableCell(withIdentifier: readerBlockedCellReuseIdentifier) as! ReaderBlockedSiteCell
     }
+
+    func tagCell(_ tableView: UITableView) -> ReaderTagCardCell {
+        return tableView.dequeueReusableCell(withIdentifier: readerTagCardCellReuseIdentifier) as! ReaderTagCardCell
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -1,0 +1,125 @@
+class ReaderTagCardCell: UITableViewCell, UICollectionViewDelegate {
+
+    private typealias DataSource = UICollectionViewDiffableDataSource<Int, NSManagedObjectID>
+    private typealias Snapshot = NSDiffableDataSourceSnapshot<Int, NSManagedObjectID>
+
+    @IBOutlet private weak var tagButton: UIButton!
+    @IBOutlet private weak var collectionView: UICollectionView!
+    @IBOutlet weak var collectionViewHeightConstraint: NSLayoutConstraint!
+
+    private var dataSource: DataSource!
+    private lazy var resultsController: NSFetchedResultsController<ReaderPost> = {
+        let fetchRequest = NSFetchRequest<ReaderPost>(entityName: ReaderPost.classNameWithoutNamespaces())
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "sortRank", ascending: true)]
+        fetchRequest.fetchLimit = Constants.displayPostLimit
+        let resultsController = NSFetchedResultsController<ReaderPost>(fetchRequest: fetchRequest,
+                                                           managedObjectContext: ContextManager.shared.mainContext,
+                                                           sectionNameKeyPath: nil,
+                                                           cacheName: nil)
+        resultsController.delegate = self
+        return resultsController
+    }()
+    private var isLoggedIn: Bool = false
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        registerTagCell()
+        setupDataSource()
+        setupButtonStyles()
+        collectionView.delegate = self
+        accessibilityElements = [tagButton, collectionView].compactMap { $0 }
+        collectionViewHeightConstraint.constant = cellSize.height
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        collectionViewHeightConstraint.constant = cellSize.height
+    }
+
+    func configure(with tag: ReaderTagTopic, isLoggedIn: Bool) {
+        self.isLoggedIn = isLoggedIn
+        tagButton.setTitle(tag.title, for: .normal)
+        resultsController.fetchRequest.predicate = NSPredicate(format: "topic = %@ AND isSiteBlocked = NO", tag)
+        try? resultsController.performFetch()
+    }
+}
+
+// MARK: - Private methods
+
+private extension ReaderTagCardCell {
+
+    var cellSize: CGSize {
+        let isAccessibilityCategory = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        let isPad = traitCollection.userInterfaceIdiom == .pad
+
+        switch (isAccessibilityCategory, isPad) {
+        case (true, true):
+            return Constants.padLargeCellSize
+        case (false, true):
+            return Constants.padDefaultCellSize
+        case (true, false):
+            return Constants.phoneLargeCellSize
+        case (false, false):
+            return Constants.phoneDefaultCellSize
+        }
+    }
+
+    func setupButtonStyles() {
+        var buttonConfig = UIButton.Configuration.filled()
+        buttonConfig.cornerStyle = .capsule
+        buttonConfig.baseForegroundColor = .label
+        buttonConfig.baseBackgroundColor = UIColor(light: .secondarySystemBackground,
+                                                   dark: .tertiarySystemBackground)
+        buttonConfig.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
+        let font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        buttonConfig.titleTextAttributesTransformer = .transformer(with: font)
+        tagButton.configuration = buttonConfig
+    }
+
+    func registerTagCell() {
+        let nib = UINib(nibName: ReaderTagCell.classNameWithoutNamespaces(), bundle: nil)
+        collectionView.register(nib, forCellWithReuseIdentifier: Constants.cellIdentifier)
+    }
+
+    func setupDataSource() {
+        dataSource = DataSource(collectionView: collectionView) { [weak self] collectionView, indexPath, objectID in
+            guard let post = try? ContextManager.shared.mainContext.existingObject(with: objectID) as? ReaderPost,
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.cellIdentifier, for: indexPath) as? ReaderTagCell else {
+                return UICollectionViewCell()
+            }
+            cell.configure(with: post, isLoggedIn: self?.isLoggedIn ?? AccountHelper.isLoggedIn)
+            return cell
+        }
+    }
+
+    struct Constants {
+        static let cellIdentifier = ReaderTagCell.classNameWithoutNamespaces()
+        static let displayPostLimit = 10
+        static let phoneDefaultCellSize = CGSize(width: 240, height: 297)
+        static let phoneLargeCellSize = CGSize(width: 240, height: 500)
+        static let padDefaultCellSize = CGSize(width: 480, height: 600)
+        static let padLargeCellSize = CGSize(width: 480, height: 900)
+    }
+
+}
+
+// MARK: - NSFetchedResultsControllerDelegate
+
+extension ReaderTagCardCell: NSFetchedResultsControllerDelegate {
+
+    func controller(_ controller: NSFetchedResultsController<any NSFetchRequestResult>,
+                    didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+        dataSource.apply(snapshot as Snapshot, animatingDifferences: false)
+    }
+
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension ReaderTagCardCell: UICollectionViewDelegateFlowLayout {
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return cellSize
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
@@ -12,17 +12,17 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" userLabel="Reader Tag Card Cell" customClass="ReaderTagCardCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="328" height="335"/>
+            <rect key="frame" x="0.0" y="0.0" width="328" height="359"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gUR-Rt-jPM">
-                    <rect key="frame" x="15.999999999999996" y="0.0" width="51.666666666666657" height="30"/>
+                    <rect key="frame" x="11.999999999999996" y="24" width="51.666666666666657" height="30"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="filled" title="Tag"/>
                 </button>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
-                    <rect key="frame" x="16" y="38" width="296" height="297"/>
+                <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
+                    <rect key="frame" x="24" y="62" width="288" height="297"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="297" id="uTt-pZ-gUW"/>
@@ -40,11 +40,11 @@
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="GeQ-Gs-OvG" secondAttribute="bottom" id="2ng-2c-tFF"/>
                 <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="gUR-Rt-jPM" secondAttribute="trailing" id="7rj-F7-Ol7"/>
-                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="8Dv-Lq-jru"/>
+                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" constant="8" id="8Dv-Lq-jru"/>
                 <constraint firstItem="GeQ-Gs-OvG" firstAttribute="top" secondItem="gUR-Rt-jPM" secondAttribute="bottom" constant="8" id="VRI-ge-6KZ"/>
                 <constraint firstItem="GeQ-Gs-OvG" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailingMargin" id="ZNj-Nk-9pY"/>
-                <constraint firstItem="gUR-Rt-jPM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="gKT-Ns-5xs"/>
-                <constraint firstItem="gUR-Rt-jPM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="h1S-EB-XTo"/>
+                <constraint firstItem="gUR-Rt-jPM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="24" id="gKT-Ns-5xs"/>
+                <constraint firstItem="gUR-Rt-jPM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" constant="-4" id="h1S-EB-XTo"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" userLabel="Reader Tag Card Cell" customClass="ReaderTagCardCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="328" height="335"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gUR-Rt-jPM">
+                    <rect key="frame" x="15.999999999999996" y="0.0" width="51.666666666666657" height="30"/>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="filled" title="Tag"/>
+                </button>
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
+                    <rect key="frame" x="16" y="38" width="296" height="297"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="297" id="uTt-pZ-gUW"/>
+                    </constraints>
+                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="0Qb-19-SWX">
+                        <size key="itemSize" width="240" height="297"/>
+                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    </collectionViewFlowLayout>
+                </collectionView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="GeQ-Gs-OvG" secondAttribute="bottom" id="2ng-2c-tFF"/>
+                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="gUR-Rt-jPM" secondAttribute="trailing" id="7rj-F7-Ol7"/>
+                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="8Dv-Lq-jru"/>
+                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="top" secondItem="gUR-Rt-jPM" secondAttribute="bottom" constant="8" id="VRI-ge-6KZ"/>
+                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailingMargin" id="ZNj-Nk-9pY"/>
+                <constraint firstItem="gUR-Rt-jPM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="gKT-Ns-5xs"/>
+                <constraint firstItem="gUR-Rt-jPM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="h1S-EB-XTo"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="collectionView" destination="GeQ-Gs-OvG" id="g7f-gE-oEO"/>
+                <outlet property="collectionViewHeightConstraint" destination="uTt-pZ-gUW" id="dbg-Ng-YeZ"/>
+                <outlet property="tagButton" destination="gUR-Rt-jPM" id="Y2f-Vg-ZQ3"/>
+            </connections>
+            <point key="canvasLocation" x="-64.122137404580144" y="-162.32394366197184"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -1,0 +1,95 @@
+class ReaderTagCell: UICollectionViewCell {
+
+    @IBOutlet private weak var contentStackView: UIStackView!
+    @IBOutlet private weak var headerStackView: UIStackView!
+    @IBOutlet private weak var siteLabel: UILabel!
+    @IBOutlet private weak var postDateLabel: UILabel!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var summaryLabel: UILabel!
+    @IBOutlet private weak var featuredImageView: CachedAnimatedImageView!
+    @IBOutlet private weak var countsLabel: UILabel!
+    @IBOutlet private weak var likeButton: UIButton!
+    @IBOutlet private weak var menuButton: UIButton!
+
+    private lazy var imageLoader = ImageLoader(imageView: featuredImageView)
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupStyles()
+        contentStackView.setCustomSpacing(0, after: featuredImageView)
+        likeButton.setTitle(NSLocalizedString("reader.tags.button.like",
+                                              value: "Like",
+                                              comment: "Text for the 'Like' button on the reader tag cell."),
+                            for: .normal)
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageLoader.prepareForReuse()
+        resetHiddenViews()
+    }
+
+    func configure(with post: ReaderPost, isLoggedIn: Bool) {
+        let blogName = post.blogNameForDisplay()
+        let postDate = post.shortDateForDisplay()
+        let postTitle = post.titleForDisplay()
+        let postSummary = post.summaryForDisplay(isPad: traitCollection.userInterfaceIdiom == .pad)
+        let postCounts = post.countsForDisplay(isLoggedIn: isLoggedIn)
+
+        siteLabel.text = blogName
+        postDateLabel.text = postDate
+        titleLabel.text = postTitle
+        summaryLabel.text = postSummary
+        countsLabel.text = postCounts
+
+        siteLabel.isHidden = blogName == nil
+        postDateLabel.isHidden = postDate == nil
+        titleLabel.isHidden = postTitle == nil
+        summaryLabel.isHidden = postSummary == nil
+        countsLabel.isHidden = postCounts == nil
+        loadFeaturedImage(with: post)
+    }
+
+}
+
+// MARK: - Private methods
+
+private extension ReaderTagCell {
+
+    func setupStyles() {
+        siteLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .semibold)
+        postDateLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
+        postDateLabel.textColor = .secondaryLabel
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+        summaryLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
+        countsLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
+        countsLabel.textColor = .secondaryLabel
+        likeButton.tintColor = .secondaryLabel
+        likeButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
+        menuButton.tintColor = .secondaryLabel
+        featuredImageView.layer.cornerRadius = 5.0
+    }
+
+    func loadFeaturedImage(with post: ReaderPost) {
+        guard let url = post.featuredImageURLForDisplay() else {
+            featuredImageView.isHidden = true
+            return
+        }
+        let imageSize = CGSize(width: featuredImageView.frame.width,
+                                   height: featuredImageView.frame.height)
+        let host = MediaHost(with: post, failure: { error in
+            DDLogError(error)
+        })
+        imageLoader.loadImage(with: url, from: host, preferredSize: imageSize)
+    }
+
+    func resetHiddenViews() {
+        siteLabel.isHidden = false
+        titleLabel.isHidden = false
+        summaryLabel.isHidden = false
+        featuredImageView.isHidden = false
+        countsLabel.isHidden = false
+        likeButton.isHidden = false
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReaderTagCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="240" height="297"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="v9V-wn-SvM">
+                    <rect key="frame" x="0.0" y="0.0" width="240" height="258"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="N0b-ln-6rk">
+                            <rect key="frame" x="0.0" y="0.0" width="240" height="20.333333333333332"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="Site Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nBe-Ng-tUu">
+                                    <rect key="frame" x="0.0" y="0.0" width="66.333333333333329" height="20.333333333333332"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" text="Post Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hSx-Fu-Ptn">
+                                    <rect key="frame" x="70.333333333333329" y="0.0" width="169.66666666666669" height="20.333333333333332"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="nBe-Ng-tUu" firstAttribute="height" secondItem="N0b-ln-6rk" secondAttribute="height" id="jXp-aM-FWa"/>
+                            </constraints>
+                        </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
+                            <rect key="frame" x="0.0" y="24.333333333333336" width="240" height="20.333333333333336"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
+                            <rect key="frame" x="0.0" y="48.666666666666664" width="240" height="20.333333333333336"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="247" verticalCompressionResistancePriority="753" translatesAutoresizingMaskIntoConstraints="NO" id="Yfj-e7-Vti" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="73" width="240" height="150"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="150" id="mXK-lY-civ">
+                                    <variation key="heightClass=regular-widthClass=regular" constant="300"/>
+                                </constraint>
+                            </constraints>
+                        </imageView>
+                        <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
+                            <rect key="frame" x="0.0" y="227" width="240" height="6.6666666666666572"/>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TWL-MA-3CF" userLabel="Counts">
+                            <rect key="frame" x="0.0" y="237.66666666666666" width="240" height="20.333333333333343"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
+                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1nC-hH-hbw">
+                    <rect key="frame" x="0.0" y="253" width="240" height="44"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B3r-hf-7wD">
+                            <rect key="frame" x="0.0" y="0.0" width="52" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="7V7-7V-Mua"/>
+                            </constraints>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="Like" image="icon-reader-star-outline">
+                                <preferredSymbolConfiguration key="preferredSymbolConfiguration"/>
+                            </state>
+                        </button>
+                        <view contentMode="scaleToFill" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0q4-yh-1OL" userLabel="Spacer">
+                            <rect key="frame" x="52" y="0.0" width="144" height="44"/>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RMF-3Z-42A">
+                            <rect key="frame" x="196" y="0.0" width="44" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="44" id="lnk-h8-Ngi"/>
+                                <constraint firstAttribute="height" constant="44" id="o9C-UX-9Am"/>
+                            </constraints>
+                            <inset key="imageEdgeInsets" minX="15" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="more-horizontal-mobile"/>
+                        </button>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="v9V-wn-SvM" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="2lW-xl-9bd"/>
+                <constraint firstItem="1nC-hH-hbw" firstAttribute="top" secondItem="v9V-wn-SvM" secondAttribute="bottom" constant="-5" id="D7s-bf-loX"/>
+                <constraint firstItem="1nC-hH-hbw" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="I43-qr-tYA"/>
+                <constraint firstAttribute="trailing" secondItem="1nC-hH-hbw" secondAttribute="trailing" id="KIo-4o-78T"/>
+                <constraint firstAttribute="trailing" secondItem="v9V-wn-SvM" secondAttribute="trailing" id="bk3-Nv-15r"/>
+                <constraint firstAttribute="bottom" secondItem="1nC-hH-hbw" secondAttribute="bottom" id="cnL-7T-qHl"/>
+                <constraint firstItem="v9V-wn-SvM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="wa0-lA-MJQ"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="contentStackView" destination="v9V-wn-SvM" id="Dh0-eP-ubs"/>
+                <outlet property="countsLabel" destination="TWL-MA-3CF" id="SLO-VX-N94"/>
+                <outlet property="featuredImageView" destination="Yfj-e7-Vti" id="BCL-Ej-cp3"/>
+                <outlet property="headerStackView" destination="N0b-ln-6rk" id="9VK-Sj-aYS"/>
+                <outlet property="likeButton" destination="B3r-hf-7wD" id="Jua-cj-3ZZ"/>
+                <outlet property="menuButton" destination="RMF-3Z-42A" id="O3N-Cs-hjz"/>
+                <outlet property="postDateLabel" destination="hSx-Fu-Ptn" id="Crv-aS-hBA"/>
+                <outlet property="siteLabel" destination="nBe-Ng-tUu" id="HGg-ZS-QDH"/>
+                <outlet property="summaryLabel" destination="5KT-0Z-POw" id="v2C-Gu-Vcs"/>
+                <outlet property="titleLabel" destination="DsY-TC-klp" id="Qc5-Ye-hs2"/>
+            </connections>
+            <point key="canvasLocation" x="-131.29770992366412" y="-168.3098591549296"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="icon-reader-star-outline" width="24" height="24"/>
+        <image name="more-horizontal-mobile" width="24" height="24"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Resources/AppImages.xcassets/icon-reader-star-outline.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/icon-reader-star-outline.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2196,6 +2196,14 @@
 		8320BDE5283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8320BDE6283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8323789928526E6E003F4443 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
+		83317ED62BC71BA8001AD2F4 /* ReaderTagCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83317ED52BC71BA8001AD2F4 /* ReaderTagCardCell.swift */; };
+		83317ED72BC71BA8001AD2F4 /* ReaderTagCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83317ED52BC71BA8001AD2F4 /* ReaderTagCardCell.swift */; };
+		83317ED92BC71CEB001AD2F4 /* ReaderTagCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83317ED82BC71CEB001AD2F4 /* ReaderTagCardCell.xib */; };
+		83317EDA2BC71CEB001AD2F4 /* ReaderTagCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83317ED82BC71CEB001AD2F4 /* ReaderTagCardCell.xib */; };
+		83317EDC2BC72DB7001AD2F4 /* ReaderTagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83317EDB2BC72DB7001AD2F4 /* ReaderTagCell.swift */; };
+		83317EDD2BC72DB7001AD2F4 /* ReaderTagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83317EDB2BC72DB7001AD2F4 /* ReaderTagCell.swift */; };
+		83317EDF2BC72DED001AD2F4 /* ReaderTagCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83317EDE2BC72DED001AD2F4 /* ReaderTagCell.xib */; };
+		83317EE02BC72DED001AD2F4 /* ReaderTagCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 83317EDE2BC72DED001AD2F4 /* ReaderTagCell.xib */; };
 		8332D7452ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */; };
 		8332D7462ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */; };
 		8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
@@ -2281,6 +2289,8 @@
 		83F1BED32BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F1BED12BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
+		83F76F312BC9DEC400C4F2A1 /* ReaderPost+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F76F302BC9DEC400C4F2A1 /* ReaderPost+Display.swift */; };
+		83F76F322BC9DEC400C4F2A1 /* ReaderPost+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F76F302BC9DEC400C4F2A1 /* ReaderPost+Display.swift */; };
 		83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */; };
 		8511CFC51C60884400B7CEED /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8511CFC41C60884400B7CEED /* SnapshotHelper.swift */; };
 		8511CFC71C60894200B7CEED /* WordPressScreenshotGeneration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8511CFC61C60894200B7CEED /* WordPressScreenshotGeneration.swift */; };
@@ -7604,6 +7614,10 @@
 		8313B9F92995A03C000AF26E /* JetpackRemoteInstallCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRemoteInstallCardView.swift; sourceTree = "<group>"; };
 		83204EDB2ACE098B000C3229 /* ReaderPostCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellViewModel.swift; sourceTree = "<group>"; };
 		8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogService+BloggingPrompts.swift"; sourceTree = "<group>"; };
+		83317ED52BC71BA8001AD2F4 /* ReaderTagCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagCardCell.swift; sourceTree = "<group>"; };
+		83317ED82BC71CEB001AD2F4 /* ReaderTagCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderTagCardCell.xib; sourceTree = "<group>"; };
+		83317EDB2BC72DB7001AD2F4 /* ReaderTagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagCell.swift; sourceTree = "<group>"; };
+		83317EDE2BC72DED001AD2F4 /* ReaderTagCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderTagCell.xib; sourceTree = "<group>"; };
 		8332D7442ADF263400EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIConfigurationTextAttributesTransformer+Font.swift"; sourceTree = "<group>"; };
 		8332DD2329259AE300802F7D /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		8332DD2729259BEB00802F7D /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
@@ -7657,6 +7671,7 @@
 		83F1BED12BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicService+FollowedSites.swift"; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
+		83F76F302BC9DEC400C4F2A1 /* ReaderPost+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPost+Display.swift"; sourceTree = "<group>"; };
 		83FB4D3E122C38F700DB9506 /* MediaPlayer.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		83FEFC7311FF6C5A0078B462 /* SiteSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SiteSettingsViewController.h; sourceTree = "<group>"; };
 		83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SiteSettingsViewController.m; sourceTree = "<group>"; };
@@ -12703,6 +12718,10 @@
 				3234BB332530EA980068DA40 /* ReaderRecommendedSiteCardCell.xib */,
 				D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */,
 				D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */,
+				83317ED52BC71BA8001AD2F4 /* ReaderTagCardCell.swift */,
+				83317ED82BC71CEB001AD2F4 /* ReaderTagCardCell.xib */,
+				83317EDB2BC72DB7001AD2F4 /* ReaderTagCell.swift */,
+				83317EDE2BC72DED001AD2F4 /* ReaderTagCell.xib */,
 			);
 			name = Cards;
 			sourceTree = "<group>";
@@ -16586,6 +16605,7 @@
 				5D08B8FC19647C0300D5B381 /* Views */,
 				5D1D04731B7A50B100CDE646 /* Reader.storyboard */,
 				837A53D62AD8C3A400B941A2 /* ReaderFollowButton.swift */,
+				83F76F302BC9DEC400C4F2A1 /* ReaderPost+Display.swift */,
 				FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */,
 			);
 			path = Reader;
@@ -19680,6 +19700,7 @@
 				17222D9D261DDDF90047B163 /* black-icon-app-83.5x83.5@2x.png in Resources */,
 				17C1D6F526711ED0006C8970 /* Emoji.txt in Resources */,
 				B5C66B761ACF072C00F68370 /* NoteBlockCommentTableViewCell.xib in Resources */,
+				83317EDF2BC72DED001AD2F4 /* ReaderTagCell.xib in Resources */,
 				17222D94261DDDF90047B163 /* pink-icon-app-76x76@2x.png in Resources */,
 				3F4D035328A5BFCE00F0A4FD /* JetpackWordPressLogoAnimation_ltr.json in Resources */,
 				3223393E24FEC2A700BDD4BF /* ReaderDetailFeaturedImageView.xib in Resources */,
@@ -19785,6 +19806,7 @@
 				E61507E42220A13B00213D33 /* richEmbedScript.js in Resources */,
 				17222D96261DDDF90047B163 /* pink-icon-app-60x60@3x.png in Resources */,
 				1761F18226209AEE000815EF /* jetpack-green-icon-app-60x60@3x.png in Resources */,
+				83317ED92BC71CEB001AD2F4 /* ReaderTagCardCell.xib in Resources */,
 				FE3E83E626A58646008CE851 /* ListSimpleOverlayView.xib in Resources */,
 				401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */,
 				17222D83261DDDF90047B163 /* celadon-classic-icon-app-60x60@2x.png in Resources */,
@@ -20102,6 +20124,7 @@
 				FABB1FE82602FC2C00C8785C /* TitleBadgeDisclosureCell.xib in Resources */,
 				FABB1FE92602FC2C00C8785C /* TextWithAccessoryButtonCell.xib in Resources */,
 				F465976E28E4669200D5F49A /* cool-green-icon-app-76@2x.png in Resources */,
+				83317EDA2BC71CEB001AD2F4 /* ReaderTagCardCell.xib in Resources */,
 				F41E4EC028F22932001880C6 /* spectrum-icon-app-83.5@2x.png in Resources */,
 				FABB1FEA2602FC2C00C8785C /* SiteStatsDetailTableViewController.storyboard in Resources */,
 				FABB1FED2602FC2C00C8785C /* InlineEditableNameValueCell.xib in Resources */,
@@ -20281,6 +20304,7 @@
 				F465977B28E6598900D5F49A /* black-on-white-icon-app-76@2x.png in Resources */,
 				FABB209A2602FC2C00C8785C /* PostListFooterView.xib in Resources */,
 				98E5501A265C977E00B4BE9A /* ReaderDetailLikesView.xib in Resources */,
+				83317EE02BC72DED001AD2F4 /* ReaderTagCell.xib in Resources */,
 				FABB209B2602FC2C00C8785C /* acknowledgements.html in Resources */,
 				F46597BF28E6687800D5F49A /* neumorphic-dark-icon-app-83.5@2x.png in Resources */,
 				F465980C28E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png in Resources */,
@@ -22045,6 +22069,7 @@
 				80A2154029CA68D5002FE8EB /* RemoteFeatureFlag.swift in Sources */,
 				74729CA62056FE6000D1394D /* SearchableItemConvertable.swift in Sources */,
 				B59D994F1C0790CC0003D795 /* SettingsListEditorViewController.swift in Sources */,
+				83317EDC2BC72DB7001AD2F4 /* ReaderTagCell.swift in Sources */,
 				9A4E215C21F75BBE00EFF212 /* QuickStartChecklistManager.swift in Sources */,
 				FAC1B81E29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */,
 				C9B477AE29CC35A0008CBF49 /* WidgetDataReader.swift in Sources */,
@@ -22705,6 +22730,7 @@
 				177076211EA206C000705A4A /* PlayIconView.swift in Sources */,
 				57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,
+				83317ED62BC71BA8001AD2F4 /* ReaderTagCardCell.swift in Sources */,
 				E14694071F3459E2004052C8 /* PluginListViewController.swift in Sources */,
 				FAD3DE812AE2965A00A3B031 /* AbstractPostMenuHelper.swift in Sources */,
 				FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */,
@@ -23151,6 +23177,7 @@
 				FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */,
 				5D1181E71B4D6DEB003F3084 /* WPStyleGuide+Reader.swift in Sources */,
 				3250490724F988220036B47F /* Interpolation.swift in Sources */,
+				83F76F312BC9DEC400C4F2A1 /* ReaderPost+Display.swift in Sources */,
 				8352AC742B2A485100F8492C /* ReaderNavigationMenu.swift in Sources */,
 				0CB424F62AE0416D0080B807 /* SolidColorActivityIndicator.swift in Sources */,
 				0C8FC9A12A8BC8630059DCE4 /* PHPickerController+Extensions.swift in Sources */,
@@ -25093,6 +25120,7 @@
 				FABB232C2602FC2C00C8785C /* PublicizeConnection.swift in Sources */,
 				FABB232D2602FC2C00C8785C /* TenorPageable.swift in Sources */,
 				83204EDD2ACE098B000C3229 /* ReaderPostCardCellViewModel.swift in Sources */,
+				83F76F322BC9DEC400C4F2A1 /* ReaderPost+Display.swift in Sources */,
 				FABB232E2602FC2C00C8785C /* AccountService+MergeDuplicates.swift in Sources */,
 				FABB232F2602FC2C00C8785C /* URL+Helpers.swift in Sources */,
 				FABB23302602FC2C00C8785C /* WPStyleGuide+Aztec.swift in Sources */,
@@ -25272,6 +25300,7 @@
 				FABB23B02602FC2C00C8785C /* Data.swift in Sources */,
 				FAA5C9102B7FC74C002E073B /* PostSyncStateViewModel.swift in Sources */,
 				FA111E392A2F474600896FCE /* BlazeCampaignsViewController.swift in Sources */,
+				83317EDD2BC72DB7001AD2F4 /* ReaderTagCell.swift in Sources */,
 				FABB23B12602FC2C00C8785C /* AccountSettingsViewController.swift in Sources */,
 				FABB23B22602FC2C00C8785C /* StatsChildRowsView.swift in Sources */,
 				FABB23B32602FC2C00C8785C /* Menu.m in Sources */,
@@ -26154,6 +26183,7 @@
 				FABB26182602FC2C00C8785C /* RegisterDomainDetailsViewModel+SectionDefinitions.swift in Sources */,
 				C395FB272822148400AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */,
 				0CD382842A4B699E00612173 /* DashboardBlazeCardCellViewModel.swift in Sources */,
+				83317ED72BC71BA8001AD2F4 /* ReaderTagCardCell.swift in Sources */,
 				9815D0B426B49A0600DF7226 /* Comment+CoreDataProperties.swift in Sources */,
 				FABB261A2602FC2C00C8785C /* AppSettingsViewController.swift in Sources */,
 				4A82C43228D321A300486CFF /* Blog+Post.swift in Sources */,


### PR DESCRIPTION
Part of #23013

## Description

Adds the UI for the "Tags" feed.

Future PRs:
- Card actions
- "More" end cell
- Accessibility
- Empty feed state
- Fetching posts for tags
- Loading placeholders
- Consolidating display functions between `ReaderPostCardCell` & `ReaderTagCell`
- Analytics

## Video

<details><summary>iPhone</summary>

https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/b930721a-2731-444e-aab0-c9279180383e
</details>

<details><summary>iPad</summary>

https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/3c3ecade-3f95-48fc-ab49-3bfd5de17280
</details>


## Testing

**Test setup:**
You'll need some cached tag posts to see any UI:
- Navigate to `Discover`
- Tap on a post
- Tap on one of the tags for that post
- If you aren't following it, follow the tag

**To test:**
- Launch Jetpack and login
- Complete the **Test setup**
- Navigate to the "Your Tags" Reader feed
- Scroll to the tag which has posts saved locally
- 🔎 **Verify** the UI matches the designs for the new cell
- Find a post with no featured image
- 🔎 **Verify** the text is expanded
- Find a post where the content doesn't fit the full height
- 🔎 **Verify**:
  - The number of likes/comments label is aligned to the bottom
  - The like button and menu button are aligned to the bottom

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
