### PR TITLE
Fix a rare crash when opening a file downloads stats view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -697,10 +697,14 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func fileDownloadsDataRows() -> [StatsTotalRowData] {
-        return store.getTopFileDownloads()?.fileDownloads.prefix(10).map { StatsTotalRowData(name: $0.file,
-                                                                                             data: $0.downloadCount.abbreviatedString(),
-                                                                                             statSection: .periodFileDownloads) }
-            ?? []
+        return store.getTopFileDownloads()?.fileDownloads.prefix(10).map {
+            StatsTotalRowData(
+                id: UUID(),
+                name: $0.file,
+                data: $0.downloadCount.abbreviatedString(),
+                statSection: .periodFileDownloads
+            )
+        } ?? []
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -814,10 +814,14 @@ private extension SiteStatsDetailsViewModel {
     }
 
     func fileDownloadsRowData() -> [StatsTotalRowData] {
-        return periodStore.getTopFileDownloads()?.fileDownloads.map { StatsTotalRowData(name: $0.file,
-                                                                                        data: $0.downloadCount.abbreviatedString(),
-                                                                                        statSection: .periodFileDownloads) }
-            ?? []
+        return periodStore.getTopFileDownloads()?.fileDownloads.map {
+            StatsTotalRowData(
+                id: UUID(),
+                name: $0.file,
+                data: $0.downloadCount.abbreviatedString(),
+                statSection: .periodFileDownloads
+            )
+        } ?? []
     }
 
     // MARK: - Post Stats

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -1058,10 +1058,14 @@ private extension SiteStatsInsightsDetailsViewModel {
     }
 
     func fileDownloadsRowData() -> [StatsTotalRowData] {
-        return periodStore.getTopFileDownloads()?.fileDownloads.map { StatsTotalRowData(name: $0.file,
+        return periodStore.getTopFileDownloads()?.fileDownloads.map {
+            StatsTotalRowData(
+                id: UUID(),
+                name: $0.file,
                 data: $0.downloadCount.abbreviatedString(),
-                statSection: .periodFileDownloads) }
-                ?? []
+                statSection: .periodFileDownloads
+            )
+        } ?? []
     }
 
     // MARK: - Post Stats

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 struct StatsTotalRowData: Equatable {
+    var id: UUID?
     var name: String
     var data: String
     var secondData: String?
@@ -18,7 +19,8 @@ struct StatsTotalRowData: Equatable {
     var statSection: StatSection?
     var isReferrerSpam: Bool
 
-    init(name: String,
+    init(id: UUID? = nil,
+         name: String,
          data: String,
          secondData: String? = nil,
          mediaID: NSNumber? = nil,
@@ -34,6 +36,7 @@ struct StatsTotalRowData: Equatable {
          childRows: [StatsTotalRowData]? = [StatsTotalRowData](),
          statSection: StatSection? = nil,
          isReferrerSpam: Bool = false) {
+        self.id = id
         self.name = name
         self.data = data
         self.secondData = secondData
@@ -65,7 +68,8 @@ struct StatsTotalRowData: Equatable {
     }
 
     static func == (lhs: StatsTotalRowData, rhs: StatsTotalRowData) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.id == rhs.id &&
+            lhs.name == rhs.name &&
             lhs.data == rhs.data &&
             lhs.mediaID == rhs.mediaID &&
             lhs.postID == rhs.postID &&


### PR DESCRIPTION
Fixes #23270

After analysing crash reports, it can happen when filename of two files is identical. Normally, when the file is uploaded to the backend, the filename gets added a suffix ( "_1"). However, I noticed that when a file is uploaded at a different date, it gets uploaded to "2024/06/file_name" url which then skips adding a suffix. It creates conditions for a crash.

## Solution

- Add a unique identifier to stats downloads rows to ensure they are always treated as unique

## To test:

I reproduced the crash manually by changing file name to be identical, and then confirming that there's no crash for file downloads details.

1. Log into the site that has a lot of files or create a new site and upload 6+ files
2. Open Stats -> Traffic
3. Scroll to File Downloads
4. Tap View More
5. Confirm there's no crash

## Regression Notes
1. Potential unintended areas of impact

Couldn't identify

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
