### PR TITLE
[Notification Refresh] Replace the old Comment Detail header with the new Content Preview component

### DIFF
--- a/Modules/Sources/DesignSystem/Components/Content Preview/ContentPreview.swift
+++ b/Modules/Sources/DesignSystem/Components/Content Preview/ContentPreview.swift
@@ -2,9 +2,15 @@ import SwiftUI
 
 public struct ContentPreview: View {
 
+    // MARK: - Constants
+
+    public enum Constants {
+        public static let imageSize: CGFloat = 32
+    }
+
     // MARK: - Metrics
 
-    @ScaledMetric private var imageSize: CGFloat = 32
+    @ScaledMetric private var imageSize: CGFloat = Constants.imageSize
     @ScaledMetric private var height: CGFloat = 40
 
     private var leadingPadding: CGFloat {
@@ -13,20 +19,16 @@ public struct ContentPreview: View {
 
     // MARK: - Properties
 
-    private let image: URL?
+    private let image: ImageConfiguration?
     private let text: String
     private let action: () -> Void
 
     // MARK: - Init
 
-    public init(image: URL?, text: String, action: @escaping () -> Void) {
+    public init(image: ImageConfiguration? = nil, text: String, action: @escaping () -> Void) {
         self.image = image
         self.text = text
         self.action = action
-    }
-
-    public init(image: String? = nil, text: String, action: @escaping () -> Void) {
-        self.init(image: URL(string: image ?? ""), text: text, action: action)
     }
 
     // MARK: - Body
@@ -34,8 +36,8 @@ public struct ContentPreview: View {
     public var body: some View {
         Button(action: action) {
             HStack(spacing: CGFloat.DS.Padding.half) {
-                if let url = image {
-                    image(url: url)
+                if let configuration = image {
+                    image(configuration: configuration)
                 }
                 Text(text)
                     .style(.bodyLarge(.regular))
@@ -53,31 +55,56 @@ public struct ContentPreview: View {
         }
     }
 
-    private func image(url: URL) -> some View {
-        AsyncImage(url: url) { phase in
+    private func image(configuration: ImageConfiguration) -> some View {
+        AsyncImage(url: configuration.url) { phase in
             Group {
                 switch phase {
                 case .success(let image):
                     image.resizable()
                 default:
-                    Color.DS.Background.tertiary
+                    if let placeholder = configuration.placeholder {
+                        placeholder
+                            .resizable()
+                    } else {
+                        Color.DS.Background.tertiary
+                    }
                 }
             }
             .frame(width: imageSize, height: imageSize)
             .clipShape(Circle())
         }
     }
+
+    // MARK: - Types
+
+    public struct ImageConfiguration {
+        
+        let url: URL?
+        let placeholder: Image?
+
+        public init(url: URL?, placeholder: Image? = nil) {
+            self.url = url
+            self.placeholder = placeholder
+        }
+
+        public init(url: String?, placeholder: Image? = nil) {
+            self.init(url: URL(string: url ?? ""), placeholder: placeholder)
+        }
+    }
 }
 
 #Preview {
     VStack {
-        ContentPreview(image: "https://i.pravatar.cc/300",
+        ContentPreview(image: .init(url: "https://i.pravatar.cc/300"),
                        text: "Great post! ❤️",
                        action: {})
         ContentPreview(text: "The Beauty of Off-the-Beaten-Path Adventures",
                        action: {})
-        ContentPreview(image: "https://i.pravatar.cc/300",
+        ContentPreview(image: .init(url: "https://i.pravatar.cc/300"),
                        text: "Absolutely loved the tips in your latest post! 😊",
+                       action: {})
+        ContentPreview(image: .init(url: URL(string: "invalid-url")),
+                       text: "Just stumbled upon your latest art piece and wow, I'm blown away!",
                        action: {})
     }
         .padding(.horizontal, CGFloat.DS.Padding.double)

--- a/Modules/Sources/DesignSystem/Components/Content Preview/ContentPreview.swift
+++ b/Modules/Sources/DesignSystem/Components/Content Preview/ContentPreview.swift
@@ -78,7 +78,6 @@ public struct ContentPreview: View {
     // MARK: - Types
 
     public struct ImageConfiguration {
-        
         let url: URL?
         let placeholder: Image?
 

--- a/WordPress/Classes/Extensions/Design System/ContentProvider+Gravatar.swift
+++ b/WordPress/Classes/Extensions/Design System/ContentProvider+Gravatar.swift
@@ -1,0 +1,33 @@
+import UIKit
+import SwiftUI
+import DesignSystem
+import Gravatar
+
+public extension ContentPreview.ImageConfiguration {
+
+    init(avatar: Avatar) {
+        self.init(url: Self.avatarURL(from: avatar), placeholder: Image("gravatar"))
+    }
+
+    private static func avatarURL(from avatar: Avatar) -> URL? {
+        if let url = avatar.url {
+            return url
+        } else if let email = avatar.email {
+            let pixels = Int(ceil(avatar.size * UIScreen.main.scale))
+            return AvatarURL.url(for: email, preferredSize: .pixels(pixels), gravatarRating: .general)
+        }
+        return nil
+    }
+
+    struct Avatar {
+        let url: URL?
+        let email: String?
+        let size: CGFloat
+
+        init(url: URL?, email: String?, size: CGFloat = 80) {
+            self.url = url
+            self.email = email
+            self.size = size
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import CoreData
 import WordPressUI
 import DesignSystem
-import Gravatar
 
 // Notification sent when a Comment is permanently deleted so the Notifications list (NotificationsViewController) is immediately updated.
 extension NSNotification.Name {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import CoreData
 import WordPressUI
 import DesignSystem
+import Gravatar
 
 // Notification sent when a Comment is permanently deleted so the Notifications list (NotificationsViewController) is immediately updated.
 extension NSNotification.Name {
@@ -450,17 +451,21 @@ private extension CommentDetailViewController {
         }
         if let comment = self.parentComment ?? notificationParentComment {
             // if the comment is a reply, show the author of the parent comment.
+            let avatar = CommentHeaderTableViewCell.Avatar(
+                url: comment.avatarURLForDisplay(),
+                email: comment.gravatarEmailForDisplay(),
+                size: CommentHeaderTableViewCell.Constants.imageSize
+            )
             self.headerCell.configure(
-                imageURL: comment.avatarURLForDisplay(),
-                text: comment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines),
+                avatar: avatar,
+                comment: comment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines),
                 action: action,
                 parent: self
             )
         } else {
             // otherwise, if this is a comment to a post, show the post title instead.
             self.headerCell.configure(
-                imageURL: nil,
-                text: comment.titleForDisplay(),
+                post: comment.titleForDisplay(),
                 action: action,
                 parent: self
             )

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -438,11 +438,22 @@ private extension CommentDetailViewController {
     // MARK: Cell configuration
 
     func configureHeaderCell() {
+        let action = { [weak self] in
+            guard let self else {
+                return
+            }
+            if self.isNotificationComment {
+                self.navigateToNotificationComment()
+            } else {
+                self.comment.hasParentComment() ? self.navigateToParentComment() : self.navigateToPost()
+            }
+        }
         if let comment = self.parentComment ?? notificationParentComment {
             // if the comment is a reply, show the author of the parent comment.
             self.headerCell.configure(
                 imageURL: comment.avatarURLForDisplay(),
                 text: comment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines),
+                action: action,
                 parent: self
             )
         } else {
@@ -450,6 +461,7 @@ private extension CommentDetailViewController {
             self.headerCell.configure(
                 imageURL: nil,
                 text: comment.titleForDisplay(),
+                action: action,
                 parent: self
             )
         }
@@ -981,12 +993,6 @@ extension CommentDetailViewController: UITableViewDelegate, UITableViewDataSourc
         switch sections[indexPath.section] {
         case .content(let rows):
             switch rows[indexPath.row] {
-            case .header:
-                if isNotificationComment {
-                    navigateToNotificationComment()
-                } else {
-                    comment.hasParentComment() ? navigateToParentComment() : navigateToPost()
-                }
             case .replyIndicator:
                 navigateToReplyComment()
             default:

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CoreData
 import WordPressUI
+import DesignSystem
 
 // Notification sent when a Comment is permanently deleted so the Notifications list (NotificationsViewController) is immediately updated.
 extension NSNotification.Name {
@@ -321,7 +322,7 @@ private extension CommentDetailViewController {
     }
 
     struct Constants {
-        static let tableHorizontalInset: CGFloat = 20.0
+        static let tableHorizontalInset: CGFloat = CGFloat.DS.Padding.double
         static let tableBottomMargin: CGFloat = 40.0
         static let replyIndicatorVerticalSpacing: CGFloat = 14.0
         static let deleteButtonInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
@@ -366,6 +367,7 @@ private extension CommentDetailViewController {
         tableView.delegate = self
         tableView.dataSource = self
         tableView.separatorInsetReference = .fromAutomaticInsets
+        tableView.separatorStyle = .none
 
         // get rid of the separator line for the last cell.
         tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: Constants.tableBottomMargin))
@@ -436,14 +438,21 @@ private extension CommentDetailViewController {
     // MARK: Cell configuration
 
     func configureHeaderCell() {
-        // if the comment is a reply, show the author of the parent comment.
-        if let parentComment = self.parentComment ?? notificationParentComment {
-            return headerCell.configure(for: .reply(parentComment.authorForDisplay()),
-                                        subtitle: parentComment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines))
+        if let comment = self.parentComment ?? notificationParentComment {
+            // if the comment is a reply, show the author of the parent comment.
+            self.headerCell.configure(
+                imageURL: comment.avatarURLForDisplay(),
+                text: comment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines),
+                parent: self
+            )
+        } else {
+            // otherwise, if this is a comment to a post, show the post title instead.
+            self.headerCell.configure(
+                imageURL: nil,
+                text: comment.titleForDisplay(),
+                parent: self
+            )
         }
-
-        // otherwise, if this is a comment to a post, show the post title instead.
-        headerCell.configure(for: .post, subtitle: comment.titleForDisplay())
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -22,10 +22,8 @@ final class CommentHeaderTableViewCell: HostingTableViewCell<ContentPreview>, Re
 
     // MARK: - Configuration
 
-    func configure(imageURL: URL?, text: String, parent: UIViewController) {
-        let content = ContentPreview(image: imageURL, text: text) {
-            print("Hello World")
-        }
+    func configure(imageURL: URL?, text: String, action: @escaping () -> Void, parent: UIViewController) {
+        let content = ContentPreview(image: imageURL, text: text, action: action)
         self.host(content, parent: parent)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -1,80 +1,37 @@
 import UIKit
+import DesignSystem
 
-class CommentHeaderTableViewCell: UITableViewCell, Reusable {
-
-    enum Title {
-        /// Title for a top-level comment on a post.
-        case post
-
-        /// Title for the comment threads.
-        case thread
-
-        /// Title for a comment that's a reply to another comment.
-        /// Requires a String describing the replied author's name.
-        case reply(String)
-
-        var stringValue: String {
-            switch self {
-            case .post:
-                return .postCommentTitleText
-            case .thread:
-                return .commentThreadTitleText
-            case .reply(let author):
-                return String(format: .replyCommentTitleFormat, author)
-            }
-        }
-    }
+final class CommentHeaderTableViewCell: HostingTableViewCell<ContentPreview>, Reusable {
 
     // MARK: Initialization
 
     required init() {
         super.init(style: .subtitle, reuseIdentifier: Self.defaultReuseID)
-        configureStyle()
+        self.selectionStyle = .none
+        self.contentView.directionalLayoutMargins = .init(
+            top: CGFloat.DS.Padding.double,
+            leading: 0,
+            bottom: CGFloat.DS.Padding.double,
+            trailing: 0
+        )
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Configures the header cell.
-    /// - Parameters:
-    ///   - title: The title type for the header. See `Title`.
-    ///   - subtitle: A text snippet of the parent object.
-    ///   - showsDisclosureIndicator: When this is `false`, the cell is configured to look non-interactive.
-    func configure(for title: Title, subtitle: String, showsDisclosureIndicator: Bool = true) {
-        textLabel?.setText(title.stringValue)
-        detailTextLabel?.setText(subtitle)
-        accessoryType = showsDisclosureIndicator ? .disclosureIndicator : .none
-        selectionStyle = showsDisclosureIndicator ? .default : .none
+    // MARK: - Configuration
+
+    func configure(imageURL: URL?, text: String, parent: UIViewController) {
+        let content = ContentPreview(image: imageURL, text: text) {
+            print("Hello World")
+        }
+        self.host(content, parent: parent)
     }
 
-    // MARK: Helpers
+    // MARK: - Layout
 
-    private typealias Style = WPStyleGuide.CommentDetail.Header
-
-    private func configureStyle() {
-        accessoryType = .disclosureIndicator
-
-        textLabel?.font = Style.font
-        textLabel?.textColor = Style.textColor
-        textLabel?.numberOfLines = 2
-
-        detailTextLabel?.font = Style.detailFont
-        detailTextLabel?.textColor = Style.detailTextColor
-        detailTextLabel?.numberOfLines = 1
+    override func layout(hostingView view: UIView) {
+        self.contentView.pinSubviewToAllEdgeMargins(view)
     }
-
-}
-
-// MARK: Localization
-
-private extension String {
-    static let postCommentTitleText = NSLocalizedString("Comment on", comment: "Provides hint that the current screen displays a comment on a post. "
-                                                            + "The title of the post will displayed below this string. "
-                                                            + "Example: Comment on \n My First Post")
-    static let replyCommentTitleFormat = NSLocalizedString("Reply to %1$@", comment: "Provides hint that the screen displays a reply to a comment."
-                                                           + "%1$@ is a placeholder for the comment author that's been replied to."
-                                                           + "Example: Reply to Pamela Nguyen")
-    static let commentThreadTitleText = NSLocalizedString("Comments on", comment: "Sentence fragment. "
-                                                          + "The full phrase is 'Comments on' followed by the title of a post on a separate line.")
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -1,7 +1,13 @@
 import UIKit
+import SwiftUI
 import DesignSystem
 
 final class CommentHeaderTableViewCell: HostingTableViewCell<ContentPreview>, Reusable {
+
+    // MARK: Typealias
+
+    typealias Constants = ContentPreview.Constants
+    typealias Avatar = ContentPreview.ImageConfiguration.Avatar
 
     // MARK: Initialization
 
@@ -22,8 +28,13 @@ final class CommentHeaderTableViewCell: HostingTableViewCell<ContentPreview>, Re
 
     // MARK: - Configuration
 
-    func configure(imageURL: URL?, text: String, action: @escaping () -> Void, parent: UIViewController) {
-        let content = ContentPreview(image: imageURL, text: text, action: action)
+    func configure(post: String, action: @escaping () -> Void, parent: UIViewController) {
+        let content = ContentPreview(text: post, action: action)
+        self.host(content, parent: parent)
+    }
+
+    func configure(avatar: Avatar, comment: String, action: @escaping () -> Void, parent: UIViewController) {
+        let content = ContentPreview(image: .init(avatar: avatar), text: comment, action: action)
         self.host(content, parent: parent)
     }
 

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/HostingTableViewCell.swift
@@ -20,11 +20,15 @@ class HostingTableViewCell<Content: View>: UITableViewCell {
             parent.addChild(swiftUICellViewController)
             contentView.addSubview(swiftUICellViewController.view)
             swiftUICellViewController.view.translatesAutoresizingMaskIntoConstraints = false
-            contentView.pinSubviewToAllEdges(swiftUICellViewController.view)
+            layout(hostingView: swiftUICellViewController.view)
 
             swiftUICellViewController.didMove(toParent: parent)
         }
 
         self.controller?.view.invalidateIntrinsicContentSize()
+    }
+
+    func layout(hostingView view: UIView) {
+        self.contentView.pinSubviewToAllEdges(view)
     }
 }

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -118,11 +118,7 @@ public class NotificationsScreen: ScreenObject {
     }
 
     public func likeComment() -> Self {
-        let isCommentOnTextDisplayed = app.staticTexts["Comment on"].firstMatch.waitForExistence(timeout: 5)
-
-        if isCommentOnTextDisplayed {
-            likeCommentButton.tap()
-        }
+        likeCommentButton.tap()
 
         return self
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3853,6 +3853,8 @@
 		F4C1FC642A44831300AD7CB0 /* PrivacySettingsAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C1FC622A44831300AD7CB0 /* PrivacySettingsAnalyticsTracker.swift */; };
 		F4C1FC662A44836300AD7CB0 /* PrivacySettingsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C1FC652A44836300AD7CB0 /* PrivacySettingsAnalytics.swift */; };
 		F4C1FC672A44836300AD7CB0 /* PrivacySettingsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C1FC652A44836300AD7CB0 /* PrivacySettingsAnalytics.swift */; };
+		F4C34C832BDA7B1B00B7E472 /* ContentProvider+Gravatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C34C822BDA7B1B00B7E472 /* ContentProvider+Gravatar.swift */; };
+		F4C34C842BDA7D1D00B7E472 /* ContentProvider+Gravatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C34C822BDA7B1B00B7E472 /* ContentProvider+Gravatar.swift */; };
 		F4CBE3D429258AE1004FFBB6 /* MeHeaderViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB0ACC292587D500F651F9 /* MeHeaderViewConfiguration.swift */; };
 		F4CBE3D6292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */; };
 		F4CBE3D7292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */; };
@@ -9237,6 +9239,7 @@
 		F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuggestionsViewModelType.swift; sourceTree = "<group>"; };
 		F4C1FC622A44831300AD7CB0 /* PrivacySettingsAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F4C1FC652A44836300AD7CB0 /* PrivacySettingsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsAnalytics.swift; sourceTree = "<group>"; };
+		F4C34C822BDA7B1B00B7E472 /* ContentProvider+Gravatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentProvider+Gravatar.swift"; sourceTree = "<group>"; };
 		F4CBE3D329258AD6004FFBB6 /* MeHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeHeaderView.h; sourceTree = "<group>"; };
 		F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewControllerConfiguration.swift; sourceTree = "<group>"; };
 		F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutActionHandler.swift; sourceTree = "<group>"; };
@@ -15595,6 +15598,7 @@
 		B587796C19B799D800E57C5A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				F4C34C812BDA7AF900B7E472 /* Design System */,
 				F407AF1529BA835B008BA5B9 /* Font */,
 				4326191322FCB8BE003C7642 /* Colors and Styles */,
 				086C4D0C1E81F7920011D960 /* Media */,
@@ -18003,6 +18007,14 @@
 				F4C1FC652A44836300AD7CB0 /* PrivacySettingsAnalytics.swift */,
 			);
 			path = "Privacy Settings";
+			sourceTree = "<group>";
+		};
+		F4C34C812BDA7AF900B7E472 /* Design System */ = {
+			isa = PBXGroup;
+			children = (
+				F4C34C822BDA7B1B00B7E472 /* ContentProvider+Gravatar.swift */,
+			);
+			path = "Design System";
 			sourceTree = "<group>";
 		};
 		F4D1401E2AFD9B8200961797 /* Transfer Domains */ = {
@@ -21785,6 +21797,7 @@
 				8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */,
 				57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */,
 				FADFBD3B265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift in Sources */,
+				F4C34C832BDA7B1B00B7E472 /* ContentProvider+Gravatar.swift in Sources */,
 				FE341705275FA157005D5CA7 /* RichCommentContentRenderer.swift in Sources */,
 				59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */,
 				FAB8FD5025AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift in Sources */,
@@ -25618,6 +25631,7 @@
 				FABB249F2602FC2C00C8785C /* RevisionBrowserState.swift in Sources */,
 				982DDF93263238A6002B3904 /* LikeUser+CoreDataProperties.swift in Sources */,
 				FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */,
+				F4C34C842BDA7D1D00B7E472 /* ContentProvider+Gravatar.swift in Sources */,
 				FABB24A02602FC2C00C8785C /* KeyValueDatabase.swift in Sources */,
 				FABB24A12602FC2C00C8785C /* UITableViewCell+enableDisable.swift in Sources */,
 				FABB24A22602FC2C00C8785C /* WPAnalyticsTrackerAutomatticTracks.m in Sources */,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/29

| Post Preview | Comment Preview | Comment Preview without avatar |
| ------------- | ------------------ | --------------------------------- |
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/ba25ca3d-05cb-4e27-b9da-246d0b41137f) | ![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/5614e9c9-759a-4778-8820-f8fe73d5bd23) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/16de3c93-0898-407a-9b2e-495b95e3fa39) |

## Test Instructions

**Post Reply Notification**

1. Run Jetpack and login
3. Navigate to the Notifications screen
4. Find a Post Reply notification and click it
5. The header should be the same as the design
6. Click on the header, it should keep the original behavior

**Comment Reply Notification**

1. Run Jetpack and login
3. Navigate to the Notifications screen
4. Find a Comment Reply notification and click it
5. The header should be the same as the design
6. Click on the header, it should keep the original behavior

## Regression Notes
1. Potential unintended areas of impact
The behavior when the header is tapped should be maintained.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

4. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
