### PR TITLE
Rename Subscribers notification details header

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -226,7 +226,11 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
     }
 
     fileprivate func refreshNavigationBar() {
-        title = note.title
+        if note.kind == .follow, let subscribersCount = note.body?.count {
+            title = NSLocalizedString("notifications.subscribers.details.title", value: "\(subscribersCount) Subscribers", comment: "Number of subscribers visible on the Subscribers notification detail screen.")
+        } else {
+            title = note.title
+        }
 
         if splitViewControllerIsHorizontallyCompact {
             enableNavigationRightBarButtonItems()


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/61

It's the final part of the Subscribers Details screen redesign. The problem is that every notification response contains a `"title"` property that is applied to a notification details screen's title. I made this little workaround to rename `Followers` to `Subscribers` without touching the backend.

<img width="300" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/16563318/5c8d3ee5-d6f2-401b-ad9d-ead174393421"/>

To test:

- [ ] Prepare a notification about new subscribers
- [ ] Go to the screen and compare it with the designs
- [ ] Make sure you can see the redesigned name of the feature "Followers" -> "Subscribers."

## Regression Notes
1. Potential unintended areas of impact
Notifications details

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests

3. What automated tests I added (or what prevented me from doing so)
Legacy code

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
