### PR TITLE
Modernize remaining publish settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
@@ -69,7 +69,7 @@ import Foundation
         refreshControl = UIRefreshControl()
         refreshControl!.addTarget(self, action: #selector(refreshCategoriesWithInteraction), for: .valueChanged)
 
-        let rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "icon-post-add"), style: .plain, target: self, action: #selector(showAddNewCategory))
+        let rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "plus"), style: .plain, target: self, action: #selector(showAddNewCategory))
 
         switch selectionMode {
         case .post:

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -107,9 +107,6 @@ class PostTagPickerViewController: UIViewController {
         textViewContainer.layer.masksToBounds = false
 
         keyboardObserver.tableView = tableView
-
-        let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: "Done button title"), style: .plain, target: self, action: #selector(doneButtonPressed))
-        navigationItem.setRightBarButton(doneButton, animated: false)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -144,10 +141,6 @@ class PostTagPickerViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         textViewContainer.layer.borderColor = UIColor.divider.cgColor
-    }
-
-    @objc func doneButtonPressed() {
-        navigationController?.popViewController(animated: true)
     }
 
     fileprivate func reloadTableData() {


### PR DESCRIPTION
The PR https://github.com/wordpress-mobile/WordPress-iOS/pull/22923 already had a couple of general minor visual improvements to the Prepublishing Sheet, and this one updates the remaining screens.

- Remove "Done" button from the "Tags" screen to match the rest of the screen (the button was doing nothing)
- Update the "Plus" sign in "Categories" to use the standard plus icon instead of the custom one (visually too large and bold)

<img width="320" alt="Screenshot 2024-04-23 at 10 09 58 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/efe5304a-ef4e-4bf4-a4b2-2cce5e6557ea">

<img width="320" alt="Screenshot 2024-04-23 at 10 10 04 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/4dac1995-53cf-4eb0-b8c2-95d18c069aab">

Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
