### PR TITLE
Remove percentage rollout for sync publishing

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -119,11 +119,6 @@ extension FeatureFlag: RolloutConfigurableFlag {
     /// If a percentage rollout isn't applicable for the flag, return nil.
     ///
     var rolloutPercentage: Double? {
-        switch self {
-        case .syncPublishing:
-            return 0.01  // 1%
-        default:
-            return nil
-        }
+        return nil
     }
 }


### PR DESCRIPTION
Follow on for https://github.com/wordpress-mobile/WordPress-iOS/pull/23196#event-12792087471

## Description
- Removes percentage rollout specified for the syncPublishing feature flag

