### PR TITLE
In-App Updates: Update blocking modal UI

### DIFF
--- a/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
@@ -34,7 +34,7 @@ final class AppUpdatePresenter: AppUpdatePresenterProtocol {
         guard let window = UIApplication.sharedIfAvailable()?.mainWindow,
               let topViewController = window.topmostPresentedViewController,
               !((topViewController as? UINavigationController)?.viewControllers.first is BlockingUpdateViewController) else {
-            wpAssertionFailure("Failed to show blocking update view")
+            // Don't show if the view is already being displayed
             return
         }
         let viewModel = AppStoreInfoViewModel(appStoreInfo)

--- a/WordPress/Classes/ViewRelated/AppUpdate/AppStoreInfoViewModel.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/AppStoreInfoViewModel.swift
@@ -9,8 +9,8 @@ struct AppStoreInfoViewModel {
     let message = Strings.message
     let whatsNewTitle = Strings.whatsNew
     let updateButtonTitle = Strings.Actions.update
+    let latestVersionButtonTitle = Strings.Actions.latestVersion
     let cancelButtonTitle = Strings.Actions.cancel
-    let moreInfoButtonTitle = Strings.Actions.moreInfo
 
     init(_ appStoreInfo: AppStoreLookupResponse.AppStoreInfo) {
         self.appName = appStoreInfo.trackName
@@ -27,7 +27,7 @@ private enum Strings {
 
     enum Actions {
         static let update = NSLocalizedString("appUpdate.action.update", value: "Update", comment: "Update button title")
+        static let latestVersion = NSLocalizedString("appUpdate.action.latestVersion", value: "Get the latest version", comment: "Get the latest version button title")
         static let cancel = NSLocalizedString("appUpdate.action.cancel", value: "Cancel", comment: "Cancel button title")
-        static let moreInfo = NSLocalizedString("appUpdate.action.moreInfo", value: "More info", comment: "More info button title")
     }
 }

--- a/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
@@ -4,8 +4,8 @@ import UIKit
 import StoreKit
 
 final class BlockingUpdateViewController: UIHostingController<BlockingUpdateView> {
-    init(viewModel: AppStoreInfoViewModel, onUpdateTapped: @escaping () -> Void) {
-        super.init(rootView: .init(viewModel: viewModel, onUpdateTapped: onUpdateTapped))
+    init(viewModel: AppStoreInfoViewModel, onButtonTapped: @escaping () -> Void) {
+        super.init(rootView: .init(viewModel: viewModel, onButtonTapped: onButtonTapped))
     }
 
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -15,7 +15,7 @@ final class BlockingUpdateViewController: UIHostingController<BlockingUpdateView
 
 struct BlockingUpdateView: View {
     let viewModel: AppStoreInfoViewModel
-    let onUpdateTapped: (() -> Void)
+    let onButtonTapped: (() -> Void)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -36,7 +36,10 @@ struct BlockingUpdateView: View {
 
             Spacer()
 
-            buttonsView
+            DSButton(title: viewModel.latestVersionButtonTitle, style: .init(emphasis: .primary, size: .large)) {
+                onButtonTapped()
+            }
+            .padding(.bottom, 20)
         }
         .padding([.leading, .trailing], 20)
         .interactiveDismissDisabled()
@@ -77,17 +80,6 @@ struct BlockingUpdateView: View {
                 Text(note)
                     .font(.system(.callout))
                     .foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    private var buttonsView: some View {
-        VStack {
-            DSButton(title: viewModel.updateButtonTitle, style: .init(emphasis: .primary, size: .large)) {
-                onUpdateTapped()
-            }
-            DSButton(title: viewModel.moreInfoButtonTitle, style: .init(emphasis: .tertiary, size: .large)) {
-                // Todo
             }
         }
     }


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/55
Part of https://github.com/Automattic/wordpress-mobile/issues/56


## Description
Ref: p1715867986819249-slack-C072JBZL84U 

- Updates the blocking modal "Update" button title to "Get the latest version"
- Removes the "More info" button

Before | After
-- | --
<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/95c65512-82bc-4d43-aa99-3c1bd6a2bdec" width=200> | <img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/5a828c86-a2f1-4495-b17a-7f13be5e7fbe" width=200>


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)