### PR TITLE
Remove incorrect release note about post visibility when switching tabs

### DIFF
--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -109,7 +109,6 @@ msgid ""
 "- Discarding changes to a draft will no longer delete the entire draft.\n"
 "- The footer will show the correct date when a draft was created.\n"
 "- You’ll now see an error message when you assign a page author who isn’t eligible to be an author.\n"
-"- Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of the first screenshot in the App Store.

--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -24,4 +24,3 @@ Finally, we squashed a long list of bugs and fixed a handful of rare crashes cau
 - Discarding changes to a draft will no longer delete the entire draft.
 - The footer will show the correct date when a draft was created.
 - You’ll now see an error message when you assign a page author who isn’t eligible to be an author.
-- Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -70,7 +70,6 @@ msgid ""
 "- If a draft on your device is different from the draft saved to the web, the app will now show a conflict resolution screen instead of making changes on its own.\n"
 "- Discarding changes to a draft will no longer delete the entire draft. You also won’t see the option to discard changes when you haven’t made any.\n"
 "- You’ll now see an error message when you assign a page author who isn’t eligible to be an author.\n"
-"- Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.\n"
 msgstr ""
 
 #. translators: This is a standard chunk of text used to tell a user what's new with a release when nothing major has changed.

--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -21,4 +21,3 @@ Finally, we squashed a long list of bugs and fixed a handful of rare crashes cau
 - If a draft on your device is different from the draft saved to the web, the app will now show a conflict resolution screen instead of making changes on its own.
 - Discarding changes to a draft will no longer delete the entire draft. You also won’t see the option to discard changes when you haven’t made any.
 - You’ll now see an error message when you assign a page author who isn’t eligible to be an author.
-- Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.

--- a/fastlane/jetpack_metadata/default/release_notes.txt
+++ b/fastlane/jetpack_metadata/default/release_notes.txt
@@ -24,4 +24,3 @@ Finally, we squashed a long list of bugs and fixed a handful of rare crashes cau
 - Discarding changes to a draft will no longer delete the entire draft.
 - The footer will show the correct date when a draft was created.
 - You’ll now see an error message when you assign a page author who isn’t eligible to be an author.
-- Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.

--- a/fastlane/metadata/default/release_notes.txt
+++ b/fastlane/metadata/default/release_notes.txt
@@ -21,4 +21,3 @@ Finally, we squashed a long list of bugs and fixed a handful of rare crashes cau
 - If a draft on your device is different from the draft saved to the web, the app will now show a conflict resolution screen instead of making changes on its own.
 - Discarding changes to a draft will no longer delete the entire draft. You also won’t see the option to discard changes when you haven’t made any.
 - You’ll now see an error message when you assign a page author who isn’t eligible to be an author.
-- Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.


### PR DESCRIPTION
The PR removes the following update from the generated release notes:

```
Switching between tabs in Posts will show all your draft posts and published content, no matter how much of it you have. Yes, even you, the user with 1,239 saved drafts. We’re impressed and slightly concerned, but we respect your writing process.
```