### PR TITLE
Offline Mode: Add if_not_modified_since support for self-hosted sites

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 16.0.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'db1aceec23321d11989d86c987bfb34555fcec5b'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '1c9aa7ec981fd3369199182605797a5ea4d5efc4'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.8, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `db1aceec23321d11989d86c987bfb34555fcec5b`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `1c9aa7ec981fd3369199182605797a5ea4d5efc4`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.117.0.podspec
   WordPressKit:
-    :commit: db1aceec23321d11989d86c987bfb34555fcec5b
+    :commit: 1c9aa7ec981fd3369199182605797a5ea4d5efc4
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -186,7 +186,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: db1aceec23321d11989d86c987bfb34555fcec5b
+    :commit: 1c9aa7ec981fd3369199182605797a5ea4d5efc4
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -234,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: f2a061cac72e6ed3e8990affb8ec03eb5f85949c
+PODFILE CHECKSUM: 8d2826e45ea32f6689cff46cf6503fe3619f38f9
 
 COCOAPODS: 1.15.2

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -984,7 +984,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // GIVEN a server where the post
         stub(condition: { _ in true }) { request in
             // THEN the app sends a partial update
-            XCTAssertEqual(request.getBodyString(), #"<?xml version="1.0"?><methodCall><methodName>metaWeblog.editPost</methodName><params><param><value><i4>974</i4></value></param><param><value><string>test</string></value></param><param><value><string>test</string></value></param><param><value><struct><member><name>title</name><value><string>title-b</string></value></member></struct></value></param></params></methodCall>"#)
+            XCTAssertEqual(request.getBodyString(), #"<?xml version="1.0"?><methodCall><methodName>wp.editPost</methodName><params><param><value><i4>0</i4></value></param><param><value><string>test</string></value></param><param><value><string>test</string></value></param><param><value><i4>974</i4></value></param><param><value><struct><member><name>post_title</name><value><string>title-b</string></value></member></struct></value></param></params></methodCall>"#)
 
             return HTTPStubsResponse(data: """
             <methodResponse>


### PR DESCRIPTION
Update WPKit to use `wp.newPost` and `wp.editPost`.

## To test:

- Verify that updating post settings works for all available fields
- Verify that content conflict detection works
- Verify that when you update a scheduled posts, it stays in the "Scheduled" tab

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
