### PR TITLE
Reader: Add remote fetching for the tags stream

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -219,6 +219,12 @@ import AutomatticTracks
     private var removedPosts = Set<ReaderPost>()
     private var showConfirmation = true
 
+    // NOTE: This is currently a workaround for the 'Your Tags' stream use case.
+    //
+    // The set object flags each tag in the stream so that we know whether or not we've fetched the remote data for the tag.
+    // We need to ensure that we only fetch the remote data once per tag to avoid the resultsController from refreshing the table view indefinitely.
+    private var tagStreamSyncTracker = Set<String>()
+
     // MARK: - Factory Methods
 
     /// Convenience method for instantiating an instance of ReaderStreamViewController
@@ -901,6 +907,12 @@ import AutomatticTracks
     /// Handles the user initiated pull to refresh action.
     ///
     @objc func handleRefresh(_ sender: UIRefreshControl) {
+        if contentType == .tags {
+            // NOTE: This is a workaround.
+            // Allow all tags to re-fetch posts.
+            tagStreamSyncTracker.removeAll()
+        }
+
         if !canSync() {
             cleanupAfterSync()
 
@@ -1624,7 +1636,14 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
 
     func cell(for tag: ReaderTagTopic) -> UITableViewCell {
         let cell = tableConfiguration.tagCell(tableView)
-        cell.configure(parent: self, tag: tag, isLoggedIn: isLoggedIn)
+
+        // check whether we should sync the tag's posts.
+        let shouldSync = !tagStreamSyncTracker.contains(tag.slug)
+        if shouldSync {
+            tagStreamSyncTracker.insert(tag.slug)
+        }
+
+        cell.configure(parent: self, tag: tag, isLoggedIn: isLoggedIn, shouldSyncRemotely: shouldSync)
         cell.selectionStyle = .none
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -35,14 +35,14 @@ class ReaderTagCardCell: UITableViewCell {
         collectionViewHeightConstraint.constant = cellSize.height
     }
 
-    func configure(parent: UIViewController, tag: ReaderTagTopic, isLoggedIn: Bool) {
+    func configure(parent: UIViewController, tag: ReaderTagTopic, isLoggedIn: Bool, shouldSyncRemotely: Bool = false) {
         weak var weakSelf = self
         viewModel = ReaderTagCardCellViewModel(parent: parent,
                                                tag: tag,
                                                collectionView: collectionView,
                                                isLoggedIn: isLoggedIn,
                                                cellSize: weakSelf?.cellSize)
-        viewModel?.fetchTagTopics()
+        viewModel?.fetchTagTopics(syncRemotely: shouldSyncRemotely)
         tagButton.setTitle(tag.title, for: .normal)
     }
 


### PR DESCRIPTION
Part of #23069 
Depends on #23057

Adds fetching logic to the 'Your Tags' stream. Note that the loading state will be addressed in the next PR.

In this PR, I had to add a variable on `ReaderStreamViewController` to track whether we've remotely synced posts for a certain tag. This is done to prevent infinite looping from the remote request and the cell being reloaded. For example:

1. Cell is loaded.
2. Cell fetches data remotely.
3. New posts are saved into context.
4. WPTableViewHandler receives a `didChange` notification and triggers a reload (because `ReaderPost` has a relation with `ReaderAbstractTopic`.)
5. Cell is reloaded. Go back to step 2.

The variable, `tagStreamSyncTracker`, is added to ensure that we only fetch once per tag. This doesn't completely remove the unnecessary reloading, but it does limit and prevent it from reloading indefinitely. Also, I've added a note that this is a temporary workaround. The proper way would be to create a new view controller conforming to `ReaderContentViewController` protocol and should no longer be driven by a `FetchedResultsController`. 

## To test

> [!TIP]
> To make it easy to verify, you could add a print statement in `ReaderTagCardCellViewModel:L80`, right below the TODO for the loading state:
>
> ```swift
>     // TODO: Add loading state.
>     print("🗒️ Remotely fetching for: \(tag.slug)")
> ```

- Go to the Reader tab and select 'Your Tags' stream.
- 🔎 Verify that new contents are fetched once per tag.
  - If you've added the debug print above, verify that `🗒️ Remotely fetching for: \(tag.slug)` appears in the console as you scroll down the list.
  - When scrolling up, also verify that `🗒️ Remotely fetching for: \(tag.slug)` no longer appears for tags that have previously fetched data remotely.
- Perform a pull-to-refresh.
- 🔎 Verify that the tags are re-fetching the contents.
- Navigate to a different stream, and then come back to 'Your Tags'.
- 🔎 Verify that the tags are re-fetching the contents.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Changes are isolated to the new stream.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
