### PR TITLE
Offline Mode: Remove Deprecated Code – P5

### DIFF
--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -12,16 +12,16 @@ class EditorFactory {
 
     // MARK: - Editor: Instantiation
 
-    func instantiateEditor(for post: AbstractPost, loadAutosaveRevision: Bool = false, replaceEditor: @escaping ReplaceEditorBlock) -> EditorViewController {
+    func instantiateEditor(for post: AbstractPost, replaceEditor: @escaping ReplaceEditorBlock) -> EditorViewController {
         if gutenbergSettings.mustUseGutenberg(for: post) {
-            return createGutenbergVC(with: post, loadAutosaveRevision: loadAutosaveRevision, replaceEditor: replaceEditor)
+            return createGutenbergVC(with: post, replaceEditor: replaceEditor)
         } else {
-            return AztecPostViewController(post: post, loadAutosaveRevision: loadAutosaveRevision, replaceEditor: replaceEditor)
+            return AztecPostViewController(post: post, replaceEditor: replaceEditor)
         }
     }
 
-    func createGutenbergVC(with post: AbstractPost, loadAutosaveRevision: Bool, replaceEditor: @escaping ReplaceEditorBlock) -> GutenbergViewController {
-        let gutenbergVC = GutenbergViewController(post: post, loadAutosaveRevision: loadAutosaveRevision, replaceEditor: replaceEditor)
+    func createGutenbergVC(with post: AbstractPost, replaceEditor: @escaping ReplaceEditorBlock) -> GutenbergViewController {
+        let gutenbergVC = GutenbergViewController(post: post, replaceEditor: replaceEditor)
 
         if gutenbergSettings.shouldAutoenableGutenberg(for: post) {
             gutenbergSettings.setGutenbergEnabled(true, for: post.blog, source: .onBlockPostOpening)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -355,11 +355,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         }
     }
 
-    /// If true, apply autosave content when the editor creates a revision.
-    ///
-    /// - warning: deprecated (kahu-offline-mode)
-    private let loadAutosaveRevision: Bool
-
     /// Active Downloads
     ///
     fileprivate var activeMediaRequests = [ImageDownloaderTask]()
@@ -453,14 +448,12 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     required init(
         post: AbstractPost,
-        loadAutosaveRevision: Bool = false,
         replaceEditor: @escaping (EditorViewController, EditorViewController) -> (),
         editorSession: PostEditorAnalyticsSession? = nil) {
 
         precondition(post.managedObjectContext != nil)
 
         self.post = post
-        self.loadAutosaveRevision = loadAutosaveRevision
         self.replaceEditor = replaceEditor
         self.editorSession = editorSession ?? PostEditorAnalyticsSession(editor: .classic, post: post)
 
@@ -498,7 +491,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         WPFontManager.loadNotoFontFamily()
 
         registerAttachmentImageProviders()
-        createRevisionOfPost(loadAutosaveRevision: loadAutosaveRevision)
+        createRevisionOfPost(loadAutosaveRevision: false)
 
         // Setup
         configureNavigationBar()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -203,10 +203,6 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         }
     }
 
-    /// If true, apply autosave content when the editor creates a revision.
-    ///
-    var loadAutosaveRevision: Bool
-
     let navigationBarManager: PostEditorNavigationBarManager
 
     // swiftlint:disable:next weak_delegate
@@ -276,13 +272,12 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     // MARK: - Initializers
     required convenience init(
-        post: AbstractPost, loadAutosaveRevision: Bool,
+        post: AbstractPost,
         replaceEditor: @escaping ReplaceEditorCallback,
         editorSession: PostEditorAnalyticsSession?
     ) {
         self.init(
             post: post,
-            loadAutosaveRevision: loadAutosaveRevision,
             replaceEditor: replaceEditor,
             editorSession: editorSession,
             // Notice this parameter.
@@ -297,14 +292,12 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     required init(
         post: AbstractPost,
-        loadAutosaveRevision: Bool = false,
         replaceEditor: @escaping ReplaceEditorCallback,
         editorSession: PostEditorAnalyticsSession? = nil,
         navigationBarManager: PostEditorNavigationBarManager? = nil
     ) {
 
         self.post = post
-        self.loadAutosaveRevision = loadAutosaveRevision
 
         self.replaceEditor = replaceEditor
         verificationPromptHelper = AztecVerificationPromptHelper(account: self.post.blog.account)
@@ -339,7 +332,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         super.viewDidLoad()
         setupKeyboardObservers()
         WPFontManager.loadNotoFontFamily()
-        createRevisionOfPost(loadAutosaveRevision: loadAutosaveRevision)
+        createRevisionOfPost(loadAutosaveRevision: false)
         setupGutenbergView()
         configureNavigationBar()
         refreshInterface()

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -16,9 +16,6 @@ class EditPostViewController: UIViewController {
     /// the entry point for the editor
     var entryPoint: PostEditorEntryPoint = .unknown
 
-    /// - warning: deprecated (kahu-offline-mode)
-    private let loadAutosaveRevision: Bool
-
     @objc fileprivate(set) var post: Post?
     private let prompt: BloggingPrompt?
     fileprivate var hasShownEditor = false
@@ -45,8 +42,8 @@ class EditPostViewController: UIViewController {
     /// Initialize as an editor with the provided post
     ///
     /// - Parameter post: post to edit
-    @objc convenience init(post: Post, loadAutosaveRevision: Bool = false) {
-        self.init(post: post, blog: post.blog, loadAutosaveRevision: loadAutosaveRevision)
+    @objc convenience init(post: Post) {
+        self.init(post: post, blog: post.blog)
     }
 
     /// Initialize as an editor to create a new post for the provided blog
@@ -70,10 +67,9 @@ class EditPostViewController: UIViewController {
     ///   - post: the post to edit
     ///   - blog: the blog to create a post for, if post is nil
     /// - Note: it's preferable to use one of the convenience initializers
-    fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: BloggingPrompt? = nil) {
+    fileprivate init(post: Post?, blog: Blog, prompt: BloggingPrompt? = nil) {
         self.post = post
         self.originalPostID = post?.original().objectID
-        self.loadAutosaveRevision = loadAutosaveRevision
         if let post = post {
             if !post.originalIsDraft() {
                 editingExistingPost = true
@@ -141,7 +137,6 @@ class EditPostViewController: UIViewController {
     fileprivate func showEditor() {
         let editor = editorFactory.instantiateEditor(
             for: postToEdit(),
-            loadAutosaveRevision: loadAutosaveRevision,
             replaceEditor: { [weak self] (editor, replacement) in
                 self?.replaceEditor(editor: editor, replacement: replacement)
         })

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -32,12 +32,10 @@ protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
     /// - Parameters:
     ///     - post: the post to edit. Must be already assigned to a `ManagedObjectContext` since
     ///     that's necessary for the edits to be saved.
-    ///     - loadAutosaveRevision: if true, apply autosave content when the editor creates a revision.
     ///     - replaceEditor: a closure that handles switching from one editor to another
     ///     - editorSession: post editor analytics session
     init(
         post: AbstractPost,
-        loadAutosaveRevision: Bool,
         replaceEditor: @escaping ReplaceEditorCallback,
         editorSession: PostEditorAnalyticsSession?)
 

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -29,7 +29,7 @@ struct PostListEditorPresenter {
             return
         }
 
-        openEditor(with: post, loadAutosaveRevision: false, in: postListViewController, entryPoint: entryPoint)
+        openEditor(with: post, in: postListViewController, entryPoint: entryPoint)
     }
 
     static func handleCopy(post: Post, in postListViewController: EditorPresenterViewController) {
@@ -51,12 +51,12 @@ struct PostListEditorPresenter {
         }
     }
 
-    private static func openEditor(with post: Post, loadAutosaveRevision: Bool, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
+    private static func openEditor(with post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
         /// This is a workaround for the lack of vie wapperance callbacks send
         /// by `EditPostViewController` due to its weird setup.
         NotificationCenter.default.post(name: .postListEditorPresenterWillShowEditor, object: nil)
 
-        let editor = EditPostViewController(post: post, loadAutosaveRevision: loadAutosaveRevision)
+        let editor = EditPostViewController(post: post)
         editor.modalPresentationStyle = .fullScreen
         editor.entryPoint = entryPoint
         editor.onClose = { _ in
@@ -73,52 +73,9 @@ struct PostListEditorPresenter {
         newPost.categories = post.categories
         newPost.postFormat = post.postFormat
 
-        openEditor(with: newPost, loadAutosaveRevision: false, in: postListViewController)
+        openEditor(with: newPost, in: postListViewController)
 
         WPAppAnalytics.track(.postListDuplicateAction, withProperties: postListViewController.propertiesForAnalytics(), with: post)
-    }
-
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter
-    }()
-
-    private static let timeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
-    private static func dateAndTime(for date: Date) -> String {
-        return dateFormatter.string(from: date) + " @ " + timeFormatter.string(from: date)
-    }
-
-    /// A dialog giving the user the choice between loading the current version a post or its autosaved version.
-    private static func autosaveOptionsViewController(forSaveDate saveDate: Date, autosaveDate: Date, didTapOption: @escaping (_ loadAutosaveRevision: Bool) -> Void) -> UIAlertController {
-
-        let title = NSLocalizedString("Which version would you like to edit?", comment: "Title displayed in popup when user has the option to load unsaved changes")
-
-        let saveDateFormatted = dateAndTime(for: saveDate)
-        let autosaveDateFormatted = dateAndTime(for: autosaveDate)
-        let message = String(format: NSLocalizedString("You recently made changes to this post but didn't save them. Choose a version to load:\n\nFrom this device\nSaved on %@\n\nFrom another device\nSaved on %@\n", comment: "Message displayed in popup when user has the option to load unsaved changes. \n is a placeholder for a new line, and the two %@ are placeholders for the date of last save on this device, and date of last autosave on another device, respectively."), saveDateFormatted, autosaveDateFormatted)
-
-        let loadSaveButtonTitle = NSLocalizedString("From this device", comment: "Button title displayed in popup indicating date of change on device")
-        let fromAutosaveButtonTitle = NSLocalizedString("From another device", comment: "Button title displayed in popup indicating date of change on another device")
-
-        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: loadSaveButtonTitle, style: .default) { _ in
-            didTapOption(false)
-        })
-        alertController.addAction(UIAlertAction(title: fromAutosaveButtonTitle, style: .default) { _ in
-            didTapOption(true)
-        })
-
-        alertController.view.accessibilityIdentifier = "autosave-options-alert"
-
-        return alertController
     }
 
     /// A dialog giving the user the choice between copying the current version of the post or resolving conflicts with edit.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -108,7 +108,7 @@ private extension ReaderReblogPresenter {
 
         post.prepareForReblog(with: readerPost, imageSize: photonSize)
         // instantiate & configure editor
-        let editor = EditPostViewController(post: post, loadAutosaveRevision: false)
+        let editor = EditPostViewController(post: post)
         editor.modalPresentationStyle = .fullScreen
         editor.postIsReblogged = true
         // present

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -31,16 +31,11 @@ public class PostsScreen: ScreenObject {
         $0.buttons["Create Post Button"]
     }
 
-    private let autosaveAlertGetter: (XCUIApplication) -> XCUIElement = {
-        $0.alerts["autosave-options-alert"]
-    }
-
     var postsTable: XCUIElement { postsTableGetter(app) }
     var publishedButton: XCUIElement { publishedButtonGetter(app) }
     var draftsButton: XCUIElement { draftsButtonGetter(app) }
     var scheduledButton: XCUIElement { scheduledButtonGetter(app) }
     var createPostButton: XCUIElement { createPostButtonGetter(app) }
-    var autosaveAlert: XCUIElement { autosaveAlertGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -77,20 +72,10 @@ public class PostsScreen: ScreenObject {
         cell.scrollIntoView(within: expectedElement)
         cell.tap()
 
-        dismissAutosaveDialogIfNeeded()
-
         let editorScreen = EditorScreen()
         try editorScreen.dismissDialogsIfNeeded()
 
         return EditorScreen()
-    }
-
-    /// If there are two versions of a local post, the app will ask which version we want to use when editing.
-    /// We always want to use the local version (which is currently the first option)
-    private func dismissAutosaveDialogIfNeeded() {
-        if autosaveAlert.exists {
-            autosaveAlert.buttons.firstMatch.tap()
-        }
     }
 
     public func verifyPostExists(withTitle title: String) {


### PR DESCRIPTION
This is a bit of a more complicated changes, so I'm opening it as an individual PR.
Autosave is now handled _inside_ the editor, so there is no need to init it with this parameter.

To test:

## Regression Notes
1. Potential unintended areas of impact: Autosave Revisions
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
