### PR TITLE
Post Settings: Minor UI tweaks 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Add "Slug" and "Excerpt" fields to "Page Settings" [#23135]
 * [*] Make it easier to "Share" and "Blaze" a published post with an updated success view [##23128]
 * [*] Add support for viewing trashed posts and pages and restoring them from the editor [#23142]
+* [*] Impove the "Post Settings" screen groups/ordering to better align with Gutenberg [#23164]
 * [*] Update the "More" menu in the Editor to use modern iOS design and update copy to match Gutenberg [#23145]
 * [*] Update the "Revisions" list design and fix an issue with the footer displaying incorrect "Date Created" for drafts [#23145]
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -406,12 +406,12 @@ FeaturedImageViewControllerDelegate>
     NSNumber *stickyPostSection = @(PostSettingsSectionStickyPost);
     NSNumber *disabledTwitterSection = @(PostSettingsSectionDisabledTwitter);
     NSNumber *remainingSharesSection = @(PostSettingsSectionSharesRemaining);
-    NSMutableArray *sections = [@[ @(PostSettingsSectionTaxonomy),
-                                   @(PostSettingsSectionMeta),
-                                   @(PostSettingsSectionFormat),
+    NSNumber *shareSection = @(PostSettingsSectionShare);
+    NSMutableArray *sections = [@[ @(PostSettingsSectionMeta),
                                    @(PostSettingsSectionFeaturedImage),
+                                   @(PostSettingsSectionTaxonomy),
                                    stickyPostSection,
-                                   @(PostSettingsSectionShare),
+                                   shareSection,
                                    disabledTwitterSection,
                                    remainingSharesSection,
                                    @(PostSettingsSectionMoreOptions) ] mutableCopy];
@@ -424,6 +424,10 @@ FeaturedImageViewControllerDelegate>
 
     if (self.unsupportedConnections.count == 0) {
         [sections removeObject:disabledTwitterSection];
+    }
+
+    if ([self numberOfRowsForShareSection] == 0) {
+        [sections removeObject:shareSection];
     }
 
     if (![self showRemainingShares]) {
@@ -448,8 +452,6 @@ FeaturedImageViewControllerDelegate>
         return 2;
     } else if (sec == PostSettingsSectionMeta) {
         return [self.postMetaSectionRows count];
-    } else if (sec == PostSettingsSectionFormat) {
-        return 1;
     } else if (sec == PostSettingsSectionFeaturedImage) {
         return 1;
     } else if (sec == PostSettingsSectionStickyPost) {
@@ -461,7 +463,7 @@ FeaturedImageViewControllerDelegate>
     } else if (sec == PostSettingsSectionSharesRemaining) {
         return 1;
     } else if (sec == PostSettingsSectionMoreOptions) {
-        return 2;
+        return 3;
     } else if (sec == PostSettingsSectionPageAttributes) {
         return 1;
     }
@@ -477,9 +479,6 @@ FeaturedImageViewControllerDelegate>
 
     } else if (sec == PostSettingsSectionMeta) {
         return NSLocalizedString(@"Publish", @"Label for the publish (verb) button. Tapping publishes a draft post.");
-
-    } else if (sec == PostSettingsSectionFormat) {
-        return NSLocalizedString(@"Post Format", @"For setting the format of a post.");
 
     } else if (sec == PostSettingsSectionFeaturedImage) {
         return NSLocalizedString(@"Featured Image", @"Label for the Featured Image area in post settings.");
@@ -572,8 +571,6 @@ FeaturedImageViewControllerDelegate>
         cell = [self configureTaxonomyCellForIndexPath:indexPath];
     } else if (sec == PostSettingsSectionMeta) {
         cell = [self configureMetaPostMetaCellForIndexPath:indexPath];
-    } else if (sec == PostSettingsSectionFormat) {
-        cell = [self configurePostFormatCellForIndexPath:indexPath];
     } else if (sec == PostSettingsSectionFeaturedImage) {
         cell = [self configureFeaturedImageCellForIndexPath:indexPath];
     } else if (sec == PostSettingsSectionStickyPost) {
@@ -990,6 +987,8 @@ FeaturedImageViewControllerDelegate>
 - (UITableViewCell *)configureMoreOptionsCellForIndexPath:(NSIndexPath *)indexPath
 {
     if (indexPath.row == 0) {
+        return [self configurePostFormatCellForIndexPath:indexPath];
+    } else if (indexPath.row == 1) {
         return [self configureSlugCellForIndexPath:indexPath];
     } else {
         return [self configureExcerptCellForIndexPath:indexPath];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
@@ -3,10 +3,9 @@
 typedef enum {
     PostSettingsSectionTaxonomy = 0,
     PostSettingsSectionMeta,
-    PostSettingsSectionFormat,
     PostSettingsSectionFeaturedImage,
-    PostSettingsSectionStickyPost,
     PostSettingsSectionShare,
+    PostSettingsSectionStickyPost,
     PostSettingsSectionDisabledTwitter, // NOTE: Clean up when Twitter has been removed from Publicize services.
     PostSettingsSectionSharesRemaining,
     PostSettingsSectionGeolocation,


### PR DESCRIPTION
(This is a suggestion / not based on any project)

- Reduce the number of sections and align more closely with Gutenberg/Android
- Fix an issue with phantom before "More Options" due to an empty "Share" section

Here's before and after:

<img width="360" alt="Screenshot 2024-05-06 at 11 34 53 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/854e43c4-bafe-4e32-af00-16c5b05b01a2">
<img width="360" alt="Screenshot 2024-05-06 at 12 09 07 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/6401f6ee-7db1-4630-bee1-43e237e61b97">

To test:

## Regression Notes


1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
