### PR TITLE
Stats: Add Subscribers `Emails Opens and Clicks` Details

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -450,6 +450,7 @@
         static let searchTerm = NSLocalizedString("Search Term", comment: "Label for list of search term")
         static let period = NSLocalizedString("Period", comment: "Label for date periods.")
         static let file = NSLocalizedString("File", comment: "Label for list of file downloads.")
+        static let emailsSummary = NSLocalizedString("stats.subscribers.emailsSummary.column.title", value: "Latest emails", comment: "A title for table's column that shows a name of an email")
     }
 
     struct DataSubtitles {
@@ -459,6 +460,8 @@
         static let since = NSLocalizedString("Since", comment: "Label for time period in list of followers.")
         static let clicks = NSLocalizedString("Clicks", comment: "Label for number of clicks.")
         static let downloads = NSLocalizedString("Downloads", comment: "Label for number of file downloads.")
+        static let emailsSummaryOpens = NSLocalizedString("stats.subscribers.emailsSummary.column.opens", value: "Opens", comment: "A title for table's column that shows a number of email openings")
+        static let emailsSummaryClicks = NSLocalizedString("stats.subscribers.emailsSummary.column.clicks", value: "Clicks", comment: "A title for table's column that shows a number of times a post was opened from an email")
     }
 
     struct TabTitles {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -814,6 +814,7 @@ struct DetailSubtitlesHeaderRow: HashableImmutableRow {
 
     let itemSubtitle: String
     let dataSubtitle: String
+    var secondDataSubtitle: String? = nil
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -822,12 +823,13 @@ struct DetailSubtitlesHeaderRow: HashableImmutableRow {
             return
         }
 
-        cell.configure(itemSubtitle: itemSubtitle, dataSubtitle: dataSubtitle, dataRows: [], forDetails: true)
+        cell.configure(itemSubtitle: itemSubtitle, dataSubtitle: dataSubtitle, secondDataSubtitle: secondDataSubtitle, dataRows: [], forDetails: true)
     }
 
     static func == (lhs: DetailSubtitlesHeaderRow, rhs: DetailSubtitlesHeaderRow) -> Bool {
         return lhs.itemSubtitle == rhs.itemSubtitle &&
-            lhs.dataSubtitle == rhs.dataSubtitle
+            lhs.dataSubtitle == rhs.dataSubtitle &&
+            lhs.secondDataSubtitle == rhs.secondDataSubtitle
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersStore.swift
@@ -56,5 +56,27 @@ extension StatsSubscribersStore {
         case loading
         case success(Value)
         case error
+
+        var data: Value? {
+            switch self {
+            case .success(let data):
+                return data
+            default:
+                return nil
+            }
+        }
+
+        var storeFetchingStatus: StoreFetchingStatus {
+            switch self {
+            case .idle:
+                return .idle
+            case .loading:
+                return .loading
+            case .success:
+                return .success
+            case .error:
+                return .error
+            }
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -78,7 +78,8 @@ final class StatsSubscribersViewController: SiteStatsBaseTableViewController {
 
 extension StatsSubscribersViewController: SiteStatsPeriodDelegate {
     func viewMoreSelectedForStatSection(_ statSection: StatSection) {
-        // TODO
-        DDLogInfo("\(statSection) selected")
+        let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
+        detailTableViewController.configure(statSection: statSection)
+        navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewModel.swift
@@ -62,9 +62,9 @@ private extension StatsSubscribersViewModel {
         case .success(let emailsSummary):
             return [
                 TopTotalsPeriodStatsRow(
-                    itemSubtitle: Strings.titleColumn,
-                    dataSubtitle: Strings.opensColumn,
-                    secondDataSubtitle: Strings.clicksColumn,
+                    itemSubtitle: StatSection.ItemSubtitles.emailsSummary,
+                    dataSubtitle: StatSection.DataSubtitles.emailsSummaryOpens,
+                    secondDataSubtitle: StatSection.DataSubtitles.emailsSummaryClicks,
                     dataRows: emailsSummaryDataRows(emailsSummary),
                     statSection: .subscribersEmailsSummary,
                     siteStatsPeriodDelegate: viewMoreDelegate
@@ -85,13 +85,5 @@ private extension StatsSubscribersViewModel {
                 statSection: .subscribersEmailsSummary
             )
         }
-    }
-}
-
-private extension StatsSubscribersViewModel {
-    struct Strings {
-        static let titleColumn = NSLocalizedString("stats.subscribers.emailsSummary.column.title", value: "Latest emails", comment: "A title for table's column that shows a name of an email")
-        static let opensColumn = NSLocalizedString("stats.subscribers.emailsSummary.column.opens", value: "Opens", comment: "A title for table's column that shows a number of email openings")
-        static let clicksColumn = NSLocalizedString("stats.subscribers.emailsSummary.column.clicks", value: "Clicks", comment: "A title for table's column that shows a number of times a post was opened from an email")
     }
 }


### PR DESCRIPTION
Fixes #23045
Continuation of https://github.com/wordpress-mobile/WordPress-iOS/pull/23056 PR

Add navigation from Subscribers `Emails Opens and Clicks` card into `Details` that displays more information.

## Solution

I decided to integrate within `SiteStatsDetailTableViewController` which is used by both Insights, and Traffic details for most of the Stat sections.

`SiteStatsDetailTableViewController` requires to comply by providing loading, error, and loaded states for a supported `StatSection`. It was fairly straightforward to do by reusing `StatsSubscribersStore`.

## To test:

1. Enable `Stats Traffic and Subscibers tab` feature flag
2. Select a high-traffic site
3. Open Stats
4. Open Subscribers
5. Confirm `Emails Opens and Clicks` card appears with "View more" button
6. Select "View more"
7. Confirm a longer `Emails Opens and Clicks` list appears in details
8. Compare the data with WP.com and confirm that it's the same data

## Regression Notes
1. Potential unintended areas of impact

None, not affecting any existing functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
