### PR TITLE
[Notifications Refresh] Improve comment moderation views transition smoothness

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationState.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationState.swift
@@ -1,6 +1,6 @@
-enum CommentModerationState: CaseIterable {
+enum CommentModerationState: Equatable {
     case pending
-    case approved
-    case liked
+    case approved(liked: Bool)
+    case spam
     case trash
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
@@ -13,106 +13,182 @@ struct CommentModerationView: View {
             Divider()
                 .foregroundStyle(Color.DS.Background.secondary)
             VStack(spacing: .DS.Padding.double) {
-                titleHStack
-                mainActionView
-                secondaryActionView
+                switch viewModel.state {
+                case .pending:
+                    Pending(viewModel: viewModel)
+                case .approved(let liked):
+                    Approved(viewModel: viewModel, liked: liked)
+                case .trash, .spam:
+                    TrashSpam(viewModel: viewModel)
+                }
             }
             .padding(.horizontal, .DS.Padding.double)
         }
+        .animation(.smooth, value: viewModel.state)
+    }
+}
+
+// MARK: - Subviews
+
+private struct Container<T: View, V: View>: View {
+
+    let title: String
+    let icon: V
+    let content: T
+
+    private let animationDuration = 0.25
+
+    private var animation: Animation {
+        return .smooth(duration: animationDuration)
     }
 
-    private var titleHStack: some View {
+    init(title: String, @ViewBuilder icon: () -> V = { EmptyView() }, @ViewBuilder content: () -> T) {
+        self.content = content()
+        self.icon = icon()
+        self.title = title
+    }
+
+    var body: some View {
+        VStack(spacing: .DS.Padding.double) {
+            titleHStack
+            content
+        }
+        .padding(.horizontal, .DS.Padding.double)
+        .transition(
+            .asymmetric(
+                insertion: .opacity.animation(animation.delay(animationDuration * 1)),
+                removal: .opacity.animation(animation)
+            )
+        )
+    }
+
+    var titleHStack: some View {
         HStack(spacing: 0) {
-            switch viewModel.state {
-            case .pending:
-                Image.DS.icon(named: .clock)
-                    .resizable()
-                    .renderingMode(.template)
-                    .frame(width: .DS.Padding.double, height: .DS.Padding.double)
-                    .foregroundStyle(Color.DS.Foreground.secondary)
-                    .padding(.trailing, .DS.Padding.half)
-            case .approved, .liked:
-                Image.DS.icon(named: .checkmark)
-                    .resizable()
-                    .frame(width: 20, height: 20)
-                    .foregroundStyle(Color.DS.Foreground.secondary)
-                    .padding(.trailing, 2)
-            case .trash:
-                EmptyView()
-            }
-            Text(viewModel.state.title)
+            icon
+            Text(title)
                 .style(.caption)
                 .foregroundStyle(Color.DS.Foreground.secondary)
         }
     }
-
-    @ViewBuilder
-    private var mainActionView: some View {
-        switch viewModel.state.mainAction {
-        case let .cta(title, iconName):
-            DSButton(
-                title: title,
-                iconName: iconName,
-                style: DSButtonStyle(
-                    emphasis: .primary,
-                    size: .large
-                )) {
-                    withAnimation(.smooth) {
-                        viewModel.didTapPrimaryCTA()
-                    }
-                }
-        case .reply:
-            ContentPreview(
-                image: .init(url: viewModel.imageURL),
-                text: viewModel.userName
-            ) {
-                viewModel.didTapReply()
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var secondaryActionView: some View {
-        if case .more = viewModel.state.secondaryAction {
-            DSButton(
-                title: Strings.moreOptionsButtonTitle,
-                style: .init(emphasis: .tertiary, size: .large)) {
-                    viewModel.didTapMore()
-                }
-        } else if case .like = viewModel.state.secondaryAction {
-            DSButton(
-                title: viewModel.state == .approved ? String(
-                    format: Strings.commentLikeTitle,
-                    viewModel.userName
-                ) : Strings.commentLikedTitle,
-                iconName: viewModel.state == .approved ? .starOutline : .starFill,
-                style: .init(
-                    emphasis: .tertiary,
-                    size: .large
-                )
-            ) {
-                withAnimation(.interactiveSpring) {
-                    viewModel.didTapLike()
-                }
-            }
-        }
-    }
 }
 
-private extension CommentModerationView {
+private struct Pending: View {
+
+    let viewModel: CommentModerationViewModel
+
+    var body: some View {
+        Container(title: Strings.title, icon: { icon }) {
+            VStack {
+                DSButton(
+                    title: Strings.approveComment,
+                    iconName: .checkmark,
+                    style: DSButtonStyle(
+                        emphasis: .primary,
+                        size: .large
+                    )) {
+                        viewModel.didTapPrimaryCTA()
+                    }
+                DSButton(
+                    title: Strings.moreOptions,
+                    style: .init(emphasis: .tertiary, size: .large)) {
+                        viewModel.didTapMore()
+                    }
+            }
+        }
+    }
+
+    @ViewBuilder
+    var icon: some View {
+        Image.DS.icon(named: .clock)
+            .resizable()
+            .renderingMode(.template)
+            .frame(width: .DS.Padding.double, height: .DS.Padding.double)
+            .foregroundStyle(Color.DS.Foreground.secondary)
+            .padding(.trailing, .DS.Padding.half)
+    }
+
     enum Strings {
-        static let moreOptionsButtonTitle = NSLocalizedString(
+        static let title = NSLocalizedString(
+            "notifications.comment.moderation.pending.title",
+            value: "Comment pending moderation",
+            comment: "Title for Comment Moderation Pending State"
+        )
+        static let approveComment = NSLocalizedString(
+            "notifications.comment.approval.cta.title",
+            value: "Approve Comment",
+            comment: "Title for Comment Approval CTA"
+        )
+        static let moreOptions = NSLocalizedString(
             "notifications.comment.moderation.more.cta.title",
             value: "More options",
             comment: "More button title for comment moderation options sheet."
         )
+    }
+}
 
+private struct Approved: View {
+
+    let viewModel: CommentModerationViewModel
+    let liked: Bool
+
+    private var likeButtonTitle: String {
+        liked ? Strings.commentLikedTitle : String(format: Strings.commentLikeTitle, viewModel.userName)
+    }
+
+    var body: some View {
+        Container(title: Strings.title, icon: { icon }) {
+            VStack {
+                ContentPreview(
+                    image: .init(url: viewModel.imageURL, placeholder: Image("gravatar")),
+                    text: viewModel.userName
+                ) {
+                }
+                DSButton(
+                    title: likeButtonTitle,
+                    iconName: liked ? .starFill : .starOutline,
+                    style: .init(
+                        emphasis: .tertiary,
+                        size: .large
+                    )
+                ) {
+                    withAnimation(.interactiveSpring) {
+                        viewModel.didTapLike()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    var icon: some View {
+        Image.DS.icon(named: .checkmark)
+            .resizable()
+            .frame(width: 20, height: 20)
+            .foregroundStyle(Color.DS.Foreground.secondary)
+            .padding(.trailing, 2)
+    }
+
+    enum Strings {
+        static let title = NSLocalizedString(
+            "notifications.comment.moderation.approved.title",
+            value: "Comment approved",
+            comment: "Title for Comment Moderation Approved State"
+        )
+        static let approveComment = NSLocalizedString(
+            "notifications.comment.approval.cta.title",
+            value: "Approve Comment",
+            comment: "Title for Comment Approval CTA"
+        )
+        static let moreOptions = NSLocalizedString(
+            "notifications.comment.moderation.more.cta.title",
+            value: "More options",
+            comment: "More button title for comment moderation options sheet."
+        )
         static let commentLikedTitle = NSLocalizedString(
             "notifications.comment.liked.title",
             value: "Comment liked",
             comment: "Liked state title for comment like button."
         )
-
         static let commentLikeTitle = NSLocalizedString(
             "notifications.comment.like.title",
             value: "Like %@'s comment",
@@ -121,126 +197,91 @@ private extension CommentModerationView {
     }
 }
 
-private extension CommentModerationState {
-    enum MainAction {
-        case cta(title: String, iconName: IconName)
-        case reply
+private struct TrashSpam: View {
+
+    @ObservedObject var viewModel: CommentModerationViewModel
+
+    @State var title: String
+
+    init(viewModel: CommentModerationViewModel) {
+        self.viewModel = viewModel
+        self.title = Self.title(for: viewModel.state) ?? ""
     }
 
-    enum SecondaryAction {
-        case more
-        case like
-        case none
-    }
-
-    var title: String {
-        switch self {
-        case .pending:
-            return NSLocalizedString(
-                "notifications.comment.moderation.pending.title",
-                value: "Comment pending moderation",
-                comment: "Title for Comment Moderation Pending State")
-        case .approved, .liked:
-            return NSLocalizedString(
-                "notifications.comment.moderation.approved.title",
-                value: "Comment approved",
-                comment: "Title for Comment Moderation Approved State")
-        case .trash:
-            return NSLocalizedString(
-                "notifications.comment.moderation.trash.title",
-                value: "Comment in trash",
-                comment: "Title for Comment Moderation Trash State")
+    var body: some View {
+        Container(title: title) {
+            DSButton(
+                title: Strings.delete,
+                iconName: .trash,
+                style: .init(
+                    emphasis: .primary,
+                    size: .large
+                )
+            ) {
+            }
+        }.onChange(of: viewModel.state) { state in
+            if let title = Self.title(for: state) {
+                self.title = title
+            }
         }
     }
 
-    var mainAction: MainAction {
-        switch self {
-        case .pending:
-            return .cta(
-                title: NSLocalizedString(
-                    "notifications.comment.approval.cta.title",
-                    value: "Approve Comment",
-                    comment: "Title for Comment Approval CTA"
-                ),
-                iconName: .checkmark
-            )
-        case .approved:
-            return .reply
-        case .liked:
-            return .reply
-        case .trash:
-            return .cta(
-                title: NSLocalizedString(
-                    "notifications.comment.delete.cta.title",
-                    value: "Delete Permanently",
-                    comment: "Title for Comment Deletion CTA"
-                ),
-                iconName: .trash
-            )
+    static func title(for state: CommentModerationState) -> String? {
+        switch state {
+        case .spam: return Strings.spamTitle
+        case .trash: return Strings.trashTitle
+        default: return nil
         }
     }
 
-    var secondaryAction: SecondaryAction {
-        switch self {
-        case .pending:
-            return .more
-        case .approved, .liked:
-            return .like
-        case .trash:
-            return .none
-        }
+    enum Strings {
+        static let trashTitle = NSLocalizedString(
+            "notifications.comment.moderation.trash.title",
+            value: "Comment in trash",
+            comment: "Title for Comment Moderation Trash State"
+        )
+        static let spamTitle = NSLocalizedString(
+            "notifications.comment.moderation.spam.title",
+            value: "Comment in spam",
+            comment: "Title for Comment Moderation Spam State"
+        )
+        static let delete = NSLocalizedString(
+            "notifications.comment.delete.cta.title",
+            value: "Delete Permanently",
+            comment: "Title for Comment Deletion CTA"
+        )
     }
 }
 
-#Preview {
-    GeometryReader { proxy in
-        if #available(iOS 17.0, *) {
-            ScrollView(.horizontal) {
-                LazyHStack(spacing: 0) {
-                    CommentModerationView(
-                        viewModel: CommentModerationViewModel(
-                            state: .pending,
-                            imageURL: URL(string: "https://i.pravatar.cc/300"),
-                            userName: "John Smith"
-                        )
-                    )
-                    .frame(
-                        width: proxy.size.width
-                    )
-                    CommentModerationView(
-                        viewModel: CommentModerationViewModel(
-                            state: .approved,
-                            imageURL: URL(string: "https://i.pravatar.cc/300"),
-                            userName: "Jane Smith"
-                        )
-                    )
-                    .frame(
-                        width: proxy.size.width
-                    )
-                    CommentModerationView(
-                        viewModel: CommentModerationViewModel(
-                            state: .liked,
-                            imageURL: URL(string: "https://i.pravatar.cc/300"),
-                            userName: "John Smith"
-                        )
-                    )
-                    .frame(
-                        width: proxy.size.width
-                    )
-                    CommentModerationView(
-                        viewModel: CommentModerationViewModel(
-                            state: .trash,
-                            imageURL: URL(string: "https://i.pravatar.cc/300"),
-                            userName: "Jane Smith"
-                        )
-                    )
-                    .frame(
-                        width: proxy.size.width
-                    )
+// MARK: - Preview
+
+struct CommentModerationView_Previews: PreviewProvider {
+    static let viewModel = CommentModerationViewModel(
+        state: .pending,
+        imageURL: URL(string: "https://i.pravatar.cc/300"),
+        userName: "John Smith"
+    )
+
+    static var previews: some View {
+        ZStack {
+            VStack(spacing: .DS.Padding.double) {
+                Button("Pending") {
+                    viewModel.state = .pending
+                }
+                Button("Approve") {
+                    viewModel.state = .approved(liked: false)
+                }
+                Button("Spam") {
+                    viewModel.state = .spam
+                }
+                Button("Trash") {
+                    viewModel.state = .trash
                 }
             }
-            .scrollTargetBehavior(.paging)
-            .scrollIndicators(.hidden)
+            VStack {
+                Spacer()
+                CommentModerationView(viewModel: viewModel)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
@@ -268,7 +268,7 @@ struct CommentModerationView_Previews: PreviewProvider {
                 Button("Pending") {
                     viewModel.state = .pending
                 }
-                Button("Approve") {
+                Button("Approved") {
                     viewModel.state = .approved(liked: false)
                 }
                 Button("Spam") {

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
@@ -36,9 +36,17 @@ private struct Container<T: View, V: View>: View {
     let icon: V
     let content: T
 
+    private var transition: AnyTransition = .opacity
+
     private let animationDuration = 0.25
 
-    private var animation: Animation {
+    private let insertionAnimationDelay = 0.8
+
+    private var insertionAnimation: Animation {
+        return removalAnimation.delay(insertionAnimationDelay)
+    }
+
+    private var removalAnimation: Animation {
         return .smooth(duration: animationDuration)
     }
 
@@ -56,8 +64,8 @@ private struct Container<T: View, V: View>: View {
         .padding(.horizontal, .DS.Padding.double)
         .transition(
             .asymmetric(
-                insertion: .opacity.animation(animation.delay(animationDuration * 0.8)),
-                removal: .opacity.animation(animation)
+                insertion: transition.animation(insertionAnimation),
+                removal: transition.animation(removalAnimation)
             )
         )
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
@@ -56,7 +56,7 @@ private struct Container<T: View, V: View>: View {
         .padding(.horizontal, .DS.Padding.double)
         .transition(
             .asymmetric(
-                insertion: .opacity.animation(animation.delay(animationDuration * 1)),
+                insertion: .opacity.animation(animation.delay(animationDuration * 0.8)),
                 removal: .opacity.animation(animation)
             )
         )

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
@@ -1,6 +1,6 @@
 final class CommentModerationViewModel: ObservableObject {
     @Published var state: CommentModerationState
-    
+
     let imageURL: URL?
     let userName: String
 

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
@@ -1,5 +1,6 @@
 final class CommentModerationViewModel: ObservableObject {
     @Published var state: CommentModerationState
+    
     let imageURL: URL?
     let userName: String
 
@@ -21,10 +22,10 @@ final class CommentModerationViewModel: ObservableObject {
     func didTapPrimaryCTA() {
         switch state {
         case .pending:
-            state = .approved
-        case .trash:
+            state = .approved(liked: false)
+        case .trash, .spam:
             () // Delete comment
-        case .approved, .liked:
+        case .approved:
             break
         }
     }
@@ -34,6 +35,11 @@ final class CommentModerationViewModel: ObservableObject {
     }
 
     func didTapLike() {
-        state = state == .approved ? .liked : .approved
+        switch state {
+        case .approved(let liked):
+            state = .approved(liked: !liked)
+        default:
+            break
+        }
     }
 }


### PR DESCRIPTION
## Description

As the black “Approve Comment” button fades out, it creates an unusual visual effect against the lighter background, potentially detracting from the overall smoothness of the transition. This PR addresses this issue to ensure a smoother animation.

| Old Transition | New Transition |
| ----- | ----- |
|  <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/304b5757-55db-4ac3-9beb-ab59c1130b5a" ></video> | <video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/24f6de9f-527c-472c-81e2-f60f3aae6f9b" ></video> |

<video src="https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/ec3fbc0b-4717-4883-9542-247ffdd43c7f" ></video>

## Test Instructions

1. Go to `CommentModerationView.swift`.
2. Enable Previews.
3. Tap the buttons at the centers to change the moderation state.
4. **Verify** the transition is smooth.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
