### PR TITLE
[Notifications Refresh] Introduce likes and subscribers details share button

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -276,7 +276,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         }
         let shareFooterView = ShareFooterView(kind: shareKind) {
             let activityViewController = UIActivityViewController(activityItems: [contentUrl as Any], applicationActivities: nil)
-            activityViewController.popoverPresentationController?.sourceView = self.stackView
+            activityViewController.popoverPresentationController?.sourceView = self.shareFooterView
             self.present(activityViewController, animated: true, completion: nil)
         }
         let hostingController = UIHostingController(rootView: shareFooterView)
@@ -287,13 +287,9 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
     }
 
     fileprivate func refreshShareFooterView() {
-        guard let shareFooterView = shareFooterView else {
-            setupShareFooterView()
-            return
-        }
-        shareFooterView.removeFromSuperview()
+        self.shareFooterView?.removeFromSuperview()
         self.shareFooterView = nil
-        setupShareFooterView()
+        self.setupShareFooterView()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -274,10 +274,10 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         default:
             return
         }
-        let shareFooterView = ShareFooterView(kind: shareKind) {
+        let shareFooterView = ShareFooterView(kind: shareKind) { [weak self] in
             let activityViewController = UIActivityViewController(activityItems: [contentUrl as Any], applicationActivities: nil)
-            activityViewController.popoverPresentationController?.sourceView = self.shareFooterView
-            self.present(activityViewController, animated: true, completion: nil)
+            activityViewController.popoverPresentationController?.sourceView = self?.shareFooterView
+            self?.present(activityViewController, animated: true, completion: nil)
         }
         let hostingController = UIHostingController(rootView: shareFooterView)
         self.shareFooterView = hostingController.view

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -4,6 +4,7 @@ import Gridicons
 import SVProgressHUD
 import WordPressShared
 import WordPressUI
+import SwiftUI
 
 ///
 ///
@@ -150,6 +151,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         setupReplyTextView()
         setupSuggestionsView()
         setupKeyboardManager()
+        setupShareButton()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -250,6 +252,30 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
 
         previousNavigationButton.accessibilityLabel = NSLocalizedString("Previous notification", comment: "Accessibility label for the previous notification button")
         nextNavigationButton.accessibilityLabel = NSLocalizedString("Next notification", comment: "Accessibility label for the next notification button")
+    }
+
+    fileprivate func setupShareButton() {
+        guard let contentUrl = note.url else {
+            return
+        }
+        var shareKind: ShareFooterView.Kind
+        switch note.kind {
+        case .like:
+            shareKind = .post
+        case .commentLike:
+            shareKind = .comment
+        case .follow:
+            shareKind = .blog
+        default:
+            return
+        }
+        let shareButton = ShareFooterView(kind: shareKind) {
+            let activityViewController = UIActivityViewController(activityItems: [contentUrl as Any], applicationActivities: nil)
+            activityViewController.popoverPresentationController?.sourceView = self.stackView
+            self.present(activityViewController, animated: true, completion: nil)
+        }
+        let hostingController = UIHostingController(rootView: shareButton)
+        stackView.addArrangedSubview(hostingController.view)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -79,7 +79,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
 
     /// Share Footer View
     ///
-    var shareFooterView: UIView!
+    var shareFooterView: UIView?
 
     /// Arrows Navigation Datasource
     ///

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -77,6 +77,10 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
     ///
     var nextNavigationButton: UIButton!
 
+    /// Share Footer View
+    ///
+    var shareFooterView: UIView!
+
     /// Arrows Navigation Datasource
     ///
     weak var dataSource: NotificationsNavigationDataSource?
@@ -218,6 +222,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         attachSuggestionsViewIfNeeded()
         adjustLayoutConstraintsIfNeeded()
         refreshNavigationBar()
+        refreshShareFooterView()
     }
 
     fileprivate func refreshNavigationBar() {
@@ -275,9 +280,20 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
             self.present(activityViewController, animated: true, completion: nil)
         }
         let hostingController = UIHostingController(rootView: shareFooterView)
+        self.shareFooterView = hostingController.view
         hostingController.view.setContentHuggingPriority(.required, for: .vertical)
         hostingController.view.setContentCompressionResistancePriority(.required, for: .vertical)
         stackView.addArrangedSubview(hostingController.view)
+    }
+
+    fileprivate func refreshShareFooterView() {
+        guard let shareFooterView = shareFooterView else {
+            setupShareFooterView()
+            return
+        }
+        shareFooterView.removeFromSuperview()
+        self.shareFooterView = nil
+        setupShareFooterView()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -151,7 +151,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         setupReplyTextView()
         setupSuggestionsView()
         setupKeyboardManager()
-        setupShareButton()
+        setupShareFooterView()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -254,7 +254,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         nextNavigationButton.accessibilityLabel = NSLocalizedString("Next notification", comment: "Accessibility label for the next notification button")
     }
 
-    fileprivate func setupShareButton() {
+    fileprivate func setupShareFooterView() {
         guard let contentUrl = note.url else {
             return
         }
@@ -269,12 +269,14 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         default:
             return
         }
-        let shareButton = ShareFooterView(kind: shareKind) {
+        let shareFooterView = ShareFooterView(kind: shareKind) {
             let activityViewController = UIActivityViewController(activityItems: [contentUrl as Any], applicationActivities: nil)
             activityViewController.popoverPresentationController?.sourceView = self.stackView
             self.present(activityViewController, animated: true, completion: nil)
         }
-        let hostingController = UIHostingController(rootView: shareButton)
+        let hostingController = UIHostingController(rootView: shareFooterView)
+        hostingController.view.setContentHuggingPriority(.required, for: .vertical)
+        hostingController.view.setContentCompressionResistancePriority(.required, for: .vertical)
         stackView.addArrangedSubview(hostingController.view)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/ShareFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/ShareFooterView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import DesignSystem
+
+struct ShareFooterView: View {
+    private let title: String
+    private let onShareClicked: () -> Void
+    @Environment(\.colorScheme) var colorScheme
+
+    init(kind: ShareFooterView.Kind, onShareClicked: @escaping () -> Void) {
+        self.onShareClicked = onShareClicked
+        switch kind {
+        case .comment:
+            title = Strings.shareCommentTitle
+        case .post:
+            title = Strings.sharePostTitle
+        case .blog:
+            title = Strings.shareBlogTitle
+        }
+    }
+
+    var body: some View {
+        VStack {
+            if colorScheme == .light {
+                Divider()
+                    .frame(height: 1)
+                    .background(Color.DS.Background.secondary)
+            }
+            DSButton(
+                title: title,
+                iconName: .blockShare,
+                style: .init(emphasis: .primary, size: .large),
+                action: onShareClicked
+            )
+            .padding(.top, .DS.Padding.double)
+            .padding(.horizontal, .DS.Padding.medium)
+            .padding(.bottom, .DS.Padding.medium)
+        }.background(colorScheme == .light ? Color.DS.Background.primary : Color.DS.Background.secondary)
+    }
+
+    enum Kind: String {
+        case comment
+        case post
+        case blog
+    }
+}
+
+private enum Strings {
+    static let sharePostTitle = NSLocalizedString(
+        "share.button.title.post",
+        value: "Share your post",
+        comment: "The title for the post share button"
+    )
+    static let shareCommentTitle = NSLocalizedString(
+        "share.button.title.comment",
+        value: "Share your comment",
+        comment: "The title for the comment share button"
+    )
+    static let shareBlogTitle = NSLocalizedString(
+        "share.button.title.blog",
+        value: "Share your blog",
+        comment: "The title for the blog share button"
+    )
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Views/ShareFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/ShareFooterView.swift
@@ -22,7 +22,6 @@ struct ShareFooterView: View {
         VStack {
             if colorScheme == .light {
                 Divider()
-                    .frame(height: 1)
                     .foregroundStyle(Color.DS.Background.secondary)
             }
             DSButton(

--- a/WordPress/Classes/ViewRelated/Notifications/Views/ShareFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/ShareFooterView.swift
@@ -23,7 +23,7 @@ struct ShareFooterView: View {
             if colorScheme == .light {
                 Divider()
                     .frame(height: 1)
-                    .background(Color.DS.Background.secondary)
+                    .foregroundStyle(Color.DS.Background.secondary)
             }
             DSButton(
                 title: title,
@@ -34,7 +34,7 @@ struct ShareFooterView: View {
             .padding(.top, .DS.Padding.double)
             .padding(.horizontal, .DS.Padding.medium)
             .padding(.bottom, .DS.Padding.medium)
-        }.background(colorScheme == .light ? Color.DS.Background.primary : Color.DS.Background.secondary)
+        }.background(Color.DS.Background.primary)
     }
 
     enum Kind: String {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1748,6 +1748,8 @@
 		74FA4BE51FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 74FA4BE31FBFA0660031EAAD /* Extensions.xcdatamodeld */; };
 		74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 74FA4BE31FBFA0660031EAAD /* Extensions.xcdatamodeld */; };
 		74FA4BED1FBFA2350031EAAD /* SharedCoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746D6B241FBF701F003C45BE /* SharedCoreDataStack.swift */; };
+		770C66562C07AA490072AFC0 /* ShareFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770C66552C07AA490072AFC0 /* ShareFooterView.swift */; };
+		770C66572C07AA490072AFC0 /* ShareFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770C66552C07AA490072AFC0 /* ShareFooterView.swift */; };
 		776D09F32BEC01B500DE07A1 /* NotificationDetailUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776D09F22BEC01B500DE07A1 /* NotificationDetailUserView.swift */; };
 		776D09F42BEC01B500DE07A1 /* NotificationDetailUserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776D09F22BEC01B500DE07A1 /* NotificationDetailUserView.swift */; };
 		77A141172B68546100BF75DD /* BooleanUserDefaultsDebugViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A141162B68546100BF75DD /* BooleanUserDefaultsDebugViewModelTests.swift */; };
@@ -7447,6 +7449,7 @@
 		74FA2EE3200E8A6C001DDC13 /* AppExtensionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExtensionsService.swift; sourceTree = "<group>"; };
 		74FA4BE41FBFA0660031EAAD /* Extensions.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Extensions.xcdatamodel; sourceTree = "<group>"; };
 		75305C06D345590B757E3890 /* Pods-Apps-WordPress.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.debug.xcconfig"; sourceTree = "<group>"; };
+		770C66552C07AA490072AFC0 /* ShareFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareFooterView.swift; sourceTree = "<group>"; };
 		776D09F22BEC01B500DE07A1 /* NotificationDetailUserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDetailUserView.swift; sourceTree = "<group>"; };
 		77A141162B68546100BF75DD /* BooleanUserDefaultsDebugViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanUserDefaultsDebugViewModelTests.swift; sourceTree = "<group>"; };
 		77B84EFD2B62D8280035AEFE /* BooleanUserDefaultsDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanUserDefaultsDebugView.swift; sourceTree = "<group>"; };
@@ -16107,6 +16110,7 @@
 				B52C4C7C199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift */,
 				776D09F22BEC01B500DE07A1 /* NotificationDetailUserView.swift */,
 				FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */,
+				770C66552C07AA490072AFC0 /* ShareFooterView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -22966,6 +22970,7 @@
 				FAB985C12697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */,
 				FAFF7A282B695EA3006A7CB2 /* NoAtomicLogsView.swift in Sources */,
 				FE3D058326C419C4002A51B0 /* ShareAppContentPresenter+TableView.swift in Sources */,
+				770C66562C07AA490072AFC0 /* ShareFooterView.swift in Sources */,
 				82FC612C1FA8B7FC00A1757E /* ActivityListRow.swift in Sources */,
 				436110E022C4241A000773AD /* UIColor+MurielColorsObjC.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,
@@ -25456,6 +25461,7 @@
 				C79C308126EA975900E88514 /* ReferrerDetailsHeaderCell.swift in Sources */,
 				8BF281FD27CEB69C00AF8CF3 /* DashboardFailureCardCell.swift in Sources */,
 				FABB237E2602FC2C00C8785C /* FormattableContentFormatter.swift in Sources */,
+				770C66572C07AA490072AFC0 /* ShareFooterView.swift in Sources */,
 				FABB237F2602FC2C00C8785C /* SearchAdsAttribution.swift in Sources */,
 				FABB23802602FC2C00C8785C /* ReaderCommentsViewController.m in Sources */,
 				FABB23812602FC2C00C8785C /* MySiteViewController.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/18

This PR introduces a footer with a share button for likes and subscribers notification details screens.

| Subscribers | Comment Likes | Post Likes |
|-------------|---------------- | -----------|
|<img width="250" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/7821206a-6f09-4cb0-8687-23460c55833f"/>|<img width="250" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/82d2f762-d432-4d6d-b518-78e281f82771"/>|<img width="250" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/192061b4-13ef-445f-b570-d3363f54112a"/>|
|<img width="250" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/bfbdd05b-e551-4f4b-a8a2-d8f3e9ac71f6"/>|<img width="250" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/e950865f-324a-4381-b609-083964753b37"/>|<img width="250" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/4e6d064d-bb55-4de1-8775-01c383d7b80c"/>|

To test:

- [ ] Prepare three types of notifications: comment likes, post likes, and subscribers
- [ ] Run the app and go to each notification and confirm all of them have a share button on the bottom of the screen
- [ ] Ensure that the share button works properly by sharing a link with either a post, comment, or blog according to the notification type.

## Regression Notes
1. Potential unintended areas of impact
Likes, Subscribers notification details screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Legacy code

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
