### PR TITLE
Reader: Prevent reloading stream view when menu is fetched

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
@@ -1,6 +1,5 @@
 struct ReaderTabItem: FilterTabBarItem, Hashable {
 
-    let id = UUID()
     let shouldHideStreamFilters: Bool
     let shouldHideSettingsButton: Bool
     let shouldHideTagFilter: Bool
@@ -20,13 +19,6 @@ struct ReaderTabItem: FilterTabBarItem, Hashable {
         shouldHideTagFilter = content.topicType == .organization || FeatureFlag.readerTagsFeed.enabled
     }
 
-    static func == (lhs: ReaderTabItem, rhs: ReaderTabItem) -> Bool {
-        return lhs.id == rhs.id
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
 }
 
 // MARK: - Localized titles
@@ -88,7 +80,7 @@ enum ReaderContentType {
     case topic
 }
 
-struct ReaderContent {
+struct ReaderContent: Hashable {
 
     private(set) var topic: ReaderAbstractTopic?
     let type: ReaderContentType

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -20,6 +20,8 @@ class ReaderTabView: UIView {
 
     private var filteredTabs: [(index: Int, topic: ReaderAbstractTopic)] = []
     private var previouslySelectedIndex: Int = 0
+    private var currentTabItems: [ReaderTabItem] = []
+    private weak var childController: UIViewController?
 
     private var discoverIndex: Int? {
         return viewModel.tabItems.firstIndex(where: { $0.content.topicType == .discover })
@@ -55,7 +57,11 @@ class ReaderTabView: UIView {
         }
 
         viewModel.onTabBarItemsDidChange { [weak self] tabItems, index in
+            if self?.childController != nil && self?.currentTabItems == tabItems {
+                return
+            }
             self?.addContentToContainerView(index: index)
+            self?.currentTabItems = tabItems
         }
 
         setupViewElements()
@@ -118,6 +124,8 @@ extension ReaderTabView {
         }
         controller.add(childController)
         containerView.pinSubviewToAllEdges(childController.view)
+
+        self.childController = childController
 
         if viewModel.shouldShowCommentSpotlight {
             let title = NSLocalizedString("Comment to start making connections.", comment: "Hint for users to grow their audience by commenting on other blogs.")


### PR DESCRIPTION
## Description

Fixes an issue where the stream view would reload when the fetch menu call finished. This issue was present for all the feeds, not just the new tags feed.

## Example

> [!NOTE]
> It's not easy to reproduce it without some extra test code. I replaced the search button's action with the fetch menu call here.

| Before | After |
|---|---|
| ![before-fetch-menu](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/b05de274-e5c6-406c-9ae7-276c542f7bbc) | ![after-fetch-menu](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/0b7ea2c9-d313-49ac-812a-86740293efca) |

## Testing

### Test Setup

Replace https://github.com/wordpress-mobile/WordPress-iOS/blob/23fac4fa1e57534adedcfa4df92d342e27dd2825/WordPress/Classes/ViewRelated/Reader/Tab%20Navigation/ReaderNavigationMenu.swift#L57

With:
```swift
viewModel.fetchReaderMenu()
```

### To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- Wait for some content to load
- Tap on the search icon
- 🔎 **Verify** the feed does not reload

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
