### PR TITLE
Rename Total Followers to Total Subscribers

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -93,7 +93,7 @@
         case .insightsCommentsTotals:
             return InsightsHeaders.commentsTotals
         case .insightsFollowerTotals:
-            return InsightsHeaders.followerTotals
+            return InsightsHeaders.subscribersTotal
         case .insightsMostPopularTime:
             return InsightsHeaders.mostPopularTime
         case .insightsTagsAndCategories:
@@ -401,7 +401,7 @@
         static let mostPopularTime = NSLocalizedString("stats.insights.mostPopularCard.title", value: "🔥 Most Popular Time", comment: "Insights 'Most Popular Time' header. Fire emoji should remain part of the string.")
         static let likesTotals = NSLocalizedString("Total Likes", comment: "Insights 'Total Likes' header")
         static let commentsTotals = NSLocalizedString("Total Comments", comment: "Insights 'Total Comments' header")
-        static let followerTotals = NSLocalizedString("Total Followers", comment: "Insights 'Total Followers' header")
+        static let subscribersTotal = NSLocalizedString("stats.insights.totalSubscribers.title", value: "Total Subscribers", comment: "Insights 'Total Subscribers' header")
         static let publicize = NSLocalizedString("Jetpack Social Connections", comment: "Insights 'Jetpack Social Connections' header")
         static let todaysStats = NSLocalizedString("Today", comment: "Insights 'Today' header")
         static let postingActivity = NSLocalizedString("Posting Activity", comment: "Insights 'Posting Activity' header")

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -492,8 +492,8 @@
     }
 
     struct TotalFollowers {
-        static let wordPress = NSLocalizedString("Total WordPress.com Followers: %@", comment: "Label displaying total number of WordPress.com followers. %@ is the total.")
-        static let email = NSLocalizedString("Total Email Followers: %@", comment: "Label displaying total number of Email followers. %@ is the total.")
+        static let wordPress = NSLocalizedString("stats.insights.totalSubscribers.dotcomCount", value: "Total WordPress.com Subscribers: %@", comment: "Label displaying total number of WordPress.com subscribers. %@ is the total.")
+        static let email = NSLocalizedString("stats.insights.totalSubscribers.emailCount", value: "Total Email Subscribers: %@", comment: "Label displaying total number of email subscribers. %@ is the total.")
     }
 
     static let noPostTitle = NSLocalizedString("(No Title)", comment: "Empty Post Title")


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/23099#issuecomment-2082055988 since some string updates got merged for 24.8 and some didn't.

I'll trigger another beta today which will submit new strings to glotpress.

## To test:

Check Stats -> Insights tab. Total Followers should be renamed to Total Subscribers. 

<img width="382" alt="total subscribers card" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/74e0e618-cc38-498d-8a74-d07332804799">

<img width="382" alt="total subscribers view" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/4062343/94b9a409-4465-4cf8-ac91-52346c18f617">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)