### PR TITLE
Reader: Add actions to Reader tag cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -35,6 +35,7 @@ struct ReaderNotificationKeys {
 enum ReaderPostMenuSource {
     case card
     case details
+    case tagCard
 
     var description: String {
         switch self {
@@ -42,6 +43,8 @@ enum ReaderPostMenuSource {
             return "post_card"
         case .details:
             return "post_details"
+        case .tagCard:
+            return "post_tag_card"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
@@ -11,7 +11,8 @@ final class ReaderMenuAction {
                  anchor: UIView,
                  vc: UIViewController,
                  source: ReaderPostMenuSource,
-                 followCommentsService: FollowCommentsService
+                 followCommentsService: FollowCommentsService,
+                 showAdditionalItems: Bool = false
     ) {
         self.execute(
             post: post,
@@ -20,7 +21,8 @@ final class ReaderMenuAction {
             anchor: .view(anchor),
             vc: vc,
             source: source,
-            followCommentsService: followCommentsService
+            followCommentsService: followCommentsService,
+            showAdditionalItems: showAdditionalItems
         )
     }
 
@@ -30,7 +32,8 @@ final class ReaderMenuAction {
                  anchor: ReaderShowMenuAction.PopoverAnchor,
                  vc: UIViewController,
                  source: ReaderPostMenuSource,
-                 followCommentsService: FollowCommentsService
+                 followCommentsService: FollowCommentsService,
+                 showAdditionalItems: Bool = false
     ) {
         let siteTopic: ReaderSiteTopic? = post.isFollowing ? (try? ReaderSiteTopic.lookup(withSiteID: post.siteID, in: context)) : nil
 
@@ -42,7 +45,8 @@ final class ReaderMenuAction {
             anchor: anchor,
             vc: vc,
             source: source,
-            followCommentsService: followCommentsService
+            followCommentsService: followCommentsService,
+            showAdditionalItems: showAdditionalItems
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -14,7 +14,8 @@ final class ReaderShowMenuAction {
                  anchor: PopoverAnchor,
                  vc: UIViewController,
                  source: ReaderPostMenuSource,
-                 followCommentsService: FollowCommentsService
+                 followCommentsService: FollowCommentsService,
+                 showAdditionalItems: Bool = false
     ) {
 
         // Create the action sheet
@@ -22,7 +23,7 @@ final class ReaderShowMenuAction {
         alertController.addCancelActionWithTitle(ReaderPostMenuButtonTitles.cancel, handler: nil)
 
         // Block site button
-        if shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post) {
+        if shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post) || showAdditionalItems {
             let handler: (UIAlertAction) -> Void = { action in
                 guard let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) else {
                     return
@@ -43,7 +44,7 @@ final class ReaderShowMenuAction {
         }
 
         // Block user button
-        if shouldShowBlockUserMenuItem(topic: readerTopic, post: post) {
+        if shouldShowBlockUserMenuItem(topic: readerTopic, post: post) || showAdditionalItems {
             let handler: (UIAlertAction) -> Void = { _ in
                 guard let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) else {
                     return
@@ -68,7 +69,7 @@ final class ReaderShowMenuAction {
         }
 
         // Report post button
-        if shouldShowReportPostMenuItem(readerTopic: readerTopic, post: post) {
+        if shouldShowReportPostMenuItem(readerTopic: readerTopic, post: post) || showAdditionalItems {
             alertController.addActionWithTitle(ReaderPostMenuButtonTitles.reportPost,
                                                style: .destructive,
                                                handler: { (action: UIAlertAction) in
@@ -79,7 +80,7 @@ final class ReaderShowMenuAction {
         }
 
         // Report user button
-        if shouldShowReportUserMenuItem(readerTopic: readerTopic, post: post) {
+        if shouldShowReportUserMenuItem(readerTopic: readerTopic, post: post) || showAdditionalItems {
             let handler: (UIAlertAction) -> Void = { _ in
                 guard let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) else {
                     return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1624,7 +1624,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
 
     func cell(for tag: ReaderTagTopic) -> UITableViewCell {
         let cell = tableConfiguration.tagCell(tableView)
-        cell.configure(with: tag, isLoggedIn: isLoggedIn)
+        cell.configure(parent: self, tag: tag, isLoggedIn: isLoggedIn)
         cell.selectionStyle = .none
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -42,7 +42,7 @@ class ReaderTagCardCell: UITableViewCell {
                                                collectionView: collectionView,
                                                isLoggedIn: isLoggedIn,
                                                cellSize: weakSelf?.cellSize)
-        viewModel?.fetchTagTopics()
+        viewModel?.fetchTagPosts()
         tagButton.setTitle(tag.title, for: .normal)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -1,60 +1,10 @@
-class ReaderTagCardCell: UITableViewCell, UICollectionViewDelegate {
-
-    private typealias DataSource = UICollectionViewDiffableDataSource<Int, NSManagedObjectID>
-    private typealias Snapshot = NSDiffableDataSourceSnapshot<Int, NSManagedObjectID>
+class ReaderTagCardCell: UITableViewCell {
 
     @IBOutlet private weak var tagButton: UIButton!
     @IBOutlet private weak var collectionView: UICollectionView!
-    @IBOutlet weak var collectionViewHeightConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var collectionViewHeightConstraint: NSLayoutConstraint!
 
-    private lazy var dataSource: DataSource = {
-        DataSource(collectionView: collectionView) { [weak self] collectionView, indexPath, objectID in
-            guard let post = try? ContextManager.shared.mainContext.existingObject(with: objectID) as? ReaderPost,
-                  let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.cellIdentifier, for: indexPath) as? ReaderTagCell else {
-                return UICollectionViewCell()
-            }
-            cell.configure(with: post, isLoggedIn: self?.isLoggedIn ?? AccountHelper.isLoggedIn)
-            return cell
-        }
-    }()
-    private lazy var resultsController: NSFetchedResultsController<ReaderPost> = {
-        let fetchRequest = NSFetchRequest<ReaderPost>(entityName: ReaderPost.classNameWithoutNamespaces())
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "sortRank", ascending: true)]
-        fetchRequest.fetchLimit = Constants.displayPostLimit
-        let resultsController = NSFetchedResultsController<ReaderPost>(fetchRequest: fetchRequest,
-                                                           managedObjectContext: ContextManager.shared.mainContext,
-                                                           sectionNameKeyPath: nil,
-                                                           cacheName: nil)
-        resultsController.delegate = self
-        return resultsController
-    }()
-    private var isLoggedIn: Bool = false
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        registerTagCell()
-        setupButtonStyles()
-        collectionView.delegate = self
-        accessibilityElements = [tagButton, collectionView].compactMap { $0 }
-        collectionViewHeightConstraint.constant = cellSize.height
-    }
-
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        collectionViewHeightConstraint.constant = cellSize.height
-    }
-
-    func configure(with tag: ReaderTagTopic, isLoggedIn: Bool) {
-        self.isLoggedIn = isLoggedIn
-        tagButton.setTitle(tag.title, for: .normal)
-        resultsController.fetchRequest.predicate = NSPredicate(format: "topic = %@ AND isSiteBlocked = NO", tag)
-        try? resultsController.performFetch()
-    }
-}
-
-// MARK: - Private methods
-
-private extension ReaderTagCardCell {
+    private var viewModel: ReaderTagCardCellViewModel?
 
     var cellSize: CGSize {
         let isAccessibilityCategory = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
@@ -72,6 +22,47 @@ private extension ReaderTagCardCell {
         }
     }
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        registerTagCell()
+        setupButtonStyles()
+        accessibilityElements = [tagButton, collectionView].compactMap { $0 }
+        collectionViewHeightConstraint.constant = cellSize.height
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        collectionViewHeightConstraint.constant = cellSize.height
+    }
+
+    func configure(parent: UIViewController, tag: ReaderTagTopic, isLoggedIn: Bool) {
+        weak var weakSelf = self
+        viewModel = ReaderTagCardCellViewModel(parent: parent,
+                                               tag: tag,
+                                               collectionView: collectionView,
+                                               isLoggedIn: isLoggedIn,
+                                               cellSize: weakSelf?.cellSize)
+        viewModel?.fetchTagTopics()
+        tagButton.setTitle(tag.title, for: .normal)
+    }
+
+    @IBAction private func onTagButtonTapped(_ sender: Any) {
+        viewModel?.onTagButtonTapped()
+    }
+
+    struct Constants {
+        static let phoneDefaultCellSize = CGSize(width: 240, height: 297)
+        static let phoneLargeCellSize = CGSize(width: 240, height: 500)
+        static let padDefaultCellSize = CGSize(width: 480, height: 600)
+        static let padLargeCellSize = CGSize(width: 480, height: 900)
+    }
+
+}
+
+// MARK: - Private methods
+
+private extension ReaderTagCardCell {
+
     func setupButtonStyles() {
         var buttonConfig = UIButton.Configuration.filled()
         buttonConfig.cornerStyle = .capsule
@@ -86,37 +77,7 @@ private extension ReaderTagCardCell {
 
     func registerTagCell() {
         let nib = UINib(nibName: ReaderTagCell.classNameWithoutNamespaces(), bundle: nil)
-        collectionView.register(nib, forCellWithReuseIdentifier: Constants.cellIdentifier)
-    }
-
-    struct Constants {
-        static let cellIdentifier = ReaderTagCell.classNameWithoutNamespaces()
-        static let displayPostLimit = 10
-        static let phoneDefaultCellSize = CGSize(width: 240, height: 297)
-        static let phoneLargeCellSize = CGSize(width: 240, height: 500)
-        static let padDefaultCellSize = CGSize(width: 480, height: 600)
-        static let padLargeCellSize = CGSize(width: 480, height: 900)
-    }
-
-}
-
-// MARK: - NSFetchedResultsControllerDelegate
-
-extension ReaderTagCardCell: NSFetchedResultsControllerDelegate {
-
-    func controller(_ controller: NSFetchedResultsController<any NSFetchRequestResult>,
-                    didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
-        dataSource.apply(snapshot as Snapshot, animatingDifferences: false)
-    }
-
-}
-
-// MARK: - UICollectionViewDelegateFlowLayout
-
-extension ReaderTagCardCell: UICollectionViewDelegateFlowLayout {
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return cellSize
+        collectionView.register(nib, forCellWithReuseIdentifier: ReaderTagCell.classNameWithoutNamespaces())
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
@@ -20,6 +20,9 @@
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="filled" title="Tag"/>
+                    <connections>
+                        <action selector="onTagButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="7G3-4m-23Y"/>
+                    </connections>
                 </button>
                 <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
                     <rect key="frame" x="24" y="62" width="288" height="297"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -51,7 +51,7 @@ class ReaderTagCardCellViewModel: NSObject {
         collectionView?.delegate = self
     }
 
-    func fetchTagTopics() {
+    func fetchTagPosts() {
         try? resultsController.performFetch()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -82,6 +82,10 @@ extension ReaderTagCardCellViewModel: NSFetchedResultsControllerDelegate {
 extension ReaderTagCardCellViewModel: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let sectionInfo = resultsController.sections?[safe: indexPath.section],
+              indexPath.row < sectionInfo.numberOfObjects else {
+            return
+        }
         let post = resultsController.object(at: indexPath)
         let controller = ReaderDetailViewController.controllerWithPost(post)
         parentViewController?.navigationController?.pushViewController(controller, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -1,0 +1,100 @@
+
+class ReaderTagCardCellViewModel: NSObject {
+
+    private typealias DataSource = UICollectionViewDiffableDataSource<Int, NSManagedObjectID>
+    private typealias Snapshot = NSDiffableDataSourceSnapshot<Int, NSManagedObjectID>
+
+    private weak var parentViewController: UIViewController?
+    private let slug: String
+    private weak var collectionView: UICollectionView?
+    private let isLoggedIn: Bool
+    private let cellSize: () -> CGSize?
+
+    private lazy var dataSource: DataSource? = {
+        guard let collectionView else {
+           return nil
+        }
+        return DataSource(collectionView: collectionView) { [weak self] collectionView, indexPath, objectID in
+            guard let post = try? ContextManager.shared.mainContext.existingObject(with: objectID) as? ReaderPost,
+                  let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReaderTagCell.classNameWithoutNamespaces(), for: indexPath) as? ReaderTagCell else {
+                return UICollectionViewCell()
+            }
+            cell.configure(parent: self?.parentViewController,
+                           post: post,
+                           isLoggedIn: self?.isLoggedIn ?? AccountHelper.isLoggedIn)
+            return cell
+        }
+    }()
+
+    private lazy var resultsController: NSFetchedResultsController<ReaderPost> = {
+        let fetchRequest = NSFetchRequest<ReaderPost>(entityName: ReaderPost.classNameWithoutNamespaces())
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "sortRank", ascending: false)]
+        fetchRequest.fetchLimit = Constants.displayPostLimit
+        let resultsController = NSFetchedResultsController<ReaderPost>(fetchRequest: fetchRequest,
+                                                           managedObjectContext: ContextManager.shared.mainContext,
+                                                           sectionNameKeyPath: nil,
+                                                           cacheName: nil)
+        resultsController.delegate = self
+        return resultsController
+    }()
+
+    init(parent: UIViewController?, tag: ReaderTagTopic, collectionView: UICollectionView?, isLoggedIn: Bool, cellSize: @escaping @autoclosure () -> CGSize?) {
+        self.parentViewController = parent
+        self.slug = tag.slug
+        self.collectionView = collectionView
+        self.isLoggedIn = isLoggedIn
+        self.cellSize = cellSize
+
+        super.init()
+
+        resultsController.fetchRequest.predicate = NSPredicate(format: "topic = %@ AND isSiteBlocked = NO", tag)
+        collectionView?.delegate = self
+    }
+
+    func fetchTagTopics() {
+        try? resultsController.performFetch()
+    }
+
+    func onTagButtonTapped() {
+        let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
+        parentViewController?.navigationController?.pushViewController(controller, animated: true)
+    }
+
+    struct Constants {
+        static let displayPostLimit = 10
+    }
+
+}
+
+// MARK: - NSFetchedResultsControllerDelegate
+
+extension ReaderTagCardCellViewModel: NSFetchedResultsControllerDelegate {
+
+    func controller(_ controller: NSFetchedResultsController<any NSFetchRequestResult>,
+                    didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
+        dataSource?.apply(snapshot as Snapshot, animatingDifferences: false)
+    }
+
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension ReaderTagCardCellViewModel: UICollectionViewDelegate {
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let post = resultsController.object(at: indexPath)
+        let controller = ReaderDetailViewController.controllerWithPost(post)
+        parentViewController?.navigationController?.pushViewController(controller, animated: true)
+    }
+
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension ReaderTagCardCellViewModel: UICollectionViewDelegateFlowLayout {
+
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return cellSize() ?? .zero
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -30,6 +30,7 @@ class ReaderTagCardCellViewModel: NSObject {
         let fetchRequest = NSFetchRequest<ReaderPost>(entityName: ReaderPost.classNameWithoutNamespaces())
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "sortRank", ascending: false)]
         fetchRequest.fetchLimit = Constants.displayPostLimit
+        fetchRequest.includesSubentities = false
         let resultsController = NSFetchedResultsController<ReaderPost>(fetchRequest: fetchRequest,
                                                            managedObjectContext: ContextManager.shared.mainContext,
                                                            sectionNameKeyPath: nil,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -12,15 +12,14 @@ class ReaderTagCell: UICollectionViewCell {
     @IBOutlet private weak var menuButton: UIButton!
 
     private lazy var imageLoader = ImageLoader(imageView: featuredImageView)
+    private var viewModel: ReaderTagCellViewModel?
 
     override func awakeFromNib() {
         super.awakeFromNib()
         setupStyles()
         contentStackView.setCustomSpacing(0, after: featuredImageView)
-        likeButton.setTitle(NSLocalizedString("reader.tags.button.like",
-                                              value: "Like",
-                                              comment: "Text for the 'Like' button on the reader tag cell."),
-                            for: .normal)
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onSiteTitleTapped))
+        headerStackView.addGestureRecognizer(tapGesture)
     }
 
     override func prepareForReuse() {
@@ -29,7 +28,9 @@ class ReaderTagCell: UICollectionViewCell {
         resetHiddenViews()
     }
 
-    func configure(with post: ReaderPost, isLoggedIn: Bool) {
+    func configure(parent: UIViewController?, post: ReaderPost, isLoggedIn: Bool) {
+        viewModel = ReaderTagCellViewModel(parent: parent, post: post, isLoggedIn: isLoggedIn)
+
         let blogName = post.blogNameForDisplay()
         let postDate = post.shortDateForDisplay()
         let postTitle = post.titleForDisplay()
@@ -47,7 +48,32 @@ class ReaderTagCell: UICollectionViewCell {
         titleLabel.isHidden = postTitle == nil
         summaryLabel.isHidden = postSummary == nil
         countsLabel.isHidden = postCounts == nil
+
+        configureLikeButton(with: post)
         loadFeaturedImage(with: post)
+    }
+
+    @objc private func onSiteTitleTapped() {
+        viewModel?.onSiteTitleTapped()
+    }
+
+    @IBAction private func onLikeButtonTapped(_ sender: Any) {
+        viewModel?.onLikeButtonTapped()
+    }
+
+    @IBAction private func onMenuButtonTapped(_ sender: UIButton) {
+        viewModel?.onMenuButtonTapped(with: sender)
+    }
+
+    private struct Constants {
+        static let likeText = NSLocalizedString("reader.tags.button.like",
+                                                value: "Like",
+                                                comment: "Text for the 'Like' button on the reader tag cell.")
+        static let likedText = NSLocalizedString("reader.tags.button.liked",
+                                                 value: "Liked",
+                                                 comment: "Text for the 'Liked' button on the reader tag cell.")
+        static let likeButtonImage = UIImage(named: "icon-reader-star-outline")?.withRenderingMode(.alwaysTemplate)
+        static let likedButtonImage = UIImage(named: "icon-reader-star-fill")?.withRenderingMode(.alwaysTemplate)
     }
 
 }
@@ -90,6 +116,14 @@ private extension ReaderTagCell {
         featuredImageView.isHidden = false
         countsLabel.isHidden = false
         likeButton.isHidden = false
+    }
+
+    func configureLikeButton(with post: ReaderPost) {
+        let isLiked = post.isLiked
+        likeButton.setTitle(isLiked ? Constants.likedText : Constants.likeText, for: .normal)
+        likeButton.setImage(isLiked ? Constants.likedButtonImage : Constants.likeButtonImage, for: .normal)
+        likeButton.tintColor = isLiked ? .jetpackGreen : .secondaryLabel
+        likeButton.setTitleColor(likeButton.tintColor, for: .normal)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -81,6 +81,9 @@
                             <state key="normal" title="Like" image="icon-reader-star-outline">
                                 <preferredSymbolConfiguration key="preferredSymbolConfiguration"/>
                             </state>
+                            <connections>
+                                <action selector="onLikeButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="O6m-T2-DAS"/>
+                            </connections>
                         </button>
                         <view contentMode="scaleToFill" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0q4-yh-1OL" userLabel="Spacer">
                             <rect key="frame" x="52" y="0.0" width="144" height="44"/>
@@ -93,6 +96,9 @@
                             </constraints>
                             <inset key="imageEdgeInsets" minX="15" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                             <state key="normal" image="more-horizontal-mobile"/>
+                            <connections>
+                                <action selector="onMenuButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="FuW-5y-aZT"/>
+                            </connections>
                         </button>
                     </subviews>
                 </stackView>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
@@ -1,0 +1,46 @@
+
+struct ReaderTagCellViewModel {
+
+    private weak var parentViewController: UIViewController?
+    private let post: ReaderPost
+    private let isLoggedIn: Bool
+    private var followCommentsService: FollowCommentsService?
+
+    init(parent: UIViewController?, post: ReaderPost, isLoggedIn: Bool) {
+        self.parentViewController = parent
+        self.post = post
+        self.isLoggedIn = isLoggedIn
+    }
+
+    func onSiteTitleTapped() {
+        guard let parentViewController else {
+            return
+        }
+        ReaderHeaderAction().execute(post: post, origin: parentViewController)
+    }
+
+    func onLikeButtonTapped() {
+        ReaderLikeAction().execute(with: post)
+    }
+
+    mutating func onMenuButtonTapped(with anchor: UIView) {
+        guard let parentViewController = parentViewController as? ReaderStreamViewController,
+              let followCommentsService = FollowCommentsService(post: post) else {
+            return
+        }
+        self.followCommentsService = followCommentsService
+
+        ReaderMenuAction(logged: isLoggedIn).execute(
+            post: post,
+            context: parentViewController.viewContext,
+            readerTopic: parentViewController.readerTopic,
+            anchor: anchor,
+            vc: parentViewController,
+            source: .tagCard,
+            followCommentsService: followCommentsService,
+            showAdditionalItems: true
+        )
+        // TODO: Analytics
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2272,6 +2272,10 @@
 		83A337A22A9FA525009ED60C /* ReaderSiteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A337A02A9FA525009ED60C /* ReaderSiteHeaderView.swift */; };
 		83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
+		83BF48BB2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BF48BA2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift */; };
+		83BF48BC2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BF48BA2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift */; };
+		83BF48BE2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BF48BD2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift */; };
+		83BF48BF2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BF48BD2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift */; };
 		83BFAE482A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */; };
 		83BFAE492A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */; };
 		83BFAE502A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83BFAE4F2A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift */; };
@@ -7661,6 +7665,8 @@
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
 		83A337A02A9FA525009ED60C /* ReaderSiteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteHeaderView.swift; sourceTree = "<group>"; };
 		83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsAttribution.swift; sourceTree = "<group>"; };
+		83BF48BA2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagCardCellViewModel.swift; sourceTree = "<group>"; };
+		83BF48BD2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagCellViewModel.swift; sourceTree = "<group>"; };
 		83BFAE472A6EBF1F00C7B683 /* DashboardJetpackSocialCardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardJetpackSocialCardCell.swift; sourceTree = "<group>"; };
 		83BFAE4F2A6EBF9900C7B683 /* DashboardJetpackSocialCardCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardJetpackSocialCardCellTests.swift; sourceTree = "<group>"; };
 		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
@@ -12720,8 +12726,10 @@
 				D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */,
 				83317ED52BC71BA8001AD2F4 /* ReaderTagCardCell.swift */,
 				83317ED82BC71CEB001AD2F4 /* ReaderTagCardCell.xib */,
+				83BF48BA2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift */,
 				83317EDB2BC72DB7001AD2F4 /* ReaderTagCell.swift */,
 				83317EDE2BC72DED001AD2F4 /* ReaderTagCell.xib */,
+				83BF48BD2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift */,
 			);
 			name = Cards;
 			sourceTree = "<group>";
@@ -22223,6 +22231,7 @@
 				E6F2788121BC1A4A008B4DB5 /* PlanGroup.swift in Sources */,
 				08216FCE1CDBF96000304BA7 /* MenuItemPostsViewController.m in Sources */,
 				4322A20D203E1885004EA740 /* SignupUsernameTableViewController.swift in Sources */,
+				83BF48BB2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift in Sources */,
 				098B8576275E76FE004D299F /* AppLocalizedString.swift in Sources */,
 				7E7BEF7022E1AED8009A880D /* Blog+Editor.swift in Sources */,
 				1756F1DF2822BB6F00CD0915 /* SparklineView.swift in Sources */,
@@ -22540,6 +22549,7 @@
 				46C984682527863E00988BB9 /* LayoutPickerAnalyticsEvent.swift in Sources */,
 				7E442FCD20F6AB9C00DEACA5 /* ActivityRange.swift in Sources */,
 				9AF9551821A1D7970057827C /* DiffAbstractValue+Attributes.swift in Sources */,
+				83BF48BE2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift in Sources */,
 				FE50965C2A20D0F300DDD071 /* CommentTableHeaderView.swift in Sources */,
 				8BD66ED42787530C00CCD95A /* PostsCardViewModel.swift in Sources */,
 				80EF928D280E83110064A971 /* QuickStartToursCollection.swift in Sources */,
@@ -24997,6 +25007,7 @@
 				FABB22DD2602FC2C00C8785C /* RevisionsTableViewCell.swift in Sources */,
 				E6D6A1312683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
 				F49B9A06293A21BF000CEFCE /* MigrationAnalyticsTracker.swift in Sources */,
+				83BF48BF2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift in Sources */,
 				E62CE58F26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,
 				0C391E622A3002950040EA91 /* BlazeCampaignStatusView.swift in Sources */,
 				FABB22DF2602FC2C00C8785C /* PlanDetailViewModel.swift in Sources */,
@@ -25999,6 +26010,7 @@
 				FECA443028350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */,
 				FABB25982602FC2C00C8785C /* JetpackRestoreHeaderView.swift in Sources */,
 				FABB25992602FC2C00C8785C /* StoryboardLoadable.swift in Sources */,
+				83BF48BC2BD6F03000C0E1A1 /* ReaderTagCardCellViewModel.swift in Sources */,
 				FABB259A2602FC2C00C8785C /* ReaderBlockSiteAction.swift in Sources */,
 				FABB259C2602FC2C00C8785C /* ReaderPostService+RelatedPosts.swift in Sources */,
 				FABB259D2602FC2C00C8785C /* Blog+Capabilities.swift in Sources */,


### PR DESCRIPTION
Part of #23013 

## Description

Adds the following tap actions to the tag cells:
- Tag title label → Show tag list
- Site header of the post → Show site posts
- "Like"/"Liked" button → Like/Unlike post
- Menu button → Show menu for post
- Anywhere else in the cell → Open the post details

## Testing

To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- Tap on each element and 🔎 verify each action:

| Element | Expected Action |
|---|---|
| Tag capsule button | Navigates to that tag's post list |
| Post site header with the site title and post time | Navigates to the site's post list |
| Like/Liked button | Like/Liked button updated to the opposite state. The like count under the feature image should update too |
| Menu button | A menu with block actions and other post actions appears. On iPad, the menu should appear where the button is located |
| Tap anywhere else on the cell besides the above elements | Navigates to the post's details |

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
