### PR TITLE
Remove labels from post create/update dates

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostHelper.swift
@@ -7,29 +7,33 @@ enum AbstractPostHelper {
     }
 
     static func getLocalizedStatusWithDate(for post: AbstractPost) -> String? {
+        _getLocalizedStatusWithDate(for: post)?.capitalized(with: .current)
+    }
+
+    private static func _getLocalizedStatusWithDate(for post: AbstractPost) -> String? {
         let timeZone = post.blog.timeZone
 
         switch post.status {
         case .scheduled:
             if let dateCreated = post.dateCreated {
-                return String(format: Strings.scheduled, dateCreated.mediumStringWithTime(timeZone: timeZone))
+                return dateCreated.mediumStringWithTime(timeZone: timeZone)
             }
         case .publish, .publishPrivate:
             if let dateCreated = post.dateCreated {
-                return String(format: Strings.published, dateCreated.toMediumString(inTimeZone: timeZone))
+                return dateCreated.toMediumString(inTimeZone: timeZone)
             }
         case .trash:
             if let dateModified = post.dateModified {
-                return String(format: Strings.trashed, dateModified.toMediumString(inTimeZone: timeZone))
+                return dateModified.toMediumString(inTimeZone: timeZone)
             }
         default:
             break
         }
         if let dateModified = post.dateModified {
-            return String(format: Strings.edited, dateModified.toMediumString(inTimeZone: timeZone))
+            return dateModified.toMediumString(inTimeZone: timeZone)
         }
         if let dateCreated = post.dateCreated {
-            return String(format: Strings.created, dateCreated.toMediumString(inTimeZone: timeZone))
+            return dateCreated.toMediumString(inTimeZone: timeZone)
         }
         return nil
     }
@@ -49,12 +53,4 @@ enum AbstractPostHelper {
         string.addAttribute(.font, value: WPStyleGuide.fontForTextStyle(.footnote), range: NSRange(location: 0, length: string.length))
         return string
     }
-}
-
-private enum Strings {
-    static let published = NSLocalizedString("post.publishedTimeAgo", value: "Published %@", comment: "Post status and date for list cells with %@ a placeholder for the date.")
-    static let scheduled = NSLocalizedString("post.scheduledForDate", value: "Scheduled %@", comment: "Post status and date for list cells with %@ a placeholder for the date.")
-    static let created = NSLocalizedString("post.createdTimeAgo", value: "Created %@", comment: "Post status and date for list cells with %@ a placeholder for the date.")
-    static let edited = NSLocalizedString("post.editedTimeAgo", value: "Edited %@", comment: "Post status and date for list cells with %@ a placeholder for the date.")
-    static let trashed = NSLocalizedString("post.trashedTimeAgo", value: "Trashed %@", comment: "Post status and date for list cells with %@ a placeholder for the date.")
 }


### PR DESCRIPTION
Remove labels from post create/update dates to match Android and Web – _much_ cleaner.

<img width="360" alt="Screenshot 2024-04-23 at 6 30 15 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/606f9a85-53cf-4a6d-aa40-fd613132ae0b">

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
