### PR TITLE
Offline Mode: Add "Discard Changes" button (RFC)

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -1085,6 +1085,19 @@ class PostCoordinator: NSObject {
         }
     }
 
+    /// Discard local changes made to the post.
+    @MainActor
+    func discardChanges(_ post: AbstractPost) async {
+        setUpdating(true, for: post)
+        defer { setUpdating(false, for: post) }
+
+        await pauseSyncing(for: post)
+        defer { resumeSyncing(for: post) }
+
+        MediaCoordinator.shared.cancelUploadOfAllMedia(for: post)
+        PostRepository(coreDataStack: coreDataStack).discardChanges(post)
+    }
+
     @MainActor
     func _delete(_ post: AbstractPost) async {
         wpAssert(post.isOriginal())

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -268,13 +268,11 @@ final class PostRepository {
         wpAssert(post.isOriginal())
 
         let context = coreDataStack.mainContext
-
         guard let postID = post.postID?.intValue, postID > 0 else {
             context.deleteObject(post) // Delete all the local data
             ContextManager.shared.saveContextAndWait(context)
             return
         }
-
         post.deleteAllRevisions()
         ContextManager.shared.saveContextAndWait(context)
 
@@ -297,6 +295,15 @@ final class PostRepository {
         }
 
         PostHelper.update(post, with: remotePost, in: context)
+        ContextManager.shared.saveContextAndWait(context)
+    }
+
+    /// Discard local changes made to the post.
+    func discardChanges(_ post: AbstractPost) {
+        wpAssert(post.isOriginal())
+
+        let context = coreDataStack.mainContext
+        post.deleteAllRevisions()
         ContextManager.shared.saveContextAndWait(context)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -723,6 +723,19 @@ class AbstractPostListViewController: UIViewController,
         alert.presentFromRootViewController()
     }
 
+    func discard(_ post: AbstractPost) {
+        let post = post.original()
+
+        let alert = UIAlertController(title: Strings.Discard.actionTitle, message: Strings.Discard.message(for: post.latest()), preferredStyle: .alert)
+        alert.addCancelActionWithTitle(Strings.cancelText) { _ in}
+        alert.addDestructiveActionWithTitle(Strings.Discard.actionTitle) { _ in
+            Task {
+                await PostCoordinator.shared.discardChanges(post)
+            }
+        }
+        alert.presentFromRootViewController()
+    }
+
     /// - warning: deprecated (kahu-offline-mode)
     func deletePost(_ post: AbstractPost) {
         Task {
@@ -877,6 +890,15 @@ private enum Strings {
 
         static func message(for post: AbstractPost) -> String {
             let format = NSLocalizedString("postList.trash.alertMessage", value: "Are you sure you want to trash \"%@\"? Any changes that weren't sent previously to the server will be lost.", comment: "Message of the trash post or page confirmation alert.")
+            return String(format: format, post.titleForDisplay() ?? "–")
+        }
+    }
+
+    enum Discard {
+        static let actionTitle = NSLocalizedString("postList.discardChanges.actionTitle", value: "Discard Changes", comment: "Action of the confirmation alert when discarding local changes made to a post or a page.")
+
+        static func message(for post: AbstractPost) -> String {
+            let format = NSLocalizedString("postList.discardChanges.alertMessage", value: "Are you sure you want to discard the local changes made to \"%@\"?", comment: "Message of the confirmation alert when discarding local changes made to a post or a page.")
             return String(format: format, post.titleForDisplay() ?? "–")
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -100,6 +100,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")
         case .delete: return UIImage(systemName: "trash")
+        case .discard: return UIImage(systemName: "xmark.circle")
         case .cancelAutoUpload: return UIImage(systemName: "xmark.icloud")
         case .share: return UIImage(systemName: "square.and.arrow.up")
         case .blaze: return UIImage(systemName: "flame")
@@ -115,7 +116,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
 
     var attributes: UIMenuElement.Attributes? {
         switch self {
-        case .trash, .delete:
+        case .trash, .delete, .discard:
             return [UIMenuElement.Attributes.destructive]
         default:
             return nil
@@ -136,6 +137,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .moveToDraft: return Strings.draft
         case .trash: return Strings.trash
         case .delete: return Strings.delete
+        case .discard: return Strings.discard
         case .cancelAutoUpload: return Strings.cancelAutoUpload
         case .share: return Strings.share
         case .blaze: return Strings.blaze
@@ -167,6 +169,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
             delegate.trash(post)
         case .delete:
             delegate.delete(post)
+        case .discard:
+            delegate.discard(post)
         case .cancelAutoUpload:
             delegate.cancelAutoUpload(post)
         case .share:
@@ -198,6 +202,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let duplicate = NSLocalizedString("posts.duplicate.actionTitle", value: "Duplicate", comment: "Label for post duplicate option. Tapping creates a copy of the post.")
         static let draft = NSLocalizedString("posts.draft.actionTitle", value: "Move to draft", comment: "Label for an option that moves a post to the draft folder")
         static let delete = NSLocalizedString("posts.delete.actionTitle", value: "Delete permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
+        static let discard = NSLocalizedString("posts.discard.actionTitle", value: "Discard changes", comment: "Label for the discard local changes button. Tapping deletes the local revisions of the post.")
         static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to trash", comment: "Label for a option that moves a post to the trash folder")
         static let view = NSLocalizedString("posts.view.actionTitle", value: "View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let preview = NSLocalizedString("posts.preview.actionTitle", value: "Preview", comment: "Label for the preview post button. Tapping displays the post as it appears on the web.")

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -23,6 +23,7 @@ enum AbstractPostButton: Equatable {
     case moveToDraft
     case trash
     case delete
+    case discard
     case cancelAutoUpload
     case share
     case blaze

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -7,6 +7,7 @@ protocol InteractivePostViewDelegate: AnyObject {
     func duplicate(_ post: AbstractPost)
     func publish(_ post: AbstractPost)
     func trash(_ post: AbstractPost, completion: @escaping () -> Void)
+    func discard(_ post: AbstractPost)
     func delete(_ post: AbstractPost, completion: @escaping () -> Void)
     func draft(_ post: AbstractPost)
     func retry(_ post: AbstractPost)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -223,7 +223,6 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
                 buttons.append(.cancelAutoUpload)
             }
         }
-
         return AbstractPostButtonSection(buttons: buttons)
     }
 
@@ -252,8 +251,17 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     private func createTrashSection() -> AbstractPostButtonSection {
-        let action: AbstractPostButton = post.original().status == .trash ? .delete : .trash
-        return AbstractPostButtonSection(buttons: [action])
+        var buttons: [AbstractPostButton] = []
+        let original = post.original()
+        if isSyncPublishingEnabled {
+            // If the post has no remote, nothing got synced, so they should
+            // simply delete it.
+            if PostCoordinator.shared.isSyncNeeded(for: original), post.hasRemote() {
+                buttons.append(.discard)
+            }
+        }
+        buttons.append(original.status == .trash ? .delete : .trash)
+        return AbstractPostButtonSection(buttons: buttons)
     }
 
     private var canCancelAutoUpload: Bool {


### PR DESCRIPTION
I've been testing different [terminal errors](https://github.com/wordpress-mobile/WordPress-iOS/pull/23080) and found myself in a need to discard locally made changes. It's like a delayed variant of "Back / Discard Changes": maybe you changed your mind, maybe some media fails to upload and you want to just give up on your changes – this button allows you do do that.

**Note**: it wasn't in the original spec.

I can't say that I liked the location of this button. It might be worth moving it somewhere deeper in the editor (or settings?). Or not including it?

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/ec5fa3c4-485a-4765-8d4c-6fec83dcf4b2

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
