### PR TITLE
Reader: Fix select interests unregistered cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -16,6 +16,7 @@ struct ReaderSelectInterestsConfiguration {
 class ReaderSelectInterestsViewController: UIViewController {
     private struct Constants {
         static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()
+        static let defaultCellIdentifier = "DefaultCell"
         static let interestsLabelMargin: CGFloat = 12
 
         static let cellCornerRadius: CGFloat = 5
@@ -168,6 +169,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     private func configureCollectionView() {
         let nib = UINib(nibName: String(describing: ReaderInterestsCollectionViewCell.self), bundle: nil)
         collectionView.register(nib, forCellWithReuseIdentifier: Constants.reuseIdentifier)
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: Constants.defaultCellIdentifier)
 
         guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
             return
@@ -325,7 +327,7 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
         guard let interest = dataSource.interest(for: indexPath.row) else {
             CrashLogging.main.logMessage("ReaderSelectInterestsViewController: Requested for data at invalid row",
                                          properties: ["row": indexPath.row], level: .warning)
-            return .init(frame: .zero)
+            return collectionView.dequeueReusableCell(withReuseIdentifier: Constants.defaultCellIdentifier, for: indexPath)
         }
 
         ReaderInterestsStyleGuide.applyCellLabelStyle(label: cell.label,


### PR DESCRIPTION
Fixes #22932 

Potentially fixes an issue where an unregistered collection view cell is returned from the `collectionView:cellForItemAtIndexPath:`. 

The crash is caused by the collection asking for an invalid index path, which is already guarded against and returns an empty `UICollectionViewCell`. However, this crashed because the cell is not registered... 😅 I believe the root cause of this is the invalid index path, which is likely to be a race condition due to updating the `interests` variable while the collection view is updating its cells.

To fix/mitigate this, I've: 

1. ~Dispatched the logic that updates `interests` AND reloads the collection view to the main thread.~ See https://github.com/wordpress-mobile/WordPress-iOS/pull/23158#discussion_r1593783869
2. Registered an empty `UICollectionViewCell` so that if the race condition is still happening, it doesn't immediately crash. It should be fine to show an empty cell since we should display a NoResults screen.

## To test

Note that I wasn't able to reproduce the crash, but these are the reproduction steps based on the logs:

- Prepare an account where you'd see the Select Interests screen when you go to Reader tab > Discover stream. 
- Launch the Jetpack app.
- Go to the Reader tab > Discover stream.
- After the select interests screen is shown, tap the Search icon.
- Minimize the app.
- Turn on airplane mode.
- Open the app again.
- Tap back.
- 🔎 Verify that the app does not crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

4. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
