### PR TITLE
Offline Mode: Add a way to cancel uploads directly from Media Uploads screen

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -282,6 +282,9 @@ class MediaCoordinator: NSObject {
     func cancelUploadAndDeleteMedia(_ media: Media) {
         cancelUpload(of: media)
         delete(media: [media])
+        if FeatureFlag.syncPublishing.enabled {
+            notifyObserversForMedia(media, ofStateChange: .cancelled)
+        }
     }
 
     /// Cancels any ongoing upload for the media object
@@ -588,6 +591,8 @@ class MediaCoordinator: NSObject {
         case ended
         case failed(error: NSError)
         case progress(value: Double)
+        /// The upload was cancelled by the user.
+        case cancelled
 
         var debugDescription: String {
             switch self {
@@ -603,6 +608,8 @@ class MediaCoordinator: NSObject {
                 return "Failed: \(error)"
             case .progress(let value):
                 return "Progress: \(value)"
+            case .cancelled:
+                return "Cancelled"
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2179,6 +2179,8 @@ extension AztecPostViewController {
             handleError(error, onAttachment: attachment)
         case .progress(let value):
             handleProgress(value, forMedia: media, onAttachment: attachment)
+        case .cancelled:
+            richTextView.remove(attachmentID: attachment.identifier)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -236,6 +236,8 @@ class GutenbergMediaInserterHelper: NSObject {
             }
         case .progress(let value):
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: Float(value), url: nil, serverID: nil)
+        case .cancelled:
+            gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .reset, progress: 0, url: nil, serverID: nil)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaPreviewViewController.swift
@@ -1,6 +1,19 @@
 import UIKit
 import Gifu
 import AVKit
+import SwiftUI
+
+struct SiteMediaPreviewView: UIViewControllerRepresentable {
+    let media: Media
+
+    func makeUIViewController(context: Context) -> SiteMediaPreviewViewController {
+        SiteMediaPreviewViewController(media: media)
+    }
+
+    func updateUIViewController(_ vc: SiteMediaPreviewViewController, context: Context) {
+        // Do nothing
+    }
+}
 
 final class SiteMediaPreviewViewController: UIViewController {
     private let imageView = GIFImageView()

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadsView.swift
@@ -2,8 +2,8 @@ import Foundation
 import SwiftUI
 
 /// Displays upload progress for the media for the given post.
-struct PostMediaUploadStatusView: View {
-    @ObservedObject var viewModel: PostMediaUploadViewModel
+struct PostMediaUploadsView: View {
+    @ObservedObject var viewModel: PostMediaUploadsViewModel
 
     var body: some View {
         contents
@@ -30,7 +30,7 @@ struct PostMediaUploadStatusView: View {
         } else {
             List {
                 ForEach(viewModel.uploads) {
-                    MediaUploadStatusView(viewModel: $0)
+                    PostMediaUploadItemView(viewModel: $0)
                 }
             }
             .listStyle(.plain)
@@ -38,16 +38,17 @@ struct PostMediaUploadStatusView: View {
     }
 }
 
-private struct MediaUploadStatusView: View {
-    @ObservedObject var viewModel: MediaUploadViewModel
+private struct PostMediaUploadItemView: View {
+    @ObservedObject var viewModel: PostMediaUploadItemViewModel
 
     var body: some View {
-        HStack(alignment: .center, spacing: 16) {
+        let view = HStack(alignment: .center, spacing: 0) {
             MediaThubmnailImageView(image: viewModel.thumbnail)
                 .aspectRatio(viewModel.thumbnailAspectRatio, contentMode: .fit)
                 .frame(maxHeight: viewModel.thumbnailMaxHeight)
                 .clipped()
                 .frame(width: 40, height: 40)
+                .padding(.trailing, 16)
 
             VStack(alignment: .leading) {
                 Text(viewModel.title)
@@ -59,21 +60,69 @@ private struct MediaUploadStatusView: View {
                     .lineLimit(3)
             }
 
-            Spacer()
+            Spacer(minLength: 8)
 
-            switch viewModel.state {
-            case .uploading:
-                MediaUploadProgressView(progress: viewModel.fractionCompleted)
-            case .failed:
-                Image(systemName: "exclamationmark.circle.fill")
-                    .foregroundStyle(.red)
-            case .uploaded:
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(.secondary.opacity(0.33))
+            HStack(alignment: .center, spacing: 8) {
+                switch viewModel.state {
+                case .uploading:
+                    MediaUploadProgressView(progress: viewModel.fractionCompleted)
+                        .padding(.trailing, 4) // To align with the exlamation mark
+                    menu
+                case .failed:
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundStyle(.red)
+                    menu
+                case .uploaded:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.secondary.opacity(0.33))
+                }
             }
         }
-        .task {
-            await viewModel.loadThumbnail()
+            .task {
+                await viewModel.loadThumbnail()
+            }
+        if #available(iOS 16, *) {
+            view.contextMenu {
+                menuItems
+            } preview: {
+                SiteMediaPreviewView(media: viewModel.media)
+            }
+        } else {
+            view
+        }
+    }
+
+    struct HostDetailsView: UIViewControllerRepresentable {
+        let media: Media
+
+        func makeUIViewController(context: Context) -> MediaItemViewController {
+            MediaItemViewController(media: media)
+        }
+
+        func updateUIViewController(_ uiViewController: MediaItemViewController, context: Context) {
+            // Do nothing
+        }
+    }
+
+    private var menu: some View {
+        Menu {
+            menuItems
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.subheadline)
+                .tint(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var menuItems: some View {
+        if viewModel.error != nil {
+            Button(action: viewModel.buttonRetryTapped) {
+                Label(Strings.retryUpload, systemImage: "arrow.clockwise")
+            }
+        }
+        Button(role: .destructive, action: viewModel.buttonCancelTapped) {
+            Label(Strings.cancelUpload, systemImage: "trash")
         }
     }
 }
@@ -84,13 +133,10 @@ struct MediaUploadProgressView: View {
     var body: some View {
         ZStack {
             Circle()
-                .stroke(
-                    Color.secondary.opacity(0.25),
-                    lineWidth: 3
-                )
+                .stroke(Color.secondary.opacity(0.25), lineWidth: 2)
             Circle()
                 .trim(from: 0, to: progress)
-                .stroke(Color(uiColor: .brand), style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                .stroke(Color(uiColor: .brand), style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .rotationEffect(.degrees(-90))
                 .animation(.easeOut, value: progress)
         }
@@ -119,5 +165,7 @@ private enum Strings {
     static let title = NSLocalizedString("postMediaUploadStatusView.title", value: "Media Uploads", comment: "Title for post media upload status view")
     static let empty = NSLocalizedString("postMediaUploadStatusView.noPendingUploads", value: "No pending uploads", comment: "Placeholder text in postMediaUploadStatusView when no uploads remain")
     static let close = NSLocalizedString("postMediaUploadStatusView.close", value: "Close", comment: "Close button in postMediaUploadStatusView")
+    static let retryUpload = NSLocalizedString("postMediaUploadStatusView.retryUpload", value: "Retry Upload", comment: "Retry (single) upload button in postMediaUploadStatusView")
+    static let cancelUpload = NSLocalizedString("postMediaUploadStatusView.cancelUpload", value: "Cancel Upload", comment: "Cancel (single) upload button in postMediaUploadStatusView")
     static let retryUploads = NSLocalizedString("postMediaUploadStatusView.retryUploads", value: "Retry Uploads", comment: "Retry upload button in postMediaUploadStatusView")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadsViewModel.swift
@@ -3,8 +3,8 @@ import SwiftUI
 import Combine
 
 /// Manages media upload for the given revision of the post.
-final class PostMediaUploadViewModel: ObservableObject {
-    private(set) var uploads: [MediaUploadViewModel]
+final class PostMediaUploadsViewModel: ObservableObject {
+    private(set) var uploads: [PostMediaUploadItemViewModel]
 
     @Published private(set) var totalFileSize: Int64 = 0
     @Published private(set) var fractionCompleted = 0.0
@@ -27,7 +27,7 @@ final class PostMediaUploadViewModel: ObservableObject {
         self.uploads = Array(post.media).filter(\.isUploadNeeded).sorted {
             ($0.creationDate ?? .now) < ($1.creationDate ?? .now)
         }.map {
-            MediaUploadViewModel(media: $0, coordinator: coordinator)
+            PostMediaUploadItemViewModel(media: $0, coordinator: coordinator)
         }
 
         coordinator.uploadMedia(for: post)
@@ -68,10 +68,10 @@ final class PostMediaUploadViewModel: ObservableObject {
 }
 
 /// Manages individual media upload.
-final class MediaUploadViewModel: ObservableObject, Identifiable {
+final class PostMediaUploadItemViewModel: ObservableObject, Identifiable {
     @Published private(set) var state: State = .uploading
 
-    private let media: Media
+    let media: Media
     private let coordinator: MediaCoordinator
 
     private var completed: Int64 = 0
@@ -190,6 +190,16 @@ final class MediaUploadViewModel: ObservableObject, Identifiable {
         } catch {
             // Continue showing placeholder
         }
+    }
+
+    // MARK: - Actions
+
+    func buttonRetryTapped() {
+        retry()
+    }
+
+    func buttonCancelTapped() {
+        coordinator.cancelUploadAndDeleteMedia(media)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -144,7 +144,7 @@ extension PostSettingsViewController {
             // The Media coordinator shows its own notice about a failed upload. We have a better, more explanatory message for users here
             // so we want to supress the one coming from the coordinator and show ours.
             ActionDispatcher.dispatch(NoticeAction.post(notice))
-        case .progress:
+        case .progress, .cancelled:
             break
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -43,7 +43,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
     private weak var mediaPollingTimer: Timer?
     private let isStandalone: Bool
-    private let uploadsViewModel: PostMediaUploadViewModel
+    private let uploadsViewModel: PostMediaUploadsViewModel
 
     private var cancellables: [AnyCancellable] = []
 
@@ -58,7 +58,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         self.post = isStandalone ? post._createRevision() : post
         self.isStandalone = isStandalone
         self.viewModel = PrepublishingViewModel(post: self.post)
-        self.uploadsViewModel = PostMediaUploadViewModel(post: post)
+        self.uploadsViewModel = PostMediaUploadsViewModel(post: post)
         self.completion = completion
         self.coreDataStack = coreDataStack
         self.persistentStore = persistentStore
@@ -450,7 +450,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
     }
 
     private func buttonShowUploadInfoTapped() {
-        let view = PostMediaUploadStatusView(viewModel: uploadsViewModel)
+        let view = PostMediaUploadsView(viewModel: uploadsViewModel)
         let host = UIHostingController(rootView: view)
         navigationController?.pushViewController(host, animated: true)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -581,10 +581,10 @@
 		0CD9FB892AFA71C2009D9C7A /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = 0CD9FB882AFA71C2009D9C7A /* DGCharts */; };
 		0CD9FB8B2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */; };
 		0CD9FB8C2AFADAFE009D9C7A /* SiteMediaPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */; };
-		0CDA09032BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */; };
-		0CDA09042BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */; };
-		0CDA090C2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */; };
-		0CDA090D2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */; };
+		0CDA09032BD022130032D123 /* PostMediaUploadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadsView.swift */; };
+		0CDA09042BD022130032D123 /* PostMediaUploadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadsView.swift */; };
+		0CDA090C2BD04B270032D123 /* PostMediaUploadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */; };
+		0CDA090D2BD04B270032D123 /* PostMediaUploadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CE538CA2B0D6E0000834BA2 /* ExternalMediaDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */; };
@@ -6369,8 +6369,8 @@
 		0CD9CCA22AD831590044A33C /* PostSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchViewModel.swift; sourceTree = "<group>"; };
 		0CD9FB7D2AF9C4DB009D9C7A /* UIBarButtonItem+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Extensions.swift"; sourceTree = "<group>"; };
 		0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPageViewController.swift; sourceTree = "<group>"; };
-		0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadStatusView.swift; sourceTree = "<group>"; };
-		0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadViewModel.swift; sourceTree = "<group>"; };
+		0CDA09022BD022130032D123 /* PostMediaUploadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadsView.swift; sourceTree = "<group>"; };
+		0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadsViewModel.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaDataSource.swift; sourceTree = "<group>"; };
 		0CE538CF2B0E317000834BA2 /* StockPhotosWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosWelcomeView.swift; sourceTree = "<group>"; };
@@ -12929,8 +12929,8 @@
 				FA141F262AEC1D9E00C9A653 /* PageMenuViewModel.swift */,
 				FAA5C90E2B7FC74C002E073B /* PostSyncStateViewModel.swift */,
 				FACA34CD2BAACE3500163B21 /* ResolveConflictView.swift */,
-				0CDA09022BD022130032D123 /* PostMediaUploadStatusView.swift */,
-				0CDA090B2BD04B270032D123 /* PostMediaUploadViewModel.swift */,
+				0CDA09022BD022130032D123 /* PostMediaUploadsView.swift */,
+				0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -22481,7 +22481,7 @@
 				B5EFB1C21B31B98E007608A3 /* NotificationSettingsService.swift in Sources */,
 				011896A829D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */,
 				011F52BD2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
-				0CDA090C2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */,
+				0CDA090C2BD04B270032D123 /* PostMediaUploadsViewModel.swift in Sources */,
 				F45EB5012B865AF4004E9053 /* NotificationTableViewCell.swift in Sources */,
 				1717139F265FE59700F3A022 /* ButtonStyles.swift in Sources */,
 				C3FF78E828354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */,
@@ -22630,7 +22630,7 @@
 				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
 				8352AC712B2A185A00F8492C /* ReaderNavigationButton.swift in Sources */,
 				80EF672527F3D63B0063B138 /* DashboardStatsStackView.swift in Sources */,
-				0CDA09032BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */,
+				0CDA09032BD022130032D123 /* PostMediaUploadsView.swift in Sources */,
 				E1D0D81616D3B86800E33F4C /* SafariActivity.m in Sources */,
 				E603C7701BC94AED00AD49D7 /* WordPress-37-38.xcmappingmodel in Sources */,
 				808D102E2B881BE20082E64F /* String+Truncate.swift in Sources */,
@@ -24753,7 +24753,7 @@
 				FABB21D52602FC2C00C8785C /* SiteDesignContentCollectionViewController.swift in Sources */,
 				C31466CC2939950900D62FC7 /* MigrationLoadWordPressViewController.swift in Sources */,
 				FABB21D62602FC2C00C8785C /* PlanComparisonViewController.swift in Sources */,
-				0CDA09042BD022130032D123 /* PostMediaUploadStatusView.swift in Sources */,
+				0CDA09042BD022130032D123 /* PostMediaUploadsView.swift in Sources */,
 				FABB21D72602FC2C00C8785C /* Routes+Stats.swift in Sources */,
 				8BF1C81B27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */,
 				FABB21D92602FC2C00C8785C /* SearchIdentifierGenerator.swift in Sources */,
@@ -26086,7 +26086,7 @@
 				DC76668626FD9AC9009254DD /* TimeZoneTableViewCell.swift in Sources */,
 				01DC4CD92B5FC8CE000110E5 /* SiteStatsPeriodTableViewControllerDeprecated.swift in Sources */,
 				FABB25862602FC2C00C8785C /* WordPress-11-12.xcmappingmodel in Sources */,
-				0CDA090D2BD04B270032D123 /* PostMediaUploadViewModel.swift in Sources */,
+				0CDA090D2BD04B270032D123 /* PostMediaUploadsViewModel.swift in Sources */,
 				C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */,
 				FABB25872602FC2C00C8785C /* DiffAbstractValue.swift in Sources */,
 				9822A8422624CFB900FD8A03 /* UserProfileSiteCell.swift in Sources */,


### PR DESCRIPTION
Add a way to cancel uploads directly from the "Media Uploads" screen.

Note: this doesn't cover drafts sync yet, and I'm working on integrating this screen in more context, but wanted to keep the PRs small.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/9dae6e7c-6605-452d-a903-5b561ee3c6f0

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/550a3bf6-c48a-4cb1-8e37-2b4ff7dcfe8a

## To test:

- Use the steps from the [following issue](https://github.com/wordpress-mobile/WordPress-iOS/pull/23091#issuecomment-2078454749) to create a post with a dangling media upload
- Tap "Publish"
- ✅ Verify that the sheet shows a "Media failed to upload message" (it is a defect, but for the purposes of this PR, it's an expected behavior)
- Open "Media Uploads"
- Tap "More" and Tap "Cancel Upload" on the danling upload
- Tap "Back"
- ✅ Verify that the "Publish" button is now available and you can publish the post

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
