### PR TITLE
Reader: Show floating button in top-level screen

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -334,6 +334,11 @@ import Foundation
     case readerTagsFeedMoreFromTagTapped
     case readerTagsFeedHeaderTapped
 
+    // Reader: Floating Button Experiment
+    case readerFloatingButtonShown
+    case readerCreateSheetAnswerPromptTapped
+    case readerCreateSheetPromptHelpTapped
+
     // App Settings
     case settingsDidChange
 
@@ -1195,6 +1200,14 @@ import Foundation
             return "reader_tags_feed_more_from_tag_tapped"
         case .readerTagsFeedHeaderTapped:
             return "reader_tags_feed_header_tapped"
+
+        // Reader: Floating Button Experiment
+        case .readerFloatingButtonShown:
+            return "reader_create_fab_shown"
+        case .readerCreateSheetAnswerPromptTapped:
+            return "my_site_create_sheet_answer_prompt_tapped"
+        case .readerCreateSheetPromptHelpTapped:
+            return "my_site_create_sheet_prompt_help_tapped"
 
         // App Settings
         case .settingsDidChange:

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -35,6 +35,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppUpdates
     case voiceToContent
     case readerTagsFeed
+    case readerFloatingButton
 
     var defaultValue: Bool {
         switch self {
@@ -104,6 +105,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .readerTagsFeed:
             return true
+        case .readerFloatingButton:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -176,6 +179,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "voice_to_content"
         case .readerTagsFeed:
             return "reader_tags_feed"
+        case .readerFloatingButton:
+            return "reader_floating_button"
         }
     }
 
@@ -247,6 +252,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Voice to Content"
         case .readerTagsFeed:
             return "Reader Tags Feed"
+        case .readerFloatingButton:
+            return "Reader Floating Button"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -9,6 +9,8 @@ class ReaderTabViewController: UIViewController {
 
     private var createButtonCoordinator: CreateButtonCoordinator?
 
+    private var isFABTracked: Bool = false
+
     private lazy var readerTabView: ReaderTabView = { [unowned viewModel] in
         return makeReaderTabView(viewModel)
     }()
@@ -115,6 +117,13 @@ class ReaderTabViewController: UIViewController {
         createButtonCoordinator?.add(to: window,
                                     trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor,
                                     bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
+
+        if !isFABTracked {
+            // we only need to track this once since it will remain visible everytime Reader is opened
+            // once a user gets the feature. For clickthrough, refer to `create_sheet_shown` with source: `reader`.
+            WPAnalytics.track(.readerFloatingButtonShown)
+            isFABTracked.toggle()
+        }
 
         // Should we hide when the onboarding is shown?
         createButtonCoordinator?.showCreateButton(for: blog)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -7,6 +7,8 @@ class ReaderTabViewController: UIViewController {
 
     private let makeReaderTabView: (ReaderTabViewModel) -> ReaderTabView
 
+    private var createButtonCoordinator: CreateButtonCoordinator?
+
     private lazy var readerTabView: ReaderTabView = { [unowned viewModel] in
         return makeReaderTabView(viewModel)
     }()
@@ -52,6 +54,8 @@ class ReaderTabViewController: UIViewController {
         ReaderTracker.shared.start(.main)
         readerTabView.disableScrollsToTop()
 
+        createFABIfNeeded()
+
         if AppConfiguration.showsWhatIsNew {
             RootViewCoordinator.shared.presentWhatIsNew(on: self)
         }
@@ -67,6 +71,8 @@ class ReaderTabViewController: UIViewController {
         super.viewWillDisappear(animated)
 
         ReaderTracker.shared.stop(.main)
+
+        createButtonCoordinator?.removeCreateButton()
 
         QuickStartTourGuide.shared.endCurrentTour()
         navigationController?.setNavigationBarHidden(false, animated: animated)
@@ -91,6 +97,38 @@ class ReaderTabViewController: UIViewController {
         viewModel.shouldShowCommentSpotlight = true
         viewModel.fetchReaderMenu()
         viewModel.showTab(at: ReaderTabConstants.discoverIndex)
+    }
+
+    // MARK: - Reader FAB
+
+    private func createFABIfNeeded() {
+        // ensure that the button is truly removed before showing a new one.
+        createButtonCoordinator?.removeCreateButton()
+
+        guard RemoteFeatureFlag.readerFloatingButton.enabled(),
+              let blog = RootViewCoordinator.sharedPresenter.currentOrLastBlog(),
+              let window = UIApplication.shared.mainWindow else {
+            return
+        }
+
+        createButtonCoordinator = makeCreateButtonCoordinator(for: blog)
+        createButtonCoordinator?.add(to: window,
+                                    trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor,
+                                    bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
+
+        // Should we hide when the onboarding is shown?
+        createButtonCoordinator?.showCreateButton(for: blog)
+    }
+
+    private func makeCreateButtonCoordinator(for blog: Blog) -> CreateButtonCoordinator {
+        let source = "reader"
+
+        let postAction = PostAction(handler: {
+            let presenter = RootViewCoordinator.sharedPresenter
+            presenter.showPostTab()
+        }, source: source)
+
+        return CreateButtonCoordinator(self, actions: [postAction], source: source, blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -138,18 +138,14 @@ import WordPressUI
             return
         }
 
-        if actions.count == 1 {
-            actions.first?.handler()
-        } else {
-            let actionSheetVC = actionSheetController(with: viewController.traitCollection)
-            viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
-                WPAnalytics.track(.createSheetShown, properties: ["source": self?.source ?? ""])
+        let actionSheetVC = actionSheetController(with: viewController.traitCollection)
+        viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
+            WPAnalytics.track(.createSheetShown, properties: ["source": self?.source ?? ""])
 
-                if let element = self?.currentTourElement {
-                    QuickStartTourGuide.shared.visited(element)
-                }
-            })
-        }
+            if let element = self?.currentTourElement {
+                QuickStartTourGuide.shared.visited(element)
+            }
+        })
     }
 
     private func actionSheetController(with traitCollection: UITraitCollection) -> UIViewController {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -300,7 +300,14 @@ private extension CreateButtonCoordinator {
         let promptsHeaderView = BloggingPromptsHeaderView.view(for: prompt)
 
         promptsHeaderView.answerPromptHandler = { [weak self] in
-            WPAnalytics.track(.promptsBottomSheetAnswerPrompt)
+            let answerPromptEvent: WPAnalyticsEvent = {
+                if self?.source == "reader" {
+                    return .readerCreateSheetAnswerPromptTapped
+                }
+                return .promptsBottomSheetAnswerPrompt
+            }()
+
+            WPAnalytics.track(answerPromptEvent)
             self?.viewController?.dismiss(animated: true) {
                 let editor = EditPostViewController(blog: blog, prompt: prompt)
                 editor.modalPresentationStyle = .fullScreen
@@ -310,7 +317,14 @@ private extension CreateButtonCoordinator {
         }
 
         promptsHeaderView.infoButtonHandler = { [weak self] in
-            WPAnalytics.track(.promptsBottomSheetHelp)
+            let helpEvent: WPAnalyticsEvent = {
+                if self?.source == "reader" {
+                    return .readerCreateSheetPromptHelpTapped
+                }
+                return .promptsBottomSheetHelp
+            }()
+
+            WPAnalytics.track(helpEvent)
             guard let presentedViewController = self?.viewController?.presentedViewController else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -85,7 +85,9 @@ import WordPressUI
         listenForQuickStart()
 
         // Only fetch the prompt if it is actually needed, i.e. on the FAB that has multiple actions.
-        if actions.count > 1 {
+        // Temporarily show the sheet when the FAB is tapped on the Reader tab.
+        // TODO: (dvdchr) clean up once `readerFloatingButton` is removed.
+        if actions.count > 1 || source == Strings.readerSource {
             fetchBloggingPrompt()
         }
     }
@@ -138,14 +140,20 @@ import WordPressUI
             return
         }
 
-        let actionSheetVC = actionSheetController(with: viewController.traitCollection)
-        viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
-            WPAnalytics.track(.createSheetShown, properties: ["source": self?.source ?? ""])
+        // Temporarily show the sheet when the FAB is tapped on the Reader tab.
+        // TODO: (dvdchr) clean up once `readerFloatingButton` is removed.
+        if actions.count == 1, source != Strings.readerSource {
+            actions.first?.handler()
+        } else {
+            let actionSheetVC = actionSheetController(with: viewController.traitCollection)
+            viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
+                WPAnalytics.track(.createSheetShown, properties: ["source": self?.source ?? ""])
 
-            if let element = self?.currentTourElement {
-                QuickStartTourGuide.shared.visited(element)
-            }
-        })
+                if let element = self?.currentTourElement {
+                    QuickStartTourGuide.shared.visited(element)
+                }
+            })
+        }
     }
 
     private func actionSheetController(with traitCollection: UITraitCollection) -> UIViewController {
@@ -301,7 +309,7 @@ private extension CreateButtonCoordinator {
 
         promptsHeaderView.answerPromptHandler = { [weak self] in
             let answerPromptEvent: WPAnalyticsEvent = {
-                if self?.source == "reader" {
+                if self?.source == Strings.readerSource {
                     return .readerCreateSheetAnswerPromptTapped
                 }
                 return .promptsBottomSheetAnswerPrompt
@@ -318,7 +326,7 @@ private extension CreateButtonCoordinator {
 
         promptsHeaderView.infoButtonHandler = { [weak self] in
             let helpEvent: WPAnalyticsEvent = {
-                if self?.source == "reader" {
+                if self?.source == Strings.readerSource {
                     return .readerCreateSheetPromptHelpTapped
                 }
                 return .promptsBottomSheetHelp
@@ -349,5 +357,6 @@ private extension CreateButtonCoordinator {
 }
 
 private enum Strings {
+    static let readerSource = "reader"
     static let createPostHint = NSLocalizedString("createPostSheet.createPostHint", value: "Create a post or page", comment: "Accessibility hint for create floating action button")
 }


### PR DESCRIPTION
This PR shows the FAB in the top level screens of the Reader tab. The options displayed in the sheet are also limited to creating a blog post or answering a prompt.

Note that this feature will be released in a limited capacity, as controlled by `reader_floating_button` flag.

## To test

- Launch the Jetpack app.
- Switch on the `readerFloatingButton` flag.
- Go to the Reader tab.
- 🔎 Verify that the floating button appears.
- 🔎 Verify that `reader_create_fab_shown` is tracked.
- Tap the floating button.
- 🔎 Verify that only the 'Blog post' option is shown.
- 🔎 Verify that `create_sheet_shown, source: reader` is tracked.
- 🔎 Verify that tapping  'Blog post' tracks `create_sheet_action_tapped, action: create_new_post, source: reader`
- 🔎 Verify that tapping Answer Prompt tracks `reader_create_sheet_answer_prompt_tapped`.
- 🔎 Verify that tapping Prompt Help icon tracks `reader_create_sheet_prompt_help_tapped`.
- 🔎  Verify that the tracking events for the floating button **in My Site** remain unchanged:
  - `create_sheet_shown, source: my_site` when the FAB is tapped
  - `create_sheet_action_tapped, action: create_new_post, source: my_site` when 'Blog post' is tapped
  - `my_site_create_sheet_answer_prompt_tapped` when Answer Prompt is tapped
  - `my_site_create_sheet_prompt_help_tapped` when Help is tapped

## Regression Notes
1. Potential unintended areas of impact
Should be none. The creation logic is new and isolated to the Reader, and does not affect the one in My Sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
