### PR TITLE
Reader: Add tracks for text highlight/copy in Reader

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -110,6 +110,10 @@ import Foundation
     case readerArticleImageTapped
     case readerFollowConversationTooltipTapped
     case readerFollowConversationAnchorTapped
+    case readerArticleTextHighlighted
+    case readerArticleTextCopied
+    case readerCommentTextHighlighted
+    case readerCommentTextCopied
 
     // Stats - Empty Stats nudges
     case statsPublicizeNudgeShown
@@ -798,6 +802,14 @@ import Foundation
             return "reader_follow_conversation_tooltip_tapped"
         case .readerFollowConversationAnchorTapped:
             return "reader_follow_conversation_anchor_tapped"
+        case .readerArticleTextHighlighted:
+            return "reader_article_text_highlighted"
+        case .readerArticleTextCopied:
+            return "reader_article_text_copied"
+        case .readerCommentTextHighlighted:
+            return "reader_comment_text_highlighted"
+        case .readerCommentTextCopied:
+            return "reader_comment_text_copied"
 
         // Stats - Empty Stats nudges
         case .statsPublicizeNudgeShown:

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/RichCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/RichCommentContentRenderer.swift
@@ -43,6 +43,10 @@ extension RichCommentContentRenderer: WPRichContentViewDelegate {
     func richContentViewDidUpdateLayoutForAttachments(_ richContentView: WPRichContentView) {
         richContentDelegate?.richContentViewDidUpdateLayoutForAttachments?(richContentView)
     }
+
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        richContentDelegate?.textViewDidChangeSelection?(textView)
+    }
 }
 
 // MARK: - Private Helpers

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -44,6 +44,7 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         webView.scrollView.showsVerticalScrollIndicator = false
         webView.scrollView.backgroundColor = .clear
         webView.configuration.allowsInlineMediaPlayback = true
+        webView.configuration.userContentController.add(self, name: "eventHandler")
     }
 
     func render() -> UIView {
@@ -109,6 +110,20 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
             self.delegate?.renderer(self, interactedWithURL: destinationURL)
         }
     }
+}
+
+// MARK: - WKScriptMessageHandler
+
+extension WebCommentContentRenderer: WKScriptMessageHandler {
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = message.body as? String,
+              let event = ReaderWebView.EventMessage(rawValue: body)?.analyticEvent else {
+            return
+        }
+        WPAnalytics.track(event)
+    }
+
 }
 
 // MARK: - Private Methods

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -105,6 +105,8 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self configureKeyboardGestureRecognizer];
     [self configureViewConstraints];
     [self configureKeyboardManager];
+
+    [self listenForClipboardChanges];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -555,6 +557,21 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     }
 
     return NO;
+}
+
+- (void)listenForClipboardChanges
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(clipboardChanged:)
+                                                 name:UIPasteboardChangedNotification
+                                               object:nil];
+}
+
+- (void)clipboardChanged:(NSNotification *)notification
+{
+    if (notification.userInfo == nil) {
+        [WPAnalytics trackEvent:WPAnalyticsEventReaderCommentTextCopied];
+    }
 }
 
 #pragma mark - Accessor methods
@@ -1294,6 +1311,13 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     UIViewController *webViewController = [WebViewControllerFactory controllerWithConfiguration:configuration source:@"reader_comments"];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
+}
+
+- (void)textViewDidChangeSelection:(UITextView *)textView
+{
+    if (!textView.selectedTextRange.isEmpty) {
+        [WPAnalytics trackEvent:WPAnalyticsEventReaderCommentTextHighlighted];
+    }
 }
 
 #pragma mark - ReaderCommentsFollowPresenterDelegate Methods

--- a/WordPress/Resources/HTML/richCommentTemplate.html
+++ b/WordPress/Resources/HTML/richCommentTemplate.html
@@ -5,6 +5,27 @@
     <style>
         %2$@
     </style>
+    <script>
+        function debounce(fn, timeout) {
+            let timer;
+            return () => {
+                clearTimeout(timer);
+                timer = setTimeout(fn, timeout);
+            }
+        }
+        const postEvent = (event) => window.webkit.messageHandlers.eventHandler.postMessage(event);
+        const textHighlighted = debounce(
+            () => postEvent("commentTextHighlighted"),
+            1000
+        );
+        document.addEventListener('selectionchange', function(event) {
+            const selection = document.getSelection().toString();
+            if (selection.length > 0) {
+                textHighlighted();
+            }
+        });
+        document.addEventListener('copy', event => postEvent("commentTextCopied"));
+    </script>
 </head>
 <body>
     %3$@


### PR DESCRIPTION
Fixes #23250 

## Description

Adds the following track events:

| Event | Condition |
|---|---|
| `reader_article_text_highlighted` | Sent when text is highlighted in the Reader article view |
| `reader_article_text_copied` | Sent when text is copied in the Reader article view |
| `reader_comment_text_highlighted` | Sent when a Reader comment text is highlighted |
| `reader_comment_text_copied` | Sent when a Reader comment text is copied |

## Testing

### Article Events
- Launch Jetpack and login
- Navigate to a Reader article
- Highlight some of the text in the article
- 🔎 **Verify** `🔵 Tracked: reader_article_text_highlighted <>` is sent
- Drag around the selection
- 🔎 **Verify** the event is NOT spammed
- Copy the selected text
- 🔎 **Verify** `🔵 Tracked: reader_article_text_copied <>` is sent

### Comment Events

#### Article Displayed Comment
- Launch Jetpack and login
- Navigate to a Reader article with multiple comments
- On the article screen (not all the comments), scroll down to the displayed comment
- Highlight some of the text on the comment
- 🔎 **Verify** `🔵 Tracked: reader_comment_text_highlighted <>` is sent
- Drag around the selection
- 🔎 **Verify** the event is NOT spammed
- Copy the selected text
- 🔎 **Verify** `🔵 Tracked: reader_comment_text_copied <>` is sent

#### All Comments Screen
- Launch Jetpack and login
- Navigate to a Reader article with multiple comments
- On the article, tap on `View all comments`
- Highlight some text on a comment
- 🔎 **Verify** `🔵 Tracked: reader_comment_text_highlighted <>` is sent
- Drag around the selection
- 🔎 **Verify** the event is NOT spammed
- Copy the selected text
- 🔎 **Verify** `🔵 Tracked: reader_comment_text_copied <>` is sent

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
