### PR TITLE
Fix snackbar draft saved message when saving drafts manually

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 25.2
 -----
 * [*] Simplify post list context menu sections [#23356]
-
+* [*] Fix an issue with incorrect snackbar shown when saving drafts manually [#23358]
 
 25.1
 -----

--- a/WordPress/Classes/Services/PostCoordinator+Notices.swift
+++ b/WordPress/Classes/Services/PostCoordinator+Notices.swift
@@ -77,7 +77,7 @@ private enum Strings {
                 return NSLocalizedString("postNotice.pagePublished", value: "Page published", comment: "Title of notification displayed when a page has been successfully published.")
             }
         default:
-            assertionFailure("Unexpected post type: \(post)")
+            wpAssertionFailure("unexpected post type", userInfo: ["post_type": String(describing: type(of: post))])
             return ""
         }
     }

--- a/WordPress/Classes/Services/PostCoordinator+Notices.swift
+++ b/WordPress/Classes/Services/PostCoordinator+Notices.swift
@@ -48,14 +48,15 @@ private enum Strings {
     static let view = NSLocalizedString("postNotice.view", value: "View", comment: "Button title. Displays a summary / sharing screen for a specific post.")
 
     static func publishSuccessTitle(for post: AbstractPost, isUpdated: Bool = false) -> String {
+        if post.status == .draft {
+            return NSLocalizedString("postNotice.draftSaved", value: "Draft Saved", comment: "Title of notification displayed when either a new or an existing draft is saved")
+        }
         switch post {
         case let post as Post:
             guard !isUpdated else {
                 return NSLocalizedString("postNotice.postUpdated", value: "Post updated", comment: "Title of notification displayed when a post has been successfully updated.")
             }
             switch post.status {
-            case .draft:
-                return NSLocalizedString("postNotice.postDraftCreated", value: "Post draft uploaded", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
             case .scheduled:
                 return NSLocalizedString("postNotice.postScheduled", value: "Post scheduled", comment: "Title of notification displayed when a post has been successfully scheduled.")
             case .pending:
@@ -68,8 +69,6 @@ private enum Strings {
                 return NSLocalizedString("postNotice.pageUpdated", value: "Page updated", comment: "Title of notification displayed when a page has been successfully updated.")
             }
             switch page.status {
-            case .draft:
-                return NSLocalizedString("postNotice.pageDraftCreated", value: "Page draft uploaded", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
             case .scheduled:
                 return NSLocalizedString("postNotice.pageScheduled", value: "Page scheduled", comment: "Title of notification displayed when a page has been successfully scheduled.")
             case .pending:


### PR DESCRIPTION
Fixes an issue where when you save a new draft the app was showing a "Post Updated" snackbar.

## To test:

- Create a new draft
- Tap "More" / "Save Draft"
- ✅ Verify that a "Draft Saved" snackbar is shown
- Repeat for making changes to an existing draft

## Regression Notes
1. Potential unintended areas of impact: Editor
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
