### PR TITLE
Offline Mode: Perform media block processing in the background

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorContentProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorContentProcessor.swift
@@ -1,0 +1,95 @@
+import Aztec
+import Foundation
+
+struct EditorUploadedMedia {
+    let mediaID: Int
+    let remoteURL: String
+    let mediaType: MediaType
+
+    let link: String
+    let uploadID: String
+    let gutenbergUploadID: Int32
+    let imageURL: String
+    let videopressGUID: String?
+    let width: Int?
+    let height: Int?
+
+    init?(media: Media) {
+        guard let mediaID = media.mediaID?.intValue, mediaID > 0,
+              let remoteURL = media.remoteURL else {
+            return nil
+        }
+        self.mediaID = mediaID
+        self.remoteURL = remoteURL
+        self.mediaType = media.mediaType
+
+        self.link = media.link
+        self.uploadID = media.uploadID
+        self.gutenbergUploadID = media.gutenbergUploadID
+        self.imageURL = (media.remoteLargeURL ?? media.remoteMediumURL ?? remoteURL)
+        self.videopressGUID = media.videopressGUID
+        self.width = media.width?.intValue
+        self.height = media.height?.intValue
+    }
+}
+
+enum EditorContentProcessor {
+    static func updateMediaReferences(for media: [EditorUploadedMedia], in content: String) async -> String {
+        var content = content
+        for item in media {
+            content = updateReferences(for: item, in: content)
+        }
+        return content
+    }
+
+    private static func updateReferences(for media: EditorUploadedMedia, in content: String) -> String {
+        // Gutenberg processors need to run first because they are more specific
+        // and target only content inside specific blocks. Aztec processors are
+        // next because they are more generic and only worried about HTML tags.
+        var content = content
+        let processors = makeGutenbergProcessors(for: media) + makeAztecProcessors(for: media)
+        for processor in processors {
+            content = processor.process(content)
+        }
+        return content
+    }
+
+    private static func makeGutenbergProcessors(for media: EditorUploadedMedia) -> [Processor] {
+        var processors: [Processor] = []
+        // File block can upload any kind of media.
+        processors.append(GutenbergFileUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.remoteURL))
+        switch media.mediaType {
+        case .image:
+            processors.append(GutenbergImgUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.imageURL))
+            processors.append(GutenbergGalleryUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.imageURL, mediaLink: media.link))
+            processors.append(GutenbergCoverUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.remoteURL))
+        case .video:
+            processors.append(GutenbergVideoUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.remoteURL))
+            processors.append(GutenbergCoverUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.remoteURL))
+            if let videoPressGUID = media.videopressGUID {
+                processors.append(GutenbergVideoPressUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, videoPressGUID: videoPressGUID))
+            }
+        case .audio:
+            processors.append(GutenbergAudioUploadProcessor(mediaUploadID: media.gutenbergUploadID, serverMediaID: media.mediaID, remoteURLString: media.remoteURL))
+        default:
+            break
+        }
+        return processors
+    }
+
+    private static func makeAztecProcessors(for media: EditorUploadedMedia) -> [Processor] {
+        var processors: [Processor] = []
+        switch media.mediaType {
+        case .image:
+            processors.append(ImgUploadProcessor(mediaUploadID: media.uploadID, remoteURLString: media.remoteURL, width: media.width, height: media.height))
+        case .video:
+            processors.append(VideoUploadProcessor(mediaUploadID: media.uploadID, remoteURLString: media.remoteURL, videoPressID: media.videopressGUID))
+        default:
+            break
+        }
+        if let remoteURL = URL(string: media.remoteURL) {
+            processors.append(DocumentUploadProcessor(mediaUploadID: media.uploadID, remoteURLString: media.remoteURL, title: remoteURL.lastPathComponent))
+        }
+        return processors
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -431,6 +431,8 @@
 		0C0453292AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C04532B2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */; };
 		0C04532C2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */; };
+		0C05E12D2BDAD02200415A5D /* EditorContentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C05E12C2BDAD02200415A5D /* EditorContentProcessor.swift */; };
+		0C05E12E2BDAD02200415A5D /* EditorContentProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C05E12C2BDAD02200415A5D /* EditorContentProcessor.swift */; };
 		0C0AD1062B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AD1052B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift */; };
 		0C0AD1072B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AD1052B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift */; };
 		0C0AD10A2B0CCFA400EC06E6 /* MediaPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AD1092B0CCFA400EC06E6 /* MediaPreviewController.swift */; };
@@ -6260,6 +6262,7 @@
 		0C03AEC92B7D995F00B64A25 /* PublishButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishButton.swift; sourceTree = "<group>"; };
 		0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaVideoDurationView.swift; sourceTree = "<group>"; };
 		0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaDocumentInfoView.swift; sourceTree = "<group>"; };
+		0C05E12C2BDAD02200415A5D /* EditorContentProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorContentProcessor.swift; sourceTree = "<group>"; };
 		0C0AD1052B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaSelectionTitleView.swift; sourceTree = "<group>"; };
 		0C0AD1092B0CCFA400EC06E6 /* MediaPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewController.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
@@ -13363,6 +13366,7 @@
 			isa = PBXGroup;
 			children = (
 				B0637542253E7E7A00FD45D2 /* GutenbergSuggestionsViewController.swift */,
+				0C05E12C2BDAD02200415A5D /* EditorContentProcessor.swift */,
 				FF2EC3BE2209A105006176E1 /* Processors */,
 				1ED046CE244F26B1008F6365 /* GutenbergWeb */,
 				4631359224AD057E0017E65C /* Layout Picker */,
@@ -21480,6 +21484,7 @@
 				8B1E62D625758AAF009A0F80 /* ActivityTypeSelectorViewController.swift in Sources */,
 				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				FAB37D4627ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */,
+				0C05E12D2BDAD02200415A5D /* EditorContentProcessor.swift in Sources */,
 				17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */,
 				D83CA3AB20842E5F0060E310 /* StockPhotosResultsPage.swift in Sources */,
 				80EF928A280D28140064A971 /* Atomic.swift in Sources */,
@@ -24753,6 +24758,7 @@
 				FA90EFF0262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */,
 				80A2153E29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */,
 				FABB220A2602FC2C00C8785C /* FilterChipButton.swift in Sources */,
+				0C05E12E2BDAD02200415A5D /* EditorContentProcessor.swift in Sources */,
 				FABB220C2602FC2C00C8785C /* Blog.m in Sources */,
 				FABB220D2602FC2C00C8785C /* JetpackRemoteInstallStateView.swift in Sources */,
 				F4552086299D147B00D9F6A8 /* BlockedSite.swift in Sources */,


### PR DESCRIPTION
This PR extracts the (relatively [slow](https://github.com/wordpress-mobile/gutenberg-mobile/issues/6696#issuecomment-1978927126)) content processors to the background. The processors were also extracted from `PostCoordinator` to a separate file. The sync engine now also runs them all at once and not on individual uploads, reducing the number of context changes. It could also potentially used for optimization techniques that reuse the work across multiple media items or processors.

## To test:

- Precondition: the app is offline
- Create a new draft with different media blocks
- Save it as a draft
- Restore the network connection
- ✅ Verify that all the media assets were uploaded and the post was updated with the valid media asset URLs

## Regression Notes
1. Potential unintended areas of impact: Post Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
