### PR TITLE
Remove custom comparison operators from Post.swift

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -2,30 +2,6 @@ import Foundation
 import CoreData
 import CocoaLumberjack
 
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l < r
-  case (nil, _?):
-    return true
-  default:
-    return false
-  }
-}
-
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l > r
-  default:
-    return rhs < lhs
-  }
-}
-
 @objc(Post)
 class Post: AbstractPost {
     @objc static let typeDefaultIdentifier = "post"
@@ -258,15 +234,15 @@ class Post: AbstractPost {
     }
 
     override func hasCategories() -> Bool {
-        return (categories?.count > 0)
+        categories?.isEmpty == false
     }
 
     override func hasTags() -> Bool {
-        return (tags?.trim().count > 0)
+        tags?.trim().isEmpty == false
     }
 
     override func authorForDisplay() -> String? {
-        return author ?? blog.account?.displayName
+        author ?? blog.account?.displayName
     }
 
     // MARK: - BasePost

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -203,7 +203,7 @@ class AbstractPostListViewController: UIViewController,
     }
 
     private func configureSearchController() {
-        assert(self is InteractivePostViewDelegate, "The subclass has to implement InteractivePostViewDelegate protocol")
+        wpAssert(self is InteractivePostViewDelegate, "The subclass has to implement InteractivePostViewDelegate protocol")
 
         searchResultsViewController.configure(searchController, self as? InteractivePostViewDelegate)
 
@@ -231,7 +231,7 @@ class AbstractPostListViewController: UIViewController,
 
     @objc private func postCoordinatorDidUpdate(_ notification: Foundation.Notification) {
         guard let updatedObjects = (notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>) else {
-            return assertionFailure("missing NSUpdatedObjectsKey")
+            return wpAssertionFailure("missing NSUpdatedObjectsKey")
         }
         let updatedIndexPaths = (tableView.indexPathsForVisibleRows ?? []).filter {
             let cell = tableView.cellForRow(at: $0) as? AbstractPostListCell
@@ -343,7 +343,7 @@ class AbstractPostListViewController: UIViewController,
     }
 
     func updateAndPerformFetchRequest() {
-        assert(Thread.isMainThread, "AbstractPostListViewController Error: NSFetchedResultsController accessed in BG")
+        wpAssert(Thread.isMainThread, "AbstractPostListViewController Error: NSFetchedResultsController accessed in BG")
 
         var predicate = predicateForFetchRequest()
         let sortDescriptors = sortDescriptorsForFetchRequest()
@@ -494,7 +494,7 @@ class AbstractPostListViewController: UIViewController,
 
     @objc func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], hasMore: Bool) {
         guard posts.count > 0 else {
-            assertionFailure("This method should not be called with no posts.")
+            wpAssertionFailure("This method should not be called with no posts.")
             return
         }
         // Reset the filter to only show the latest sync point, based on the oldest post date in the posts just synced.


### PR DESCRIPTION
As the title describes + add more assertions.

To test:

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): (review the code)
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
