### PR TITLE
Offline Mode: Deduplicate new posts

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -265,3 +265,14 @@ extension AbstractPost {
         }
     }
 }
+
+extension AbstractPost {
+    var postHash: Int {
+        var hasher = Hasher()
+        hasher.combine(authorID)
+        hasher.combine(postTitle)
+        hasher.combine(content)
+        hasher.combine(dateCreated)
+        return hasher.finalize()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -541,7 +541,7 @@ class AbstractPostListViewController: UIViewController,
         let posts = try result.map { try coreDataStack.mainContext.existingObject(with: $0) }
         let hasMore = result.count >= number
 
-        return (posts, hasMore)
+        return (posts.deduplicated(by: \.postHash), hasMore)
     }
 
     func syncHelper(_ syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((_ hasMore: Bool) -> ())?, failure: ((_ error: NSError) -> ())?) {


### PR DESCRIPTION
Fixes  pe7hp4-N2-p2#comment-328

## Description 
* Fixes duplicate posts from appearing in the posts list when refresh and sync (upon regaining connectivity) happens in parallel

## Notes
* According to [Apple Docs](https://developer.apple.com/documentation/coredata/nsmanagedobject#1653965), you must not override `hash` for `NSManagedObject`, which is why I added the `postHash` computed variable

## How to test

Precondition: you are offline

- Create and save a new draft
- Open the post for editing and make more changes
- Enable connectivity
- Pull to refresh
- ✅ Verify that duplicate posts don't appear when refresh and sync (upon regaining connectivity) happens in parallel

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.