### PR TITLE
Offline Mode: Add support for terminal media uploads errors in the list

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -622,16 +622,14 @@ class PostCoordinator: NSObject {
     static func isTerminalError(_ error: Error) -> Bool {
         if let saveError = error as? PostRepository.PostSaveError {
             switch saveError {
-            case .deleted:
-                return false
-            case .conflict:
-                return false
+            case .deleted, .conflict:
+                return true
             }
         }
         if let error = error as? SavingError, case .mediaFailure(_, let error) = error {
             return MediaCoordinator.isTerminalError(error)
         }
-        return true
+        return false
     }
 
     private func didRetryTimerFire(for worker: SyncWorker) {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -600,7 +600,7 @@ class PostCoordinator: NSObject {
             worker.error = error
             postDidUpdateNotification(for: operation.post)
 
-            if shouldScheduleRetry(for: error) {
+            if !PostCoordinator.isTerminalError(error) {
                 let delay = worker.nextRetryDelay
                 worker.retryTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self, weak worker] _ in
                     guard let self, let worker else { return }
@@ -617,7 +617,9 @@ class PostCoordinator: NSObject {
         }
     }
 
-    private func shouldScheduleRetry(for error: Error) -> Bool {
+    /// Returns `true` if the error can't be resolved by simply retrying and
+    /// requires user interventions, for example, resolving a conflict.
+    static func isTerminalError(_ error: Error) -> Bool {
         if let saveError = error as? PostRepository.PostSaveError {
             switch saveError {
             case .deleted:
@@ -625,6 +627,9 @@ class PostCoordinator: NSObject {
             case .conflict:
                 return false
             }
+        }
+        if let error = error as? SavingError, case .mediaFailure(_, let error) = error {
+            return MediaCoordinator.isTerminalError(error)
         }
         return true
     }


### PR DESCRIPTION
As a follow-up to https://github.com/wordpress-mobile/WordPress-iOS/pull/23079, this PR integrates the new `MediaCoordinator.isTerminalError` method in the post/pages list. If a media fails with an error that requires user intervention, the app will now inform the user by transitioning into the failed state.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/89dc33ab-e826-48a7-81ae-57963d0da521

## To test:

- Mocking: update Blog+Quota.swift to mock one of the terminal media errors (file too large is a good one)
- Add a draft of a post with an image
- Tap "Back" and "Save as Draft"
- ✅ Verify that the list displays an error indicator instead of a spinner

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
