### PR TITLE
Add .networkConnectionLost to the list of "offline" scenarios

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,8 @@
 * [*] Fix a rare crash when trashing posts [#23321]
 * [*] Fix an issue with a missing navigation bar background in Post Settings [#23334]
 * [*] Fix an issue where the app will sometimes save empty drafts [#23342]
+* [*] Add `.networkConnectionLost` to the list of "offline" scenarios so that the "offline changes" badge and fast retries work for this use case [#23348]
+
 
 25.0
 -----

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -566,7 +566,7 @@ class PostCoordinator: NSObject {
         for worker in workers.values {
             if let error = worker.error,
                let urlError = (error as NSError).underlyingErrors.first as? URLError,
-               urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
+               urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost || urlError.code == .timedOut {
                 worker.log("connection is reachable – retrying now")
                 startSync(for: worker.post)
             }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -566,7 +566,7 @@ class PostCoordinator: NSObject {
         for worker in workers.values {
             if let error = worker.error,
                let urlError = (error as NSError).underlyingErrors.first as? URLError,
-               urlError.code == .notConnectedToInternet {
+               urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
                 worker.log("connection is reachable – retrying now")
                 startSync(for: worker.post)
             }

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadsViewModel.swift
@@ -174,7 +174,8 @@ final class PostMediaUploadItemViewModel: ObservableObject, Identifiable {
               (reachable as? Bool) == true else {
             return
         }
-        if (media.error as? URLError)?.code == .notConnectedToInternet {
+        let code = (media.error as? URLError)?.code
+        if code == .notConnectedToInternet || code == .networkConnectionLost {
             retry()
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -26,7 +26,7 @@ final class PostSyncStateViewModel {
                 return .failed
             }
             if let urlError = (error as NSError).underlyingErrors.first as? URLError,
-               urlError.code == .notConnectedToInternet {
+               urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
                 return .offlineChanges // A better indicator on what's going on
             }
         }


### PR DESCRIPTION
See title.

## To test:

I don't know how to reproduce `.networkConnectionLost` exactly, but, based on Tracks, it makes up for 1/3 of the network issues. The app shows an "Offline Changes" indicator in case of these errors and fast-tracks retries when the connection is restored. By not including `.networkConnectionLost`, this logic doesn't work in 1/3 of the scenarios where it should.

## Regression Notes
1. Potential unintended areas of impact: Post List
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so): yes

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
