### PR TITLE
In-App Updates: Open app store listing

### DIFF
--- a/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
@@ -7,6 +7,7 @@ struct AppStoreLookupResponse: Decodable {
 struct AppStoreInfo: Decodable {
     let trackName: String
     let trackId: Int
+    let trackViewUrl: String
     let version: String
     let releaseNotes: String
     let minimumOsVersion: String

--- a/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
@@ -4,7 +4,7 @@ import WordPressFlux
 protocol AppUpdatePresenterProtocol {
     func showNotice(using appStoreInfo: AppStoreInfo)
     func showBlockingUpdate(using appStoreInfo: AppStoreInfo)
-    func openAppStore()
+    func openAppStore(appStoreUrl: String)
 }
 
 final class AppUpdatePresenter: AppUpdatePresenterProtocol {
@@ -20,7 +20,7 @@ final class AppUpdatePresenter: AppUpdatePresenterProtocol {
         ) { accepted in
             if accepted {
                 WPAnalytics.track(.inAppUpdateAccepted, properties: ["type": "flexible"])
-                self.openAppStore()
+                self.openAppStore(appStoreUrl: appStoreInfo.trackViewUrl)
             } else {
                 WPAnalytics.track(.inAppUpdateDismissed)
             }
@@ -40,13 +40,16 @@ final class AppUpdatePresenter: AppUpdatePresenterProtocol {
         let viewModel = AppStoreInfoViewModel(appStoreInfo)
         let controller = BlockingUpdateViewController(viewModel: viewModel) {
             WPAnalytics.track(.inAppUpdateAccepted, properties: ["type": "blocking"])
-            self.openAppStore()
+            self.openAppStore(appStoreUrl: appStoreInfo.trackViewUrl)
         }
         let navigation = UINavigationController(rootViewController: controller)
         topViewController.present(navigation, animated: true)
     }
 
-    func openAppStore() {
-        // TODO
+    func openAppStore(appStoreUrl: String) {
+        guard let url = URL(string: appStoreUrl) else {
+            return
+        }
+        UIApplication.shared.open(url)
     }
 }

--- a/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
+++ b/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
@@ -144,7 +144,7 @@ private final class MockAppUpdatePresenter: AppUpdatePresenterProtocol {
         didShowBlockingUpdate = true
     }
 
-    func openAppStore() {
+    func openAppStore(appStoreUrl: String) {
         didOpenAppStore = true
     }
 }


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/55
Part of https://github.com/Automattic/wordpress-mobile/issues/56

## Description
- Opens app store listing from "Update" CTA for flexible and blocking update views

## Note
- SKStoreProductViewController isn't a good choice for this use case, since the app will terminate during updating. Simply opening the app store listing provides a better experience.

## How to test
### Flexible update
Precondition: In Xcode, change the app version to something lower than the current app store version, e.g. 24.6

- Run on a real device
- When the flexible update is displayed, tap on "Update"
- ✅ Verify the app store listing is displayed

### Blocking update
Precondition: In Xcode, change the app version to something lower than the current app store version, e.g. 24.6

Precondition: Change the in app update remote config value to the current app store version

- Run on a real device
- When the blocking update is displayed, tap on "Update"
- ✅ Verify the app store listing is displayed


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
