### PR TITLE
Fix a couple of post editing analytics events

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -173,6 +173,7 @@ extension AbstractPost {
         [
             "post_type": analyticsPostType ?? "",
             "status": status?.rawValue ?? "",
+            "password_protected": PostVisibility(post: self) == .protected
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -135,14 +135,14 @@ extension PublishingEditor {
             guard !isUploadingMedia else {
                 return displayMediaIsUploadingAlert()
             }
-            performUpdateAction()
+            performUpdateAction(analyticsStat: .editorUpdatedPost)
         case .submitForReview:
             guard !isUploadingMedia else {
                 return displayMediaIsUploadingAlert()
             }
             var changes = RemotePostUpdateParameters()
             changes.status = Post.Status.pending.rawValue
-            performUpdateAction(changes: changes)
+            performUpdateAction(changes: changes, analyticsStat: .editorPublishedPost)
         case .save, .saveAsDraft:
             wpAssertionFailure("No longer used and supported")
             break
@@ -177,7 +177,7 @@ extension PublishingEditor {
         dismissOrPopView()
     }
 
-    private func performUpdateAction(changes: RemotePostUpdateParameters? = nil) {
+    private func performUpdateAction(changes: RemotePostUpdateParameters? = nil, analyticsStat: WPAnalyticsStat) {
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.show()
         postEditorStateContext.updated(isBeingPublished: true)
@@ -187,6 +187,7 @@ extension PublishingEditor {
                 let post = try await PostCoordinator.shared._save(post, changes: changes)
                 self.post = post
                 self.createRevisionOfPost()
+                self.trackPostSave(stat: analyticsStat)
             } catch {
                 postEditorStateContext.updated(isBeingPublished: false)
             }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -220,6 +220,19 @@ extension PostSettingsViewController {
     }
 }
 
+// MARK: - PostSettingsViewController (Publish Date)
+
+extension PostSettingsViewController {
+    @objc func showPublishDatePicker() {
+        var viewModel = PublishSettingsViewModel(post: self.apost)
+        let viewController = PublishDatePickerViewController.make(viewModel: viewModel) { date in
+            WPAnalytics.track(.editorPostScheduledChanged, properties: ["via": "settings"])
+            viewModel.setDate(date)
+        }
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 // MARK: - PostSettingsViewController (Page Attributes)
 
 extension PostSettingsViewController {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1075,13 +1075,6 @@ FeaturedImageViewControllerDelegate>
     return cell;
 }
 
-- (void)showPublishDatePicker
-{
-    BOOL isRequired = self.apost.status == PostStatusPublish || self.apost.status == PostStatusScheduled;
-    UIViewController *vc = [PublishDatePickerHelper makeDatePickerWithPost:self.apost isRequired:isRequired];
-    [self.navigationController pushViewController:vc animated:YES];
-}
-
 - (void)showPostStatusSelector
 {
     if ([self.apost.status isEqualToString:PostStatusPrivate]) {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishDatePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishDatePickerViewController.swift
@@ -50,16 +50,6 @@ extension PublishDatePickerViewController {
     }
 }
 
-/// - warning: deprecated (kahu-offline-mode)
-final class PublishDatePickerHelper: NSObject {
-    @objc class func makeDatePicker(post: AbstractPost, isRequired: Bool) -> UIViewController {
-        var viewModel = PublishSettingsViewModel(post: post)
-        return PublishDatePickerViewController.make(viewModel: viewModel) { date in
-            viewModel.setDate(date)
-        }
-    }
-}
-
 struct PublishDatePickerView: View {
     @State var configuration: PublishDatePickerConfiguration
 


### PR DESCRIPTION
- Fixes an issue with `editor_post_scheduled_changed` not being tracked when changing scheduled date from PostSettingsViewContoller (it was previously tracked in [PublishSettingsViewController](https://github.com/wordpress-mobile/WordPress-iOS/blob/d93c4ec72d5ede8c80582954573fa2fbbeaafdf3/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift#L205) and this intermediate step was removed and it now goes straight into the date picker)
- Fixes an issue with `editor_post_published` not being tracked for the "Submit for Review" CTA (yes, it is tracking a "wrong" event and there is a [comment](https://github.com/wordpress-mobile/WordPress-iOS/blob/5abd3445a652e150f1eeeaa553bc045762a3bd70/WordPress/Classes/ViewRelated/Post/PostEditorState.swift#L137) about it in the production version).
- Add tracking on how many posts are password protected

To test: n/a

## Regression Notes
1. Potential unintended areas of impact: Post Analytics
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
