### PR TITLE
VtC: Add remote feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -33,6 +33,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case readingPreferencesFeedback
     case readerAnnouncementCard
     case inAppUpdates
+    case voiceToContent
 
     var defaultValue: Bool {
         switch self {
@@ -98,6 +99,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .inAppUpdates:
             return false
+        case .voiceToContent:
+            return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -166,6 +169,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "reader_announcement_card"
         case .inAppUpdates:
             return "in_app_updates"
+        case .voiceToContent:
+            return "voice_to_content"
         }
     }
 
@@ -233,6 +238,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Reader Announcement Card"
         case .inAppUpdates:
             return "In-App Updates"
+        case .voiceToContent:
+            return "Voice to Content"
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/98

## How to test
- Open the feature flag screen from the debug menu
- ✅ Verify the VtC feature flag is displayed

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/e06291e7-fff3-486d-b21f-0050be1c9a2e" width=200>

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

