### PR TITLE
Offline Mode: Remove Deprecated Code – P8

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+Local.swift
+++ b/WordPress/Classes/Models/AbstractPost+Local.swift
@@ -1,17 +1,6 @@
 import Foundation
 
 extension AbstractPost {
-    /// Returns true if the post is a draft and has never been uploaded to the server.
-    /// - note: deprecated (kahu-offline-mode)
-    var isLocalDraft: Bool {
-        return self.isDraft() && !self.hasRemote()
-    }
-
-    /// - warning: deprecated (kahu-offline-mode)
-    var isLocalRevision: Bool {
-        return self.originalIsDraft() && self.isRevision() && self.remoteStatus == .local
-    }
-
     /// Count posts that have never been uploaded to the server.
     ///
     /// - Parameter context: A `NSManagedObjectContext` in which to count the posts

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -103,8 +103,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 #pragma mark - Conveniece Methods
 /// - note: deprecated (kahu-offline-mode)
-- (void)publishImmediately;
-/// - note: deprecated (kahu-offline-mode)
 - (BOOL)shouldPublishImmediately;
 - (NSString *)authorNameForDisplay;
 - (NSString *)blavatarForDisplay;
@@ -115,13 +113,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 
 #pragma mark - Unsaved Changes
-
-/**
- *  @brief      Wether the post can be saved or not.
- *
- *  @returns    YES if the post can be saved, NO otherwise.
- */
-- (BOOL)canSave;
 
 /**
  *  @brief      Call this method to know if the post has either local or remote unsaved changes.
@@ -172,14 +163,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  */
 /// - note: deprecated (kahu-offline-mode)
 - (BOOL)dateCreatedIsNilOrEqualToDateModified;
-
-/**
- *  Whether there was any attempt ever to upload this post, either successful or failed.
- *
- *  @returns    YES if there ever was an attempt to upload this post, NO otherwise.
- */
-/// - warning: deprecated (kahu-offline-mode)
-- (BOOL)hasNeverAttemptedToUpload;
 
 /**
  *  Whether the post has local changes or not.  Local changes are all changes that are have not been

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -82,30 +82,6 @@
 - (void)setDateCreated:(NSDate *)localDate
 {
     self.date_created_gmt = localDate;
-
-    if ([Feature enabled:FeatureFlagSyncPublishing]) {
-        return;
-    }
-
-    /*
-     If the date is nil it means publish immediately so set the status to publish.
-     If the date is in the future set the status to scheduled if current status is published.
-     If the date is now or in the past, and the status is scheduled, set the status
-     to published.
-     */
-    if ([self dateCreatedIsNilOrEqualToDateModified]) {
-        // A nil date means publish immediately.
-        self.status = PostStatusPublish;
-
-    } else if ([self hasFuturePublishDate]) {
-        // Needs to be a nested conditional so future date + scheduled status
-        // is handled correctly.
-        if ([self.status isEqualToString:PostStatusPublish]) {
-            self.status = PostStatusScheduled;
-        }
-    } else if ([self.status isEqualToString:PostStatusScheduled]) {
-        self.status = PostStatusPublish;
-    }
 }
 
 #pragma mark -
@@ -329,11 +305,6 @@
     return self.revision != nil;
 }
 
-- (BOOL)hasNeverAttemptedToUpload
-{
-    return self.remoteStatus == AbstractPostRemoteStatusLocal;
-}
-
 - (BOOL)hasRemote
 {
     return ((self.postID != nil) && ([self.postID longLongValue] > 0));
@@ -385,12 +356,6 @@
         return YES;
     }
     return NO;
-}
-
-- (void)publishImmediately
-{
-    self.dateModified = [NSDate date];
-    [self setDateCreated:self.dateModified];
 }
 
 - (BOOL)shouldPublishImmediately
@@ -470,19 +435,6 @@
 
 
 #pragma mark - Post
-
-/// - note: Deprecated (kahu-offline-mode)
-- (BOOL)canSave
-{
-    NSString* titleWithoutSpaces = [self.postTitle stringByReplacingOccurrencesOfString:@" " withString:@""];
-    NSString* contentWithoutSpaces = [self.content stringByReplacingOccurrencesOfString:@" " withString:@""];
-    
-    BOOL isTitleEmpty = (titleWithoutSpaces == nil || titleWithoutSpaces.length == 0);
-    BOOL isContentEmpty = (contentWithoutSpaces == nil || contentWithoutSpaces.length == 0);
-    BOOL areBothTitleAndContentsEmpty = isTitleEmpty && isContentEmpty;
-    
-    return (!areBothTitleAndContentsEmpty && [self hasUnsavedChanges]);
-}
 
 - (BOOL)hasUnsavedChanges
 {

--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -33,13 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL isFeaturedImageChanged;
 
-/**
- BOOL flag set to true if the post is first time published.
-
- - note: Deprecated (kahu-offline-mode)
- */
-@property (nonatomic, assign) BOOL isFirstTimePublish;
-
 //date conversion
 @property (nonatomic, strong, nullable) NSDate * dateCreated;
 

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -22,7 +22,6 @@
 @dynamic pathForDisplayImage;
 
 @synthesize isFeaturedImageChanged;
-@synthesize isFirstTimePublish;
 
 - (NSDate *)dateCreated
 {
@@ -91,11 +90,6 @@
         return self.wp_slug;
     }
     return self.suggested_slug;
-}
-
-- (NSString *)statusForDisplay
-{
-    return [self valueForKey:@"status"];
 }
 
 - (BOOL)hasContent

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -297,28 +297,6 @@ class Post: AbstractPost {
         return false
     }
 
-    override func statusForDisplay() -> String? {
-        var statusString: String?
-
-        if status == .trash || status == .scheduled {
-            statusString = ""
-        } else if status != .publish && status != .draft {
-            statusString = statusTitle
-        }
-
-        if isRevision() {
-            let localOnly = NSLocalizedString("Local changes", comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
-
-            if let tempStatusString = statusString, !tempStatusString.isEmpty {
-                statusString = String(format: "%@, %@", tempStatusString, localOnly)
-            } else {
-                statusString = localOnly
-            }
-        }
-
-        return statusString
-    }
-
     override func titleForDisplay() -> String {
         var title = postTitle?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
         title = title

--- a/WordPress/Classes/Models/PostContentProvider.h
+++ b/WordPress/Classes/Models/PostContentProvider.h
@@ -10,8 +10,6 @@
 - (NSDate *)dateForDisplay;
 @optional
 - (NSString *)blogNameForDisplay;
-- (NSString *)statusForDisplay;
-- (BOOL)unreadStatusForDisplay;
 - (NSURL *)featuredImageURLForDisplay;
 - (NSURL *)authorURL;
 - (NSString *)slugForDisplay;

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -12,7 +12,7 @@
 }
 
 + (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext overwrite:(BOOL)overwrite {
-    if ([Feature enabled:FeatureFlagSyncPublishing] && (post.revision != nil && !overwrite)) {
+    if ((post.revision != nil && !overwrite)) {
         return;
     }
 
@@ -271,12 +271,7 @@
 
     if (purge) {
         // Set up predicate for fetching any posts that could be purged for the sync.
-        NSPredicate *predicate = nil;
-        if ([Feature enabled:FeatureFlagSyncPublishing]) {
-            predicate = [NSPredicate predicateWithFormat:@"(postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", blog];
-        } else {
-            predicate = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];
-        }
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"(postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", blog];
         if ([statuses count] > 0) {
             NSPredicate *statusPredicate = [NSPredicate predicateWithFormat:@"status IN %@", statuses];
             predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, statusPredicate]];

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,7 +11,6 @@ enum FeatureFlag: Int, CaseIterable {
     case compliancePopover
     case googleDomainsCard
     case newTabIcons
-    case syncPublishing
     case autoSaveDrafts
 
     /// Returns a boolean indicating if the feature is enabled
@@ -38,8 +37,6 @@ enum FeatureFlag: Int, CaseIterable {
         case .googleDomainsCard:
             return false
         case .newTabIcons:
-            return true
-        case .syncPublishing:
             return true
         case .autoSaveDrafts:
             return false
@@ -83,8 +80,6 @@ extension FeatureFlag {
             return "Google Domains Promotional Card"
         case .newTabIcons:
             return "New Tab Icons"
-        case .syncPublishing:
-            return "Synchronous Publishing"
         case .autoSaveDrafts:
             return "Autosave Drafts"
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1152,7 +1152,7 @@ private extension AztecPostViewController {
         }
 
         if post.original().isStatus(in: [.draft, .pending]) && editorHasChanges {
-            alert.addDefaultActionWithTitle(PostEditorAction.saveDraftLocalizedTitle) { _ in
+            alert.addDefaultActionWithTitle(MoreSheetAlert.saveDraft) { _ in
                 self.buttonSaveDraftTapped()
             }
         }
@@ -3168,6 +3168,7 @@ extension AztecPostViewController {
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
         static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
+        static let saveDraft = NSLocalizedString("classicEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button in the 'More' menu")
         static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -179,6 +179,6 @@ private enum Strings {
     static let postSettings = NSLocalizedString("postEditor.moreMenu.postSettings", value: "Post Settings", comment: "Post Editor / Button in the 'More' menu")
     static let helpAndSupport = NSLocalizedString("postEditor.moreMenu.helpAndSupport", value: "Help & Support", comment: "Post Editor / Button in the 'More' menu")
     static let help = NSLocalizedString("postEditor.moreMenu.help", value: "Help", comment: "Post Editor / Button in the 'More' menu")
-    static var saveDraft: String { PostEditorAction.saveDraftLocalizedTitle }
+    static let saveDraft = NSLocalizedString("postEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button in the 'More' menu")
     static let contentStructure = NSLocalizedString("postEditor.moreMenu.contentStructure", value: "Blocks: %li, Words: %li, Characters: %li", comment: "Post Editor / 'More' menu details labels with 'Blocks', 'Words' and 'Characters' counts as parameters (in that order)")
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -439,10 +439,8 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         borderBottom.autoresizingMask = [.flexibleWidth, .flexibleTopMargin]
         navigationController?.navigationBar.addSubview(borderBottom)
 
-        if FeatureFlag.syncPublishing.enabled {
-            navigationBarManager.moreButton.menu = makeMoreMenu()
-            navigationBarManager.moreButton.showsMenuAsPrimaryAction = true
-        }
+        navigationBarManager.moreButton.menu = makeMoreMenu()
+        navigationBarManager.moreButton.showsMenuAsPrimaryAction = true
     }
 
     @objc private func buttonMoreTapped() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -376,12 +376,6 @@ private enum Strings {
     static let closeConfirmationAlertSaveDraft = NSLocalizedString("postEditor.closeConfirmationAlert.saveDraft", value: "Save Draft", comment: "Button in an alert confirming saving a new draft")
 }
 
-extension PostEditorAction {
-    /// This value needs to be replaced with a separate entry in l10n.
-    /// - warning: Deprecated (kahu-offline-mode)
-    static var saveDraftLocalizedTitle: String { Strings.closeConfirmationAlertSaveDraft }
-}
-
 private struct MediaUploadingAlert {
     static let title = NSLocalizedString("Uploading media", comment: "Title for alert when trying to save/exit a post before media upload process is complete.")
     static let message = NSLocalizedString("You are currently uploading media. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")

--- a/WordPress/WordPressTest/OldReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/OldReaderPostCardCellTests.swift
@@ -18,10 +18,6 @@ class MockContentProvider: NSObject, ReaderPostContentProvider {
         return "A blog name"
     }
 
-    func statusForDisplay() -> String! {
-        return "A status"
-    }
-
     func contentForDisplay() -> String! {
         return "The post content"
     }

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -276,60 +276,6 @@ class PostTests: CoreDataTestCase {
         XCTAssertEqual(post.contentPreviewForDisplay(), "some contents\u{A0}go here")
     }
 
-    func testThatStatusForDisplayWorksForOriginalPost() {
-        let post = newTestPost()
-
-        post.status = .draft
-        XCTAssertNil(post.statusForDisplay())
-
-        post.status = .pending
-        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .pending))
-
-        post.status = .publishPrivate
-        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .publishPrivate))
-
-        post.status = .publish
-        XCTAssertNil(post.statusForDisplay())
-
-        post.status = .scheduled
-        XCTAssertEqual(post.statusForDisplay(), "")
-
-        post.status = .trash
-        XCTAssertEqual(post.statusForDisplay(), "")
-
-        post.status = .deleted
-        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .deleted))
-    }
-
-    func testThatStatusForDisplayWorksForRevisionPost() {
-        let original = newTestPost()
-        let revision = original.createRevision()
-        let local = NSLocalizedString("Local changes", comment: "Local")
-        revision.status = .draft
-        XCTAssertEqual(revision.statusForDisplay(), local)
-
-        revision.status = .pending
-        let pendingStatusDisplay = "\(Post.title(for: .pending))"
-        XCTAssertEqual(revision.statusForDisplay(), String(format: "%@, %@", pendingStatusDisplay, local))
-
-        revision.status = .publishPrivate
-        let publishPrivateStatusDisplay = "\(Post.title(for: .publishPrivate))"
-        XCTAssertEqual(revision.statusForDisplay(), String(format: "%@, %@", publishPrivateStatusDisplay, local))
-
-        revision.status = .publish
-        XCTAssertEqual(revision.statusForDisplay(), NSLocalizedString("Local changes", comment: "Local"))
-
-        revision.status = .scheduled
-        XCTAssertEqual(revision.statusForDisplay(), local)
-
-        revision.status = .trash
-        XCTAssertEqual(revision.statusForDisplay(), local)
-
-        revision.status = .deleted
-        let deletedStatusDisplay = "\(Post.title(for: .deleted))"
-        XCTAssertEqual(revision.statusForDisplay(), String(format: "%@, %@", deletedStatusDisplay, local))
-    }
-
     func testThatHasLocalChangesWorks() {
         let original = newTestPost()
         var revision = original.createRevision() as! Post


### PR DESCRIPTION
- Removes more of the deprecated and now unused code
- Removes the last remaining usages of the `syncPublishing` feature flag
- Removes the temporary localizable string introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/23298

To test: n/a 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
