### PR TITLE
Fix an issue with post content structure not loading in some scenarios

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 * [*] Fix an issue with a missing navigation bar background in Post Settings [#23334]
 * [*] Fix an issue where the app will sometimes save empty drafts [#23342]
 * [*] Add `.networkConnectionLost` to the list of "offline" scenarios so that the "offline changes" badge and fast retries work for this use case [#23348]
-
+* [*] Fix an issue with post content structure not loading in some scenarios [#23347]
 
 25.0
 -----


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23341

The "More" menu now loads the actions that require the latest post content asynchronously to ensure it is up-to-date. These actions include: "Save Draft" and the "Content Structure" footer.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/cf3042b2-2144-45da-b5d1-7b26cc345b38


## To test:

**Scenario 1**

Follow the steps from https://github.com/wordpress-mobile/WordPress-iOS/issues/23341.

**Scenario 2**

- Open an existing draft
- Make an edit and _quickly_ tap "More"
- ✅ Verify that the "Save Draft" button is always enabled after an edit (might be worth using a longer post)

## Regression Notes
1. Potential unintended areas of impact: Post Editor / More Menu
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
