### PR TITLE
Fix an issue with missing navigation bar background in Post Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] [internal] Block editor: Add onContentUpdate bridge functionality [#23234]
 * [*] Fix a rare crash when trashing posts [#23321]
+* [*] Fix an issue with a missing navigation bar background in Post Settings [#23334]
 
 25.0
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -4,21 +4,18 @@ import WordPressFlux
 extension PostEditor {
 
     func displayPostSettings() {
-        let settingsViewController: PostSettingsViewController
-        if post is Page {
-            settingsViewController = PageSettingsViewController(post: post)
-        } else {
-            settingsViewController = PostSettingsViewController(post: post)
-        }
-        settingsViewController.featuredImageDelegate = self as? FeaturedImageDelegate
+        let viewController = PostSettingsViewController.make(for: post)
+        viewController.featuredImageDelegate = self as? FeaturedImageDelegate
+        viewController.configureDefaultNavigationBarAppearance()
         let doneButton = UIBarButtonItem(systemItem: .done, primaryAction: .init(handler: { [weak self] _ in
             self?.editorContentWasUpdated()
             self?.navigationController?.dismiss(animated: true)
         }))
         doneButton.accessibilityIdentifier = "close"
-        settingsViewController.navigationItem.rightBarButtonItem = doneButton
+        viewController.navigationItem.rightBarButtonItem = doneButton
 
-        let navigation = UINavigationController(rootViewController: settingsViewController)
+        let navigation = UINavigationController(rootViewController: viewController)
+        navigation.navigationBar.isTranslucent = true // Reset to default
         self.navigationController?.present(navigation, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -188,6 +188,7 @@ extension PostSettingsViewController {
             WPAnalytics.track(.editorPostScheduledChanged, properties: ["via": "settings"])
             viewModel.setDate(date)
         }
+        viewController.configureDefaultNavigationBarAppearance()
         self.navigationController?.pushViewController(viewController, animated: true)
     }
 }


### PR DESCRIPTION
- Fix an issue with missing navigation bar background in Post Visibility picker when it's shown in the Post Settings screen embedded in the editor
- Update the Post Settings screen embedded in the editor to use the modern navigation bar style (same as the "standalone" Post Settings screen that can be opened from the Post List directly)

> [!NOTE]  
> This fix targets 25.1.

## To test:

- Open "Post Settings" screen from the editor and from the "Post List" screen
- ✅ Verify that in both cases the navigation bar looks good



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
