### PR TITLE
Reader: Skip showing announcement card in Search

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -177,6 +177,12 @@ extension ReaderStreamViewController {
     ///
     /// - Returns: A configured UIView, or nil if the conditions are not met.
     func makeAnnouncementHeader() -> UIView? {
+        // don't show the announcement while searching.
+        if let readerTopic,
+           ReaderHelpers.isTopicSearchTopic(readerTopic) {
+            return nil
+        }
+
         guard readerAnnouncementCoordinator.canShowAnnouncement,
               tableView.tableHeaderView == nil,
               !isContentFiltered,


### PR DESCRIPTION
Fixes #23215 

> [!WARNING]
> Auto-merge is enabled.

## To test

- Launch the Jetpack app
- Switch to the Reader tab.
- Tap Search.
- Enter any text and hit Return to load search results.
- 🔎 Verify that the announcement card no longer appears in search results.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
