### PR TITLE
Reader: Fix comment colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -139,28 +139,27 @@ private extension WebCommentContentRenderer {
         ReaderDisplaySetting.customizationEnabled ? displaySetting.color.foreground : .text
     }
 
-    var highlightColor: UIColor {
-        ReaderDisplaySetting.customizationEnabled ? Constants.highlightColor : displaySetting.color.foreground
-    }
-
     var mentionBackgroundColor: UIColor {
-        ReaderDisplaySetting.customizationEnabled ? Constants.mentionBackgroundColor : .clear
+        guard ReaderDisplaySetting.customizationEnabled else {
+            return Constants.mentionBackgroundColor
+        }
+
+        return displaySetting.color == .system ? Constants.mentionBackgroundColor : displaySetting.color.secondaryBackground
     }
 
     var linkColor: UIColor {
         guard ReaderDisplaySetting.customizationEnabled else {
-            return highlightColor
+            return Constants.highlightColor
         }
 
-        return displaySetting.color == .system ? .muriel(color: .init(name: .blue)) : displaySetting.color.foreground
+        return displaySetting.color == .system ? Constants.highlightColor : displaySetting.color.foreground
     }
 
     var secondaryBackgroundColor: UIColor {
-        guard ReaderDisplaySetting.customizationEnabled,
-              displaySetting.color != .system else {
+        guard ReaderDisplaySetting.customizationEnabled else {
             return .secondarySystemBackground
         }
-        return displaySetting.color.border
+        return displaySetting.color.secondaryBackground
     }
 
     /// Cache the HTML template format. We only need read the template once.
@@ -229,8 +228,7 @@ private extension WebCommentContentRenderer {
         return """
         :root {
             --text-color: \(textColor.color(for: trait).cssRGBAString());
-            --text-secondary-color: \(displaySetting.color.secondaryForeground.color(for: trait).cssRGBAString())
-            --primary-color: \(highlightColor.color(for: trait).cssRGBAString());
+            --text-secondary-color: \(displaySetting.color.secondaryForeground.color(for: trait).cssRGBAString());
             --link-color: \(linkColor.color(for: trait).cssRGBAString());
             --mention-background-color: \(mentionBackgroundColor.color(for: trait).cssRGBAString());
             --background-secondary-color: \(secondaryBackgroundColor.color(for: trait).cssRGBAString());

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -75,7 +75,6 @@ figure.wp-block-embed.is-type-video {
 
 /* Temporary override for Reader Customization */
 .reader-full-post__story-content blockquote {
-    color: var(--color-text) !important;
-    border-left: 3px solid var(--color-text) !important;
-    filter: brightness(250%);
+    color: var(--color-text);
+    border-left: 3px solid var(--color-neutral-50);
 }

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySetting.swift
@@ -180,6 +180,17 @@ struct ReaderDisplaySetting: Codable, Equatable {
             }
         }
 
+        var secondaryBackground: UIColor {
+            switch self {
+            case .system:
+                return .secondarySystemBackground
+            case .evening, .oled, .hacker:
+                return foreground.withAlphaComponent(0.15) // slightly higher contrast for dark themes.
+            default:
+                return foreground.withAlphaComponent(0.1)
+            }
+        }
+
         var border: UIColor {
             switch self {
             case .system:

--- a/WordPress/Resources/HTML/richCommentStyle.css
+++ b/WordPress/Resources/HTML/richCommentStyle.css
@@ -27,17 +27,7 @@
     color-scheme: light dark;
 
     /* custom variables. */
-    --primary-color: rgba(6, 117, 196, 1);
-    --mention-background-color: rgba(2, 103, 255, .1);
     --monospace-font: ui-monospace, monospace;
-}
-
-/* overrides for dark color scheme. */
-@media(prefers-color-scheme: dark) {
-    :root {
-        --primary-color: rgba(57, 156, 227, 1);
-        --mention-background-color: rgba(2, 103, 255, .2);
-    }
 }
 
 /* disable WebKit text inflation algorithm to prevent text size increase on orientation change. */


### PR DESCRIPTION
Internal ref p1714064447126199-slack-C0180B5PRJ4

> [!WARNING]
> This targets `release/24.7`.

This PR fixes some visual regression issues on the comment cell:
- Removed the use of `filter: brightness(percentage-value)` CSS property to have a more predictable outcome for blockquote. This is the root cause of the issue raised in p1714064447126199-slack-C0180B5PRJ4.
- Fixed a missing semicolon on the injected CSS values, causing `--link-color` to be ignored.
- Tweaked the colors to improve contrast/legibility.

Some previews:

State | Light | Dark
-|-|-
Feature flag disabled | ![flag-off_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/411da4c1-64ea-4e6c-914f-a59f4c5bb100) | ![flag-off_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/e921c632-67d5-4daa-b8a4-5bfa18d7741e)
Default theme | ![system_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/e41cc074-c785-4adf-9df4-2d45f8fd81e5) | ![system_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/fcd5eb09-46ab-48ef-a220-1445259ba8fa)
Paper theme | ![paper](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1eec01d8-fbb2-464e-9c6c-88585d4c8374) | (not affected by color scheme)
Sepia theme | ![sepia](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/b806cb17-aae9-4021-817c-293aa6414899) | (not affected by color scheme)
Evening theme | ![evening](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/89103afb-912c-4fed-abd4-aacbd115d446) | (not affected by color scheme)
OLED theme | ![oled](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/14fd2f31-9b61-4e94-b8cb-5daabf0323ad) | (not affected by color scheme)
h4x0r theme | ![h4x0r](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/70df1cb2-1050-4ee9-8523-c0906775fd2a) | (not affected by color scheme)
Candy theme | ![candy](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/a512a6bf-eb97-4a9d-98e3-e80d3094f908) | (not affected by color scheme)
Notification comments | ![notifications_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/2d9832db-9ab9-430f-bd07-3379f537eb06) | ![notifications_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/49ee3f9b-ab03-45db-be35-02da756c39ca)
Site comments | ![site-comments_light](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/5a30ec65-7884-4560-a5c0-fa38a656da16) | ![site-comments_dark](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/1d0c8195-dade-47d0-a0db-c0be52f4e4be)

## To test

> [!TIP]
> Before starting the test, prepare a post (ideally a P2) and post a first comment from another account that mentions your account's username. In general, the comment should contain:
> - A username mention,
> - A link, and
> - A link nested inside a blockquote.
>
> When posted, you should get a mention notification on your account. Then: 
> 1. Open that notification. 
> 2. Tap the comment header to go to the comment threads.
> 3. Tap the header view again to go to the Reader Post screen.
> 4. Save the post for easy access.

### With the feature flag OFF

Navigate to Me > App Settings > Debug > Set `Reading Preferences` to OFF.

- Go to Notifications and open the Mention notification.
- 🔎 Verify that the comment is rendered correctly in light and dark mode.
- Go to My Site > Comments and open the prepared comment.
- 🔎 Verify that the comment is rendered correctly in light and dark mode.
- Open your saved post.
- 🔎 Verify that the comment is rendered correctly in light and dark mode.

### With the feature flag ON

Navigate to Me > App Settings > Debug > Set `Reading Preferences` to ON.

- Go to Notifications and open the Mention notification.
- 🔎 Verify that the comment is rendered correctly in light and dark mode.
- Go to My Site > Comments and open the prepared comment.
- 🔎 Verify that the comment is rendered correctly in light and dark mode.
- Open your saved post.
- Select the `Default` theme.
- 🔎 Verify that the comment is rendered correctly in light and dark mode.
- 🔎 Verify that the comment is rendered correctly in all the other themes (refer to the screenshots in the description).

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)