### PR TITLE
Offline Mode: Remove Deprecated Code – P10

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -114,7 +114,7 @@ class PostCoordinator: NSObject {
 
         do {
             let repository = PostRepository(coreDataStack: coreDataStack)
-            try await repository._save(post, changes: parameters)
+            try await repository.save(post, changes: parameters)
             didPublish(post)
             show(PostCoordinator.makeUploadSuccessNotice(for: post))
         } catch {
@@ -148,7 +148,7 @@ class PostCoordinator: NSObject {
 
         do {
             let previousStatus = post.status
-            try await PostRepository()._save(post, changes: changes)
+            try await PostRepository().save(post, changes: changes)
             show(PostCoordinator.makeUploadSuccessNotice(for: post, previousStatus: previousStatus))
             return post
         } catch {
@@ -166,7 +166,7 @@ class PostCoordinator: NSObject {
 
         let post = post.original()
         do {
-            try await PostRepository(coreDataStack: coreDataStack)._update(post, changes: changes)
+            try await PostRepository(coreDataStack: coreDataStack).update(post, changes: changes)
         } catch {
             trackError(error, operation: "post-patch")
             handleError(error, for: post)
@@ -896,7 +896,7 @@ class PostCoordinator: NSObject {
         defer { resumeSyncing(for: post) }
 
         do {
-            try await PostRepository(coreDataStack: coreDataStack)._trash(post)
+            try await PostRepository(coreDataStack: coreDataStack).trash(post)
 
             MediaCoordinator.shared.cancelUploadOfAllMedia(for: post)
             SearchManager.shared.deleteSearchableItem(post)
@@ -914,7 +914,7 @@ class PostCoordinator: NSObject {
         defer { setUpdating(false, for: post) }
 
         do {
-            try await PostRepository(coreDataStack: coreDataStack)._delete(post)
+            try await PostRepository(coreDataStack: coreDataStack).delete(post)
         } catch {
             trackError(error, operation: "post-delete")
             handleError(error, for: post)

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -105,18 +105,14 @@ final class PostRepository {
     ///   or its latest revision.
     ///   - overwrite: Set to `true` to overwrite the values on the server and
     ///   ignore the ``PostSaveError/conflict(latest:)`` error.
-    ///
-    /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
-    func _save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil, overwrite: Bool = false) async throws {
+    func save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil, overwrite: Bool = false) async throws {
         try await _sync(post, revision: post.latest(), changes: changes, overwrite: overwrite)
     }
 
     /// Syncs revisions that have unsaved changes (see `isSyncNeeded`).
     ///
     /// - note: This method is designed to be used with drafts.
-    ///
-    /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
     func sync(_ post: AbstractPost, revision: AbstractPost? = nil) async throws {
         wpAssert(post.original == nil, "Must be called on an original post")
@@ -202,7 +198,7 @@ final class PostRepository {
     /// - note: This method can be used for quick edits for published posts where
     /// revisions are used only for content.
     @MainActor
-    func _update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
+    func update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
         wpAssert(post.isOriginal())
 
         guard post.revision == nil else {
@@ -269,9 +265,10 @@ final class PostRepository {
         }
     }
 
-    /// - warning: Work-in-progress (kahu-offline-mode)
+    /// Resolves the conflict by overwriting the changes made locally with the
+    /// selected remote revision.
     @MainActor
-    func _resolveConflict(for post: AbstractPost, pickingRemoteRevision revision: RemotePost) throws {
+    func resolveConflict(for post: AbstractPost, pickingRemoteRevision revision: RemotePost) throws {
         let context = coreDataStack.mainContext
         post.deleteRevision()
         PostHelper.update(post, with: revision, in: context)
@@ -281,9 +278,8 @@ final class PostRepository {
     /// Trashes the given post.
     ///
     /// - warning: This method delets all local revision of the post.
-    /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
-    func _trash(_ post: AbstractPost) async throws {
+    func trash(_ post: AbstractPost) async throws {
         wpAssert(post.isOriginal())
 
         let context = coreDataStack.mainContext
@@ -320,9 +316,8 @@ final class PostRepository {
     }
 
     /// Permanently delete the given post.
-    /// - warning: Work-in-progress (kahu-offline-mode)
     @MainActor
-    func _delete(_ post: AbstractPost) async throws {
+    func delete(_ post: AbstractPost) async throws {
         wpAssert(post.isOriginal())
 
         let context = coreDataStack.mainContext

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -249,11 +249,11 @@ final class PostRepository {
                 let remotePost = try await service.post(withID: postID)
                 // Check for false positives
                 if changes.content != nil && remotePost.content != changes.content && remotePost.content != original.content {
-                    WPAnalytics.track(.postRepositoryConflictEncountered, properties: ["false-positive": false])
+                    WPAnalytics.track(.postRepositoryConflictEncountered, properties: ["false_positive": false])
                     // The conflict in content can be resolved only manually
                     throw PostSaveError.conflict(latest: remotePost)
                 }
-                WPAnalytics.track(.postRepositoryConflictEncountered, properties: ["false-positive": true])
+                WPAnalytics.track(.postRepositoryConflictEncountered, properties: ["false_positive": true])
 
                 // There is no conflict, so go ahead and overwrite the changes
                 changes.ifNotModifiedSince = nil

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -710,7 +710,7 @@ class AbstractPostListViewController: UIViewController,
         alert.addDestructiveActionWithTitle(Strings.Delete.actionTitle) { _ in
             completion()
             Task {
-                await PostCoordinator.shared._delete(post)
+                await PostCoordinator.shared.delete(post)
             }
         }
         alert.presentFromRootViewController()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -36,7 +36,7 @@ extension PostEditor {
                     SVProgressHUD.show(withStatus: Strings.savingDraft)
 
                     let original = post.original()
-                    try await coordinator._save(original)
+                    try await coordinator.save(original)
                     self.post = original
                     self.createRevisionOfPost()
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -148,7 +148,7 @@ extension PublishingEditor {
 
         Task { @MainActor in
             do {
-                let post = try await PostCoordinator.shared._save(post, changes: changes)
+                let post = try await PostCoordinator.shared.save(post, changes: changes)
                 self.post = post
                 self.createRevisionOfPost()
                 self.trackPostSave(stat: analyticsStat)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -91,7 +91,7 @@ extension PostSettingsViewController {
                 if coordinator.isSyncAllowed(for: apost) {
                     coordinator.setNeedsSync(for: apost)
                 } else {
-                    try await coordinator._save(apost)
+                    try await coordinator.save(apost)
                 }
                 presentingViewController?.dismiss(animated: true)
             } catch {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -563,7 +563,7 @@ private final class PrepublishingViewModel {
     func publish() async throws {
         wpAssert(post.isRevision())
 
-        try await coordinator._publish(post.original(), options: .init(
+        try await coordinator.publish(post.original(), options: .init(
             visibility: visibility.type,
             password: visibility.password,
             publishDate: publishDate

--- a/WordPress/Classes/ViewRelated/Post/ResolveConflictView.swift
+++ b/WordPress/Classes/ViewRelated/Post/ResolveConflictView.swift
@@ -78,7 +78,7 @@ struct ResolveConflictView: View {
     private func handleLocalVersionSelected(for post: AbstractPost) {
         Task { @MainActor in
             do {
-                try await repository._save(post, overwrite: true)
+                try await repository.save(post, overwrite: true)
                 PostCoordinator.shared.didResolveConflict(for: post)
                 dismiss?()
             } catch {
@@ -91,7 +91,7 @@ struct ResolveConflictView: View {
     @MainActor
     private func handleRemoteVersionSelected(for post: AbstractPost, remoteRevision: RemotePost) {
         do {
-            try repository._resolveConflict(for: post, pickingRemoteRevision: remoteRevision)
+            try repository.resolveConflict(for: post, pickingRemoteRevision: remoteRevision)
             PostCoordinator.shared.didResolveConflict(for: post)
             dismiss?()
         } catch {

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -406,7 +406,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         await fulfillment(of: [expectation], timeout: 2)
 
         // WHEN
-        try await coordinator._publish(post, options: .init(visibility: .public, password: nil, publishDate: nil))
+        try await coordinator.publish(post, options: .init(visibility: .public, password: nil, publishDate: nil))
 
         // THEN the coordinator wait for the sync to complete and the post to
         // be created and only then sends a parial update to get it published
@@ -461,7 +461,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await coordinator._publish(post, options: .init(visibility: .public, password: nil, publishDate: nil))
+        try await coordinator.publish(post, options: .init(visibility: .public, password: nil, publishDate: nil))
 
         // THEN
         XCTAssertEqual(post.publicizeMessage, "message-a")
@@ -539,7 +539,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await coordinator._save(post)
+        try await coordinator.save(post)
 
         // THEN all changes were synced
         XCTAssertEqual(post.content, "content-c")
@@ -573,7 +573,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
         // WHEN
         do {
-            try await coordinator._save(post)
+            try await coordinator.save(post)
             XCTFail("Expected a failure")
         } catch {
             // Expect an error

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -64,7 +64,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN the post was created
         XCTAssertEqual(post.postID, 974)
@@ -143,7 +143,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN the post was created
         XCTAssertEqual(post.postID, 974)
@@ -191,7 +191,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // WHEN publishing a post
         var parameters = RemotePostUpdateParameters()
         parameters.status = Post.Status.publish.rawValue
-        try await repository._save(post, changes: parameters)
+        try await repository.save(post, changes: parameters)
 
         // THEN the post is published
         XCTAssertEqual(post.postID, 974)
@@ -240,7 +240,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // WHEN publishing a post
         var parameters = RemotePostUpdateParameters()
         parameters.status = Post.Status.scheduled.rawValue
-        try await repository._save(post, changes: parameters)
+        try await repository.save(post, changes: parameters)
 
         // THEN the post is scheduled
         XCTAssertEqual(post.postID, 974)
@@ -288,7 +288,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         var parameters = RemotePostUpdateParameters()
         parameters.status = Post.Status.publish.rawValue
         do {
-            try await repository._save(post, changes: parameters)
+            try await repository.save(post, changes: parameters)
             XCTFail("Expected the save to fail")
         } catch {
             let error = try XCTUnwrap((error as NSError).underlyingErrors.first)
@@ -332,7 +332,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // WHEN publishing the post
         var parameters = RemotePostUpdateParameters()
         parameters.status = Post.Status.publish.rawValue
-        try await repository._save(post, changes: parameters)
+        try await repository.save(post, changes: parameters)
 
         // THEN the post got published
         XCTAssertEqual(post.status, .publish)
@@ -373,7 +373,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN saving the post
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN the title got updated
         XCTAssertEqual(post.postTitle, "new-title")
@@ -425,7 +425,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         var parameters = RemotePostUpdateParameters()
         parameters.status = Post.Status.publish.rawValue
         parameters.date = dateCreated.addingTimeInterval(5)
-        try await repository._save(post, changes: parameters)
+        try await repository.save(post, changes: parameters)
 
         // THEN the post got published
         XCTAssertEqual(post.status, .publish)
@@ -508,7 +508,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN saving the post
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN the title got updated
         XCTAssertEqual(post.postTitle, "title-b")
@@ -552,7 +552,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN saving the post
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN post got updated and the status now reflects the status on backend
         XCTAssertEqual(post.status, .trash)
@@ -592,7 +592,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         // WHEN saving the post with changes but without creating a new revision
         var changes = RemotePostUpdateParameters()
         changes.isSticky = true
-        try await repository._save(post, changes: changes)
+        try await repository.save(post, changes: changes)
 
         // THEN post got updated
         XCTAssertTrue(post.isStickyPost)
@@ -636,7 +636,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
 
         // WHEN saving the post that was deleted on the backend
         do {
-            try await repository._save(post)
+            try await repository.save(post)
             XCTFail("Expected the save to fail")
         } catch {
             let error = try XCTUnwrap(error as? PostRepository.PostSaveError)
@@ -698,7 +698,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         var latest: RemotePost!
         do {
             // WHEN
-            try await repository._save(post)
+            try await repository.save(post)
             XCTFail("Expected the request to fail")
         } catch {
             let error = try XCTUnwrap(error as? PostRepository.PostSaveError)
@@ -712,7 +712,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN the user resolves a conflict by picking the server revision
-        try repository._resolveConflict(for: post, pickingRemoteRevision: latest)
+        try repository.resolveConflict(for: post, pickingRemoteRevision: latest)
 
         // THEN the content got updated to the server's version
         XCTAssertEqual(post.content, "content-c")
@@ -799,7 +799,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
 
         do {
             // WHEN
-            try await repository._save(post)
+            try await repository.save(post)
             XCTFail("Expected the request to fail")
         } catch {
             let error = try XCTUnwrap(error as? PostRepository.PostSaveError)
@@ -813,7 +813,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN the user picks the local version and overwrites what's on the remote
-        try await repository._save(post, overwrite: true)
+        try await repository.save(post, overwrite: true)
 
         // THEN the content got updated to the version from the local revision
         XCTAssertEqual(post.content, "content-b")
@@ -900,7 +900,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             try HTTPStubsResponse(value: serverPost, statusCode: 200)
         }
 
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN the content got updated to the version from the local revision
         XCTAssertEqual(post.content, "content-b")
@@ -986,7 +986,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             try HTTPStubsResponse(value: serverPost, statusCode: 200)
         }
 
-        try await repository._save(post)
+        try await repository.save(post)
 
         // THEN the content got updated to the version from the local revision
         XCTAssertEqual(post.content, "content-b")
@@ -1051,7 +1051,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
 
         // WHEN saving the post that was deleted on the backend
         do {
-            try await repository._save(post)
+            try await repository.save(post)
             XCTFail("Expected the save to fail")
         } catch {
             let error = try XCTUnwrap(error as? PostRepository.PostSaveError)
@@ -1376,7 +1376,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await repository._trash(post)
+        try await repository.trash(post)
 
         // THEN the post is deleted
         XCTAssertNil(post.managedObjectContext)
@@ -1405,7 +1405,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await repository._trash(post)
+        try await repository.trash(post)
 
         // THEN the post is trashed
         XCTAssertEqual(post.status, .trash)
@@ -1436,7 +1436,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // WHEN
-        try await repository._trash(post)
+        try await repository.trash(post)
 
         // THEN the post is trashed
         XCTAssertEqual(post.status, .trash)
@@ -1466,7 +1466,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
 
         // WHEN
         do {
-            try await repository._trash(post)
+            try await repository.trash(post)
             XCTFail("Expected failure")
         } catch {
             let error = try XCTUnwrap(error as? PostRepository.PostSaveError)


### PR DESCRIPTION
- Remove the `work-in-progress` markers and rename the methods that previous had underscores to ensure that don't collide with the existing ones
- Fix `.postRepositoryConflictEncountered` tracking (it was using the wrong format for a key)

To test: n/a

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
