### PR TITLE
Offline Mode: Media upload status view

### DIFF
--- a/WordPress/Classes/Services/MediaImageService.swift
+++ b/WordPress/Classes/Services/MediaImageService.swift
@@ -114,8 +114,12 @@ final class MediaImageService {
 
     // MARK: - Media (Thumbnails)
 
+    static func isThubmnailSupported(for mediaType: MediaType) -> Bool {
+        mediaType == .image || mediaType == .video
+    }
+
     private func thumbnail(for media: SafeMedia, size: ImageSize) async throws -> UIImage {
-        guard media.mediaType == .image || media.mediaType == .video else {
+        guard MediaImageService.isThubmnailSupported(for: media.mediaType) else {
             assertionFailure("Unsupported thubmnail media type: \(media.mediaType)")
             throw Error.unsupportedMediaType(media.mediaType)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
@@ -1,0 +1,128 @@
+import Foundation
+import SwiftUI
+
+/// Displays upload progress for the media for the given post.
+struct PostMediaUploadStatusView: View {
+    @ObservedObject var viewModel: PostMediaUploadViewModel
+    let onCloseTapped: () -> Void
+
+    var body: some View {
+        List {
+            ForEach(viewModel.uploads) {
+                MediaUploadStatusView(viewModel: $0)
+            }
+        }
+        .listStyle(.plain)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Strings.close, action: onCloseTapped)
+            }
+            ToolbarItem(placement: .principal) {
+                PostMediaUploadTitleView(viewModel: viewModel)
+            }
+        }
+        .navigationTitle(Strings.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct PostMediaUploadTitleView: View {
+    @ObservedObject var viewModel: PostMediaUploadViewModel
+
+    var body: some View {
+        if viewModel.isCompleted {
+            Text(Strings.title)
+                .font(.headline)
+        } else {
+            VStack(spacing: 6) {
+                Text(Strings.titleUploading)
+                    .font(.headline)
+                ProgressView(value: viewModel.fractionCompleted)
+                    .progressViewStyle(.linear)
+                    .tint(.secondary)
+                    .background()
+            }
+            .fixedSize()
+        }
+    }
+}
+
+private struct MediaUploadStatusView: View {
+    @ObservedObject var viewModel: MediaUploadViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            MediaThubmnailImageView(image: viewModel.thumbnail)
+                .aspectRatio(viewModel.thumbnailAspectRatio, contentMode: .fit)
+                .frame(maxHeight: viewModel.thumbnailMaxHeight)
+                .clipped()
+                .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading) {
+                Text(viewModel.title)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                Text(viewModel.details)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            switch viewModel.state {
+            case .uploaded:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.secondary.opacity(0.5))
+            case .uploading:
+                MediaUploadProgressView(progress: viewModel.fractionCompleted)
+            }
+        }
+        .task {
+            await viewModel.loadThumbnail()
+        }
+    }
+}
+
+private struct MediaUploadProgressView: View {
+    let progress: Double
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(
+                    Color.secondary.opacity(0.25),
+                    lineWidth: 3
+                )
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(Color(uiColor: .brand), style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.easeOut, value: progress)
+        }
+        .frame(width: 16, height: 16)
+    }
+}
+
+private struct MediaThubmnailImageView: View {
+    let image: UIImage?
+
+    var body: some View {
+        ZStack {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .cornerRadius(6)
+            } else {
+                Color(uiColor: .secondarySystemBackground)
+                    .cornerRadius(6)
+            }
+        }
+    }
+}
+
+private enum Strings {
+    static let title = NSLocalizedString("postMediaUploadStatusView.title", value: "Media Uploads", comment: "Title for post media upload status view")
+    static let titleUploading = NSLocalizedString("postMediaUploadStatusView.titleUploading", value: "Uploading media", comment: "Title for a footer view in the post media upload status view")
+    static let close = NSLocalizedString("postMediaUploadStatusView.close", value: "Close", comment: "Close button in postMediaUploadStatusView")
+}

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
@@ -17,33 +17,9 @@ struct PostMediaUploadStatusView: View {
             ToolbarItem(placement: .cancellationAction) {
                 Button(Strings.close, action: onCloseTapped)
             }
-            ToolbarItem(placement: .principal) {
-                PostMediaUploadTitleView(viewModel: viewModel)
-            }
         }
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
-    }
-}
-
-private struct PostMediaUploadTitleView: View {
-    @ObservedObject var viewModel: PostMediaUploadViewModel
-
-    var body: some View {
-        if viewModel.isCompleted {
-            Text(Strings.title)
-                .font(.headline)
-        } else {
-            VStack(spacing: 6) {
-                Text(Strings.titleUploading)
-                    .font(.headline)
-                ProgressView(value: viewModel.fractionCompleted)
-                    .progressViewStyle(.linear)
-                    .tint(.secondary)
-                    .background()
-            }
-            .fixedSize()
-        }
     }
 }
 
@@ -123,6 +99,5 @@ private struct MediaThubmnailImageView: View {
 
 private enum Strings {
     static let title = NSLocalizedString("postMediaUploadStatusView.title", value: "Media Uploads", comment: "Title for post media upload status view")
-    static let titleUploading = NSLocalizedString("postMediaUploadStatusView.titleUploading", value: "Uploading media", comment: "Title for a footer view in the post media upload status view")
     static let close = NSLocalizedString("postMediaUploadStatusView.close", value: "Close", comment: "Close button in postMediaUploadStatusView")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
@@ -1,0 +1,168 @@
+import Foundation
+import SwiftUI
+
+/// Manages media upload for the given revision of the post.
+final class PostMediaUploadViewModel: ObservableObject {
+    let uploads: [MediaUploadViewModel]
+
+    @Published private(set) var totalFileSize: Int64 = 0
+    @Published private(set) var fractionCompleted = 0.0
+    @Published private(set) var completedUploadsCount = 0
+
+    var isCompleted: Bool { uploads.count == completedUploadsCount }
+
+    private let post: AbstractPost
+    private let coordinator: MediaCoordinator
+    private weak var timer: Timer?
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    init(post: AbstractPost, coordinator: MediaCoordinator = .shared) {
+        self.post = post
+        self.coordinator = coordinator
+        self.uploads = Array(post.media).filter(\.isUploadNeeded).sorted {
+            ($0.creationDate ?? .now) < ($1.creationDate ?? .now)
+        }.map {
+            MediaUploadViewModel(media: $0, coordinator: coordinator)
+        }
+
+        coordinator.uploadMedia(for: post)
+
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            self?.update()
+        }
+    }
+
+    private func update() {
+        for upload in uploads {
+            upload.update()
+        }
+
+        totalFileSize = uploads.map(\.fileSize).reduce(0, +)
+        fractionCompleted = uploads.map(\.fractionCompleted).reduce(0, +) / Double(uploads.count)
+        completedUploadsCount = uploads.filter({ $0.state == .uploaded }).count
+    }
+}
+
+/// Manages individual media upload.
+final class MediaUploadViewModel: ObservableObject, Identifiable {
+    @Published private(set) var state: State = .uploading
+
+    private let media: Media
+    private let coordinator: MediaCoordinator
+
+    private var completed: Int64 = 0
+
+    @Published private(set) var thumbnail: UIImage?
+    @Published private(set) var title = ""
+    @Published private(set) var details = ""
+
+    @Published private(set) var fileSize: Int64 = 0
+    @Published private(set) var fractionCompleted = 0.0
+
+    private weak var retryTimer: Timer?
+
+    private var nextRetryDelay: TimeInterval {
+        retryDelay = min(32, retryDelay * 1.5)
+        return retryDelay
+    }
+    private var retryDelay: TimeInterval = 8
+
+    var id: NSManagedObjectID { media.objectID }
+
+    var thumbnailAspectRatio: CGFloat {
+        guard let width = media.width?.floatValue, width > 0,
+              let height = media.height?.floatValue, height > 0 else {
+            return 1
+        }
+        return CGFloat(width / height)
+    }
+
+    var thumbnailMaxHeight: CGFloat {
+        MediaImageService.isThubmnailSupported(for: media.mediaType) ? 40 : 24
+    }
+
+    enum State {
+        case uploaded
+        case uploading
+    }
+
+    deinit {
+        retryTimer?.invalidate()
+    }
+
+    init(media: Media, coordinator: MediaCoordinator) {
+        self.media = media
+        self.coordinator = coordinator
+
+        title = media.filename ?? "–"
+        update()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(didUpdateReachability), name: .reachabilityChanged, object: nil)
+    }
+
+    fileprivate func update() {
+        self.state = media.isUploadNeeded ? .uploading : .uploaded
+        self.fileSize = media.filesize?.int64Value ?? 0 // Should never be `0`
+
+        if media.remoteStatus == .failed, retryTimer == nil {
+            retryTimer = Timer.scheduledTimer(withTimeInterval: nextRetryDelay, repeats: false) { [weak self] _ in self?.retry() }
+        }
+
+        if media.isUploadNeeded {
+            if let progress = coordinator.progress(for: media),
+               let uploadProgress = progress.userInfo[.uploadProgress] as? Progress {
+                let completed = Int64(Double(fileSize) * uploadProgress.fractionCompleted)
+                self.fractionCompleted = uploadProgress.fractionCompleted
+                self.completed = max(completed, self.completed)
+            }
+            details = Strings.progress(completed: completed, total: fileSize)
+        } else {
+            fractionCompleted = 1.0
+            details = ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+        }
+    }
+
+    private func retry() {
+        retryTimer = nil
+        coordinator.retryMedia(media)
+    }
+
+    @objc private func didUpdateReachability(_ notification: Foundation.Notification) {
+        guard let reachable = notification.userInfo?[Foundation.Notification.reachabilityKey],
+              (reachable as? Bool) == true else {
+            return
+        }
+        if (media.error as? URLError)?.code == .notConnectedToInternet {
+            retry()
+        }
+    }
+
+    @MainActor
+    func loadThumbnail() async {
+        do {
+            if MediaImageService.isThubmnailSupported(for: media.mediaType) {
+                thumbnail = try await MediaImageService.shared.image(for: media, size: .small)
+            } else {
+                thumbnail = SiteMediaDocumentInfoViewModel.make(with: media).image
+            }
+        } catch {
+            // Continue showing placeholder
+        }
+    }
+}
+
+private extension Media {
+    var isUploadNeeded: Bool {
+        mediaID == nil || mediaID?.intValue == 0
+    }
+}
+
+private enum Strings {
+    static func progress(completed: Int64, total: Int64) -> String {
+        let format = NSLocalizedString("postMediaUploadStatusView.progress", value: "%@ of %@", comment: "Shows the upload progress with two parameters: preformatted completed and total bytes")
+        return String(format: format, ByteCountFormatter.string(fromByteCount: completed, countStyle: .file), ByteCountFormatter.string(fromByteCount: total, countStyle: .file))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
@@ -162,7 +162,7 @@ private extension Media {
 
 private enum Strings {
     static func progress(completed: Int64, total: Int64) -> String {
-        let format = NSLocalizedString("postMediaUploadStatusView.progress", value: "%@ of %@", comment: "Shows the upload progress with two parameters: preformatted completed and total bytes")
+        let format = NSLocalizedString("postMediaUploadStatusView.progress", value: "%1$@ of %2$@", comment: "Shows the upload progress with two preformatted parameters: %1$@ is the placeholder for completed bytes, and %2$@ is the placeholder for total bytes")
         return String(format: format, ByteCountFormatter.string(fromByteCount: completed, countStyle: .file), ByteCountFormatter.string(fromByteCount: total, countStyle: .file))
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController.swift
@@ -423,18 +423,6 @@ final class DeprecatedPrepublishingViewController: UIViewController, UITableView
 
     // MARK: - Publish Button
 
-    private func updatePublishButtonState() {
-        if let state = PublishButtonState.uploadingState(for: post) {
-            publishButtonViewModel.state = state
-        } else {
-            if case .loading = publishButtonViewModel.state {
-                // Do nothing
-            } else {
-                publishButtonViewModel.state = .default
-            }
-        }
-    }
-
     private func updatePublishButtonLabel() {
         publishButtonViewModel.title = post.isScheduled() ? Strings.schedule : Strings.publish
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -82,11 +82,6 @@ struct PublishButton: View {
         }
     }
 
-    @ViewBuilder
-    private func makeUploadingView(title: String, progress: PublishButtonState.Progress) -> some View {
-
-    }
-
     private var isDisabled: Bool {
         switch viewModel.state {
         case .default: false

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -23,7 +23,7 @@ struct PublishButton: View {
             case .loading:
                 ProgressView()
                     .tint(Color.secondary)
-            case let .uploading(title, progress):
+            case let .uploading(title, progress, onInfoTapped):
                 HStack(spacing: 10) {
                     ProgressView()
                         .tint(Color.secondary)
@@ -42,6 +42,13 @@ struct PublishButton: View {
                     .foregroundStyle(Color.primary)
 
                     Spacer()
+
+                    if let onInfoTapped {
+                        Button(action: onInfoTapped, label: {
+                            Image(systemName: "info.circle")
+                                .foregroundStyle(.secondary)
+                        })
+                    }
                 }
                 .padding(.horizontal)
             case let .failed(title, details, onRetryTapped):
@@ -95,44 +102,12 @@ final class PublishButtonViewModel: ObservableObject {
 enum PublishButtonState {
     case `default`
     case loading
-    case uploading(title: String, progress: Progress?)
+    case uploading(title: String, progress: Progress?, onInfoTapped: (() -> Void)? = nil)
     case failed(title: String, details: String? = nil, onRetryTapped: (() -> Void)? = nil)
 
     struct Progress {
         var completed: Int64
         var total: Int64
-    }
-
-    /// Returns the state of the button based on the current upload progress
-    /// for the given post.
-    static func uploadingState(for post: AbstractPost, coordinator: MediaCoordinator = .shared) -> PublishButtonState? {
-        if post.hasFailedMedia {
-            return .failed(title: Strings.mediaUploadFailed, onRetryTapped: {
-                coordinator.uploadMedia(for: post)
-            })
-        }
-        if coordinator.isUploadingMedia(for: post) {
-            var totalUploadProgress = Progress(completed: 0, total: 0)
-            var completedUploadCount = 0
-            var totalUploadCount = 0
-
-            for media in post.media {
-                if let progress = coordinator.progress(for: media) {
-                    if let uploadProgress = progress.userInfo[.uploadProgress] as? Foundation.Progress,
-                    let filesize = media.filesize?.int64Value {
-                        totalUploadProgress.completed += Int64(Double(filesize) * uploadProgress.fractionCompleted)
-                        totalUploadProgress.total += filesize
-                    }
-
-                    if progress.fractionCompleted >= 1.0 {
-                        completedUploadCount += 1
-                    }
-                    totalUploadCount += 1
-                }
-            }
-            return .uploading(title: Strings.uploadingMedia + ": \(completedUploadCount) / \(totalUploadCount)", progress: totalUploadProgress)
-        }
-        return nil
     }
 }
 
@@ -143,8 +118,6 @@ private enum Strings {
     }
 
     static let retry = NSLocalizedString("publishButton.retry", value: "Retry", comment: "Retry button title")
-    static let mediaUploadFailed = NSLocalizedString("prepublishing.mediaUploadFailed", value: "Failed to upload media", comment: "Title for an error messaage in the pre-publishing sheet")
-    static let uploadingMedia = NSLocalizedString("prepublishing.uploadingMedia", value: "Uploading media", comment: "Title for a publish button state in the pre-publishing sheet")
 }
 
 #Preview {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -24,7 +24,7 @@ struct PublishButton: View {
                 ProgressView()
                     .tint(Color.secondary)
             case let .uploading(title, progress, onInfoTapped):
-                HStack(spacing: 10) {
+                let content =  HStack(spacing: 10) {
                     ProgressView()
                         .tint(Color.secondary)
 
@@ -43,14 +43,17 @@ struct PublishButton: View {
 
                     Spacer()
 
-                    if let onInfoTapped {
-                        Button(action: onInfoTapped, label: {
-                            Image(systemName: "info.circle")
-                                .foregroundStyle(.secondary)
-                        })
+                    if onInfoTapped != nil {
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.secondary)
                     }
+                }.padding(.horizontal)
+
+                if let onInfoTapped {
+                    Button(action: onInfoTapped) { content }
+                } else {
+                    content
                 }
-                .padding(.horizontal)
             case let .failed(title, details, onRetryTapped):
                 HStack {
                     Image(systemName: "exclamationmark.triangle.fill")
@@ -77,6 +80,11 @@ struct PublishButton: View {
                 .padding(.horizontal)
             }
         }
+    }
+
+    @ViewBuilder
+    private func makeUploadingView(title: String, progress: PublishButtonState.Progress) -> some View {
+
     }
 
     private var isDisabled: Bool {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -565,6 +565,10 @@
 		0CD9FB892AFA71C2009D9C7A /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = 0CD9FB882AFA71C2009D9C7A /* DGCharts */; };
 		0CD9FB8B2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */; };
 		0CD9FB8C2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */; };
+		0CDA09032BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */; };
+		0CDA09042BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */; };
+		0CDA090C2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */; };
+		0CDA090D2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CE538CA2B0D6E0000834BA2 /* ExternalMediaDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */; };
@@ -6316,6 +6320,8 @@
 		0CD9CCA22AD831590044A33C /* PostSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchViewModel.swift; sourceTree = "<group>"; };
 		0CD9FB7D2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Extensions.swift"; sourceTree = "<group>"; };
 		0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPageViewController.swift; sourceTree = "<group>"; };
+		0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadStatusView.swift; sourceTree = "<group>"; };
+		0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadViewModel.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaDataSource.swift; sourceTree = "<group>"; };
 		0CE538CF2B0E317000834BA2 /* StockPhotosWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosWelcomeView.swift; sourceTree = "<group>"; };
@@ -12836,6 +12842,8 @@
 				FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */,
 				FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */,
 				FACA34CD2BAACE3500163B21 /* ResolveConflictView.swift */,
+				0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */,
+				0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -22352,6 +22360,7 @@
 				B5EFB1C21B31B98E007608A3 /* NotificationSettingsService.swift in Sources */,
 				011896A829D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */,
 				011F52BD2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
+				0CDA090C2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */,
 				F45EB5012B865AF4004E9053 /* NotificationTableViewCell.swift in Sources */,
 				1717139F265FE59700F3A022 /* ButtonStyles.swift in Sources */,
 				C3FF78E828354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */,
@@ -22500,6 +22509,7 @@
 				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
 				8352AC712B2A185A00F8492C /* ReaderNavigationButton.swift in Sources */,
 				80EF672527F3D63B0063B138 /* DashboardStatsStackView.swift in Sources */,
+				0CDA09032BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */,
 				E1D0D81616D3B86800E33F4C /* SafariActivity.m in Sources */,
 				E603C7701BC94AED00AD49D7 /* WordPress-37-38.xcmappingmodel in Sources */,
 				808D102E2B881BE20082E64F /* String+Truncate.swift in Sources */,
@@ -24609,6 +24619,7 @@
 				FABB21D52602FC2C00C8785C /* SiteDesignContentCollectionViewController.swift in Sources */,
 				C31466CC2939950900D62FC7 /* MigrationLoadWordPressViewController.swift in Sources */,
 				FABB21D62602FC2C00C8785C /* PlanComparisonViewController.swift in Sources */,
+				0CDA09042BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */,
 				FABB21D72602FC2C00C8785C /* Routes+Stats.swift in Sources */,
 				8BF1C81B27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */,
 				FABB21D92602FC2C00C8785C /* SearchIdentifierGenerator.swift in Sources */,
@@ -25933,6 +25944,7 @@
 				DC76668626FD9AC9009254DD /* TimeZoneTableViewCell.swift in Sources */,
 				01DC4CD92B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */,
 				FABB25862602FC2C00C8785C /* WordPress-11-12.xcmappingmodel in Sources */,
+				0CDA090D2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */,
 				C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */,
 				FABB25872602FC2C00C8785C /* DiffAbstractValue.swift in Sources */,
 				9822A8422624CFB900FD8A03 /* UserProfileSiteCell.swift in Sources */,


### PR DESCRIPTION
This PR adds a media upload status view to surface the uploads information to both users and developers. It also changes the (new) UI/UX for managing media uploads prior to publishing. In the previous implementation, on any upload failure, the app would instantly show a "Retry" button that you had to tap manually - awkward UX. Now, the retries happen automatically, and instantly in case of the re-connects.

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0275406e-1838-4c60-bf4a-d7c90aa0e629" width="360px">

## To test:

- Enable Airplane mode
- Create a draft with media
- Tap "Publish"
- Open Upload Status view
- ✅  Verify that the upload status is "Pending"
- Disable Airplane mode
- ✅  Verify that the upload restated and completed automatically 

## Known Issues

There is something going on with the network protocols / uploads where status is now always reported accurately.

## Regression Notes
1. Potential unintended areas of impact: Publishing 
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
