### PR TITLE
Reader: Add tags chip button to the tags feed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
@@ -3,6 +3,7 @@ struct ReaderTabItem: FilterTabBarItem, Hashable {
     let shouldHideStreamFilters: Bool
     let shouldHideSettingsButton: Bool
     let shouldHideTagFilter: Bool
+    let shouldHideBlogFilter: Bool
 
     let content: ReaderContent
 
@@ -14,9 +15,12 @@ struct ReaderTabItem: FilterTabBarItem, Hashable {
     init(_ content: ReaderContent) {
         self.content = content
         let filterableTopicTypes = [ReaderTopicType.following, .organization]
-        shouldHideStreamFilters = !filterableTopicTypes.contains(content.topicType) && content.type != .selfHostedFollowing
+        shouldHideStreamFilters = !filterableTopicTypes.contains(content.topicType)
+        && content.type != .selfHostedFollowing
+        && content.type != .tags
         shouldHideSettingsButton = content.type == .selfHostedFollowing
-        shouldHideTagFilter = content.topicType == .organization || FeatureFlag.readerTagsFeed.enabled
+        shouldHideTagFilter = content.topicType == .organization || (content.type != .tags && FeatureFlag.readerTagsFeed.enabled)
+        shouldHideBlogFilter = content.type == .tags
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -203,10 +203,14 @@ extension ReaderTabViewModel {
             return .none
         }()
 
-        var filters = [ReaderSiteTopic.filterProvider(for: siteType)]
+        var filters = [FilterProvider]()
 
         if !selectedStream.shouldHideTagFilter {
-            filters.insert(ReaderTagTopic.filterProvider(), at: 0)
+            filters.append(ReaderTagTopic.filterProvider())
+        }
+
+        if !selectedStream.shouldHideBlogFilter {
+            filters.append(ReaderSiteTopic.filterProvider(for: siteType))
         }
 
         streamFilters = filters


### PR DESCRIPTION
Fixes #23129 

## Description

Adds the tags chip button to the tags feed.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- 🔎 **Verify** the tags chip button is displayed and works correctly
- Navigate to the other feeds
- 🔎 **Verify** the tags chip does not appear

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
