### PR TITLE
Reader: Update tags feature flag to be a remote flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,7 +11,6 @@ enum FeatureFlag: Int, CaseIterable {
     case compliancePopover
     case googleDomainsCard
     case newTabIcons
-    case readerTagsFeed
     case syncPublishing
     case autoSaveDrafts
 
@@ -40,8 +39,6 @@ enum FeatureFlag: Int, CaseIterable {
             return false
         case .newTabIcons:
             return true
-        case .readerTagsFeed:
-            return false
         case .syncPublishing:
             return true
         case .autoSaveDrafts:
@@ -86,8 +83,6 @@ extension FeatureFlag {
             return "Google Domains Promotional Card"
         case .newTabIcons:
             return "New Tab Icons"
-        case .readerTagsFeed:
-            return "Reader Tags Feed"
         case .syncPublishing:
             return "Synchronous Publishing"
         case .autoSaveDrafts:

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -34,6 +34,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case readerAnnouncementCard
     case inAppUpdates
     case voiceToContent
+    case readerTagsFeed
 
     var defaultValue: Bool {
         switch self {
@@ -101,6 +102,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return false
         case .voiceToContent:
             return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        case .readerTagsFeed:
+            return false
         }
     }
 
@@ -171,6 +174,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "in_app_updates"
         case .voiceToContent:
             return "voice_to_content"
+        case .readerTagsFeed:
+            return "reader_tags_feed"
         }
     }
 
@@ -240,6 +245,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "In-App Updates"
         case .voiceToContent:
             return "Voice to Content"
+        case .readerTagsFeed:
+            return "Reader Tags Feed"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -679,7 +679,7 @@ extension ReaderHelpers {
         let savedPosition = min(mutableItems.count, defaultSavedItemPosition)
         mutableItems.insert(ReaderTabItem(ReaderContent(topic: nil, contentType: .saved)), at: savedPosition)
 
-        if FeatureFlag.readerTagsFeed.enabled {
+        if RemoteFeatureFlag.readerTagsFeed.enabled() {
             mutableItems.append(ReaderTabItem(ReaderContent(topic: nil, contentType: .tags)))
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderNavigationButton.swift
@@ -12,7 +12,7 @@ struct ReaderNavigationButton: View {
                         menuButton(for: item)
                     }
                     if group == menuItemGroups.last && viewModel.listItems.count > 0 {
-                        if !FeatureFlag.readerTagsFeed.enabled {
+                        if !RemoteFeatureFlag.readerTagsFeed.enabled() {
                             Divider()
                         }
                         listMenuItem

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
@@ -19,7 +19,7 @@ struct ReaderTabItem: FilterTabBarItem, Hashable {
         && content.type != .selfHostedFollowing
         && content.type != .tags
         shouldHideSettingsButton = content.type == .selfHostedFollowing
-        shouldHideTagFilter = content.topicType == .organization || (content.type != .tags && FeatureFlag.readerTagsFeed.enabled)
+        shouldHideTagFilter = content.topicType == .organization || (content.type != .tags && RemoteFeatureFlag.readerTagsFeed.enabled())
         shouldHideBlogFilter = content.type == .tags
     }
 


### PR DESCRIPTION
## Description

Updates the local tags feed feature flag to a remote feature flag.

## Testing

To test:
- Launch Jetpack and login
- Enable the tags feature flag
- 🔎 **Verify** the tags feed appears and works properly
- Disable the feature flag
- Restart the app
- Relaunch and navigate to the Reader
- 🔎 **Verify** the tags feed feature does not appear

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
