### PR TITLE
[Notifications Refresh] Present Comment Moderations Options View

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -140,6 +140,10 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
         return cell
     }()
 
+    private weak var changeStatusViewController: UIViewController?
+
+    // MARK: -
+
     private lazy var commentService: CommentService = {
         return .init(coreDataStack: ContextManager.shared)
     }()
@@ -449,8 +453,8 @@ private extension CommentDetailViewController {
                 editButtonTapped()
             case .share:
                 shareCommentURL(sourceView: cell)
-            case .changeStatus(let status):
-                print("Option \(status) tapped")
+            case .changeStatus:
+                presentChangeStatusSheet()
             }
         }
         let contentConfig = CommentDetailContentTableViewCell.ContentConfiguration(comment: comment) { [weak self] _ in
@@ -711,6 +715,20 @@ private extension CommentDetailViewController {
         let bottomSheet = BottomSheetViewController(childViewController: viewController, customHeaderSpacing: 0)
         bottomSheet.show(from: self)
     }
+
+    func presentChangeStatusSheet() {
+        self.changeStatusViewController?.dismiss(animated: false)
+        let controller = CommentModerationOptionsViewController { [weak self] status in
+            guard let self else {
+                return
+            }
+            self.updateCommentStatus(status)
+            self.changeStatusViewController?.dismiss(animated: true)
+        }
+        let bottomSheetViewController = BottomSheetViewController(childViewController: controller, customHeaderSpacing: 0)
+        bottomSheetViewController.show(from: self)
+        self.changeStatusViewController = bottomSheetViewController
+    }
 }
 
 // MARK: - Strings
@@ -751,6 +769,15 @@ private extension CommentStatusType {
 // MARK: - Comment Moderation Actions
 
 private extension CommentDetailViewController {
+    func updateCommentStatus(_ status: CommentModerationOptionsView.Option) {
+        switch status {
+        case .pending: unapproveComment()
+        case .approve: approveComment()
+        case .spam: spamComment()
+        case .trash: trashComment()
+        }
+    }
+
     func unapproveComment() {
         isNotificationComment ? WPAppAnalytics.track(.notificationsCommentUnapproved,
                                                      withProperties: Constants.notificationDetailSource,

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -140,7 +140,7 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
         return cell
     }()
 
-    private weak var changeStatusViewController: UIViewController?
+    private weak var changeStatusViewController: BottomSheetViewController?
 
     // MARK: -
 

--- a/WordPress/Classes/ViewRelated/Comments/Content/CommentContentHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Content/CommentContentHeaderView.swift
@@ -54,11 +54,7 @@ struct CommentContentHeaderView: View {
         let onOptionSelected: (Option) -> Void
 
         enum Option {
-            case userInfo, share, editComment, changeStatus(Status)
-        }
-
-        enum Status {
-            case approve, pending, spam, trash
+            case userInfo, share, editComment, changeStatus
         }
     }
 }
@@ -94,12 +90,7 @@ private struct CommentContentHeaderMenu: View {
                 button(title: Strings.editComment, icon: .edit) { config.onOptionSelected(.editComment) }
             }
             if config.changeStatus {
-                Menu(Strings.changeStatus) {
-                    button(title: Strings.approve) { config.onOptionSelected(.changeStatus(.approve)) }
-                    button(title: Strings.pending) { config.onOptionSelected(.changeStatus(.pending)) }
-                    button(title: Strings.spam) { config.onOptionSelected(.changeStatus(.spam)) }
-                    button(title: Strings.trash) { config.onOptionSelected(.changeStatus(.trash)) }
-                }
+                button(title: Strings.changeStatus) { config.onOptionSelected(.changeStatus) }
             }
         } label: {
             Image.DS.icon(named: .ellipsisHorizontal)
@@ -146,26 +137,6 @@ private extension CommentContentHeaderMenu {
             "comment.moderation.content.menu.changeStatus.title",
             value: "Change status",
             comment: "Change status option title for the comment moderation content menu."
-        )
-        static let approve = NSLocalizedString(
-            "comment.moderation.content.menu.approve.title",
-            value: "Approve",
-            comment: "Approve option title for the comment moderation content menu."
-        )
-        static let pending = NSLocalizedString(
-            "comment.moderation.content.menu.pending.title",
-            value: "Pending",
-            comment: "Pending option title for the comment moderation content menu."
-        )
-        static let trash = NSLocalizedString(
-            "comment.moderation.content.menu.trash.title",
-            value: "Trash",
-            comment: "Trash option title for the comment moderation content menu."
-        )
-        static let spam = NSLocalizedString(
-            "comment.moderation.content.menu.spam.title",
-            value: "Spam",
-            comment: "Spam option title for the comment moderation content menu."
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationOptionsView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationOptionsView.swift
@@ -10,15 +10,20 @@ struct CommentModerationOptionsView: View {
         .spam
     ]
 
-    var optionSelected: ((Option) -> Void)?
+    let onOptionSelected: (Option) -> Void
+
+    init(onOptionSelected: @escaping (Option) -> Void) {
+        self.onOptionSelected = onOptionSelected
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: .DS.Padding.medium) {
+        VStack(alignment: .leading, spacing: .DS.Padding.double) {
             title
             optionsVStack
         }
-        .padding(.horizontal, .DS.Padding.double)
+        .padding(.DS.Padding.double)
         .background(Color.DS.Background.primary)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     private var title: some View {
@@ -31,12 +36,13 @@ struct CommentModerationOptionsView: View {
         VStack(spacing: .DS.Padding.medium) {
             ForEach(options, id: \.title) { option in
                 Button {
-                    optionSelected?(option)
+                    onOptionSelected(option)
                 } label: {
                     optionHStack(option: option)
                 }
             }
         }
+        .padding(.vertical, .DS.Padding.double)
     }
 
     private func optionHStack(option: Option) -> some View {
@@ -144,6 +150,20 @@ private extension CommentModerationOptionsView.Option {
     }
 }
 
+final class CommentModerationOptionsViewController: BottomSheetContentViewController {
+
+    typealias Option = CommentModerationOptionsView.Option
+
+    init(onOptionSelected: @escaping (Option) -> Void) {
+        let content = CommentModerationOptionsView(onOptionSelected: onOptionSelected)
+        super.init(contentView: content)
+    }
+
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 #Preview {
-    CommentModerationOptionsView()
+    CommentModerationOptionsView(onOptionSelected: { _ in })
 }

--- a/WordPress/Classes/ViewRelated/System/Bottom Sheet/BottomSheetContentViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Bottom Sheet/BottomSheetContentViewController.swift
@@ -1,0 +1,113 @@
+import UIKit
+import SwiftUI
+import WordPressUI
+
+class BottomSheetContentViewController: UIViewController {
+
+    // MARK: - Views
+
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.showsVerticalScrollIndicator = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let contentView: UIView
+
+    private var hostingController: UIViewController?
+
+    // MARK: - Init
+
+    init(contentView: UIView) {
+        self.contentView = contentView
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    init<T: View>(contentView: T) {
+        let hostingController = UIHostingController(rootView: contentView)
+        self.contentView = hostingController.view
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if let hostingController {
+            self.setupHostingController(hostingController)
+        } else {
+            self.setupContentView()
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.updateContentSize()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        guard previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else {
+            return
+        }
+        self.view.setNeedsLayout()
+        self.view.layoutIfNeeded()
+        self.updateContentSize()
+        if let presentationController = parent?.presentationController as? DrawerPresentationController {
+            presentationController.transition(to: presentationController.currentPosition)
+        }
+    }
+
+    // MARK: - Setup Content View
+
+    private func setupContentView() {
+        self.view.addSubview(scrollView)
+        self.view.pinSubviewToAllEdges(scrollView)
+        self.contentView.translatesAutoresizingMaskIntoConstraints = true
+        self.scrollView.addSubview(contentView)
+    }
+
+    private func setupHostingController(_ hostingController: UIViewController) {
+        hostingController.willMove(toParent: self)
+        self.addChild(hostingController)
+        self.setupContentView()
+        hostingController.didMove(toParent: self)
+    }
+
+    private func updateContentSize() {
+        // Calculate the size needed for the view to fit its content
+        let targetSize = CGSize(width: view.bounds.width, height: 0)
+        self.contentView.frame = CGRect(origin: .zero, size: targetSize)
+        let contentViewSize = contentView.systemLayoutSizeFitting(targetSize)
+        self.contentView.frame.size = contentViewSize
+
+        // Set the scrollView's content size to match the contentView's size
+        //
+        // Scroll is enabled / disabled automatically depending on whether the `contentSize` is bigger than the its size.
+        self.scrollView.contentSize = contentViewSize
+
+        // Set the preferred content size for the view controller to match the contentView's size
+        //
+        // This property should be updated when `DrawerPresentable.collapsedHeight` is `intrinsicHeight`.
+        // Because under the hood the `BottomSheetViewController` reads this property to layout its subviews.
+        self.preferredContentSize = contentViewSize
+    }
+}
+
+extension BottomSheetContentViewController: DrawerPresentable {
+
+    var collapsedHeight: DrawerHeight {
+        if traitCollection.verticalSizeClass == .compact {
+            return .maxHeight
+        }
+        return .intrinsicHeight
+    }
+
+    var allowsUserTransition: Bool {
+        return false
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3784,6 +3784,9 @@
 		F46546312AF2F8D30017E3D1 /* DomainsStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46546302AF2F8D20017E3D1 /* DomainsStateViewModel.swift */; };
 		F46546332AF54DCD0017E3D1 /* AllDomainsListItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46546322AF54DCD0017E3D1 /* AllDomainsListItemViewModelTests.swift */; };
 		F46546352AF550A20017E3D1 /* AllDomainsListItem+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F46546342AF550A20017E3D1 /* AllDomainsListItem+Helpers.swift */; };
+		F4654FAA2BEBC75B005AB177 /* CommentModerationOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08169B9C2BDA68F600055454 /* CommentModerationOptionsView.swift */; };
+		F4654FAD2BEBE994005AB177 /* BottomSheetContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4654FAC2BEBE994005AB177 /* BottomSheetContentViewController.swift */; };
+		F4654FAE2BEBE994005AB177 /* BottomSheetContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4654FAC2BEBE994005AB177 /* BottomSheetContentViewController.swift */; };
 		F465976E28E4669200D5F49A /* cool-green-icon-app-76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */; };
 		F465976F28E4669200D5F49A /* cool-green-icon-app-76.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */; };
 		F465977028E4669200D5F49A /* cool-green-icon-app-60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465976B28E4669200D5F49A /* cool-green-icon-app-60@3x.png */; };
@@ -9219,6 +9222,7 @@
 		F46546302AF2F8D20017E3D1 /* DomainsStateViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsStateViewModel.swift; sourceTree = "<group>"; };
 		F46546322AF54DCD0017E3D1 /* AllDomainsListItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllDomainsListItemViewModelTests.swift; sourceTree = "<group>"; };
 		F46546342AF550A20017E3D1 /* AllDomainsListItem+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AllDomainsListItem+Helpers.swift"; sourceTree = "<group>"; };
+		F4654FAC2BEBE994005AB177 /* BottomSheetContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentViewController.swift; sourceTree = "<group>"; };
 		F465976928E4669200D5F49A /* cool-green-icon-app-76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76@2x.png"; sourceTree = "<group>"; };
 		F465976A28E4669200D5F49A /* cool-green-icon-app-76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-76.png"; sourceTree = "<group>"; };
 		F465976B28E4669200D5F49A /* cool-green-icon-app-60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cool-green-icon-app-60@3x.png"; sourceTree = "<group>"; };
@@ -14133,6 +14137,7 @@
 		8584FDB619243AC40019C02E /* System */ = {
 			isa = PBXGroup;
 			children = (
+				F4654FAB2BEBE978005AB177 /* Bottom Sheet */,
 				0CED1FFE2B6809C100E6DD52 /* FilterCompact */,
 				F5E032E22408D537003AF350 /* Action Sheet */,
 				F551E7F323F6EA1400751212 /* Floating Create Button */,
@@ -17864,6 +17869,14 @@
 				9815D0B226B49A0600DF7226 /* Comment+CoreDataProperties.swift */,
 			);
 			path = Comment;
+			sourceTree = "<group>";
+		};
+		F4654FAB2BEBE978005AB177 /* Bottom Sheet */ = {
+			isa = PBXGroup;
+			children = (
+				F4654FAC2BEBE994005AB177 /* BottomSheetContentViewController.swift */,
+			);
+			path = "Bottom Sheet";
 			sourceTree = "<group>";
 		};
 		F465976528E464DE00D5F49A /* Icons */ = {
@@ -22500,6 +22513,7 @@
 				0CEA55522BC55940008D0FE5 /* WPInstrumentation.swift in Sources */,
 				80F8DAC1282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */,
 				FAFF7A1C2B693D8B006A7CB2 /* PHPLogsView.swift in Sources */,
+				F4654FAD2BEBE994005AB177 /* BottomSheetContentViewController.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
 				321955BF24BE234C00E3F316 /* ReaderInterestsCoordinator.swift in Sources */,
 				4A5DE7382B0D511900363171 /* PageTree.swift in Sources */,
@@ -24560,6 +24574,7 @@
 				93F72150271831820021A09F /* SiteStatsPinnedItemStore.swift in Sources */,
 				FABB212A2602FC2C00C8785C /* BadgeLabel.swift in Sources */,
 				FABB212B2602FC2C00C8785C /* ReaderTagsTableViewController.swift in Sources */,
+				F4654FAA2BEBC75B005AB177 /* CommentModerationOptionsView.swift in Sources */,
 				FE50965A2A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift in Sources */,
 				FABB212C2602FC2C00C8785C /* NotificationsViewController+AppRatings.swift in Sources */,
 				FABB212D2602FC2C00C8785C /* BlogService.m in Sources */,
@@ -25420,6 +25435,7 @@
 				83914BD52A2EA03A0017A588 /* PostSettingsViewController+JetpackSocial.swift in Sources */,
 				F46546312AF2F8D30017E3D1 /* DomainsStateViewModel.swift in Sources */,
 				FABB23852602FC2C00C8785C /* WPError.m in Sources */,
+				F4654FAE2BEBE994005AB177 /* BottomSheetContentViewController.swift in Sources */,
 				FABB23862602FC2C00C8785C /* ContentRouter.swift in Sources */,
 				FABB23872602FC2C00C8785C /* BlogToBlog32to33.swift in Sources */,
 				FABB23882602FC2C00C8785C /* WPStyleGuide+ApplicationStyles.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/38

## Description

This pull request adds logic where tapping the 'Change Status' button in the header menu brings up the Comment Moderation Options view.

| iPhone | iPad |
| ------ | ----- |
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/c3a9c0da-5305-49b0-b2a2-c7a2824eef02) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/f9b51cd6-1d0e-4369-94c2-a96ae737f05c) |
| ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/a8549a16-c80b-4190-9310-f4f9225c7a7d) | ![](https://github.com/wordpress-mobile/WordPress-iOS/assets/9609223/5cb42676-a5fa-42f2-928a-bfbd54c37332) |

## Test Instructions

1. Run Jetpack and login.
2. Navigate to "Notifications" screen.
3. Select a "Comment" notification.
6. Tap the more menu.
7. Tap "Change Status" button.
8. **Expect** the Comment Moderation Options sheet to appear.
9. Select any option.
     - The status is updated but I didn't bother to update the outdated comment status moderation view since it will be removed.
11. Go back to the previous screen.
12. Tap the same comment notification.
13. **Verify** the outdated comment moderation UI is updated.

## Regression Notes
1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
