### PR TITLE
[Voice to Content] Fix an issue wtih VtoC draft not being saved

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
@@ -59,15 +59,15 @@ extension MySiteViewController {
         let viewModel = VoiceToContentViewModel(blog: blog) { [weak self] transcription in
             guard let self else { return }
             self.dismiss(animated: true) {
-                // TODO: Are we adding all necessary fields?
                 let presenter = RootViewCoordinator.sharedPresenter
                 let post = blog.createDraftPost()
-                post.content = """
+                let revision = post._createRevision() as! Post
+                revision.content = """
                 <!-- wp:paragraph -->
                 <p>\(transcription.escapeHtmlNamedEntities())</p>
                 <!-- /wp:paragraph -->
                 """
-                presenter.showPostTab(animated: true, post: post)
+                presenter.showPostTab(animated: true, post: revision)
             }
         }
         let view = VoiceToContentView(viewModel: viewModel)


### PR DESCRIPTION
## To test:

- Create a new "Post from Audio"
- ✅ Verify that the editor opens
- Tap "Back"
- ✅ Verify that the post gets saved as a draft

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
