### PR TITLE
Remove Jetpack-only entries from WordPress 24.7 raw release notes

### DIFF
--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -1,4 +1,3 @@
 
-* [*] [Jetpack-only] Stats: Optimized the Insights tab to enhance loading and scrolling performance. [#22592]
 
 


### PR DESCRIPTION
Update release notes for WordPress 24.7
