### PR TITLE
Do not reject builds waiting for TestFlight review to avoid CI failure

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -434,8 +434,12 @@ platform :ios do
       changelog: File.read(whats_new_path),
       distribute_external: true,
       groups: distribution_groups,
-      # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
-      reject_build_waiting_for_review: true
+      # If there is a build waiting for beta review, we ~~want~~ would like to to reject that so the new build can be submitted instead.
+      # Unfortunately, this is not (no longer?) possible via the ASC API.
+      # See https://github.com/fastlane/fastlane/issues/18408
+      #
+      # As a quick workaround to avoid CI failures, let's explicitly disable rejecting builds waiting for review.
+      reject_build_waiting_for_review: false
     )
   end
 


### PR DESCRIPTION
There is a [known](https://github.com/fastlane/fastlane/issues/18408)  limitation in the ASC API that does not allow removing builds from TestFlight review, despite Fastlane offering a parameter to do so.

To avoid failures in CI in the (rare) occurrence of submitting a beta while another one is still waiting or in review, this PR disables rejecting builds. 

## Testing

Unfortunately, the only way to test this would be to create two beta one after the other and verify the TestFlight upload from CI does not fail for the second one. This is possible but "expensive" to do. 

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.
