### PR TITLE
Fix an issue with parentPageID removal

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ end
 
 def wordpress_kit
   # pod 'WordPressKit', '~> 17.0.0'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'd95c88b8bb8dceada952ecbf9dcb78a8cb03f1f1'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '1a0955f6cbc20b258f82be7887d6e8e56a6fbce3'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.8, ~> 9.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `d95c88b8bb8dceada952ecbf9dcb78a8cb03f1f1`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `1a0955f6cbc20b258f82be7887d6e8e56a6fbce3`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `688ee5e4efddc1fc23626626ef17b7e929bdafb0`)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -177,7 +177,7 @@ EXTERNAL SOURCES:
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.117.0.podspec
   WordPressKit:
-    :commit: d95c88b8bb8dceada952ecbf9dcb78a8cb03f1f1
+    :commit: 1a0955f6cbc20b258f82be7887d6e8e56a6fbce3
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 688ee5e4efddc1fc23626626ef17b7e929bdafb0
@@ -188,7 +188,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   WordPressKit:
-    :commit: d95c88b8bb8dceada952ecbf9dcb78a8cb03f1f1
+    :commit: 1a0955f6cbc20b258f82be7887d6e8e56a6fbce3
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: 688ee5e4efddc1fc23626626ef17b7e929bdafb0
@@ -239,6 +239,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 18c2b48ec12b16596b0b5afa5270f3e79bf71faf
+PODFILE CHECKSUM: 2ee1661530a005e266006f993a65e84299509019
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -246,7 +246,8 @@ class ParentPageSettingsViewController: UIViewController {
     private func saveChanges() async {
         do {
             var changes = RemotePostUpdateParameters()
-            changes.parentPageID = selectedParentID?.intValue
+            // - warning: `.some` is important to make sure the parameter is included
+            changes.parentPageID = .some(selectedParentID?.intValue)
             try await PostCoordinator.shared._update(selectedPage.original(), changes: changes)
 
             await SVProgressHUD.dismiss()


### PR DESCRIPTION
Fix an issue where you could not set a page back as a top level page.

Related PR in WordPressKit https://github.com/wordpress-mobile/WordPressKit-iOS/pull/796

Maybe using double-optionals wasn't such a great idea after all.

## To test:

For .com and self-hosted sites:

**Test 1.1**

- Set a page parent as some other page
- ✅ Verify that the hierarchy was updated
- Set the page back as a top level page
- ✅ Verify that the hierarchy was updated

**Test 1.2 (Regression Test)**

- Removal a featured image
- ✅ Verify that the image got removed

## Regression Notes
1. Potential unintended areas of impact: Page Hierarchy 
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
