### PR TITLE
Fix: Ensure that the content exists before loading it to the web view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import AutomatticTracks
 
 typealias RelatedPostsSection = (postType: RemoteReaderSimplePost.PostType, posts: [RemoteReaderSimplePost])
 
@@ -603,9 +604,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         featuredImage.displaySetting = displaySetting
 
         // Update Reader Post web view
-        if let post {
+        if let contentForDisplay = post?.contentForDisplay() {
             webView.displaySetting = displaySetting
-            webView.loadHTMLString(post.contentForDisplay())
+            webView.loadHTMLString(contentForDisplay)
+        } else {
+            // It's unexpected for the `post` or `contentForDisplay()` to be nil. Let's keep track of it.
+            CrashLogging.main.logMessage("Expected contentForDisplay() to exist", level: .error)
         }
 
         // Likes view

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -336,10 +336,12 @@ class ReaderDisplaySettingStore: NSObject {
             return ReaderDisplaySetting.customizationEnabled ? _setting : .standard
         }
         set {
-            guard ReaderDisplaySetting.customizationEnabled else {
+            guard ReaderDisplaySetting.customizationEnabled,
+                  newValue != _setting else {
                 return
             }
             _setting = newValue
+            broadcastChangeNotification()
         }
     }
 
@@ -352,7 +354,6 @@ class ReaderDisplaySettingStore: NSObject {
                 return
             }
             repository.set(dictionary, forKey: Constants.key)
-            broadcastChangeNotification()
         }
     }
 


### PR DESCRIPTION
Fixes #23039

> [!WARNING]
> This targets the `release/24.7` branch.

Continuing from https://github.com/wordpress-mobile/WordPress-iOS/issues/23039#issuecomment-2066751282, it looks like the `ReaderDetailViewController` is in an awkward state restoration mode where the `Post` object is not properly "hydrated" yet (i.e., all of its properties are still nil) but the view controller already received a change notification from the display setting being changed in another place.

I couldn't replicate this state where the `Post` object's properties are still nil. For now, I'm addressing this crash issue by ensuring that the `contentForDisplay()` exists before loading it into the web view. I'll also log it to Sentry to ensure that this issue remains visible when it happens.

In addition, this PR also fixes a bug where the change notification is broadcasted from the wrong place, causing the observers to receive more broadcasts than intended. The original intent was for the observers to get notified only when the setting changes in other places.

## To test

First, we'll need to trigger a state restoration on the Reader tab. The easiest way is to have an Xcode-connected debug build to a Simulator or device. Here are the steps:
  - Run a debug build from Xcode.
  - Open a post in the Reader tab.
  - Press the Home button to suspend the app.
  - Lastly, stop the app from Xcode.

> [!NOTE]
> If you don't have access to Xcode right now, **after suspending the app**, there are some user-level steps you can follow to trigger state restoration, [based on this post](https://forums.developer.apple.com/forums/thread/68675):
> - Restart the phone
> - Update the app
> - Run a bunch of resource-hungry apps, which results in the system kicking the Jetpack app out of memory

Now that the state restoration is set:

- Launch the Jetpack app again. The app should default to the My Sites tab.
- Go to the Notifications tab.
- Open one of the notifications that can lead to a Reader Post (mentions, likes, comments).
- Change the display setting from the Reader Post that was opened from Notifications.
- 🔎 Verify that the app does not crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes. I couldn't reproduce the crash, but this PR prevents the crash from happening based on the stack trace, and instead logs them to Sentry when it happens.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A.

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
