### PR TITLE
Reader: Add announcement card

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -94,7 +94,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .readingPreferencesFeedback:
             return true
         case .readerAnnouncementCard:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -31,6 +31,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case siteSwitcherRedesign
     case readingPreferences
     case readingPreferencesFeedback
+    case readerAnnouncementCard
 
     var defaultValue: Bool {
         switch self {
@@ -92,6 +93,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return true
         case .readingPreferencesFeedback:
             return true
+        case .readerAnnouncementCard:
+            return false
         }
     }
 
@@ -156,6 +159,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "reading_preferences"
         case .readingPreferencesFeedback:
             return "reading_preferences_feedback"
+        case .readerAnnouncementCard:
+            return "reader_announcement_card"
         }
     }
 
@@ -219,6 +224,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Reading Preferences"
         case .readingPreferencesFeedback:
             return "Reading Preferences Feedback"
+        case .readerAnnouncementCard:
+            return "Reader Announcement Card"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -151,6 +151,7 @@ fileprivate extension ReaderAnnouncementHeader {
                 .foregroundColor(Color(.systemBackground))
                 .background(.primary)
                 .clipShape(Circle())
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(entry.title)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -51,52 +51,17 @@ class ReaderAnnouncementHeaderView: UITableViewHeaderFooterView, ReaderStreamHea
 
 fileprivate struct ReaderAnnouncementHeader: View {
 
+    // Determines what features should be listed (and its order).
+    let entries: [Entry] = [.tagsStream, .readingPreferences]
+
     var body: some View {
         VStack(alignment: .leading, spacing: .DS.Padding.double) {
             Text(Strings.title)
                 .font(.callout)
                 .fontWeight(.semibold)
 
-            // TODO: Display announcement items, Localization
-
-            HStack(spacing: .DS.Padding.double) {
-                Image("reader-menu-tags", bundle: nil)
-                    .renderingMode(.template)
-                    .resizable()
-                    .frame(width: 24, height: 24)
-                    .padding(12)
-                    .foregroundColor(Color(.systemBackground))
-                    .background(.primary)
-                    .clipShape(Circle())
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Tags Stream")
-                        .font(.callout)
-                        .fontWeight(.semibold)
-                    Text("Tap the dropdown at the top and select Tags to access streams from your followed tags.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            HStack(spacing: .DS.Padding.double) {
-                Image("reader-reading-preferences", bundle: nil)
-                    .renderingMode(.template)
-                    .resizable()
-                    .frame(width: 24, height: 24)
-                    .padding(12)
-                    .foregroundColor(Color(.systemBackground))
-                    .background(.primary)
-                    .clipShape(Circle())
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("Reading Preferences")
-                        .font(.callout)
-                        .fontWeight(.semibold)
-                    Text("Choose colors and fonts that suit you. When you’re reading a post tap the AA icon at the top of the screen.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
+            ForEach(entries, id: \.title) { entry in
+                announcementEntryView(entry)
             }
 
             // DismissButton
@@ -110,9 +75,80 @@ fileprivate struct ReaderAnnouncementHeader: View {
         .background(Color(.listForeground))
     }
 
-    // TODO: Localization
+    // MARK: Constants
+
     private struct Strings {
-        static let title = "New in Reader"
-        static let buttonTitle = "Done"
+        static let title = NSLocalizedString(
+            "reader.announcement.title",
+            value: "New in Reader",
+            comment: "Title text for the announcement card component in the Reader."
+        )
+        static let buttonTitle = NSLocalizedString(
+            "reader.announcement.button",
+            value: "Done",
+            comment: "Text for a button that dismisses the announcement card in the Reader."
+        )
+    }
+}
+
+// MARK: - Announcement Item
+
+fileprivate extension ReaderAnnouncementHeader {
+
+    struct Entry {
+        static let tagsStream = Entry(
+            imageName: "reader-menu-tags",
+            title: NSLocalizedString(
+                "reader.announcement.entry.tagsStream.title",
+                value: "Tags Stream",
+                comment: "The title part of the feature announcement content for Tags Stream."
+            ),
+            description: NSLocalizedString(
+                "reader.announcement.entry.tagsStream.description",
+                value: "Tap the dropdown at the top and select Tags to access streams from your followed tags.",
+                comment: "The description part of the feature announcement content for Tags Stream."
+            )
+        )
+
+        static let readingPreferences = Entry(
+            imageName: "reader-reading-preferences",
+            title: NSLocalizedString(
+                "reader.announcement.entry.tagsStream.title",
+                value: "Tags Stream",
+                comment: "The title part of the feature announcement content for Tags Stream."
+            ),
+            description: NSLocalizedString(
+                "reader.announcement.entry.tagsStream.description",
+                value: "Tap the dropdown at the top and select Tags to access streams from your followed tags.",
+                comment: "The description part of the feature announcement content for Tags Stream."
+            )
+        )
+
+        let imageName: String
+        let title: String
+        let description: String
+    }
+
+    @ViewBuilder
+    func announcementEntryView(_ entry: Entry) -> some View {
+        HStack(spacing: .DS.Padding.double) {
+            Image(entry.imageName, bundle: nil)
+                .renderingMode(.template)
+                .resizable()
+                .frame(width: 24, height: 24)
+                .padding(12)
+                .foregroundColor(Color(.systemBackground))
+                .background(.primary)
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(entry.title)
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                Text(entry.description)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -30,7 +30,7 @@ class ReaderAnnouncementHeaderView: UITableViewHeaderFooterView, ReaderStreamHea
             view.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
         ])
 
-        applyBackgroundColor(.secondarySystemGroupedBackground)
+        applyBackgroundColor(Constants.backgroundColor)
         addBottomBorder(withColor: .separator)
     }
 
@@ -48,6 +48,10 @@ class ReaderAnnouncementHeaderView: UITableViewHeaderFooterView, ReaderStreamHea
 
     func configureHeader(_ topic: ReaderAbstractTopic) {
         // no-op; this header doesn't rely on the supplied topic.
+    }
+
+    fileprivate struct Constants {
+        static let backgroundColor = UIColor.systemBackground
     }
 }
 
@@ -72,7 +76,6 @@ fileprivate struct ReaderAnnouncementHeader: View {
                 announcementEntryView(entry)
             }
 
-            // DismissButton
             DSButton(title: Strings.buttonTitle,
                      style: DSButtonStyle(emphasis: .primary, size: .large)) {
                 onButtonTap?()
@@ -80,7 +83,7 @@ fileprivate struct ReaderAnnouncementHeader: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(.vertical, .DS.Padding.medium)
-        .background(Color(.listForeground))
+        .background(Color(ReaderAnnouncementHeaderView.Constants.backgroundColor))
     }
 
     // MARK: Constants

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -167,7 +167,20 @@ class ReaderAnnouncementCoordinator {
 
     let repository: UserPersistentRepository = UserPersistentStoreFactory.instance()
 
-    lazy var isFeatureEnabled: Bool = {
-        return RemoteFeatureFlag.readerAnnouncementCard.enabled()
+    lazy var canShowAnnouncement: Bool = {
+        return !isDismissed && RemoteFeatureFlag.readerAnnouncementCard.enabled()
     }()
+
+    var isDismissed: Bool {
+        get {
+            repository.bool(forKey: Constants.key)
+        }
+        set {
+            repository.set(newValue, forKey: Constants.key)
+        }
+    }
+
+    private struct Constants {
+        static let key = "readerAnnouncementCardDismissedKey"
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -160,3 +160,14 @@ fileprivate extension ReaderAnnouncementHeader {
         }
     }
 }
+
+// MARK: - Reader Announcement Coordinator
+
+class ReaderAnnouncementCoordinator {
+
+    let repository: UserPersistentRepository = UserPersistentStoreFactory.instance()
+
+    lazy var isFeatureEnabled: Bool = {
+        return RemoteFeatureFlag.readerAnnouncementCard.enabled()
+    }()
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -5,7 +5,13 @@ class ReaderAnnouncementHeaderView: UITableViewHeaderFooterView, ReaderStreamHea
 
     weak var delegate: ReaderStreamHeaderDelegate?
 
-    init() {
+    private let header: ReaderAnnouncementHeader
+
+    init(doneButtonTapped: (() -> Void)? = nil) {
+        self.header = ReaderAnnouncementHeader { [doneButtonTapped] in
+            doneButtonTapped?()
+        }
+
         super.init(reuseIdentifier: ReaderSiteHeaderView.classNameWithoutNamespaces())
         setupViews()
     }
@@ -15,7 +21,7 @@ class ReaderAnnouncementHeaderView: UITableViewHeaderFooterView, ReaderStreamHea
     }
 
     private func setupViews() {
-        let view = UIView.embedSwiftUIView(ReaderAnnouncementHeader())
+        let view = UIView.embedSwiftUIView(self.header)
         addSubview(view)
         NSLayoutConstraint.activate([
             view.topAnchor.constraint(equalTo: topAnchor),
@@ -54,6 +60,8 @@ fileprivate struct ReaderAnnouncementHeader: View {
     // Determines what features should be listed (and its order).
     let entries: [Entry] = [.tagsStream, .readingPreferences]
 
+    var onButtonTap: (() -> Void)? = nil
+
     var body: some View {
         VStack(alignment: .leading, spacing: .DS.Padding.double) {
             Text(Strings.title)
@@ -67,7 +75,7 @@ fileprivate struct ReaderAnnouncementHeader: View {
             // DismissButton
             DSButton(title: Strings.buttonTitle,
                      style: DSButtonStyle(emphasis: .primary, size: .large)) {
-                // TODO: Dismiss the header
+                onButtonTap?()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -113,14 +121,14 @@ fileprivate extension ReaderAnnouncementHeader {
         static let readingPreferences = Entry(
             imageName: "reader-reading-preferences",
             title: NSLocalizedString(
-                "reader.announcement.entry.tagsStream.title",
-                value: "Tags Stream",
-                comment: "The title part of the feature announcement content for Tags Stream."
+                "reader.announcement.entry.readingPreferences.title",
+                value: "Reading Preferences",
+                comment: "The title part of the feature announcement content for Reading Preferences."
             ),
             description: NSLocalizedString(
-                "reader.announcement.entry.tagsStream.description",
-                value: "Tap the dropdown at the top and select Tags to access streams from your followed tags.",
-                comment: "The description part of the feature announcement content for Tags Stream."
+                "reader.announcement.entry.readingPreferences.description",
+                value: "Choose colors and fonts that suit you. When you’re reading a post tap the AA icon at the top of the screen.",
+                comment: "The description part of the feature announcement content for Reading Preferences."
             )
         )
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import DesignSystem
+
+class ReaderAnnouncementHeaderView: UITableViewHeaderFooterView, ReaderStreamHeader {
+
+    weak var delegate: ReaderStreamHeaderDelegate?
+
+    init() {
+        super.init(reuseIdentifier: ReaderSiteHeaderView.classNameWithoutNamespaces())
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        let view = UIView.embedSwiftUIView(ReaderAnnouncementHeader())
+        addSubview(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: topAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
+        ])
+
+        applyBackgroundColor(.secondarySystemGroupedBackground)
+        addBottomBorder(withColor: .separator)
+    }
+
+    private func applyBackgroundColor(_ color: UIColor) {
+        let backgroundView = UIView(frame: bounds)
+        backgroundView.backgroundColor = color
+        self.backgroundView = backgroundView
+    }
+
+    // MARK: ReaderStreamHeader
+
+    func enableLoggedInFeatures(_ enable: Bool) {
+        // no-op
+    }
+
+    func configureHeader(_ topic: ReaderAbstractTopic) {
+        // no-op; this header doesn't rely on the supplied topic.
+    }
+}
+
+// TODO: ReaderAnnouncementItem / Models
+
+// MARK: - SwiftUI View
+
+fileprivate struct ReaderAnnouncementHeader: View {
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: .DS.Padding.double) {
+            Text(Strings.title)
+                .font(.callout)
+                .fontWeight(.semibold)
+
+            // TODO: Display announcement items, Localization
+
+            HStack(spacing: .DS.Padding.double) {
+                Image("reader-menu-tags", bundle: nil)
+                    .renderingMode(.template)
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .padding(12)
+                    .foregroundColor(Color(.systemBackground))
+                    .background(.primary)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Tags Stream")
+                        .font(.callout)
+                        .fontWeight(.semibold)
+                    Text("Tap the dropdown at the top and select Tags to access streams from your followed tags.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: .DS.Padding.double) {
+                Image("reader-reading-preferences", bundle: nil)
+                    .renderingMode(.template)
+                    .resizable()
+                    .frame(width: 24, height: 24)
+                    .padding(12)
+                    .foregroundColor(Color(.systemBackground))
+                    .background(.primary)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Reading Preferences")
+                        .font(.callout)
+                        .fontWeight(.semibold)
+                    Text("Choose colors and fonts that suit you. When you’re reading a post tap the AA icon at the top of the screen.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // DismissButton
+            DSButton(title: Strings.buttonTitle,
+                     style: DSButtonStyle(emphasis: .primary, size: .large)) {
+                // TODO: Dismiss the header
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.vertical, .DS.Padding.medium)
+        .background(Color(.listForeground))
+    }
+
+    // TODO: Localization
+    private struct Strings {
+        static let title = "New in Reader"
+        static let buttonTitle = "Done"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-class ReaderSiteHeaderView: UIView, ReaderStreamHeader {
+class ReaderSiteHeaderView: UITableViewHeaderFooterView, ReaderStreamHeader {
 
     weak var delegate: ReaderStreamHeaderDelegate?
 
@@ -14,8 +14,8 @@ class ReaderSiteHeaderView: UIView, ReaderStreamHeader {
     }()
 
     init() {
-        super.init(frame: .zero)
-        backgroundColor = .secondarySystemGroupedBackground
+        super.init(reuseIdentifier: ReaderSiteHeaderView.classNameWithoutNamespaces())
+        applyBackgroundColor(.secondarySystemGroupedBackground)
         setupHeader()
     }
 
@@ -46,9 +46,28 @@ class ReaderSiteHeaderView: UIView, ReaderStreamHeader {
         let header = ReaderSiteHeader(viewModel: weakSelf?.headerViewModel ?? ReaderSiteHeaderViewModel())
         let view = UIView.embedSwiftUIView(header)
         addSubview(view)
-        pinSubviewToAllEdges(view)
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: topAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
+        ])
+
+        addBottomBorder(withColor: .separator)
     }
 
+    /// Sets the background color of the container view.
+    ///
+    /// For `UITableViewHeaderFooterView`, we'll need to assign a `UIView` with the desired
+    /// background color to the `backgroundView` property. Setting the `backgroundColor`
+    /// directly will pop a warning in the console.
+    ///
+    /// - Parameter color: The background color
+    private func applyBackgroundColor(_ color: UIColor) {
+        let backgroundView = UIView(frame: bounds)
+        backgroundView.backgroundColor = .secondarySystemGroupedBackground
+        self.backgroundView = backgroundView
+    }
 }
 
 // MARK: - ReaderSiteHeader

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -65,7 +65,7 @@ class ReaderSiteHeaderView: UITableViewHeaderFooterView, ReaderStreamHeader {
     /// - Parameter color: The background color
     private func applyBackgroundColor(_ color: UIColor) {
         let backgroundView = UIView(frame: bounds)
-        backgroundView.backgroundColor = .secondarySystemGroupedBackground
+        backgroundView.backgroundColor = color
         self.backgroundView = backgroundView
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -19,11 +19,16 @@ extension ReaderStreamViewController {
     ///
     /// - Returns: A configured instance of UIView.
     ///
-    func headerForStream(_ topic: ReaderAbstractTopic, isLoggedIn: Bool, container: UITableViewController) -> UIView? {
+    func headerForStream(_ topic: ReaderAbstractTopic?, isLoggedIn: Bool, container: UITableViewController) -> UIView? {
+        if let topic,
+           let header = headerForStream(topic) {
+            configure(header, topic: topic, isLoggedIn: isLoggedIn, delegate: self)
+            return header
+        }
 
-        let header = headerForStream(topic)
-        configure(header, topic: topic, isLoggedIn: isLoggedIn, delegate: self)
-        return header
+        // The announcement header should have the lowest display priority.
+        // Only return the announcement when there's no other header.
+        return makeAnnouncementHeader()
     }
 
     func configure(_ header: ReaderHeader?, topic: ReaderAbstractTopic, isLoggedIn: Bool, delegate: ReaderStreamHeaderDelegate) {
@@ -151,6 +156,20 @@ extension ReaderStreamViewController {
         messageText.replace("[bookmark-outline]", with: icon)
 
         resultsStatusView.configureForLocalData(title: noResultsResponse.title, attributedSubtitle: messageText, image: "wp-illustration-reader-empty")
+    }
+}
+
+// MARK: - Reader Announcement Header
+
+private extension ReaderStreamViewController {
+    /// Returns a header view for Reader-related announcements.
+    /// Note that the announcement can be shown on topicless streams (e.g., Saved, Tags).
+    ///
+    /// - Returns: A configured UIView, or nil if the conditions are not met.
+    func makeAnnouncementHeader() -> UIView? {
+        // TODO: Add conditions
+        // TODO: Create and configure the views
+        return nil
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -167,15 +167,15 @@ extension ReaderStreamViewController {
     ///
     /// - Returns: A configured UIView, or nil if the conditions are not met.
     func makeAnnouncementHeader() -> UIView? {
-        // TODO: Add more conditions: dismiss flag check
-        guard readerAnnouncementCoordinator.isFeatureEnabled,
+        guard readerAnnouncementCoordinator.canShowAnnouncement,
               tableView.tableHeaderView == nil,
               !contentIsEmpty() else {
             return nil
         }
 
         return ReaderAnnouncementHeaderView(doneButtonTapped: { [weak self] in
-            // TODO: Update the dismiss flag.
+            // Set the card as dismissed.
+            self?.readerAnnouncementCoordinator.isDismissed = true
 
             // Animate the header removal so it feels less jarring.
             UIView.animate(withDuration: 0.3) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -161,14 +161,15 @@ extension ReaderStreamViewController {
 
 // MARK: - Reader Announcement Header
 
-private extension ReaderStreamViewController {
+extension ReaderStreamViewController {
     /// Returns a header view for Reader-related announcements.
-    /// Note that the announcement can be shown on topicless streams (e.g., Saved, Tags).
+    /// Note that the announcement can also be shown on topicless streams (e.g., Saved, Tags).
     ///
     /// - Returns: A configured UIView, or nil if the conditions are not met.
     func makeAnnouncementHeader() -> UIView? {
-        // TODO: Add more conditions
-        guard !contentIsEmpty() else {
+        // TODO: Add more conditions: remote feature flag, dismiss flag check
+        guard tableView.tableHeaderView == nil,
+              !contentIsEmpty() else {
             return nil
         }
 
@@ -184,6 +185,18 @@ private extension ReaderStreamViewController {
                 })
             }
         })
+    }
+
+    // The header may be configured when the content is still empty (i.e., Discover stream).
+    // This method is added to provide a way to inject the announcement card outside of
+    // `configureStreamHeader()`. For example, after syncing completes.
+    func showAnnouncementHeaderIfNeeded(completion: (() -> Void)? = nil) {
+        guard let headerView = makeAnnouncementHeader() else {
+            return
+        }
+
+        tableView.tableHeaderView = headerView
+        completion?()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -169,6 +169,7 @@ extension ReaderStreamViewController {
     func makeAnnouncementHeader() -> UIView? {
         guard readerAnnouncementCoordinator.canShowAnnouncement,
               tableView.tableHeaderView == nil,
+              !isContentFiltered,
               !contentIsEmpty() else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -169,7 +169,7 @@ private extension ReaderStreamViewController {
     func makeAnnouncementHeader() -> UIView? {
         // TODO: Add conditions
         // TODO: Create and configure the views
-        return nil
+        return ReaderAnnouncementHeaderView()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -167,8 +167,9 @@ extension ReaderStreamViewController {
     ///
     /// - Returns: A configured UIView, or nil if the conditions are not met.
     func makeAnnouncementHeader() -> UIView? {
-        // TODO: Add more conditions: remote feature flag, dismiss flag check
-        guard tableView.tableHeaderView == nil,
+        // TODO: Add more conditions: dismiss flag check
+        guard readerAnnouncementCoordinator.isFeatureEnabled,
+              tableView.tableHeaderView == nil,
               !contentIsEmpty() else {
             return nil
         }
@@ -198,6 +199,7 @@ extension ReaderStreamViewController {
         tableView.tableHeaderView = headerView
         completion?()
     }
+
 }
 
 // MARK: - Undo cell for saved posts

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -167,9 +167,23 @@ private extension ReaderStreamViewController {
     ///
     /// - Returns: A configured UIView, or nil if the conditions are not met.
     func makeAnnouncementHeader() -> UIView? {
-        // TODO: Add conditions
-        // TODO: Create and configure the views
-        return ReaderAnnouncementHeaderView()
+        // TODO: Add more conditions
+        guard !contentIsEmpty() else {
+            return nil
+        }
+
+        return ReaderAnnouncementHeaderView(doneButtonTapped: { [weak self] in
+            // TODO: Update the dismiss flag.
+
+            // Animate the header removal so it feels less jarring.
+            UIView.animate(withDuration: 0.3) {
+                self?.tableView.tableHeaderView?.layer.opacity = 0.0
+            } completion: { _ in
+                self?.tableView.performBatchUpdates({
+                    self?.tableView.tableHeaderView = nil
+                })
+            }
+        })
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -226,6 +226,8 @@ import AutomatticTracks
     // We need to ensure that we only fetch the remote data once per tag to avoid the resultsController from refreshing the table view indefinitely.
     private var tagStreamSyncTracker = Set<String>()
 
+    /// Controls whether the Reader announcement card can be displayed.
+    ///
     let readerAnnouncementCoordinator = ReaderAnnouncementCoordinator()
 
     lazy var selectInterestsViewController: ReaderSelectInterestsViewController = {
@@ -1114,9 +1116,9 @@ import AutomatticTracks
                 // Show the announcement card if possible.
                 // Context: `configureStreamHeader()` may be called while the content is still empty.
                 // Calling it here manually ensures that we know whether the content is actually empty or not.
-                self?.showAnnouncementHeaderIfNeeded(completion: {
+                self?.showAnnouncementHeaderIfNeeded { [weak self] in
                     self?.refreshTableViewHeaderLayout()
-                })
+                }
 
                 success?(hasMore)
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1107,6 +1107,14 @@ import AutomatticTracks
                     }
                     strongSelf.updateLastSyncedForTopic(objectID)
                 }
+
+                // Show the announcement card if possible.
+                // Context: `configureStreamHeader()` may be called while the content is still empty.
+                // Calling it here manually ensures that we know whether the content is actually empty or not.
+                self?.showAnnouncementHeaderIfNeeded(completion: {
+                    self?.refreshTableViewHeaderLayout()
+                })
+
                 success?(hasMore)
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -595,12 +595,7 @@ import AutomatticTracks
     // MARK: - Configuration / Topic Presentation
 
     @objc private func configureStreamHeader() {
-        guard let topic = readerTopic else {
-            assertionFailure()
-            return
-        }
-
-        guard let headerView = headerForStream(topic, isLoggedIn: isLoggedIn, container: tableViewController) else {
+        guard let headerView = headerForStream(readerTopic, isLoggedIn: isLoggedIn, container: tableViewController) else {
             tableView.tableHeaderView = nil
             return
         }
@@ -658,11 +653,7 @@ import AutomatticTracks
         hideResultsStatus()
         recentlyBlockedSitePostObjectIDs.removeAllObjects()
         updateAndPerformFetchRequest()
-        if readerTopic != nil {
-            configureStreamHeader()
-        } else {
-            tableView.tableHeaderView = nil
-        }
+        configureStreamHeader()
         tableView.setContentOffset(CGPoint.zero, animated: false)
         content.refresh()
         refreshTableViewHeaderLayout()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -225,6 +225,9 @@ import AutomatticTracks
     // The set object flags each tag in the stream so that we know whether or not we've fetched the remote data for the tag.
     // We need to ensure that we only fetch the remote data once per tag to avoid the resultsController from refreshing the table view indefinitely.
     private var tagStreamSyncTracker = Set<String>()
+
+    let readerAnnouncementCoordinator = ReaderAnnouncementCoordinator()
+
     lazy var selectInterestsViewController: ReaderSelectInterestsViewController = {
         let title = NSLocalizedString(
             "reader.select.tags.title",

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -186,6 +186,7 @@ import AutomatticTracks
         }
     }
 
+    /// Whether the stream is being filtered by a site or tag.
     var isContentFiltered: Bool = false
 
     var contentType: ReaderContentType = .topic {
@@ -599,34 +600,17 @@ import AutomatticTracks
             return
         }
 
-        guard let header = headerForStream(topic, isLoggedIn: isLoggedIn, container: tableViewController) else {
+        guard let headerView = headerForStream(topic, isLoggedIn: isLoggedIn, container: tableViewController) else {
             tableView.tableHeaderView = nil
             return
         }
 
-        let isNewHeader = !isContentFiltered
-        let isNewSiteHeader = isNewHeader && ReaderHelpers.isTopicSite(topic)
-
-        let headerView = {
-            guard isNewSiteHeader else {
-                return header
-            }
-
-            // The container view is added so that the header respects the safe area boundaries and expands
-            // the header's background color to the screen's edges.
-            let containerView = UIView()
-            containerView.translatesAutoresizingMaskIntoConstraints = false
-            containerView.backgroundColor = header.backgroundColor
-            header.translatesAutoresizingMaskIntoConstraints = false
-            containerView.addSubview(header)
-            return containerView
-        }()
-
         if let tableHeaderView = tableView.tableHeaderView {
             headerView.isHidden = tableHeaderView.isHidden
         }
+
         tableView.tableHeaderView = headerView
-        streamHeader = header as? ReaderStreamHeader
+        streamHeader = headerView as? ReaderStreamHeader
 
         // This feels somewhat hacky, but it is the only way I found to insert a stack view into the header without breaking the autolayout constraints.
         let centerConstraint = headerView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor)
@@ -635,37 +619,12 @@ import AutomatticTracks
         headerWidthConstraint.priority = UILayoutPriority(999)
         centerConstraint.priority = UILayoutPriority(999)
 
-        var constraints = [
+        NSLayoutConstraint.activate([
             centerConstraint,
             headerWidthConstraint,
             topConstraint
-        ]
+        ])
 
-        if isNewSiteHeader {
-            constraints.append(contentsOf: [
-                header.topAnchor.constraint(equalTo: headerView.topAnchor),
-                header.bottomAnchor.constraint(equalTo: headerView.bottomAnchor),
-                header.trailingAnchor.constraint(equalTo: tableView.readableContentGuide.trailingAnchor),
-                header.leadingAnchor.constraint(equalTo: tableView.readableContentGuide.leadingAnchor),
-            ])
-        }
-
-        // manually add a separator for the new header views.
-        if isNewHeader {
-            let borderView = UIView()
-            borderView.backgroundColor = .separator
-            borderView.translatesAutoresizingMaskIntoConstraints = false
-            headerView.addSubview(borderView)
-
-            constraints.append(contentsOf: [
-                borderView.bottomAnchor.constraint(equalTo: headerView.bottomAnchor),
-                borderView.heightAnchor.constraint(equalToConstant: 0.5),
-                borderView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                borderView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-            ])
-        }
-
-        NSLayoutConstraint.activate(constraints)
         tableView.tableHeaderView?.layoutIfNeeded()
         tableView.tableHeaderView = tableView.tableHeaderView
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -13,6 +13,7 @@ import WordPressShared
 
         applyStyles()
         adjustInsetsForTextDirection()
+        addBottomBorder(withColor: .separator)
     }
 
     @objc func applyStyles() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,13 +34,13 @@
             <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
             <color key="tintColor" systemColor="linkColor"/>
             <constraints>
-                <constraint firstItem="IFQ-dS-FSp" firstAttribute="top" secondItem="7PP-0C-EJV" secondAttribute="bottom" constant="16" id="BGh-Ef-dXj"/>
-                <constraint firstItem="7PP-0C-EJV" firstAttribute="top" secondItem="Zt2-QZ-5QS" secondAttribute="top" constant="16" id="CJ7-g8-NPl"/>
-                <constraint firstItem="7PP-0C-EJV" firstAttribute="leading" secondItem="Zt2-QZ-5QS" secondAttribute="leadingMargin" id="Moo-2i-lF7"/>
-                <constraint firstAttribute="trailingMargin" secondItem="7PP-0C-EJV" secondAttribute="trailing" id="XE2-Y7-Z5x"/>
-                <constraint firstItem="IFQ-dS-FSp" firstAttribute="leading" secondItem="Zt2-QZ-5QS" secondAttribute="leadingMargin" id="f4x-dn-pDf"/>
-                <constraint firstAttribute="bottom" secondItem="IFQ-dS-FSp" secondAttribute="bottom" constant="16" id="gxg-Nl-MT8"/>
-                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="IFQ-dS-FSp" secondAttribute="trailing" id="iNu-iN-yhk"/>
+                <constraint firstItem="IFQ-dS-FSp" firstAttribute="top" secondItem="7PP-0C-EJV" secondAttribute="bottom" priority="999" constant="16" id="BGh-Ef-dXj"/>
+                <constraint firstItem="7PP-0C-EJV" firstAttribute="top" secondItem="Zt2-QZ-5QS" secondAttribute="top" priority="999" constant="16" id="CJ7-g8-NPl"/>
+                <constraint firstItem="7PP-0C-EJV" firstAttribute="leading" secondItem="Zt2-QZ-5QS" secondAttribute="leadingMargin" priority="999" id="Moo-2i-lF7"/>
+                <constraint firstAttribute="trailingMargin" secondItem="7PP-0C-EJV" secondAttribute="trailing" priority="999" id="XE2-Y7-Z5x"/>
+                <constraint firstItem="IFQ-dS-FSp" firstAttribute="leading" secondItem="Zt2-QZ-5QS" secondAttribute="leadingMargin" priority="999" id="f4x-dn-pDf"/>
+                <constraint firstAttribute="bottom" secondItem="IFQ-dS-FSp" secondAttribute="bottom" priority="999" constant="16" id="gxg-Nl-MT8"/>
+                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="IFQ-dS-FSp" secondAttribute="trailing" priority="999" id="iNu-iN-yhk"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5705,6 +5705,7 @@
 		FE50965C2A20D0F300DDD071 /* CommentTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE50965B2A20D0F300DDD071 /* CommentTableHeaderView.swift */; };
 		FE50965D2A20D0F300DDD071 /* CommentTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE50965B2A20D0F300DDD071 /* CommentTableHeaderView.swift */; };
 		FE59025F2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE59025E2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift */; };
+		FE5902602BF3795600115D08 /* ReaderAnnouncementHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE59025E2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift */; };
 		FE6AFE432B18EDF200F76520 /* BloganuaryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */; };
 		FE6AFE442B18EDF200F76520 /* BloganuaryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */; };
 		FE6AFE472B1A351F00F76520 /* SOTWCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */; };
@@ -22678,6 +22679,7 @@
 				80EF928D280E83110064A971 /* QuickStartToursCollection.swift in Sources */,
 				7E58879A20FE8D9300DB6F80 /* AppEnvironment.swift in Sources */,
 				591232691CCEAA5100B86207 /* AbstractPostListViewController.swift in Sources */,
+				FE5902602BF3795600115D08 /* ReaderAnnouncementHeaderView.swift in Sources */,
 				E14200781C117A2E00B3B115 /* ManagedAccountSettings.swift in Sources */,
 				0C23F3362AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift in Sources */,
 				401AC82722DD2387006D78D4 /* Blog+Plans.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5704,6 +5704,7 @@
 		FE50965A2A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5096582A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift */; };
 		FE50965C2A20D0F300DDD071 /* CommentTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE50965B2A20D0F300DDD071 /* CommentTableHeaderView.swift */; };
 		FE50965D2A20D0F300DDD071 /* CommentTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE50965B2A20D0F300DDD071 /* CommentTableHeaderView.swift */; };
+		FE59025F2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE59025E2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift */; };
 		FE6AFE432B18EDF200F76520 /* BloganuaryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */; };
 		FE6AFE442B18EDF200F76520 /* BloganuaryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */; };
 		FE6AFE472B1A351F00F76520 /* SOTWCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6AFE462B1A351F00F76520 /* SOTWCardView.swift */; };
@@ -9624,6 +9625,7 @@
 		FE5096572A13D5BA00DDD071 /* WordPress 149.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 149.xcdatamodel"; sourceTree = "<group>"; };
 		FE5096582A17A69F00DDD071 /* TwitterDeprecationTableFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterDeprecationTableFooterView.swift; sourceTree = "<group>"; };
 		FE50965B2A20D0F300DDD071 /* CommentTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTableHeaderView.swift; sourceTree = "<group>"; };
+		FE59025E2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderAnnouncementHeaderView.swift; sourceTree = "<group>"; };
 		FE59DA9527D1FD0700624D26 /* WordPress 138.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 138.xcdatamodel"; sourceTree = "<group>"; };
 		FE5F52D82AF9461200371A3A /* WordPress 153.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 153.xcdatamodel"; sourceTree = "<group>"; };
 		FE6AFE422B18EDF200F76520 /* BloganuaryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloganuaryTracker.swift; sourceTree = "<group>"; };
@@ -17490,6 +17492,7 @@
 				E6D2E16B1B8B423B0000ED14 /* ReaderStreamHeader.swift */,
 				E6D2E1661B8AAD8C0000ED14 /* ReaderTagStreamHeader.swift */,
 				E6D2E1601B8AA4410000ED14 /* ReaderTagStreamHeader.xib */,
+				FE59025E2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift */,
 			);
 			name = Headers;
 			sourceTree = "<group>";
@@ -25256,6 +25259,7 @@
 				FABB231F2602FC2C00C8785C /* SignupUsernameTableViewController.swift in Sources */,
 				FABB23202602FC2C00C8785C /* Blog+Editor.swift in Sources */,
 				FABB23212602FC2C00C8785C /* ReaderCardService.swift in Sources */,
+				FE59025F2BF2558300115D08 /* ReaderAnnouncementHeaderView.swift in Sources */,
 				FABB23222602FC2C00C8785C /* UITableViewCell+Stats.swift in Sources */,
 				FABB23232602FC2C00C8785C /* Delay.swift in Sources */,
 				FABB23242602FC2C00C8785C /* Pageable.swift in Sources */,


### PR DESCRIPTION
Part of #23069 

Adds the announcement card to the Reader stream. The card is only shown when:

- There's no other header being displayed. The announcement card should have the lowest display priority.
- There are no active filters.
- There are contents to display. It shouldn't be displayed when the no results or error view is displayed.
- The announcement card hasn't been dismissed yet.
- Lastly, of course, the remote feature flag `reader_announcement_card` needs to be enabled.

Preview:

Light | Dark
-|-
![Simulator Screenshot - iPhone 15 - 2024-05-14 at 02 25 27](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/0669564e-81ef-4725-b802-8bf90471e331) | ![Simulator Screenshot - iPhone 15 - 2024-05-14 at 02 20 20](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/6bb7c868-8bea-4a47-9554-a2878e2dbb92)


## To test

> [!TIP]
> To avoid dismissing the card and never seeing it again, you could temporarily disable the dismiss logic by commenting out the line in `ReaderStreamViewController+Helper.swift:L179`:
> ```swift
>     self?.readerAnnouncementCoordinator.isDismissed = false
> ```
> This way, the announcement card will reappear on the next stream after you dismiss it.


- Make sure the `readerAnnouncementCard` flag is enabled.
- Launch the Jetpack app.
- Go to the Reader tab.
- 🔎 Verify that the announcement card is displayed in the Discover stream.
- Navigate to other (non-empty) streams.
- 🔎 Verify that the announcement card is visible.
- Navigate to an empty stream.
- 🔎 Verify that the announcement card is NOT visible.
- Go to `Subscriptions` or `Your Tags` and filter the stream.
- 🔎 Verify that the announcement card is NOT visible.

#### Offline case
- Turn on airplane mode and relaunch the Jetpack app.
- Go to the Reader stream > Discover.
- 🔎 Verify that the announcement card is NOT visible.

#### Spam test

<details>

<summary>Context</summary>

During development, I stumbled on some crashes while switching to `Discover`, and it crashed with this message:

```
Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'unable to dequeue a cell with identifier ReaderSitesCell - must register a nib or a class for the identifier or connect a prototype cell in a storyboard'
```

https://github.com/wordpress-mobile/WordPress-iOS/blob/c055c21bfb03461fd18bb70f53ba62f25c38a2de/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift#L93

However, after a while, it seems like the crash stopped happening... I'm guessing it may be related to this commit: https://github.com/wordpress-mobile/WordPress-iOS/commit/45d58e409e3f51cf0f9a82c1ac8e5a1de79c880a since the refresh method calls `layoutIfNeeded` on the table view, and perhaps there might be a retain cycle somewhere.

</details>

- Ensure that the connectivity is enabled.
- Go to the Reader stream > Discover.
- Quickly switch to different streams.
  - Note: you could also try activating the Network Link Conditioner to switch streams while the request is in progress.
- 🔎 Ensure that the app does not crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The card is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
