### PR TITLE
Revert 'Save Draft' changes

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -32,6 +32,7 @@ import Foundation
     case editorPostTagsChanged
     case editorPostAuthorChanged
     case editorPostPublishNowTapped
+    case editorPostSaveDraftTapped
     case editorPostCategoryChanged
     case editorPostStatusChanged
     case editorPostFormatChanged
@@ -667,6 +668,8 @@ import Foundation
             return "editor_post_tags_changed"
         case .editorPostPublishNowTapped:
             return "editor_post_publish_now_tapped"
+        case .editorPostSaveDraftTapped:
+            return "editor_post_save_draft_tapped"
         case .editorPostCategoryChanged:
             return "editor_post_category_changed"
         case .editorPostStatusChanged:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -43,7 +43,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .syncPublishing:
             return true
         case .autoSaveDrafts:
-            return true
+            return false
         case .voiceToContent:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1164,7 +1164,7 @@ private extension AztecPostViewController {
         }
 
         if post.original().isStatus(in: [.draft, .pending]) && editorHasChanges {
-            alert.addDefaultActionWithTitle(MoreSheetAlert.saveDraft) { _ in
+            alert.addDefaultActionWithTitle(PostEditorAction.saveDraftLocalizedTitle) { _ in
                 self.buttonSaveDraftTapped()
             }
         }
@@ -3188,7 +3188,6 @@ extension AztecPostViewController {
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
         static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
-        static let saveDraft = NSLocalizedString("classicEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button `Save Draft``")
         static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1163,6 +1163,12 @@ private extension AztecPostViewController {
             alert.title = textCounterTitle
         }
 
+        if post.original().isStatus(in: [.draft, .pending]) && editorHasChanges {
+            alert.addDefaultActionWithTitle(MoreSheetAlert.saveDraft) { _ in
+                self.buttonSaveDraftTapped()
+            }
+        }
+
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
 
@@ -3182,6 +3188,7 @@ extension AztecPostViewController {
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
         static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
+        static let saveDraft = NSLocalizedString("classicEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button `Save Draft``")
         static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -188,6 +188,6 @@ private enum Strings {
     static let postSettings = NSLocalizedString("postEditor.moreMenu.postSettings", value: "Post Settings", comment: "Post Editor / Button in the 'More' menu")
     static let helpAndSupport = NSLocalizedString("postEditor.moreMenu.helpAndSupport", value: "Help & Support", comment: "Post Editor / Button in the 'More' menu")
     static let help = NSLocalizedString("postEditor.moreMenu.help", value: "Help", comment: "Post Editor / Button in the 'More' menu")
-    static let saveDraft = NSLocalizedString("postEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button `Save Draft``")
+    static var saveDraft: String { PostEditorAction.saveDraftLocalizedTitle }
     static let contentStructure = NSLocalizedString("postEditor.moreMenu.contentStructure", value: "Blocks: %li, Words: %li, Characters: %li", comment: "Post Editor / 'More' menu details labels with 'Blocks', 'Words' and 'Characters' counts as parameters (in that order)")
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -101,12 +101,25 @@ extension GutenbergViewController {
 
     private func makeMoreMenuSections() -> [UIMenuElement] {
         var sections: [UIMenuElement] = [
-            UIMenu(title: "", subtitle: "", options: .displayInline, children: makeMoreMenuActions())
+            // Common actions at the top so they are always in the same relative place
+            UIMenu(title: "", subtitle: "", options: .displayInline, children: makeMoreMenuActions()),
+            // Dynamic actions at the bottom
+            UIMenu(title: "", subtitle: "", options: .displayInline, children: makeSecondaryActions())
         ]
         if let string = makeContextStructureString() {
             sections.append(UIAction(subtitle: string, attributes: [.disabled], handler: { _ in }))
         }
         return sections
+    }
+
+    private func makeSecondaryActions() -> [UIAction] {
+        var actions: [UIAction] = []
+        if post.original().isStatus(in: [.draft, .pending]) {
+            actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: editorHasChanges ? [] : [.disabled]) { [weak self] _ in
+                self?.buttonSaveDraftTapped()
+            })
+        }
+        return actions
     }
 
     private func makeMoreMenuActions() -> [UIAction] {
@@ -175,5 +188,6 @@ private enum Strings {
     static let postSettings = NSLocalizedString("postEditor.moreMenu.postSettings", value: "Post Settings", comment: "Post Editor / Button in the 'More' menu")
     static let helpAndSupport = NSLocalizedString("postEditor.moreMenu.helpAndSupport", value: "Help & Support", comment: "Post Editor / Button in the 'More' menu")
     static let help = NSLocalizedString("postEditor.moreMenu.help", value: "Help", comment: "Post Editor / Button in the 'More' menu")
+    static let saveDraft = NSLocalizedString("postEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button `Save Draft``")
     static let contentStructure = NSLocalizedString("postEditor.moreMenu.contentStructure", value: "Blocks: %li, Words: %li, Characters: %li", comment: "Post Editor / 'More' menu details labels with 'Blocks', 'Words' and 'Characters' counts as parameters (in that order)")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -833,6 +833,12 @@ private enum Strings {
     static let closeConfirmationAlertSaveDraft = NSLocalizedString("postEditor.closeConfirmationAlert.saveDraft", value: "Save Draft", comment: "Button in an alert confirming saving a new draft")
 }
 
+extension PostEditorAction {
+    /// This value needs to be replaced with a separate entry in l10n.
+    /// - warning: Deprecated (kahu-offline-mode)
+    static var saveDraftLocalizedTitle: String { Strings.closeConfirmationAlertSaveDraft }
+}
+
 private struct MediaUploadingAlert {
     static let title = NSLocalizedString("Uploading media", comment: "Title for alert when trying to save/exit a post before media upload process is complete.")
     static let message = NSLocalizedString("You are currently uploading media. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -99,6 +99,15 @@ extension PublishingEditor {
         performEditorAction(action, analyticsStat: postEditorStateContext.publishActionAnalyticsStat)
     }
 
+    func buttonSaveDraftTapped() {
+        WPAnalytics.track(.editorPostSaveDraftTapped)
+        mapUIContentToPostAndSave(immediate: true)
+        guard !isUploadingMedia else {
+            return displayMediaIsUploadingAlert()
+        }
+        performUpdateAction(analyticsStat: .editorSavedDraft)
+    }
+
     /// - note: deprecated (kahu-offline-mode)
     func handleSecondaryActionButtonTap() {
         guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {


### PR DESCRIPTION
We've received some feedback about the "Save Draft" changes in 24.9, and decide to revert a part of the change.

Changes:

- Add "Save Draft", "Discard Changes" dialog when you tap "Back" (as opposed to saving automatically)
- Add "Save Draft" more menu action for saving without as you edit (folks asked for it and it's more discoverable – let's just keep it for now)

<img src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/eaae5204-9cf8-4892-a44d-43debb31c5ff" width="340px">

## To test:

Test matrix: Gutenberg and Aztec.

**Scenario 1.1**

- Tap "+" to create a new draft
- Do **NOT** make any changes
- Tap "Back"
- ✅ Verify that the editor was closed with no confirmation and the draft post is not saved

**Scenario 1.2**

- Tap "+" to create a new draft
- Make some changes
- Tap "Back"
- ✅ Verify that the confirmation dialog appeared
  - ✅ Verify that if you save "Save Draft", it saves a new post
  - ✅ Verify that if you save "Discard Draft", it discards the post
 
**Scenario 1.3**

- Open an existing draft
- Make some changes
- Tap "Back"
- ✅ Verify that the confirmation dialog appeared
  - ✅ Verify that if you save "Save Draft", it saves a new post
  - ✅ Verify that if you save "Discard Changes", it discards the recent changes (and only them)

**Scenario 2.1**

- Tap "+" to create a new draft
- Make some changes
- Tap "More" / "Save Draft"
- ✅ Verify that it saves the draft
- Open "More" / "Post Settings"
- ✅ Verify that the slug was populated

**Scenario 2.2**

- Open an existing draft
- Do NOT make any changes
- Tap "More" / "Save Draft"
- ✅ Verify that the "Save Draft" option is grayed out
- ❗ known issue: there is a bit of a delay after modifying content and before the editor "learns" about the changes

## Regression Notes
1. Potential unintended areas of impact: Post Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
