### PR TITLE
VtC: Animate button icon transition

### DIFF
--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -37,6 +37,10 @@ struct VoiceToContentView: View {
                     VoiceToContenProcessingView(viewModel: viewModel)
                 }
             }
+
+            if [VoiceToContentViewModel.Step.welcome, .recording].contains(viewModel.step) {
+                buttonRecord(viewModel: viewModel)
+            }
         }
         .padding(.horizontal, 20)
         .padding(.top, 24)
@@ -79,13 +83,12 @@ private struct VoiceToContentWelcomeView: View {
     @ObservedObject fileprivate var viewModel: VoiceToContentViewModel
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack {
             if let isEligible = viewModel.isEligible, !isEligible {
                 Spacer()
                 notEnoughRequestsView
             }
             Spacer()
-            buttonRecord
         }
     }
 
@@ -100,26 +103,6 @@ private struct VoiceToContentWelcomeView: View {
                 }
             }
         }.frame(maxWidth: 320)
-    }
-
-    private var buttonRecord: some View {
-        VStack(spacing: 16) {
-            Button(action: viewModel.buttonRecordTapped) {
-                Image(systemName: "mic")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 36, height: 36)
-                    .padding(24)
-                    .background(viewModel.isButtonRecordEnabled ? Color(uiColor: .brand) : Color.secondary.opacity(0.5))
-                    .foregroundColor(.white)
-                    .clipShape(Circle())
-            }
-
-            Text(Strings.beginRecording)
-                .foregroundStyle(.primary)
-        }
-        .opacity(viewModel.isButtonRecordEnabled ? 1 : 0.5)
-        .disabled(!viewModel.isButtonRecordEnabled)
     }
 }
 
@@ -140,7 +123,6 @@ private struct VoiceToContentRecordingView: View {
                 }
             }
             Spacer()
-            buttonDone
         }
     }
 
@@ -168,6 +150,48 @@ private struct VoiceToContentRecordingView: View {
             Text(Strings.done)
                 .foregroundStyle(.primary)
         }
+    }
+}
+
+private struct buttonRecord: View {
+    @ObservedObject fileprivate var viewModel: VoiceToContentViewModel
+
+    private var isRecording: Bool { viewModel.step == .recording }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Button(action: isRecording ? viewModel.buttonDoneRecordingTapped : viewModel.buttonRecordTapped) {
+                if #available(iOS 17.0, *) {
+                    icon
+                        .contentTransition(.symbolEffect(.replace, options: .speed(4)))
+                } else {
+                    icon
+                }
+            }
+
+            Text(Strings.done)
+                .foregroundStyle(.primary)
+        }
+        .opacity(viewModel.isButtonRecordEnabled ? 1 : 0.5)
+        .disabled(!viewModel.isButtonRecordEnabled)
+    }
+
+    private var backgroundColor: Color {
+        if !isRecording {
+            return viewModel.isButtonRecordEnabled ? Color(uiColor: .brand) : Color.secondary.opacity(0.5)
+        }
+        return .black
+    }
+
+    private var icon: some View {
+        Image(systemName: isRecording ? "stop.fill" : "mic")
+            .resizable()
+            .scaledToFit()
+            .frame(width: isRecording ? 28 : 36)
+            .padding(isRecording ? 28 : 24)
+            .background(backgroundColor)
+            .foregroundColor(.white)
+            .clipShape(Circle())
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -39,7 +39,7 @@ struct VoiceToContentView: View {
             }
 
             if [VoiceToContentViewModel.Step.welcome, .recording].contains(viewModel.step) {
-                buttonRecord(viewModel: viewModel)
+                RecordButton(viewModel: viewModel)
             }
         }
         .padding(.horizontal, 20)
@@ -153,7 +153,7 @@ private struct VoiceToContentRecordingView: View {
     }
 }
 
-private struct buttonRecord: View {
+private struct RecordButton: View {
     @ObservedObject fileprivate var viewModel: VoiceToContentViewModel
 
     private var isRecording: Bool { viewModel.step == .recording }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -315,7 +315,7 @@ extension JetpackAssistantFeatureDetails {
 
 extension TimeInterval {
     var minuteSecond: String {
-        String(format: "%d:%02d", minute, second)
+        String(format: "%02d:%02d", minute, second)
     }
     var minute: Int {
         Int((self / 60).truncatingRemainder(dividingBy: 60))


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/102

## Description
- Add animation to button icon 

## How to test
- Verify the button icon animates when you tap the record button


https://github.com/wordpress-mobile/WordPress-iOS/assets/6711616/efb0cc75-ce77-4653-9589-c755d32fdc40



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
