### PR TITLE
Fix non-scrollable whats new in BlockingUpdateView

### DIFF
--- a/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
@@ -32,9 +32,9 @@ struct BlockingUpdateView: View {
             appInfoView
                 .padding([.top, .bottom], 16)
 
-            whatsNewView
-
-            Spacer()
+            ScrollView {
+                whatsNewView
+            }
 
             DSButton(title: viewModel.latestVersionButtonTitle, style: .init(emphasis: .primary, size: .large)) {
                 onButtonTapped()


### PR DESCRIPTION
Fixes an issue with "What's New" not being scrollable (this also works if text is short).

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/cbf8e5f4-e4c5-4b22-8d83-de08aa09ca18

To test: see CfT.

## Regression Notes
1. Potential unintended areas of impact: Blocking Update View
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
