### PR TITLE
Offline Mode: Fix keyboard avoidance in submit button

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/DeprecatedPrepublishingViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import WordPressAuthenticator
 import Combine
 import WordPressUI
-import SwiftUI
 
 /// - warning: deprecated (kahu-offline-mode)
 enum PrepublishingIdentifier {
@@ -55,11 +54,14 @@ final class DeprecatedPrepublishingViewController: UIViewController, UITableView
     let tableView = UITableView(frame: .zero, style: .plain)
     private let footerSeparator = UIView()
 
-    private weak var titleField: UITextField?
+    let publishButton: NUXButton = {
+        let nuxButton = NUXButton()
+        nuxButton.isPrimary = true
+        nuxButton.accessibilityIdentifier = "publish"
+        return nuxButton
+    }()
 
-    private lazy var publishButtonViewModel = PublishButtonViewModel(title: "Publish") { [weak self] in
-        self?.buttonPublishTapped()
-    }
+    private weak var titleField: UITextField?
 
     /// Determines whether the text has been first responder already. If it has, don't force it back on the user unless it's been selected by them.
     private var hasSelectedText: Bool = false
@@ -163,13 +165,11 @@ final class DeprecatedPrepublishingViewController: UIViewController, UITableView
 
     private func setupPublishButton() -> UIView {
         let footerView = UIView()
+        footerView.addSubview(publishButton)
+        publishButton.translatesAutoresizingMaskIntoConstraints = false
+        footerView.pinSubviewToSafeArea(publishButton, insets: Constants.nuxButtonInsets)
 
-        let hostingViewController = UIHostingController(rootView: PublishButton(viewModel: publishButtonViewModel).tint(Color(uiColor: .primary)))
-        addChild(hostingViewController)
-
-        footerView.addSubview(hostingViewController.view)
-        hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        footerView.pinSubviewToSafeArea(hostingViewController.view, insets: Constants.nuxButtonInsets)
+        publishButton.addTarget(self, action: #selector(publish), for: .touchUpInside)
 
         updatePublishButtonLabel()
 
@@ -424,34 +424,15 @@ final class DeprecatedPrepublishingViewController: UIViewController, UITableView
     // MARK: - Publish Button
 
     private func updatePublishButtonLabel() {
-        publishButtonViewModel.title = post.isScheduled() ? Strings.schedule : Strings.publish
+        publishButton.setTitle(post.isScheduled() ? Strings.schedule : Strings.publish, for: .normal)
     }
 
-    private func buttonPublishTapped() {
+    @objc func publish(_ sender: UIButton) {
         didTapPublish = true
-
         let completion = getCompletion()
         navigationController?.dismiss(animated: true) {
             WPAnalytics.track(.editorPostPublishNowTapped)
             completion?(.confirmed)
-        }
-    }
-
-    private func setLoading(_ isLoading: Bool) {
-        publishButtonViewModel.state = isLoading ? .loading : .default
-        isModalInPresentation = isLoading
-        view.isUserInteractionEnabled = !isLoading
-
-        var subviews: [UIView] = [view]
-        while let view = subviews.popLast() {
-            switch view {
-            case let control as UIControl:
-                control.isEnabled = !isLoading
-            case let cell as UITableViewCell:
-                isLoading ? cell.disable() : cell.enable()
-            default:
-                subviews += view.subviews
-            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -36,7 +36,6 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
     private let headerView = PrepublishingHeaderView()
     let tableView = UITableView(frame: .zero, style: .plain)
-    private let footerSeparator = UIView()
 
     private lazy var publishButtonViewModel = PublishButtonViewModel(title: "Publish") { [weak self] in
         self?.buttonPublishTapped()
@@ -124,14 +123,11 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         configurePublishButton()
         observePostConflictResolved()
 
-        WPStyleGuide.applyBorderStyle(footerSeparator)
-
         title = ""
 
         let stackView = UIStackView(arrangedSubviews: [
             headerView,
-            tableView,
-            footerSeparator
+            tableView
         ])
         stackView.axis = .vertical
 
@@ -139,7 +135,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             PrepublishingStackView(view: stackView)
             PublishButton(viewModel: publishButtonViewModel)
                 .tint(Color(uiColor: .primary))
-                .padding() // TODO: ok padding?
+                .padding()
         }.ignoresSafeArea(.keyboard)
 
         // Making the entire view `UIHostingController` to make sure keyboard
@@ -193,12 +189,6 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
             .publisher(for: .postConflictResolved)
             .sink { [weak self] notification in self?.postConflictResolved(notification) }
             .store(in: &cancellables)
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        footerSeparator.isHidden = tableView.contentSize.height < tableView.bounds.height
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -121,6 +121,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
         configureHeader()
         configureTableView()
+        configurePublishButton()
         observePostConflictResolved()
 
         WPStyleGuide.applyBorderStyle(footerSeparator)
@@ -130,14 +131,25 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         let stackView = UIStackView(arrangedSubviews: [
             headerView,
             tableView,
-            footerSeparator,
-            setupPublishButton()
+            footerSeparator
         ])
         stackView.axis = .vertical
 
-        view.addSubview(stackView)
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToSafeArea(stackView)
+        let contentView = VStack {
+            PrepublishingStackView(view: stackView)
+            PublishButton(viewModel: publishButtonViewModel)
+                .tint(Color(uiColor: .primary))
+                .padding() // TODO: ok padding?
+        }.ignoresSafeArea(.keyboard)
+
+        // Making the entire view `UIHostingController` to make sure keyboard
+        // avoidance can be disabled (see https://steipete.com/posts/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/?utm_campaign=%20SwiftUI%20Weekly&utm_medium=email&utm_source=Revue%20newsletter)
+        let hostingViewController = UIHostingController(rootView: contentView)
+        addChild(hostingViewController)
+
+        view.addSubview(hostingViewController.view)
+        hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(hostingViewController.view)
 
         view.backgroundColor = .systemBackground
 
@@ -168,23 +180,12 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         tableView.rowHeight = UITableView.automaticDimension
     }
 
-    private func setupPublishButton() -> UIView {
-        let footerView = UIView()
-
-        let hostingViewController = UIHostingController(rootView: PublishButton(viewModel: publishButtonViewModel).tint(Color(uiColor: .primary)))
-        addChild(hostingViewController)
-
-        footerView.addSubview(hostingViewController.view)
-        hostingViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        footerView.pinSubviewToSafeArea(hostingViewController.view, insets: Constants.nuxButtonInsets)
-
+    private func configurePublishButton() {
         updatePublishButtonLabel()
         updatePublishButtonState()
         mediaPollingTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             self?.updatePublishButtonState()
         }
-
-        return footerView
     }
 
     private func observePostConflictResolved() {
@@ -579,6 +580,18 @@ private final class PrepublishingViewModel {
             password: password,
             publishDate: publishDate
         ))
+    }
+}
+
+private struct PrepublishingStackView: UIViewRepresentable {
+    let view: UIStackView
+
+    func makeUIView(context: Context) -> some UIView {
+        view
+    }
+
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+        // Do nothing
     }
 }
 


### PR DESCRIPTION

## To test

> [!IMPORTANT]
> Make sure to check with "Sync Publishing" both ON and OFF

- Select a post and tap "Publish" to open the prepublishing sheet
- ✅ Verify that the "Publish" button and everything else is in place
- Tap "Tags"
- ✅ Verify that the keyboard appeared (must be enabled if in a simulator)
- Tap "Back"
- ✅ Verify that the "Publish" button is still in the same place (at the bottom)

## Regression Notes
1. Potential unintended areas of impact: Prepublishing Sheet
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
