### PR TITLE
Integrate gutenberg-mobile release v1.118.0

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: b5afe640373f481d9224ff5df4fdd77a0c81bf59
+  tag: v1.118.0
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  tag: v1.117.0
+  commit: b5afe640373f481d9224ff5df4fdd77a0c81bf59
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - Gifu (3.3.1)
   - Gravatar (1.0.1)
   - Gridicons (1.2.0)
-  - Gutenberg (1.117.0)
+  - Gutenberg (1.118.0)
   - JTAppleCalendar (8.0.5)
   - Kanvas (1.4.9):
     - CropViewController
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Gifu (= 3.3.1)
   - Gravatar (= 1.0.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.117.0.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b5afe640373f481d9224ff5df4fdd77a0c81bf59.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -175,7 +175,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.117.0.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b5afe640373f481d9224ff5df4fdd77a0c81bf59.podspec
   WordPressKit:
     :commit: 14aa53a2e1cfa764e3e9e3e91d1f39f4ef09e098
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
@@ -207,7 +207,7 @@ SPEC CHECKSUMS:
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gravatar: 51437de6811c1d8d6f60c52985f2ca00a85cfc8e
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 2249ee2bdac042ce129297aee696c7926930bc00
+  Gutenberg: 74bc722d74e2276557fe1d851a1eef0df963bb33
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES:
   - Gifu (= 3.3.1)
   - Gravatar (= 1.0.1)
   - Gridicons (~> 1.2)
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b5afe640373f481d9224ff5df4fdd77a0c81bf59.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.118.0.podspec`)
   - JTAppleCalendar (~> 8.0.5)
   - Kanvas (~> 1.4.4)
   - MediaEditor (>= 1.2.2, ~> 1.2)
@@ -175,7 +175,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-b5afe640373f481d9224ff5df4fdd77a0c81bf59.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.118.0.podspec
   WordPressKit:
     :commit: 14aa53a2e1cfa764e3e9e3e91d1f39f4ef09e098
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
@@ -207,7 +207,7 @@ SPEC CHECKSUMS:
   Gifu: 416d4e38c4c2fed012f019e0a1d3ffcb58e5b842
   Gravatar: 51437de6811c1d8d6f60c52985f2ca00a85cfc8e
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
-  Gutenberg: 74bc722d74e2276557fe1d851a1eef0df963bb33
+  Gutenberg: 3117b6fe578fb7f0bb75377ba96f436ee05c30fe
   JTAppleCalendar: 16c6501b22cb27520372c28b0a2e0b12c8d0cd73
   Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
   MediaEditor: d08314cfcbfac74361071a306b4bc3a39b3356ae


### PR DESCRIPTION
## Description
This PR incorporates the 1.118.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6832

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.