### PR TITLE
Offline Mode: Fix an issue with posting a re-drafted scheduled post

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -185,6 +185,10 @@ class PostCoordinator: NSObject {
         }
         if let publishDate = options.publishDate {
             parameters.date = publishDate
+        } else {
+            // If the post was previously scheduled for a different date,
+            // the app has to send a new value to override it.
+            parameters.date = post.shouldPublishImmediately() ? nil : Date()
         }
 
         do {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -57,7 +57,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         // its own revision.
         self.post = isStandalone ? post._createRevision() : post
         self.isStandalone = isStandalone
-        self.viewModel = PrepublishingViewModel(post: post)
+        self.viewModel = PrepublishingViewModel(post: self.post)
         self.completion = completion
         self.coreDataStack = coreDataStack
         self.persistentStore = persistentStore


### PR DESCRIPTION
## To test:

- Create a draft post
- Schedule the post
- Move it back to draft
- Tap "Publish" and verify that the "Publish Date" says "Immediately"
- Confirm publishing
- ✅  Verify that the post got published immediately 

Test for both .com and self-hosted.

## Regression Notes
1. Potential unintended areas of impact: Publishing
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual 
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
