### PR TITLE
Stats Widgets: Retain StatsService when making API calls from the widget

### DIFF
--- a/WordPress/JetpackStatsWidgets/Remote service/StatsWidgetsService.swift
+++ b/WordPress/JetpackStatsWidgets/Remote service/StatsWidgetsService.swift
@@ -140,12 +140,22 @@ class StatsWidgetsService {
             }
 
             let summaryData = summary?.summaryData.reversed() ?? []
-            let newWidgetData = HomeWidgetThisWeekData(siteID: widgetData.siteID,
-                                                       siteName: widgetData.siteName,
-                                                       url: widgetData.url,
-                                                       timeZone: widgetData.timeZone,
-                                                       date: Date(),
-                                                       stats: ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData.map { ThisWeekWidgetStats.Input(periodStartDate: $0.periodStartDate, viewsCount: $0.viewsCount) })))
+            let newWidgetData = HomeWidgetThisWeekData(
+                siteID: widgetData.siteID,
+                siteName: widgetData.siteName,
+                url: widgetData.url,
+                timeZone: widgetData.timeZone,
+                date: Date(),
+                stats: ThisWeekWidgetStats(
+                    days: ThisWeekWidgetStats.daysFrom(
+                        summaryData: summaryData.map {
+                            ThisWeekWidgetStats.Input(
+                                periodStartDate: $0.periodStartDate,
+                                viewsCount: $0.viewsCount)
+                        }
+                    )
+                )
+            )
             completion(.success(newWidgetData))
 
             DispatchQueue.global().async {
@@ -168,10 +178,13 @@ private extension Date {
 }
 
 private extension StatsWidgetsService {
-    private func getInsight<InsightType: StatsInsightData>(widgetData: HomeWidgetData, limit: Int = 10, completion: @escaping ((InsightType?, Error?) -> Void)) {
+    private func getInsight<InsightType: StatsInsightData>(
+        widgetData: HomeWidgetData,
+        limit: Int = 10,
+        completion: @escaping ((InsightType?, Error?) -> Void)
+    ) {
         do {
             self.service = try createStatsService(for: widgetData)
-
             self.service?.getInsight(limit: limit, completion: { [weak self] in
                 completion($0, $1)
                 self?.service = nil
@@ -182,12 +195,14 @@ private extension StatsWidgetsService {
         }
     }
 
-    private func getData<TimeStatsType: StatsTimeIntervalData>(widgetData: HomeWidgetData,
-                                                               for period: StatsPeriodUnit,
-                                                               unit: StatsPeriodUnit? = nil,
-                                                               endingOn: Date,
-                                                               limit: Int = 10,
-                                                               completion: @escaping ((TimeStatsType?, Error?) -> Void)) {
+    private func getData<TimeStatsType: StatsTimeIntervalData>(
+        widgetData: HomeWidgetData,
+        for period: StatsPeriodUnit,
+        unit: StatsPeriodUnit? = nil,
+        endingOn: Date,
+        limit: Int = 10,
+        completion: @escaping ((TimeStatsType?, Error?) -> Void)
+    ) {
         do {
             self.service = try createStatsService(for: widgetData)
             self.service?.getData(for: period, unit: unit, endingOn: endingOn, limit: limit, completion: { [weak self] in
@@ -201,9 +216,11 @@ private extension StatsWidgetsService {
     }
 
     private func createStatsService(for widgetData: HomeWidgetData) throws -> StatsServiceRemoteV2 {
-        let token = try SFHFKeychainUtils.getPasswordForUsername(AppConfiguration.Widget.Stats.keychainTokenKey,
-                                                                 andServiceName: AppConfiguration.Widget.Stats.keychainServiceName,
-                                                                 accessGroup: WPAppKeychainAccessGroup)
+        let token = try SFHFKeychainUtils.getPasswordForUsername(
+            AppConfiguration.Widget.Stats.keychainTokenKey,
+            andServiceName: AppConfiguration.Widget.Stats.keychainServiceName,
+            accessGroup: WPAppKeychainAccessGroup
+        )
         let wpApi = WordPressComRestApi(oAuthToken: token)
         return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: widgetData.siteID, siteTimezone: widgetData.timeZone)
     }


### PR DESCRIPTION
Fixes #23087

⚠️ Merging to release/24.7

Stats Widgets don't update automatically on their own anymore. I investigated the bug, and it looks like the issue is caused by `self` being nil since `StatsServiceRemoteV2` is not retained in `StatsWidgetService`. There may have been some internal fixes/changes within `StatsServiceRemoteV2` or API code that removed some retain cycles which made the widget code work in the first place.

![image](https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/c4ee2348-4366-4427-b612-1110b4babf4c)

## To test:

1. Install Jetpack app
2. Login to an account with multiple sites for easier testing
3. Go to iOS home screen
4. Add any widget (e.g. "This Week")
5. Confirm data is loaded when the widget is added
6. Switch between sites from the widget
7. Confirm data is loaded when the site is changed

### Before

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/25fd05b4-d638-4329-a8b9-ae992fa49da2

### After

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/c3309762-9d3b-4e15-9cb0-89da2db4b5e6


## Regression Notes
1. Potential unintended areas of impact

None, retaining `StatsServiceRemote` should be a normal practice

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
