### PR TITLE
Offline Mode: Remove Deprecated Code – P11

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -68,11 +68,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 // Revision management
 - (AbstractPost *)createRevision;
-/// A new version of `createRevision` that allows you to create revisions based
-/// on other revisions.
-/// 
-/// - warning: Work-in-progress (kahu-offline-mode)
-- (AbstractPost *)_createRevision;
 - (void)deleteRevision;
 - (void)applyRevision;
 - (AbstractPost *)updatePostFrom:(AbstractPost *)revision;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -97,23 +97,6 @@
 
 - (AbstractPost *)createRevision
 {
-    if ([self isRevision]) {
-        DDLogInfo(@"Post is already a revision, no need to create a new one");
-        return self;
-    }
-    if (self.revision) {
-        DDLogInfo(@"Returning existing revision");
-        return self.revision;
-    }
-
-    AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];
-    [post cloneFrom:self];
-    [post setValue:self forKey:@"original"];
-    [post setValue:nil forKey:@"revision"];
-    return post;
-}
-
-- (AbstractPost *)_createRevision {
     NSParameterAssert(self.revision == nil);
 
     AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -346,7 +346,7 @@ extension PublishingEditor {
 
         if !post.isUnsavedRevision && post.status != .trash {
             DDLogDebug("Creating new revision")
-            post = post._createRevision()
+            post = post.createRevision()
         }
 
         if loadAutosaveRevision {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -17,7 +17,7 @@ extension PostSettingsViewController {
     }
 
     static func showStandaloneEditor(for post: AbstractPost, from presentingViewController: UIViewController) {
-        let revision = post._createRevision()
+        let revision = post.createRevision()
         let viewController = PostSettingsViewController.make(for: revision)
         viewController.isStandalone = true
         let navigation = UINavigationController(rootViewController: viewController)

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -51,7 +51,7 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         // If presented from the editor, it make changes to the revision managed by
         // the editor. But for a standalone publishing sheet, it has to manage
         // its own revision.
-        self.post = isStandalone ? post._createRevision() : post
+        self.post = isStandalone ? post.createRevision() : post
         self.isStandalone = isStandalone
         self.viewModel = PrepublishingViewModel(post: self.post)
         self.uploadsViewModel = PostMediaUploadsViewModel(post: post)

--- a/WordPress/WordPressTest/AbstractPostTest.swift
+++ b/WordPress/WordPressTest/AbstractPostTest.swift
@@ -44,13 +44,13 @@ class AbstractPostTest: CoreDataTestCase {
         XCTAssertNil(post.getLatestRevisionNeedingSync())
 
         // GIVEN a post with a revision that doesn't need sync
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
 
         // THEN
         XCTAssertNil(post.getLatestRevisionNeedingSync())
 
         // GIVEN a post with a revision that needs sync
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.remoteStatus = .syncNeeded
 
         // THEN
@@ -60,9 +60,9 @@ class AbstractPostTest: CoreDataTestCase {
     func testDeleteSyncedRevisions() {
         // GIVEN a post with three revisions
         let post = PostBuilder(mainContext).build()
-        let revision1 = post._createRevision()
-        let revision2 = revision1._createRevision()
-        let revision3 = revision2._createRevision()
+        let revision1 = post.createRevision()
+        let revision2 = revision1.createRevision()
+        let revision3 = revision2.createRevision()
 
         // WHEN
         post.deleteSyncedRevisions(until: revision2)
@@ -78,8 +78,8 @@ class AbstractPostTest: CoreDataTestCase {
     func testDeleteRevisionDeletsAll() {
         // GIVEN a post with two revisions
         let post = PostBuilder(mainContext).build()
-        let revision1 = post._createRevision()
-        let revision2 = revision1._createRevision()
+        let revision1 = post.createRevision()
+        let revision2 = revision1.createRevision()
 
         // WHEN
         post.deleteAllRevisions()

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -37,7 +37,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.status = .draft
         post.authorID = 29043
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.content = "content-a"
 
@@ -62,7 +62,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.status = .draft
         post.authorID = 29043
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.content = "content-a"
 
@@ -100,7 +100,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.status = .draft
         post.authorID = 29043
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-a"
         revision1.content = "content-a"
 
@@ -108,7 +108,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/new")) { _ in
             XCTAssertFalse(Thread.isMainThread)
             DispatchQueue.main.sync {
-                let revision2 = revision1._createRevision()
+                let revision2 = revision1.createRevision()
                 revision2.postTitle = "title-b"
                 self.coordinator.setNeedsSync(for: revision2)
             }
@@ -164,7 +164,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         // important otherwise MediaService will use temporary objectID and fail
         try mainContext.save()
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.media = [media]
         let uploadID = media.gutenbergUploadID
@@ -203,7 +203,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.status = .draft
         post.authorID = 29043
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.content = "content-a"
 
@@ -263,7 +263,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         // important otherwise MediaService will use temporary objectID and fail
         try mainContext.save()
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.media = [media]
         let uploadID = media.gutenbergUploadID
@@ -282,7 +282,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         coordinator.setNeedsSync(for: revision1)
         await fulfillment(of: [expectation], timeout: 2)
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.media = []
         revision2.content = "empty"
 
@@ -309,7 +309,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.postTitle = "title-b"
         post.content = "content-a"
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.content = "content-b"
 
         // GIVEN a server where the post was deleted
@@ -342,7 +342,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.status = .draft
         post.authorID = 29043
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.content = "content-a"
 
@@ -374,12 +374,12 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.status = .draft
         post.authorID = 29043
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-a"
         revision1.content = "content-a"
 
         // WHEN a slug was changes during the current editor session
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.wp_slug = "hello"
 
         // GIVEN
@@ -433,7 +433,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.bloggingPromptID = "prompt-a"
 
         // GIVEN an editor revision
-        let revision = post._createRevision() as! Post
+        let revision = post.createRevision() as! Post
         revision.publicizeMessage = "message-a"
 
         // GIVEN
@@ -479,15 +479,15 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.authorID = 29043
         post.content = "content-a"
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.content = "content-b"
         revision1.remoteStatus = .syncNeeded
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.content = "content-c"
         revision2.remoteStatus = .syncNeeded
 
-        let revision3 = revision2._createRevision()
+        let revision3 = revision2.createRevision()
         revision3.content = "content-d"
         XCTAssertFalse(revision3.isSyncNeeded)
 
@@ -521,11 +521,11 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.authorID = 29043
         post.content = "content-a"
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.content = "content-b"
         revision1.remoteStatus = .syncNeeded
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.content = "content-c"
 
         try mainContext.save()
@@ -557,11 +557,11 @@ class PostCoordinatorTests: CoreDataTestCase {
         post.authorID = 29043
         post.content = "content-a"
 
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.content = "content-b"
         revision1.remoteStatus = .syncNeeded
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.content = "content-c"
 
         try mainContext.save()

--- a/WordPress/WordPressTest/PostRepositorySaveTests.swift
+++ b/WordPress/WordPressTest/PostRepositorySaveTests.swift
@@ -1083,16 +1083,16 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // GIVEN a post that has changes that need to be synced (across two local revision)
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.remoteStatus = .syncNeeded
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.postTitle = "title-c"
         revision2.remoteStatus = .syncNeeded
 
         // GIVEN a revision created by an editor
-        let revision3 = revision2._createRevision()
+        let revision3 = revision2.createRevision()
         revision3.postTitle = "title-d"
 
         // GIVEN a server where the post was deleted
@@ -1165,11 +1165,11 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // GIVEN a post that has changes that need to be synced (across two local revision)
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.content = "content-b"
         revision1.remoteStatus = .syncNeeded
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.content = "content-c"
 
         // GIVEN a server where the post was deleted
@@ -1282,11 +1282,11 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // GIVEN a change that was reverted in a more recent revision
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-b"
         revision1.remoteStatus = .syncNeeded
 
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.postTitle = "title-a"
         revision2.remoteStatus = .syncNeeded
 
@@ -1319,13 +1319,13 @@ class PostRepositorySaveTests: CoreDataTestCase {
         }
 
         // GIVEN a saved revision
-        let revision1 = post._createRevision()
+        let revision1 = post.createRevision()
         revision1.postTitle = "title-a"
         revision1.content = "content-a"
         revision1.remoteStatus = .syncNeeded
 
         // GIVEN a local revision
-        let revision2 = revision1._createRevision()
+        let revision2 = revision1.createRevision()
         revision2.postTitle = "title-b"
 
         // GIVEN a server accepting the new post
@@ -1391,7 +1391,7 @@ class PostRepositorySaveTests: CoreDataTestCase {
             $0.content = "content-a"
         }
 
-        let revision = post._createRevision()
+        let revision = post.createRevision()
         revision.content = "content-b"
 
         // GIVEN


### PR DESCRIPTION
This PR removes the deprecated `createRevision` version. The main difference in the new one is that it doesn't stop you from making more than one revision, and it was critical to implement certain workflows.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
