### PR TITLE
Remove obsolete lane to register a device on the developer portal

### DIFF
--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -3,50 +3,6 @@
 # Lanes related to Code Signing and Provisioning Profiles
 #
 platform :ios do
-  # Registers a new device in the Developer Portal and update all the Provisioning Profiles
-  #
-  # @option [String] device_name name to give to the device. Will be prompted interactively if not provided.
-  # @option [String] device_id UDID of the device to add. Will be prompted interactively if not provided.
-  #
-  desc 'Registers a Device in the developer console'
-  lane :register_new_device do |options|
-    device_name = UI.input('Device Name: ') if options[:device_name].nil?
-    device_id = UI.input('Device ID: ') if options[:device_id].nil?
-    all_bundle_ids = ALL_WORDPRESS_BUNDLE_IDENTIFIERS + ALL_JETPACK_BUNDLE_IDENTIFIERS
-
-    UI.message "Registering #{device_name} with ID #{device_id} and registering it with any provisioning profiles associated with these bundle identifiers:"
-    all_bundle_ids.each do |identifier|
-      puts "\t#{identifier}"
-    end
-
-    team_id = get_required_env('EXT_EXPORT_TEAM_ID')
-
-    # Register the user's device
-    register_device(
-      name: device_name,
-      udid: device_id,
-      team_id: team_id,
-      api_key_path: APP_STORE_CONNECT_KEY_PATH
-    )
-
-    # We're about to use `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`.
-    # These actions use Developer Portal APIs that don't yet support authentication via API key (-.-').
-    # Let's preemptively ask for and set the email here to avoid being asked twice for it if not set.
-    prompt_user_for_app_store_connect_credentials
-
-    # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
-    add_development_certificates_to_provisioning_profiles(
-      team_id: team_id,
-      app_identifier: all_bundle_ids
-    )
-
-    # Add all devices to the provisioning profiles
-    add_all_devices_to_provisioning_profiles(
-      team_id: team_id,
-      app_identifier: all_bundle_ids
-    )
-  end
-
   # Downloads all the required certificates and profiles (using `match`) for all variants.
   # Optionally, it can create any new necessary certificate or profile.
   #


### PR DESCRIPTION
Automatticians have been able to use an internal GUI self-service tool for this for quite some time.


To test: Nothing to test here, this PR only removes unused code.
## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.