### PR TITLE
Update Site Switcher Avatars to be Rectangle

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
@@ -159,8 +159,11 @@ struct BlogListView: View {
 
     private func siteHStack(site: Site) -> some View {
         HStack(spacing: 0) {
-            AvatarsView(style: .single(site.imageURL))
-                .padding(.trailing, .DS.Padding.split)
+            AvatarsView(
+                avatarShape: RoundedRectangle(cornerRadius: 5),
+                style: .single(site.imageURL)
+            )
+            .padding(.trailing, .DS.Padding.split)
 
             textsVStack(title: site.title, domain: site.domain)
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
@@ -21,7 +21,7 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
         }()
         let description = notification.renderSnippet()?.string
         let inlineAction = inlineAction(viewModel: viewModel, notification: notification, parent: parent)
-        let avatarStyle = AvatarsView.Style(urls: notification.allAvatarURLs) ?? .single(notification.iconURL)
+        let avatarStyle = AvatarsView<Circle>.Style(urls: notification.allAvatarURLs) ?? .single(notification.iconURL)
         let style = NotificationsTableViewCellContent.Style.regular(
             .init(
                 title: title,

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/AvatarsView.swift
@@ -3,7 +3,7 @@ import Gravatar
 import DesignSystem
 import WordPressUI
 
-struct AvatarsView: View {
+struct AvatarsView<S: Shape>: View {
     enum Style {
         case single(URL?)
         case double(URL?, URL?)
@@ -32,6 +32,7 @@ struct AvatarsView: View {
         }
     }
 
+    private let avatarShape: S
     private let doubleAvatarHorizontalOffset: CGFloat = 18
     private let style: Style
     private let borderColor: Color
@@ -39,10 +40,12 @@ struct AvatarsView: View {
     @ScaledMetric private var scale = 1
 
     init(
+        avatarShape: S = Circle(),
         style: Style,
         borderColor: Color = .DS.Background.primary,
         placeholderImage: Image? = nil
     ) {
+        self.avatarShape = avatarShape
         self.style = style
         self.borderColor = borderColor
         self.placeholderImage = placeholderImage
@@ -53,7 +56,7 @@ struct AvatarsView: View {
         case let .single(primaryURL):
             avatar(url: primaryURL)
                 .overlay {
-                    Circle()
+                    avatarShape
                         .stroke(Color.DS.Foreground.primary.opacity(0.1), lineWidth: 0.5)
                 }
         case let .double(primaryURL, secondaryURL):
@@ -89,7 +92,7 @@ struct AvatarsView: View {
             }
         }
         .frame(width: style.diameter * scale, height: style.diameter * scale)
-        .clipShape(Circle())
+        .clipShape(avatarShape)
     }
 
     private func doubleAvatarView(primaryURL: URL?, secondaryURL: URL?) -> some View {
@@ -97,7 +100,7 @@ struct AvatarsView: View {
             avatar(url: secondaryURL)
                 .padding(.trailing, doubleAvatarHorizontalOffset * scale)
             avatar(url: primaryURL)
-                .avatarBorderOverlay()
+                .avatarBorderOverlay(shape: avatarShape)
                 .padding(.leading, doubleAvatarHorizontalOffset * scale)
         }
     }
@@ -111,11 +114,11 @@ struct AvatarsView: View {
             avatar(url: tertiaryURL)
                 .padding(.trailing, .DS.Padding.medium * scale)
             avatar(url: secondaryURL)
-                .avatarBorderOverlay()
+                .avatarBorderOverlay(shape: avatarShape)
                 .offset(y: -.DS.Padding.split * scale)
                 .padding(.bottom, .DS.Padding.split/2 * scale)
             avatar(url: primaryURL)
-                .avatarBorderOverlay()
+                .avatarBorderOverlay(shape: avatarShape)
                 .padding(.leading, .DS.Padding.medium * scale)
         }
         .padding(.top, .DS.Padding.split)
@@ -155,9 +158,9 @@ extension AvatarsView.Style {
 }
 
 private extension View {
-    func avatarBorderOverlay() -> some View {
+    func avatarBorderOverlay<S: Shape>(shape: S) -> some View {
         self.overlay(
-            Circle()
+            shape
                 .stroke(Color.DS.Background.primary, lineWidth: 1)
         )
     }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -7,7 +7,7 @@ struct NotificationsTableViewCellContent: View {
             let title: AttributedString?
             let description: String?
             let shouldShowIndicator: Bool
-            let avatarStyle: AvatarsView.Style
+            let avatarStyle: AvatarsView<Circle>.Style
             let inlineAction: InlineAction.Configuration?
         }
 


### PR DESCRIPTION
## Description
After a request from @kean , we are updating Site Switcher Images to be rounded rectangle. This PR adds support for AvatarsView to allow that since that component was used on Site Switcher.

## Screenshot Reference
| Site Swithcer | Notifications |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 - 2024-06-05 at 23 48 44](https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/8d610f79-37e6-4b41-9fe8-e2d48bf87737) | ![Simulator Screenshot - iPhone 15 - 2024-06-05 at 23 52 07](https://github.com/wordpress-mobile/WordPress-iOS/assets/15968946/f0224377-0f2d-4724-a40e-09a8e56dcef8) |

## Testing Steps
1. Launch & Login Jetpack app
2. ✅  Navigate to Site Switcher and verify the site icons are rectangle
3. ✅ Navigate to Notifications and verify the avatars are still circles.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
