### PR TITLE
[Site Switcher] Pre iOS 17.0 search functionality fix.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
@@ -44,21 +44,16 @@ struct BlogListView: View {
 
     var body: some View {
         if #available(iOS 16.0, *) {
-            contentVStack
+            contentList
                 .scrollContentBackground(.hidden)
-                .onAppear {
-                    viewModel.viewAppeared()
-                }
         } else {
-            contentVStack
-                .onAppear {
-                    viewModel.viewAppeared()
-                }
+            contentList
         }
     }
 
-    private var contentVStack: some View {
-        List {
+    @ViewBuilder
+    private var contentList: some View {
+        let list = List {
             if isSearching {
                 ForEach(viewModel.searchSites, id: \.id) { site in
                     siteButton(site: site)
@@ -71,8 +66,15 @@ struct BlogListView: View {
                 recentsSection
                 allRemainingSitesSection
             }
+        }.onAppear {
+            viewModel.viewAppeared()
         }
-        .listStyle(.grouped)
+
+        if isSearching {
+            list.listStyle(.plain)
+        } else {
+            list.listStyle(.grouped)
+        }
     }
 
     private func sectionHeader(title: String) -> some View {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -22,13 +22,7 @@ struct SiteSwitcherView: View {
     var body: some View {
         if #available(iOS 17.0, *) {
             NavigationStack {
-                VStack(spacing: 0) {
-                    blogListView
-                        .offset(y: isSearching ? -.DS.Padding.medium : 0)
-                    if !isSearching {
-                        addSiteButtonVStack
-                    }
-                }
+                blogListVStack
             }
             .searchable(
                 text: $searchText,
@@ -37,21 +31,24 @@ struct SiteSwitcherView: View {
             )
         } else {
             NavigationView {
-                VStack(spacing: 0) {
-                    blogListView
-                        .offset(y: isSearching ? -.DS.Padding.medium : 0)
-                    if !isSearching {
-                        addSiteButtonVStack
+                blogListVStack
+                    .navigationBarTitleDisplayMode(.inline)
+                    .searchable(
+                        text: $searchText,
+                        placement: .navigationBarDrawer(displayMode: .always)
+                    )
+                    .onChange(of: searchText) { newValue in
+                        isSearching = !newValue.isEmpty
                     }
-                }
-                .navigationBarTitleDisplayMode(.inline)
-                .searchable(
-                    text: $searchText,
-                    placement: .navigationBarDrawer(displayMode: .always)
-                )
-                .onChange(of: searchText) { newValue in
-                    isSearching = !newValue.isEmpty
-                }
+            }
+        }
+    }
+
+    private var blogListVStack: some View {
+        VStack(spacing: 0) {
+            blogListView
+            if !isSearching {
+                addSiteButtonVStack
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -39,12 +39,20 @@ struct SiteSwitcherView: View {
             NavigationView {
                 VStack(spacing: 0) {
                     blogListView
+                        .offset(y: isSearching ? -.DS.Padding.medium : 0)
                     if !isSearching {
                         addSiteButtonVStack
                     }
                 }
+                .navigationBarTitleDisplayMode(.inline)
+                .searchable(
+                    text: $searchText,
+                    placement: .navigationBarDrawer(displayMode: .always)
+                )
+                .onChange(of: searchText) { newValue in
+                    isSearching = !newValue.isEmpty
+                }
             }
-            .searchable(text: $searchText)
         }
     }
 


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/23209

## Description
Fixes the the new site picker's search not working issue on versions prior to iOS 17.0

## Testing Steps
1. Install & Login Jetpack App on a device that is below iOS 17.0 (15.0 to 16.*)
2. Enable Site switcher Redesign Remote Feature Flag
3. Navigate to site switcher from My Site
4. ✅ Verify the search works fine.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
