### PR TITLE
Reader: Fix a cycle with `ReaderTagCardCellViewModel`'s data source

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -33,25 +33,11 @@ class ReaderTagCardCellViewModel: NSObject {
     }()
 
     private lazy var dataSource: DataSource? = { [weak self] in
-        guard let self,
-              let collectionView else {
-           return nil
+        guard let collectionView = self?.collectionView else {
+            return nil
         }
 
-        let dataSource = DataSource(collectionView: collectionView, cellProvider: self.cardCellProvider)
-        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
-            guard kind == UICollectionView.elementKindSectionFooter,
-                  let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind,
-                                                                             withReuseIdentifier: ReaderTagFooterView.classNameWithoutNamespaces(),
-                                                                             for: indexPath) as? ReaderTagFooterView else {
-                return nil
-            }
-            view.configure(with: self.slug) { [weak self] in
-                self?.onTagButtonTapped()
-            }
-            return view
-        }
-        return dataSource
+        return self?.createDataSource(with: collectionView)
     }()
 
     private lazy var resultsController: NSFetchedResultsController<ReaderPost> = {
@@ -176,6 +162,49 @@ private extension ReaderTagCardCellViewModel {
         snapshot.appendItems(isEmpty ? [.empty] : coreDataSnapshot.itemIdentifiers.map { .post(id: $0) })
 
         return snapshot
+    }
+
+    private func createDataSource(with collectionView: UICollectionView) -> DataSource {
+        let dataSource = DataSource(collectionView: collectionView) { [weak self] collectionView, indexPath, item in
+            switch item {
+            case .empty:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReaderTagCardEmptyCell.defaultReuseID,
+                                                                    for: indexPath) as? ReaderTagCardEmptyCell else {
+                    return UICollectionViewCell()
+                }
+
+                cell.configure(tagTitle: self?.slug ?? "") { [weak self] in
+                    self?.fetchTagPosts(syncRemotely: true)
+                }
+
+                return cell
+
+            case .post(let objectID):
+                guard let post = try? ContextManager.shared.mainContext.existingObject(with: objectID) as? ReaderPost,
+                      let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReaderTagCell.classNameWithoutNamespaces(),
+                                                                    for: indexPath) as? ReaderTagCell else {
+                    return UICollectionViewCell()
+                }
+
+                cell.configure(parent: self?.parentViewController,
+                               post: post,
+                               isLoggedIn: self?.isLoggedIn ?? AccountHelper.isLoggedIn)
+                return cell
+            }
+        }
+        dataSource.supplementaryViewProvider = { [weak self] collectionView, kind, indexPath in
+            guard kind == UICollectionView.elementKindSectionFooter,
+                  let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind,
+                                                                             withReuseIdentifier: ReaderTagFooterView.classNameWithoutNamespaces(),
+                                                                             for: indexPath) as? ReaderTagFooterView else {
+                return nil
+            }
+            view.configure(with: self?.slug ?? "") { [weak self] in
+                self?.onTagButtonTapped()
+            }
+            return view
+        }
+        return dataSource
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -115,36 +115,6 @@ class ReaderTagCardCellViewModel: NSObject {
 // MARK: - Private Methods
 
 private extension ReaderTagCardCellViewModel {
-    /// Configures and returns a collection view cell according to the index path and `CardCellItem`.
-    /// This method that satisfies the `UICollectionViewDiffableDataSource.CellProvider` closure signature.
-    func cardCellProvider(_ collectionView: UICollectionView,
-                          _ indexPath: IndexPath,
-                          _ item: CardCellItem) -> UICollectionViewCell? {
-        switch item {
-        case .empty:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReaderTagCardEmptyCell.defaultReuseID,
-                                                                for: indexPath) as? ReaderTagCardEmptyCell else {
-                return UICollectionViewCell()
-            }
-
-            cell.configure(tagTitle: slug) { [weak self] in
-                self?.fetchTagPosts(syncRemotely: true)
-            }
-
-            return cell
-
-        case .post(let objectID):
-            guard let post = try? ContextManager.shared.mainContext.existingObject(with: objectID) as? ReaderPost,
-                  let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReaderTagCell.classNameWithoutNamespaces(),
-                                                                for: indexPath) as? ReaderTagCell else {
-                return UICollectionViewCell()
-            }
-
-            cell.configure(parent: parentViewController, post: post, isLoggedIn: isLoggedIn)
-            return cell
-        }
-    }
-
     /// Translates a diffable snapshot from `NSFetchedResultsController` to a snapshot that fits the collection view.
     ///
     /// Snapshots returned from `NSFetchedResultsController` always have the type `<String, NSManagedObjectID>`, so


### PR DESCRIPTION
## Description

I noticed a crash from a data source which had zero elements. After inspecting the active data sources, I noticed that the `ReaderTagCardCellViewModel` wasn't deallocating:

<img width="328" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/36af8446-5ccf-49b2-a038-b1f47546b024">

Inspecting `ReaderTagCardCellViewModel` shows there was a cycle due to the data source object:

<img width="968" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/77c7f7e0-d1d2-4621-93b5-267ea6b50908">

So I rewrote setting the data source variable to ensure `self` wasn't strongly retained. After these changes, the number of view models is limited to ~7:

<img width="320" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/cf69078e-51e3-486d-8cf0-9ea745687eef">

I'm hoping that by fixing the memory leak, the crash also gets resolved.

## Testing

To test:
- Launch Jetpack and login
- Navigate to the "Your Tags" feed
- Scroll down the feed and back up multiple times
- Tap on the "Debug Memory Graph" (<img width="26" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/2454408/41fd1690-7ef7-4132-804c-a0a7c5610888">) button in Xcode
- Filter the results for `ReaderTagCardCellViewModel`
- 🔎 **Verify** there's a reasonable number of view model objects (< 10)
- Resume the execution of the program by tapping on the continue button
- Scroll down the feed and back up multiple times again
- Debug the memory again and 🔎 **verify** the number of view model objects remains roughly the same

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
