### PR TITLE
Add Publish Date button to Post Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 25.1
 -----
 * [*] [internal] Block editor: Add onContentUpdate bridge functionality [#23234]
+* [*] Add Publish Date option to Post Settings for draft and pending posts [#23333]
 * [*] Fix a rare crash when trashing posts [#23321]
 
 25.0

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -298,6 +298,21 @@
     return NO;
 }
 
+/// - warning: There are multiple pitfalls with how the "Publish Date" field
+/// is represented in the WordPress API and database.
+///
+/// When you just create a draft for the first time without setting a custom
+/// "Publish Date", the `date` field contains the creation date of a draft.
+/// However, WordPress also uses the same `date` field to represent the
+/// "Publish Date" if it's set to a custom value. How does it know if the `date`
+/// field means "Creation" or "Publish" date? If `date` equals `dateModified`,
+/// then WordPress thinks the "Publish" date is not set, and the post should be
+/// published immediately. But `dateModified` gets updated every time you make
+/// changes to a post, so how does it solve it? It automatically sets `date`
+/// to `dateModified` every time you modify the post, losing its original value.
+///
+/// - warning: If you pass `date` in the original request to create a draft post,
+/// WordPress sets `dateModified` to the same date (in the future or past).
 - (BOOL)shouldPublishImmediately
 {
     /// - warning: Yes, this is WordPress logic and it matches the behavior on

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -104,13 +104,7 @@ class PostCoordinator: NSObject {
         if (latest.password ?? "") != (options.password ?? "") {
             parameters.password = options.password
         }
-        if let publishDate = options.publishDate {
-            parameters.date = publishDate
-        } else {
-            // If the post was previously scheduled for a different date,
-            // the app has to send a new value to override it.
-            parameters.date = post.shouldPublishImmediately() ? nil : Date()
-        }
+        parameters.date = options.publishDate ?? .now
 
         do {
             let repository = PostRepository(coreDataStack: coreDataStack)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -99,7 +99,7 @@ extension PublishingEditor {
         mapUIContentToPostAndSave(immediate: true)
 
         switch action {
-        case .publish:
+        case .publish, .schedule:
             showPublishingConfirmation(for: action, analyticsStat: analyticsStat)
         case .update:
             guard !isUploadingMedia else {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -137,6 +137,13 @@ extension PublishingEditor {
     }
 
     private func performSaveDraftAction() {
+        if post.original().isNewDraft && post.dateCreated != nil {
+            // If the app sends `date` field in the original request, the existing
+            // API interprets it as "Created Date" and not "Publish Date".
+            // See `AbstractPost/shouldPublishImmediately` for more details.
+            // TODO: remove this workaround
+            post.dateCreated = nil
+        }
         PostCoordinator.shared.setNeedsSync(for: post)
         dismissOrPopView()
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -74,7 +74,11 @@ public class PostEditorStateContext {
 
     fileprivate var originalPostStatus: BasePost.Status?
     fileprivate var currentPostStatus: BasePost.Status?
-    fileprivate var currentPublishDate: Date?
+    fileprivate var currentPublishDate: Date? {
+        didSet {
+            updatePublishAction()
+        }
+    }
     fileprivate var userCanPublish: Bool
     private weak var delegate: PostEditorStateContextDelegate?
 
@@ -103,8 +107,7 @@ public class PostEditorStateContext {
     }
 
     convenience init(post: AbstractPost,
-                     delegate: PostEditorStateContextDelegate,
-                     action: PostEditorAction? = nil) {
+                     delegate: PostEditorStateContextDelegate) {
         var originalPostStatus: BasePost.Status? = nil
 
         let originalPost = post.original()
@@ -121,10 +124,6 @@ public class PostEditorStateContext {
                   userCanPublish: userCanPublish,
                   publishDate: post.dateCreated,
                   delegate: delegate)
-
-        if let action = action {
-            self.action = action
-        }
     }
 
     /// The default initializer
@@ -215,6 +214,10 @@ public class PostEditorStateContext {
     ///
     var publishActionAnalyticsStat: WPAnalyticsStat {
         return action.publishActionAnalyticsStat
+    }
+
+    private func updatePublishAction() {
+        action = PostEditorStateContext.initialAction(for: originalPostStatus, publishDate: currentPublishDate, userCanPublish: userCanPublish)
     }
 
     /// Indicates whether the Publish Action should be allowed, or not

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -650,13 +650,12 @@ FeaturedImageViewControllerDelegate>
         [metaRows addObject:@(PostSettingsRowAuthor)];
     }
 
+    [metaRows addObject:@(PostSettingsRowPublishDate)];
+
     if (self.isDraftOrPending) {
         [metaRows addObject:@(PostSettingsRowPendingReview)];
     } else {
-        [metaRows addObjectsFromArray:@[
-            @(PostSettingsRowPublishDate),
-            @(PostSettingsRowVisibility)
-        ]];
+        [metaRows addObject:@(PostSettingsRowVisibility)];
     }
 
     self.postMetaSectionRows = [metaRows copy];
@@ -678,11 +677,11 @@ FeaturedImageViewControllerDelegate>
         // Publish date
         cell = [self getWPTableViewDisclosureCellWithIdentifier:@"PostSettingsRowPublishDate"];
         cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
-        if (self.apost.dateCreated) {
+        if (self.apost.dateCreated && ![self.apost shouldPublishImmediately]) {
             cell.detailTextLabel.text = [self.postDateFormatter stringFromDate:self.apost.dateCreated];
         } else {
             // Should never happen as this field is displayed only for published/scheduled posts
-            cell.detailTextLabel.text = @"";
+            cell.detailTextLabel.text = NSLocalizedStringWithDefaultValue(@"postSettings.publishDateImmediately", nil, [NSBundle mainBundle], @"Immediately", @"The placeholder value for 'Publish Date' field");
         }
 
         if ([self.apost.status isEqualToString:PostStatusPrivate]) {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -555,8 +555,7 @@ private final class PrepublishingViewModel {
         self.post = post
 
         self.visibility = .init(post: post)
-        // Ask the user to provide the date every time (ignore the obscure WP dateCreated/dateModified logic)
-        self.publishDate = nil
+        self.publishDate = post.shouldPublishImmediately() ? nil : post.dateCreated
     }
 
     @MainActor

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -33,7 +33,19 @@ struct PublishSettingsViewModel {
 
     private let post: AbstractPost
 
-    var isRequired: Bool { (post.original ?? post).status == .publish }
+    var isRequired: Bool {
+        if post.original().isStatus(in: [.publish, .publishPrivate, .scheduled]) {
+            // You can't remove the publish date for these statuses.
+            return true
+        }
+        if post.original().isStatus(in: [.draft, .pending]) && !(post.original?.shouldPublishImmediately() ?? false) {
+            // If you ever set a publish date for a draft, the API that the app
+            // uses doesn't allow you to remove it.
+            return true
+        }
+        return false
+    }
+
     let dateFormatter: DateFormatter
     let dateTimeFormatter: DateFormatter
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -392,6 +392,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         }
         stub(condition: isPath("/rest/v1.2/sites/80511/posts/974")) { request in
             XCTAssertEqual(request.getBodyParameters(), [
+                "date": "2024-03-07T23:00:40+0000",
                 "slug": "hello",
                 "status": "publish"
             ])
@@ -406,7 +407,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         await fulfillment(of: [expectation], timeout: 2)
 
         // WHEN
-        try await coordinator.publish(post, options: .init(visibility: .public, password: nil, publishDate: nil))
+        try await coordinator.publish(post, options: .init(visibility: .public, password: nil, publishDate: Date(timeIntervalSince1970: 1709852440)))
 
         // THEN the coordinator wait for the sync to complete and the post to
         // be created and only then sends a parial update to get it published


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23326.

I tried to re-implement it on top of the new infrastructure and avoid the old issues. 99% of users will just go "Post Settings" → Set "Publish Date" → "Schedule" → "Schedule". Other scenarios – and it opens the door for dozens of these – are largely irrelevant.

For reference, here are the related previous issues (some might by misclassified): #12121, #13724, #14251, #18517, #17086, #15767, #16514, #13654.

> [!NOTE]  
> This fix targets 25.1.

## To test:

**Scenario 1**

Scheduling a draft post using Post Settings.

- Create a new draft
- Open "Post Settings" 
- ✅ Verify that "Publish Date" has placeholder "Immediately"
- Set "Publish Date" to the date in the future
- Close "Post Settings"
- ✅ Verify that the "Publish" button changes to "Schedule"
- Tap "Schedule"
- ✅ Verify that the "Publish Date" field displays the selected publish date and the primary button also says "Schedule"
- Tap "Schedule"
- ✅ Verify that the post got scheduled

**Scenario 2**

- Create a new draft
- Save the draft
- Open the same draft on wp.com
- Set "Publish Date" to the date in the future and save it
- Return to the app and refresh the Post List
- Open the same draft again
- ✅ Verify that the "Publish" button changes to "Schedule"

**Scenario 3**

- Create a new draft
- Open "Post Settings" 
- Set "Publish Date" to the date in the future
- Save draft
- Open it again
- ✅ Verify that the "Publish" button say "Schedule"
- Tap "Schedule"
- Open "Publish Date" and remove it 
- ✅ Verify that the value changes to "Immediately"
- Tap "Shedule" to confirm publishing
- ✅ Verify that the post actually got scheduled

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
