### PR TITLE
Fix duplicate localization keys

### DIFF
--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -168,7 +168,7 @@ private extension SubmitFeedbackViewController {
         )
 
         static let submitLoadingAnonymouslyMessage = NSLocalizedString(
-            "submit.feedback.submit.loading",
+            "submit.feedback.submitAnonymously.loading",
             value: "Sending anonymously",
             comment: "Notice informing user that their feedback is being submitted anonymously."
         )

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -267,7 +267,7 @@ extension PeopleViewController {
             case .viewers:
                 return NSLocalizedString("Viewers", comment: "Blog Viewers")
             case .email:
-                return NSLocalizedString("users.list.title.subscribers", value: "Email Subscribers", comment: "Site Email Subscribers")
+                return NSLocalizedString("users.list.title.emailSubscribers", value: "Email Subscribers", comment: "Site Email Subscribers")
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -157,7 +157,7 @@ extension ReaderSiteTopic {
         }
 
         let emptyTitle = NSLocalizedString(
-            "reader.no.tags.title",
+            "reader.no.blog.title",
             value: "Add a blog",
             comment: "No Tags View Button Label"
         )

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -7608,6 +7608,9 @@ with the filter chip button. */
 /* Reader settings button accessibility label. */
 "reader.navigation.settings.button.label" = "Reader Settings";
 
+/* No Tags View Button Label */
+"reader.no.blog.title" = "Add a blog";
+
 /* Title for button on the no followed blogs result screen */
 "reader.no.blogs.button" = "Discover Blogs";
 
@@ -7633,7 +7636,7 @@ with the filter chip button. */
 "reader.no.results.subscriptions.button" = "Go to Subscriptions";
 
 /* No Tags View Button Label */
-"reader.no.tags.title" = "Add a blog";
+"reader.no.tags.title" = "Add a tag";
 
 /* Notice title when blocking a blog fails. */
 "reader.notice.blog.blocked.failure" = "Unable to block blog";
@@ -9573,9 +9576,11 @@ Refer to: `reader.preferences.preview.body.feedback.format` */
 /* The button title for the Submit button in the In-App Feedback screen */
 "submit.feedback.submit.button" = "Submit";
 
-/* Notice informing user that their feedback is being submitted anonymously.
-   Notice informing user that their feedback is being submitted. */
+/* Notice informing user that their feedback is being submitted. */
 "submit.feedback.submit.loading" = "Sending";
+
+/* Notice informing user that their feedback is being submitted anonymously. */
+"submit.feedback.submitAnonymously.loading" = "Sending anonymously";
 
 /* The title for the the In-App Feedback screen */
 "submit.feedback.title" = "Feedback";
@@ -10962,8 +10967,10 @@ Refer to: `reader.preferences.preview.body.feedback.format` */
 /* Blog Users */
 "Users" = "Users";
 
-/* Site Email Subscribers
-   Site Subscribers */
+/* Site Email Subscribers */
+"users.list.title.emailSubscribers" = "Email Subscribers";
+
+/* Site Subscribers */
 "users.list.title.subscribers" = "Subscribers";
 
 /* Menus label for describing which menu the location uses in the header. */


### PR DESCRIPTION
While running `fastlane generate_strings_file_for_glotpress` command, it displayed warnings related to duplicated localization keys. We should fix it, otherwise, some screens will not have the expected translation if the same key is used with different values in different parts of the code

```
[13:00:59]: ▸ Key "submit.feedback.submit.loading" used with multiple values. Value "Sending" kept. Value "Sending anonymously" ignored.
[13:01:01]: ▸ Key "users.list.title.subscribers" used with multiple values. Value "Subscribers" kept. Value "Email Subscribers" ignored.
[13:01:01]: ▸ Key "reader.no.tags.title" used with multiple values. Value "Add a blog" kept. Value "Add a tag" ignored.
```