### PR TITLE
In-App Updates: Add remote config param for blocking version

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -34,6 +34,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
     case blazeFlowCompletedStep
     case wordPressPluginOverlayMaxShown
     case phaseFourOverlayFrequency
+    case wordPressInAppUpdateBlockingVersion
+    case jetpackInAppUpdateBlockingVersion
 
     var key: String {
         switch self {
@@ -57,6 +59,10 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "wp_plugin_overlay_max_shown"
         case .phaseFourOverlayFrequency:
             return "phase_four_overlay_frequency_in_days"
+        case .wordPressInAppUpdateBlockingVersion:
+            return "wp_in_app_update_blocking_version_ios"
+        case .jetpackInAppUpdateBlockingVersion:
+            return "jp_in_app_update_blocking_version_ios"
         }
     }
 
@@ -82,6 +88,10 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return 3
         case .phaseFourOverlayFrequency:
             return -1
+        case .wordPressInAppUpdateBlockingVersion:
+            return nil
+        case .jetpackInAppUpdateBlockingVersion:
+            return nil
         }
     }
 
@@ -107,6 +117,10 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "WP Plugin Overlay Max Frequency"
         case .phaseFourOverlayFrequency:
             return "Phase Four Overlay Frequency"
+        case .wordPressInAppUpdateBlockingVersion:
+            return "WP In-App Update Blocking Version"
+        case .jetpackInAppUpdateBlockingVersion:
+            return "JP In-App Update Blocking Version"
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/53

## Description
- Adds remote config params for WP and JP apps

## How to test
- Open remote config values via the debug menu
- ✅ Verify `WP In-App Update Blocking Version` and `JP In-App Update Blocking Version` are present

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/35f5a4a2-0af1-48e7-a181-f90df4ae215d" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
