### PR TITLE
Offline Mode: Update post.status handling in post/page settings

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -26,6 +26,7 @@ import Foundation
     case editorPostPublishTap
     case editorPostPublishDismissed
     case editorPostScheduledChanged
+    case editorPostPendingReviewChanged
     case editorPostTitleChanged
     case editorPostVisibilityChanged
     case editorPostTagsChanged
@@ -627,6 +628,8 @@ import Foundation
             return "editor_post_publish_dismissed"
         case .editorPostScheduledChanged:
             return "editor_post_scheduled_changed"
+        case .editorPostPendingReviewChanged:
+            return "editor_post_pending_review_changed"
         case .editorPostTitleChanged:
             return "editor_post_title_changed"
         case .editorPostVisibilityChanged:

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -110,7 +110,7 @@ extension PostSettingsViewController {
         Task { @MainActor in
             do {
                 let coordinator = PostCoordinator.shared
-                if apost.original().status == .draft {
+                if coordinator.isSyncAllowed(for: apost) {
                     coordinator.setNeedsSync(for: apost)
                 } else {
                     try await coordinator._save(apost)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSInteger, PostSettingsRow) {
     PostSettingsRowTags,
     PostSettingsRowAuthor,
     PostSettingsRowPublishDate,
+    // - warning: deprecated (kahu-offline-mode)
     PostSettingsRowStatus,
     PostSettingsRowPendingReview,
     PostSettingsRowVisibility,
@@ -675,9 +676,10 @@ FeaturedImageViewControllerDelegate>
         if (self.isDraftOrPending) {
             [metaRows addObject:@(PostSettingsRowPendingReview)];
         } else {
-            [metaRows addObject:@(PostSettingsRowPublishDate)];
-            [metaRows addObjectsFromArray:@[  @(PostSettingsRowStatus),
-                                              @(PostSettingsRowVisibility) ]];
+            [metaRows addObjectsFromArray:@[
+                @(PostSettingsRowPublishDate),
+                @(PostSettingsRowVisibility)
+            ]];
             if (self.apost.password) {
                 [metaRows addObject:@(PostSettingsRowPassword)];
             }


### PR DESCRIPTION
## Changes

### Pending Review

"Pending review" is now a toggle (like in Gutenberg):

<img width="320" alt="Screenshot 2024-04-23 at 6 13 05 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/782f5ca0-9d99-4ebd-84d8-099c6f6daa32">

### Status

In the previous implementation, there was an overlap between "Visibility" and "Status":

<img width="320" alt="Screenshot 2024-04-23 at 5 05 39 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/e33003d4-c873-4bc1-a23e-9df58ef4f6f9">

The new implementation matches Gutenberg:

<img width="320" alt="Screenshot 2024-04-23 at 6 10 39 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/46877c40-b554-4bb7-bf05-73007c9f6e2a">

With these settings you can change the visibility of the posts using "Visibility" and move the post to draft or trash it using dedicated context menu actions, so there is now complete parity with Gutenberg.

### Post Settings

- Fix an issue where saving "Post Settings" changes was a sync operation for `.pending` posts (but async for `.draft`)

> [!NOTE]
> - The changes are under the "Sync Publishing" feature flag

## To test:

**Test 1.1**

- Create and save a draft post
- ✅ Use the new "Pending Review" toggle from Post Settings to move the post in and out of review

**Test 1.2**

- Open "Post Settings" for a pending post
- Change some of the settings
- Tap "Save"
- ✅ Verify that the save is performed asynchronously and can be performed offline

**Test 1.3**

- Open "Post Settings" for a published or a scheduled post
- ✅ Verify that the "Status" field is no longer present

## Regression Notes
1. Potential unintended areas of impact: Post List & Settings
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
