### PR TITLE
Offline Mode: Fix update button not being enabled after changing settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -12,6 +12,7 @@ extension PostEditor {
         }
         settingsViewController.featuredImageDelegate = self as? FeaturedImageDelegate
         let doneButton = UIBarButtonItem(systemItem: .done, primaryAction: .init(handler: { [weak self] _ in
+            self?.editorContentWasUpdated()
             self?.navigationController?.dismiss(animated: true)
         }))
         doneButton.accessibilityIdentifier = "close"


### PR DESCRIPTION

## RCA

The Post Settings screen is a modal and they no longer cover the entire screen. When it closes, `GutenbergViewController/viewDidAppear` does not get called and it does not call `editorContentWasUpdated`. 

Note: ideally, the app would simply listen to the managed object changes, but I think this is OK for now.

## To test:

- Open an published post
- Open post settings and change some values
- Tap Close
- ✅  Verify that the "Update" button became enabled

## Regression Notes
1. Potential unintended areas of impact: Post Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
