### PR TITLE
Reader: Show empty state for individual rows

### DIFF
--- a/WordPress/Classes/Utility/CollectionView/AdaptiveCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/Utility/CollectionView/AdaptiveCollectionViewFlowLayout.swift
@@ -1,0 +1,18 @@
+/// A flow layout that properly invalidates the layout when the collection view's bounds changed,
+/// (e.g., orientation changes).
+///
+/// This method ensures that we work with the latest/correct bounds after the size change, and potentially
+/// avoids race conditions where we might get incorrect bounds while the view is still in transition.
+///
+/// See: https://developer.apple.com/documentation/uikit/uicollectionviewlayout/1617781-shouldinvalidatelayout
+class AdaptiveCollectionViewFlowLayout: UICollectionViewFlowLayout {
+
+    override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {
+        // NOTE: Apparently we need to *manually* invalidate the layout because `invalidateLayout()`
+        // is NOT called after this method returns true.
+        if let collectionView, collectionView.bounds.size != newBounds.size {
+            invalidateLayout()
+        }
+        return super.shouldInvalidateLayout(forBoundsChange: newBounds)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -123,6 +123,7 @@ private extension ReaderTagCardCell {
     func registerCells() {
         let tagCell = UINib(nibName: ReaderTagCell.classNameWithoutNamespaces(), bundle: nil)
         let footerView = UINib(nibName: ReaderTagFooterView.classNameWithoutNamespaces(), bundle: nil)
+        collectionView.register(ReaderTagCardEmptyCell.self, forCellWithReuseIdentifier: ReaderTagCardEmptyCell.defaultReuseID)
         collectionView.register(tagCell, forCellWithReuseIdentifier: ReaderTagCell.classNameWithoutNamespaces())
         collectionView.register(footerView,
                                 forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
@@ -25,12 +25,12 @@
                     </connections>
                 </button>
                 <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
-                    <rect key="frame" x="24" y="62" width="288" height="297"/>
+                    <rect key="frame" x="16" y="62" width="296" height="297"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="297" id="uTt-pZ-gUW"/>
                     </constraints>
-                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="0Qb-19-SWX">
+                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="0Qb-19-SWX" customClass="AdaptiveCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
                         <size key="itemSize" width="240" height="297"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
                         <size key="footerReferenceSize" width="50" height="50"/>
@@ -43,7 +43,7 @@
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="GeQ-Gs-OvG" secondAttribute="bottom" id="2ng-2c-tFF"/>
                 <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="gUR-Rt-jPM" secondAttribute="trailing" id="7rj-F7-Ol7"/>
-                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" constant="8" id="8Dv-Lq-jru"/>
+                <constraint firstItem="GeQ-Gs-OvG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="8Dv-Lq-jru"/>
                 <constraint firstItem="GeQ-Gs-OvG" firstAttribute="top" secondItem="gUR-Rt-jPM" secondAttribute="bottom" constant="8" id="VRI-ge-6KZ"/>
                 <constraint firstItem="GeQ-Gs-OvG" firstAttribute="trailing" secondItem="iN0-l3-epB" secondAttribute="trailingMargin" id="ZNj-Nk-9pY"/>
                 <constraint firstItem="gUR-Rt-jPM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="24" id="gKT-Ns-5xs"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardEmptyCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardEmptyCell.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+import DesignSystem
+
+class ReaderTagCardEmptyCell: UICollectionViewCell, Reusable {
+
+    var tagTitle: String {
+        get {
+            swiftUIView.tagTitle
+        }
+        set {
+            swiftUIView.tagTitle = newValue
+        }
+    }
+
+    var retryHandler: (() -> Void)? = nil
+
+    private lazy var swiftUIView: ReaderTagCardEmptyCellView = {
+        ReaderTagCardEmptyCellView(buttonTapped: { [weak self] in
+            self?.retryHandler?()
+        })
+    }()
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+
+        let viewToEmbed = UIView.embedSwiftUIView(swiftUIView)
+        contentView.addSubview(viewToEmbed)
+        contentView.pinSubviewToAllEdges(viewToEmbed)
+    }
+
+    override func prepareForReuse() {
+        tagTitle = String()
+        retryHandler = nil
+        super.prepareForReuse()
+    }
+
+    func configure(tagTitle: String, retryHandler: (() -> Void)?) {
+        self.tagTitle = tagTitle
+        self.retryHandler = retryHandler
+    }
+}
+
+// MARK: - SwiftUI
+
+private struct ReaderTagCardEmptyCellView: View {
+
+    var tagTitle = String()
+    var buttonTapped: (() -> Void)? = nil
+
+    @ScaledMetric(relativeTo: Font.TextStyle.callout)
+    private var iconLength = 32.0
+
+    var body: some View {
+        VStack(spacing: .DS.Padding.double) {
+            Image(systemName: "wifi.slash")
+                .resizable()
+                .frame(width: iconLength, height: iconLength)
+                .foregroundStyle(Color.DS.Foreground.secondary)
+
+            // added to double the padding between the Image and the VStack.
+            Spacer().frame(height: .hairlineBorderWidth)
+
+            VStack(spacing: .DS.Padding.single) {
+                Text(Strings.title)
+                    .font(.callout)
+                    .fontWeight(.semibold)
+
+                Text(Strings.body)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button {
+                buttonTapped?()
+            } label: {
+                Text(Strings.buttonTitle)
+                    .font(.callout)
+                    .padding(.vertical, .DS.Padding.half)
+                    .padding(.horizontal, .DS.Padding.single)
+            }
+        }
+        .padding(.DS.Padding.single)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    private struct Strings {
+        static let title = NSLocalizedString(
+            "reader.tagStream.cards.emptyView.error.title",
+            value: "Posts failed to load",
+            comment: """
+            The title of an empty state component for one of the tags in the tag stream.
+            This empty state component is displayed only when the app fails to load posts under this tag.
+            """
+        )
+
+        static let body = NSLocalizedString(
+            "reader.tagStream.cards.emptyView.error.body",
+            value: "We couldn't load posts from this tag right now",
+            comment: """
+            The body text of an empty state component for one of the tags in the tag stream.
+            This empty state component is displayed only when the app fails to load posts under this tag.
+            """
+        )
+
+        static let buttonTitle = NSLocalizedString(
+            "reader.tagStream.cards.emptyView.button",
+            value: "Retry",
+            comment: """
+            Verb. The button title of an empty state component for one of the tags in the tag stream.
+            This empty state component is displayed only when the app fails to load posts under this tag.
+            When tapped, the app will try to reload posts under this tag.
+            """
+        )
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5651,6 +5651,8 @@
 		FE23EB4A26E7C91F005A1698 /* richCommentTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */; };
 		FE23EB4B26E7C91F005A1698 /* richCommentStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4826E7C91F005A1698 /* richCommentStyle.css */; };
 		FE23EB4C26E7C91F005A1698 /* richCommentStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4826E7C91F005A1698 /* richCommentStyle.css */; };
+		FE2590992BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2590982BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift */; };
+		FE25909A2BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2590982BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift */; };
 		FE25C235271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE25C236271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE29EFCD29A91160007CE034 /* WPAdminConvertibleRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29EFCC29A91160007CE034 /* WPAdminConvertibleRouter.swift */; };
@@ -5732,6 +5734,8 @@
 		FEAA6F79298CE4A600ADB44C /* PluginJetpackProxyServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAA6F78298CE4A600ADB44C /* PluginJetpackProxyServiceTests.swift */; };
 		FEAC916E28001FC4005026E7 /* AvatarTrainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAC916D28001FC4005026E7 /* AvatarTrainView.swift */; };
 		FEAC916F28001FC4005026E7 /* AvatarTrainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAC916D28001FC4005026E7 /* AvatarTrainView.swift */; };
+		FEC1B0CE2BE41A7400CB4A3D /* AdaptiveCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC1B0CD2BE41A7400CB4A3D /* AdaptiveCollectionViewFlowLayout.swift */; };
+		FEC1B0CF2BE41E1C00CB4A3D /* AdaptiveCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC1B0CD2BE41A7400CB4A3D /* AdaptiveCollectionViewFlowLayout.swift */; };
 		FEC26030283FBA1A003D886A /* BloggingPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC2602F283FBA1A003D886A /* BloggingPromptCoordinator.swift */; };
 		FEC26031283FBA1A003D886A /* BloggingPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC2602F283FBA1A003D886A /* BloggingPromptCoordinator.swift */; };
 		FEC26033283FC902003D886A /* RootViewCoordinator+BloggingPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC26032283FC902003D886A /* RootViewCoordinator+BloggingPrompt.swift */; };
@@ -9582,6 +9586,7 @@
 		FE1E201D2A49D59400CE7C90 /* JetpackSocialServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSocialServiceTests.swift; sourceTree = "<group>"; };
 		FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = richCommentTemplate.html; path = Resources/HTML/richCommentTemplate.html; sourceTree = "<group>"; };
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
+		FE2590982BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagCardEmptyCell.swift; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
 		FE29EFCC29A91160007CE034 /* WPAdminConvertibleRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAdminConvertibleRouter.swift; sourceTree = "<group>"; };
 		FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceTests.swift; sourceTree = "<group>"; };
@@ -9635,6 +9640,7 @@
 		FEAA6F78298CE4A600ADB44C /* PluginJetpackProxyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginJetpackProxyServiceTests.swift; sourceTree = "<group>"; };
 		FEAC916D28001FC4005026E7 /* AvatarTrainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarTrainView.swift; sourceTree = "<group>"; };
 		FEB7A8922718852A00A8CF85 /* WordPress 134.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 134.xcdatamodel"; sourceTree = "<group>"; };
+		FEC1B0CD2BE41A7400CB4A3D /* AdaptiveCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		FEC2602F283FBA1A003D886A /* BloggingPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptCoordinator.swift; sourceTree = "<group>"; };
 		FEC26032283FC902003D886A /* RootViewCoordinator+BloggingPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RootViewCoordinator+BloggingPrompt.swift"; sourceTree = "<group>"; };
 		FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptRemindersScheduler.swift; sourceTree = "<group>"; };
@@ -12800,6 +12806,7 @@
 				83BF48BD2BD6FA3000C0E1A1 /* ReaderTagCellViewModel.swift */,
 				83A8A2922BDC557E001F9133 /* ReaderTagFooterView.swift */,
 				83A8A2932BDC557E001F9133 /* ReaderTagFooterView.xib */,
+				FE2590982BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift */,
 			);
 			name = Cards;
 			sourceTree = "<group>";
@@ -14033,6 +14040,7 @@
 		8584FDB4192437160019C02E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				FEC1B0CC2BE41A5F00CB4A3D /* CollectionView */,
 				F4FF50E42B4D7D590076DB0C /* In-App Feedback */,
 				FE6BB14129322798001E5F7A /* Migration */,
 				8B85AED8259230C500ADBEC9 /* AB Testing */,
@@ -18883,6 +18891,14 @@
 			name = Detail;
 			sourceTree = "<group>";
 		};
+		FEC1B0CC2BE41A5F00CB4A3D /* CollectionView */ = {
+			isa = PBXGroup;
+			children = (
+				FEC1B0CD2BE41A7400CB4A3D /* AdaptiveCollectionViewFlowLayout.swift */,
+			);
+			path = CollectionView;
+			sourceTree = "<group>";
+		};
 		FEC2602D283FB9D4003D886A /* Blogging Prompts */ = {
 			isa = PBXGroup;
 			children = (
@@ -22602,6 +22618,7 @@
 				E62CE58E26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,
 				3F4A4C232AD3FA2E00DE5DF8 /* MySiteViewModel.swift in Sources */,
 				FACF66D02ADD6CD8008C3E13 /* PostListItemViewModel.swift in Sources */,
+				FE2590992BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift in Sources */,
 				B0F2EFBF259378E600C7EB6D /* SiteSuggestionService.swift in Sources */,
 				4388FF0020A4E19C00783948 /* NotificationsViewController+PushPrimer.swift in Sources */,
 				800035BD291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift in Sources */,
@@ -22625,6 +22642,7 @@
 				E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */,
 				981C3494218388CA00FC2683 /* SiteStatsDashboardViewController.swift in Sources */,
 				E1C5457E1C6B962D001CEB0E /* MediaSettings.swift in Sources */,
+				FEC1B0CE2BE41A7400CB4A3D /* AdaptiveCollectionViewFlowLayout.swift in Sources */,
 				02BF30532271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift in Sources */,
 				93C4864F181043D700A24725 /* ActivityLogDetailViewController.m in Sources */,
 				B57B99DE19A2DBF200506504 /* NSObject+Helpers.m in Sources */,
@@ -25170,6 +25188,7 @@
 				FABB22FB2602FC2C00C8785C /* ReaderFollowAction.swift in Sources */,
 				FABB22FC2602FC2C00C8785C /* SheetActions.swift in Sources */,
 				FABB22FD2602FC2C00C8785C /* ReaderTracker.swift in Sources */,
+				FEC1B0CF2BE41E1C00CB4A3D /* AdaptiveCollectionViewFlowLayout.swift in Sources */,
 				FABB22FE2602FC2C00C8785C /* PlanFeature.swift in Sources */,
 				17C1D7DD26735631006C8970 /* EmojiRenderer.swift in Sources */,
 				FABB22FF2602FC2C00C8785C /* Spotlightable.swift in Sources */,
@@ -25723,6 +25742,7 @@
 				0CED200D2B68425A00E6DD52 /* WebKitView.swift in Sources */,
 				FABB247F2602FC2C00C8785C /* StockPhotosPageable.swift in Sources */,
 				FABB24802602FC2C00C8785C /* JetpackRestoreStatusViewController.swift in Sources */,
+				FE25909A2BE3F4E2005690E9 /* ReaderTagCardEmptyCell.swift in Sources */,
 				B038A81E2BD70FCA00763731 /* StatsSubscribersChartCell.swift in Sources */,
 				FABB24812602FC2C00C8785C /* BindableTapGestureRecognizer.swift in Sources */,
 				FABB24822602FC2C00C8785C /* ReaderSearchSuggestion.swift in Sources */,


### PR DESCRIPTION
Part of #23069 

As titled, this shows an empty state cell when there are no posts under a tag. For cases with no internet connection, after loading fails, the collection view will still display cached posts (if it exists) before displaying the empty state cell. Some more technical changes:

- Added `Section` and `CardCellItem` in `ReaderTagCardCell` to encapsulate the section & item identifier of the diffable data source. Since the generic type now differs from the one returned from `NSFetchedResultsController`, I've added a method to translate them to the correct structure.
- Added `ReaderTagCardEmptyCell` for the empty state cell. This cell's width is set to the collection view's width.
- Added `AdaptiveCollectionViewFlowLayout` so that the collection view properly resizes on orientation change.
- In the `ReaderTagCardCell.xib`, I've removed the 8pt leading constraint since it made the empty cell look skewed/not centered. I can revert this if this value was intended.

Here's a preview:

Light | Dark
-|-
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/7c53aefb-c7ad-41ab-bc36-20850964881c" width=250> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/814d9cbd-6819-4e89-8ca8-718308a81872" width=250>


## To test

Since the collection view will still display the list if there are cached items, you can modify this line (ReaderTagCardCellViewModel.swift:L171) to ensure that the empty state cell will always be shown:

```swift
    let isEmpty = true // coreDataSnapshot.numberOfItems == .zero
```

- Launch the Jetpack app.
- Go to the Reader tab and switch to the tags stream.
- 🔎 Verify that the empty state cell is displayed correctly.
- Tap the 'Retry' button.
- 🔎 Verify that the cell shows the loading state, and then dismisses it after the request completes.
- Rotate the device.
- 🔎 Verify that the collection view resizes correctly.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Component is isolated and hidden behind a feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
