### PR TITLE
In-App Updates: Prompt update after phased release is complete

### DIFF
--- a/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
@@ -10,6 +10,13 @@ struct AppStoreLookupResponse: Decodable {
         let version: String
         let releaseNotes: String
         let minimumOsVersion: String
+        let currentVersionReleaseDate: Date
+        
+        func currentVersionHasBeenReleased(for days: Int) -> Bool {
+            let secondsInDay: TimeInterval = 86_400
+            let secondsSinceRelease = -currentVersionReleaseDate.timeIntervalSinceNow
+            return secondsSinceRelease > Double(days) * secondsInDay
+        }
     }
 }
 
@@ -31,7 +38,9 @@ final class AppStoreSearchService: AppStoreSearchProtocol {
         }
         let (data, response) = try await URLSession.shared.data(from: url)
         try validate(response: response)
-        return try JSONDecoder().decode(AppStoreLookupResponse.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(AppStoreLookupResponse.self, from: data)
     }
 
     private func validate(response: URLResponse) throws {

--- a/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
@@ -11,7 +11,7 @@ struct AppStoreLookupResponse: Decodable {
         let releaseNotes: String
         let minimumOsVersion: String
         let currentVersionReleaseDate: Date
-        
+
         func currentVersionHasBeenReleased(for days: Int) -> Bool {
             let secondsInDay: TimeInterval = 86_400
             let secondsSinceRelease = -currentVersionReleaseDate.timeIntervalSinceNow

--- a/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -15,6 +15,7 @@ final class AppUpdateCoordinator {
     private let isJetpack: Bool
     private let isLoggedIn: Bool
     private let isInAppUpdatesEnabled: Bool
+    private let delayInDays: Int
 
     init(
         currentVersion: String?,
@@ -24,7 +25,8 @@ final class AppUpdateCoordinator {
         remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
         isJetpack: Bool = AppConfiguration.isJetpack,
         isLoggedIn: Bool = AccountHelper.isLoggedIn,
-        isInAppUpdatesEnabled: Bool = RemoteFeatureFlag.inAppUpdates.enabled()
+        isInAppUpdatesEnabled: Bool = RemoteFeatureFlag.inAppUpdates.enabled(),
+        delayInDays: Int = 7
     ) {
         self.currentVersion = currentVersion
         self.currentOsVersion = currentOsVersion
@@ -34,6 +36,7 @@ final class AppUpdateCoordinator {
         self.isJetpack = isJetpack
         self.isLoggedIn = isLoggedIn
         self.isInAppUpdatesEnabled = isInAppUpdatesEnabled
+        self.delayInDays = delayInDays
     }
 
     @MainActor
@@ -65,6 +68,9 @@ final class AppUpdateCoordinator {
             }
             guard !currentOsVersion.isLower(than: appStoreInfo.minimumOsVersion) else {
                 // Can't update if the device OS version is lower than the minimum OS version
+                return nil
+            }
+            guard appStoreInfo.currentVersionHasBeenReleased(for: delayInDays) else {
                 return nil
             }
             if let blockingVersion, currentVersion.isLower(than: blockingVersion), blockingVersion.isLowerThanOrEqual(to: appStoreInfo.version) {

--- a/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
+++ b/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
@@ -50,6 +50,28 @@ final class AppUpdateCoordinatorTests: XCTestCase {
         XCTAssertFalse(presenter.didShowBlockingUpdate)
     }
 
+    func testNotEnoughDaysHaveElapsedSinceCurrentVersionHasBeenReleased() async {
+        // Given
+        let coordinator = AppUpdateCoordinator(
+            currentVersion: "24.6",
+            currentOsVersion: "17.0",
+            service: service,
+            presenter: presenter,
+            remoteConfigStore: remoteConfigStore,
+            isLoggedIn: false,
+            isInAppUpdatesEnabled: true,
+            delayInDays: Int.max
+        )
+
+        // When
+        await coordinator.checkForAppUpdates()
+
+        // Then
+        XCTAssertFalse(service.didLookup)
+        XCTAssertFalse(presenter.didShowNotice)
+        XCTAssertFalse(presenter.didShowBlockingUpdate)
+    }
+
     func testFlexibleUpdateAvailableButOsVersionTooLow() async {
         // Given
         let coordinator = AppUpdateCoordinator(
@@ -153,7 +175,9 @@ private final class MockAppStoreSearchService: AppStoreSearchProtocol {
 
     private func getMockLookupResponse() throws -> AppStoreLookupResponse {
         let data = try Bundle.test.json(named: "app-store-lookup-response")
-        return try JSONDecoder().decode(AppStoreLookupResponse.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(AppStoreLookupResponse.self, from: data)
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/55
Part of https://github.com/Automattic/wordpress-mobile/issues/56

## Description
- Adds a check to only show the update prompts if it's been 7 days since the latest version was released (i.e. [phased release](https://developer.apple.com/help/app-store-connect/update-your-app/release-a-version-update-in-phases/) is at 100%), to prevent showing the prompt to users who have automatic updated enabled.

## How to test

### Flexible update

**Preconditions**
- In Xcode, change the app version to something lower than the current app store version, e.g. 24.6
- Enable the `In-App Updates` remote feature flag

**Test 1.1**
- Run on a real device
- ✅ Verify the flexible update is NOT displayed

**Test 1.2**
- Change `delayInDays` default value to 1
- Run on a real device
- ✅ Verify the flexible update is displayed

### Blocking update

**Preconditions**
- In Xcode, change the app version to something lower than the current app store version, e.g. 24.6
- Enable the `In-App Updates` remote feature flag
- Change the `In-App Update Blocking Version` remote config value to 24.7

**Test 2.1**
- Run on a real device
- ✅ Verify the blocking update is NOT displayed

**Test 2.2**
- Change `delayInDays` default value to 1
- Run on a real device
- ✅ Verify the blocking update is displayed


## Regression Notes
1. Potential unintended areas of impact
Showing app update prompt

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit test

3. What automated tests I added (or what prevented me from doing so)
AppUpdateCoordinatorTests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
