### PR TITLE
Copy release note from #22999

### DIFF
--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -1,4 +1,5 @@
 
+* [**] [Jetpack-only] Reader: Introducing Reading Preferences, an experimental feature that allows users to customize their Reader post content screen with the color, font, and size that they like the most. [#22999]
 * [*] [Jetpack-only] Stats: Optimized the Insights tab to enhance loading and scrolling performance. [#22592]
 
 


### PR DESCRIPTION
Manually copy release note from https://github.com/wordpress-mobile/WordPress-iOS/pull/22999, so that it gets included in the editorialization request

Slack ref: p1713260981620719/1713259861.053799-slack-C06CKSPHYA1