### PR TITLE
Update nav bar style for Me tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -12,6 +12,7 @@ class MeViewController: UITableViewController {
 
     override init(style: UITableView.Style) {
         super.init(style: style)
+        navigationItem.title = NSLocalizedString("Me", comment: "Me page title")
         clearsSelectionOnViewWillAppear = false
     }
 

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -12,7 +12,6 @@ class MeViewController: UITableViewController {
 
     override init(style: UITableView.Style) {
         super.init(style: style)
-        navigationItem.title = NSLocalizedString("Me", comment: "Me page title")
         clearsSelectionOnViewWillAppear = false
     }
 
@@ -50,6 +49,7 @@ class MeViewController: UITableViewController {
         reloadViewModel()
 
         extendedLayoutIncludesOpaqueBars = true
+        configureDefaultNavigationBarAppearance()
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Addressing this as part of the hack week. Before and after below:

<img width="340" alt="Screenshot 2024-06-05 at 6 36 48 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/d7c6722a-a41a-4991-985c-48ab3f267437">

<img width="340" alt="Screenshot 2024-06-05 at 6 35 48 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/5e2626a9-19f6-46cd-bf8b-f149e1f863d5">

## Regression Notes
1. Potential unintended areas of impact: Me tab
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
