### PR TITLE
[Voice to Content] Update eligibility checks

### DIFF
--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -48,7 +48,7 @@ struct VoiceToContentView: View {
             VStack(alignment: .leading, spacing: 12) {
                 Text(viewModel.title)
                     .font(.title3.weight(.bold))
-                HStack {
+                HStack(spacing: 5) {
                     Text(viewModel.subtitle)
                         .font(.subheadline.monospacedDigit())
                         .foregroundStyle(.secondary)

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -56,7 +56,6 @@ struct VoiceToContentView: View {
                         ProgressView()
                             .tint(.secondary)
                             .controlSize(.small)
-                            .padding(.leading, 2)
                     }
                 }
             }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -107,11 +107,8 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
             self.subtitle = Strings.subtitleRequestsAvailable + " 0"
             self.isEligible = false
         } else {
-            let requestLimit = info.currentTier?.limit ?? info.requestsLimit
-            let requestsCount = (info.usagePeriod?.requestsCount ?? 0)
-            let remainingRequestCount = max(0, requestLimit - requestsCount)
-            let value = info.currentTier?.readableLimit ?? remainingRequestCount.description
-            self.subtitle = Strings.subtitleRequestsAvailable + " \(value)"
+            let limit = info.getLocalizedRequestLimit()
+            self.subtitle = Strings.subtitleRequestsAvailable + " \(limit)"
             self.isEligible = true
         }
     }
@@ -262,4 +259,24 @@ private enum Strings {
     static let subtitleRequestsAvailable = NSLocalizedString("postFromAudio.subtitleRequestsAvailable", value: "Requests available:", comment: "The screen subtitle")
     static let titleRecoding = NSLocalizedString("postFromAudio.titleRecoding", value: "Recording…", comment: "The screen title when recording")
     static let titleProcessing = NSLocalizedString("postFromAudio.titleProcessing", value: "Processing…", comment: "The screen title when recording")
+}
+
+extension JetpackAssistantFeatureDetails {
+    func getLocalizedRequestLimit() -> String {
+        // For a free plan, the root `requests-count` has to be used.
+        if currentTier?.slug == "jetpack_ai_free" {
+            return max(0, requestsLimit - requestsCount).description
+        }
+        // The backend uses `1` as an indicator of unlimited requests.
+        if currentTier?.value == 1 {
+            return "∞"
+        }
+        // The `usage-period.requests-count` is only valid for paid plans with
+        // a limited number of requests.
+        wpAssert(usagePeriod != nil, "missing usage-period")
+        wpAssert(currentTier != nil, "missing current-tier")
+        let requestsLimit = currentTier?.limit ?? requestsLimit
+        let requestsCount = usagePeriod?.requestsCount ?? requestsCount
+        return max(0, requestsLimit - requestsCount).description
+    }
 }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -259,6 +259,7 @@ private enum Strings {
     static let subtitleRequestsAvailable = NSLocalizedString("postFromAudio.subtitleRequestsAvailable", value: "Requests available:", comment: "The screen subtitle")
     static let titleRecoding = NSLocalizedString("postFromAudio.titleRecoding", value: "Recording…", comment: "The screen title when recording")
     static let titleProcessing = NSLocalizedString("postFromAudio.titleProcessing", value: "Processing…", comment: "The screen title when recording")
+    static let unlimited = NSLocalizedString("postFromAudio.unlimited", value: "Unlimited", comment: "The value for the `requests available:` field for an unlimited plan")
 }
 
 extension JetpackAssistantFeatureDetails {
@@ -269,7 +270,7 @@ extension JetpackAssistantFeatureDetails {
         }
         // The backend uses `1` as an indicator of unlimited requests.
         if currentTier?.value == 1 {
-            return "∞"
+            return Strings.unlimited
         }
         // The `usage-period.requests-count` is only valid for paid plans with
         // a limited number of requests.

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -103,16 +103,16 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
 
     private func didFetchFeatureDetails(_ info: JetpackAssistantFeatureDetails) {
         self.loadingState = nil
-        if info.hasFeature, !info.isOverLimit {
+        if info.isSiteUpdateRequired == true {
+            self.subtitle = Strings.subtitleRequestsAvailable + " 0"
+            self.isEligible = false
+        } else {
             let requestLimit = info.currentTier?.limit ?? info.requestsLimit
             let requestsCount = (info.usagePeriod?.requestsCount ?? 0)
             let remainingRequestCount = max(0, requestLimit - requestsCount)
             let value = info.currentTier?.readableLimit ?? remainingRequestCount.description
             self.subtitle = Strings.subtitleRequestsAvailable + " \(value)"
             self.isEligible = true
-        } else {
-            self.subtitle = Strings.subtitleRequestsAvailable + " 0"
-            self.isEligible = false
         }
     }
 


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/103Fixes https://github.com/Automattic/wordpress-mobile/issues/103

To test:

- ✅ Verify that for "Free" plan, it shows a request limit starting with 20 and the limit reduces with every request
- ✅ Verify that for "Unlimited" plans – P2 plans are – the request available shows "Unlimited"

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
