### PR TITLE
Offline Mode: Integrate "Media Uploads" with a sync engine for drafts

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -512,10 +512,11 @@ class PostCoordinator: NSObject {
     }
 
     private func startSync(for post: AbstractPost) {
-        guard let revision = post.getLatestRevisionNeedingSync() else {
-            let worker = getWorker(for: post)
+        if let worker = workers[post.objectID], worker.error != nil {
             worker.error = nil
             postDidUpdateNotification(for: post)
+        }
+        guard let revision = post.getLatestRevisionNeedingSync() else {
             return DDLogInfo("sync: \(post.objectID.shortDescription) is already up to date")
         }
         startSync(for: post, revision: revision)

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadsView.swift
@@ -1,6 +1,19 @@
 import Foundation
 import SwiftUI
 
+final class PostMediaUploadsViewController: UIHostingController<PostMediaUploadsView> {
+    private let viewModel: PostMediaUploadsViewModel
+
+    init(post: AbstractPost) {
+        self.viewModel = PostMediaUploadsViewModel(post: post) // Manange lifecycle
+        super.init(rootView: PostMediaUploadsView(viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// Displays upload progress for the media for the given post.
 struct PostMediaUploadsView: View {
     @ObservedObject var viewModel: PostMediaUploadsViewModel


### PR DESCRIPTION
There needed to be a way to somehow inform the user why the sync fails in case of a terminal error with media uploads.

- Integrate PostMediaUploadsView with draft sync engine
- Perform sync retries on terminal error but with longer delay (otherwise there is no retry mechanism)

## To test:

- Mock one of the terminal media failures (e.g. change `var maxUploadSize: NSNumber?`)
- Follow the steps from the video:

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/2df7a479-2d62-4f89-a984-eba5b1f4a81e

## Regression Notes
1. Potential unintended areas of impact: Post Media
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
