### PR TITLE
In-App Updates: Add Version model

### DIFF
--- a/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -171,24 +171,3 @@ private enum Constants {
     static let lastFetchedAppStoreInfoDateKey = "last-fetched-app-store-info-date-key"
     static let lastFetchedAppStoreInfoThresholdInDays = 1
 }
-
- extension Version {
-    init?(from versionString: String) {
-        let components = versionString.components(separatedBy: ".")
-        guard (2...4).contains(components.count) else {
-            return nil
-        }
-        guard
-            let major = Int(components[0]),
-            let minor = Int(components[1]),
-            let patch = Int(components[safe: 2] ?? "0")
-        else {
-            return nil
-        }
-        if components.count == 4 {
-            self.init(major, minor, patch, prereleaseIdentifiers: [components[3]])
-        } else {
-            self.init(major, minor, patch)
-        }
-    }
-}

--- a/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -135,7 +135,7 @@ extension AppUpdateCoordinator {
         guard let daysElapsed = Calendar.current.dateComponents([.day], from: lastFetchedAppStoreInfoDate, to: Date.now).day else {
             return false
         }
-        return daysElapsed > Constants.lastFetchedAppStoreInfoThresholdInDays
+        return daysElapsed >= Constants.lastFetchedAppStoreInfoThresholdInDays
     }
 
     private var flexibleIntervalInDays: Int? {
@@ -162,7 +162,7 @@ extension AppUpdateCoordinator {
         guard let daysElapsed = Calendar.current.dateComponents([.day], from: lastSeenFlexibleUpdateDate, to: Date.now).day else {
             return false
         }
-        return daysElapsed > flexibleIntervalInDays
+        return daysElapsed >= flexibleIntervalInDays
     }
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -645,8 +645,7 @@ extension WordPressAppDelegate {
 
     private func checkForAppUpdates() {
         guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
-            DDLogError("No CFBundleShortVersionString found in Info.plist")
-            return
+            return wpAssertionFailure("No CFBundleShortVersionString found in Info.plist")
         }
         let coordinator = AppUpdateCoordinator(currentVersion: version)
         Task {

--- a/WordPress/Classes/Utility/Version.swift
+++ b/WordPress/Classes/Utility/Version.swift
@@ -36,14 +36,14 @@ public struct Version: Sendable {
         prereleaseIdentifiers: [String] = [],
         buildMetadataIdentifiers: [String] = []
     ) {
-        precondition(major >= 0 && minor >= 0 && patch >= 0, "Negative versioning is invalid.")
-        precondition(
+        wpAssert(major >= 0 && minor >= 0 && patch >= 0, "Negative versioning is invalid.")
+        wpAssert(
             prereleaseIdentifiers.allSatisfy {
                 $0.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
             },
             #"Pre-release identifiers can contain only ASCII alpha-numeric characters and "-"."#
         )
-        precondition(
+        wpAssert(
             buildMetadataIdentifiers.allSatisfy {
                 $0.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
             },
@@ -55,7 +55,7 @@ public struct Version: Sendable {
         self.prereleaseIdentifiers = prereleaseIdentifiers
         self.buildMetadataIdentifiers = buildMetadataIdentifiers
     }
-    
+
     /// Initializes a version struct from a string representation of a semantic version.
     ///
     public init?(from versionString: String) {

--- a/WordPress/Classes/Utility/Version.swift
+++ b/WordPress/Classes/Utility/Version.swift
@@ -1,0 +1,139 @@
+/// A version according to the semantic versioning specification.
+///
+public struct Version: Sendable {
+
+    /// The major version according to the semantic versioning standard.
+    public let major: Int
+
+    /// The minor version according to the semantic versioning standard.
+    public let minor: Int
+
+    /// The patch version according to the semantic versioning standard.
+    public let patch: Int
+
+    /// The pre-release identifier according to the semantic versioning standard, such as `-beta.1`.
+    public let prereleaseIdentifiers: [String]
+
+    /// The build metadata of this version according to the semantic versioning standard, such as a commit hash.
+    public let buildMetadataIdentifiers: [String]
+
+    /// Initializes a version struct with the provided components of a semantic version.
+    ///
+    /// - Parameters:
+    ///   - major: The major version number.
+    ///   - minor: The minor version number.
+    ///   - patch: The patch version number.
+    ///   - prereleaseIdentifiers: The pre-release identifier.
+    ///   - buildMetaDataIdentifiers: Build metadata that identifies a build.
+    ///
+    /// - Precondition: `major >= 0 && minor >= 0 && patch >= 0`.
+    /// - Precondition: `prereleaseIdentifiers` can contain only ASCII alpha-numeric characters and "-".
+    /// - Precondition: `buildMetaDataIdentifiers` can contain only ASCII alpha-numeric characters and "-".
+    public init(
+        _ major: Int,
+        _ minor: Int,
+        _ patch: Int,
+        prereleaseIdentifiers: [String] = [],
+        buildMetadataIdentifiers: [String] = []
+    ) {
+        precondition(major >= 0 && minor >= 0 && patch >= 0, "Negative versioning is invalid.")
+        precondition(
+            prereleaseIdentifiers.allSatisfy {
+                $0.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+            },
+            #"Pre-release identifiers can contain only ASCII alpha-numeric characters and "-"."#
+        )
+        precondition(
+            buildMetadataIdentifiers.allSatisfy {
+                $0.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+            },
+            #"Build metadata identifiers can contain only ASCII alpha-numeric characters and "-"."#
+        )
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prereleaseIdentifiers = prereleaseIdentifiers
+        self.buildMetadataIdentifiers = buildMetadataIdentifiers
+    }
+}
+
+extension Version: Comparable {
+    // Although `Comparable` inherits from `Equatable`, it does not provide a new default implementation of `==`, but instead uses `Equatable`'s default synthesised implementation. The compiler-synthesised `==`` is composed of [member-wise comparisons](https://github.com/apple/swift-evolution/blob/main/proposals/0185-synthesize-equatable-hashable.md#implementation-details), which leads to a false `false` when 2 semantic versions differ by only their build metadata identifiers, contradicting SemVer 2.0.0's [comparison rules](https://semver.org/#spec-item-10).
+
+    /// Returns a Boolean value indicating whether two values are equal.
+    ///
+    /// Equality is the inverse of inequality. For any values `a` and `b`, `a ==
+    /// b` implies that `a != b` is `false`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
+    ///
+    /// - Returns: A boolean value indicating the result of the equality test.
+    @inlinable
+    public static func == (lhs: Version, rhs: Version) -> Bool {
+        !(lhs < rhs) && !(lhs > rhs)
+    }
+
+    /// Returns a Boolean value indicating whether the value of the first
+    /// argument is less than that of the second argument.
+    ///
+    /// The precedence is determined according to rules described in the [Semantic Versioning 2.0.0](https://semver.org) standard, paragraph 11.
+    ///
+    /// - Parameters:
+    ///   - lhs: A value to compare.
+    ///   - rhs: Another value to compare.
+    public static func < (lhs: Version, rhs: Version) -> Bool {
+        let lhsComparators = [lhs.major, lhs.minor, lhs.patch]
+        let rhsComparators = [rhs.major, rhs.minor, rhs.patch]
+
+        if lhsComparators != rhsComparators {
+            return lhsComparators.lexicographicallyPrecedes(rhsComparators)
+        }
+
+        guard lhs.prereleaseIdentifiers.count > 0 else {
+            return false // Non-prerelease lhs >= potentially prerelease rhs
+        }
+
+        guard rhs.prereleaseIdentifiers.count > 0 else {
+            return true // Prerelease lhs < non-prerelease rhs
+        }
+
+        for (lhsPrereleaseIdentifier, rhsPrereleaseIdentifier) in zip(lhs.prereleaseIdentifiers, rhs.prereleaseIdentifiers) {
+            if lhsPrereleaseIdentifier == rhsPrereleaseIdentifier {
+                continue
+            }
+
+            // Check if either of the 2 pre-release identifiers is numeric.
+            let lhsNumericPrereleaseIdentifier = Int(lhsPrereleaseIdentifier)
+            let rhsNumericPrereleaseIdentifier = Int(rhsPrereleaseIdentifier)
+
+            if let lhsNumericPrereleaseIdentifier,
+               let rhsNumericPrereleaseIdentifier = rhsNumericPrereleaseIdentifier {
+                return lhsNumericPrereleaseIdentifier < rhsNumericPrereleaseIdentifier
+            } else if lhsNumericPrereleaseIdentifier != nil {
+                return true // numeric pre-release < non-numeric pre-release
+            } else if rhsNumericPrereleaseIdentifier != nil {
+                return false // non-numeric pre-release > numeric pre-release
+            } else {
+                return lhsPrereleaseIdentifier < rhsPrereleaseIdentifier
+            }
+        }
+
+        return lhs.prereleaseIdentifiers.count < rhs.prereleaseIdentifiers.count
+    }
+}
+
+extension Version: CustomStringConvertible {
+    /// A textual description of the version object.
+    public var description: String {
+        var base = "\(major).\(minor).\(patch)"
+        if !prereleaseIdentifiers.isEmpty {
+            base += "-" + prereleaseIdentifiers.joined(separator: ".")
+        }
+        if !buildMetadataIdentifiers.isEmpty {
+            base += "+" + buildMetadataIdentifiers.joined(separator: ".")
+        }
+        return base
+    }
+}

--- a/WordPress/Classes/Utility/Version.swift
+++ b/WordPress/Classes/Utility/Version.swift
@@ -55,6 +55,27 @@ public struct Version: Sendable {
         self.prereleaseIdentifiers = prereleaseIdentifiers
         self.buildMetadataIdentifiers = buildMetadataIdentifiers
     }
+    
+    /// Initializes a version struct from a string representation of a semantic version.
+    ///
+    public init?(from versionString: String) {
+        let components = versionString.components(separatedBy: ".")
+        guard (2...4).contains(components.count) else {
+            return nil
+        }
+        guard
+            let major = Int(components[0]),
+            let minor = Int(components[1]),
+            let patch = Int(components[safe: 2] ?? "0")
+        else {
+            return nil
+        }
+        if components.count == 4 {
+            self.init(major, minor, patch, prereleaseIdentifiers: [components[3]])
+        } else {
+            self.init(major, minor, patch)
+        }
+    }
 }
 
 extension Version: Comparable {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4130,6 +4130,8 @@
 		FA7F92CA25E61C9300502D2A /* ReaderTagsFooter.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA7F92C925E61C9300502D2A /* ReaderTagsFooter.xib */; };
 		FA85F5F52A9DFDCC001D8425 /* NoSitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA85F5F42A9DFDCC001D8425 /* NoSitesViewModel.swift */; };
 		FA85F5F62A9DFDCC001D8425 /* NoSitesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA85F5F42A9DFDCC001D8425 /* NoSitesViewModel.swift */; };
+		FA87A22E2BF798E40062154A /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87A22D2BF798E40062154A /* Version.swift */; };
+		FA87A22F2BF798E40062154A /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87A22D2BF798E40062154A /* Version.swift */; };
 		FA88EAD6260AE69C001D232B /* TemplatePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99B08FB26081AD600CA71EB /* TemplatePreviewViewController.swift */; };
 		FA8E1F7725EEFA7300063673 /* ReaderPostService+RelatedPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E1F7625EEFA7300063673 /* ReaderPostService+RelatedPosts.swift */; };
 		FA8E2FE027C6377000DA0982 /* DashboardQuickStartCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E2FDF27C6377000DA0982 /* DashboardQuickStartCardCell.swift */; };
@@ -9517,6 +9519,7 @@
 		FA7F92B725E61C7E00502D2A /* ReaderTagsFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagsFooter.swift; sourceTree = "<group>"; };
 		FA7F92C925E61C9300502D2A /* ReaderTagsFooter.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderTagsFooter.xib; sourceTree = "<group>"; };
 		FA85F5F42A9DFDCC001D8425 /* NoSitesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoSitesViewModel.swift; sourceTree = "<group>"; };
+		FA87A22D2BF798E40062154A /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		FA8E1F7625EEFA7300063673 /* ReaderPostService+RelatedPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostService+RelatedPosts.swift"; sourceTree = "<group>"; };
 		FA8E2FDF27C6377000DA0982 /* DashboardQuickStartCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickStartCardCell.swift; sourceTree = "<group>"; };
 		FA8E2FE427C6AE4500DA0982 /* QuickStartChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistView.swift; sourceTree = "<group>"; };
@@ -14163,6 +14166,7 @@
 				801D9519291AC0B00051993E /* OverlayFrequencyTracker.swift */,
 				0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */,
 				4A5DE7372B0D511900363171 /* PageTree.swift */,
+				FA87A22D2BF798E40062154A /* Version.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -21731,6 +21735,7 @@
 				08216FCB1CDBF96000304BA7 /* MenuItemEditingHeaderView.m in Sources */,
 				17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */,
 				1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */,
+				FA87A22E2BF798E40062154A /* Version.swift in Sources */,
 				F5B9152124465FB400179876 /* ReaderTagsTableViewController.swift in Sources */,
 				4388FEFE20A4E0B900783948 /* NotificationsViewController+AppRatings.swift in Sources */,
 				93C1148518EDF6E100DAC95C /* BlogService.m in Sources */,
@@ -25164,6 +25169,7 @@
 				FABB22A52602FC2C00C8785C /* SignupEpilogueViewController.swift in Sources */,
 				FAB985C22697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */,
 				FABB22A72602FC2C00C8785C /* BlogListViewController+Activity.swift in Sources */,
+				FA87A22F2BF798E40062154A /* Version.swift in Sources */,
 				3F810A5B2616870C00ADDCC2 /* UnifiedPrologueIntroContentView.swift in Sources */,
 				FABB22A82602FC2C00C8785C /* TableDataCoordinator.swift in Sources */,
 				0C02E6C62BE3B6E30055F0F6 /* PostTrashedOverlayView.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/23195#pullrequestreview-2057967801

## Description
- Adds the Version model, which has more robust comparison logic

## How to test
- Make sure `AppUpdateCoordinatorTests` is all green

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
