### PR TITLE
Stats Subscribers Deep link support

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -11,6 +11,7 @@ enum StatsRoute {
     case dayCategory
     case annualStats
     case activityLog
+    case subscribers
 
     var tab: StatsTabType? {
         switch self {
@@ -24,6 +25,8 @@ enum StatsRoute {
             return .years
         case .insights:
             return .insights
+        case .subscribers:
+            return .subscribers
         default:
             return nil
         }
@@ -61,6 +64,8 @@ extension StatsRoute: Route {
             return "/stats/annualstats/:domain"
         case .activityLog:
             return "/stats/activity/:domain"
+        case .subscribers:
+            return "/stats/subscribers/:domain"
         }
     }
 
@@ -105,6 +110,8 @@ extension StatsRoute: NavigationAction {
                 showMySitesAndFailureNotice(using: coordinator,
                                             values: values)
             }
+        case .subscribers:
+            showStatsForBlog(from: values, tab: .subscribers, using: coordinator)
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -12,6 +12,7 @@ enum StatsRoute {
     case annualStats
     case activityLog
     case subscribers
+    case daySubscribers
 
     var tab: StatsTabType? {
         switch self {
@@ -26,6 +27,8 @@ enum StatsRoute {
         case .insights:
             return .insights
         case .subscribers:
+            return .subscribers
+        case .daySubscribers:
             return .subscribers
         default:
             return nil
@@ -66,6 +69,8 @@ extension StatsRoute: Route {
             return "/stats/activity/:domain"
         case .subscribers:
             return "/stats/subscribers/:domain"
+        case .daySubscribers:
+            return "/stats/subscribers/day/:domain"
         }
     }
 
@@ -110,7 +115,7 @@ extension StatsRoute: NavigationAction {
                 showMySitesAndFailureNotice(using: coordinator,
                                             values: values)
             }
-        case .subscribers:
+        case .subscribers, .daySubscribers:
             showStatsForBlog(from: values, tab: .subscribers, using: coordinator)
         }
     }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -95,7 +95,8 @@ struct UniversalLinkRouter: LinkRouter {
         StatsRoute.dayCategory,
         StatsRoute.annualStats,
         StatsRoute.activityLog,
-        StatsRoute.subscribers
+        StatsRoute.subscribers,
+        StatsRoute.daySubscribers
     ]
 
     static let mySitesRoutes: [Route] = MySitesRoute.allCases

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -94,7 +94,8 @@ struct UniversalLinkRouter: LinkRouter {
         StatsRoute.insights,
         StatsRoute.dayCategory,
         StatsRoute.annualStats,
-        StatsRoute.activityLog
+        StatsRoute.activityLog,
+        StatsRoute.subscribers
     ]
 
     static let mySitesRoutes: [Route] = MySitesRoute.allCases

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -148,6 +148,17 @@ class RouteMatcherTests: XCTestCase {
         XCTAssertEqual(match.source, DeepLinkSource.widget)
     }
 
+    func testStatsSubscribersRoute() {
+        routes = [ StatsRoute.subscribers ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/stats/subscribers/testsite.com")!)
+
+        let match = matches.first!
+        XCTAssertEqual(match.section, DeepLinkSection.stats)
+        XCTAssertEqual(match.source, DeepLinkSource.link)
+    }
+
     // MARK: - AppBanner
 
     func testAppBannerRouter() throws {

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -159,6 +159,17 @@ class RouteMatcherTests: XCTestCase {
         XCTAssertEqual(match.source, DeepLinkSource.link)
     }
 
+    func testStatsSubscribersDayRoute() {
+        routes = [ StatsRoute.daySubscribers ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/stats/subscribers/day/testsite.com")!)
+
+        let match = matches.first!
+        XCTAssertEqual(match.section, DeepLinkSection.stats)
+        XCTAssertEqual(match.source, DeepLinkSource.link)
+    }
+
     // MARK: - AppBanner
 
     func testAppBannerRouter() throws {


### PR DESCRIPTION
Fixes #23047

Add support to deep link from `/stats/subscribers/domain` into the app.

## To test:

### Feature flag enabled
1. Enable `Stats Subscribers and Traffic` feature flag
2. Open wp.com/stats
3. Try opening the app from stats/insights, stats/subscribers
4. Confirm respective tabs on the app are opened
5. Try opening the app from wp.com traffic tab with different days/weeks/months/years granularity selected
6. Confirm Traffic tab is opened on the app with correct date picker granularity selected

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/9475e808-475b-43dc-bcaa-53ff8d20e3d3

### Feature flag disabled
1. Disable `Stats Subscribers and Traffic` feature flag
2. stats/subscribers should open a default insights tab
3. Other routes should work as before

https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/aa2e4d55-2b25-43cb-be8b-7a557b5c8a34

## Regression Notes
1. Potential unintended areas of impact

Breaking functionality when feature flag is disabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
