### PR TITLE
Reader: Fix filter titles and stream list order for logged-out users

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -4,6 +4,10 @@ class FilterProvider: NSObject, Identifiable, Observable, FilterTabBarItem {
 
     let id: UUID = UUID()
 
+    enum FilterProviderError: Error {
+        case notAuthorized
+    }
+
     enum State {
         case loading
         case ready([TableDataItem])
@@ -187,6 +191,12 @@ extension ReaderSiteTopic {
                 }
             }
             completion(itemResult)
+        }
+
+        // User needs to be logged in to follow sites.
+        guard ReaderHelpers.isLoggedIn() else {
+            completionBlock(.failure(FilterProvider.FilterProviderError.notAuthorized))
+            return
         }
 
         fetchStoredFollowedSites(completion: completionBlock)

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -265,8 +265,8 @@ extension ReaderSiteTopic {
 
     private struct Strings {
         static let unnumberedFilterTitle = NSLocalizedString(
-            "reader.navigation.filter.blog.unnumbered",
-            value: "Tags",
+            "reader.navigation.filter.blog.unspecified",
+            value: "Blogs",
             comment: """
                 Button title to filter the Reader stream by blog.
                 This is displayed when we don't know the number of blogs yet.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -683,9 +683,11 @@ extension ReaderHelpers {
             mutableItems.append(ReaderTabItem(ReaderContent(topic: nil, contentType: .tags)))
         }
 
-        // in case of log in with a self hosted site, prepend a 'dummy' Following tab
+        // in case of log in with a self hosted site, prepend a 'dummy' Following tab after Discover.
         if !isLoggedIn() {
-            mutableItems.insert(ReaderTabItem(ReaderContent(topic: nil, contentType: .selfHostedFollowing)), at: 0)
+            // to safeguard, ensure that there are items in the array before inserting. Otherwise, insert at index 0.
+            let targetIndex = mutableItems.count > 0 ? 1 : 0
+            mutableItems.insert(ReaderTabItem(ReaderContent(topic: nil, contentType: .selfHostedFollowing)), at: targetIndex)
         }
 
         return mutableItems


### PR DESCRIPTION
> [!WARNING]
> Auto-merge is turned on.

This fixes several bugs for the logged-out / self-hosted context:

- Subscriptions stream showing `Tags` as the title of the filter chip. The expected title is `Blogs`.
- The Subscriptions stream is shown first in the list. The expected order is for Subscriptions to be listed 2nd, after Discover.
- There's a visual glitch for the filter chip text when transitioning to the Subscriptions stream, where it briefly shows `0 Blog` before being updated to `Blogs` mid-transition.

Before | After
-|-
![Simulator Screenshot - iPhone 15 - 2024-05-24 at 19 19 10](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/c41416af-2305-4a90-bd9d-f2505b427bd6) | ![Simulator Screenshot - iPhone 15 - 2024-05-24 at 19 17 16](https://github.com/wordpress-mobile/WordPress-iOS/assets/1299411/49c3e7a5-381d-4c7f-8051-1cea7fa4c33d)

We could improve the wording in a lot of areas since lots of features require users to be logged in. For example, use a copy that nudges them to sign up. But this could be a separate project.

## To test

Prepare a non-Jetpack, self-hosted site. Make sure that the Jetpack plugin is deactivated and uninstalled.

- Launch the Jetpack app and log in to the self-hosted site.
- Navigate to the Reader.
- 🔎 Verify that the Discover stream is shown.
- Tap the Discover button.
- 🔎 Verify that Subscriptions is 2nd on the list.
- Tap Subscriptions.
- 🔎 Verify that the filter chip title says "Blogs".
- Log out and log in with a WP.com account.
- 🔎  Verify that Reader works as expected for the logged-in use case.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
