### PR TITLE
Improve visibility picker and integrate it in Post Settings

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+TitleForVisibility.swift
+++ b/WordPress/Classes/Models/AbstractPost+TitleForVisibility.swift
@@ -6,9 +6,15 @@ extension AbstractPost {
     static let publicLabel = NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP.")
 
     /// A title describing the status. Ie.: "Public" or "Private" or "Password protected"
-    ///
-    /// - warning: deprecated (kahu-offline-mode) (use ``PostVisibility``)
     @objc var titleForVisibility: String {
+        guard FeatureFlag.syncPublishing.enabled else {
+            return _titleForVisibility
+        }
+        return PostVisibility(status: status ?? .draft, password: password).localizedTitle
+    }
+
+    /// - warning: deprecated (kahu-offline-mode) (use ``PostVisibility``)
+    @objc private var _titleForVisibility: String {
         if password != nil {
             return AbstractPost.passwordProtectedLabel
         } else if status == .publishPrivate {

--- a/WordPress/Classes/Models/AbstractPost+TitleForVisibility.swift
+++ b/WordPress/Classes/Models/AbstractPost+TitleForVisibility.swift
@@ -10,7 +10,7 @@ extension AbstractPost {
         guard FeatureFlag.syncPublishing.enabled else {
             return _titleForVisibility
         }
-        return PostVisibility(status: status ?? .draft, password: password).localizedTitle
+        return PostVisibility(post: self).localizedTitle
     }
 
     /// - warning: deprecated (kahu-offline-mode) (use ``PostVisibility``)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -97,14 +97,10 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
             return .warning
         }
         switch post.status ?? .draft {
-        case .pending:
-            return .success
-        case .scheduled:
-            return .primary(.shade40)
         case .trash:
             return .error
         default:
-            return .neutral(.shade70)
+            return .secondaryLabel
         }
     }
 
@@ -277,9 +273,18 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     func statusAndBadges(separatedBy separator: String) -> String {
         let sticky = post.isStickyPost ? Constants.stickyLabel : ""
         let pending = (post.status == .pending && isSyncPublishingEnabled) ? Constants.pendingReview : ""
+        let visibility: String = {
+            let visibility = PostVisibility(post: post)
+            switch visibility {
+            case .public:
+                return ""
+            case .private, .protected:
+                return visibility.localizedTitle
+            }
+        }()
         let status = self.status ?? ""
 
-        return [status, pending, sticky].filter { !$0.isEmpty }.joined(separator: separator)
+        return [status, visibility, pending, sticky].filter { !$0.isEmpty }.joined(separator: separator)
     }
 
     /// Determine what the failed status message should be and return it.

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -186,6 +186,8 @@ extension PostSettingsViewController {
         let view = PostVisibilityPicker(visibility: PostVisibility(post: apost)) { [weak self] selection in
             guard let self else { return }
 
+            WPAnalytics.track(.editorPostVisibilityChanged, properties: ["via": "settings"])
+
             switch selection.visibility {
             case .public:
                 self.apost.status = .publish

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -2,6 +2,7 @@ import UIKit
 import CoreData
 import Combine
 import WordPressKit
+import SwiftUI
 
 extension PostSettingsViewController {
     static func make(for post: AbstractPost) -> PostSettingsViewController {
@@ -175,6 +176,32 @@ extension PostSettingsViewController {
 extension PostSettingsViewController: UIAdaptivePresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         deleteRevision()
+    }
+}
+
+// MARK: - PostSettingsViewController (Visibility)
+
+extension PostSettingsViewController {
+    @objc func showUpdatedPostVisibilityPicker() {
+        let view = PostVisibilityPicker(visibility: PostVisibility(post: apost)) { [weak self] selection in
+            guard let self else { return }
+
+            switch selection.visibility {
+            case .public:
+                self.apost.status = .publish
+            case .private:
+                self.apost.status = .publishPrivate
+            case .protected:
+                self.apost.status = .publish
+            }
+            self.apost.password = selection.password
+            self.navigationController?.popViewController(animated: true)
+            self.reloadData()
+        }
+        let viewController = UIHostingController(rootView: view)
+        viewController.title = PostVisibilityPicker.title
+        viewController.configureDefaultNavigationBarAppearance()
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -187,15 +187,16 @@ extension PostSettingsViewController {
             guard let self else { return }
 
             WPAnalytics.track(.editorPostVisibilityChanged, properties: ["via": "settings"])
-            NSLog("set-visibility: \(selection)")
 
             switch selection.type {
-            case .public:
-                self.apost.status = .publish
+            case .public, .protected:
+                if self.apost.status == .scheduled {
+                    // Keep it scheduled
+                } else {
+                    self.apost.status = .publish
+                }
             case .private:
                 self.apost.status = .publishPrivate
-            case .protected:
-                self.apost.status = .publish
             }
             self.apost.password = selection.password.isEmpty ? nil : selection.password
             self.navigationController?.popViewController(animated: true)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -187,6 +187,7 @@ extension PostSettingsViewController {
             guard let self else { return }
 
             WPAnalytics.track(.editorPostVisibilityChanged, properties: ["via": "settings"])
+            NSLog("set-visibility: \(selection)")
 
             switch selection.type {
             case .public:
@@ -196,7 +197,7 @@ extension PostSettingsViewController {
             case .protected:
                 self.apost.status = .publish
             }
-            self.apost.password = selection.password
+            self.apost.password = selection.password.isEmpty ? nil : selection.password
             self.navigationController?.popViewController(animated: true)
             self.reloadData()
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -190,12 +190,17 @@ extension PostSettingsViewController {
 
             switch selection.type {
             case .public, .protected:
-                if self.apost.status == .scheduled {
+                if self.apost.original().status == .scheduled {
                     // Keep it scheduled
                 } else {
                     self.apost.status = .publish
                 }
             case .private:
+                if self.apost.original().status == .scheduled {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
+                        self.showWarningPostWillBePublishedAlert()
+                    }
+                }
                 self.apost.status = .publishPrivate
             }
             self.apost.password = selection.password.isEmpty ? nil : selection.password
@@ -206,6 +211,12 @@ extension PostSettingsViewController {
         viewController.title = PostVisibilityPicker.title
         viewController.configureDefaultNavigationBarAppearance()
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    private func showWarningPostWillBePublishedAlert() {
+        let alert = UIAlertController(title: nil, message: Strings.warningPostWillBePublishedAlertMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Ok", comment: "Ok"), style: .default))
+        present(alert, animated: true)
     }
 }
 
@@ -270,4 +281,6 @@ extension PostSettingsViewController {
 
 private enum Strings {
     static let errorMessage = NSLocalizedString("postSettings.updateFailedMessage", value: "Failed to update the post settings", comment: "Error message on post/page settings screen")
+
+    static let warningPostWillBePublishedAlertMessage = NSLocalizedString("postSettings.warningPostWillBePublishedAlertMessage", value: "By changing the visibility to 'Private', the post will be published immediately", comment: "An alert message explaning that by changing the visibility to private, the post will be published immediately to your site")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -183,12 +183,12 @@ extension PostSettingsViewController: UIAdaptivePresentationControllerDelegate {
 
 extension PostSettingsViewController {
     @objc func showUpdatedPostVisibilityPicker() {
-        let view = PostVisibilityPicker(visibility: PostVisibility(post: apost)) { [weak self] selection in
+        let view = PostVisibilityPicker(selection: .init(post: apost)) { [weak self] selection in
             guard let self else { return }
 
             WPAnalytics.track(.editorPostVisibilityChanged, properties: ["via": "settings"])
 
-            switch selection.visibility {
+            switch selection.type {
             case .public:
                 self.apost.status = .publish
             case .private:

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -215,7 +215,7 @@ extension PostSettingsViewController {
 
     private func showWarningPostWillBePublishedAlert() {
         let alert = UIAlertController(title: nil, message: Strings.warningPostWillBePublishedAlertMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("postSettings.ok",  value: "OK", comment: "Button OK"), style: .default))
+        alert.addAction(UIAlertAction(title: NSLocalizedString("postSettings.ok", value: "OK", comment: "Button OK"), style: .default))
         present(alert, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -215,7 +215,7 @@ extension PostSettingsViewController {
 
     private func showWarningPostWillBePublishedAlert() {
         let alert = UIAlertController(title: nil, message: Strings.warningPostWillBePublishedAlertMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Ok", comment: "Ok"), style: .default))
+        alert.addAction(UIAlertAction(title: NSLocalizedString("postSettings.ok",  value: "OK", comment: "Button OK"), style: .default))
         present(alert, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -711,7 +711,7 @@ FeaturedImageViewControllerDelegate>
         cell.tag = PostSettingsRowAuthor;
     } else if (row == PostSettingsRowPublishDate) {
         // Publish date
-        cell = [self getWPTableViewDisclosureCell];
+        cell = [self getWPTableViewDisclosureCellWithIdentifier:@"PostSettingsRowPublishDate"];
         cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
         // Note: it's safe to remove `shouldPublishImmediately` when
         // `RemoteFeatureFlagSyncPublishing` is enabled because this cell is not displayed.
@@ -746,7 +746,7 @@ FeaturedImageViewControllerDelegate>
 
     } else if (row == PostSettingsRowVisibility) {
         // Visibility
-        cell = [self getWPTableViewDisclosureCell];
+        cell = [self getWPTableViewDisclosureCellWithIdentifier:@"PostSettingsRowVisibility"];
         cell.textLabel.text = NSLocalizedString(@"Visibility", @"The visibility settings of the post. Should be the same as in core WP.");
         cell.detailTextLabel.text = [self.apost titleForVisibility];
         cell.tag = PostSettingsRowVisibility;
@@ -1016,12 +1016,15 @@ FeaturedImageViewControllerDelegate>
     return cell;
 }
 
-- (WPTableViewCell *)getWPTableViewDisclosureCell
+- (WPTableViewCell *)getWPTableViewDisclosureCell {
+    return [self getWPTableViewDisclosureCellWithIdentifier:@"WPTableViewDisclosureCellIdentifier"];
+}
+
+- (WPTableViewCell *)getWPTableViewDisclosureCellWithIdentifier:(NSString *)identifier
 {
-    static NSString *WPTableViewDisclosureCellIdentifier = @"WPTableViewDisclosureCellIdentifier";
-    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:WPTableViewDisclosureCellIdentifier];
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:identifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:WPTableViewDisclosureCellIdentifier];
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:identifier];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         [WPStyleGuide configureTableViewCell:cell];
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -67,7 +67,6 @@ FeaturedImageViewControllerDelegate>
 @property (nonatomic, strong) UITextField *passwordTextField;
 @property (nonatomic, strong) UIButton *passwordVisibilityButton;
 @property (nonatomic, strong) NSArray *postMetaSectionRows;
-@property (nonatomic, strong) NSArray *visibilityList;
 @property (nonatomic, strong) NSArray *formatsList;
 @property (nonatomic, strong) UIImage *featuredImage;
 @property (nonatomic, strong) NSData *animatedFeaturedImageData;
@@ -130,10 +129,6 @@ FeaturedImageViewControllerDelegate>
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [WPStyleGuide configureAutomaticHeightRowsFor:self.tableView];
-
-    self.visibilityList = @[NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),
-                           NSLocalizedString(@"Password protected", @"Privacy setting for posts set to 'Password protected'. Should be the same as in core WP."),
-                           NSLocalizedString(@"Private", @"Privacy setting for posts set to 'Private'. Should be the same as in core WP.")];
 
     [self setupFormatsList];
     [self setupPublicizeConnections];
@@ -689,9 +684,6 @@ FeaturedImageViewControllerDelegate>
                 @(PostSettingsRowPublishDate),
                 @(PostSettingsRowVisibility)
             ]];
-            if (self.apost.password) {
-                [metaRows addObject:@(PostSettingsRowPassword)];
-            }
         }
     } else {
         [metaRows addObject:@(PostSettingsRowPublishDate)];
@@ -1119,6 +1111,10 @@ FeaturedImageViewControllerDelegate>
 
 - (void)showPostVisibilitySelector
 {
+    if ([Feature enabled:FeatureFlagSyncPublishing]) {
+        [self showUpdatedPostVisibilityPicker];
+        return;
+    }
     PostVisibilitySelectorViewController *vc = [[PostVisibilitySelectorViewController alloc] init:self.apost];
     __weak PostVisibilitySelectorViewController *weakVc = vc;
     vc.completion = ^(NSString *__unused visibility) {

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
@@ -146,6 +146,10 @@ enum PostVisibility: Identifiable, CaseIterable {
         }
     }
 
+    init(post: AbstractPost) {
+        self.init(status: post.status ?? .draft, password: post.password)
+    }
+
     var id: PostVisibility { self }
 
     var localizedTitle: String {
@@ -163,7 +167,6 @@ enum PostVisibility: Identifiable, CaseIterable {
         case .private: NSLocalizedString("postVisibility.private.details", value: "Only visible to site admins and editors", comment: "Details for a 'Private' privacy setting")
         }
     }
-
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
@@ -10,7 +10,7 @@ struct PostVisibilityPicker: View {
         var password = ""
 
         init(post: AbstractPost) {
-            self.type = PostVisibility(status: post.status ?? .draft, password: post.password)
+            self.type = PostVisibility(post: post)
             self.password = post.password ?? ""
         }
     }
@@ -143,6 +143,10 @@ enum PostVisibility: Identifiable, CaseIterable {
     case `public`
     case `private`
     case protected
+
+    init(post: AbstractPost) {
+        self.init(status: post.status ?? .draft, password: post.password)
+    }
 
     init(status: AbstractPost.Status, password: String?) {
         if let password, !password.isEmpty {

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilityPicker.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct PostVisibilityPicker: View {
     @State private var selection: Selection
-    @State private var isEnteringPassword = false
     @State private var isDismissing = false
+    @FocusState private var isPasswordFieldFocused: Bool
 
     struct Selection {
         var type: PostVisibility
@@ -37,10 +37,12 @@ struct PostVisibilityPicker: View {
     private func makeRow(for visibility: PostVisibility) -> some View {
         Button(action: {
             withAnimation {
+                selection.type = visibility
+                selection.password = ""
+
                 if visibility == .protected {
-                    isEnteringPassword = true
+                    isPasswordFieldFocused = true
                 } else {
-                    selection.type = visibility
                     onSubmit(selection)
                 }
             }
@@ -51,48 +53,51 @@ struct PostVisibilityPicker: View {
                     Text(visibility.localizedDetails)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
-                        .opacity(isEnteringPassword ? 0.5 : 1)
+                        .opacity(visibility != .protected && isPasswordFieldFocused ? 0.4 : 1)
                 }
                 Spacer()
                 Image(systemName: "checkmark")
                     .tint(Color(uiColor: .primary))
-                    .opacity((selection.type == visibility && !isEnteringPassword) ? 1 : 0)
+                    .opacity((selection.type == visibility && !isPasswordFieldFocused) ? 1 : 0)
             }
         })
         .tint(.primary)
-        .disabled(isEnteringPassword && visibility != .protected)
+        .disabled(isPasswordFieldFocused && visibility != .protected)
 
-        if visibility == .protected, isEnteringPassword {
+        if visibility == .protected, selection.type == .protected {
             enterPasswordRows
         }
     }
 
     @ViewBuilder
     private var enterPasswordRows: some View {
-        PasswordField(password: $selection.password)
-            .onSubmit(savePassword)
+        PasswordField(password: $selection.password, isFocused: isPasswordFieldFocused)
+            .focused($isPasswordFieldFocused)
+            .onSubmit(buttonSavePasswordTapped)
 
-        HStack {
-            Button(Strings.cancel) {
-                withAnimation {
-                    selection.password = ""
-                    isEnteringPassword = false
+        if isPasswordFieldFocused {
+            HStack {
+                Button(Strings.cancel) {
+                    withAnimation {
+                        selection.type = .public
+                        selection.password = ""
+                    }
                 }
+                .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button(Strings.save, action: buttonSavePasswordTapped)
+                    .font(.body.weight(.medium))
+                    .disabled(selection.password.trimmingCharacters(in: .whitespaces).isEmpty)
             }
-            .keyboardShortcut(.cancelAction)
-            Spacer()
-            Button(Strings.save, action: savePassword)
-                .font(.body.weight(.medium))
-                .disabled(selection.password.isEmpty)
+            .buttonStyle(.plain)
+            .foregroundStyle(Color(uiColor: .brand))
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(Color(uiColor: .brand))
     }
 
-    private func savePassword() {
+    private func buttonSavePasswordTapped() {
         withAnimation {
-            selection.type = .protected
-            isEnteringPassword = false
+            isPasswordFieldFocused = false
+            selection.password = selection.password.trimmingCharacters(in: .whitespaces)
             isDismissing = true
             // Let the keyboard dismiss first to avoid janky animation
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(550)) {
@@ -105,13 +110,12 @@ struct PostVisibilityPicker: View {
 private struct PasswordField: View {
     @Binding var password: String
     @State var isSecure = true
-    @FocusState private var isFocused: Bool
+    let isFocused: Bool
 
     var body: some View {
         HStack {
             textField
-                .focused($isFocused)
-            if !password.isEmpty {
+            if isFocused && !password.isEmpty {
                 Button(action: { password = "" }) {
                     Image(systemName: "xmark.circle")
                         .foregroundStyle(.secondary)
@@ -123,8 +127,8 @@ private struct PasswordField: View {
             }
         }
         .buttonStyle(.plain)
-        .onAppear { isFocused = true }
     }
+
     @ViewBuilder
     private var textField: some View {
         if isSecure {

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -71,7 +71,7 @@ final class SiteCreator {
 
 // MARK: - Helper Extensions
 
-extension String {
+private extension String {
     var subdomain: String {
         return components(separatedBy: ".").first ?? ""
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21944. Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/23149.

This PR contains multiple fixes and improvements to the experience of changing Post Visibility. This is another change that lifted straight from Gutenberg to ensure it's familiar to WordPress users.

## Changes

- Integrate the new `PostVisibilityPicker` in `PostSettingsViewController` to allow us to remove `PostVisibilitySelectorViewController` in 24.9 or later. The password field is now displayed in the visibility picker to match Gutenberg.
- Fixes this crash https://github.com/wordpress-mobile/WordPress-iOS/issues/21944
- Fixes an issue where sometimes "Visibility" cell becomes disabled when not needed
    **RCA** *WPTableViewCell* doesn't implement `prepareForReuse`
- Update visibility picker to show current password (that's what Gutenberg and the production versions of the app do)
- Add missing "Password Protected" and "Private" badges to Post List
- Add an alert warning that changing the scheduled post status to "private" will lead to it being published immediately (matches Gutenberg)
- Fix how list applies badges color (just use `.secondary` for everything). Previously it would display seemingly arbitrary colors for certain post types.

## To test:

**Test 1.2**

- Publish a password-protected post
- Open Post Settings
- Change visibility to "public"
- Save
- ✅ Verify that save is successful (← was failing due TBD)

**Test 1.3**

- Publish a public post
- Open Post Settings
- Change visibility to "private"
- ✅ Verify that the "Publish Date" cell is disabled
- Open visibility picker again
- Close the picker
- ✅ Verify that the "Publish Date" cell is disabled and "Visibiliy" is not (← it was failing due to the cell reuse)

**Test 1.4**

- Open a scheduled post (without a password)
- Open Post Settings
- Change visibility to "protected" and select a password
- "Save" the visibility and "Save" post settings
- ✅ Verify that the post is still scheduled

**Test 1.5**

- Open a scheduled post (without a password)
- Open Post Settings
- Change visibility to "private" and "Save"
- ✅ Verify that an alert warning that the post will be published immediately is displayed
- Tap "Save" to save settings
- ✅ Verify that the post got published

**Test 1.6**

- ✅ Verify that the Post List screen display "private" and "password protected" visibility in status labels

## Regression Notes
1. Potential unintended areas of impact: Post Visibility
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
