### PR TITLE
Enable performance monitoring

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -54,7 +54,7 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
     var shouldEnableAutomaticSessionTracking: Bool {
         return !UserSettings.userHasOptedOutOfCrashLogging
     }
-    
+
     let performanceTracking: PerformanceTracking = {
         let config = PerformanceTracking.Configuration(
             sampler: { 0.005 },

--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -54,6 +54,16 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
     var shouldEnableAutomaticSessionTracking: Bool {
         return !UserSettings.userHasOptedOutOfCrashLogging
     }
+    
+    let performanceTracking: PerformanceTracking = {
+        let config = PerformanceTracking.Configuration(
+            sampler: { 0.005 },
+            profilingRate: 0.01,
+            trackCoreData: true,
+            trackNetwork: false
+        )
+        return .enabled(config)
+    }()
 
     var currentUser: TracksUser? {
         return contextManager.performQuery { context -> TracksUser? in


### PR DESCRIPTION
This PR enables Performance Monitoring in the app.

To test:
1. Open `WPCrashLoggingProvider`
2. Update `sampler` to `{ 1.0 }` and `profilingRate` to `1.0`
3. Run the app in Release variant
4. Verify that in Sentry Performance and Profiling tabs there are new reports generated by your device.

## Regression Notes
1. Potential unintended areas of impact


5. What I did to test those areas of impact (or what existing automated tests I relied on)


6. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
