### PR TITLE
Improve sync engine for drafts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Fix an issue with a missing navigation bar background in Post Settings [#23334]
 * [*] Fix an issue where the app will sometimes save empty drafts [#23342]
 * [*] Add `.networkConnectionLost` to the list of "offline" scenarios so that the "offline changes" badge and fast retries work for this use case [#23348]
+* [*] If draft sync fails, the app will now show the "Retry" button in the context menu along with the error message [#23355]
 * [*] Fix an issue with post content structure not loading in some scenarios [#23347]
 
 25.0

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -54,8 +54,8 @@ class PostCoordinator: NSObject {
     private let mediaCoordinator: MediaCoordinator
     private let actionDispatcherFacade: ActionDispatcherFacade
 
-    /// The initial sync retry delay. By default, 20 seconds.
-    var syncRetryDelay: TimeInterval = 20
+    /// The initial sync retry delay. By default, 15 seconds.
+    var syncRetryDelay: TimeInterval = 15
 
     // MARK: - Initializers
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -14,7 +14,6 @@ class PostCoordinator: NSObject {
 
     enum SavingError: Error, LocalizedError, CustomNSError {
         case mediaFailure(AbstractPost, Error)
-        case unknown
 
         var errorDescription: String? {
             Strings.genericErrorTitle
@@ -24,8 +23,6 @@ class PostCoordinator: NSObject {
             switch self {
             case .mediaFailure(_, let error):
                 return [NSUnderlyingErrorKey: error]
-            case .unknown:
-                return [:]
             }
         }
     }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -379,12 +379,14 @@ class PostCoordinator: NSObject {
         var error: Error? // The previous sync error
 
         var nextRetryDelay: TimeInterval {
-            retryDelay = min(60, retryDelay * 2)
+            retryDelay = min(90, retryDelay * 2)
             return retryDelay
         }
+
         func setLongerDelay() {
-            retryDelay = max(retryDelay, 30)
+            retryDelay = max(retryDelay, 45)
         }
+
         var retryDelay: TimeInterval
         weak var retryTimer: Timer?
         var showNextError = false
@@ -578,7 +580,10 @@ class PostCoordinator: NSObject {
 
     /// Returns `true` if the error can't be resolved by simply retrying and
     /// requires user interventions, for example, resolving a conflict.
-    static func isTerminalError(_ error: Error) -> Bool {
+    private static func isTerminalError(_ error: Error) -> Bool {
+        if error is WordPressKit.WordPressComRestApiEndpointError {
+            return true
+        }
         if let saveError = error as? PostRepository.PostSaveError {
             switch saveError {
             case .deleted, .conflict:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -305,6 +305,8 @@ import Foundation
     case postListSetHomePageAction
     case postListSetAsRegularPageAction
     case postListSettingsAction
+    case postListDeleteAction
+    case postListRetryAction
 
     // Page List
     case pageListEditHomepageTapped
@@ -1166,6 +1168,10 @@ import Foundation
             return "post_list_button_pressed"
         case .postListSettingsAction:
             return "post_list_button_pressed"
+        case .postListDeleteAction:
+            return "post_list_button_pressed"
+        case .postListRetryAction:
+            return "post_list_button_pressed"
 
         // Page List
         case .pageListEditHomepageTapped:
@@ -1741,6 +1747,10 @@ import Foundation
             return ["button": "set_regular_page"]
         case .postListSettingsAction:
             return ["button": "settings"]
+        case .postListDeleteAction:
+            return ["button": "delete"]
+        case .postListRetryAction:
+            return ["button": "retry"]
         default:
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -716,6 +716,10 @@ class AbstractPostListViewController: UIViewController,
         alert.presentFromRootViewController()
     }
 
+    func retry(_ post: AbstractPost) {
+        PostCoordinator.shared.retrySync(for: post.original())
+    }
+
     func stats(for post: AbstractPost) {
         viewStatsForPost(post)
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -677,6 +677,8 @@ class AbstractPostListViewController: UIViewController,
     }
 
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
+        WPAnalytics.track(.postListTrashAction, withProperties: propertiesForAnalytics())
+
         let post = post.original()
 
         func performAction() {
@@ -701,6 +703,8 @@ class AbstractPostListViewController: UIViewController,
     }
 
     func delete(_ post: AbstractPost, completion: @escaping () -> Void) {
+        WPAnalytics.track(.postListDeleteAction, properties: propertiesForAnalytics())
+
         let post = post.original()
 
         let alert = UIAlertController(title: Strings.Delete.actionTitle, message: Strings.Delete.message(for: post.latest()), preferredStyle: .alert)
@@ -717,6 +721,7 @@ class AbstractPostListViewController: UIViewController,
     }
 
     func retry(_ post: AbstractPost) {
+        WPAnalytics.track(.postListRetryAction, properties: propertiesForAnalytics())
         PostCoordinator.shared.retrySync(for: post.original())
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -141,14 +141,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         }
     }
 
-    func subtitle(for post: AbstractPost) -> String? {
-        if self == .retry {
-            let error = PostCoordinator.shared.syncError(for: post.original())
-            return error?.localizedDescription
-        }
-        return nil
-    }
-
     func performAction(for post: AbstractPost, view: UIView, delegate: InteractivePostViewDelegate) {
         switch self {
         case .view:

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuHelper.swift
@@ -47,7 +47,7 @@ struct AbstractPostMenuHelper {
             .filter { !$0.buttons.isEmpty }
             .map { section in
                 let actions = makeActions(for: section.buttons, presentingView: presentingView, delegate: delegate)
-                let menu = UIMenu(title: "", options: .displayInline, children: actions)
+                let menu = UIMenu(title: section.title ?? "", subtitle: "", options: .displayInline, children: actions)
 
                 if let submenuButton = section.submenuButton {
                     return UIMenu(
@@ -99,6 +99,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .moveToDraft: return UIImage(systemName: "pencil.line")
         case .trash: return UIImage(systemName: "trash")
         case .delete: return UIImage(systemName: "trash")
+        case .retry: return UIImage(systemName: "arrow.triangle.2.circlepath")
         case .share: return UIImage(systemName: "square.and.arrow.up")
         case .blaze: return UIImage(systemName: "flame")
         case .comments: return UIImage(systemName: "bubble.right")
@@ -128,6 +129,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .moveToDraft: return Strings.draft
         case .trash: return Strings.trash
         case .delete: return Strings.delete
+        case .retry: return Strings.retry
         case .share: return Strings.share
         case .blaze: return Strings.blaze
         case .comments: return Strings.comments
@@ -137,6 +139,14 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .setRegularPage: return Strings.setRegularPage
         case .pageAttributes: return Strings.pageAttributes
         }
+    }
+
+    func subtitle(for post: AbstractPost) -> String? {
+        if self == .retry {
+            let error = PostCoordinator.shared.syncError(for: post.original())
+            return error?.localizedDescription
+        }
+        return nil
     }
 
     func performAction(for post: AbstractPost, view: UIView, delegate: InteractivePostViewDelegate) {
@@ -155,6 +165,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
             delegate.trash(post)
         case .delete:
             delegate.delete(post)
+        case .retry:
+            delegate.retry(post)
         case .share:
             delegate.share(post, fromView: view)
         case .blaze:
@@ -182,6 +194,8 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let draft = NSLocalizedString("posts.draft.actionTitle", value: "Move to draft", comment: "Label for an option that moves a post to the draft folder")
         static let delete = NSLocalizedString("posts.delete.actionTitle", value: "Delete permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
         static let trash = NSLocalizedString("posts.trash.actionTitle", value: "Move to trash", comment: "Label for a option that moves a post to the trash folder")
+        // TODO: Replace with a namespaced string
+        static let retry = NSLocalizedString("Retry", comment: "User action to retry media upload.")
         static let view = NSLocalizedString("posts.view.actionTitle", value: "View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let preview = NSLocalizedString("posts.preview.actionTitle", value: "Preview", comment: "Label for the preview post button. Tapping displays the post as it appears on the web.")
         static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish", comment: "Label for the publish post button.")

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostMenuViewModel.swift
@@ -5,10 +5,12 @@ protocol AbstractPostMenuViewModel {
 }
 
 struct AbstractPostButtonSection {
+    let title: String?
     let buttons: [AbstractPostButton]
     let submenuButton: AbstractPostButton?
 
-    init(buttons: [AbstractPostButton], submenuButton: AbstractPostButton? = nil) {
+    init(title: String? = nil, buttons: [AbstractPostButton], submenuButton: AbstractPostButton? = nil) {
+        self.title = title
         self.buttons = buttons
         self.submenuButton = submenuButton
     }
@@ -22,6 +24,7 @@ enum AbstractPostButton: Equatable {
     case moveToDraft
     case trash
     case delete
+    case retry
     case share
     case blaze
     case comments

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -9,6 +9,7 @@ protocol InteractivePostViewDelegate: AnyObject {
     func trash(_ post: AbstractPost, completion: @escaping () -> Void)
     func delete(_ post: AbstractPost, completion: @escaping () -> Void)
     func draft(_ post: AbstractPost)
+    func retry(_ post: AbstractPost)
     func share(_ post: AbstractPost, fromView view: UIView)
     func blaze(_ post: AbstractPost)
     func comments(_ post: AbstractPost)

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -15,7 +15,8 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             createBlazeSection(),
             createSetPageAttributesSection(),
             createNavigationSection(),
-            createTrashSection()
+            createTrashSection(),
+            createUploadStatusSection()
         ]
     }
 
@@ -124,5 +125,13 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
 
         let action: AbstractPostButton = page.original().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
+    }
+
+    private func createUploadStatusSection() -> AbstractPostButtonSection {
+        guard let error = PostCoordinator.shared.syncError(for: page.original()),
+           PostCoordinator.isTerminalError(error) else {
+            return AbstractPostButtonSection(buttons: [])
+        }
+        return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PageMenuViewModel.swift
@@ -128,8 +128,7 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
     }
 
     private func createUploadStatusSection() -> AbstractPostButtonSection {
-        guard let error = PostCoordinator.shared.syncError(for: page.original()),
-           PostCoordinator.isTerminalError(error) else {
+        guard let error = PostCoordinator.shared.syncError(for: page.original()) else {
             return AbstractPostButtonSection(buttons: [])
         }
         return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -124,8 +124,7 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     private func createUploadStatusSection() -> AbstractPostButtonSection {
-        guard let error = PostCoordinator.shared.syncError(for: post.original()),
-           PostCoordinator.isTerminalError(error) else {
+        guard let error = PostCoordinator.shared.syncError(for: post.original()) else {
             return AbstractPostButtonSection(buttons: [])
         }
         return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -60,7 +60,8 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
             createSecondarySection(),
             createBlazeSection(),
             createNavigationSection(),
-            createTrashSection()
+            createTrashSection(),
+            createUploadStatusSection()
         ]
     }
 
@@ -120,6 +121,14 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     private func createTrashSection() -> AbstractPostButtonSection {
         let action: AbstractPostButton = post.original().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
+    }
+
+    private func createUploadStatusSection() -> AbstractPostButtonSection {
+        guard let error = PostCoordinator.shared.syncError(for: post.original()),
+           PostCoordinator.isTerminalError(error) else {
+            return AbstractPostButtonSection(buttons: [])
+        }
+        return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])
     }
 
     private var canPublish: Bool {

--- a/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSyncStateViewModel.swift
@@ -22,12 +22,11 @@ final class PostSyncStateViewModel {
             return .uploading
         }
         if let error = PostCoordinator.shared.syncError(for: post.original()) {
-            if PostCoordinator.isTerminalError(error) {
-                return .failed
-            }
             if let urlError = (error as NSError).underlyingErrors.first as? URLError,
                urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
                 return .offlineChanges // A better indicator on what's going on
+            } else {
+                return .failed
             }
         }
         if PostCoordinator.shared.isSyncNeeded(for: post) {

--- a/WordPress/Classes/ViewRelated/Post/ResolveConflictView.swift
+++ b/WordPress/Classes/ViewRelated/Post/ResolveConflictView.swift
@@ -23,7 +23,14 @@ struct ResolveConflictView: View {
     var body: some View {
         Form {
             Section {
-                Text(Strings.description)
+                VStack(alignment: .leading, spacing: 12) {
+                    if let title = post.latest().titleForDisplay() {
+                        Text("\"\(title)\"")
+                            .font(.headline)
+                            .lineLimit(2)
+                    }
+                    Text(Strings.description)
+                }
                 ForEach(versions) { version in
                     PostVersionView(version: version, selectedVersion: $selectedVersion)
                 }


### PR DESCRIPTION
The original implementation introduced in 24.9 was intentionally over-simplified. The goal was to get the system out of the door for testing, prove that it works, and then enhance it based on the data. The data is in, and it turns out the original "let's simply keep retrying and showing spinner indefinitely" approach doesn't really work for WordPress because if the sync fails, in 90%+ cases, it requires manual intervention. The new approach is to fail early, communicate errors to the user early, and give them more manual controls.

## Changes

- If the sync fails, show an error in the post context menu (at the bottom to ensure the order of the rest of the controls is stable). When you tap a new "Retry" button, the request is performed immediately and, if it fails again, the app shows the user full error message.
- The app shows an "error state" in post list for any errors and not just the ones we considered "terminal". Remove the concept of "terminal" errors and increase the default retry delays for all errors (the app still has "fast retry" for connectivity errors).
- If the app fails to upload a draft in three days, it will stop re-retrying completely until the user taps "Retry" manually
- Show post title in the "Resolve Conflict" view

<img width="340" alt="Screenshot 2024-06-13 at 7 09 09 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/1a90db0f-f59b-4a32-b780-a5ce752c7bb3">

## To test:

**Note**: ideally, the tests should be performed for pages as well as posts.

**Conflict Resolution**

- (App) Open an existing **draft** for editing 
- (Desktop) Open the same post, make changes and tap "Save Draft"
- (App) Make changes to the app and tap "Back", "Save Draft"
- ✅ Verify that the "Error" badge is displayed in the post list
- Tap "More"
- ✅ Verify that the error "The content was modified on another device" message is shown along with the "Retry" button (**new**)
- Tap "Retry"
- ✅ Verify that the spinner is briefly shown
- ✅ Verify that an alert with an error message is shown and on "OK", the "Resolve Conflict" view is shown
- ✅ Verify that the "Resolve Conflict" view has the post title (**new**)

**Retry Limit**

- (Setup) Set `SyncWorker.maximumRetryTimeInterval` to a low value
- (Setup) Disable network connection
- (Setup) Use a proxy or check network requests and/or monitor "sync-worker" logs in Xcode
- Save a new draft or update an existing draft
- Wait until `SyncWorker.maximumRetryTimeInterval` is reached
- Restart the app to upload the post (you'll see `2024-06-13 16:25:40:880 Jetpack[3663:4058188] sync-worker(p1072) stopping – failing to upload changes for too long` in console)
- ✅ Verify that the app doesn't attempt to upload the post again
- Open the post list 
- Tap "More" on the post
- ✅ Verify that the context menu shows a generic error message
- Tap "Retry"
- ✅ Verify that the request was sent again (note: it also restarts the `SyncWorker.maximumRetryTimeInterval` counter)

**Note**: the main scenario we are targeting with this change is when the user has multiple blogs, some that they don't interact with often. We don't want the app to keep retrying uploads for these posts indefinitely.

**Network Errors**

This is a regression test.

- (Setup) turn network connection off
- Create a new or save changes to an existing draft (or pending post)
- ✅ Verify that the post list shows an "Offline Changes" badges on the post
- Turn network connection on
- ✅ Verify that the app quickly re-reties the upload

**Note**: the user now also have an option to retry manually. You can safely tap "Retry" at any point. The sync is managed by `PostCoordinator`, and it ultimately decides when to sync or pause syncing.

## Regression Notes
1. Potential unintended areas of impact: Post Sync
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
