### PR TITLE
Reader: Enable the tags feed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Improve performance of Image and Gallery block processors to avoid long delay when saving a post [#22896]
 * [*] Improve performance of File block processor [#22897]
 * [*] [internal] Prompt users to keep the app up to date on their devices, so they can try new features, as well as benefit from performance improvements and bug fixes [#23195, #23216, #23218, #23211] 
+* [**] [Jetpack-only] Reader: Add a new feed dedicated to tags [#23242]
 
 24.9
 -----

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -103,7 +103,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .voiceToContent:
             return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .readerTagsFeed:
-            return false
+            return true
         }
     }
 


### PR DESCRIPTION
Merges into: https://github.com/wordpress-mobile/WordPress-iOS/pull/23241

## Description

Enables the tags feed feature for Reader.

## Testing

To test:
- Launch Jetpack and login
- Double check that the tags feature flag is not overridden
- Navigate to the Reader
- 🔎 **Verify** the tags feed appears in the navigation menu
- Perform a quick smoke test of the feature and 🔎 **verify** it works properly

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
