### PR TITLE
Fix button overlap in the "Post Published" sheet on small devices

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 25.0
 -----
-
+* [*] Fix button overlap in the "Post Published" sheet on small devices [#23210]
 
 24.9
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
@@ -47,7 +47,11 @@ class PostNoticeNavigationCoordinator {
         let viewController = UIHostingController(rootView: view)
         if UIDevice.current.userInterfaceIdiom == .phone {
             if let sheetController = viewController.sheetPresentationController {
-                sheetController.detents = [.medium()]
+                if #available(iOS 16, *) {
+                    sheetController.detents = [.custom { _ in 420 }]
+                } else {
+                    sheetController.detents = [.medium()]
+                }
                 sheetController.preferredCornerRadius = 20
             }
         } else {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23208

To test: follow the linked ticket.

<img width="340" alt="Screenshot 2024-05-15 at 10 32 55 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b5b49595-43e3-4fe3-9976-4d25be081dba">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
