### PR TITLE
Stats Subscribers: Dynamic type support improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -72,6 +72,8 @@ extension WPStyleGuide {
         static func configureLabelAsSubtitle(_ label: UILabel) {
             label.textColor = .DS.Foreground.secondary
             label.font = .DS.font(.footnote)
+            label.adjustsFontSizeToFitWidth = true
+            label.maximumContentSizeCategory = .accessibilityLarge
         }
 
         static func configureLabelAsLink(_ label: UILabel) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -7,6 +7,8 @@ class StatsBaseCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .headline)
+        label.maximumContentSizeCategory = .extraExtraExtraLarge
+        label.adjustsFontForContentSizeCategory = true
         label.adjustsFontSizeToFitWidth = true
         label.numberOfLines = 0
         return label

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -215,6 +215,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
         countLabel.adjustsFontSizeToFitWidth = true
         countLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         countLabel.setContentHuggingPriority(.required, for: .vertical)
+        countLabel.maximumContentSizeCategory = .accessibilityLarge
 
         comparisonLabel.font = .preferredFont(forTextStyle: .subheadline)
         comparisonLabel.textColor = .textSubtle

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -269,6 +269,11 @@ private extension StatsTotalRow {
         Style.configureViewAsSeparator(topExpandedSeparatorLine)
         Style.configureViewAsDataBar(dataBar)
 
+        [itemLabel, itemDetailLabel, dataLabel, secondDataLabel].forEach {
+            $0?.adjustsFontForContentSizeCategory = true
+            $0?.maximumContentSizeCategory = .extraExtraLarge
+        }
+
         [itemLabel, itemDetailLabel].forEach {
             $0?.numberOfLines = rowData.multiline ? 0 : 1
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -40,6 +40,7 @@ private extension ViewMoreRow {
         backgroundColor = .listForeground
         viewMoreLabel.text = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         viewMoreLabel.textColor = WPStyleGuide.Stats.actionTextColor
+        viewMoreLabel.maximumContentSizeCategory = .extraExtraExtraLarge
         if statSection == .insightsFollowersWordPress ||
             statSection == .insightsFollowersEmail ||
             statSection == .subscribersList ||


### PR DESCRIPTION
Fixes #23060

Make dynamic type improvements for Stats cells used in Subscribers tab. In most cases, I just limit the maximum content size category so the labels would grow to the appropriate size without breaking layout.

## To test:

1. Open Stats -> Subscribers
2. Increase/decrease dynamic type font size
3. Confirm that layout grows up until the point the UI is not broken

## Regression Notes
1. Potential unintended areas of impact

Shouldn't be any

4. What I did to test those areas of impact (or what existing automated tests I relied on)


5. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
