### PR TITLE
Update release notes for entry related to PR 22886

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 25.0
 -----
 * [*] Fix button overlap in the "Post Published" sheet on small devices [#23210]
+* [*] [internal] Incorporate a parser to handle Gutenberg blocks more efficiently for improved performance [#22886]
 
 24.9
 -----
@@ -48,7 +49,6 @@
 * [**] Block editor: Highlight text fixes [https://github.com/WordPress/gutenberg/pull/57650]
 * [*] [Jetpack-only] Stats: Eliminated common error causes in the Insights tab. [#22890]
 * [*] [Jetpack-only] Reader: Fix displaying stale site information [#22885]
-* [*] [internal] Incorporate a parser to handle Gutenberg blocks more efficiently for improved performance [#22886]
 
 24.5
 -----


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-iOS/pull/22886/files#r1602816777.

This PR only updates the release notes to move one of the entries to `25.0` section.

**To test:**
N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
