### PR TITLE
Offline Mode: Fix an issue with fixLocalMediaURLs not being called

### DIFF
--- a/WordPress/Classes/Extensions/AbstractPost+fixLocalMediaURLs.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+fixLocalMediaURLs.swift
@@ -1,15 +1,11 @@
 import Foundation
 
 extension AbstractPost {
-    /// If a post is in the failed state it can contain references to local files.
-    /// When updating the app through the App Store the local paths can change.
-    /// This will fix any outdated local path with the correct one.
-    ///
+    /// When updating the app through the App Store or installing a new version
+    /// of the app from Xcode, the local paths can change. This will fix any
+    /// outdated local path with the correct one.
     func fixLocalMediaURLs() {
-        guard isFailed,
-            var content = self.content else {
-            return
-        }
+        guard var content = self.content else { return }
 
         media.forEach { media in
             guard !media.hasRemote else {


### PR DESCRIPTION
Fix an issue with fixLocalMediaURLs not being called.

**Test 1.1**

- Set a breakpoint on `/rest/v1.1/sites/*/media/new?locale=en` or mock media upload failure in other ways
- Create a new draft post
- Add a media asset
- Abort the `media/new` request
- ✅ Verify that the media cell shows "Waiting for connection"
- Save the post as draft
- Reinstall the app using Xcode (important!)
- Re-open the post and remove the breakpoints
- Tap "Retry" on media upload
- ✅ Verify that the media got uploaded

**Production Issues:**

- The editor doesn't trigger retries for media uploads when it opens
- The editor is not capable of showing the local thumbnails when re-opening the post

> **Note**: I'm not sure this fix actually does anything – I just made sure it gets called, as it did before. `MediaCoordinator` uses relative links already.

## Regression Notes
1. Potential unintended areas of impact: Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
