### PR TITLE
Reader: Update when the results controller is reset for tags feed

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -111,6 +111,7 @@
 - (void)clearCachedRowHeights;
 - (void)refreshCachedRowHeightsForWidth:(CGFloat)width;
 - (void)invalidateCachedRowHeightAtIndexPath:(nonnull NSIndexPath *)indexPath;
+- (void)resetResultsController;
 
 /**
  A convenience method for clearing cached row heights and reloading the table view.

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -286,6 +286,11 @@ static CGFloat const DefaultCellHeight = 44.0;
     [self clearCachedRowHeightAtIndexPath:indexPath];
 }
 
+- (void)resetResultsController
+{
+    _resultsController = nil;
+}
+
 
 #pragma mark - Required Delegate Methods
 
@@ -598,10 +603,6 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (NSFetchedResultsController *)resultsController
 {
-    if (_resultsController != nil && ![_resultsController.fetchRequest.entityName isEqualToString:[self fetchRequest].entityName]) {
-        _resultsController = nil;
-    }
-
     if (_resultsController != nil) {
         return _resultsController;
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -2112,6 +2112,7 @@ extension ReaderStreamViewController: ReaderContentViewController {
         isContentFiltered = content.topicType == .tag || content.topicType == .site
         readerTopic = content.topicType == .discover ? nil : content.topic
         contentType = content.type
+        self.content.resetResultsController()
 
         guard !shouldDisplayNoTopicController else {
             return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableContent.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableContent.swift
@@ -9,6 +9,16 @@ final class ReaderTableContent {
         tableViewHandler?.delegate = delegate
     }
 
+    func resetResultsController() {
+        tableViewHandler?.resetResultsController()
+        tableViewHandler?.tableView.reloadData()
+        tableViewHandler?.tableView.layoutIfNeeded()
+
+        if !isEmpty {
+            tableViewHandler?.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+        }
+    }
+
     /// The fetch request can need a different predicate depending on how the content
     /// being displayed has changed (blocking sites for instance).  Call this method to
     /// update the fetch request predicate and then perform a new fetch.
@@ -16,6 +26,7 @@ final class ReaderTableContent {
     func updateAndPerformFetchRequest(predicate: NSPredicate) {
         assert(Thread.isMainThread, "Reader Error: updating fetch request on a background thread.")
 
+        tableViewHandler?.resetResultsController()
         tableViewHandler?.resultsController?.fetchRequest.predicate = predicate
         do {
             try tableViewHandler?.resultsController?.performFetch()


### PR DESCRIPTION
## Description

Fixes selecting a filter on the "Your Tags" feed. There was a race condition with recreating the results controller which caused unexpected behavior. This moves the recreation of that controller to when the `setContent` is called.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- Scroll the feed down
- Tap on the tags filter chip
- Select a tag to filter
- 🔎 **Verify** the feed is properly filtered and scrolls to the top
- Scroll down on the filtered feed
- Tap on the `X` to remove the filter
- 🔎 **Verify** the filter is removed, the tags feed displays again, and it starts at the top of the feed

## Regression Notes
1. Potential unintended areas of impact
Subscriptions feed filtering

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
