### PR TITLE
Offline Mode: Switch to local feature flag

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -81,7 +81,7 @@
 {
     self.date_created_gmt = localDate;
 
-    if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+    if ([Feature enabled:FeatureFlagSyncPublishing]) {
         return;
     }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -68,7 +68,7 @@ class PostCoordinator: NSObject {
          failedPostsFetcher: FailedPostsFetcher? = nil,
          actionDispatcherFacade: ActionDispatcherFacade = ActionDispatcherFacade(),
          coreDataStack: CoreDataStackSwift = ContextManager.sharedInstance(),
-         isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+         isSyncPublishingEnabled: Bool = FeatureFlag.syncPublishing.enabled) {
         self.coreDataStack = coreDataStack
 
         let mainContext = self.coreDataStack.mainContext

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -12,7 +12,7 @@
 }
 
 + (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext overwrite:(BOOL)overwrite {
-    if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing] && (post.revision != nil && !overwrite)) {
+    if ([Feature enabled:FeatureFlagSyncPublishing] && (post.revision != nil && !overwrite)) {
         return;
     }
 
@@ -255,7 +255,7 @@
     if (purge) {
         // Set up predicate for fetching any posts that could be purged for the sync.
         NSPredicate *predicate = nil;
-        if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+        if ([Feature enabled:FeatureFlagSyncPublishing]) {
             predicate = [NSPredicate predicateWithFormat:@"(postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", blog];
         } else {
             predicate = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -23,7 +23,7 @@ final class PostRepository {
 
     init(coreDataStack: CoreDataStackSwift = ContextManager.shared,
          remoteFactory: PostServiceRemoteFactory = PostServiceRemoteFactory(),
-         isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+         isSyncPublishingEnabled: Bool = FeatureFlag.syncPublishing.enabled) {
         self.coreDataStack = coreDataStack
         self.remoteFactory = remoteFactory
         self.isSyncPublishingEnabled = isSyncPublishingEnabled

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -110,13 +110,13 @@ extension FeatureFlag: OverridableFlag {
 extension FeatureFlag: RolloutConfigurableFlag {
     /// Represents the percentage of users to roll the flag out to.
     ///
-    /// To set a percentage rollout, return a value between 1 and 100 inclusive.
+    /// To set a percentage rollout, return a value between 0.0 and 1.0.
     /// If a percentage rollout isn't applicable for the flag, return nil.
     ///
-    var rolloutPercentage: Int? {
+    var rolloutPercentage: Double? {
         switch self {
         case .syncPublishing:
-            return 1
+            return 0.01  // 1%
         default:
             return nil
         }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -42,7 +42,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .readerTagsFeed:
             return false
         case .syncPublishing:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting] || FeatureFlagRolloutStore().isRolloutEnabled(for: self)
         }
     }
 
@@ -103,6 +103,22 @@ extension FeatureFlag: OverridableFlag {
             return false
         default:
             return true
+        }
+    }
+}
+
+extension FeatureFlag: RolloutConfigurableFlag {
+    /// Represents the percentage of users to roll the flag out to.
+    ///
+    /// To set a percentage rollout, return a value between 1 and 100 inclusive.
+    /// If a percentage rollout isn't applicable for the flag, return nil.
+    ///
+    var rolloutPercentage: Int? {
+        switch self {
+        case .syncPublishing:
+            return 1
+        default:
+            return nil
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -12,6 +12,7 @@ enum FeatureFlag: Int, CaseIterable {
     case googleDomainsCard
     case newTabIcons
     case readerTagsFeed
+    case syncPublishing
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -40,6 +41,8 @@ enum FeatureFlag: Int, CaseIterable {
             return true
         case .readerTagsFeed:
             return false
+        case .syncPublishing:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -82,6 +85,8 @@ extension FeatureFlag {
             return "New Tab Icons"
         case .readerTagsFeed:
             return "Reader Tags Feed"
+        case .syncPublishing:
+            return "Synchronous Publishing"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlagRolloutStore.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlagRolloutStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// Protocol allows easier unit testing, so we can implement mock
+// feature flags to use in test cases.
+//
+protocol RolloutConfigurableFlag: CustomStringConvertible {
+    var rolloutPercentage: Int? { get }
+}
+
+/// Used to configure rollout groups for feature flags
+///
+struct FeatureFlagRolloutStore {
+    private let store: KeyValueDatabase
+
+    init(store: KeyValueDatabase = UserDefaults.standard) {
+        self.store = store
+    }
+
+    private func key(for featureFlag: RolloutConfigurableFlag) -> String {
+        return "ff-rollout-group-\(String(describing: featureFlag))"
+    }
+
+    /// Returns `true` if the assigned group is included in the specificed rollout.
+    ///
+    func isRolloutEnabled(for featureFlag: RolloutConfigurableFlag) -> Bool {
+        guard let rolloutPercentage = featureFlag.rolloutPercentage else {
+            return false
+        }
+        assert(rolloutPercentage >= 1 && rolloutPercentage <= 100, "Value must be between 1 and 100 inclusive")
+        let rolloutThreshold = rolloutPercentage * Constants.multiplier
+        return (1..<rolloutThreshold).contains(rolloutGroup(for: featureFlag))
+    }
+
+    /// Returns the assigned rollout group for the specified feature flag.
+    /// If the feature flag hasn't been assigned to a rollout group yet, assigns the flag to a group.
+    ///
+    private func rolloutGroup(for featureFlag: RolloutConfigurableFlag) -> Int {
+        let key = key(for: featureFlag)
+        if let value = store.object(forKey: key) as? Int {
+            return value
+        }
+        let group = Int.random(in: 0..<Constants.groupSize)
+        store.set(group, forKey: key)
+        return group
+    }
+}
+
+private enum Constants {
+    static let groupSize = 100 * multiplier
+    static let multiplier = 10
+}

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlagRolloutStore.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlagRolloutStore.swift
@@ -16,10 +16,6 @@ struct FeatureFlagRolloutStore {
         self.store = store
     }
 
-    private func key(for featureFlag: RolloutConfigurableFlag) -> String {
-        return "ff-rollout-group-\(String(describing: featureFlag))"
-    }
-
     /// Returns `true` if the assigned group is included in the specificed rollout.
     ///
     func isRolloutEnabled(for featureFlag: RolloutConfigurableFlag) -> Bool {
@@ -28,24 +24,24 @@ struct FeatureFlagRolloutStore {
         }
         assert(rolloutPercentage >= 1 && rolloutPercentage <= 100, "Value must be between 1 and 100 inclusive")
         let rolloutThreshold = rolloutPercentage * Constants.multiplier
-        return (1..<rolloutThreshold).contains(rolloutGroup(for: featureFlag))
+        return (1..<rolloutThreshold).contains(rolloutGroup)
     }
 
     /// Returns the assigned rollout group for the specified feature flag.
     /// If the feature flag hasn't been assigned to a rollout group yet, assigns the flag to a group.
     ///
-    private func rolloutGroup(for featureFlag: RolloutConfigurableFlag) -> Int {
-        let key = key(for: featureFlag)
-        if let value = store.object(forKey: key) as? Int {
+    private var rolloutGroup: Int {
+        if let value = store.object(forKey: Constants.rolloutGroupKey) as? Int {
             return value
         }
         let group = Int.random(in: 0..<Constants.groupSize)
-        store.set(group, forKey: key)
+        store.set(group, forKey: Constants.rolloutGroupKey)
         return group
     }
 }
 
 private enum Constants {
+    static let rolloutGroupKey = "ff-rollout-group-key"
     static let groupSize = 100 * multiplier
     static let multiplier = 10
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -27,7 +27,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppRating
     case statsTrafficSubscribersTabs
     case siteMonitoring
-    case syncPublishing
     case readerDiscoverEndpoint
     case readingPreferences
     case readingPreferencesFeedback
@@ -84,8 +83,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .siteMonitoring:
             return false
-        case .syncPublishing:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .readerDiscoverEndpoint:
             return true
         case .readingPreferences:
@@ -148,9 +145,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "stats_traffic_subscribers_tabs"
         case .siteMonitoring:
             return "site_monitoring"
-        case .syncPublishing:
-            /// - warning: Work-in-progress (kahu-offline-mode)
-            return "_sync_publishing"
         case .readerDiscoverEndpoint:
             return "reader_discover_new_endpoint"
         case .readingPreferences:
@@ -212,8 +206,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Stats Traffic and Subscribers Tabs"
         case .siteMonitoring:
             return "Site Monitoring"
-        case .syncPublishing:
-            return "Synchronous Publishing"
         case .readerDiscoverEndpoint:
             return "Reader Discover New Endpoint"
         case .readingPreferences:

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -516,7 +516,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
     }
 
     private func presentNewPageNoticeIfNeeded() {
-        guard !RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard !FeatureFlag.syncPublishing.enabled else {
             return
         }
         // Validate if the post is a newly created page or not.

--- a/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
@@ -13,7 +13,7 @@ struct PageEditorPresenter {
             return false
         }
 
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             guard !PostCoordinator.shared.isUpdating(page) else {
                 return false // It's clear from the UI that the cells are not interactive
             }

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -83,7 +83,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
     }
 
     private func configure(with viewModel: PostSyncStateViewModel) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return
         }
 
@@ -135,7 +135,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         labelsStackView.spacing = 4
         labelsStackView.axis = .vertical
 
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             contentStackView.addArrangedSubviews([
                 indentationIconView, labelsStackView, UIView(), icon, indicator, featuredImageView, ellipsisButton
             ])
@@ -169,7 +169,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
     }
 
     private func setupIcon() {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return
         }
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -9,7 +9,7 @@ final class PageListItemViewModel {
     let accessibilityIdentifier: String?
     let syncStateViewModel: PostSyncStateViewModel
 
-    init(page: Page, isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+    init(page: Page, isSyncPublishingEnabled: Bool = FeatureFlag.syncPublishing.enabled) {
         self.page = page
         self.title = makeContentAttributedString(for: page)
         self.badgeIcon = makeBadgeIcon(for: page)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -17,7 +17,7 @@ extension PageListViewController: InteractivePostViewDelegate {
     }
 
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             guard let page = post as? Page else { return }
             return trashPage(page, completion: completion)
         }

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -233,7 +233,7 @@ class ParentPageSettingsViewController: UIViewController {
 
         selectedParentID = selectedRow?.page?.postID
 
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             Task {
                 await self.saveChanges()
             }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -14,7 +14,7 @@ struct AbstractPostMenuHelper {
     ///   - presentingView: The view presenting the menu
     ///   - delegate: The delegate that performs post actions
     func makeMenu(presentingView: UIView, delegate: InteractivePostViewDelegate) -> UIMenu? {
-        if RemoteFeatureFlag.syncPublishing.enabled(), !PostSyncStateViewModel(post: post).isEditable {
+        if FeatureFlag.syncPublishing.enabled, !PostSyncStateViewModel(post: post).isEditable {
             return nil
         }
         return UIMenu(title: "", options: .displayInline, children: [
@@ -127,7 +127,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .retry: return Strings.retry
         case .view: return post.status == .publish ? Strings.view : Strings.preview
         case .publish:
-            guard RemoteFeatureFlag.syncPublishing.enabled() else {
+            guard FeatureFlag.syncPublishing.enabled else {
                 return AbstractPostHelper.editorPublishAction(for: post).publishActionLabel
             }
             return Strings.publish

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -87,7 +87,7 @@ class EditPostViewController: UIViewController {
         modalPresentationStyle = .fullScreen
         modalTransitionStyle = .coverVertical
 
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             NotificationCenter.default.addObserver(self, selector: #selector(didChangeObjects), name: NSManagedObjectContext.didChangeObjectsNotification, object: blog.managedObjectContext)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -30,7 +30,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         isSitePostsPage: Bool,
         isJetpackFeaturesEnabled: Bool = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
         isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled(),
-        isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()
+        isSyncPublishingEnabled: Bool = FeatureFlag.syncPublishing.enabled
     ) {
         self.page = page
         self.isSiteHomepage = isSiteHomepage

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -36,7 +36,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
          isInternetReachable: Bool = ReachabilityUtils.isInternetReachable(),
          isJetpackFeaturesEnabled: Bool = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
          isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled(),
-         isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+         isSyncPublishingEnabled: Bool = FeatureFlag.syncPublishing.enabled) {
         self.post = post
         self.isInternetReachable = isInternetReachable
         self.isJetpackFeaturesEnabled = isJetpackFeaturesEnabled

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -32,7 +32,7 @@ extension PostEditor {
     }
 
     private func savePostBeforePreview(completion: @escaping ((String?, Error?) -> Void)) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _savePostBeforePreview(completion: completion)
         }
 
@@ -115,7 +115,7 @@ extension PostEditor {
             return
         }
 
-        if !RemoteFeatureFlag.syncPublishing.enabled() {
+        if !FeatureFlag.syncPublishing.enabled {
             guard post.remoteStatus != .pushing else {
                 displayPostIsUploadingAlert()
                 return
@@ -158,7 +158,7 @@ extension PostEditor {
     }
 
     func displayHistory() {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             _displayHistory()
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -75,7 +75,7 @@ extension PublishingEditor {
                 return
             }
 
-            let hasChanges = RemoteFeatureFlag.syncPublishing.enabled() ? self.post.hasChanges : self.post.hasLocalChanges()
+            let hasChanges = FeatureFlag.syncPublishing.enabled ? self.post.hasChanges : self.post.hasLocalChanges()
             if hasChanges {
                 guard let context = self.post.managedObjectContext else {
                     return
@@ -88,7 +88,7 @@ extension PublishingEditor {
     func handlePrimaryActionButtonTap() {
         let action = self.postEditorStateContext.action
 
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             publishPost(
                 action: action,
                 dismissWhenDone: action.dismissesEditor,
@@ -362,7 +362,7 @@ extension PublishingEditor {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(uploadFailureNoticeTag))
         stopEditing()
 
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _cancelEditing()
         }
 
@@ -418,7 +418,7 @@ extension PublishingEditor {
 
     @discardableResult
     func discardChanges() -> Bool {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _discardChanges()
         }
 
@@ -701,7 +701,7 @@ extension PublishingEditor {
     }
 
     func createRevisionOfPost(loadAutosaveRevision: Bool = false) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _createRevisionOfPost(loadAutosaveRevision: loadAutosaveRevision)
         }
         guard let managedObjectContext = post.managedObjectContext else {
@@ -795,7 +795,7 @@ private enum EditorError: Int {
 }
 
 struct PostEditorDebouncerConstants {
-    static let autoSavingDelay =  RemoteFeatureFlag.syncPublishing.enabled() ? Double(7.0) : Double(0.5)
+    static let autoSavingDelay =  FeatureFlag.syncPublishing.enabled ? Double(7.0) : Double(0.5)
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -103,7 +103,7 @@ extension PostEditor {
     }
 
     var editorHasChanges: Bool {
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             return !post.changes.isEmpty
         } else {
             return post.hasUnsavedChanges()
@@ -138,7 +138,7 @@ extension PostEditor {
 
 extension PostEditor where Self: UIViewController {
     func onViewDidLoad() {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return
         }
         showAutosaveAvailableAlertIfNeeded()

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -247,7 +247,7 @@ public class PostEditorStateContext {
         newPostStatus: BasePost.Status,
         userCanPublish: Bool
     ) -> PostEditorAction {
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             return action(status: originalPostStatus ?? .draft, userCanPublish: userCanPublish)
         } else {
             return _action(for: originalPostStatus, newPostStatus: newPostStatus, userCanPublish: userCanPublish)
@@ -384,7 +384,7 @@ public class PostEditorStateContext {
 
     /// - note: deprecated (kahu-offline-mode)
     var isSecondaryPublishButtonShown: Bool {
-        guard !RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard !FeatureFlag.syncPublishing.enabled else {
             return false
         }
 
@@ -436,7 +436,7 @@ public class PostEditorStateContext {
     /// Indicates whether the Publish Action should be allowed, or not
     ///
     private func updatePublishActionAllowed() {
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             switch action {
             case .schedule, .publish, .submitForReview:
                 publishActionAllowed = hasContent

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -87,7 +87,7 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
     }
 
     private func configure(with viewModel: PostSyncStateViewModel) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return
         }
         contentView.isUserInteractionEnabled = viewModel.isEditable

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -15,7 +15,7 @@ protocol EditorAnalyticsProperties: AnyObject {
 struct PostListEditorPresenter {
 
     static func handle(post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _handle(post: post, in: postListViewController)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -85,7 +85,7 @@ import Foundation
         let statuses: [BasePost.Status] = [.publish, .publishPrivate]
 
         let predicate: NSPredicate
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             let query =
             // existing published/private posts
             "(statusAfterSync = status AND status IN (%@))"
@@ -128,7 +128,7 @@ import Foundation
         let statusesForLocalDrafts: [BasePost.Status] = [.draft, .pending, .publish, .publishPrivate, .scheduled]
 
         let predicate: NSPredicate
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             let query =
             // Existing draft/pending posts
             "(statusAfterSync = status AND status IN (%@))"
@@ -170,7 +170,7 @@ import Foundation
         let statuses: [BasePost.Status] = [.scheduled]
 
         let predicate: NSPredicate
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             let query =
             // existing scheduled posts
             "(statusAfterSync = status AND status IN (%@))"
@@ -213,7 +213,7 @@ import Foundation
         let statuses: [BasePost.Status] = [.draft, .pending, .publish, .publishPrivate, .scheduled]
 
         let predicate: NSPredicate
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             let query =
             // Existing non-trashed posts
             "(statusAfterSync = status AND status IN (%@))"

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -36,7 +36,7 @@ final class PostListHeaderView: UIView {
     }
 
     func configure(with viewModel: PostSyncStateViewModel) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return
         }
 
@@ -67,7 +67,7 @@ final class PostListHeaderView: UIView {
         setupEllipsisButton()
 
         let stackView: UIStackView
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             let innerStackView = UIStackView(arrangedSubviews: [icon, indicator, ellipsisButton])
             innerStackView.spacing = 4
             stackView = UIStackView(arrangedSubviews: [textLabel, innerStackView])
@@ -84,7 +84,7 @@ final class PostListHeaderView: UIView {
     }
 
     private func setupIcon() {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return
         }
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListItemViewModel.swift
@@ -67,7 +67,7 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
     if !title.isEmpty {
         let attributes: [NSAttributedString.Key: Any] = [
             .font: WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold),
-            .foregroundColor: RemoteFeatureFlag.syncPublishing.enabled() ? foregroundColor : UIColor.text
+            .foregroundColor: FeatureFlag.syncPublishing.enabled ? foregroundColor : UIColor.text
         ]
         let titleAttributedString = NSAttributedString(string: title, attributes: attributes)
         string.append(titleAttributedString)
@@ -80,7 +80,7 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
         }
         let attributes: [NSAttributedString.Key: Any] = [
             .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular),
-            .foregroundColor: RemoteFeatureFlag.syncPublishing.enabled() ? foregroundColor : UIColor.text
+            .foregroundColor: FeatureFlag.syncPublishing.enabled ? foregroundColor : UIColor.text
         ]
         let snippetAttributedString = NSAttributedString(string: adjustedSnippet, attributes: attributes)
         string.append(snippetAttributedString)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -227,7 +227,7 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
     }
 
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return trashPost(post, completion: completion)
         }
         return super._trash(post, completion: completion)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -16,7 +16,7 @@ extension PostSettingsViewController {
     }
 
     static func showStandaloneEditor(for post: AbstractPost, from presentingViewController: UIViewController) {
-        let revision = RemoteFeatureFlag.syncPublishing.enabled() ? post._createRevision() : post.latest()
+        let revision = FeatureFlag.syncPublishing.enabled ? post._createRevision() : post.latest()
         let viewController = PostSettingsViewController.make(for: revision)
         viewController.isStandalone = true
         let navigation = UINavigationController(rootViewController: viewController)
@@ -31,7 +31,7 @@ extension PostSettingsViewController {
     @objc func setupStandaloneEditor() {
         guard isStandalone else { return }
 
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _setupStandaloneEditor()
         }
 
@@ -93,14 +93,14 @@ extension PostSettingsViewController {
     }
 
     @objc private func buttonCancelTapped() {
-        if RemoteFeatureFlag.syncPublishing.enabled() {
+        if FeatureFlag.syncPublishing.enabled {
             deleteRevision()
         }
         presentingViewController?.dismiss(animated: true)
     }
 
     @objc private func buttonSaveTapped() {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _buttonSaveTapped()
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -181,7 +181,7 @@ FeaturedImageViewControllerDelegate>
     [super viewWillDisappear:animated];
 
     if (self.isStandalone) {
-        if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+        if ([Feature enabled:FeatureFlagSyncPublishing]) {
             return; // No longer needed
         }
         if ((self.isBeingDismissed || self.parentViewController.isBeingDismissed) && !self.isStandaloneEditorDismissingAfterSave) {
@@ -672,7 +672,7 @@ FeaturedImageViewControllerDelegate>
         [metaRows addObject:@(PostSettingsRowAuthor)];
     }
 
-    if ([RemoteFeature enabled:RemoteFeatureFlagSyncPublishing]) {
+    if ([Feature enabled:FeatureFlagSyncPublishing]) {
         if (self.isDraftOrPending) {
             [metaRows addObject:@(PostSettingsRowPendingReview)];
         } else {

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -16,7 +16,7 @@ final class PostSyncStateViewModel {
 
     init(post: AbstractPost,
          isInternetReachable: Bool = ReachabilityUtils.isInternetReachable(),
-         isSyncPublishingEnabled: Bool = RemoteFeatureFlag.syncPublishing.enabled()) {
+         isSyncPublishingEnabled: Bool = FeatureFlag.syncPublishing.enabled) {
         self.post = post
         self.isInternetReachable = isInternetReachable
         self.isSyncPublishingEnabled = isSyncPublishingEnabled

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension PrepublishingViewController {
     static func show(for revision: AbstractPost, action: PostEditorAction, isStandalone: Bool = false, from presentingViewController: UIViewController, completion: @escaping (PrepublishingSheetResult) -> Void) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _show(for: revision, action: action, from: presentingViewController, completion: completion)
         }
         show(post: revision, isStandalone: isStandalone, from: presentingViewController, completion: completion)

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -10,7 +10,7 @@ struct PublishSettingsViewModel {
         case immediately
 
         init(post: AbstractPost) {
-            if RemoteFeatureFlag.syncPublishing.enabled() {
+            if FeatureFlag.syncPublishing.enabled {
                 if let date = post.dateCreated {
                     self = date > .now ? .scheduled(date) : .published(date)
                 } else {
@@ -31,7 +31,7 @@ struct PublishSettingsViewModel {
     let title: String?
 
     var detailString: String {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _detailString
         }
         switch state {
@@ -79,7 +79,7 @@ struct PublishSettingsViewModel {
     }
 
     mutating func setDate(_ date: Date?) {
-        guard RemoteFeatureFlag.syncPublishing.enabled() else {
+        guard FeatureFlag.syncPublishing.enabled else {
             return _setDate(date)
         }
         post.dateCreated = date

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5513,6 +5513,16 @@
 		FABB263F2602FC2C00C8785C /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF4DEAD7244B56E200ACA032 /* CoreServices.framework */; };
 		FABB28472603067C00C8785C /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FABB28462603067C00C8785C /* Launch Screen.storyboard */; };
 		FABB286C2603086900C8785C /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FABB286B2603086900C8785C /* AppImages.xcassets */; };
+		FABEC3502BDAABA8009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3512BDAABA8009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3522BDAAE60009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3532BDAAE61009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3542BDAAE62009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3552BDAAE62009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3572BDAAE6F009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3582BDAAE70009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC3592BDAAE71009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
+		FABEC35A2BDAAE71009F513C /* FeatureFlagRolloutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */; };
 		FAC086D725EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC086D525EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift */; };
 		FAC086D825EDFB1E00B94F2A /* ReaderRelatedPostsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FAC086D625EDFB1E00B94F2A /* ReaderRelatedPostsCell.xib */; };
 		FAC1B81E29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC1B81D29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift */; };
@@ -9470,6 +9480,7 @@
 		FABB26872602FCCA00C8785C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FABB28462603067C00C8785C /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		FABB286B2603086900C8785C /* AppImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppImages.xcassets; sourceTree = "<group>"; };
+		FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRolloutStore.swift; sourceTree = "<group>"; };
 		FAC086D525EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderRelatedPostsCell.swift; sourceTree = "<group>"; };
 		FAC086D625EDFB1E00B94F2A /* ReaderRelatedPostsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderRelatedPostsCell.xib; sourceTree = "<group>"; };
 		FAC1B81D29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeOverlayViewModel.swift; sourceTree = "<group>"; };
@@ -11027,7 +11038,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -17536,6 +17547,7 @@
 				F1D690141F828FF000200E30 /* BuildConfiguration.swift */,
 				F1D690151F828FF000200E30 /* FeatureFlag.swift */,
 				17A09B98238FE13B0022AE0D /* FeatureFlagOverrideStore.swift */,
+				FABEC34F2BDAABA8009F513C /* FeatureFlagRolloutStore.swift */,
 				803DE81528FFAEF2007D4E9C /* RemoteConfigParameter.swift */,
 				80A2153F29CA68D5002FE8EB /* RemoteFeatureFlag.swift */,
 				80A2154529D15B88002FE8EB /* RemoteConfigOverrideStore.swift */,
@@ -19464,7 +19476,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
@@ -21081,11 +21093,11 @@
 			files = (
 			);
 			inputPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 				"",
@@ -21280,13 +21292,13 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.inputs.xcfilelist,
 			);
 			inputPaths = (
 			);
 			name = "Copy Gutenberg JS";
 			outputFileListPaths = (
-				"$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist",
+				$SRCROOT/../Scripts/BuildPhases/CopyGutenbergJS.outputs.xcfilelist,
 			);
 			outputPaths = (
 			);
@@ -21318,6 +21330,7 @@
 			files = (
 				C9B4778729C85949008CBF49 /* LockScreenStatsWidgetEntry.swift in Sources */,
 				0107E0B428F97D5000DE87DB /* Constants.m in Sources */,
+				FABEC35A2BDAAE71009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				01CE5012290A890B00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				C9C21D7C29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */,
 				C9FE382F29C204E700D39841 /* LockScreenSingleStatViewModel.swift in Sources */,
@@ -21929,6 +21942,7 @@
 				F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */,
 				74989B8C2088E3650054290B /* BlogDetailsViewController+Activity.swift in Sources */,
 				FA3A28182A38D36900206D74 /* BlazeCampaignTableViewCell.swift in Sources */,
+				FABEC3502BDAABA8009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				B532D4EB199D4357006E4DF6 /* NoteBlockTableViewCell.swift in Sources */,
 				43DDFE8C21715ADD008BE72F /* WPTabBarController+QuickStart.swift in Sources */,
 				01616C8B2B5AA6E50023C123 /* StatsTrafficBarChartTabs.swift in Sources */,
@@ -23420,6 +23434,7 @@
 				736584EB2137533A0029C9A4 /* NotificationContentView.swift in Sources */,
 				73D5AC63212622B200ADDDD2 /* NotificationViewController.swift in Sources */,
 				436110DE22C41B02000773AD /* BuildConfiguration.swift in Sources */,
+				FABEC3542BDAAE62009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				01CE500F290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */,
 				FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				73F6DD44212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
@@ -23443,6 +23458,7 @@
 				7335AC5B21220ADD0012EF2D /* FormattableContentStyles.swift in Sources */,
 				7335AC6A21220ED90012EF2D /* FormattableRangesFactory.swift in Sources */,
 				7335AC5C21220AF40012EF2D /* FormattableContentAction.swift in Sources */,
+				FABEC3552BDAAE62009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				7335AC6B21220EF80012EF2D /* DefaultFormattableContentAction.swift in Sources */,
 				7335AC6421220E880012EF2D /* FormattableMediaContent.swift in Sources */,
 				7335AC6521220E940012EF2D /* FormattableTextContent.swift in Sources */,
@@ -23503,6 +23519,7 @@
 				740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */,
 				9822D8DE214194EB0092CBD1 /* NoResultsViewController.swift in Sources */,
 				74021A1A202E1502006CC39F /* WPStyleGuide+Gridicon.swift in Sources */,
+				FABEC3532BDAAE61009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				74021A04202E1307006CC39F /* String+Extensions.swift in Sources */,
 				747F88C42037791B00523C7C /* TableViewKeyboardObserver.swift in Sources */,
 				4338672822B2E17F00C8DEBD /* BuildConfiguration.swift in Sources */,
@@ -23578,6 +23595,7 @@
 				809620E228E540D700940A5D /* AppExtensionsService.swift in Sources */,
 				809620E328E540D700940A5D /* ExtensionNotificationManager.swift in Sources */,
 				809620E428E540D700940A5D /* NoResultsViewController.swift in Sources */,
+				FABEC3572BDAAE6F009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				809620E528E540D700940A5D /* NSAttributedStringKey+Conversion.swift in Sources */,
 				809620E628E540D700940A5D /* SharePost.swift in Sources */,
 				809620E728E540D700940A5D /* ShareData.swift in Sources */,
@@ -23653,6 +23671,7 @@
 				8096214328E55C9400940A5D /* NoResultsViewController.swift in Sources */,
 				8096214428E55C9400940A5D /* WPStyleGuide+Gridicon.swift in Sources */,
 				8096214528E55C9400940A5D /* String+Extensions.swift in Sources */,
+				FABEC3582BDAAE70009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				8096214628E55C9400940A5D /* TableViewKeyboardObserver.swift in Sources */,
 				8096214728E55C9400940A5D /* BuildConfiguration.swift in Sources */,
 				8096214828E55C9400940A5D /* ShareExtensionAbstractViewController.swift in Sources */,
@@ -23718,6 +23737,7 @@
 				80F6D02728EE866A00953C1A /* FormattableRangesFactory.swift in Sources */,
 				0107E11428FD7FE300DE87DB /* AppConfiguration.swift in Sources */,
 				80F6D02828EE866A00953C1A /* FormattableContentAction.swift in Sources */,
+				FABEC3592BDAAE71009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				80F6D02928EE866A00953C1A /* DefaultFormattableContentAction.swift in Sources */,
 				80F6D02A28EE866A00953C1A /* FormattableMediaContent.swift in Sources */,
 				80F6D02B28EE866A00953C1A /* FormattableTextContent.swift in Sources */,
@@ -23792,6 +23812,7 @@
 				74D06FEB1FE0788500AF1788 /* TextList+WordPress.swift in Sources */,
 				74FA2EE4200E8A6C001DDC13 /* AppExtensionsService.swift in Sources */,
 				74F89407202A1965008610FA /* ExtensionNotificationManager.swift in Sources */,
+				FABEC3522BDAAE60009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				9822D8DD214194EB0092CBD1 /* NoResultsViewController.swift in Sources */,
 				74D06FEC1FE0869D00AF1788 /* NSAttributedStringKey+Conversion.swift in Sources */,
 				E125F1E51E8E596200320B67 /* SharePost.swift in Sources */,
@@ -25297,6 +25318,7 @@
 				FABB23942602FC2C00C8785C /* LoginEpilogueUserInfo.swift in Sources */,
 				086F2483284F52DF00032F39 /* Tooltip.swift in Sources */,
 				8313B9FB2995A03C000AF26E /* JetpackRemoteInstallCardView.swift in Sources */,
+				FABEC3512BDAABA8009F513C /* FeatureFlagRolloutStore.swift in Sources */,
 				FABB23962602FC2C00C8785C /* StatsTableFooter.swift in Sources */,
 				FABB23972602FC2C00C8785C /* BlogSyncFacade.m in Sources */,
 				083683DE2B4859BB00331ED0 /* NotificationsViewModel.swift in Sources */,


### PR DESCRIPTION
## Description
* Switches `syncPublishing` flag to a local feature flag
* Adds `FeatureFlagRolloutStore` to facilitate rolling out the flag to a specified percentage of users

## How to test

- Change `FeatureFlag.swift` L45 to `return FeatureFlagRolloutStore().isRolloutEnabled(for: self)` in order to test the percentage rollout mechanism
- Set a breakpoint on L43 of `FeatureFlagRolloutStore.swift`
- Run the app with the `syncPublishing` rollout percentage set to 1% 
- ✅ The sync publishing feature flag should disabled (highly likely, but not impossible that it's enabled if you make it into the 1% rollout group) 
- When the app hits the breakpoint, note the assigned rollout group and release the breakpoint
- Run the app with the `syncPublishing` rollout percentage set to a value higher than `assigned rollout group / 10` (e.g. if the assigned group was 120, set the rollout percentage to 13)
- ✅ The sync publishing feature flag should enabled  

## Regression Notes
1. Potential unintended areas of impact
sync publishing feature flag

2. What I did to test those areas of impact (or what existing automated tests I relied on)
tested manually

3. What automated tests I added (or what prevented me from doing so)
none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

