### PR TITLE
[Notifications Refresh] Revert Packages.resolved changes

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
           "branch": null,
-          "revision": "14b10de6d21b0d2e9ee41fc63b1cffc840d73003",
-          "version": "1.1.3"
+          "revision": "0f784591b324e5d3ddc5771808ef8eca923e3de2",
+          "version": "1.1.2"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/danielgindi/Charts",
         "state": {
           "branch": null,
-          "revision": "dd9c72e3d7e751e769971092a6bd72d39198ae63",
-          "version": "5.1.0"
+          "revision": "0a229f8c914b0ec93798cee058cf75b339297513",
+          "version": "5.0.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "3ef6999c73b6938cc0da422f2c912d0158abb0a0",
-          "version": "2.2.0"
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "2ef56b2caf25f55fa7eef8784c30d5a767550f54",
-          "version": "2.2.1"
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/airbnb/lottie-ios.git",
         "state": {
           "branch": null,
-          "revision": "769b88d83a42ca8d5572b020c96f47e3690b3796",
-          "version": "4.4.3"
+          "revision": "f522990668c2f9132323a2e68d924c7dcb9130b4",
+          "version": "4.4.0"
         }
       },
       {


### PR DESCRIPTION
## Description
This PR reverts `Package.resolved` changes introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/23147

## Test Instructions
Verify the content of `Package.resolved` in [trunk](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved) matches the one in this branch.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

