### PR TITLE
Fix Crash when opening Post Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -119,7 +119,7 @@ private extension PostStatsViewModel {
 
     func overviewTableRows() -> [any HashableImmutableRow] {
         var tableRows = [any HashableImmutableRow]()
-        tableRows.append(PostStatsEmptyCellHeaderRow())
+        tableRows.append(PostStatsEmptyCellHeaderRow(statSection: .postStatsGraph))
 
         let lastTwoWeeks = postStats?.lastTwoWeeks ?? []
         let dayData = dayDataFrom(lastTwoWeeks)
@@ -160,7 +160,8 @@ private extension PostStatsViewModel {
                                                dataSubtitle: dataSubtitle,
                                                dataRows: yearsDataRows(forAverages: forAverages),
                                                limitRowsDisplayed: true,
-                                               postStatsDelegate: postStatsDelegate))
+                                               postStatsDelegate: postStatsDelegate,
+                                               statSection: statSection))
 
         return tableRows
     }
@@ -202,12 +203,14 @@ private extension PostStatsViewModel {
     func recentWeeksTableRows() -> [any HashableImmutableRow] {
         var tableRows = [any HashableImmutableRow]()
 
-        tableRows.append(CellHeaderRow(statSection: StatSection.postStatsRecentWeeks))
+        let statSection = StatSection.postStatsRecentWeeks
+        tableRows.append(CellHeaderRow(statSection: statSection))
         tableRows.append(TopTotalsPostStatsRow(itemSubtitle: StatSection.postStatsRecentWeeks.itemSubtitle,
                                                dataSubtitle: StatSection.postStatsRecentWeeks.dataSubtitle,
                                                dataRows: recentWeeksDataRows(),
                                                limitRowsDisplayed: false,
-                                               postStatsDelegate: postStatsDelegate))
+                                               postStatsDelegate: postStatsDelegate,
+                                               statSection: statSection))
 
         return tableRows
     }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -656,7 +656,7 @@ struct PostStatsTitleRow: HashableImmutableRow {
     }
 }
 
-struct TopTotalsPostStatsRow: HashableImmutableRow {
+struct TopTotalsPostStatsRow: StatsHashableImmuTableRow {
 
     typealias CellType = TopTotalsCell
 
@@ -670,6 +670,7 @@ struct TopTotalsPostStatsRow: HashableImmutableRow {
     let limitRowsDisplayed: Bool
     weak var postStatsDelegate: PostStatsDelegate?
     let action: ImmuTableAction? = nil
+    let statSection: StatSection?
 
     func configureCell(_ cell: UITableViewCell) {
 
@@ -688,11 +689,12 @@ struct TopTotalsPostStatsRow: HashableImmutableRow {
         return lhs.itemSubtitle == rhs.itemSubtitle &&
             lhs.dataSubtitle == rhs.dataSubtitle &&
             lhs.dataRows == rhs.dataRows &&
-            lhs.limitRowsDisplayed == rhs.limitRowsDisplayed
+            lhs.limitRowsDisplayed == rhs.limitRowsDisplayed &&
+            lhs.statSection == rhs.statSection
     }
 }
 
-struct PostStatsEmptyCellHeaderRow: HashableImmutableRow {
+struct PostStatsEmptyCellHeaderRow: StatsHashableImmuTableRow {
     typealias CellType = StatsCellHeader
 
     static let cell: ImmuTableCell = {
@@ -700,6 +702,7 @@ struct PostStatsEmptyCellHeaderRow: HashableImmutableRow {
     }()
 
     let action: ImmuTableAction? = nil
+    var statSection: StatSection? = nil
 
     func configureCell(_ cell: UITableViewCell) {
 
@@ -711,7 +714,7 @@ struct PostStatsEmptyCellHeaderRow: HashableImmutableRow {
     }
 
     static func == (lhs: PostStatsEmptyCellHeaderRow, rhs: PostStatsEmptyCellHeaderRow) -> Bool {
-        return true
+        return lhs.statSection == rhs.statSection
     }
 }
 


### PR DESCRIPTION
Fixes #23036

I couldn't 100% reproduce the issue myself but the issue happens in PostsStats due to identical identifiers. The solution is to make sure the same cell used in a different section would have a different identifier.

To test:

1. Log into the Jetpack app
2. Go to Posts
3. Open the ... menu
4. Tap Stats
5. The app shouldn't crash

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
