### PR TITLE
Fix an issue where the app will sometimes save empty drafts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] [internal] Block editor: Add onContentUpdate bridge functionality [#23234]
 * [*] Fix a rare crash when trashing posts [#23321]
 * [*] Fix an issue with a missing navigation bar background in Post Settings [#23334]
+* [*] Fix an issue where the app will sometimes save empty drafts [#23342]
 
 25.0
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -106,7 +106,7 @@ extension GutenbergViewController {
     private func makeSecondaryActions() -> [UIAction] {
         var actions: [UIAction] = []
         if post.original().isStatus(in: [.draft, .pending]) {
-            actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: editorHasChanges ? [] : [.disabled]) { [weak self] _ in
+            actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: (editorHasChanges && editorHasContent) ? [] : [.disabled]) { [weak self] _ in
                 self?.buttonSaveDraftTapped()
             })
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -198,7 +198,7 @@ extension PublishingEditor {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(uploadFailureNoticeTag))
         stopEditing()
 
-        guard !post.changes.isEmpty else {
+        guard !post.changes.isEmpty && post.hasContent() else {
             return discardAndDismiss()
         }
 


### PR DESCRIPTION
The app now will no longer save empty drafts. See test scenarios for more details.

## To test:

**Scenario 1**

The draft has an empty title and an empty paragraph block.

- Create a new draft post
- Tap in the "Content" area (Gutenberg creates an empty paragraph)
- Tap "Back"
- ✅ Verify that the editor was closed without a confirmation alert and the draft was not created

**Scenario 2**

An existing draft with no content.

- Create a new draft post
- Add a title (but no content)
- Tap "Back" and "Save Draft"
- Reopen the draft
- Remove the title
- Tap "More"
- ✅ Verify that button "Save Draft" is disabled (you can't save an empty draft and the server will 500 if you try)
- Tap "Back"
- ✅ Verify that the changes were discard (this was the previous production behavior, so I'm simply reverting to it)

## Regression Notes
1. Potential unintended areas of impact: Post Editor / Drafts
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
