### PR TITLE
Offline Mode: Fix an issue with restore revisions not clearing media uploads

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -173,6 +173,12 @@ extension PostEditor {
                 self.post.content = revision.postContent
                 self.post.mt_excerpt = revision.postExcerpt
 
+                // It's important to clear the pending uploads associated with the
+                // post. The assumption is that if the revision on the remote,
+                // its associated media has to be also uploaded.
+                MediaCoordinator.shared.cancelUploadOfAllMedia(for: self.post)
+                self.post.media = []
+
                 self.post = self.post // Reload the ui
 
                 let notice = Notice(title: Strings.revisionLoaded, feedbackType: .success)


### PR DESCRIPTION
Fix an issue with "Restore Revision" feature not clearing media uploads. This issue is especially problematic if the post had media with terminal errors.

## To test:

- Mocking: make sure all media uploads fail
- Open a draft post that has a couple of saved revisions ("History")
- Add an image to the post and tap "Save as Draft"
- Re-open the post for editing
- Open "History" (revisions)
- Load a revision that had no images
- Tap "Save as Draft"
- ✅  Verify that the post got uploaded


https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/f6a41c00-3553-4814-9957-a96166d8b5ac

## Discussion

We'll might run into more issues due to the current media upload architecture, its relation to post content, and the fact that you can now open drafts with changes that are still syncing for editing. The problem is that the `media` is closely tied to the `content`.  During sync, `PostCoordinator` updates the post content whenever a media upload complete (this is an existing behavior). It breaks the invariant that the saved revisions are immutable. Here's one problematic scenario:

- Create and save a draft post
- Save a new revision with an image (upload is pending & slow)
- Open the post for editing but change nothing
- Wait until the image upload completes
- Tap "Back"

Expected behavior: the editor is closed
Observed behavior: the editor shows a "Discard Change" confirmation dialog

**Note**: this is theoretical; I haven't yet tested it.

## Regression Notes
1. Potential unintended areas of impact: Post Editor & Media Uploads
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
