### PR TITLE
Reader: Fix crash when stacking site streams of the same type

### DIFF
--- a/WordPress/Classes/Services/ReaderPostStreamService.swift
+++ b/WordPress/Classes/Services/ReaderPostStreamService.swift
@@ -41,9 +41,9 @@ class ReaderPostStreamService {
                 }
 
                 // Clean up
-                let serivce = ReaderPostService(coreDataStack: self.coreDataStack)
-                serivce.deletePostsInExcessOfMaxAllowed(for: readerTopic)
-                serivce.deletePostsFromBlockedSites()
+                let service = ReaderPostService(coreDataStack: self.coreDataStack)
+                service.deletePostsInExcessOfMaxAllowed(for: readerTopic)
+                service.deletePostsFromBlockedSites()
             }, completion: {
                 let hasMore = pageHandle != nil
                 success(posts.count, hasMore)

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -551,16 +551,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
         NSManagedObjectID * __block topicObjectID = nil;
         [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-            ReaderSiteTopic *siteTopic = nil;
-            if (isFeed) {
-                siteTopic = [ReaderSiteTopic lookupWithFeedID:siteID inContext:context];
-            } else {
-                siteTopic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:context];
-            }
-            if (siteTopic) {
-                [context deleteObject:siteTopic];
-            }
-
+            // always upsert new data to existing site topic.
             ReaderSiteTopic *topic = [self siteTopicForRemoteSiteInfo:siteInfo inContext:context];
             [context obtainPermanentIDsForObjects:@[topic] error:nil];
             topicObjectID = topic.objectID;


### PR DESCRIPTION
Fixes #22165
Cherry-picked from #23317 

As described in https://github.com/wordpress-mobile/WordPress-iOS/issues/22165#issuecomment-2134116245, when navigating to the same site stream multiple times, the site topic could be deleted, causing the post objects to be faulted when they're still being displayed in the previous screens. Any access to the faulted object's properties raises an exception.

**Root cause:** When requesting a `ReaderSiteTopic`, any existing site topic with the same site ID gets deleted from the context. The problem is that `ReaderSiteTopic` has a cascade delete relationship with posts, which turns all post objects in the previous screens into a fault.

https://github.com/wordpress-mobile/WordPress-iOS/pull/23330/commits/07994ad845abc01ef5f32e0d659f968b82dab500 solves this by not deleting the existing site topic whenever we request a new one. If the site topic already exists, the method `[self siteTopicForRemoteSiteInfo:siteInfo inContext:context];` performs an upsert. This means that if we have several site streams (for the same site) on the navigation stack, they will all reference the same site topic.

## To test

Run the unit tests and ensure they pass 🟢 . In addition, here are the manual testing steps for each scenario:

1. Launch the Jetpack app
2. Navigate to Reader
3. From the Discover stream, tap any post
4. Tap the site title to go into the site stream (stream no. 1)
5. Tap any post from the site stream
6. Tap the site title to go into the site stream again (stream no. 2)
7. Tap any post from the site stream again
8. Tap the site title to go into the site stream again (stream no. 3)
9. Tap back
10. Tap the site title
11. 🔎 Verify that the app does not crash

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes

4. What automated tests I added (or what prevented me from doing so)
Added unit tests to cover the specific scenarios covered by this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)

