### PR TITLE
Fix MediaRequestAuthenticator Core Data threading issue

### DIFF
--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -33,6 +33,7 @@ class MediaRequestAuthenticator {
     // MARK: - Request Authentication
 
     /// Returns an authenticated request for the given URL and the media host.
+    @MainActor
     func authenticatedRequest(for url: URL, host: MediaHost) async throws -> URLRequest {
         try await withUnsafeThrowingContinuation { continuation in
             authenticatedRequest(for: url, from: host) { request in


### PR DESCRIPTION
Fixes an issue discovered when testing private Atomic sites.

There is a threading violation in this line that's being called from the background.

```swift
try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)
```

I moved it to the main thread as a quick fix, but it really needs to be redesigned together with how session dependencies are managed in the app.

## To test:

- Open a private Atomic site
- Open Media
- Verify that Xcode doesn't report any Core Data threading violations

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
