### PR TITLE
Update page context menu with Stats and Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 24.8
 -----
-
+* [*] Move "Settings" context menu action in "Pages" from the submenu to a separate section to make it easily discoverable [#23065]
+* [*] Add "Stats" context menu action to "Pages" [#23065]
 
 24.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 24.8
 -----
-* [*] Move "Settings" context menu action in "Pages" from the submenu to a separate section to make it easily discoverable [#23065]
+* [*] Move "Settings" context menu action in "Pages" from the submenu to a separate section to make it easily discoverable and make it available for unpublished posts [#23065]
 * [*] Add "Stats" context menu action to "Pages" [#23065]
 
 24.7

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -11,10 +11,6 @@ extension PageListViewController: InteractivePostViewDelegate {
         viewPost(apost)
     }
 
-    func stats(for apost: AbstractPost) {
-        // Not available for pages
-    }
-
     func duplicate(_ apost: AbstractPost) {
         guard let page = apost as? Page else { return }
         copyPage(page)

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -26,7 +26,8 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.blaze],
-            [.setParent, .setHomepage, .setPostsPage, .settings],
+            [.setParent, .setHomepage, .setPostsPage],
+            [.stats, .settings],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -53,7 +54,8 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
-            [.setParent, .setHomepage, .setPostsPage, .settings],
+            [.setParent, .setHomepage, .setPostsPage],
+            [.stats, .settings],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -80,7 +82,8 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
-            [.setParent, .setHomepage, .setPostsPage, .settings],
+            [.setParent, .setHomepage, .setPostsPage],
+            [.settings],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -108,7 +111,8 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.duplicate, .share],
             [.blaze],
-            [.setParent, .setPostsPage, .settings]
+            [.setParent, .setPostsPage],
+            [.stats, .settings]
         ]
         expect(buttons).to(equal(expectedButtons))
     }
@@ -135,7 +139,8 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.blaze],
-            [.setParent, .setHomepage, .setRegularPage, .settings],
+            [.setParent, .setHomepage, .setRegularPage],
+            [.stats, .settings],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -156,6 +161,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.publish, .duplicate],
             [.setParent],
+            [.settings],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -176,6 +182,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft],
             [.setParent],
+            [.settings],
             [.trash]
         ]
         expect(buttons).to(equal(expectedButtons))

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -730,6 +730,37 @@ class AbstractPostListViewController: UIViewController,
         }
     }
 
+    func stats(for post: AbstractPost) {
+        viewStatsForPost(post)
+    }
+
+    fileprivate func viewStatsForPost(_ post: AbstractPost) {
+        // Check the blog
+        let blog = post.blog
+
+        guard blog.supports(.stats) else {
+            // Needs Jetpack.
+            return
+        }
+
+        WPAnalytics.track(.postListStatsAction, withProperties: propertiesForAnalytics())
+
+        // Push the Post Stats ViewController
+        guard let postID = post.postID as? Int else {
+            return
+        }
+
+        SiteStatsInformation.sharedInstance.siteTimeZone = blog.timeZone
+        SiteStatsInformation.sharedInstance.oauth2Token = blog.authToken
+        SiteStatsInformation.sharedInstance.siteID = blog.dotComID
+
+        let postURL = URL(string: post.permaLink! as String)
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: post.titleForDisplay(),
+                                                                                            postURL: postURL)
+        navigationController?.pushViewController(postStatsTableViewController, animated: true)
+    }
+
     @objc func copyPostLink(_ post: AbstractPost) {
         let pasteboard = UIPasteboard.general
         guard let link = post.permaLink else { return }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -95,7 +95,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .retry: return UIImage(systemName: "arrow.clockwise")
         case .view: return UIImage(systemName: "safari")
         case .publish: return UIImage(systemName: "tray.and.arrow.up")
-        case .stats: return UIImage(systemName: "chart.bar.xaxis")
+        case .stats: return UIImage(systemName: "chart.line.uptrend.xyaxis")
         case .duplicate: return UIImage(systemName: "doc.on.doc")
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -15,6 +15,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             createSecondarySection(),
             createBlazeSection(),
             createSetPageAttributesSection(),
+            createNavigationSection(),
             createTrashSection()
         ]
     }
@@ -124,11 +125,18 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         } else {
             buttons.append(.setRegularPage)
         }
+        return AbstractPostButtonSection(buttons: buttons, submenuButton: .pageAttributes)
+    }
+
+    private func createNavigationSection() -> AbstractPostButtonSection {
+        var buttons = [AbstractPostButton]()
+        if isJetpackFeaturesEnabled, page.status == .publish && page.hasRemote() {
+            buttons.append(.stats)
+        }
         if page.status != .trash {
             buttons.append(.settings)
         }
-
-        return AbstractPostButtonSection(buttons: buttons, submenuButton: .pageAttributes)
+        return AbstractPostButtonSection(buttons: buttons)
     }
 
     private func createTrashSection() -> AbstractPostButtonSection {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -212,33 +212,6 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
         PostListEditorPresenter.handleCopy(post: post, in: self)
     }
 
-    fileprivate func viewStatsForPost(_ post: AbstractPost) {
-        // Check the blog
-        let blog = post.blog
-
-        guard blog.supports(.stats) else {
-            // Needs Jetpack.
-            return
-        }
-
-        WPAnalytics.track(.postListStatsAction, withProperties: propertiesForAnalytics())
-
-        // Push the Post Stats ViewController
-        guard let postID = post.postID as? Int else {
-            return
-        }
-
-        SiteStatsInformation.sharedInstance.siteTimeZone = blog.timeZone
-        SiteStatsInformation.sharedInstance.oauth2Token = blog.authToken
-        SiteStatsInformation.sharedInstance.siteID = blog.dotComID
-
-        let postURL = URL(string: post.permaLink! as String)
-        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
-                                                                                            postTitle: post.titleForDisplay(),
-                                                                                            postURL: postURL)
-        navigationController?.pushViewController(postStatsTableViewController, animated: true)
-    }
-
     // MARK: - InteractivePostViewDelegate
 
     func edit(_ post: AbstractPost) {
@@ -247,10 +220,6 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
 
     func view(_ post: AbstractPost) {
         viewPost(post)
-    }
-
-    func stats(for post: AbstractPost) {
-        viewStatsForPost(post)
     }
 
     func duplicate(_ post: AbstractPost) {


### PR DESCRIPTION
- Make "Settings" more discoverable by moving it from a submenu to a separate section and make it available for unpublished posts
- Add "Stats" to the same section to match "Posts"
- Update the stats icon – open to suggestions but it just **has** to be non-filled like the rest of the icons 😅 

**Note**: "Page Attributes" should ideally be moved to the "Settings" page.

<img width="320" alt="Screenshot 2024-04-23 at 8 30 28 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/10b7328f-53e4-4952-be90-88bf1ca46c31">

## Regression Notes
1. Potential unintended areas of impact: Page Context Menu
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
