### PR TITLE
VtC: Limit recording to 5 minutes

### DIFF
--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import DesignSystem
 
-// TODO: Add localization
 struct VoiceToContentView: View {
     @StateObject var viewModel: VoiceToContentViewModel
     @Environment(\.dismiss) var dismiss

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -129,7 +129,7 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
         self.audioSession = recordingSession
 
         self.title = Strings.titleRecoding
-        self.subtitle = Constants.recordingTimeLimitFormatted
+        self.subtitle = Constants.recordingTimeLimit.minuteSecond
 
         do {
             try recordingSession.setCategory(.playAndRecord, mode: .default)
@@ -281,7 +281,6 @@ private enum VoiceToContentError: Error, LocalizedError {
 
 private enum Constants {
     static let recordingTimeLimit: TimeInterval = 5 * 60 // 5 Minutes
-    static let recordingTimeLimitFormatted = "05:00" // 5 Minutes
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -182,7 +182,7 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
                 self.subtitle = Duration.seconds(self.audioRecorder?.currentTime ?? 0)
                     .formatted(.time(pattern: .minuteSecond(padMinuteToLength: 2, fractionalSecondsLength: 2)))
             } else {
-                // TODO: Make this feature available on iOS 16+?
+                self.subtitle = (self.audioRecorder?.currentTime ?? 0).minuteSecondMillisecond
             }
         }
     }
@@ -296,5 +296,20 @@ extension JetpackAssistantFeatureDetails {
         let requestsLimit = currentTier?.limit ?? requestsLimit
         let requestsCount = usagePeriod?.requestsCount ?? requestsCount
         return max(0, requestsLimit - requestsCount).description
+    }
+}
+
+extension TimeInterval {
+    var minuteSecondMillisecond: String {
+        String(format: "%d:%02d.%02d", minute, second, millisecond)
+    }
+    var minute: Int {
+        Int((self / 60).truncatingRemainder(dividingBy: 60))
+    }
+    var second: Int {
+        Int(truncatingRemainder(dividingBy: 60))
+    }
+    var millisecond: Int {
+        Int((self * 1000).truncatingRemainder(dividingBy: 1000))
     }
 }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -94,7 +94,7 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
             let info = try await service.getAssistantFeatureDetails()
             didFetchFeatureDetails(info)
         } catch {
-            self.subtitle = Strings.subtitleError
+            self.subtitle = Strings.errorMessageGeneric
             self.loadingState = .failed(message: error.localizedDescription) { [weak self] in
                 self?.checkFeatureAvailability()
             }
@@ -244,10 +244,10 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
     // MARK: - AVAudioRecorderDelegate
 
     func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
-        // TODO: Handle error when iOS finished recording due to an interruption
         if !flag {
             audioRecorder?.stop()
             self.step = .welcome
+            showError(VoiceToContentError.generic)
         }
     }
 
@@ -260,10 +260,12 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
 }
 
 private enum VoiceToContentError: Error, LocalizedError {
+    case generic
     case cantUnderstandRequest
 
     var errorDescription: String? {
         switch self {
+        case .generic: return Strings.errorMessageGeneric
         case .cantUnderstandRequest: return Strings.errorMessageCantUnderstandRequest
         }
     }
@@ -271,7 +273,7 @@ private enum VoiceToContentError: Error, LocalizedError {
 
 private enum Strings {
     static let title = NSLocalizedString("postFromAudio.title", value: "Post from Audio", comment: "The screen title")
-    static let subtitleError = NSLocalizedString("postFromAudio.subtitleError", value: "Something went wrong", comment: "The screen subtitle in the error state")
+    static let errorMessageGeneric = NSLocalizedString("postFromAudio.errorMessage.generic", value: "Something went wrong", comment: "The screen subtitle in the error state")
     static let errorMessageCantUnderstandRequest = NSLocalizedString("postFromAudio.errorMessage.cantUnderstandRequest", value: "There were some issues processing the request. Please, try again later.", comment: "The AI failed to understand the request for any reasons")
     static let subtitleRequestsAvailable = NSLocalizedString("postFromAudio.subtitleRequestsAvailable", value: "Requests available:", comment: "The screen subtitle")
     static let titleRecoding = NSLocalizedString("postFromAudio.titleRecoding", value: "Recording…", comment: "The screen title when recording")


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/107

## Description
- Limits recording to 5 minutes; automatically opens the editor with the transcription if the recording limit has been reached
- Switched to counting down from 5 minutes, rather than counting up


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/8a9a9211-f72f-4380-b93a-696c3df4b3dd



## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
