### PR TITLE
Offline Mode: Always enable Retry All button on the Media Upload

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadStatusView.swift
@@ -12,7 +12,7 @@ struct PostMediaUploadStatusView: View {
                     Menu {
                         Button(action: viewModel.buttonRetryTapped) {
                             Label(Strings.retryUploads, systemImage: "arrow.clockwise")
-                        }.disabled(viewModel.isButtonRetryDisabled)
+                        }
                     } label: {
                         Image(systemName: "ellipsis")
                     }

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadViewModel.swift
@@ -17,10 +17,6 @@ final class PostMediaUploadViewModel: ObservableObject {
     private weak var timer: Timer?
     private var cancellables: [AnyCancellable] = []
 
-    var isButtonRetryDisabled: Bool {
-        !(uploads.contains(where: { $0.error != nil }))
-    }
-
     deinit {
         timer?.invalidate()
     }
@@ -168,6 +164,7 @@ final class MediaUploadViewModel: ObservableObject, Identifiable {
     }
 
     fileprivate func retry() {
+        retryTimer?.invalidate()
         retryTimer = nil
         coordinator.retryMedia(media)
     }


### PR DESCRIPTION
As discussed, enabled the "Retry" button. It just does nothing for uploads that are already running.

## Regression Notes
1. Potential unintended areas of impact: Media Progress View
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
