### PR TITLE
Add defensive code for PostCategory save

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 * [*] Fix an issue where the app will sometimes save empty drafts [#23342]
 * [*] Add `.networkConnectionLost` to the list of "offline" scenarios so that the "offline changes" badge and fast retries work for this use case [#23348]
 * [*] Fix an issue with post content structure not loading in some scenarios [#23347]
-* [*] Fix a rare crash when updating posts with newly added categories [#23354]
+* [*] Fix a rare crash when updating posts with categories [#23354]
 
 
 25.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,8 @@
 * [*] Fix an issue where the app will sometimes save empty drafts [#23342]
 * [*] Add `.networkConnectionLost` to the list of "offline" scenarios so that the "offline changes" badge and fast retries work for this use case [#23348]
 * [*] Fix an issue with post content structure not loading in some scenarios [#23347]
+* [*] Fix a rare crash when updating posts with newly added categories [#23354]
+
 
 25.0
 -----

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -165,15 +165,19 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray *categories = [NSMutableArray arrayWithCapacity:remoteCategories.count];
 
     for (RemotePostCategory *remoteCategory in remoteCategories) {
-        PostCategory *category = [PostCategory lookupWithBlogObjectID:blog.objectID categoryID:remoteCategory.categoryID inContext:context];
-        if (!category) {
-            category = [PostCategory createWithBlogObjectID:blog.objectID inContext:context];
-            category.categoryID = remoteCategory.categoryID;
-        }
-        category.categoryName = remoteCategory.name;
-        category.parentID = remoteCategory.parentID;
+        if (remoteCategory.categoryID) {
+            PostCategory *category = [PostCategory lookupWithBlogObjectID:blog.objectID categoryID:remoteCategory.categoryID inContext:context];
+            if (!category) {
+                category = [PostCategory createWithBlogObjectID:blog.objectID inContext:context];
+                category.categoryID = remoteCategory.categoryID;
+            }
+            category.categoryName = remoteCategory.name;
+            if (remoteCategory.parentID) {
+                category.parentID = remoteCategory.parentID;
+            }
 
-        [categories addObject:category];
+            [categories addObject:category];
+        }
     }
 }
 

--- a/WordPress/Classes/Services/PostHelper+Metadata.swift
+++ b/WordPress/Classes/Services/PostHelper+Metadata.swift
@@ -11,4 +11,22 @@ extension PostHelper {
             value: dictionary["value"] as? String
         )
     }
+
+    @objc(createOrUpdateCategoryForRemoteCategory:blog:context:)
+    class func createOrUpdateCategory(for remoteCategory: RemotePostCategory, in blog: Blog, in context: NSManagedObjectContext) -> PostCategory? {
+        guard let categoryID = remoteCategory.categoryID else {
+            wpAssertionFailure("remote category missing categoryID")
+            return nil
+        }
+        if let category = try? PostCategory.lookup(withBlogID: blog.objectID, categoryID: categoryID, in: context) {
+            return category
+        }
+        let category = PostCategory(context: context)
+        // - warning: these PostCategory fields are explicitly unwrapped optionals!
+        category.blog = blog
+        category.categoryID = categoryID
+        category.categoryName = remoteCategory.name ?? ""
+        category.parentID = remoteCategory.parentID ?? 0 // `0` means "no parent"
+        return category
+    }
 }

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -104,18 +104,13 @@
 }
 
 + (void)updatePost:(Post *)post withRemoteCategories:(NSArray *)remoteCategories inContext:(NSManagedObjectContext *)managedObjectContext {
-    NSManagedObjectID *blogObjectID = post.blog.objectID;
     NSMutableSet *categories = [post mutableSetValueForKey:@"categories"];
     [categories removeAllObjects];
     for (RemotePostCategory *remoteCategory in remoteCategories) {
-        PostCategory *category = [PostCategory lookupWithBlogObjectID:blogObjectID categoryID:remoteCategory.categoryID inContext:managedObjectContext];
-        if (!category) {
-            category = [PostCategory createWithBlogObjectID:blogObjectID inContext:managedObjectContext];
-            category.categoryID = remoteCategory.categoryID;
-            category.categoryName = remoteCategory.name;
-            category.parentID = remoteCategory.parentID;
+        PostCategory *category = [PostHelper createOrUpdateCategoryForRemoteCategory:remoteCategory blog:post.blog context:managedObjectContext];
+        if (category) {
+            [categories addObject:category];
         }
-        [categories addObject:category];
     }
 }
 


### PR DESCRIPTION
I don't want to say that it fixes the issue https://github.com/wordpress-mobile/WordPress-iOS/issues/21138 entirely, but there was a recent spike in production in these crashes, and it adds some basic defensive and monitoring code.

The assumption is that it is a faulty plugin or misconfiguration on some sites that leads to invalid responses (more details in https://github.com/wordpress-mobile/WordPress-iOS/issues/23352#issuecomment-2165918514). The options in this scenario are limited. The app definitely can't simply crash. I think it's acceptable if it will still display the post but maybe fail to display some of the categories. I also focused on keeping the changes to the minimum since this PR targets the release branch.

## To test:

- Put breakpoint on line  `let category = PostCategory(context: context)`
- Open Post List in the app
- Open wp-admin and open one of the existing posts
- **Test 1**
  - Add a new category to a post (one with and one without a parent)
  - Refresh the post list in the app
  - ✅ Verify that the breakpoint was hit
  - Open Post Settings for the post
  - ✅ Verify that the new categories are displayed
- **Test 2**
  - Add an _existing_ category to the post
  - Refresh the post list in the app
  - ✅ Verify that the breakpoint was NOT hit
  - ✅ Verify that the category is displayed

Note: I tested it only on self-hosted sites, and I would appreciate a smoke-test on wp.com as well.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
