### PR TITLE
Stats Insights: Remove social (publicize) subscribers

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -827,23 +827,12 @@ extension StatsInsightsStore {
     func getTotalFollowerCount() -> Int {
         let totalDotComFollowers = getDotComFollowers()?.dotComFollowersCount ?? 0
         let totalEmailFollowers = getEmailFollowers()?.emailFollowersCount ?? 0
-        let totalPublicize = getPublicizeCount()
 
-        return totalDotComFollowers + totalEmailFollowers + totalPublicize
+        return totalDotComFollowers + totalEmailFollowers
     }
 
     func getPublicize() -> StatsPublicizeInsight? {
         return state.publicizeFollowers
-    }
-
-    func getPublicizeCount() -> Int {
-        var totalPublicize = 0
-        if let publicize = getPublicize(),
-           !publicize.publicizeServices.isEmpty {
-            totalPublicize = publicize.publicizeServices.compactMap({$0.followers}).reduce(0, +)
-        }
-
-        return totalPublicize
     }
 
     func getTopCommentsInsight() -> StatsCommentsInsight? {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -531,7 +531,6 @@ private extension SiteStatsInsightsViewModel {
         static let total = NSLocalizedString("Total", comment: "Label for total followers")
         static let wordPress = NSLocalizedString("WordPress.com", comment: "Label for WordPress.com followers")
         static let email = NSLocalizedString("Email", comment: "Label for email followers")
-        static let social = NSLocalizedString("Social", comment: "Follower Totals label for social media followers")
     }
 
     struct TodaysStats {
@@ -612,36 +611,6 @@ private extension SiteStatsInsightsViewModel {
                                            rightColumnName: MostPopularStats.bestHour,
                                            rightColumnData: timeString)]
 
-    }
-
-    func createTotalFollowersRows() -> [StatsTwoColumnRowData] {
-        let totalDotComFollowers = insightsStore.getDotComFollowers()?.dotComFollowersCount ?? 0
-        let totalEmailFollowers = insightsStore.getEmailFollowers()?.emailFollowersCount ?? 0
-
-        var totalPublicize = 0
-        if let publicize = insightsStore.getPublicize(),
-           !publicize.publicizeServices.isEmpty {
-            totalPublicize = publicize.publicizeServices.compactMap({$0.followers}).reduce(0, +)
-        }
-
-        let totalFollowers = insightsStore.getTotalFollowerCount()
-        guard totalFollowers > 0 else {
-            return []
-        }
-
-        var dataRows = [StatsTwoColumnRowData]()
-
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: FollowerTotals.total,
-                                                   leftColumnData: totalFollowers.abbreviatedString(),
-                                                   rightColumnName: FollowerTotals.wordPress,
-                                                   rightColumnData: totalDotComFollowers.abbreviatedString()))
-
-        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: FollowerTotals.email,
-                                                   leftColumnData: totalEmailFollowers.abbreviatedString(),
-                                                   rightColumnName: FollowerTotals.social,
-                                                   rightColumnData: totalPublicize.abbreviatedString()))
-
-        return dataRows
     }
 
     func createLikesTotalInsightsRow() -> StatsTotalInsightsData {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -325,12 +325,10 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
                 let dotComFollowersCount = insightsStore.getDotComFollowers()?.dotComFollowersCount ?? 0
                 let emailFollowersCount = insightsStore.getEmailFollowers()?.emailFollowersCount ?? 0
-                let publicizeCount = insightsStore.getPublicizeCount()
 
-                if dotComFollowersCount > 0 || emailFollowersCount > 0 || publicizeCount > 0 {
+                if dotComFollowersCount > 0 || emailFollowersCount > 0 {
                     let chartViewModel = StatsFollowersChartViewModel(dotComFollowersCount: dotComFollowersCount,
-                                                                      emailFollowersCount: emailFollowersCount,
-                                                                      publicizeCount: publicizeCount)
+                                                                      emailFollowersCount: emailFollowersCount)
 
                     let chartView: UIView = chartViewModel.makeFollowersChartView()
 
@@ -338,8 +336,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                             dataSubtitle: "",
                             dataRows: followersRowData(dotComFollowersCount: dotComFollowersCount,
                                                                              emailFollowersCount: emailFollowersCount,
-                                                                             othersCount: publicizeCount,
-                                                                             totalCount: dotComFollowersCount + emailFollowersCount + publicizeCount),
+                                                                             totalCount: dotComFollowersCount + emailFollowersCount),
                             statSection: StatSection.insightsFollowersWordPress,
                             siteStatsPeriodDelegate: nil, //TODO - look at if I need to be not null
                             siteStatsReferrerDelegate: nil)
@@ -1003,7 +1000,7 @@ private extension SiteStatsInsightsDetailsViewModel {
     }
 
     // MARK: - Followers
-    func followersRowData(dotComFollowersCount: Int, emailFollowersCount: Int, othersCount: Int, totalCount: Int) -> [StatsTotalRowData] {
+    func followersRowData(dotComFollowersCount: Int, emailFollowersCount: Int, totalCount: Int) -> [StatsTotalRowData] {
         var rowData = [StatsTotalRowData]()
 
         rowData.append(
@@ -1016,12 +1013,6 @@ private extension SiteStatsInsightsDetailsViewModel {
                 StatsTotalRowData(name: StatSection.insightsFollowersEmail.tabTitle,
                         data: "\(emailFollowersCount.abbreviatedString()) (\(roundedPercentage(numerator: emailFollowersCount, denominator: totalCount))%)",
                         statSection: .insightsFollowersEmail)
-        )
-
-        rowData.append(
-                StatsTotalRowData(name: StatSection.insightsPublicize.tabTitle,
-                        data: "\(othersCount.abbreviatedString()) (\(roundedPercentage(numerator: othersCount, denominator: totalCount))%)",
-                        statSection: .insightsFollowersWordPress)
         )
 
         return rowData

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
@@ -2,9 +2,8 @@ import Foundation
 
 struct StatsFollowersChartViewModel {
 
-    public let dotComFollowersCount: Int
-    public let emailFollowersCount: Int
-    public let publicizeCount: Int
+    let dotComFollowersCount: Int
+    let emailFollowersCount: Int
 
     func makeFollowersChartView() -> UIView {
         // The followers chart currently shows 3 segments. If available, it will show:
@@ -20,14 +19,13 @@ struct StatsFollowersChartViewModel {
     }
 
     internal func totalCount() -> Int {
-        return dotComFollowersCount + emailFollowersCount + publicizeCount
+        return dotComFollowersCount + emailFollowersCount
     }
 
     internal func segments() -> [DonutChartView.Segment] {
         var segments: [DonutChartView.Segment] = []
         segments.append(segmentWith(title: Constants.wpComGroupTitle, count: dotComFollowersCount, color: Constants.wpComColor))
         segments.append(segmentWith(title: Constants.emailGroupTitle, count: emailFollowersCount, color: Constants.emailColor))
-        segments.append(segmentWith(title: Constants.socialGroupTitle, count: publicizeCount, color: Constants.socialColor))
         return segments
     }
 
@@ -42,7 +40,6 @@ struct StatsFollowersChartViewModel {
     private enum Constants {
         static let wpComGroupTitle = NSLocalizedString("WordPress", comment: "Title of Stats section that shows WordPress.com followers.")
         static let emailGroupTitle = NSLocalizedString("Email", comment: "Title of Stats section that shows email followers.")
-        static let socialGroupTitle = NSLocalizedString("Social", comment: "Title of Stats section that shows social followers.")
 
         static let wpComColor: UIColor = .muriel(name: .blue, .shade50)
         static let emailColor: UIColor = .muriel(name: .blue, .shade5)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
@@ -6,10 +6,9 @@ struct StatsFollowersChartViewModel {
     let emailFollowersCount: Int
 
     func makeFollowersChartView() -> UIView {
-        // The followers chart currently shows 3 segments. If available, it will show:
+        // The followers chart currently shows 2 segments. If available, it will show:
         // - WordPress.com followers
         // - Email followers
-        // - Social
 
         let chartView = DonutChartView()
         chartView.configure(title: "", totalCount: CGFloat(totalCount()), segments: segments())
@@ -43,7 +42,6 @@ struct StatsFollowersChartViewModel {
 
         static let wpComColor: UIColor = .muriel(name: .blue, .shade50)
         static let emailColor: UIColor = .muriel(name: .blue, .shade5)
-        static let socialColor: UIColor = .muriel(name: .orange, .shade30)
 
         static let chartHeight: CGFloat = 231.0
     }


### PR DESCRIPTION
Fixes #23085

Removing social (publicize) subscribers from:
- Insights -> Total Subscribers
- Insights -> Total Subscribers -> Details

Social (publicize) subscribers should no longer be account for when calculating total subscribers.

## To test:

- `Insights -> Total Subscribers` card shouldn't contain publicize numbers (can be tested by comparing `en.blog` numbers in previous and current versions).
- `Insights -> Total Subscribers -> Details` chart should no longer contain `Social` subscribers.

Email subscribers will be removed when we make a final move to the Subscribers tab and remove existing elements from Insights tab.

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/de1e14da-0e64-4e8f-ba17-dfa3f0e97edd" width="200">

## Regression Notes
1. Potential unintended areas of impact

Make sure Insights continue working

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
