### PR TITLE
Offline Mode: Context menu items for posts with a version conflict

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -44,7 +44,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         var buttons = [AbstractPostButton]()
 
         if isSyncPublishingEnabled {
-            if page.status != .trash {
+            if !isTerminalError, page.status != .trash {
                 buttons.append(.view)
             }
         } else {
@@ -67,7 +67,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             buttons.append(.moveToDraft)
         }
 
-        if page.status == .publish || page.status == .draft {
+        if !isTerminalError && (page.status == .publish || page.status == .draft) {
             buttons.append(.duplicate)
         }
 
@@ -82,6 +82,13 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         }
 
         return AbstractPostButtonSection(buttons: buttons)
+    }
+
+    private var isTerminalError: Bool {
+        guard isSyncPublishingEnabled else {
+            return false
+        }
+        return PostSyncStateViewModel(post: page).state == .failed
     }
 
     private var canPublish: Bool {
@@ -106,7 +113,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
     private func createSetPageAttributesSection() -> AbstractPostButtonSection {
         var buttons = [AbstractPostButton]()
 
-        guard page.status != .trash else {
+        guard !isTerminalError, page.status != .trash else {
             return AbstractPostButtonSection(buttons: buttons)
         }
 
@@ -133,7 +140,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
         if isJetpackFeaturesEnabled, page.status == .publish && page.hasRemote() {
             buttons.append(.stats)
         }
-        if page.status != .trash {
+        if !isTerminalError, page.status != .trash {
             buttons.append(.settings)
         }
         return AbstractPostButtonSection(buttons: buttons)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -181,7 +181,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
         var buttons = [AbstractPostButton]()
 
         if isSyncPublishingEnabled {
-            if post.status != .trash {
+            if !isTerminalError, post.status != .trash {
                 buttons.append(.view)
             }
         } else {
@@ -204,7 +204,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
             buttons.append(.moveToDraft)
         }
 
-        if post.status == .publish || post.status == .draft || post.status == .pending {
+        if !isTerminalError && (post.status == .publish || post.status == .draft || post.status == .pending) {
             buttons.append(.duplicate)
         }
 
@@ -244,7 +244,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
         if isJetpackFeaturesEnabled, post.status == .publish && post.hasRemote() {
             buttons.append(contentsOf: [.stats, .comments])
         }
-        if post.status != .trash {
+        if !isTerminalError, post.status != .trash {
             buttons.append(.settings)
         }
 
@@ -254,6 +254,13 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     private func createTrashSection() -> AbstractPostButtonSection {
         let action: AbstractPostButton = post.original().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
+    }
+
+    private var isTerminalError: Bool {
+        guard isSyncPublishingEnabled else {
+            return false
+        }
+        return PostSyncStateViewModel(post: post).state == .failed
     }
 
     private var canCancelAutoUpload: Bool {


### PR DESCRIPTION
Fixes pe7hp4-N2-p2#comment-335

## Description
* Hides preview, duplicate, and settings context menu items if a post has a version conflict

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/8b277f0b-45d8-4e01-9ade-1d64ed50f445" width=200>


## Regression Notes
1. Potential unintended areas of impact
post context menu

2. What I did to test those areas of impact (or what existing automated tests I relied on)
tested manually

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
