### PR TITLE
Posts: Show "duplicate" action for pending posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -204,7 +204,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
             buttons.append(.moveToDraft)
         }
 
-        if post.status == .publish || post.status == .draft {
+        if post.status == .publish || post.status == .draft || post.status == .pending {
             buttons.append(.duplicate)
         }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -88,6 +88,26 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
         expect(buttons).to(equal(expectedButtons))
     }
 
+    func testPendingPostButtons() {
+        // Given
+        let post = PostBuilder(mainContext)
+            .pending()
+            .build()
+        let viewModel = PostCardStatusViewModel(post: post, isJetpackFeaturesEnabled: true, isBlazeFlagEnabled: true)
+
+        // When & Then
+        let buttons = viewModel.buttonSections
+            .filter { !$0.buttons.isEmpty }
+            .map { $0.buttons }
+        let expectedButtons: [[AbstractPostButton]] = [
+            [.view],
+            [.publish, .moveToDraft, .duplicate],
+            [.settings],
+            [.trash]
+        ]
+        expect(buttons).to(equal(expectedButtons))
+    }
+
     func testScheduledPostButtons() {
         // Given
         let post = PostBuilder(mainContext)


### PR DESCRIPTION
Fixes #22854 

## Description
* Fixes an issue where the "duplicate" action wasn't available for pending posts

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/fff9902e-2e13-4fa6-a77a-455b80c1157f" width=200>

## How to test

- Create a contributor post for a site and submit for review (on the web or app, whichever is easier)
- On the app, log in via an account that has admin access and locate the above post
- Tap on the context menu for the post
- ✅ Verify: The duplicate action is available

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
added tests

3. What automated tests I added (or what prevented me from doing so)
added a test for pending posts context menu actions


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
