### PR TITLE
Reader: Limit tag feed content length

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
@@ -32,10 +32,12 @@ extension ReaderPost {
                 .replacingOccurrences(of: "^\n+", with: "", options: .regularExpression)
                 .replacingOccurrences(of: "\n{2,}", with: "\n\n", options: .regularExpression)
                 .trim()
-            return content ?? contentPreviewForDisplay()
-        } else {
-            return contentPreviewForDisplay()
+            if let content {
+                let maxContentLength = isPad ? 4000 : 500
+                return String(content.prefix(maxContentLength))
+            }
         }
+        return contentPreviewForDisplay()
     }
 
     func countsForDisplay(isLoggedIn: Bool) -> String? {


### PR DESCRIPTION
## Description

Setting a label to an entire post's content was causing animation hitches on posts which had a lot of data. This sets a limit to the content's length depending on the device it'll display on.

Example of the issue with a long post:
<img width="625" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/0747a8a9-547f-4359-8c34-2b986c82e5ae">

## Testing

This was mostly visible on iPad, since it always return the extended content summary. 

To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- Scroll on the feed and find a post without a feature image and expanded content
- Scroll the table and collection views so that the post is loaded/unloaded
- 🔎 **Verify** there are no animation hitches while performing the above step


## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
