### PR TITLE
Make the first Stats tab a default one if there's none selected

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -7,6 +7,7 @@ protocol UserPersistentRepositoryReader {
     func array(forKey key: String) -> [Any]?
     func dictionary(forKey key: String) -> [String: Any]?
     func url(forKey key: String) -> URL?
+    func value(forKey key: String) -> Any?
     func dictionaryRepresentation() -> [String: Any]
 }
 

--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -7,7 +7,6 @@ protocol UserPersistentRepositoryReader {
     func array(forKey key: String) -> [Any]?
     func dictionary(forKey key: String) -> [String: Any]?
     func url(forKey key: String) -> URL?
-    func value(forKey key: String) -> Any?
     func dictionaryRepresentation() -> [String: Any]
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -364,7 +364,12 @@ struct SiteStatsDashboardPreferences {
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else { return nil }
 
         let key = Self.lastSelectedStatsTabTypeKey(forSiteID: siteID)
-        return StatsTabType(rawValue: UserPersistentStoreFactory.instance().integer(forKey: key))
+
+        guard let tabRawValue = UserPersistentStoreFactory.instance().value(forKey: key) as? Int else {
+            return nil
+        }
+
+        return StatsTabType(rawValue: tabRawValue)
     }
 
     static func getSelectedPeriodUnit() -> StatsPeriodUnit? {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -365,7 +365,7 @@ struct SiteStatsDashboardPreferences {
 
         let key = Self.lastSelectedStatsTabTypeKey(forSiteID: siteID)
 
-        guard let tabRawValue = UserPersistentStoreFactory.instance().value(forKey: key) as? Int else {
+        guard let tabRawValue = UserPersistentStoreFactory.instance().object(forKey: key) as? Int else {
             return nil
         }
 


### PR DESCRIPTION
Fixes [#](https://github.com/Automattic/wordpress-mobile/issues/46#issuecomment-2096697512)

Make the first Stats tab a default one if there's none selected.

The issue with the current code is that user defaults return 0 even if integer value doesn't exist. 0 is the raw value of `Insights` tab. 

### To test:

#### Feature flag enabled
1. Fresh install Jetpack app
2. Enable Stats Subscribers and Traffic tab feature flag
3. Open Stats
4. Confirm Traffic is selected by default
5. Change to Subscribers
6. Leave and come back
7. Confirm Subscribers is selected

#### Feature flag disabled
1. Fresh install Jetpack app
2. Disable Stats Subscribers and Traffic tab feature flag
3. Open Stats
4. Confirm Insights is selected by default
5. Change to Years
6. Leave and come back
7. Confirm Years is selected

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


10. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
