### PR TITLE
Reader: Add analytics for the tags stream

### DIFF
--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.h
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.h
@@ -102,6 +102,19 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
                    failure:(void (^)(NSError *error))failure;
 
 /**
+ Toggle the liked status of the specified post.
+
+ @param post The reader post to like/unlike.
+ @param source A string that hints the source of where action was performed. Optional.
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)toggleLikedForPost:(ReaderPost *)post
+                    source:(nullable NSString *)source
+                   success:(void (^)(void))success
+                   failure:(void (^)(NSError *error))failure;
+
+/**
  Toggle the following status of the specified post's blog.
 
  @param post The ReaderPost whose blog should be followed.

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -324,6 +324,11 @@ import Foundation
     case readerDropdownOpened
     case readerDropdownItemTapped
 
+    // Reader: Tags Feed
+    case readerTagsFeedShown
+    case readerTagsFeedMoreFromTagTapped
+    case readerTagsFeedHeaderTapped
+
     // App Settings
     case settingsDidChange
 
@@ -1163,6 +1168,13 @@ import Foundation
             return "reader_dropdown_menu_opened"
         case .readerDropdownItemTapped:
             return "reader_dropdown_menu_item_tapped"
+
+        case .readerTagsFeedShown:
+            return "reader_tags_feed_shown"
+        case .readerTagsFeedMoreFromTagTapped:
+            return "reader_tags_feed_more_from_tag_tapped"
+        case .readerTagsFeedHeaderTapped:
+            return "reader_tags_feed_header_tapped"
 
         // App Settings
         case .settingsDidChange:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHeaderAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHeaderAction.swift
@@ -1,6 +1,9 @@
 final class ReaderHeaderAction {
-    func execute(post: ReaderPost, origin: UIViewController) {
+    func execute(post: ReaderPost, origin: UIViewController, source: ReaderStreamViewController.StatSource? = nil) {
         let controller = ReaderStreamViewController.controllerWithSiteID(post.siteID, isFeed: post.isExternal)
+        if let source {
+            controller.statSource = source
+        }
         origin.navigationController?.pushViewController(controller, animated: true)
 
         let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.blogURL as AnyObject?, forKey: "url")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderLikeAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderLikeAction.swift
@@ -1,6 +1,6 @@
 /// Encapsulates a command to toggle a post's liked status
 final class ReaderLikeAction {
-    func execute(with post: ReaderPost, completion: (() -> Void)? = nil) {
+    func execute(with post: ReaderPost, source: String? = nil, completion: (() -> Void)? = nil) {
         if !post.isLiked {
             // Consider a like from the list to be enough to push a page view.
             // Solves a long-standing question from folks who ask 'why do I
@@ -9,7 +9,7 @@ final class ReaderLikeAction {
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         }
         let service = ReaderPostService(coreDataStack: ContextManager.shared)
-        service.toggleLiked(for: post, success: {
+        service.toggleLiked(for: post, source: source, success: {
             completion?()
         }, failure: { (error: Error?) in
             if let anError = error {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -159,6 +159,16 @@ extension ReaderStreamViewController {
     }
 }
 
+// MARK: - Tags Feed
+
+extension ReaderStreamViewController {
+
+    var isTagsFeed: Bool {
+        contentType == .tags && readerTopic == nil
+    }
+
+}
+
 // MARK: - Reader Announcement Header
 
 extension ReaderStreamViewController {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -208,6 +208,7 @@ import AutomatticTracks
     enum StatSource: String {
         case reader
         case notif_like_list_user_profile
+        case tagsFeed = "tags_feed"
     }
     var statSource: StatSource = .reader
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -962,9 +962,18 @@ import AutomatticTracks
             return
         }
 
+        guard isViewLoaded, view.window != nil else {
+            return
+        }
+
+        if isTagsFeed {
+            didBumpStats = true
+            WPAnalytics.trackReader(.readerTagsFeedShown)
+            return
+        }
+
         guard let topic = readerTopic,
-              let properties = topicPropertyForStats(),
-              isViewLoaded && view.window != nil else {
+              let properties = topicPropertyForStats() else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCell.swift
@@ -80,7 +80,7 @@ class ReaderTagCardCell: UITableViewCell {
     }
 
     @IBAction private func onTagButtonTapped(_ sender: Any) {
-        viewModel?.onTagButtonTapped()
+        viewModel?.onTagButtonTapped(source: .header)
     }
 
     struct Constants {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -203,6 +203,8 @@ extension ReaderTagCardCellViewModel: UICollectionViewDelegate {
         }
         let post = resultsController.object(at: indexPath)
         let controller = ReaderDetailViewController.controllerWithPost(post)
+
+        WPAnalytics.trackReader(.readerPostCardTapped, properties: ["source": "tags_feed"])
         parentViewController?.navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -204,7 +204,8 @@ extension ReaderTagCardCellViewModel: UICollectionViewDelegate {
         let post = resultsController.object(at: indexPath)
         let controller = ReaderDetailViewController.controllerWithPost(post)
 
-        WPAnalytics.trackReader(.readerPostCardTapped, properties: ["source": "tags_feed"])
+        WPAnalytics.trackReader(.readerPostCardTapped,
+                                properties: ["source": ReaderStreamViewController.StatSource.tagsFeed.rawValue])
         parentViewController?.navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCardCellViewModel.swift
@@ -6,6 +6,20 @@ protocol ReaderTagCardCellViewModelDelegate: NSObjectProtocol {
 
 class ReaderTagCardCellViewModel: NSObject {
 
+    enum TagButtonSource {
+        case header
+        case footer
+
+        var event: WPAnalyticsEvent {
+            switch self {
+            case .header:
+                return .readerTagsFeedHeaderTapped
+            case .footer:
+                return .readerTagsFeedMoreFromTagTapped
+            }
+        }
+    }
+
     enum Section: Int {
         case emptyState = 101
         case posts
@@ -100,8 +114,11 @@ class ReaderTagCardCellViewModel: NSObject {
         }
     }
 
-    func onTagButtonTapped() {
+    func onTagButtonTapped(source: TagButtonSource) {
         let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
+        controller.statSource = .tagsFeed
+
+        WPAnalytics.track(source.event)
         parentViewController?.navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -170,7 +187,7 @@ private extension ReaderTagCardCellViewModel {
                 return nil
             }
             view.configure(with: self?.slug ?? "") { [weak self] in
-                self?.onTagButtonTapped()
+                self?.onTagButtonTapped(source: .footer)
             }
             return view
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
@@ -20,7 +20,7 @@ struct ReaderTagCellViewModel {
     }
 
     func onLikeButtonTapped() {
-        ReaderLikeAction().execute(with: post)
+        ReaderLikeAction().execute(with: post, source: ReaderStreamViewController.StatSource.tagsFeed.rawValue)
     }
 
     mutating func onMenuButtonTapped(with anchor: UIView) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
@@ -16,7 +16,7 @@ struct ReaderTagCellViewModel {
         guard let parentViewController else {
             return
         }
-        ReaderHeaderAction().execute(post: post, origin: parentViewController)
+        ReaderHeaderAction().execute(post: post, origin: parentViewController, source: .tagsFeed)
     }
 
     func onLikeButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagCellViewModel.swift
@@ -40,7 +40,7 @@ struct ReaderTagCellViewModel {
             followCommentsService: followCommentsService,
             showAdditionalItems: true
         )
-        // TODO: Analytics
+        WPAnalytics.trackReader(.postCardMoreTapped)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -256,7 +256,8 @@ extension ReaderTabViewModel {
             return
         }
 
-        WPAnalytics.track(.readerFilterSheetCleared)
+        let type = ((activeStreamFilter?.topic as? ReaderSiteTopic) != nil) ? "blog" : "tag"
+        WPAnalytics.track(.readerFilterSheetCleared, properties: ["type": type])
         activeStreamFilter = nil
         setContent?(currentTab.content)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -256,7 +256,7 @@ extension ReaderTabViewModel {
             return
         }
 
-        let type = ((activeStreamFilter?.topic as? ReaderSiteTopic) != nil) ? "site" : "topic"
+        let type = activeStreamFilter?.topic is ReaderSiteTopic ? "site" : "topic"
         WPAnalytics.track(.readerFilterSheetCleared, properties: ["type": type])
         activeStreamFilter = nil
         setContent?(currentTab.content)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -256,7 +256,7 @@ extension ReaderTabViewModel {
             return
         }
 
-        let type = ((activeStreamFilter?.topic as? ReaderSiteTopic) != nil) ? "blog" : "tag"
+        let type = ((activeStreamFilter?.topic as? ReaderSiteTopic) != nil) ? "site" : "topic"
         WPAnalytics.track(.readerFilterSheetCleared, properties: ["type": type])
         activeStreamFilter = nil
         setContent?(currentTab.content)


### PR DESCRIPTION
Part of #23069
Internal ref pctCYC-1lG-p2

This PR adds tracking for the tags stream:

- New events
  - `reader_tags_feed_shown` — this is tracked upon opening the 'Your Tags' stream.
  - `reader_tags_feed_more_from_tag_tapped` — tracked when tapping the 'More' cell at the end of a tag post list.
  - `reader_tags_feed_header_tapped` — tracked when tapping the tag headers in the tags stream.
- Added `source: tags_feed` parameter to
  -  `reader_article_liked`
  -  `reader_article_unliked`
  -  `reader_blog_previewed`
  -  `reader_tag_loaded`
  -  `reader_post_card_tapped`
- Added `type: site|topic` to `reader_filter_sheet_cleared`
- Tracked `post_card_more_tapped` when the ellipsis menu of the post card is tapped in the tags stream.

## To test

- Launch the Jetpack app.
- Go to the Reader tab, and switch to the 'Your Tags' stream.
  - 🔎 Verify `🔵 Tracked: reader_dropdown_menu_item_tapped <id: tags>` appears.
  - 🔎 Verify `🔵 Tracked: reader_tags_feed_shown` appears.
- Tap one of the posts.
  - 🔎 Verify `🔵 Tracked: reader_post_card_tapped <source: tags_feed>` appears.
  - Go back, and tap the site title of any post.
  - 🔎 Verify `🔵 Tracked: reader_blog_previewed <source: tags_feed>` appears.
- Go back, and like one of the posts.
  - 🔎 Verify `🔵 Tracked: reader_article_liked <source: tags_feed>` appears.
- Unlike the same post.
  - 🔎 Verify `🔵 Tracked: reader_article_unliked <source: tags_feed>` appears.
- Tap the ellipsis menu on any post.
  - 🔎 Verify `🔵 Tracked: post_card_more_tapped` appears.
- Do a smoke test by tapping one of the context menu items.
  - For example, if you tap `Visit`, verify that `🔵 Tracked: reader_article_visited` appears.
- Go back to the tag stream.
- Tap one of the tag button/header.
  - 🔎 Verify `🔵 Tracked: reader_tags_feed_header_tapped` appears.
  - 🔎 Verify `🔵 Tracked: reader_tag_loaded <source: tags_feed>` appears.
- Go back.
- Scroll to the end of a post list of any tag, and tap the 'More' button.
  - 🔎 Verify `🔵 Tracked: reader_tags_feed_more_from_tag_tapped` appears.
  - 🔎 Verify `🔵 Tracked: reader_tag_loaded <source: tags_feed>` appears. 
- Go back.
- Filter the stream by any tag.
- Tap 'X' to remove the filter.
  - 🔎 Verify `🔵 Tracked: reader_filter_sheet_cleared <type: topic>` appears. 

#### Testing `reader_filter_sheet_cleared` in the Subscriptions stream

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A. Not a user-facing change.

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)