### PR TITLE
Reader: Only reload filters when tab items change

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -102,8 +102,10 @@ import Combine
             guard let self else {
                 return
             }
-            self.tabItems = self.tabItemsStore.items
-            self.reloadStreamFilters()
+            if self.tabItems != self.tabItemsStore.items {
+                self.tabItems = self.tabItemsStore.items
+                self.reloadStreamFilters()
+            }
 
             // reset if the selectedIndex is out of bounds to avoid showing a blank screen.
             if self.selectedIndex >= self.tabItems.count {


### PR DESCRIPTION
## Description

There was an `onChange` causing the current selected filter to be reset. I updated it to only reset the active filter if the tab items actually change.

## Testing

I used some test code to replicate the issue. Change:
https://github.com/wordpress-mobile/WordPress-iOS/blob/65bed381368c3d8d70d3ec91c10cdb08c0007ea6/WordPress/Classes/ViewRelated/Reader/Tab%20Navigation/ReaderNavigationMenu.swift#L57

To:
```swift
viewModel.fetchReaderMenu()
```

To test:
- Use the test code from above
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- Tap on the tags chip and select a tag to filter the feed
- Tap on the search icon
- 🔎 **Verify** the filter is not reset
- Repeat the above steps with the "Subscriptions" feed and the blog filter

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
