### PR TITLE
Fix an issue with -logout-at-launch option not removing self-hosted sites

### DIFF
--- a/WordPress/Classes/System/UITestConfigurator.swift
+++ b/WordPress/Classes/System/UITestConfigurator.swift
@@ -22,7 +22,17 @@ struct UITestConfigurator {
 
     private static func logoutAtLaunch() {
         if CommandLine.arguments.contains("-logout-at-launch") {
+            removeSelfHostedSites()
             AccountHelper.logOutDefaultWordPressComAccount()
+        }
+    }
+
+    private static func removeSelfHostedSites() {
+        let context = ContextManager.shared.mainContext
+        let service = BlogService(coreDataStack: ContextManager.shared)
+        let blogs = try? BlogQuery().hostedByWPCom(false).blogs(in: context)
+        for blog in blogs ?? [] {
+            service.remove(blog)
         }
     }
 


### PR DESCRIPTION
Fix an issue with -logout-at-launch option not removing self-hosted sites

## To test:

- Launch a WP/JP app manually
- Add a self-hosted site
- Enable mocks and launch one of the UI tests
- Verify that the self-hosted site was removed and the mocked once are shown
- Verify that the UI test completes successfully

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
