### PR TITLE
Fix scroll to comment issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -813,16 +813,20 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self.tableView performBatchUpdates:nil completion:nil];
 }
 
-
-- (void)refreshTableViewAndNoResultsView
-{
+- (void)refreshTableViewAndNoResultsView:(BOOL)scrollToHighlightedComment {
     [self.tableViewHandler refreshTableView];
     [self refreshNoResultsView];
     [self.managedObjectContext performBlock:^{
         [self updateCachedContent];
     }];
 
-    [self navigateToCommentIDIfNeeded];
+    if (scrollToHighlightedComment) {
+        [self navigateToCommentIDIfNeeded];
+    }
+}
+
+- (void)refreshTableViewAndNoResultsView {
+    [self refreshTableViewAndNoResultsView:YES];
 }
 
 - (void)updateCachedContent
@@ -919,7 +923,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         // Dispatch is used here to address an issue in iOS 15 where some cells could disappear from the screen after `reloadData`.
         // This seems to be affecting the Simulator environment only since I couldn't reproduce it on the device, but I'm fixing it just in case.
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf refreshTableViewAndNoResultsView];
+            [weakSelf refreshTableViewAndNoResultsView:NO];
         });
     };
 
@@ -929,7 +933,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", "Reply Failure Message");
         [weakSelf displayNoticeWithTitle:message message:nil];
 
-        [weakSelf refreshTableViewAndNoResultsView];
+        [weakSelf refreshTableViewAndNoResultsView:NO];
     };
 
     CommentService *service = [[CommentService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -848,33 +848,40 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 /// method locates that comment and scrolls the tableview to display it.
 - (void)navigateToCommentIDIfNeeded
 {
-    if (self.navigateToCommentID != nil) {
-        // Find the comment if it exists
-        NSArray<Comment *> *comments = [self.tableViewHandler.resultsController fetchedObjects];
-        NSArray<Comment *> *filteredComments = [comments filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"commentID == %@", self.navigateToCommentID]];
-        Comment *comment = [filteredComments firstObject];
+    if (self.navigateToCommentID == nil) {
+        return;
+    }
+    double delayInSeconds = 0.5;
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+        [self scrollToCommentID];
+    });
+}
 
-        if (!comment) {
-            return;
-        }
+- (void)scrollToCommentID
+{
+    // Find the comment if it exists
+    NSArray<Comment *> *comments = [self.tableViewHandler.resultsController fetchedObjects];
+    NSArray<Comment *> *filteredComments = [comments filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"commentID == %@", self.navigateToCommentID]];
+    Comment *comment = [filteredComments firstObject];
 
-        // Force the table view to be laid out first before scrolling to indexPath.
-        // This avoids a case where a cell instance could be orphaned and displayed randomly on top of the other cells.
-        NSIndexPath *indexPath = [self.tableViewHandler.resultsController indexPathForObject:comment];
-        [self.tableView layoutIfNeeded];
+    if (!comment) {
+        return;
+    }
 
-        // Ensure that the indexPath exists before scrolling to it.
-        if (indexPath.section >=0
-            && indexPath.row >=0
-            && indexPath.section < self.tableView.numberOfSections
-            && indexPath.row < [self.tableView numberOfRowsInSection:indexPath.section])
-        {
-            [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
-            self.highlightedIndexPath = indexPath;
-        }
+    // Force the table view to be laid out first before scrolling to indexPath.
+    // This avoids a case where a cell instance could be orphaned and displayed randomly on top of the other cells.
+    NSIndexPath *indexPath = [self.tableViewHandler.resultsController indexPathForObject:comment];
+    [self.tableView layoutIfNeeded];
 
-        // Reset the commentID so we don't do this again.
-        self.navigateToCommentID = nil;
+    // Ensure that the indexPath exists before scrolling to it.
+    if (indexPath.section >=0
+        && indexPath.row >=0
+        && indexPath.section < self.tableView.numberOfSections
+        && indexPath.row < [self.tableView numberOfRowsInSection:indexPath.section])
+    {
+        [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
+        self.highlightedIndexPath = indexPath;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16897

It's an improvement for the original fix from https://github.com/wordpress-mobile/WordPress-iOS/pull/23255
In addition to that workaround, I've added a small delay to let the TableView calculate cells' height and render them properly before scrolling to a highlighted comment.

Please let me know if you have any ideas on how to improve it. 
More context: p1709841569628759-slack-C06BWNSR02K

To test:
- [ ] Run the original app from `trunk` and find a comment notification that leads to a post with a big number of comments.
- [ ] Go to the comment details and then to the original comment with the full comments tree.
- [ ] Notice that the list scrolled to a wrong comment instead of the highlighted one.
- [ ] Run the app from this PR and make the same steps with the same comments.
- [ ] Confirm that the list is scrolled to the proper highlighted comment after a few attempts.

## Regression Notes
1. Potential unintended areas of impact
Reader Comments screen `ReaderCommentsViewController`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Legacy code

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)