### PR TITLE
Add support for __JETPACK_AI_ERROR__

### DIFF
--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -227,6 +227,12 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
             let transcription = try await service.transcribeAudio(from: fileURL, token: token)
             let content = try await service.makePostContent(fromPlainText: transcription, token: token)
 
+            // "the __JETPACK_AI_ERROR__ is a special marker we ask GPT to add to
+            // the request when it can’t understand the request for any reason"
+            guard content != "__JETPACK_AI_ERROR__" else {
+                showError(VoiceToContentError.cantUnderstandRequest)
+                return
+            }
             self.completion(content)
         } catch {
             showError(error)
@@ -256,9 +262,20 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
     }
 }
 
+private enum VoiceToContentError: Error, LocalizedError {
+    case cantUnderstandRequest
+
+    var errorDescription: String? {
+        switch self {
+        case .cantUnderstandRequest: return Strings.errorMessageCantUnderstandRequest
+        }
+    }
+}
+
 private enum Strings {
     static let title = NSLocalizedString("postFromAudio.title", value: "Post from Audio", comment: "The screen title")
     static let subtitleError = NSLocalizedString("postFromAudio.subtitleError", value: "Something went wrong", comment: "The screen subtitle in the error state")
+    static let errorMessageCantUnderstandRequest = NSLocalizedString("postFromAudio.errorMessage.cantUnderstandRequest", value: "There were some issues processing the request. Please, try again later.", comment: "The AI failed to understand the request for any reasons")
     static let subtitleRequestsAvailable = NSLocalizedString("postFromAudio.subtitleRequestsAvailable", value: "Requests available:", comment: "The screen subtitle")
     static let titleRecoding = NSLocalizedString("postFromAudio.titleRecoding", value: "Recording…", comment: "The screen title when recording")
     static let titleProcessing = NSLocalizedString("postFromAudio.titleProcessing", value: "Processing…", comment: "The screen title when recording")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -241,7 +241,7 @@ module FastlaneActionLogGroup
 
   def execute_action(action_name)
     print_group(action_name)
-    super(action_name)
+    super
   end
 end
 


### PR DESCRIPTION
Add support for `__JETPACK_AI_ERROR__` as discussed in the channel.

To test: n/a (no way to reproduce)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
