### PR TITLE
Integrate new PostServiceRemoteREST/createAutosave API

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -55,8 +55,8 @@ def gravatar
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 17.1.2'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
+  # pod 'WordPressKit', '~> 17.1.2'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '470171b779a6ffa7ca0cf7252f334c69563aef7a'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.8, ~> 9.0)
-  - WordPressKit (~> 17.1.2)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `470171b779a6ffa7ca0cf7252f334c69563aef7a`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -132,7 +132,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
   trunk:
     - Alamofire
@@ -178,11 +177,17 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.120.0-alpha1.podspec
+  WordPressKit:
+    :commit: 470171b779a6ffa7ca0cf7252f334c69563aef7a
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressKit:
+    :commit: 470171b779a6ffa7ca0cf7252f334c69563aef7a
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
@@ -216,7 +221,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c
   WordPressAuthenticator: 898acaac75c5ade9b900c02622a15b9aef8fde1a
-  WordPressKit: 2e8e897866f7cf1a2ce1b3e6780a019841360caa
+  WordPressKit: bf29888bc32c1ac18669b81d49b148d867787666
   WordPressShared: 0160364ed24f4d67fed4e85003fefa837faad84f
   WordPressUI: ec5ebcf7e63e797ba51d07513e340c1b14cf45a4
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -229,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 773ff2ee571ca51428446770fa314e733099a7b4
+PODFILE CHECKSUM: 124ead48f43ab80708479ff2d516a79377d63c34
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
+++ b/WordPress/Classes/Services/PostServiceRemote+Concurrency.swift
@@ -15,23 +15,3 @@ extension PostServiceRemote {
         }
     }
 }
-
-extension PostServiceRemoteREST {
-    struct AutosaveResponse {
-        var previewURL: URL
-    }
-
-    func createAutosave(with post: RemotePost) async throws -> AutosaveResponse {
-        try await withCheckedThrowingContinuation { continuation in
-            self.autoSave(post, success: { _, previewURL in
-                guard let previewURL = previewURL.flatMap(URL.init) else {
-                    return continuation.resume(throwing: URLError(.unknown))
-                }
-                let response = AutosaveResponse(previewURL: previewURL)
-                continuation.resume(returning: response)
-            }, failure: {
-                continuation.resume(throwing: $0 ?? URLError(.unknown))
-            })
-        }
-    }
-}


### PR DESCRIPTION
This PR integrates a new version of `PostServiceRemoteREST/createAutosave` added in WPKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/807.

The new version uses `RemotePostCreateParameters` (released in 24.9) as the input parameter. It also uses a new type to represent the response that includes only the field that are actually present in it. The legacy version uses mismatched `RemotePost` type while the response has only the following fields:

```json
{
  "ID": 799,
  "post_ID": 720,
  "modified": "2024-06-04T22:46:33-04:00",
  "preview_URL": "https://offlinemode1.wordpress.com/2024/05/16/s02/?preview=true&preview_id=720&preview_nonce=9cbb690821"
}
```

There will be one more change needed, and we'll be able to fully remove [`+ (RemotePost *)remotePostWithPost:(AbstractPost *)post`](https://github.com/wordpress-mobile/WordPress-iOS/blob/ac48c9bb0a419715faa51a9e3fcef263913723fd/WordPress/Classes/Services/PostHelper.m#L136). This is one of the stretch tasks from the Offline Mode project.

## To test:

- Open an existing published post on a wp.com site
- Make some changes to the content 
- Tap "More" / "Preview"
- ✅  Verify that the preview is displayed

**Note:** yes, the preview uses autosave API.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
