### PR TITLE
[Voce to Content] Upgrade URL

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -55,8 +55,7 @@ def gravatar
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 17.2.0'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'c334dad3c0e8fced5a61c5bf1d745d23d1924a9c'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -121,7 +121,7 @@ DEPENDENCIES:
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
   - WordPressAuthenticator (>= 9.0.8, ~> 9.0)
-  - WordPressKit (~> 17.2.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `c334dad3c0e8fced5a61c5bf1d745d23d1924a9c`)
   - WordPressShared (>= 2.3.1, ~> 2.3)
   - WordPressUI (~> 1.16)
   - ZendeskSupportSDK (= 5.3.0)
@@ -160,7 +160,6 @@ SPEC REPOS:
     - SVProgressHUD
     - SwiftLint
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressUI
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -178,11 +177,17 @@ EXTERNAL SOURCES:
     :tag: 0.2.0
   Gutenberg:
     :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.120.0.podspec
+  WordPressKit:
+    :commit: c334dad3c0e8fced5a61c5bf1d745d23d1924a9c
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  WordPressKit:
+    :commit: c334dad3c0e8fced5a61c5bf1d745d23d1924a9c
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 02b772c9910e8eba1a079227c32fbd9e46c90a24
@@ -229,6 +234,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: d170fa8e270b2a32bef9dcdcabff5b8f1a5deced
 
-PODFILE CHECKSUM: 739f6071356a5d136381ca7788feb63eab4a3062
+PODFILE CHECKSUM: c0cebe0945c26f689b810c6ea6ed7ad16580048d
 
 COCOAPODS: 1.15.2

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -96,10 +96,12 @@ private struct VoiceToContentWelcomeView: View {
         VStack(spacing: 4) {
             Text(Strings.notEnoughRequests)
                 .multilineTextAlignment(.center)
-            Button(action: viewModel.buttonUpgradeTapped) {
-                HStack {
-                    Text(Strings.upgrade)
-                    Image("icon-post-actionbar-view")
+            if let upgradeURL = viewModel.upgradeURL {
+                Button(action: { viewModel.buttonUpgradeTapped(withUpgradeURL: upgradeURL) }) {
+                    HStack {
+                        Text(Strings.upgrade)
+                        Image("icon-post-actionbar-view")
+                    }
                 }
             }
         }.frame(maxWidth: 320)

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -24,6 +24,9 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
         return isEligible
     }
 
+    var upgradeURL: URL? {
+        featureInfo?.upgradeURL.flatMap(URL.init)
+    }
     private var featureInfo: JetpackAssistantFeatureDetails?
     private var audioSession: AVAudioSession?
     private var audioRecorder: AVAudioRecorder?
@@ -112,15 +115,8 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
         }
     }
 
-    func buttonUpgradeTapped() {
+    func buttonUpgradeTapped(withUpgradeURL upgradeURL: URL) {
         WPAnalytics.track(.voiceToContentButtonUpgradeTapped)
-
-        guard let featureInfo else {
-            return wpAssertionFailure("feature info missing")
-        }
-        guard let upgradeURL = featureInfo.upgradeURL.flatMap(URL.init) else {
-            return wpAssertionFailure("invalid or missing upgrade URL")
-        }
         UIApplication.shared.open(upgradeURL)
     }
 

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -24,6 +24,7 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
         return isEligible
     }
 
+    private var featureInfo: JetpackAssistantFeatureDetails?
     private var audioSession: AVAudioSession?
     private var audioRecorder: AVAudioRecorder?
     private weak var timer: Timer?
@@ -99,6 +100,7 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
     }
 
     private func didFetchFeatureDetails(_ info: JetpackAssistantFeatureDetails) {
+        self.featureInfo = info
         self.loadingState = nil
         if info.isSiteUpdateRequired == true {
             self.subtitle = Strings.subtitleRequestsAvailable + " 0"
@@ -113,11 +115,12 @@ final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorder
     func buttonUpgradeTapped() {
         WPAnalytics.track(.voiceToContentButtonUpgradeTapped)
 
-        // TODO: this does not work
-        guard let siteURL = blog.url.flatMap(URL.init) else {
-            return wpAssertionFailure("invalid blog URL")
+        guard let featureInfo else {
+            return wpAssertionFailure("feature info missing")
         }
-        let upgradeURL = siteURL.appendingPathComponent("/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai")
+        guard let upgradeURL = featureInfo.upgradeURL.flatMap(URL.init) else {
+            return wpAssertionFailure("invalid or missing upgrade URL")
+        }
         UIApplication.shared.open(upgradeURL)
     }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wordpress-mobile/issues/103.

The `upgradeURL` is now controlled by the server.

**Note**: this is not one of the primary flows in this scenario, so the decision was to simply open it in external Safari.

## To test:

- Open a free wp.com site (limit is 20 requests)
- Exhaust the request limit
- Tap "Voice to Content"
- ✅ Verify that it shows the upgrade URL
- Tap "Upgrade" 
- ✅ Verify that it opens one of the upgrade/checkout pages

<img width="360" alt="Screenshot 2024-06-10 at 4 09 24 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/d1f0ce57-fd55-45b7-b8ec-e4715e27e089">
<img width="360" alt="Screenshot 2024-06-10 at 4 09 33 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/d983c1f0-d087-491b-a672-de546ff3601a">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
