### PR TITLE
Offline Mode: Fix trash post swipe action

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper+Actions.swift
@@ -26,6 +26,14 @@ extension AbstractPostHelper {
             style: .destructive,
             title: post.status == .trash ? Strings.swipeActionDeletePermanently : Strings.swipeActionTrash
         ) { [weak delegate] _, _, completion in
+
+            guard post.status != .trash else {
+                delegate?.delete(post) {
+                    completion(true)
+                }
+                return
+            }
+
             delegate?.trash(post) {
                 completion(true)
             }


### PR DESCRIPTION
## Description
Fixes an issue where trashed posts couldn't be deleted permanently via the swipe action

## How to test
- Left swipe on a published/draft/scheduled post
- ✅ Verify: the destructive swipe action trashes the post
- Left swipe on a trashed post
- ✅ Verify: the destructive swipe action permanently deletes the post

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/f9591a9c-181c-4c47-afa2-d2b1612592fa" width=200>

## Regression Notes
1. Potential unintended areas of impact
trashing/deleting a post

2. What I did to test those areas of impact (or what existing automated tests I relied on)
tested manually

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
