### PR TITLE
Offline Mode: Add error handling to media upload status view

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -798,6 +798,26 @@ extension MediaCoordinator {
 
         }, for: nil)
     }
+
+    /// Returns `true` if the error can't be resolved by simply retrying and
+    /// requires user interventions, for example, making more room in the
+    /// Media library.
+    static func isTerminalError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        switch nsError.domain {
+        case MediaServiceErrorDomain:
+            switch nsError.code {
+            case MediaServiceError.fileDoesNotExist.rawValue,
+                MediaServiceError.fileLargerThanMaxFileSize.rawValue,
+                MediaServiceError.fileLargerThanDiskQuotaAvailable.rawValue:
+                return true
+            default:
+                return false
+            }
+        default:
+            return false
+        }
+    }
 }
 
 extension Media {

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
@@ -8,13 +8,22 @@ struct PostMediaUploadStatusView: View {
 
     var body: some View {
         contents
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(Strings.close, action: onCloseTapped)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(Strings.close, action: onCloseTapped)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button(action: viewModel.buttonRetryTapped) {
+                            Label(Strings.retryUploads, systemImage: "arrow.clockwise")
+                        }.disabled(viewModel.isButtonRetryDisabled)
+                    } label: {
+                        Image(systemName: "ellipsis")
+                    }
+                }
             }
-        }
-        .navigationTitle(Strings.title)
-        .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(Strings.title)
+            .navigationBarTitleDisplayMode(.inline)
     }
 
     @ViewBuilder
@@ -59,11 +68,9 @@ private struct MediaUploadStatusView: View {
             switch viewModel.state {
             case .uploading:
                 MediaUploadProgressView(progress: viewModel.fractionCompleted)
-                makeMenu()
             case .failed:
                 Image(systemName: "exclamationmark.circle.fill")
                     .foregroundStyle(.red)
-                makeMenu()
             case .uploaded:
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(.secondary.opacity(0.33))
@@ -72,23 +79,6 @@ private struct MediaUploadStatusView: View {
         .task {
             await viewModel.loadThumbnail()
         }
-    }
-
-    @ViewBuilder
-    private func makeMenu() -> some View {
-        Menu {
-            Button(action: viewModel.buttonRetryTapped) {
-                Label(Strings.retry, systemImage: "arrow.clockwise")
-            }
-            Button(role: .destructive, action: viewModel.buttonRemoveTapped) {
-                Label(Strings.remove, systemImage: "trash")
-            }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.footnote)
-                .foregroundStyle(.secondary.opacity(0.75))
-        }
-        .buttonStyle(.plain)
     }
 }
 
@@ -133,6 +123,5 @@ private enum Strings {
     static let title = NSLocalizedString("postMediaUploadStatusView.title", value: "Media Uploads", comment: "Title for post media upload status view")
     static let empty = NSLocalizedString("postMediaUploadStatusView.noPendingUploads", value: "No pending uploads", comment: "Placeholder text in postMediaUploadStatusView when no uploads remain")
     static let close = NSLocalizedString("postMediaUploadStatusView.close", value: "Close", comment: "Close button in postMediaUploadStatusView")
-    static let retry = NSLocalizedString("postMediaUploadStatusView.retry", value: "Retry", comment: "Retry upload button in postMediaUploadStatusView")
-    static let remove = NSLocalizedString("postMediaUploadStatusView.remove", value: "Remove", comment: "Remove media button in postMediaUploadStatusView")
+    static let retryUploads = NSLocalizedString("postMediaUploadStatusView.retryUploads", value: "Retry Uploads", comment: "Retry upload button in postMediaUploadStatusView")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
@@ -4,14 +4,10 @@ import SwiftUI
 /// Displays upload progress for the media for the given post.
 struct PostMediaUploadStatusView: View {
     @ObservedObject var viewModel: PostMediaUploadViewModel
-    let onCloseTapped: () -> Void
 
     var body: some View {
         contents
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(Strings.close, action: onCloseTapped)
-                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
                         Button(action: viewModel.buttonRetryTapped) {

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
@@ -92,7 +92,7 @@ private struct MediaUploadStatusView: View {
     }
 }
 
-private struct MediaUploadProgressView: View {
+struct MediaUploadProgressView: View {
     let progress: Double
 
     var body: some View {

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
@@ -104,6 +104,11 @@ final class MediaUploadViewModel: ObservableObject, Identifiable {
         return false
     }
 
+    var error: Error? {
+        if case .failed(let error) = state { return error }
+        return nil
+    }
+
     enum State {
         case uploading
         case failed(Error)

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -437,8 +437,8 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         guard !viewModel.isCompleted else {
             return nil
         }
-        if let error = viewModel.uploads.lazy.map(\.error).first {
-            return .failed(title: Strings.mediaUploadFailedTitle, details: error?.localizedDescription) { [weak self] in
+        if let error = viewModel.uploads.lazy.compactMap(\.error).first {
+            return .failed(title: Strings.mediaUploadFailedTitle, details: error.localizedDescription) { [weak self] in
                 self?.buttonShowUploadInfoTapped()
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -437,8 +437,10 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         guard !viewModel.isCompleted else {
             return nil
         }
-        if let error = viewModel.uploads.lazy.compactMap(\.error).first {
-            return .failed(title: Strings.mediaUploadFailedTitle, details: error.localizedDescription) { [weak self] in
+        let errors = viewModel.uploads.compactMap(\.error)
+        if !errors.isEmpty {
+            let details = errors.count == 1 ? errors[0].localizedDescription : String(format: Strings.mediaUploadFailedDetailsMultipleFailures, errors.count.description)
+            return .failed(title: Strings.mediaUploadFailedTitle, details: details) { [weak self] in
                 self?.buttonShowUploadInfoTapped()
             }
         }
@@ -606,5 +608,5 @@ private enum Strings {
         String(format: count == 1 ? Strings.uploadMediaOneItemRemaining : Strings.uploadMediaManyItemsRemaining, count.description)
     }
     static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
-    static let mediaUploadFailedDetails = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "Some of the uploads failed", comment: "Details for a publish button state in the pre-publishing sheet")
+    static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "%@ items failed to upload", comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter")
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -437,8 +437,12 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         guard !viewModel.isCompleted else {
             return nil
         }
-        let progress = PublishButtonState.Progress(completed: Int64(Double(viewModel.totalFileSize) * viewModel.fractionCompleted), total: viewModel.totalFileSize)
-        return .uploading(title: Strings.uploadingMedia + ": \(viewModel.completedUploadsCount) / \(viewModel.uploads.count)", progress: progress, onInfoTapped: { [weak self] in
+        if let error = viewModel.uploads.lazy.map(\.error).first {
+            return .failed(title: Strings.mediaUploadFailedTitle, details: error?.localizedDescription) { [weak self] in
+                self?.buttonShowUploadInfoTapped()
+            }
+        }
+        return .uploading(title: Strings.uploadingMedia, details: Strings.uploadMediaRemaining(count: viewModel.uploads.count - viewModel.completedUploadsCount), progress: viewModel.fractionCompleted, onInfoTapped: { [weak self] in
             self?.buttonShowUploadInfoTapped()
         })
     }
@@ -596,4 +600,11 @@ private enum Strings {
     static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
     static let immediately = NSLocalizedString("prepublishing.publishDateImmediately", value: "Immediately", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
     static let uploadingMedia = NSLocalizedString("prepublishing.uploadingMedia", value: "Uploading media", comment: "Title for a publish button state in the pre-publishing sheet")
+    private static let uploadMediaOneItemRemaining = NSLocalizedString("prepublishing.uploadMediaOneItemRemaining", value: "%@ item remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
+    private static let uploadMediaManyItemsRemaining = NSLocalizedString("prepublishing.uploadMediaManyItemsRemaining", value: "%@ items remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
+    static func uploadMediaRemaining(count: Int) -> String {
+        String(format: count == 1 ? Strings.uploadMediaOneItemRemaining : Strings.uploadMediaManyItemsRemaining, count.description)
+    }
+    static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
+    static let mediaUploadFailedDetails = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "Some of the uploads failed", comment: "Details for a publish button state in the pre-publishing sheet")
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -450,13 +450,9 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     private func buttonShowUploadInfoTapped() {
-        let view = PostMediaUploadStatusView(viewModel: uploadsViewModel) { [weak self] in
-            self?.dismiss(animated: true, completion: nil)
-        }
+        let view = PostMediaUploadStatusView(viewModel: uploadsViewModel)
         let host = UIHostingController(rootView: view)
-        let navigation = UINavigationController(rootViewController: host)
-        navigation.navigationBar.isTranslucent = true // Reset to default
-        present(navigation, animated: true)
+        navigationController?.pushViewController(host, animated: true)
     }
 
     private func updatePublishButtonLabel() {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -101,7 +101,7 @@ struct PublishButton: View {
 }
 
 private enum Constants {
-    static let accessoryViewWidth: CGFloat = 22
+    static let accessoryViewWidth: CGFloat = 20
 }
 
 final class PublishButtonViewModel: ObservableObject {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -17,69 +17,79 @@ struct PublishButton: View {
             .buttonBorderShape(.roundedRectangle(radius: 8))
             .accessibilityIdentifier("publish")
 
-            switch viewModel.state {
-            case .default:
-                EmptyView()
-            case .loading:
-                ProgressView()
-                    .tint(Color.secondary)
-            case let .uploading(title, progress, onInfoTapped):
-                let content =  HStack(spacing: 10) {
-                    ProgressView()
-                        .tint(Color.secondary)
+            stateView
+        }
+    }
 
-                    VStack(alignment: .leading) {
-                        Text(title)
-                            .font(.subheadline.weight(.medium))
-                        if let progress {
-                            Text(Strings.progress(progress))
-                                .foregroundStyle(Color.secondary)
-                                .font(.footnote)
-                                .monospacedDigit()
-                        }
-                    }
-                    .lineLimit(1)
-                    .foregroundStyle(Color.primary)
-
-                    Spacer()
-
-                    if onInfoTapped != nil {
-                        Image(systemName: "info.circle")
-                            .foregroundStyle(.secondary)
-                    }
-                }.padding(.horizontal)
-
-                if let onInfoTapped {
-                    Button(action: onInfoTapped) { content }
+    @ViewBuilder
+    private var stateView: some View {
+        switch viewModel.state {
+        case .default:
+            EmptyView()
+        case .loading:
+            ProgressView()
+                .tint(Color.secondary)
+        case let .uploading(title, details, progress, onInfoTapped):
+            let content =  HStack(spacing: 10) {
+                if let progress {
+                    MediaUploadProgressView(progress: progress)
+                        .frame(width: Constants.accessoryViewWidth)
                 } else {
-                    content
+                    ProgressView()
+                        .foregroundStyle(.secondary)
+                        .frame(width: Constants.accessoryViewWidth)
                 }
-            case let .failed(title, details, onRetryTapped):
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(Color.red)
-                    VStack(alignment: .leading) {
-                        Text(title)
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(.primary)
-                        if let details {
-                            Text(details)
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .lineLimit(1)
-
-                    Spacer()
-
-                    if let onRetryTapped {
-                        Button(Strings.retry, action: onRetryTapped)
-                            .font(.subheadline)
-                    }
+                makeDetailsView(title: title, details: details)
+                Spacer()
+                if onInfoTapped != nil {
+                    chevronUpView
                 }
-                .padding(.horizontal)
+            }.padding(.horizontal)
+
+            if let onInfoTapped {
+                Button(action: onInfoTapped) { content }
+            } else {
+                content
+            }
+        case let .failed(title, details, onInfoTapped):
+            let content = HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Color.red)
+                    .frame(width: Constants.accessoryViewWidth)
+                makeDetailsView(title: title, details: details)
+                Spacer()
+                if onInfoTapped != nil {
+                    chevronUpView
+                }
+            }.padding(.horizontal)
+
+            if let onInfoTapped {
+                Button(action: onInfoTapped) { content }
+            } else {
+                content
             }
         }
+    }
+
+    private func makeDetailsView(title: String, details: String?) -> some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.primary)
+            if let details {
+                Text(details)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .tint(.primary)
+        .lineLimit(1)
+    }
+
+    private var chevronUpView: some View {
+        Image(systemName: "chevron.up")
+            .font(.subheadline.weight(.semibold))
+            .tint(Color.secondary)
     }
 
     private var isDisabled: Bool {
@@ -88,6 +98,10 @@ struct PublishButton: View {
         case .loading, .uploading, .failed: true
         }
     }
+}
+
+private enum Constants {
+    static let accessoryViewWidth: CGFloat = 22
 }
 
 final class PublishButtonViewModel: ObservableObject {
@@ -105,31 +119,17 @@ final class PublishButtonViewModel: ObservableObject {
 enum PublishButtonState {
     case `default`
     case loading
-    case uploading(title: String, progress: Progress?, onInfoTapped: (() -> Void)? = nil)
-    case failed(title: String, details: String? = nil, onRetryTapped: (() -> Void)? = nil)
-
-    struct Progress {
-        var completed: Int64
-        var total: Int64
-    }
-}
-
-private enum Strings {
-    static func progress(_ progress: PublishButtonState.Progress) -> String {
-        let format = NSLocalizedString("publishButton.progress", value: "%@ of %@", comment: "Shows the download or upload progress with two parameters: preformatted completed and total bytes")
-        return String(format: format, ByteCountFormatter.string(fromByteCount: progress.completed, countStyle: .file), ByteCountFormatter.string(fromByteCount: progress.total, countStyle: .file))
-    }
-
-    static let retry = NSLocalizedString("publishButton.retry", value: "Retry", comment: "Retry button title")
+    case uploading(title: String, details: String, progress: Double?, onInfoTapped: (() -> Void)? = nil)
+    case failed(title: String, details: String? = nil, onInfoTapped: (() -> Void)? = nil)
 }
 
 #Preview {
     VStack(spacing: 16) {
         PublishButton(viewModel: .init(title: "Publish", state: .default) {})
         PublishButton(viewModel: .init(title: "Publish", state: .loading) {})
-        PublishButton(viewModel: .init(title: "Publish", state: .uploading(title: "Uploading media...", progress: .init(completed: 100, total: 2000))) {})
+        PublishButton(viewModel: .init(title: "Publish", state: .uploading(title: "Uploading media...", details: "2 items remaining", progress: 0.2)) {})
         PublishButton(viewModel: .init(title: "Publish", state: .failed(title: "Failed to upload media")) {})
-        PublishButton(viewModel: .init(title: "Publish", state: .failed(title: "Failed to upload media", details: "Not connected to Internet", onRetryTapped: {})) {})
+        PublishButton(viewModel: .init(title: "Publish", state: .failed(title: "Failed to upload media", details: "Not connected to Internet", onInfoTapped: {})) {})
     }
     .padding()
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PublishButton.swift
@@ -87,7 +87,7 @@ struct PublishButton: View {
     }
 
     private var chevronUpView: some View {
-        Image(systemName: "chevron.up")
+        Image(systemName: "chevron.right")
             .font(.subheadline.weight(.semibold))
             .tint(Color.secondary)
     }


### PR DESCRIPTION
This PR adds error handing to the media upload status views. In some cases, the errors require user intervention. For example, if there is no empty space in the Media storage, we should inform the user, which is what the new screen does.

This PR also slightly changes the design of the "PublishButton". It now uses `chevron.up` to indicate that the entire button is tappable, and it has a simple UI: more details are available in the details view.

> **Note**: I also considered adding an ability to remove the upload right from the details view. It doesn't seem to be feasible right now, but it needs more investigation. Informing the user is the first step.

<img width="340" alt="Screenshot 2024-04-24 at 5 54 28 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/508ba89a-5166-4548-8430-168b6c980b47">

<img width="340" alt="Screenshot 2024-04-24 at 5 54 33 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/20d23d98-4b8f-445e-8f7f-97ab97d92874">

<img width="340" alt="Screenshot 2024-04-24 at 5 47 50 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/3147b428-2aa7-4f1b-9b09-dc70f10bd9ef">

<img width="340" alt="Screenshot 2024-04-24 at 5 47 59 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/f6aeb0f9-404b-47bf-8e7f-2946a764da74">

## To test:

TBD

## Regression Notes
1. Potential unintended areas of impact: Prepublishing / Media Uploads
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
