### PR TITLE
Reader: Track when the Reader announcement card is dismissed

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -82,6 +82,7 @@ import Foundation
     case readerPostCardTapped
     case readerPullToRefresh
     case readerDiscoverTopicTapped
+    case readerAnnouncementDismissed
     case postCardMoreTapped
     case followedBlogNotificationsReaderMenuOff
     case followedBlogNotificationsReaderMenuOn
@@ -741,6 +742,8 @@ import Foundation
             return "reader_pull_to_refresh"
         case .readerDiscoverTopicTapped:
             return "reader_discover_topic_tapped"
+        case .readerAnnouncementDismissed:
+            return "reader_announcement_card_dismissed"
         case .postCardMoreTapped:
             return "post_card_more_tapped"
         case .followedBlogNotificationsReaderMenuOff:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -187,6 +187,7 @@ extension ReaderStreamViewController {
         return ReaderAnnouncementHeaderView(doneButtonTapped: { [weak self] in
             // Set the card as dismissed.
             self?.readerAnnouncementCoordinator.isDismissed = true
+            WPAnalytics.track(.readerAnnouncementDismissed)
 
             // Animate the header removal so it feels less jarring.
             UIView.animate(withDuration: 0.3) {


### PR DESCRIPTION
## Description

Adds a track for when the announcement card is dismissed.

## Testing

To test:
- Set up the app to show the Reader announcement card by changing the code or fresh install
- Launch Jetpack and login
- Enable the Reader announcement card if necessary
- Navigate to the Reader
- On the announcement card, tap on the primary action
- 🔎 **Verify** `🔵 Tracked: reader_announcement_card_dismissed <>` is tracked

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
