### PR TITLE
Reader: Update `ReaderTagCell` to new UI

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -22,6 +22,8 @@ extension NSNotification.Name {
     static let ReaderUserBlockingWillBegin = NSNotification.Name(rawValue: "ReaderUserBlockingWillBegin")
     // Sent when the user blocking request is complete
     static let ReaderUserBlockingDidEnd = NSNotification.Name(rawValue: "ReaderUserBlockingDidEnd")
+    // Sent when the filter from a feed is updated
+    static let ReaderFilterUpdated = NSNotification.Name(rawValue: "ReaderFilterUpdated")
 }
 
 struct ReaderNotificationKeys {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
@@ -40,26 +40,4 @@ extension ReaderPost {
         return contentPreviewForDisplay()
     }
 
-    func countsForDisplay(isLoggedIn: Bool) -> String? {
-        let likes: String? = {
-            guard isLikesEnabled(isLoggedIn: isLoggedIn),
-                  let count = likeCount()?.intValue,
-                  count > 0 else {
-                return nil
-            }
-            return WPStyleGuide.likeCountForDisplay(count)
-        }()
-        let comments: String? = {
-            guard isCommentsEnabled,
-                  let count = commentCount()?.intValue,
-                  count > 0 else {
-                return nil
-            }
-            return WPStyleGuide.commentCountForDisplay(count)
-        }()
-
-        let countStrings = [likes, comments].compactMap { $0 }
-        return countStrings.count > 0 ? countStrings.joined(separator: " • ") : nil
-    }
-
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
@@ -24,20 +24,8 @@ extension ReaderPost {
     }
 
     func summaryForDisplay(isPad: Bool = false) -> String? {
-        if isPad {
-            let content = contentForDisplay()?
-                .stringByDecodingXMLCharacters()
-                .replacingOccurrences(of: "<br>", with: "\n")
-                .strippingHTML()
-                .replacingOccurrences(of: "^\n+", with: "", options: .regularExpression)
-                .replacingOccurrences(of: "\n{2,}", with: "\n\n", options: .regularExpression)
-                .trim()
-            if let content {
-                let maxContentLength = 3000
-                return String(content.prefix(maxContentLength))
-            }
-        }
-        return contentPreviewForDisplay()
+        return contentPreviewForDisplay()?
+            .replacingOccurrences(of: "\n{2,}", with: "\n\n", options: .regularExpression)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPost+Display.swift
@@ -24,7 +24,7 @@ extension ReaderPost {
     }
 
     func summaryForDisplay(isPad: Bool = false) -> String? {
-        if featuredImageURLForDisplay() == nil || isPad {
+        if isPad {
             let content = contentForDisplay()?
                 .stringByDecodingXMLCharacters()
                 .replacingOccurrences(of: "<br>", with: "\n")
@@ -33,7 +33,7 @@ extension ReaderPost {
                 .replacingOccurrences(of: "\n{2,}", with: "\n\n", options: .regularExpression)
                 .trim()
             if let content {
-                let maxContentLength = isPad ? 4000 : 500
+                let maxContentLength = 3000
                 return String(content.prefix(maxContentLength))
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -86,8 +86,8 @@ class ReaderTagCardCell: UITableViewCell {
     struct Constants {
         static let phoneDefaultCellSize = CGSize(width: 300, height: 150)
         static let phoneLargeCellSize = CGSize(width: 300, height: 300)
-        static let padDefaultCellSize = CGSize(width: 600, height: 300)
-        static let padLargeCellSize = CGSize(width: 600, height: 600)
+        static let padDefaultCellSize = CGSize(width: 480, height: 206)
+        static let padLargeCellSize = CGSize(width: 480, height: 400)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -84,10 +84,10 @@ class ReaderTagCardCell: UITableViewCell {
     }
 
     struct Constants {
-        static let phoneDefaultCellSize = CGSize(width: 240, height: 297)
-        static let phoneLargeCellSize = CGSize(width: 240, height: 500)
-        static let padDefaultCellSize = CGSize(width: 480, height: 600)
-        static let padLargeCellSize = CGSize(width: 480, height: 900)
+        static let phoneDefaultCellSize = CGSize(width: 300, height: 150)
+        static let phoneLargeCellSize = CGSize(width: 300, height: 300)
+        static let padDefaultCellSize = CGSize(width: 600, height: 300)
+        static let padLargeCellSize = CGSize(width: 600, height: 600)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
@@ -12,11 +12,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" userLabel="Reader Tag Card Cell" customClass="ReaderTagCardCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="328" height="359"/>
+            <rect key="frame" x="0.0" y="0.0" width="328" height="209"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gUR-Rt-jPM">
-                    <rect key="frame" x="11.999999999999996" y="24" width="51.666666666666657" height="30"/>
+                    <rect key="frame" x="11.999999999999996" y="24" width="51.666666666666657" height="27"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="filled" title="Tag"/>
@@ -25,13 +25,13 @@
                     </connections>
                 </button>
                 <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
-                    <rect key="frame" x="16" y="62" width="296" height="297"/>
+                    <rect key="frame" x="16" y="59" width="296" height="150"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="297" id="uTt-pZ-gUW"/>
+                        <constraint firstAttribute="height" constant="150" id="uTt-pZ-gUW"/>
                     </constraints>
-                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="0Qb-19-SWX" customClass="AdaptiveCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
-                        <size key="itemSize" width="240" height="297"/>
+                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="24" minimumInteritemSpacing="24" id="0Qb-19-SWX" customClass="AdaptiveCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
+                        <size key="itemSize" width="300" height="150"/>
                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
                         <size key="footerReferenceSize" width="50" height="50"/>
                         <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <device id="ipad12_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
@@ -12,11 +12,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" userLabel="Reader Tag Card Cell" customClass="ReaderTagCardCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="328" height="209"/>
+            <rect key="frame" x="0.0" y="0.0" width="328" height="256"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gUR-Rt-jPM">
-                    <rect key="frame" x="11.999999999999996" y="24" width="51.666666666666657" height="27"/>
+                    <rect key="frame" x="12" y="24" width="51.5" height="18"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                     <state key="normal" title="Button"/>
                     <buttonConfiguration key="configuration" style="filled" title="Tag"/>
@@ -25,10 +25,12 @@
                     </connections>
                 </button>
                 <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="GeQ-Gs-OvG">
-                    <rect key="frame" x="16" y="59" width="296" height="150"/>
+                    <rect key="frame" x="16" y="50" width="296" height="206"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="150" id="uTt-pZ-gUW"/>
+                        <constraint firstAttribute="height" constant="150" id="uTt-pZ-gUW">
+                            <variation key="heightClass=regular-widthClass=regular" constant="206"/>
+                        </constraint>
                     </constraints>
                     <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="24" minimumInteritemSpacing="24" id="0Qb-19-SWX" customClass="AdaptiveCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
                         <size key="itemSize" width="300" height="150"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -36,6 +36,7 @@ class ReaderTagCardCellViewModel: NSObject {
     let slug: String
     weak var viewDelegate: ReaderTagCardCellViewModelDelegate? = nil
 
+    private let tag: ReaderAbstractTopic
     private let coreDataStack: CoreDataStackSwift
     private weak var parentViewController: UIViewController?
     private weak var collectionView: UICollectionView?
@@ -78,6 +79,7 @@ class ReaderTagCardCellViewModel: NSObject {
          cellSize: @escaping @autoclosure () -> CGSize?) {
         self.parentViewController = parent
         self.slug = tag.slug
+        self.tag = tag
         self.collectionView = collectionView
         self.isLoggedIn = isLoggedIn
         self.viewDelegate = viewDelegate
@@ -115,11 +117,18 @@ class ReaderTagCardCellViewModel: NSObject {
     }
 
     func onTagButtonTapped(source: TagButtonSource) {
-        let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
-        controller.statSource = .tagsFeed
+        switch source {
+        case .footer:
+            let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
+            controller.statSource = .tagsFeed
+            parentViewController?.navigationController?.pushViewController(controller, animated: true)
+        case .header:
+            NotificationCenter.default.post(name: .ReaderFilterUpdated,
+                                            object: nil,
+                                            userInfo: [ReaderNotificationKeys.topic: tag])
+        }
 
         WPAnalytics.track(source.event)
-        parentViewController?.navigationController?.pushViewController(controller, animated: true)
     }
 
     struct Constants {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardEmptyCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardEmptyCell.swift
@@ -55,7 +55,7 @@ private struct ReaderTagCardEmptyCellView: View {
     private var iconLength = 32.0
 
     var body: some View {
-        VStack(spacing: .DS.Padding.double) {
+        VStack(spacing: .DS.Padding.single) {
             Image(systemName: "wifi.slash")
                 .resizable()
                 .frame(width: iconLength, height: iconLength)
@@ -64,7 +64,7 @@ private struct ReaderTagCardEmptyCellView: View {
             // added to double the padding between the Image and the VStack.
             Spacer().frame(height: .hairlineBorderWidth)
 
-            VStack(spacing: .DS.Padding.single) {
+            VStack(spacing: .DS.Padding.half) {
                 Text(Strings.title)
                     .font(.callout)
                     .fontWeight(.semibold)
@@ -73,6 +73,7 @@ private struct ReaderTagCardEmptyCellView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Button {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -81,6 +81,7 @@ private extension ReaderTagCell {
         postDateLabel.textColor = .secondaryLabel
         titleLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
         summaryLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
+        summaryLabel.numberOfLines = UIDevice.isPad() ? 5 : 3
         countsLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
         countsLabel.textColor = .secondaryLabel
         likeButton.tintColor = .secondaryLabel

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -17,6 +17,7 @@ class ReaderTagCell: UICollectionViewCell {
     @IBOutlet weak var spacerView: UIView!
     @IBOutlet weak var titleSpacerView: UIView!
     @IBOutlet weak var countsLabelSpacerView: UIView!
+    @IBOutlet private var contentBoundsConstraints: [NSLayoutConstraint]!
 
     private lazy var imageLoader = ImageLoader(imageView: featuredImageView)
     private var viewModel: ReaderTagCellViewModel?
@@ -31,12 +32,15 @@ class ReaderTagCell: UICollectionViewCell {
         spacerView.isGhostableDisabled = true
         titleSpacerView.isGhostableDisabled = true
         countsLabelSpacerView.isGhostableDisabled = true
+
+        updateContentConstraints()
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
         imageLoader.prepareForReuse()
         resetHiddenViews()
+        updateContentConstraints()
     }
 
     func configure(parent: UIViewController?, post: ReaderPost, isLoggedIn: Bool) {
@@ -142,6 +146,11 @@ private extension ReaderTagCell {
         headerStackView.accessibilityTraits = .button
         menuButton.accessibilityLabel = AccessibilityConstants.menuButtonLabel
         menuButton.accessibilityHint = AccessibilityConstants.menuButtonHint
+    }
+
+    func updateContentConstraints() {
+        let isExtraLargeCategory = traitCollection.preferredContentSizeCategory >= .extraLarge
+        contentBoundsConstraints.forEach { $0.isActive = !isExtraLargeCategory }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -82,7 +82,6 @@ private extension ReaderTagCell {
         postDateLabel.textColor = .secondaryLabel
         titleLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
         summaryLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
-        summaryLabel.numberOfLines = UIDevice.isPad() ? 5 : 3
         likeButton.tintColor = .secondaryLabel
         likeButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
         menuButton.tintColor = .secondaryLabel

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -10,6 +10,7 @@ class ReaderTagCell: UICollectionViewCell {
     @IBOutlet private weak var postDateLabel: UILabel!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var summaryLabel: UILabel!
+    @IBOutlet private weak var featuredImageViewContainer: UIView!
     @IBOutlet private weak var featuredImageView: CachedAnimatedImageView!
     @IBOutlet private weak var countsLabel: UILabel!
     @IBOutlet private weak var likeButton: UIButton!
@@ -90,6 +91,7 @@ private extension ReaderTagCell {
 
     func loadFeaturedImage(with post: ReaderPost) {
         guard let url = post.featuredImageURLForDisplay() else {
+            featuredImageViewContainer.isHidden = true
             featuredImageView.isHidden = true
             return
         }
@@ -105,6 +107,7 @@ private extension ReaderTagCell {
         siteLabel.isHidden = false
         titleLabel.isHidden = false
         summaryLabel.isHidden = false
+        featuredImageViewContainer.isHidden = false
         featuredImageView.isHidden = false
         countsLabel.isHidden = false
         likeButton.isHidden = false

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.swift
@@ -12,10 +12,10 @@ class ReaderTagCell: UICollectionViewCell {
     @IBOutlet private weak var summaryLabel: UILabel!
     @IBOutlet private weak var featuredImageViewContainer: UIView!
     @IBOutlet private weak var featuredImageView: CachedAnimatedImageView!
-    @IBOutlet private weak var countsLabel: UILabel!
     @IBOutlet private weak var likeButton: UIButton!
     @IBOutlet private weak var menuButton: UIButton!
     @IBOutlet weak var spacerView: UIView!
+    @IBOutlet weak var titleSpacerView: UIView!
     @IBOutlet weak var countsLabelSpacerView: UIView!
 
     private lazy var imageLoader = ImageLoader(imageView: featuredImageView)
@@ -29,6 +29,7 @@ class ReaderTagCell: UICollectionViewCell {
         headerStackView.addGestureRecognizer(tapGesture)
 
         spacerView.isGhostableDisabled = true
+        titleSpacerView.isGhostableDisabled = true
         countsLabelSpacerView.isGhostableDisabled = true
     }
 
@@ -82,8 +83,6 @@ private extension ReaderTagCell {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
         summaryLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
         summaryLabel.numberOfLines = UIDevice.isPad() ? 5 : 3
-        countsLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
-        countsLabel.textColor = .secondaryLabel
         likeButton.tintColor = .secondaryLabel
         likeButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
         menuButton.tintColor = .secondaryLabel
@@ -110,7 +109,6 @@ private extension ReaderTagCell {
         summaryLabel.isHidden = false
         featuredImageViewContainer.isHidden = false
         featuredImageView.isHidden = false
-        countsLabel.isHidden = false
         likeButton.isHidden = false
     }
 
@@ -128,25 +126,21 @@ private extension ReaderTagCell {
         let postDate = post.shortDateForDisplay()
         let postTitle = post.titleForDisplay()
         let postSummary = post.summaryForDisplay(isPad: traitCollection.userInterfaceIdiom == .pad)
-        let postCounts = post.countsForDisplay(isLoggedIn: isLoggedIn)
 
         siteLabel.text = blogName
         postDateLabel.text = postDate
         titleLabel.text = postTitle
         summaryLabel.text = postSummary
-        countsLabel.text = postCounts
 
         siteLabel.isHidden = blogName == nil
         postDateLabel.isHidden = postDate == nil
         titleLabel.isHidden = postTitle == nil
         summaryLabel.isHidden = postSummary == nil
-        countsLabel.isHidden = postCounts == nil
 
         headerStackView.isAccessibilityElement = true
         headerStackView.accessibilityLabel = [blogName, postDate].compactMap { $0 }.joined(separator: ", ")
         headerStackView.accessibilityHint = AccessibilityConstants.siteStackViewHint
         headerStackView.accessibilityTraits = .button
-        countsLabel.accessibilityLabel = postCounts?.replacingOccurrences(of: " • ", with: ", ")
         menuButton.accessibilityLabel = AccessibilityConstants.menuButtonLabel
         menuButton.accessibilityHint = AccessibilityConstants.menuButtonHint
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -12,14 +12,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReaderTagCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="206"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="v9V-wn-SvM">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="261"/>
+                    <rect key="frame" x="0.0" y="0.0" width="480" height="167"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="N0b-ln-6rk">
-                            <rect key="frame" x="0.0" y="0.0" width="600" height="20.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="480" height="20.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="Site Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nBe-Ng-tUu">
                                     <rect key="frame" x="0.0" y="0.0" width="66.5" height="20.5"/>
@@ -28,7 +28,7 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" text="Post Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hSx-Fu-Ptn">
-                                    <rect key="frame" x="70.5" y="0.0" width="529.5" height="20.5"/>
+                                    <rect key="frame" x="70.5" y="0.0" width="409.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -39,39 +39,39 @@
                             </constraints>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kbG-di-VIy">
-                            <rect key="frame" x="0.0" y="24.5" width="600" height="212"/>
+                            <rect key="frame" x="0.0" y="24.5" width="480" height="118"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6wc-NQ-auo">
-                                    <rect key="frame" x="0.0" y="0.0" width="440" height="212"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="352" height="118"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
-                                            <rect key="frame" x="0.0" y="0.0" width="440" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
-                                            <rect key="frame" x="0.0" y="20.5" width="440" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="20.5" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
-                                            <rect key="frame" x="0.0" y="41" width="440" height="171"/>
+                                            <rect key="frame" x="0.0" y="41" width="352" height="77"/>
                                         </view>
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4xC-jQ-qSx">
-                                    <rect key="frame" x="440" y="0.0" width="160" height="212"/>
+                                    <rect key="frame" x="352" y="0.0" width="128" height="118"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="247" verticalCompressionResistancePriority="753" translatesAutoresizingMaskIntoConstraints="NO" id="Yfj-e7-Vti" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="16" y="42" width="128" height="128"/>
+                                            <rect key="frame" x="16" y="11" width="96" height="96"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="64" id="XBK-3t-dbs">
-                                                    <variation key="heightClass=regular-widthClass=regular" constant="128"/>
+                                                    <variation key="heightClass=regular-widthClass=regular" constant="96"/>
                                                 </constraint>
                                                 <constraint firstAttribute="width" constant="64" id="w56-oE-UTR">
-                                                    <variation key="heightClass=regular-widthClass=regular" constant="128"/>
+                                                    <variation key="heightClass=regular-widthClass=regular" constant="96"/>
                                                 </constraint>
                                             </constraints>
                                         </imageView>
@@ -88,7 +88,7 @@
                             </subviews>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TWL-MA-3CF" userLabel="Counts">
-                            <rect key="frame" x="0.0" y="240.5" width="600" height="20.5"/>
+                            <rect key="frame" x="0.0" y="146.5" width="480" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -96,7 +96,7 @@
                     </subviews>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1nC-hH-hbw">
-                    <rect key="frame" x="0.0" y="256" width="600" height="44"/>
+                    <rect key="frame" x="0.0" y="162" width="480" height="44"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B3r-hf-7wD">
                             <rect key="frame" x="0.0" y="0.0" width="52" height="44"/>
@@ -112,10 +112,10 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0q4-yh-1OL" userLabel="Spacer">
-                            <rect key="frame" x="52" y="0.0" width="504" height="44"/>
+                            <rect key="frame" x="52" y="0.0" width="384" height="44"/>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RMF-3Z-42A">
-                            <rect key="frame" x="556" y="0.0" width="44" height="44"/>
+                            <rect key="frame" x="436" y="0.0" width="44" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="44" id="lnk-h8-Ngi"/>
                                 <constraint firstAttribute="height" constant="44" id="o9C-UX-9Am"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -39,28 +39,28 @@
                             </constraints>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kbG-di-VIy">
-                            <rect key="frame" x="0.0" y="24.5" width="480" height="118"/>
+                            <rect key="frame" x="0.0" y="24.5" width="480" height="142.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6wc-NQ-auo">
-                                    <rect key="frame" x="0.0" y="0.0" width="352" height="118"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="352" height="142.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="pBB-XH-eiv" userLabel="Spacer">
-                                            <rect key="frame" x="0.0" y="0.0" width="352" height="38.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="352" height="51"/>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
-                                            <rect key="frame" x="0.0" y="38.5" width="352" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="51" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
-                                            <rect key="frame" x="0.0" y="59" width="352" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="71.5" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
-                                            <rect key="frame" x="0.0" y="79.5" width="352" height="38.5"/>
+                                            <rect key="frame" x="0.0" y="92" width="352" height="50.5"/>
                                         </view>
                                     </subviews>
                                     <constraints>
@@ -68,10 +68,10 @@
                                     </constraints>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4xC-jQ-qSx">
-                                    <rect key="frame" x="352" y="0.0" width="128" height="118"/>
+                                    <rect key="frame" x="352" y="0.0" width="128" height="142.5"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="247" verticalCompressionResistancePriority="753" translatesAutoresizingMaskIntoConstraints="NO" id="Yfj-e7-Vti" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="16" y="11" width="96" height="96"/>
+                                            <rect key="frame" x="16" y="23.5" width="96" height="96"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="64" id="XBK-3t-dbs">
                                                     <variation key="heightClass=regular-widthClass=regular" constant="96"/>
@@ -93,12 +93,6 @@
                                 </view>
                             </subviews>
                         </stackView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TWL-MA-3CF" userLabel="Counts">
-                            <rect key="frame" x="0.0" y="146.5" width="480" height="20.5"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                     </subviews>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1nC-hH-hbw">
@@ -149,7 +143,6 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="contentStackView" destination="v9V-wn-SvM" id="Dh0-eP-ubs"/>
-                <outlet property="countsLabel" destination="TWL-MA-3CF" id="SLO-VX-N94"/>
                 <outlet property="countsLabelSpacerView" destination="l2P-MZ-TCd" id="8QA-n2-RoI"/>
                 <outlet property="featuredImageView" destination="Yfj-e7-Vti" id="BCL-Ej-cp3"/>
                 <outlet property="featuredImageViewContainer" destination="4xC-jQ-qSx" id="rAQ-lq-Xsz"/>
@@ -161,6 +154,7 @@
                 <outlet property="spacerView" destination="0q4-yh-1OL" id="Ssw-MQ-d7t"/>
                 <outlet property="summaryLabel" destination="5KT-0Z-POw" id="v2C-Gu-Vcs"/>
                 <outlet property="titleLabel" destination="DsY-TC-klp" id="Qc5-Ye-hs2"/>
+                <outlet property="titleSpacerView" destination="pBB-XH-eiv" id="b5m-pu-5kl"/>
             </connections>
             <point key="canvasLocation" x="-131.29770992366412" y="-168.3098591549296"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -15,7 +15,7 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="206"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="v9V-wn-SvM">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="v9V-wn-SvM">
                     <rect key="frame" x="0.0" y="0.0" width="480" height="167"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="N0b-ln-6rk">
@@ -39,28 +39,28 @@
                             </constraints>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kbG-di-VIy">
-                            <rect key="frame" x="0.0" y="24.5" width="480" height="142.5"/>
+                            <rect key="frame" x="0.0" y="28.5" width="480" height="138.5"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6wc-NQ-auo">
-                                    <rect key="frame" x="0.0" y="0.0" width="352" height="142.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="352" height="138.5"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="pBB-XH-eiv" userLabel="Spacer">
-                                            <rect key="frame" x="0.0" y="0.0" width="352" height="51"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="352" height="49"/>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
-                                            <rect key="frame" x="0.0" y="51" width="352" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="49" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
-                                            <rect key="frame" x="0.0" y="71.5" width="352" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="69.5" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
-                                            <rect key="frame" x="0.0" y="92" width="352" height="50.5"/>
+                                            <rect key="frame" x="0.0" y="90" width="352" height="48.5"/>
                                         </view>
                                     </subviews>
                                     <constraints>
@@ -68,10 +68,10 @@
                                     </constraints>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4xC-jQ-qSx">
-                                    <rect key="frame" x="352" y="0.0" width="128" height="142.5"/>
+                                    <rect key="frame" x="352" y="0.0" width="128" height="138.5"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="247" verticalCompressionResistancePriority="753" translatesAutoresizingMaskIntoConstraints="NO" id="Yfj-e7-Vti" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="16" y="23.5" width="96" height="96"/>
+                                            <rect key="frame" x="16" y="21.5" width="96" height="96"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="64" id="XBK-3t-dbs">
                                                     <variation key="heightClass=regular-widthClass=regular" constant="96"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -161,6 +161,10 @@
                 <outlet property="summaryLabel" destination="5KT-0Z-POw" id="v2C-Gu-Vcs"/>
                 <outlet property="titleLabel" destination="DsY-TC-klp" id="Qc5-Ye-hs2"/>
                 <outlet property="titleSpacerView" destination="pBB-XH-eiv" id="b5m-pu-5kl"/>
+                <outletCollection property="contentBoundsConstraints" destination="4E1-8Q-Umk" collectionClass="NSMutableArray" id="w51-J3-YwH"/>
+                <outletCollection property="contentBoundsConstraints" destination="XP1-dF-ShA" collectionClass="NSMutableArray" id="SeC-ny-f9t"/>
+                <outletCollection property="contentBoundsConstraints" destination="5Us-VT-zN0" collectionClass="NSMutableArray" id="V6S-Lu-3RC"/>
+                <outletCollection property="contentBoundsConstraints" destination="CNx-el-qmz" collectionClass="NSMutableArray" id="2xj-id-88q"/>
             </connections>
             <point key="canvasLocation" x="-131.29770992366412" y="-168.3098591549296"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -44,22 +44,28 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6wc-NQ-auo">
                                     <rect key="frame" x="0.0" y="0.0" width="352" height="118"/>
                                     <subviews>
+                                        <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="pBB-XH-eiv" userLabel="Spacer">
+                                            <rect key="frame" x="0.0" y="0.0" width="352" height="38.5"/>
+                                        </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
-                                            <rect key="frame" x="0.0" y="0.0" width="352" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="38.5" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
-                                            <rect key="frame" x="0.0" y="20.5" width="352" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="59" width="352" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
-                                            <rect key="frame" x="0.0" y="41" width="352" height="77"/>
+                                            <rect key="frame" x="0.0" y="79.5" width="352" height="38.5"/>
                                         </view>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="l2P-MZ-TCd" firstAttribute="height" secondItem="pBB-XH-eiv" secondAttribute="height" id="cGL-Qq-cVT"/>
+                                    </constraints>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4xC-jQ-qSx">
                                     <rect key="frame" x="352" y="0.0" width="128" height="118"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <device id="ipad12_9rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
@@ -12,23 +12,23 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReaderTagCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="240" height="297"/>
+            <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="v9V-wn-SvM">
-                    <rect key="frame" x="0.0" y="0.0" width="240" height="258"/>
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="261"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="252" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="N0b-ln-6rk">
-                            <rect key="frame" x="0.0" y="0.0" width="240" height="20.333333333333332"/>
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="20.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="Site Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nBe-Ng-tUu">
-                                    <rect key="frame" x="0.0" y="0.0" width="66.333333333333329" height="20.333333333333332"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="66.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="751" text="Post Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hSx-Fu-Ptn">
-                                    <rect key="frame" x="70.333333333333329" y="0.0" width="169.66666666666669" height="20.333333333333332"/>
+                                    <rect key="frame" x="70.5" y="0.0" width="529.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -38,31 +38,57 @@
                                 <constraint firstItem="nBe-Ng-tUu" firstAttribute="height" secondItem="N0b-ln-6rk" secondAttribute="height" id="jXp-aM-FWa"/>
                             </constraints>
                         </stackView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
-                            <rect key="frame" x="0.0" y="24.333333333333336" width="240" height="20.333333333333336"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
-                            <rect key="frame" x="0.0" y="48.666666666666664" width="240" height="20.333333333333336"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="247" verticalCompressionResistancePriority="753" translatesAutoresizingMaskIntoConstraints="NO" id="Yfj-e7-Vti" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="73" width="240" height="150"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="150" id="mXK-lY-civ">
-                                    <variation key="heightClass=regular-widthClass=regular" constant="300"/>
-                                </constraint>
-                            </constraints>
-                        </imageView>
-                        <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
-                            <rect key="frame" x="0.0" y="227" width="240" height="6.6666666666666572"/>
-                        </view>
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kbG-di-VIy">
+                            <rect key="frame" x="0.0" y="24.5" width="600" height="212"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="6wc-NQ-auo">
+                                    <rect key="frame" x="0.0" y="0.0" width="440" height="212"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DsY-TC-klp" userLabel="Title">
+                                            <rect key="frame" x="0.0" y="0.0" width="440" height="20.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5KT-0Z-POw" userLabel="Summary">
+                                            <rect key="frame" x="0.0" y="20.5" width="440" height="20.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <view contentMode="scaleToFill" verticalHuggingPriority="248" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="l2P-MZ-TCd" userLabel="Spacer">
+                                            <rect key="frame" x="0.0" y="41" width="440" height="171"/>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4xC-jQ-qSx">
+                                    <rect key="frame" x="440" y="0.0" width="160" height="212"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="247" verticalCompressionResistancePriority="753" translatesAutoresizingMaskIntoConstraints="NO" id="Yfj-e7-Vti" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
+                                            <rect key="frame" x="16" y="42" width="128" height="128"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="64" id="XBK-3t-dbs">
+                                                    <variation key="heightClass=regular-widthClass=regular" constant="128"/>
+                                                </constraint>
+                                                <constraint firstAttribute="width" constant="64" id="w56-oE-UTR">
+                                                    <variation key="heightClass=regular-widthClass=regular" constant="128"/>
+                                                </constraint>
+                                            </constraints>
+                                        </imageView>
+                                    </subviews>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Yfj-e7-Vti" secondAttribute="bottom" id="KBw-an-VIL"/>
+                                        <constraint firstItem="Yfj-e7-Vti" firstAttribute="centerY" secondItem="4xC-jQ-qSx" secondAttribute="centerY" id="LuZ-lC-ZId"/>
+                                        <constraint firstAttribute="trailing" secondItem="Yfj-e7-Vti" secondAttribute="trailing" constant="16" id="laL-w6-T4j"/>
+                                        <constraint firstItem="Yfj-e7-Vti" firstAttribute="leading" secondItem="4xC-jQ-qSx" secondAttribute="leading" constant="16" id="oxv-Ga-1sZ"/>
+                                        <constraint firstItem="Yfj-e7-Vti" firstAttribute="top" relation="greaterThanOrEqual" secondItem="4xC-jQ-qSx" secondAttribute="top" id="qlz-me-zhX"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                        </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TWL-MA-3CF" userLabel="Counts">
-                            <rect key="frame" x="0.0" y="237.66666666666666" width="240" height="20.333333333333343"/>
+                            <rect key="frame" x="0.0" y="240.5" width="600" height="20.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -70,7 +96,7 @@
                     </subviews>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1nC-hH-hbw">
-                    <rect key="frame" x="0.0" y="253" width="240" height="44"/>
+                    <rect key="frame" x="0.0" y="256" width="600" height="44"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="252" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B3r-hf-7wD">
                             <rect key="frame" x="0.0" y="0.0" width="52" height="44"/>
@@ -86,10 +112,10 @@
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="0q4-yh-1OL" userLabel="Spacer">
-                            <rect key="frame" x="52" y="0.0" width="144" height="44"/>
+                            <rect key="frame" x="52" y="0.0" width="504" height="44"/>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RMF-3Z-42A">
-                            <rect key="frame" x="196" y="0.0" width="44" height="44"/>
+                            <rect key="frame" x="556" y="0.0" width="44" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="44" id="lnk-h8-Ngi"/>
                                 <constraint firstAttribute="height" constant="44" id="o9C-UX-9Am"/>
@@ -120,6 +146,7 @@
                 <outlet property="countsLabel" destination="TWL-MA-3CF" id="SLO-VX-N94"/>
                 <outlet property="countsLabelSpacerView" destination="l2P-MZ-TCd" id="8QA-n2-RoI"/>
                 <outlet property="featuredImageView" destination="Yfj-e7-Vti" id="BCL-Ej-cp3"/>
+                <outlet property="featuredImageViewContainer" destination="4xC-jQ-qSx" id="rAQ-lq-Xsz"/>
                 <outlet property="headerStackView" destination="N0b-ln-6rk" id="9VK-Sj-aYS"/>
                 <outlet property="likeButton" destination="B3r-hf-7wD" id="Jua-cj-3ZZ"/>
                 <outlet property="menuButton" destination="RMF-3Z-42A" id="O3N-Cs-hjz"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCell.xib
@@ -92,6 +92,12 @@
                                     </constraints>
                                 </view>
                             </subviews>
+                            <constraints>
+                                <constraint firstItem="DsY-TC-klp" firstAttribute="bottom" relation="lessThanOrEqual" secondItem="Yfj-e7-Vti" secondAttribute="bottom" id="4E1-8Q-Umk"/>
+                                <constraint firstItem="5KT-0Z-POw" firstAttribute="bottom" relation="lessThanOrEqual" secondItem="Yfj-e7-Vti" secondAttribute="bottom" id="5Us-VT-zN0"/>
+                                <constraint firstItem="5KT-0Z-POw" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Yfj-e7-Vti" secondAttribute="top" id="CNx-el-qmz"/>
+                                <constraint firstItem="DsY-TC-klp" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Yfj-e7-Vti" secondAttribute="top" id="XP1-dF-ShA"/>
+                            </constraints>
                         </stackView>
                     </subviews>
                 </stackView>

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -69,6 +69,7 @@ class ReaderTabView: UIView {
 
         NotificationCenter.default.addObserver(self, selector: #selector(topicUnfollowed(_:)), name: .ReaderTopicUnfollowed, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(siteFollowed(_:)), name: .ReaderSiteFollowed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(filterUpdated(_:)), name: .ReaderFilterUpdated, object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -213,6 +214,16 @@ private extension ReaderTabView {
         // If a P2 is followed but the P2 tab is not in the Reader tab bar,
         // refresh the Reader menu to display it.
         viewModel.fetchReaderMenu()
+    }
+
+    @objc func filterUpdated(_ notification: Foundation.Notification) {
+        guard let userInfo = notification.userInfo,
+              let topic = userInfo[ReaderNotificationKeys.topic] as? ReaderTagTopic,
+              let filterProvider = viewModel.streamFilters.first(where: { $0.reuseIdentifier == FilterProvider.ReuseIdentifiers.tags }) else {
+            return
+        }
+        viewModel.setFilterContent(topic: topic)
+        viewModel.activeStreamFilter = (filterProvider.id, topic)
     }
 
 }


### PR DESCRIPTION
Fixes #23184 

## Description

Updates the Reader tag cell to the new UI: p1715247952499939/1715197207.367749-slack-C05N140C8H5

## Testing

To test:
- Launch Jetpack and login
- Enable the "Reader Tags Feed" feature flag
- Navigate to the "Your Tags" feed
- After the feed loads, 🔎 **verify** the UI is updated to the UI referenced above 

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)