### PR TITLE
Task/notifications add reply text input

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailReplyTextViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailReplyTextViewController.swift
@@ -1,0 +1,195 @@
+import UIKit
+
+final class CommentDetailReplyTextViewController: NSObject, UIScrollViewDelegate {
+
+    // MARK: - Properties
+
+    let replyTextView: ReplyTextView
+
+    private lazy var dismissKeyboardTapGesture: UITapGestureRecognizer = {
+        UITapGestureRecognizer(
+            target: self,
+            action: #selector(handleTapGesture(_:))
+        )
+    }()
+
+    private weak var bottomConstraint: NSLayoutConstraint?
+
+    // MARK: - Init
+
+    init(placeholder: String, onReply: ((String) -> Void)? = nil) {
+        let replyView = ReplyTextView(width: 0)
+        replyView.placeholder = placeholder
+        replyView.accessibilityIdentifier = Strings.replyViewAccessibilityId
+        replyView.accessibilityHint = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
+        replyView.onReply = onReply
+        self.replyTextView = replyView
+        super.init()
+        self.observeKeyboardNotifications()
+    }
+
+    convenience init(comment: Comment, onReply: ((String) -> Void)? = nil) {
+        self.init(placeholder: Self.placeholder(from: comment), onReply: onReply)
+    }
+
+    // MARK: - API
+
+    func showReplyView(in view: UIView) {
+        guard !replyTextView.isFirstResponder else {
+            return
+        }
+        self.layout(in: view)
+        self.replyTextView.isHidden = true
+        self.replyTextView.becomeFirstResponder()
+        view.addGestureRecognizer(dismissKeyboardTapGesture)
+    }
+
+    func update(with comment: Comment) {
+        self.replyTextView.placeholder = Self.placeholder(from: comment)
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension CommentDetailReplyTextViewController {
+
+    // MARK: Layout
+
+    private func layout(in view: UIView) {
+        replyTextView.removeFromSuperview()
+        view.addSubview(replyTextView)
+        if #available(iOS 17.0, *) {
+            view.keyboardLayoutGuide.usesBottomSafeArea = false
+        }
+        let bottomConstraint: NSLayoutConstraint = {
+            if #available(iOS 16.0, *) {
+                return replyTextView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
+            } else {
+                return replyTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            }
+        }()
+        NSLayoutConstraint.activate([
+            replyTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            replyTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomConstraint
+        ])
+        self.bottomConstraint = bottomConstraint
+    }
+
+    // MARK: Keyboard Notifications
+
+    private func observeKeyboardNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(
+            self,
+            selector: #selector(keyboardWillShow),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        nc.addObserver(
+            self,
+            selector: #selector(keyboardWillDisappear),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+        nc.addObserver(
+            self,
+            selector: #selector(keyboardWillChangeFrame),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+        nc.addObserver(
+            self,
+            selector: #selector(keyboardDidHide),
+            name: UIResponder.keyboardDidHideNotification,
+            object: nil
+        )
+    }
+
+    @objc func keyboardWillShow(_ note: Foundation.Notification) {
+        guard replyTextView.isFirstResponder else {
+            return
+        }
+        self.replyTextView.isHidden = false
+    }
+
+    @objc func keyboardWillChangeFrame(_ note: Foundation.Notification) {
+        guard let view = replyTextView.superview, let bottomConstraint = bottomConstraint, replyTextView.isFirstResponder else {
+            return
+        }
+        let keyboardCoordinateSpace = keyboardCoordinateSpaceFromNote(note) ?? view.window?.window ?? view.coordinateSpace
+        let keyboardFrame = keyboardCoordinateSpace.convert(keyboardFrameEndFromNote(note), to: view.coordinateSpace)
+        print("WILL CHANGE FRAME TO: \(keyboardFrame)")
+    }
+
+    @objc func keyboardWillDisappear() {
+        guard let view = replyTextView.superview, replyTextView.isFirstResponder else {
+            return
+        }
+    }
+
+    @objc func keyboardDidHide(_ note: Foundation.Notification) {
+        guard !replyTextView.isFirstResponder, replyTextView.window != nil else {
+            return
+        }
+        let duration = durationFromKeyboardNote(note)
+        let curve = curveFromKeyboardNote(note)
+        let options = UIView.AnimationOptions(rawValue: UInt(curve.rawValue))
+        UIView.animate(withDuration: duration, delay: 0, options: options) {
+            self.replyTextView.frame.origin.y += self.replyTextView.bounds.height
+        } completion: { _ in
+            self.removeReplyTextView()
+
+        }
+    }
+
+    func durationFromKeyboardNote(_ note: Foundation.Notification) -> TimeInterval {
+        guard let duration = note.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval else {
+            return TimeInterval(0)
+        }
+        return duration
+    }
+
+    func curveFromKeyboardNote(_ note: Foundation.Notification) -> UIView.AnimationCurve {
+        guard let rawCurve = note.userInfo?[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
+            let curve = UIView.AnimationCurve(rawValue: rawCurve) else {
+            return .easeInOut
+        }
+        return curve
+    }
+
+    func keyboardFrameEndFromNote(_ note: Foundation.Notification) -> CGRect {
+        return note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect ?? .zero
+    }
+
+    func keyboardCoordinateSpaceFromNote(_ note: Foundation.Notification) -> UICoordinateSpace? {
+        return (note.object as? UIScreen)?.coordinateSpace
+    }
+
+    // MARK: -
+
+    @objc func handleTapGesture(_ gesture: UITapGestureRecognizer) {
+        self.replyTextView.resignFirstResponder()
+    }
+
+    func removeReplyTextView() {
+        self.replyTextView.removeFromSuperview()
+        if let view = dismissKeyboardTapGesture.view {
+            view.removeGestureRecognizer(dismissKeyboardTapGesture)
+        }
+    }
+
+    static func placeholder(from comment: Comment) -> String {
+        String(format: Strings.replyPlaceholderFormat, comment.authorForDisplay())
+    }
+
+    enum Strings {
+        static let replyPlaceholderFormat = NSLocalizedString(
+            "Reply to %1$@",
+            comment: "Placeholder text for the reply text field."
+            + "%1$@ is a placeholder for the comment author."
+            + "Example: Reply to Pamela Nguyen"
+        )
+        static let replyViewAccessibilityId = "reply-comment-view"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -23,7 +23,7 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
 
     // Reply properties
 
-    private lazy var replyTextViewController = CommentDetailReplyTextViewController(comment: comment) { [weak self] content in
+    private lazy var replyTextViewController = CommentDetailReplyTextViewController(view: view, comment: comment) { [weak self] content in
         self?.createReply(content: content)
     }
 
@@ -286,15 +286,13 @@ private extension CommentDetailViewController {
     }
 
     func configureTableView() {
+        self.tableView.keyboardDismissMode = .interactive
         self.tableView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(tableView)
         self.view.pinSubviewToAllEdges(tableView)
     }
 
     func configureReplyView() {
-        if #available(iOS 16.0, *) {
-            self.tableView.keyboardDismissMode = .interactive
-        }
         self.replyTextView.delegate = self
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -23,11 +23,15 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
 
     // Reply properties
 
-    private lazy var replyTextViewController = CommentDetailReplyTextViewController(view: view, comment: comment) { [weak self] content in
+    private lazy var replyTextViewController = CommentDetailReplyTextViewController(
+        view: view,
+        moderationViewModel: commentModerationViewModel,
+        comment: comment
+    ) { [weak self] content in
         self?.createReply(content: content)
     }
 
-    private var replyTextView: ReplyTextView {
+    private var replyTextView: NewReplyTextView {
         return replyTextViewController.replyTextView
     }
 
@@ -195,6 +199,7 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
         configureSections()
         configureReplyView()
         refreshCommentReplyIfNeeded()
+        _ = replyTextViewController
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -293,7 +298,7 @@ private extension CommentDetailViewController {
     }
 
     func configureReplyView() {
-        self.replyTextView.delegate = self
+//        self.replyTextView.delegate = self
     }
 
     func configureModerationView() {

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationCoordinator.swift
@@ -20,4 +20,8 @@ final class CommentModerationCoordinator {
     func didDeleteComment() {
         commentDetailViewController.navigationController?.popViewController(animated: true)
     }
+
+    func didTapReply() {
+        commentDetailViewController.showReplyView()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationSheetHostingView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationSheetHostingView.swift
@@ -81,6 +81,7 @@ final class CommentModerationSheetHostingView: UIView {
                 CommentModerationView(viewModel: viewModel)
                     .readSize(sizeChanged)
             }
+            .ignoresSafeArea(.keyboard)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationView.swift
@@ -157,6 +157,7 @@ private struct Approved: View {
                     image: .init(url: viewModel.imageURL, placeholder: Image("gravatar")),
                     text: viewModel.userName
                 ) {
+                    self.viewModel.didTapReply()
                 }
                 DSButton(
                     title: likeButtonTitle,

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
@@ -5,6 +5,8 @@ final class CommentModerationViewModel: ObservableObject {
 
     @Published var state: CommentModerationState
     @Published var isLoading: Bool = false
+    @Published var reply: String? = nil
+
     private let comment: Comment
     private let coordinator: CommentModerationCoordinator
     private let notification: Notification?
@@ -63,7 +65,7 @@ final class CommentModerationViewModel: ObservableObject {
     }
 
     func didTapReply() {
-        // TODO
+        self.coordinator.didTapReply()
     }
 
     func didTapPrimaryCTA() {

--- a/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Comment Moderation/CommentModerationViewModel.swift
@@ -5,7 +5,9 @@ final class CommentModerationViewModel: ObservableObject {
 
     @Published var state: CommentModerationState
     @Published var isLoading: Bool = false
-    @Published var reply: String? = nil
+    @Published var reply: String = ""
+
+    let textView = NewReplyTextView(frame: .zero)
 
     private let comment: Comment
     private let coordinator: CommentModerationCoordinator

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/NewReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/NewReplyTextView.swift
@@ -1,0 +1,232 @@
+import UIKit
+import DesignSystem
+
+// MARK: - ReplyTextViewDelegate
+//
+ @objc public protocol NewReplyTextViewDelegate: UITextViewDelegate {
+     @objc optional func textView(_ textView: UITextView, didTypeWord word: String)
+}
+
+// MARK: - ReplyTextView
+//
+ open class NewReplyTextView: UIView, UITextViewDelegate {
+
+    // MARK: - Views
+
+    private let textView = UITextView()
+    private let placeholderLabel = UILabel()
+
+    // MARK: - Initializers
+
+     public convenience init() {
+        self.init(frame: .zero)
+    }
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+     
+     required public init?(coder: NSCoder) {
+         fatalError("init(coder:) has not been implemented")
+     }
+     
+    // MARK: - Public Properties
+
+     open weak var delegate: NewReplyTextViewDelegate?
+
+     open var text: String! {
+        set {
+            textView.text = newValue ?? String()
+            refreshInterface()
+        }
+        get {
+            return textView.text
+        }
+    }
+
+     open var placeholder: String! {
+        set {
+            placeholderLabel.text = newValue ?? String()
+            textView.accessibilityLabel = placeholderLabel.text
+        }
+        get {
+            return placeholderLabel.text
+        }
+    }
+
+     open var autocorrectionType: UITextAutocorrectionType {
+        set {
+            textView.autocorrectionType = newValue
+        }
+        get {
+            return textView.autocorrectionType
+        }
+    }
+
+     open var keyboardType: UIKeyboardType {
+        set {
+            textView.keyboardType = newValue
+        }
+        get {
+            return textView.keyboardType
+        }
+    }
+
+    open override var isFirstResponder: Bool {
+        return textView.isFirstResponder
+    }
+
+    // MARK: - Public Methods
+
+     open func replaceTextAtCaret(_ text: NSString?, withText replacement: String?) {
+        guard let replacementText = replacement,
+              let textToReplace = text,
+              let selectedRange = textView.selectedTextRange,
+              let newPosition = textView.position(from: selectedRange.start, offset: -textToReplace.length),
+              let newRange = textView.textRange(from: newPosition, to: selectedRange.start) else {
+            return
+        }
+
+        textView.replace(newRange, withText: replacementText)
+    }
+
+    // MARK: - UITextViewDelegate Methods
+
+    open func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        return delegate?.textViewShouldBeginEditing?(textView) ?? true
+    }
+
+    open func textViewDidBeginEditing(_ textView: UITextView) {
+        delegate?.textViewDidBeginEditing?(textView)
+    }
+
+    open func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
+        return delegate?.textViewShouldEndEditing?(textView) ?? true
+    }
+
+    open func textViewDidEndEditing(_ textView: UITextView) {
+        delegate?.textViewDidEndEditing?(textView)
+    }
+
+    open func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let shouldChange = delegate?.textView?(textView, shouldChangeTextIn: range, replacementText: text) ?? true
+        let respondsToDidType = delegate?.responds(to: #selector(NewReplyTextViewDelegate.textView(_:didTypeWord:))) ?? false
+
+        if shouldChange && respondsToDidType {
+            let textViewText: NSString = textView.text as NSString
+            let prerange = NSMakeRange(0, range.location)
+            let pretext = textViewText.substring(with: prerange) + text
+            let words = pretext.components(separatedBy: CharacterSet.whitespacesAndNewlines)
+            let lastWord: NSString = words.last! as NSString
+
+            delegate?.textView?(textView, didTypeWord: lastWord as String)
+        }
+
+        return shouldChange
+    }
+
+    open func textViewDidChange(_ textView: UITextView) {
+        refreshInterface()
+        delegate?.textViewDidChange?(textView)
+    }
+
+    open func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        return delegate?.textView?(textView, shouldInteractWith: URL, in: characterRange, interaction: interaction) ?? true
+    }
+
+    // MARK: - View Methods
+
+    @discardableResult open override func becomeFirstResponder() -> Bool {
+        return textView.becomeFirstResponder()
+    }
+
+    @discardableResult open override func resignFirstResponder() -> Bool {
+        endEditing(true)
+        return textView.resignFirstResponder()
+    }
+
+    open override func layoutSubviews() {
+        self.sizeToFit()
+        super.layoutSubviews()
+        self.textView.frame = bounds
+        self.placeholderLabel.preferredMaxLayoutWidth = bounds.width - (textView.textContainerInset.left + textView.textContainerInset.right)
+        self.placeholderLabel.sizeToFit()
+        self.placeholderLabel.frame.origin = .init(x: textView.textContainerInset.left, y: textView.textContainerInset.top)
+    }
+
+    open override func sizeToFit() {
+        self.textView.sizeToFit()
+        self.invalidateIntrinsicContentSize()
+    }
+
+    // MARK: - Autolayout Helpers
+
+    open override var intrinsicContentSize: CGSize {
+        return .init(width: UIView.noIntrinsicMetric, height: textView.contentSize.height)
+    }
+
+    // MARK: - Setup Helpers
+
+    fileprivate func setupView() {
+        // Setup Layout
+        translatesAutoresizingMaskIntoConstraints = false
+        layer.borderColor = UIColor.darkGray.cgColor
+        layer.borderWidth = 2.0
+
+        // TextView
+        textView.translatesAutoresizingMaskIntoConstraints = true
+        textView.delegate = self
+        textView.scrollsToTop = false
+        textView.contentInset = .zero
+        textView.textContainerInset = .init(top: 8, left: 16, bottom: 8, right: 16)
+        textView.autocorrectionType = .yes
+        textView.textColor = Style.textColor
+        textView.font = Style.font
+        textView.textContainer.lineFragmentPadding = 0
+        textView.layoutManager.allowsNonContiguousLayout = false
+        textView.accessibilityIdentifier = "reply-text-view"
+        self.addSubview(textView)
+
+        // Placeholder
+        placeholderLabel.textColor = Style.placeholderTextColor
+        placeholderLabel.translatesAutoresizingMaskIntoConstraints = true
+        placeholderLabel.font = textView.font
+        placeholderLabel.isUserInteractionEnabled = false
+        self.addSubview(placeholderLabel)
+
+        //
+        refreshInterface()
+    }
+
+    // MARK: - Refresh Helpers
+
+    fileprivate func refreshInterface() {
+        refreshPlaceholder()
+        refreshSizeIfNeeded()
+        refreshScrollPosition()
+    }
+
+    fileprivate func refreshSizeIfNeeded() {
+        sizeToFit()
+    }
+
+    fileprivate func refreshPlaceholder() {
+        placeholderLabel.isHidden = !textView.text.isEmpty
+    }
+
+    fileprivate func refreshScrollPosition() {
+        let selectedRangeStart = textView.selectedTextRange?.start ?? UITextPosition()
+        var caretRect = textView.caretRect(for: selectedRangeStart)
+        caretRect = caretRect.integral
+        textView.scrollRectToVisible(caretRect, animated: false)
+    }
+
+    // MARK: - Types
+
+    private struct Style {
+        static let font = UIFont.DS.font(.bodyMedium(.regular))
+        static let textColor = UIColor.DS.Foreground.primary
+        static let placeholderTextColor = UIColor.DS.Foreground.secondary
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -249,7 +249,7 @@ import Gridicons
 
         // Calculate the entire control's size
         let newHeight = min(max(contentHeight, minimumHeight), maximumHeight)
-        let intrinsicSize = CGSize(width: frame.width, height: newHeight)
+        let intrinsicSize = CGSize(width: UIView.noIntrinsicMetric, height: newHeight)
 
         return intrinsicSize
     }

--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -5,7 +5,7 @@ extension XCTestCase {
 
     // Require main actor isolation because of the calls to app.terminate() and app.activate()
     // which require running on the main thread.
-    @MainActor
+//    @MainActor
     public func setUpTestSuite(
         for app: XCUIApplication = XCUIApplication(),
         removeBeforeLaunching: Bool = false,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3896,6 +3896,8 @@
 		F48EE3052C072F8C0068EA92 /* View+ReadSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EE3032C072E570068EA92 /* View+ReadSize.swift */; };
 		F48EE3072C0747520068EA92 /* CommentModerationSheetHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EE3062C0747520068EA92 /* CommentModerationSheetHostingView.swift */; };
 		F48EE3082C07478C0068EA92 /* CommentModerationSheetHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48EE3062C0747520068EA92 /* CommentModerationSheetHostingView.swift */; };
+		F49114BC2C12163D00FCC030 /* NewReplyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49114BB2C12163D00FCC030 /* NewReplyTextView.swift */; };
+		F49114BD2C12163D00FCC030 /* NewReplyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49114BB2C12163D00FCC030 /* NewReplyTextView.swift */; };
 		F499CFB32BD978340072FB00 /* DynamicDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F499CFB22BD978340072FB00 /* DynamicDashboardCard.swift */; };
 		F499CFB42BD978340072FB00 /* DynamicDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F499CFB22BD978340072FB00 /* DynamicDashboardCard.swift */; };
 		F49B99FF2937C9B4000CEFCE /* MigrationEmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */; };
@@ -9332,6 +9334,7 @@
 		F48EBF912B333111004CD561 /* dashboard-200-with-only-one-dynamic-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-only-one-dynamic-card.json"; sourceTree = "<group>"; };
 		F48EE3032C072E570068EA92 /* View+ReadSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ReadSize.swift"; sourceTree = "<group>"; };
 		F48EE3062C0747520068EA92 /* CommentModerationSheetHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentModerationSheetHostingView.swift; sourceTree = "<group>"; };
+		F49114BB2C12163D00FCC030 /* NewReplyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewReplyTextView.swift; sourceTree = "<group>"; };
 		F499CFB22BD978340072FB00 /* DynamicDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicDashboardCard.swift; sourceTree = "<group>"; };
 		F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
 		F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAnalyticsTracker.swift; sourceTree = "<group>"; };
@@ -15644,6 +15647,7 @@
 			children = (
 				B54E1DEE1A0A7BAA00807537 /* ReplyTextView.swift */,
 				B54E1DEF1A0A7BAA00807537 /* ReplyTextView.xib */,
+				F49114BB2C12163D00FCC030 /* NewReplyTextView.swift */,
 			);
 			path = ReplyTextView;
 			sourceTree = "<group>";
@@ -22264,6 +22268,7 @@
 				B5AC00681BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift in Sources */,
 				B0637543253E7E7A00FD45D2 /* GutenbergSuggestionsViewController.swift in Sources */,
 				F4F7B2542AFA5D8600207282 /* AllDomainsListCardView.swift in Sources */,
+				F49114BC2C12163D00FCC030 /* NewReplyTextView.swift in Sources */,
 				D816C1F620E0896F00C4D82F /* TrashComment.swift in Sources */,
 				8384C64128AAC82600EABE26 /* KeychainUtils.swift in Sources */,
 				08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */,
@@ -24838,6 +24843,7 @@
 				803DE822290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift in Sources */,
 				F4FF50ED2B4ECE320076DB0C /* MySiteOverlaysCoordinator.swift in Sources */,
 				FABB21B12602FC2C00C8785C /* Array.swift in Sources */,
+				F49114BD2C12163D00FCC030 /* NewReplyTextView.swift in Sources */,
 				FABB21B22602FC2C00C8785C /* NotificationActionParser.swift in Sources */,
 				FABB21B32602FC2C00C8785C /* SiteTagsViewController.swift in Sources */,
 				FABB21B42602FC2C00C8785C /* GutenbergImageLoader.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3906,6 +3906,8 @@
 		F49B9A0A293A3249000CEFCE /* MigrationAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */; };
 		F49D7BEB29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */; };
 		F49D7BEC29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */; };
+		F4A1A3D92C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A1A3D82C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift */; };
+		F4A1A3DA2C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A1A3D82C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift */; };
 		F4AA1E5E2AF66D3300EBA201 /* AllDomainsListItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4141EEB2AE945C7000D2AAE /* AllDomainsListItemViewModel.swift */; };
 		F4B0F4832ADED9B5003ABC61 /* DomainsService+AllDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B0F4822ADED9B5003ABC61 /* DomainsService+AllDomains.swift */; };
 		F4B0F4842ADED9B5003ABC61 /* DomainsService+AllDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B0F4822ADED9B5003ABC61 /* DomainsService+AllDomains.swift */; };
@@ -9335,6 +9337,7 @@
 		F49B9A05293A21BF000CEFCE /* MigrationAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAnalyticsTracker.swift; sourceTree = "<group>"; };
 		F49B9A07293A21F4000CEFCE /* MigrationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationEvent.swift; sourceTree = "<group>"; };
 		F49D7BEA29DF329500CB93A5 /* UIPopoverPresentationController+PopoverAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPopoverPresentationController+PopoverAnchor.swift"; sourceTree = "<group>"; };
+		F4A1A3D82C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentDetailReplyTextViewController.swift; sourceTree = "<group>"; };
 		F4B0F4822ADED9B5003ABC61 /* DomainsService+AllDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DomainsService+AllDomains.swift"; sourceTree = "<group>"; };
 		F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuggestionsViewModelType.swift; sourceTree = "<group>"; };
 		F4C1FC622A44831300AD7CB0 /* PrivacySettingsAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsAnalyticsTracker.swift; sourceTree = "<group>"; };
@@ -15735,6 +15738,7 @@
 				2906F810110CDA8900169D56 /* EditCommentViewController.m */,
 				0A3FCA1C28B71CBC00499A15 /* FullScreenCommentReplyViewModel.swift */,
 				328CEC5D23A532BA00A6899E /* FullScreenCommentReplyViewController.swift */,
+				F4A1A3D82C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -22641,6 +22645,7 @@
 				B532D4E9199D4357006E4DF6 /* NoteBlockCommentTableViewCell.swift in Sources */,
 				4AA33EF829963ABE005B6E23 /* ReaderAbstractTopic+Lookup.swift in Sources */,
 				73BFDA8A211D054800907245 /* Notifiable.swift in Sources */,
+				F4A1A3D92C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift in Sources */,
 				404B35D322E9BA0800AD0B37 /* RegisterDomainDetailsViewModel+CountryDialCodes.swift in Sources */,
 				F41D98D72B389735004EC050 /* DashboardDynamicCardAnalyticsEvent.swift in Sources */,
 				D8EB1FD121900810002AE1C4 /* BlogListViewController+SiteCreation.swift in Sources */,
@@ -25787,6 +25792,7 @@
 				FABB24532602FC2C00C8785C /* GutenbergGalleryUploadProcessor.swift in Sources */,
 				FABB24542602FC2C00C8785C /* StoriesIntroViewController.swift in Sources */,
 				FABB24552602FC2C00C8785C /* WPStyleGuide+Suggestions.m in Sources */,
+				F4A1A3DA2C0F84F700B2EFA9 /* CommentDetailReplyTextViewController.swift in Sources */,
 				FABB24562602FC2C00C8785C /* SiteStatsInsightsViewModel.swift in Sources */,
 				0C71959C2A3CA582002EA18C /* SiteSettingsRelatedPostsView.swift in Sources */,
 				FACF66CE2ADD645C008C3E13 /* PostListHeaderView.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/Automattic/wordpress-mobile/issues/37

## Test Instructions

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

## PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
