### PR TITLE
Fix scrolling to the comment from notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -855,9 +855,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
             [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
             self.highlightedIndexPath = indexPath;
         }
-
-        // Reset the commentID so we don't do this again.
-        self.navigateToCommentID = nil;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16897

This workaround does not stop navigating to the highlighted comment after the first unsuccessful attempt. Instead of that, when the comments pages are loaded one by one until the highlighted comment is loaded, we scroll down to the last available comment. It looks a bit laggy because it scrolls the list multiple times but reaches the destination after all.
This fix should be treated as a temporary patch. Ideally, the entire comments loading mechanism should be revamped.

Please let me know if you have any ideas on how to improve it. 
More context: p1709841569628759-slack-C06BWNSR02K

To test:
- [ ] Run the original app from `trunk` and find a comment notification that leads to a post with a big number of comments.
- [ ] Go to the comment details and then to the original comment with the full comments tree.
- [ ] Notice that the list scrolled to a wrong comment instead of the highlighted one.
- [ ] Run the app from this PR and make the same steps with the same comments.
- [ ] Confirm that the list is scrolled to the proper highlighted comment after a few attempts.

## Regression Notes
1. Potential unintended areas of impact
Reader Comments screen `ReaderCommentsViewController`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Legacy code

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)