### PR TITLE
In-App Updates: Show flexible update again after a specified interval

### DIFF
--- a/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
@@ -13,9 +13,10 @@ struct AppStoreLookupResponse: Decodable {
         let currentVersionReleaseDate: Date
 
         func currentVersionHasBeenReleased(for days: Int) -> Bool {
-            let secondsInDay: TimeInterval = 86_400
-            let secondsSinceRelease = -currentVersionReleaseDate.timeIntervalSinceNow
-            return secondsSinceRelease > Double(days) * secondsInDay
+            guard let daysElapsed = Calendar.current.dateComponents([.day], from: currentVersionReleaseDate, to: Date.now).day else {
+                return false
+            }
+            return daysElapsed > days
         }
     }
 }

--- a/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -143,6 +143,7 @@ extension AppUpdateCoordinator {
 
     private var shouldShowFlexibleUpdate: Bool {
         guard let flexibleIntervalInDays else {
+            wpAssertionFailure("Remote config value missing or invalid")
             return false
         }
         guard let lastSeenFlexibleUpdateDate else {

--- a/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -49,7 +49,7 @@ final class AppUpdateCoordinator {
         guard isLoggedIn else {
             return
         }
-        guard let updateType = await inAppUpdateType else {
+        guard let updateType = await appUpdateType else {
             return
         }
 
@@ -62,7 +62,7 @@ final class AppUpdateCoordinator {
         }
     }
 
-    private var inAppUpdateType: AppUpdateType? {
+    private var appUpdateType: AppUpdateType? {
         get async {
             guard let currentVersion else {
                 return nil

--- a/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
@@ -27,7 +27,6 @@ final class AppUpdatePresenter: AppUpdatePresenterProtocol {
         }
         ActionDispatcher.dispatch(NoticeAction.post(notice))
         WPAnalytics.track(.inAppUpdateShown, properties: ["type": "flexible"])
-        // Todo: if the notice is dismissed, show notice again after a defined interval
     }
 
     func showBlockingUpdate(using appStoreInfo: AppStoreLookupResponse.AppStoreInfo) {

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -36,6 +36,7 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
     case phaseFourOverlayFrequency
     case wordPressInAppUpdateBlockingVersion
     case jetpackInAppUpdateBlockingVersion
+    case inAppUpdateFlexibleIntervalInDays
 
     var key: String {
         switch self {
@@ -63,6 +64,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "wp_in_app_update_blocking_version_ios"
         case .jetpackInAppUpdateBlockingVersion:
             return "jp_in_app_update_blocking_version_ios"
+        case .inAppUpdateFlexibleIntervalInDays:
+            return "in_app_update_flexible_interval_in_days_ios"
         }
     }
 
@@ -91,6 +94,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
         case .wordPressInAppUpdateBlockingVersion:
             return nil
         case .jetpackInAppUpdateBlockingVersion:
+            return nil
+        case .inAppUpdateFlexibleIntervalInDays:
             return nil
         }
     }
@@ -121,6 +126,8 @@ enum RemoteConfigParameter: CaseIterable, RemoteParameter {
             return "WP In-App Update Blocking Version"
         case .jetpackInAppUpdateBlockingVersion:
             return "JP In-App Update Blocking Version"
+        case .inAppUpdateFlexibleIntervalInDays:
+            return "In-App Update Flexible Interval (Days)"
         }
     }
 }

--- a/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
+++ b/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
@@ -7,6 +7,12 @@ final class AppUpdateCoordinatorTests: XCTestCase {
     private let service = MockAppStoreSearchService()
     private let presenter = MockAppUpdatePresenter()
     private let remoteConfigStore = RemoteConfigStoreMock()
+    private var store = UserDefaults(suiteName: "app-update-coordinator-tests")!
+
+    override func tearDown() {
+        super.tearDown()
+        store.removePersistentDomain(forName: "app-update-coordinator-tests")
+    }
 
     func testInAppUpdatesDisabled() async {
         // Given
@@ -58,6 +64,7 @@ final class AppUpdateCoordinatorTests: XCTestCase {
             service: service,
             presenter: presenter,
             remoteConfigStore: remoteConfigStore,
+            store: store,
             isLoggedIn: false,
             isInAppUpdatesEnabled: true,
             delayInDays: Int.max
@@ -80,6 +87,7 @@ final class AppUpdateCoordinatorTests: XCTestCase {
             service: service,
             presenter: presenter,
             remoteConfigStore: remoteConfigStore,
+            store: store,
             isJetpack: true,
             isLoggedIn: true,
             isInAppUpdatesEnabled: true
@@ -102,6 +110,7 @@ final class AppUpdateCoordinatorTests: XCTestCase {
             service: service,
             presenter: presenter,
             remoteConfigStore: remoteConfigStore,
+            store: store,
             isJetpack: true,
             isLoggedIn: true,
             isInAppUpdatesEnabled: true
@@ -117,7 +126,7 @@ final class AppUpdateCoordinatorTests: XCTestCase {
         XCTAssertFalse(presenter.didShowBlockingUpdate)
     }
 
-    func testFlexibleUpdateAvailable() async {
+    func testFlexibleUpdateAvailableShownOnceWithinInterval() async {
         // Given
         let coordinator = AppUpdateCoordinator(
             currentVersion: "24.6",
@@ -125,10 +134,12 @@ final class AppUpdateCoordinatorTests: XCTestCase {
             service: service,
             presenter: presenter,
             remoteConfigStore: remoteConfigStore,
+            store: store,
             isJetpack: true,
             isLoggedIn: true,
             isInAppUpdatesEnabled: true
         )
+        remoteConfigStore.inAppUpdateFlexibleIntervalInDays = 5
 
         // When
         await coordinator.checkForAppUpdates()
@@ -136,6 +147,15 @@ final class AppUpdateCoordinatorTests: XCTestCase {
         // Then
         XCTAssertTrue(service.didLookup)
         XCTAssertTrue(presenter.didShowNotice)
+        XCTAssertFalse(presenter.didShowBlockingUpdate)
+
+        // When we check for updates again within the flexible interval
+        presenter.didShowNotice = false // Reset
+        await coordinator.checkForAppUpdates()
+
+        // Then the flexible notice isn't shown again
+        XCTAssertTrue(service.didLookup)
+        XCTAssertFalse(presenter.didShowNotice)
         XCTAssertFalse(presenter.didShowBlockingUpdate)
     }
 

--- a/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
+++ b/WordPress/WordPressTest/AppUpdate/AppUpdateCoordinatorTests.swift
@@ -139,7 +139,7 @@ final class AppUpdateCoordinatorTests: XCTestCase {
             isLoggedIn: true,
             isInAppUpdatesEnabled: true
         )
-        remoteConfigStore.inAppUpdateFlexibleIntervalInDays = 5
+        remoteConfigStore.inAppUpdateFlexibleIntervalInDays = 90
 
         // When
         await coordinator.checkForAppUpdates()

--- a/WordPress/WordPressTest/RemoteConfigStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteConfigStoreMock.swift
@@ -10,6 +10,7 @@ class RemoteConfigStoreMock: RemoteConfigStore {
     var blazeNonDismissibleStep: String?
     var blazeFlowCompletedStep: String?
     var jetpackInAppUpdateBlockingVersion: String?
+    var inAppUpdateFlexibleIntervalInDays: Int?
 
     override func value(for key: String) -> Any? {
         if key == "phase_three_blog_post" {
@@ -32,6 +33,9 @@ class RemoteConfigStoreMock: RemoteConfigStore {
         }
         if key == "jp_in_app_update_blocking_version_ios" {
             return jetpackInAppUpdateBlockingVersion
+        }
+        if key == "in_app_update_flexible_interval_in_days_ios" {
+            return inAppUpdateFlexibleIntervalInDays
         }
         return super.value(for: key)
     }


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/56

## Description
Ref: p1715166447222309-slack-C072JBZL84U

- Shows the flexible update again for a version after a specified interval

## How to test

**Preconditions**
- In Xcode, change the app version to something lower than the current app store version, e.g. 24.6
- Enable the `In-App Updates` remote feature flag
- Change `delayInDays` default value to 1

**Test 1.1**
- Run on a real device
- ✅ Verify the flexible update is displayed
- Quit/reopen the app again
- ✅ Verify the flexible update is NOT displayed

1. Potential unintended areas of impact
Flexible/blocking update logic

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added a test

3. What automated tests I added (or what prevented me from doing so)
AppUpdateCoordinatorTests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)