### PR TITLE
Add defensive code to PostCoordinator.startSync

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -510,9 +510,10 @@ class PostCoordinator: NSObject {
 
     private func startSync(for post: AbstractPost) {
         guard let revision = post.getLatestRevisionNeedingSync() else {
-            let worker = getWorker(for: post)
-            worker.error = nil
-            postDidUpdateNotification(for: post)
+            if let worker = workers[post.objectID] {
+                worker.error = nil
+                postDidUpdateNotification(for: post)
+            }
             return DDLogInfo("sync: \(post.objectID.shortDescription) is already up to date")
         }
         startSync(for: post, revision: revision)


### PR DESCRIPTION
I'm not sure if it fixes anything, but this is a more precise version that doesn't create a new worker in case there is nothing to sync.

To test: n/a

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
