### PR TITLE
Reader: Add accessibility labels to Reader tags feed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -2,6 +2,8 @@ import WordPressUI
 
 class ReaderTagCell: UICollectionViewCell {
 
+    private typealias AccessibilityConstants = ReaderPostCardCell.Constants.Accessibility
+
     @IBOutlet private weak var contentStackView: UIStackView!
     @IBOutlet private weak var headerStackView: UIStackView!
     @IBOutlet private weak var siteLabel: UILabel!
@@ -38,24 +40,7 @@ class ReaderTagCell: UICollectionViewCell {
     func configure(parent: UIViewController?, post: ReaderPost, isLoggedIn: Bool) {
         viewModel = ReaderTagCellViewModel(parent: parent, post: post, isLoggedIn: isLoggedIn)
 
-        let blogName = post.blogNameForDisplay()
-        let postDate = post.shortDateForDisplay()
-        let postTitle = post.titleForDisplay()
-        let postSummary = post.summaryForDisplay(isPad: traitCollection.userInterfaceIdiom == .pad)
-        let postCounts = post.countsForDisplay(isLoggedIn: isLoggedIn)
-
-        siteLabel.text = blogName
-        postDateLabel.text = postDate
-        titleLabel.text = postTitle
-        summaryLabel.text = postSummary
-        countsLabel.text = postCounts
-
-        siteLabel.isHidden = blogName == nil
-        postDateLabel.isHidden = postDate == nil
-        titleLabel.isHidden = postTitle == nil
-        summaryLabel.isHidden = postSummary == nil
-        countsLabel.isHidden = postCounts == nil
-
+        setupLabels(with: post, isLoggedIn: isLoggedIn)
         configureLikeButton(with: post)
         loadFeaturedImage(with: post)
     }
@@ -131,6 +116,35 @@ private extension ReaderTagCell {
         likeButton.setImage(isLiked ? Constants.likedButtonImage : Constants.likeButtonImage, for: .normal)
         likeButton.tintColor = isLiked ? .jetpackGreen : .secondaryLabel
         likeButton.setTitleColor(likeButton.tintColor, for: .normal)
+        likeButton.accessibilityHint = post.isLiked ? AccessibilityConstants.likedButtonHint : AccessibilityConstants.likeButtonHint
+    }
+
+    func setupLabels(with post: ReaderPost, isLoggedIn: Bool) {
+        let blogName = post.blogNameForDisplay()
+        let postDate = post.shortDateForDisplay()
+        let postTitle = post.titleForDisplay()
+        let postSummary = post.summaryForDisplay(isPad: traitCollection.userInterfaceIdiom == .pad)
+        let postCounts = post.countsForDisplay(isLoggedIn: isLoggedIn)
+
+        siteLabel.text = blogName
+        postDateLabel.text = postDate
+        titleLabel.text = postTitle
+        summaryLabel.text = postSummary
+        countsLabel.text = postCounts
+
+        siteLabel.isHidden = blogName == nil
+        postDateLabel.isHidden = postDate == nil
+        titleLabel.isHidden = postTitle == nil
+        summaryLabel.isHidden = postSummary == nil
+        countsLabel.isHidden = postCounts == nil
+
+        headerStackView.isAccessibilityElement = true
+        headerStackView.accessibilityLabel = [blogName, postDate].compactMap { $0 }.joined(separator: ", ")
+        headerStackView.accessibilityHint = AccessibilityConstants.siteStackViewHint
+        headerStackView.accessibilityTraits = .button
+        countsLabel.accessibilityLabel = postCounts?.replacingOccurrences(of: " • ", with: ", ")
+        menuButton.accessibilityLabel = AccessibilityConstants.menuButtonLabel
+        menuButton.accessibilityHint = AccessibilityConstants.menuButtonHint
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagFooterView.swift
@@ -12,10 +12,14 @@ class ReaderTagFooterView: UICollectionReusableView {
         setupStyles()
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onViewTapped))
         addGestureRecognizer(tapGesture)
+        isAccessibilityElement = true
+        accessibilityTraits = .button
     }
 
     func configure(with slug: String, onTapped: @escaping () -> Void) {
-        moreLabel.setText(String(format: Constants.moreText, slug))
+        let moreText = String(format: Constants.moreText, slug)
+        moreLabel.setText(moreText)
+        accessibilityLabel = moreText
         self.onTapped = onTapped
     }
 


### PR DESCRIPTION
Fixes #23137 

## Description

- Adds accessibility labels to the "Your Tags" feed
- Reuses accessibility labels/hints from `ReaderPostCardCell`

## Testing

To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- If you're using the simulator: Open the Accessibility Inspector
- If you're using a device: Enable VoiceOver
- Go through the accessibility labels and 🔎 **verify** each is set and voiced correctly

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
