### PR TITLE
Hot Fix: Open AppStore directly rather than through SKStoreProductViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,9 @@
 25.0
 -----
 
+24.9.1
+-----
+* [**] Fix bug where the option to switch to the Jetpack app is broken [#23276]
 
 24.9
 -----

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
@@ -31,63 +31,11 @@ class JetpackRedirector {
 
         // First, check if the WordPress app can open Jetpack by testing its URL scheme.
         // if we can potentially open Jetpack app, let's open it through universal link to avoid scheme conflicts (e.g., a certain game :-).
-        // finally, if the user might not have Jetpack installed, open App Store view controller through StoreKit.
+        // finally, if the user might not have Jetpack installed, open App Store
         if UIApplication.shared.canOpenURL(jetpackDeepLinkURL) {
             UIApplication.shared.open(jetpackUniversalLinkURL)
         } else {
-            showJetpackAppInstallation(fallbackURL: jetpackAppStoreURL)
+            UIApplication.shared.open(jetpackAppStoreURL)
         }
     }
-
-    private static func showJetpackAppInstallation(fallbackURL: URL) {
-        let viewController = RootViewCoordinator.sharedPresenter.rootViewController.topmostPresentedViewController
-        let storeProductVC = SKStoreProductViewController()
-        let appID = [SKStoreProductParameterITunesItemIdentifier: "1565481562"]
-
-        configureNavigationBarAppearance(storeProductVC)
-
-        storeProductVC.loadProduct(withParameters: appID) { (result, error) in
-            if result {
-                viewController.present(storeProductVC, animated: true)
-            } else if let error = error {
-                DDLogError("Failed loading Jetpack App product: \(error.localizedDescription)")
-                UIApplication.shared.open(fallbackURL)
-            }
-        }
-    }
-
-    // MARK: - SKStoreProductViewController navigation bar appearance
-
-    /// Sets SKStoreProductViewController navigation bar translucent
-    ///
-    /// Application's global navigation appearance settings interferes with SKStoreProductViewController
-    /// which requires for this temporary workaround
-    private static func configureNavigationBarAppearance(_ controller: SKStoreProductViewController) {
-        let previousisTranslucentValue = UINavigationBar.appearance().isTranslucent
-        UINavigationBar.appearance().isTranslucent = true
-
-        /// Reset to default translucent value
-        storeProductViewControllerObserver = StoreProductViewControllerObserver(onDismiss: {
-            UINavigationBar.appearance().isTranslucent = previousisTranslucentValue
-            storeProductViewControllerObserver = nil
-        })
-
-        controller.delegate = storeProductViewControllerObserver
-    }
-
-    /// Observe product view controller dismissal
-    class StoreProductViewControllerObserver: NSObject, SKStoreProductViewControllerDelegate {
-        private let onDismiss: () -> ()
-
-        init(onDismiss: @escaping () -> ()) {
-            self.onDismiss = onDismiss
-            super.init()
-        }
-
-        func productViewControllerDidFinish(_ viewController: SKStoreProductViewController) {
-            onDismiss()
-        }
-    }
-
-    private static var storeProductViewControllerObserver: StoreProductViewControllerObserver?
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
@@ -1,5 +1,4 @@
 import Foundation
-import StoreKit
 
 class JetpackRedirector {
 


### PR DESCRIPTION
Context: p1717015105844129-slack-C012H19SZQ8

"Switch to Jetpack app" doesn't work on full-screen pop-up overlays. It happens because full-screen overlays are presented on separate windows, and "Switch to Jetpack app" tries to show `SKStoreProductViewController` on a topmost view controller on the main window.

To fix presentation issues and avoid substantial navigation changes for a hotifx, I'm reverting to safe option of opening the App Store directly

### To test:

1. Fresh install the WordPress app
2. Login to a new account
3. Observe the full screen popover appear
4. Tap "Switch to Jetpack app"
5. Confirm AppStore is opened
6. Install the app
7. Confirm "Switch to Jetpack app" open the app

## Regression Notes
1. Potential unintended areas of impact

I'm reverting to a previous solution. Opening `UIApplication` will get around any internal presentation issues.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)