### PR TITLE
[Voice to Content] Error Handling

### DIFF
--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -34,7 +34,7 @@ struct VoiceToContentView: View {
                 case .recording:
                     VoiceToContentRecordingView(viewModel: viewModel)
                 case .processing:
-                    VoiceToContenProcessingView(viewModel: viewModel)
+                    VoiceToContentProcessingView(viewModel: viewModel)
                 }
             }
 
@@ -195,15 +195,17 @@ private struct RecordButton: View {
     }
 }
 
-private struct VoiceToContenProcessingView: View {
+private struct VoiceToContentProcessingView: View {
     @ObservedObject fileprivate var viewModel: VoiceToContentViewModel
 
     var body: some View {
         VStack {
             Spacer()
 
-            ProgressView()
-                .controlSize(.large)
+            if case .loading = viewModel.loadingState {
+                ProgressView()
+                    .controlSize(.large)
+            }
 
             Spacer()
         }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -238,14 +238,14 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
         let service = JetpackAIServiceRemote(wordPressComRestApi: api, siteID: blog.dotComID ?? 0)
         do {
             let token = try await service.getAuthorizationToken()
-            // TODO: this doesn't seem to handle 401 and other "error" status codes correctly
             let transcription = try await service.transcribeAudio(from: fileURL, token: token)
             let content = try await service.makePostContent(fromPlainText: transcription, token: token)
 
             // "the __JETPACK_AI_ERROR__ is a special marker we ask GPT to add to
             // the request when it can’t understand the request for any reason"
             guard content != "__JETPACK_AI_ERROR__" else {
-                showError(VoiceToContentError.cantUnderstandRequest)
+                // There is no point in retrying, but the transcription can still be useful.
+                self.completion(transcription)
                 return
             }
             self.completion(content)


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/107

Changes:

- On "Processing..." error, show an error inline and allow the user to "Retry"
- If Jetpack AI returns `__JETPACK_AI_ERROR__`, use the transcription as is – no point in retrying.

<img width="320" alt="Screenshot 2024-06-10 at 3 45 48 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/97ef6697-00a7-4296-8b6a-9496d8d46f4d">

(**note**: the screenshot shows an error with no localizable description – usually they do have it)

## To test:

**Scenario 1**

- Start recording
- Turn off network connection
- Tap "Done"
- ✅ Verify that an error message is shown
- Turn on network connection
- Tap "Retry"
- ✅ Verify that the audio got processed and the editor was shown

**Scenario 2**

Replace the following lines:

```swift
// Replace this 
let content = try await service.makePostContent(fromPlainText: transcription, token: token)

// With this
let content = "__JETPACK_AI_ERROR__"
```

- Start and finish the recording
- ✅ Verify that the app dislplays the transcription as is (no formatting, no markdown, no heading – only transcription)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
