### PR TITLE
Reader: Add empty state for tags feed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -18,31 +18,6 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         return ReaderCardService()
     }()
 
-    /// Tracks whether or not we should force sync
-    /// This is set to true after the Reader Manage view is dismissed
-    private var shouldForceRefresh = false
-
-    private lazy var selectInterestsViewController: ReaderSelectInterestsViewController = {
-        let title = NSLocalizedString("Discover and follow blogs you love", comment: "Reader select interests title label text")
-        let subtitle = NSLocalizedString(
-            "reader.select.tags.subtitle",
-            value: "Choose your tags",
-            comment: "Reader select interests subtitle label text"
-        )
-        let buttonTitleEnabled = NSLocalizedString("Done", comment: "Reader select interests next button enabled title text")
-        let buttonTitleDisabled = NSLocalizedString("Select a few to continue", comment: "Reader select interests next button disabled title text")
-        let loading = NSLocalizedString("Finding blogs and stories you’ll love...", comment: "Label displayed to the user while loading their selected interests")
-
-        let configuration = ReaderSelectInterestsConfiguration(
-            title: title,
-            subtitle: subtitle,
-            buttonTitle: (enabled: buttonTitleEnabled, disabled: buttonTitleDisabled),
-            loading: loading
-        )
-
-        return ReaderSelectInterestsViewController(configuration: configuration)
-    }()
-
     /// Whether the current view controller is visible
     private var isVisible: Bool {
         return isViewLoaded && view.window != nil
@@ -259,46 +234,6 @@ private extension ReaderCardsStreamViewController {
             } else {
                 self.showSelectInterestsView()
             }
-        }
-    }
-
-    func hideSelectInterestsView() {
-        guard selectInterestsViewController.parent != nil else {
-            if shouldForceRefresh {
-                scrollViewToTop()
-                displayLoadingStream()
-                super.syncIfAppropriate(forceSync: true)
-                shouldForceRefresh = false
-            }
-
-            return
-        }
-
-        scrollViewToTop()
-        displayLoadingStream()
-        super.syncIfAppropriate(forceSync: true)
-
-        UIView.animate(withDuration: 0.2, animations: {
-            self.selectInterestsViewController.view.alpha = 0
-        }) { _ in
-            self.selectInterestsViewController.remove()
-            self.selectInterestsViewController.view.alpha = 1
-        }
-    }
-
-    func showSelectInterestsView() {
-        guard selectInterestsViewController.parent == nil else {
-            return
-        }
-
-        selectInterestsViewController.view.frame = self.view.bounds
-        self.add(selectInterestsViewController)
-
-        selectInterestsViewController.didSaveInterests = { [weak self] _ in
-            guard let self else {
-                return
-            }
-            self.hideSelectInterestsView()
         }
     }
 }


### PR DESCRIPTION
Fixes #23131 

## Description

Adds the empty state for the "Your Tags" feed.

## Screenshots

| Light | Dark |
|---|---|
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-04-30 at 20 21 37](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/2c79b552-aea6-4b46-8dc4-acf04a60fa9e) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-04-30 at 20 21 35](https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/3ad087ce-70aa-4562-8537-42c83a4ea827) |

## Testing

To test:
- Launch Jetpack and login
- Remove all followed tags if necessary
- Navigate to the "Your Tags" feed
- 🔎 **Verify** the select tags view appears
- Tap on some tags
- Tap on Done
- 🔎 **Verify** the feed is updated, displaying the followed tags
- Unfollow all tags
- 🔎 **Verify** the select tags view appears
- Tap on the tags chip
- Tap on Manage
- Add a tag
- Navigate back
- 🔎 **Verify** the feed is updated, displaying the followed tags

## Regression Notes
1. Potential unintended areas of impact
Discover feed select interests view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
