### PR TITLE
Stats Subscribers Analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -594,6 +594,11 @@ import Foundation
     case readingPreferencesSaved
     case readingPreferencesClosed
 
+    // Stats Subscribers
+    case statsSubscribersViewMoreTapped
+    case statsEmailsViewMoreTapped
+    case statsSubscribersChartTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1614,6 +1619,14 @@ import Foundation
             return "reader_reading_preferences_saved"
         case .readingPreferencesClosed:
             return "reader_reading_preferences_closed"
+
+        // Stats Subscribers
+        case .statsSubscribersViewMoreTapped:
+            return "stats_subscribers_view_more_tapped"
+        case .statsEmailsViewMoreTapped:
+            return "stats_emails_view_more_tapped"
+        case .statsSubscribersChartTapped:
+            return "stats_subscribers_chart_tapped"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsLineChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsLineChartView.swift
@@ -115,9 +115,10 @@ private extension StatsLineChartView {
 
         if case let .viewsAndVisitors(statsInsightsFilterDimension) = statType {
             properties[LineChartAnalyticsPropertyKey] = statsInsightsFilterDimension.analyticsProperty
+            WPAnalytics.track(.statsLineChartTapped, properties: properties)
+        } else if case .subscribers = statType {
+            WPAnalytics.track(.statsSubscribersChartTapped)
         }
-
-        WPAnalytics.track(.statsLineChartTapped, properties: properties)
     }
 
     func configureAndPopulateData() {

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -85,13 +85,14 @@ extension StatsSubscribersViewController: SiteStatsPeriodDelegate {
             guard let blog = RootViewCoordinator.sharedPresenter.mySitesCoordinator.currentBlog,
                   let peopleViewController = PeopleViewController.controllerWithBlog(blog, selectedFilter: .followers) else { return }
             navigationController?.pushViewController(peopleViewController, animated: true)
+            WPAnalytics.track(.statsSubscribersViewMoreTapped)
         case .subscribersEmailsSummary:
             let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
             detailTableViewController.configure(statSection: statSection)
             navigationController?.pushViewController(detailTableViewController, animated: true)
+            WPAnalytics.track(.statsEmailsViewMoreTapped)
         default:
-            // TODO
-            DDLogInfo("\(statSection) selected")
+            break
         }
     }
 }


### PR DESCRIPTION
Fixes #23058

#### Subscribers tab events

| Description                        | Event                           |
|------------------------------------|---------------------------------|
| Subscribers tab accessed                | `stats_subscribers_accessed`      |
| Subscribers list Card, View More tapped        | `stats_subscribers_view_more_tapped` |
| Emails Opens and Clicks Card, View More more tapped             | `stats_emails_view_more_tapped`   |
|    Tapping on Subscribers Line Chart     | `stats_subscribers_chart_tapped `  |


## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
