### PR TITLE
Move ParentPageSettingsViewController to PostSettingsViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 24.9
 -----
-
+* [*] Add "Parent Page" to "Page Settings" [#23136]
 
 24.8
 -----

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController+Menu.swift
@@ -60,13 +60,6 @@ extension PageListViewController: InteractivePostViewDelegate {
         PostSettingsViewController.showStandaloneEditor(for: post, from: self)
     }
 
-    func setParent(for apost: AbstractPost) {
-        guard let page = apost as? Page else { return }
-        Task {
-            await setParentPage(for: page)
-        }
-    }
-
     func setHomepage(for apost: AbstractPost) {
         guard let page = apost as? Page else { return }
         WPAnalytics.track(.postListSetAsPostsPageAction)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -217,7 +217,7 @@ final class PageListViewController: AbstractPostListViewController {
             let pageIDs = pages.map { TaggedManagedObjectID($0) }
 
             do {
-                self.pages = try await buildPageTree(pageIDs: pageIDs)
+                self.pages = try await PostRepository().buildPageTree(pageIDs: pageIDs)
                     .map { pageID, hierarchyIndex in
                         let page = try coreDataStack.mainContext.existingObject(with: pageID)
                         page.hierarchyIndex = hierarchyIndex
@@ -232,29 +232,6 @@ final class PageListViewController: AbstractPostListViewController {
 
         tableView.reloadData()
         refreshResults()
-    }
-
-    /// Build page hierachy in background, which should not take long (less than 2 seconds for 6000+ pages).
-    @MainActor
-    func buildPageTree(pageIDs: [TaggedManagedObjectID<Page>]? = nil, request: NSFetchRequest<Page>? = nil) async throws -> [(pageID: TaggedManagedObjectID<Page>, hierarchyIndex: Int)] {
-        assert(pageIDs != nil || request != nil, "`pageIDs` and `request` can not both be nil")
-
-        let coreDataStack = ContextManager.shared
-        return try await coreDataStack.performQuery { context in
-            var pages = [Page]()
-
-            if let pageIDs {
-                pages = try pageIDs.map(context.existingObject(with:))
-            } else if let request {
-                pages = try context.fetch(request)
-            }
-
-            pages = pages.setHomePageFirst()
-
-            // The `hierarchyIndex` is not a managed property, so it needs to be returend along with the page object id.
-            return PageTree.hierarchyList(of: pages)
-                .map { (TaggedManagedObjectID($0), $0.hierarchyIndex) }
-        }
     }
 
     override func syncContentEnded(_ syncHelper: WPContentSyncHelper) {
@@ -428,40 +405,6 @@ final class PageListViewController: AbstractPostListViewController {
     }
 
     // MARK: - Cell Action Handling
-
-    @MainActor
-    func setParentPage(for page: Page) async {
-        let request = NSFetchRequest<Page>(entityName: Page.entityName())
-        let filter = PostListFilter.publishedFilter()
-        request.predicate = filter.predicate(for: blog, author: .everyone)
-        request.sortDescriptors = filter.sortDescriptors
-        do {
-            let context = ContextManager.shared.mainContext
-            var pages = try await buildPageTree(request: request)
-                .map { pageID, hierarchyIndex in
-                    let page = try context.existingObject(with: pageID)
-                    page.hierarchyIndex = hierarchyIndex
-                    return page
-                }
-            if let index = pages.firstIndex(of: page) {
-                pages = pages.remove(from: index)
-            }
-            let viewController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: page, onClose: { [weak self] in
-                self?.updateAndPerformFetchRequestRefreshingResults()
-            }, onSuccess: { [weak self] in
-                self?.handleSetParentSuccess()
-            } )
-            present(viewController, animated: true)
-        } catch {
-            assertionFailure("Failed to fetch pages: \(error)") // This should never happen
-        }
-    }
-
-    private func handleSetParentSuccess() {
-        let setParentSuccefullyNotice =  NSLocalizedString("Parent page successfully updated.", comment: "Message informing the user that their pages parent has been set successfully")
-        let notice = Notice(title: setParentSuccefullyNotice, feedbackType: .success)
-        ActionDispatcher.global.dispatch(NoticeAction.post(notice))
-    }
 
     func setPageAsHomepage(_ page: Page) {
         guard let homePageID = page.postID?.intValue else { return }

--- a/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageMenuViewModelTests.swift
@@ -26,7 +26,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.blaze],
-            [.setParent, .setHomepage, .setPostsPage],
+            [.setHomepage, .setPostsPage],
             [.stats, .settings],
             [.trash]
         ]
@@ -54,7 +54,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
-            [.setParent, .setHomepage, .setPostsPage],
+            [.setHomepage, .setPostsPage],
             [.stats, .settings],
             [.trash]
         ]
@@ -82,7 +82,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft, .duplicate, .share],
-            [.setParent, .setHomepage, .setPostsPage],
+            [.setHomepage, .setPostsPage],
             [.settings],
             [.trash]
         ]
@@ -111,7 +111,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.duplicate, .share],
             [.blaze],
-            [.setParent, .setPostsPage],
+            [.setPostsPage],
             [.stats, .settings]
         ]
         expect(buttons).to(equal(expectedButtons))
@@ -139,7 +139,7 @@ final class PageMenuViewModelTests: CoreDataTestCase {
             [.view],
             [.moveToDraft, .duplicate, .share],
             [.blaze],
-            [.setParent, .setHomepage, .setRegularPage],
+            [.setHomepage, .setRegularPage],
             [.stats, .settings],
             [.trash]
         ]
@@ -160,7 +160,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.publish, .duplicate],
-            [.setParent],
             [.settings],
             [.trash]
         ]
@@ -181,7 +180,6 @@ final class PageMenuViewModelTests: CoreDataTestCase {
         let expectedButtons: [[AbstractPostButton]] = [
             [.view],
             [.moveToDraft],
-            [.setParent],
             [.settings],
             [.trash]
         ]

--- a/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
@@ -10,7 +10,11 @@
 
 - (void)configureSections
 {
-    self.sections = @[@(PostSettingsSectionMeta),@(PostSettingsSectionFeaturedImage)];
+    self.sections = @[
+        @(PostSettingsSectionMeta),
+        @(PostSettingsSectionFeaturedImage),
+        @(PostSettingsSectionPageAttributes)
+    ];
 }
 
 - (Page *)page

--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -1,32 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Navigation Controller-->
-        <scene sceneID="sxx-aJ-IGT">
-            <objects>
-                <navigationController storyboardIdentifier="ParentPageSettings" id="QcV-Yi-qZN" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="i29-WU-Owk">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="en5-L6-oun" kind="relationship" relationship="rootViewController" id="vRa-sH-3cd"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="XES-bJ-l3d" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="516" y="1043"/>
-        </scene>
         <!--Parent Page Settings View Controller-->
         <scene sceneID="pZd-4V-qlT">
             <objects>
-                <viewController id="en5-L6-oun" customClass="ParentPageSettingsViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ParentPageSettings" id="en5-L6-oun" customClass="ParentPageSettingsViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="iSZ-D8-Et4"/>
                         <viewControllerLayoutGuide type="bottom" id="AEa-4M-1Cd"/>
@@ -35,18 +19,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="rFc-KI-K05">
-                                <rect key="frame" x="0.0" y="120" width="375" height="547"/>
-                                <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="rFc-KI-K05">
+                                <rect key="frame" x="0.0" y="76" width="375" height="591"/>
                             </tableView>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="DaX-Id-Nby">
-                                <rect key="frame" x="0.0" y="64" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="56"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="AEa-4M-1Cd" firstAttribute="top" secondItem="rFc-KI-K05" secondAttribute="bottom" id="B3g-Fs-lQX"/>
+                            <constraint firstAttribute="bottom" secondItem="rFc-KI-K05" secondAttribute="bottom" id="B3g-Fs-lQX"/>
                             <constraint firstAttribute="trailing" secondItem="rFc-KI-K05" secondAttribute="trailing" id="BNx-y3-pCd"/>
                             <constraint firstItem="rFc-KI-K05" firstAttribute="top" secondItem="DaX-Id-Nby" secondAttribute="bottom" id="G3L-26-jPU"/>
                             <constraint firstItem="rFc-KI-K05" firstAttribute="leading" secondItem="2DW-5s-50f" secondAttribute="leading" id="NDe-TA-NNm"/>
@@ -55,21 +38,8 @@
                             <constraint firstAttribute="trailing" secondItem="DaX-Id-Nby" secondAttribute="trailing" id="pDw-6f-r70"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="fJK-CD-lVY">
-                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="vsX-CE-sq7">
-                            <connections>
-                                <action selector="cancelAction:" destination="en5-L6-oun" id="7nD-eL-LcM"/>
-                            </connections>
-                        </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" enabled="NO" title="Done" id="Ybc-8A-PTe">
-                            <connections>
-                                <action selector="doneAction:" destination="en5-L6-oun" id="pGj-nC-QNQ"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="fJK-CD-lVY"/>
                     <connections>
-                        <outlet property="cancelButton" destination="vsX-CE-sq7" id="nQK-bh-bZX"/>
-                        <outlet property="doneButton" destination="Ybc-8A-PTe" id="dxy-DZ-9VV"/>
                         <outlet property="searchBar" destination="DaX-Id-Nby" id="3r8-LD-SOe"/>
                         <outlet property="tableView" destination="rFc-KI-K05" id="BE5-XQ-QGl"/>
                     </connections>
@@ -79,9 +49,4 @@
             <point key="canvasLocation" x="1240.8" y="1047.5262368815593"/>
         </scene>
     </scenes>
-    <resources>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -32,22 +32,12 @@ private struct Row: ImmuTableRow {
     }
 }
 
-extension Row: Equatable {
-    static func == (lhs: Row, rhs: Row) -> Bool {
-        return lhs.page?.postID == rhs.page?.postID
-    }
-}
-
 class ParentPageSettingsViewController: UIViewController {
     var onClose: (() -> Void)?
-    var onSuccess: (() -> Void)?
 
-    @IBOutlet private var cancelButton: UIBarButtonItem!
-    @IBOutlet private var doneButton: UIBarButtonItem!
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var searchBar: UISearchBar!
 
-    private let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
     private lazy var noResultsViewController = NoResultsViewController.controller()
     private var isSearching = false
     private var sections: [ImmuTableSection] {
@@ -59,14 +49,6 @@ class ParentPageSettingsViewController: UIViewController {
     private var rows: [ImmuTableSection]!
     private var filteredRows: [ImmuTableSection]!
     private var selectedPage: Page!
-    private var originalRow: Row?
-    private var selectedRow: Row? {
-        didSet {
-            doneButton.isEnabled = selectedRow != originalRow
-        }
-    }
-
-    private var selectedParentID: NSNumber?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -89,9 +71,6 @@ class ParentPageSettingsViewController: UIViewController {
 
     func set(pages: [Page], for page: Page) {
         selectedPage = page
-        selectedParentID = selectedPage.parentID
-        originalRow = originalRow(with: pages)
-        selectedRow = originalRow
 
         filteredRows = []
 
@@ -103,15 +82,10 @@ class ParentPageSettingsViewController: UIViewController {
     // MARK: - Private methods
 
     private func setupUI() {
-        navigationItem.title = NSLocalizedString("Set Parent", comment: "Navigation title displayed on the navigation bar")
-
-        cancelButton.title = NSLocalizedString("Cancel", comment: "Text displayed by the left navigation button title")
-        doneButton.title = NSLocalizedString("Done", comment: "Text displayed by the right navigation button title")
+        navigationItem.title = NSLocalizedString("parentPageSettings.title", value: "Parent Page", comment: "Navigation title displayed on the navigation bar")
 
         searchBar.delegate = self
 
-        WPStyleGuide.setRightBarButtonItemWithCorrectSpacing(doneButton, for: navigationItem)
-        WPStyleGuide.setLeftBarButtonItemWithCorrectSpacing(cancelButton, for: navigationItem)
         WPStyleGuide.configureSearchBar(searchBar)
 
         setupTableView()
@@ -173,20 +147,12 @@ class ParentPageSettingsViewController: UIViewController {
         tableView.reloadSections(sections, with: animation)
     }
 
-    private func updatePage(_ completion: ((_ page: AbstractPost?, _ error: Error?) -> Void)?) {
-        postService.uploadPost(selectedPage, success: { uploadedPost in
-            completion?(uploadedPost, nil)
-        }) { error in
-            completion?(nil, error)
-        }
-    }
-
     private func originalRow(with pages: [Page]) -> Row? {
         if selectedPage.isTopLevelPage {
             return Row()
         }
 
-        guard let parent = (pages.first { $0.postID == selectedParentID }) else {
+        guard let parent = (pages.first { $0.postID == selectedPage.parentID }) else {
             return nil
         }
 
@@ -216,70 +182,6 @@ class ParentPageSettingsViewController: UIViewController {
             noResultsViewController.removeFromView()
         }
     }
-
-    private func dismiss() {
-        onClose?()
-        dismiss(animated: true)
-    }
-
-    // MARK: IBAction
-
-    @IBAction func doneAction(_ sender: UIBarButtonItem) {
-        WPAnalytics.track(.pageSetParentDonePressed)
-
-        SVProgressHUD.setDefaultMaskType(.clear)
-        SVProgressHUD.show(withStatus: NSLocalizedString("Updating...",
-                                                         comment: "Text displayed in HUD while a draft or scheduled post is being updated."))
-
-        selectedParentID = selectedRow?.page?.postID
-
-        if FeatureFlag.syncPublishing.enabled {
-            Task {
-                await self.saveChanges()
-            }
-        } else {
-            _saveChanges()
-        }
-    }
-
-    @MainActor
-    private func saveChanges() async {
-        do {
-            var changes = RemotePostUpdateParameters()
-            // - warning: `.some` is important to make sure the parameter is included
-            changes.parentPageID = .some(selectedParentID?.intValue)
-            try await PostCoordinator.shared._update(selectedPage.original(), changes: changes)
-
-            await SVProgressHUD.dismiss()
-            self.dismiss()
-            self.onSuccess?()
-        } catch {
-            await SVProgressHUD.dismiss()
-        }
-    }
-
-    /// - warning: deprecated (kahu-offline-mode)
-    private func _saveChanges() {
-        let parentId: NSNumber? = selectedPage.parentID
-        selectedPage.parentID = selectedRow?.page?.postID
-        updatePage { [weak self] (_, error) in
-            SVProgressHUD.dismiss()
-
-            if let error = error {
-                DDLogError("Error publishing post: \(error.localizedDescription)")
-                SVProgressHUD.showDismissibleError(withStatus: NSLocalizedString("Error occurred\nduring saving",
-                                                                                 comment: "Text displayed in HUD after attempting to save a draft post and an error occurred."))
-                self?.selectedPage.parentID = parentId
-            } else {
-                self?.dismiss()
-                self?.onSuccess?()
-            }
-        }
-    }
-
-    @IBAction func cancelAction(_ sender: UIBarButtonItem) {
-        dismiss()
-    }
 }
 
 extension ParentPageSettingsViewController: UITableViewDataSource {
@@ -297,7 +199,7 @@ extension ParentPageSettingsViewController: UITableViewDataSource {
         }
 
         let cell: CheckmarkTableViewCell = self.cell(for: tableView, at: indexPath, identifier: row.reusableIdentifier)
-        cell.on = selectedRow == row
+        cell.on = row.page?.postID == selectedPage.parentID
         row.configureCell(cell)
         return cell
     }
@@ -316,12 +218,10 @@ extension ParentPageSettingsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let row = sections[indexPath.section].rows[indexPath.row] as? Row,
-            row != selectedRow else {
+        guard let row = sections[indexPath.section].rows[indexPath.row] as? Row else {
             return
         }
-
-        selectedRow = row
+        selectedPage.parentID = row.page?.postID
         tableView.reloadData()
     }
 }
@@ -329,18 +229,14 @@ extension ParentPageSettingsViewController: UITableViewDelegate {
 /// ParentPageSettingsViewController class constructor
 //
 extension ParentPageSettingsViewController {
-    class func navigationController(with pages: [Page], selectedPage: Page, onClose: (() -> Void)? = nil, onSuccess: (() -> Void)? = nil) -> UINavigationController {
-        let storyBoard = UIStoryboard(name: "Pages", bundle: Bundle.main)
-        guard let controller = storyBoard.instantiateViewController(withIdentifier: "ParentPageSettings") as? UINavigationController else {
-            fatalError("A navigation view controller is required for Parent Page Settings")
+    class func make(with pages: [Page], selectedPage: Page, onClose: @escaping () -> Void) -> UIViewController {
+        let storyboard = UIStoryboard(name: "Pages", bundle: Bundle.main)
+        guard let viewController = storyboard.instantiateViewController(withIdentifier: "ParentPageSettings") as? ParentPageSettingsViewController else {
+            fatalError("A ParentPageSettingsViewController view controller is required for Parent Page Settings")
         }
-        guard let parentPageSettingsViewController = controller.viewControllers.first as? ParentPageSettingsViewController else {
-            fatalError("A ParentPageSettingsViewController is required for Parent Page Settings")
-        }
-        parentPageSettingsViewController.set(pages: pages, for: selectedPage)
-        parentPageSettingsViewController.onClose = onClose
-        parentPageSettingsViewController.onSuccess = onSuccess
-        return controller
+        viewController.set(pages: pages, for: selectedPage)
+        viewController.onClose = onClose
+        return viewController
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -105,7 +105,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .blaze: return UIImage(systemName: "flame")
         case .comments: return UIImage(systemName: "bubble.right")
         case .settings: return UIImage(systemName: "gearshape")
-        case .setParent: return UIImage(systemName: "text.append")
         case .setHomepage: return UIImage(systemName: "house")
         case .setPostsPage: return UIImage(systemName: "text.word.spacing")
         case .setRegularPage: return UIImage(systemName: "arrow.uturn.backward")
@@ -141,7 +140,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .blaze: return Strings.blaze
         case .comments: return Strings.comments
         case .settings: return Strings.settings
-        case .setParent: return Strings.setParent
         case .setHomepage: return Strings.setHomepage
         case .setPostsPage: return Strings.setPostsPage
         case .setRegularPage: return Strings.setRegularPage
@@ -177,8 +175,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
             delegate.comments(post)
         case .settings:
             delegate.showSettings(for: post)
-        case .setParent:
-            delegate.setParent(for: post)
         case .setHomepage:
             delegate.setHomepage(for: post)
         case .setPostsPage:
@@ -205,7 +201,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let retry = NSLocalizedString("posts.retry.actionTitle", value: "Retry", comment: "Retry uploading the post.")
         static let share = NSLocalizedString("posts.share.actionTitle", value: "Share", comment: "Share the post.")
         static let blaze = NSLocalizedString("posts.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the post with Blaze.")
-        static let setParent = NSLocalizedString("posts.setParent.actionTitle", value: "Set parent", comment: "Set the parent page for the selected page.")
         static let setHomepage = NSLocalizedString("posts.setHomepage.actionTitle", value: "Set as homepage", comment: "Set the selected page as the homepage.")
         static let setPostsPage = NSLocalizedString("posts.setPostsPage.actionTitle", value: "Set as posts page", comment: "Set the selected page as a posts page.")
         static let setRegularPage = NSLocalizedString("posts.setRegularPage.actionTitle", value: "Set as regular page", comment: "Set the selected page as a regular page.")

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -31,7 +31,6 @@ enum AbstractPostButton: Equatable {
 
     /// Specific to pages
     case pageAttributes
-    case setParent
     case setHomepage
     case setPostsPage
     case setRegularPage

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -15,14 +15,12 @@ protocol InteractivePostViewDelegate: AnyObject {
     func blaze(_ post: AbstractPost)
     func comments(_ post: AbstractPost)
     func showSettings(for post: AbstractPost)
-    func setParent(for post: AbstractPost)
     func setHomepage(for post: AbstractPost)
     func setPostsPage(for post: AbstractPost)
     func setRegularPage(for post: AbstractPost)
 }
 
 extension InteractivePostViewDelegate {
-    func setParent(for post: AbstractPost) {}
     func setHomepage(for post: AbstractPost) {}
     func setPostsPage(for post: AbstractPost) {}
     func setRegularPage(for post: AbstractPost) {}

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -110,8 +110,6 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             return AbstractPostButtonSection(buttons: buttons)
         }
 
-        buttons.append(.setParent)
-
         guard page.status == .publish else {
             return AbstractPostButtonSection(buttons: buttons)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -42,7 +42,8 @@ typedef NS_ENUM(NSInteger, PostSettingsRow) {
     PostSettingsRowSlug,
     PostSettingsRowExcerpt,
     PostSettingsRowSocialNoConnections,
-    PostSettingsRowSocialRemainingShares
+    PostSettingsRowSocialRemainingShares,
+    PostSettingsRowParentPage
 };
 
 static CGFloat CellHeight = 44.0f;
@@ -466,6 +467,8 @@ FeaturedImageViewControllerDelegate>
         return 1;
     } else if (sec == PostSettingsSectionMoreOptions) {
         return 2;
+    } else if (sec == PostSettingsSectionPageAttributes) {
+        return 1;
     }
 
     return 0;
@@ -502,6 +505,8 @@ FeaturedImageViewControllerDelegate>
     } else if (sec == PostSettingsSectionMoreOptions) {
         return NSLocalizedString(@"More Options", @"Label for the More Options area in post settings. Should use the same translation as core WP.");
 
+    } else if (sec == PostSettingsSectionPageAttributes) {
+        return NSLocalizedStringWithDefaultValue(@"postSettings.section.pageAttributes", nil, [NSBundle mainBundle], @"Page Attributes", @"Section title for Page Attributes");
     }
     return nil;
 }
@@ -584,6 +589,8 @@ FeaturedImageViewControllerDelegate>
         cell = [self configureRemainingSharesCell];
     } else if (sec == PostSettingsSectionMoreOptions) {
         cell = [self configureMoreOptionsCellForIndexPath:indexPath];
+    } else if (sec == PostSettingsSectionPageAttributes) {
+        cell = [self configurePageAttributesCellForIndexPath:indexPath];
     }
 
     return cell ?: [UITableViewCell new];
@@ -626,6 +633,8 @@ FeaturedImageViewControllerDelegate>
         [self showEditSlugController];
     } else if (cell.tag == PostSettingsRowExcerpt) {
         [self showEditExcerptController];
+    } else if (cell.tag == PostSettingsRowParentPage) {
+        [self showParentPageController];
     }
 }
 
@@ -1397,6 +1406,23 @@ FeaturedImageViewControllerDelegate>
     NSIndexPath *featureImageCellPath = [NSIndexPath indexPathForRow:0 inSection:[self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)]];
     [self.tableView reloadRowsAtIndexPaths:@[featureImageCellPath]
                           withRowAnimation:UITableViewRowAnimationFade];
+}
+
+// MARK: - Page Attributes
+
+- (UITableViewCell *)configurePageAttributesCellForIndexPath:(NSIndexPath *)indexPath
+{
+    return [self configureParentPageCell];
+}
+
+- (UITableViewCell *)configureParentPageCell
+{
+    UITableViewCell *cell = [self getWPTableViewDisclosureCell];
+    cell.textLabel.text = NSLocalizedStringWithDefaultValue(@"postSettings.parentPage", nil, [NSBundle mainBundle], @"Parent page", @"The 'Parent Page' setting of the post");
+    cell.detailTextLabel.text = [self getParentPageTitle];
+    cell.tag = PostSettingsRowParentPage;
+    cell.accessibilityIdentifier = @"Parent";
+    return cell;
 }
 
 #pragma mark - PostCategoriesViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
@@ -10,7 +10,8 @@ typedef enum {
     PostSettingsSectionDisabledTwitter, // NOTE: Clean up when Twitter has been removed from Publicize services.
     PostSettingsSectionSharesRemaining,
     PostSettingsSectionGeolocation,
-    PostSettingsSectionMoreOptions
+    PostSettingsSectionMoreOptions,
+    PostSettingsSectionPageAttributes
 } PostSettingsSection;
 
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13150

There are multiple pros to this approach:

- You can now create a new page, set a parent, and publish it without ever closing the editor
- Cleaner context menu with fewer rarely used actions (I'd fully remove "Page Attributes" if there is time)
- Much simpler implementation with one less entry point for syncing: we now simply use the existing code from PostSettingsViewController

## To test:

Follow these steps to change the parent page:

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0b45b859-7369-4bad-9792-b24153716602

- ✅ Verify that the "Set parent" context menu action was removed from the context menu in the post list

## Regression Notes
1. Potential unintended areas of impact: Page Settings
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
