### PR TITLE
Reader: Enable announcement header for Jetpack

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -97,7 +97,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .readingPreferencesFeedback:
             return true
         case .readerAnnouncementCard:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return AppConfiguration.isJetpack
         case .inAppUpdates:
             return false
         case .voiceToContent:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -241,7 +241,7 @@ module FastlaneActionLogGroup
 
   def execute_action(action_name)
     print_group(action_name)
-    super(action_name)
+    super
   end
 end
 


### PR DESCRIPTION
Part of #23069

Enables the Reader announcement card.

## To test

- Launch the Jetpack app
- Navigate to the Reader tab
- 🔎 Verify that the announcement card is shown

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
N/A.

- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
