### PR TITLE
In-App Updates: Track events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -600,6 +600,11 @@ import Foundation
     case statsEmailsViewMoreTapped
     case statsSubscribersChartTapped
 
+    // In-App Updates
+    case inAppUpdateShown
+    case inAppUpdateDismissed
+    case inAppUpdateAccepted
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1630,6 +1635,14 @@ import Foundation
             return "stats_emails_view_more_tapped"
         case .statsSubscribersChartTapped:
             return "stats_subscribers_chart_tapped"
+
+        // In-App Updates
+        case .inAppUpdateShown:
+            return "in_app_update_shown"
+        case .inAppUpdateDismissed:
+            return "in_app_update_dismissed"
+        case .inAppUpdateAccepted:
+            return "in_app_update_accepted"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/AppUpdate/AppStoreInfoViewModel.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/AppStoreInfoViewModel.swift
@@ -4,7 +4,6 @@ struct AppStoreInfoViewModel {
     let appName: String
     let version: String
     let releaseNotes: [String.SubSequence]
-    let onUpdateTapped: () -> Void
 
     let title = Strings.title
     let message = Strings.message
@@ -13,11 +12,10 @@ struct AppStoreInfoViewModel {
     let cancelButtonTitle = Strings.Actions.cancel
     let moreInfoButtonTitle = Strings.Actions.moreInfo
 
-    init(_ appStoreInfo: AppStoreInfo, onUpdateTapped: @escaping () -> Void) {
+    init(_ appStoreInfo: AppStoreInfo) {
         self.appName = appStoreInfo.trackName
         self.version = String(format: Strings.versionFormat, appStoreInfo.version)
         self.releaseNotes = appStoreInfo.releaseNotes.split(whereSeparator: \.isNewline)
-        self.onUpdateTapped = onUpdateTapped
     }
 }
 

--- a/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
@@ -4,8 +4,8 @@ import UIKit
 import StoreKit
 
 final class BlockingUpdateViewController: UIHostingController<BlockingUpdateView> {
-    init(viewModel: AppStoreInfoViewModel) {
-        super.init(rootView: .init(viewModel: viewModel))
+    init(viewModel: AppStoreInfoViewModel, onUpdateTapped: @escaping () -> Void) {
+        super.init(rootView: .init(viewModel: viewModel, onUpdateTapped: onUpdateTapped))
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -15,6 +15,7 @@ final class BlockingUpdateViewController: UIHostingController<BlockingUpdateView
 
 struct BlockingUpdateView: View {
     let viewModel: AppStoreInfoViewModel
+    let onUpdateTapped: (() -> Void)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -40,7 +41,7 @@ struct BlockingUpdateView: View {
         .padding([.leading, .trailing], 20)
         .interactiveDismissDisabled()
         .onAppear {
-            // Todo: track event
+            WPAnalytics.track(.inAppUpdateShown, properties: ["type": "blocking"])
         }
     }
 
@@ -83,7 +84,7 @@ struct BlockingUpdateView: View {
     private var buttonsView: some View {
         VStack {
             DSButton(title: viewModel.updateButtonTitle, style: .init(emphasis: .primary, size: .large)) {
-                viewModel.onUpdateTapped()
+                onUpdateTapped()
             }
             DSButton(title: viewModel.moreInfoButtonTitle, style: .init(emphasis: .tertiary, size: .large)) {
                 // Todo


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/55
Part of https://github.com/Automattic/wordpress-mobile/issues/56

## Description
- Adds event tracking for in-app updates

## How to test

### Flexible update
Precondition: In Xcode, change the app version to something lower than the current app store version, e.g. 24.6

- ✅ Verify `in_app_update_shown <type: flexible>` is tracked when the prompt is shown
- ✅ Verify `Tracked: in_app_update_dismissed <>` is tracked when the "Cancel" is tapped
- ✅ Verify `Tracked: in_app_update_accepted <type: flexible>` is tracked when the "Update" is tapped

### Blocking update
Precondition: In Xcode, change the app version to something lower than the current app store version, e.g. 24.6

Precondition: Change the in app update remote config value to the current app store version

- ✅ Verify `in_app_update_shown <type: blocking>` is tracked when the prompt is shown
- ✅ Verify `Tracked: in_app_update_accepted <type: blocking>` is tracked when the "Update" is tapped

## Todo
- [ ] Validate / register events

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
