### PR TITLE
Improve how assertions are tracked in Tracks

### DIFF
--- a/WordPress/Classes/Utility/WPInstrumentation.swift
+++ b/WordPress/Classes/Utility/WPInstrumentation.swift
@@ -13,9 +13,7 @@ func wpAssert(_ closure: @autoclosure () -> Bool, _ message: StaticString = "–
 
     WPAnalytics.track(.assertionFailure, properties: {
         var properties: [String: Any] = [
-            "file": filename,
-            "line": line,
-            "message": "\(filename)–\(line): \(message)"
+            "assertion": "\(filename)–\(line): \(message)"
         ]
         for (key, value) in userInfo ?? [:] {
             properties[key] = value


### PR DESCRIPTION
I focus on Sentry and overlooked the formatting for Tracks. It made no sense to send file and line separately. To uniquely identify an assertion, you need file AND line AND message (note: `message` is a `StaticString`).

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
