### PR TITLE
Reader: Fix crash in site stream and bug leading to data loss in tag stream

### DIFF
--- a/WordPress/Classes/Services/ReaderPostStreamService.swift
+++ b/WordPress/Classes/Services/ReaderPostStreamService.swift
@@ -41,9 +41,9 @@ class ReaderPostStreamService {
                 }
 
                 // Clean up
-                let serivce = ReaderPostService(coreDataStack: self.coreDataStack)
-                serivce.deletePostsInExcessOfMaxAllowed(for: readerTopic)
-                serivce.deletePostsFromBlockedSites()
+                let service = ReaderPostService(coreDataStack: self.coreDataStack)
+                service.deletePostsInExcessOfMaxAllowed(for: readerTopic)
+                service.deletePostsFromBlockedSites()
             }, completion: {
                 let hasMore = pageHandle != nil
                 success(posts.count, hasMore)

--- a/WordPress/Classes/Services/ReaderPostStreamService.swift
+++ b/WordPress/Classes/Services/ReaderPostStreamService.swift
@@ -62,10 +62,15 @@ class ReaderPostStreamService {
         do {
             let results = try context.fetch(fetchRequest)
             for object in results {
-                guard let objectData = object as? NSManagedObject else { continue }
-                context.delete(objectData)
-
-                // Checar se ta em uso ou foi salvo
+                // do not delete if the post is displayed somewhere or saved by the user.
+                // the content and all the metadata should be updated correctly later while preserving
+                // `inUse` and `isSavedForLater`.
+                guard let post = object as? ReaderPost,
+                      !post.inUse,
+                      !post.isSavedForLater else {
+                    continue
+                }
+                context.delete(post)
             }
         } catch let error {
             print("Clean post error:", error)

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -551,16 +551,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
         NSManagedObjectID * __block topicObjectID = nil;
         [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-            ReaderSiteTopic *siteTopic = nil;
-            if (isFeed) {
-                siteTopic = [ReaderSiteTopic lookupWithFeedID:siteID inContext:context];
-            } else {
-                siteTopic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:context];
-            }
-            if (siteTopic) {
-                [context deleteObject:siteTopic];
-            }
-
+            // always upsert new data to existing site topic.
             ReaderSiteTopic *topic = [self siteTopicForRemoteSiteInfo:siteInfo inContext:context];
             [context obtainPermanentIDsForObjects:@[topic] error:nil];
             topicObjectID = topic.objectID;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5751,6 +5751,7 @@
 		FEE48EFC2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFD2A4C8312008A48E0 /* Blog+JetpackSocial.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */; };
 		FEE48EFF2A4C9855008A48E0 /* Blog+PublicizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */; };
+		FEE54C4C2C12393A00740A68 /* ReaderPostStreamServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE54C4B2C12393A00740A68 /* ReaderPostStreamServiceTest.swift */; };
 		FEF207F42AF2903E0025CB2C /* BloggingPromptRemoteObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */; };
 		FEF207F52AF2904D0025CB2C /* BloggingPromptRemoteObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */; };
 		FEF28E822ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */; };
@@ -9641,6 +9642,7 @@
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+JetpackSocial.swift"; sourceTree = "<group>"; };
 		FEE48EFE2A4C9855008A48E0 /* Blog+PublicizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+PublicizeTests.swift"; sourceTree = "<group>"; };
+		FEE54C4B2C12393A00740A68 /* ReaderPostStreamServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostStreamServiceTest.swift; sourceTree = "<group>"; };
 		FEF207F22AF2882A0025CB2C /* BloggingPromptRemoteObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptRemoteObject.swift; sourceTree = "<group>"; };
 		FEF28E812ACB3DCE006C6579 /* ReaderDetailNewHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailNewHeaderView.swift; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
@@ -15878,6 +15880,7 @@
 				5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */,
 				4AEF2DD829A84B2C00345734 /* ReaderSiteServiceTests.swift */,
 				E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */,
+				FEE54C4B2C12393A00740A68 /* ReaderPostStreamServiceTest.swift */,
 				FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */,
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 				40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */,
@@ -24294,6 +24297,7 @@
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				932645A41E7C206600134988 /* GutenbergSettingsTests.swift in Sources */,
 				933D1F471EA64108009FB462 /* TestingAppDelegate.m in Sources */,
+				FEE54C4C2C12393A00740A68 /* ReaderPostStreamServiceTest.swift in Sources */,
 				0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */,
 				C8567498243F41CA001A995E /* MockTenorService.swift in Sources */,
 				1D19C56629C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderPostStreamServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderPostStreamServiceTest.swift
@@ -1,0 +1,109 @@
+import XCTest
+import OHHTTPStubs
+
+@testable import WordPress
+
+final class ReaderPostStreamServiceTest: CoreDataTestCase {
+
+    lazy var service: ReaderPostStreamService = {
+        return .init(coreDataStack: contextManager)
+    }()
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+
+        super.tearDown()
+    }
+
+    // MARK: Tests
+
+    func testFetchPostsNotRemovingPostsInUseOrSaved() async throws {
+        // Given
+        let slug = "test"
+        let postCount = 5
+        let postIDInUse = 1
+        let postIDSaved = 3
+
+        stubFetchPostsReturningEmptyResults()
+
+        // Seed tag locally
+        let tag = try makeTag(slug)
+        let posts = try seedPosts(for: tag, count: postCount)
+
+        // Mark a post as in use
+        let postInUse = try XCTUnwrap(posts.first { $0.postID?.intValue == postIDInUse })
+        postInUse.inUse = true
+
+        // Mark a post as saved
+        let savedPost = try XCTUnwrap(posts.first { $0.postID?.intValue == postIDSaved })
+        savedPost.isSavedForLater = true
+
+        try mainContext.save()
+
+        // When
+        try await withCheckedThrowingContinuation { continuation in
+            service.fetchPosts(for: tag, isFirstPage: true) { _, _ in
+                continuation.resume()
+            } failure: { error in
+                continuation.resume(throwing: error!)
+            }
+        }
+
+        // Then
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderPost.classNameWithoutNamespaces())
+        request.predicate = NSPredicate(format: "topic == %@", tag)
+        let count = try mainContext.count(for: request)
+
+        // Ensure that posts in use or saved are not wiped
+        XCTAssertEqual(count, 2)
+    }
+
+}
+
+// MARK: - Private helpers
+
+private extension ReaderPostStreamServiceTest {
+
+    @discardableResult
+    func makeTag(_ slug: String) throws -> ReaderTagTopic {
+        let topic = ReaderTagTopic(context: mainContext)
+        topic.title = slug
+        topic.path = "/tags/\(slug)"
+        topic.type = ReaderTagTopic.TopicType
+
+        try mainContext.save()
+        return topic
+    }
+
+    @discardableResult
+    func seedPosts(for topic: ReaderAbstractTopic, count: Int = 3) throws -> [ReaderPost] {
+        var posts = [ReaderPost]()
+        for i in 0..<count {
+            let post = ReaderPost(context: mainContext)
+            post.postID = NSNumber(value: i)
+            post.postTitle = "post\(i)"
+            post.content = "post\(i)"
+            post.topic = topic
+            posts.append(post)
+        }
+
+        try mainContext.save()
+        return posts
+    }
+
+    func stubFetchPostsReturningEmptyResults() {
+        stub(condition: isPath("read/tags/posts")) { _ in
+            let responseObject: [String: Any] = [
+                "success": true,
+                "tags": [],
+                "sort": "date",
+                "lang": "en",
+                "page": 1,
+                "posts": []
+            ]
+
+            return HTTPStubsResponse(jsonObject: responseObject, statusCode: 200, headers: nil)
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #22165

This PR fixes two issues in the Reader:

1. As described in https://github.com/wordpress-mobile/WordPress-iOS/issues/22165#issuecomment-2134116245, when navigating to the same site stream multiple times, the site topic could be deleted, causing the post objects to be faulted when they're still being displayed in the previous screens. Any access to the faulted object's properties raises an exception.
    - **Root cause:** When requesting for a `ReaderSiteTopic`, any existing site topic having the same site ID gets deleted from context. The problem is, `ReaderSiteTopic` has a cascade delete relationship with posts, which turns all post objects in the previous screens into a fault.
    - https://github.com/wordpress-mobile/WordPress-iOS/commit/a94ca1fafe516d3e6fbbde32dba0fa2a3aee09f2 solves this by not deleting the existing site topic whenever we're requesting a new site topic. If there's an existing one, the method `[self siteTopicForRemoteSiteInfo:siteInfo inContext:context];` already performs an upsert. This means that if we have several site streams (for the same site) on the navigation stack, they will all reference the same site topic.

2. When performing a pull-to-refresh on the tag stream, the service wipes out all posts associated with the tag, and this could also delete saved posts (i.e., data loss).
    - **Root cause:** `ReaderPostStreamService` is used to fetch data for tag streams. When fetching data for the first page, the service wipes all data related to the tag, but there's no check in place for posts that are in use or saved.
    - https://github.com/wordpress-mobile/WordPress-iOS/commit/62703dae563cd560babaf239b8291448d9ed0896 solves this by skipping posts that are in use (`inUse == true`) or saved (`isSavedForLater == true`) when deleting posts associated to the tag. The fetch operation merges the new remote object with existing objects based on the `globalID` property (see `ReaderPost.createOrReplace`). Since `inUse` and `isSavedForLater` is purely a client-side property, it won't be overridden by the values from remote.

## To test

Run the unit tests and ensure they pass 🟢 . In addition, here are the manual testing steps for each scenario:

### Case 1: Crash when previewing site

Follow the reproduction steps described in https://github.com/wordpress-mobile/WordPress-iOS/issues/22165#issuecomment-2134116245:

1. Launch the Jetpack app
2. Navigate to Reader
3. From the Discover stream, tap any post
4. Tap the site title to go into the site stream (stream no. 1)
5. Tap any post from the site stream
6. Tap the site title to go into the site stream again (stream no. 2)
7. Tap any post from the site stream again
8. Tap the site title to go into the site stream again (stream no. 3)
9. Tap back
10. Tap the site title
11. 🔎 Verify that the app does not crash

### Case 2: Saved post loss in Tags stream

Ensure that you at least follow one tag.

1. Launch the Jetpack app
2. Navigate to Reader
3. Go to the 'Your Tags' stream
4. On one of the tags, scroll to the end and tap 'More'
5. In the Tags stream page, tap the ellipsis button on the first post and tap 'Save'
6. Perform a pull-to-refresh
7. Find the post that you've saved before
8. 🔎 Verify that when tapping the ellipsis menu, the menu item says 'Remove Saved Post' (or the equivalent in your locale)
9. Go to the 'Saved' stream from the stream switcher
10. 🔎 Verify that the post is visible in this stream

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes

4. What automated tests I added (or what prevented me from doing so)
Added unit tests to cover the specific scenarios covered by this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

