### PR TITLE
Fix site icon selection keyboard issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Impove the "Post Settings" screen groups/ordering to better align with Gutenberg [#23164]
 * [*] Update the "More" menu in the Editor to use modern iOS design and update copy to match Gutenberg [#23145]
 * [*] Update the "Revisions" list design and fix an issue with the footer displaying incorrect "Date Created" for drafts [#23145]
+* [*] Fix an issue where the keyboard got stuck in some cases after selecting a new site icon [#23180]
 
 24.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 * [*] Impove the "Post Settings" screen groups/ordering to better align with Gutenberg [#23164]
 * [*] Update the "More" menu in the Editor to use modern iOS design and update copy to match Gutenberg [#23145]
 * [*] Update the "Revisions" list design and fix an issue with the footer displaying incorrect "Date Created" for drafts [#23145]
-* [*] Fix an issue where the keyboard got stuck in some cases after selecting a new site icon [#23180]
+* [*] Fix an issue where the keyboard got stuck in some cases after selecting a new site icon [#23181]
 * [***] Fix multiple post sync issues: [#21895], [#22037], [#8111], [#10168], [#17343], [#14221], [#12800], [#12073], [#14572], [#9319], [#21941], [#3070], [#3978], [#9449], [#13023], [#21472]
 * [**] Fix [#4870], [#14798], an issue where the app sometimes overwrites the changes made on the remote. The app will now show a new "Conflict Resolution" screen if there is a conflict. It will also no longer try to auto-upload changes to an existing published post or publish a draft, eliminating multiple possible failure points.
 * [**] Fix [#12121], [#13724], [#14251], [#18517], [#17086], [#15767], [#16514], [#13654] and other untracked issues with the "Publish Date" field in Post Settings. The app now has a new date picker that makes it easier to pick and remove the selected date. It also makes it clear if the blog is in a different time zones from your local timezone. The "Publish Date" field was also removed from the Post Settings screen for draft posts – the date needs to be selected right before publishing.

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteIconPickerPresenter.swift
@@ -105,8 +105,11 @@ final class SiteIconPickerPresenter: NSObject {
 
 extension SiteIconPickerPresenter: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        guard let presenter = picker.presentingViewController else {
+            return
+        }
+        presenter.dismiss(animated: true)
         guard let result = results.first else {
-            picker.presentingViewController?.dismiss(animated: true)
             return
         }
         WPAnalytics.track(.siteSettingsSiteIconGalleryPicked)
@@ -114,7 +117,7 @@ extension SiteIconPickerPresenter: PHPickerViewControllerDelegate {
         self.originalMedia = nil
         PHPickerResult.loadImage(for: result) { [weak self] image, error in
             if let image {
-                self?.showImageCropViewController(image, presentingViewController: picker)
+                self?.showImageCropViewController(image, presentingViewController: presenter)
             } else {
                 DDLogError("Failed to load image: \(String(describing: error))")
                 self?.showErrorLoadingImageMessage()


### PR DESCRIPTION
Fixes #21520

The solution I used here is to dismiss the picker (which closes the keyboard) before opening the Resize & Crop screen. I guess many users who change their site icons have run into this bug because they often have lots of images, and the Photos search (which triggers the keyboard) is very useful for finding the image they're looking for.

The Resize & Crop screen is presented over the `PHPickerViewController`. This is an uncommon way of doing things because the `PHPickerViewController` is left open after the user selects their media. In other parts of the app where the picker is used, it's dismissed immediately after selection (e.g. uploading to site media, image block, profile photo picker, etc). 

Presumably, leaving the picker open saves users time if they want to choose a new image on the Resize & Crop screen. By leaving the picker open, users can move back and forth between the picker and the Resize & Crop screen with little friction.

All the known ways of closing the keyboard don't work with the `PHPickerViewController`'s keyboard, as noted in https://stackoverflow.com/questions/76738328/dismiss-keyboard-for-phpickerviewcontroller-not-working.

With this PR, this is how choosing a site icon works now (see the video at https://github.com/wordpress-mobile/WordPress-iOS/issues/21520#issue-1885915478 for how it worked before):

https://github.com/wordpress-mobile/WordPress-iOS/assets/1898325/2fc942a9-a347-4d74-b884-aff34cfebb6e


To test
1. Log in to the Jetpack app
2. Tap the site icon on the My Site screen
3. Tap "Choose from Device" 
4. In the image picker, make the keyboard appear by doing a search (⚠️ not available on simulators)
5. Choose an image
6. Notice the keyboard is dismissed along with the picker (previously the picker remained open)
7. Complete the flow through the Resize & Crop screen


## Regression Notes
1. Potential unintended areas of impact

The could inadvertently introduce regressions in the the site icon selection flow

9. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing 

10. What automated tests I added (or what prevented me from doing so)

Since this flow involves the photo picker, I don't think tests are suitable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist (left unchecked the ones that seem irrelevant for this PR):
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)