### PR TITLE
Add slug and excerpt fields to Page Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 24.9
 -----
 * [*] Add "Parent Page" to "Page Settings" [#23136]
+* [*] Add "Slug" and "Excerpt" fields to "Page Settings" [#23135]
 
 24.8
 -----

--- a/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
@@ -13,6 +13,7 @@
     self.sections = @[
         @(PostSettingsSectionMeta),
         @(PostSettingsSectionFeaturedImage),
+        @(PostSettingsSectionMoreOptions),
         @(PostSettingsSectionPageAttributes)
     ];
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11225

## To test:

- Open Page Settings
- ✅ Verify that the settings contain "Slug" and "Excerpt" fields
- Update the fields and save
- ✅ Verify that the changes are reflected on the web

<img width="360" alt="Screenshot 2024-05-01 at 2 42 20 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/fbb7dde8-663e-4f9f-af61-de2970581978">

## Regression Notes
1. Potential unintended areas of impact: Page Settings
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
