### PR TITLE
Offline Mode: Remove Deprecated Code – P13

### DIFF
--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -211,10 +211,6 @@ class StoryEditor: CameraController {
 }
 
 extension StoryEditor: PublishingEditor {
-    var prepublishingSourceView: UIView? {
-        return nil
-    }
-
     var alertBarButtonItem: UIBarButtonItem? {
         return nil
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1228,15 +1228,6 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
         }
 
         switch keyPath {
-        case BasePost.statusKeyPath:
-            if let status = post.status {
-                postEditorStateContext.updated(postStatus: status)
-                editorContentWasUpdated()
-            }
-        case #keyPath(AbstractPost.date_created_gmt):
-            let dateCreated = post.dateCreated ?? Date()
-            postEditorStateContext.updated(publishDate: dateCreated)
-            editorContentWasUpdated()
         case #keyPath(AbstractPost.content):
             editorContentWasUpdated()
         default:
@@ -1253,14 +1244,10 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
     }
 
     internal func addObservers(toPost: AbstractPost) {
-        toPost.addObserver(self, forKeyPath: AbstractPost.statusKeyPath, options: [], context: nil)
-        toPost.addObserver(self, forKeyPath: #keyPath(AbstractPost.date_created_gmt), options: [], context: nil)
         toPost.addObserver(self, forKeyPath: #keyPath(AbstractPost.content), options: [], context: nil)
     }
 
     internal func removeObservers(fromPost: AbstractPost) {
-        fromPost.removeObserver(self, forKeyPath: AbstractPost.statusKeyPath)
-        fromPost.removeObserver(self, forKeyPath: #keyPath(AbstractPost.date_created_gmt))
         fromPost.removeObserver(self, forKeyPath: #keyPath(AbstractPost.content))
     }
 }
@@ -2504,21 +2491,6 @@ extension AztecPostViewController {
             failedIDs.append(mediaUploadID)
         }
         return failedIDs
-    }
-
-    var hasFailedMedia: Bool {
-        return !failedMediaIDs.isEmpty
-    }
-
-    func removeFailedMedia() {
-        for mediaID in failedMediaIDs {
-            if let attachment = self.findAttachment(withUploadID: mediaID) {
-                richTextView.remove(attachmentID: attachment.identifier)
-            }
-            if let media = mediaCoordinator.media(withObjectID: mediaID) {
-                mediaCoordinator.delete(media)
-            }
-        }
     }
 
     fileprivate func retryAllFailedMediaUploads() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -125,10 +125,6 @@ class GutenbergMediaInserterHelper: NSObject {
         _ = mediaCoordinator.uploadMedia(for: post, automatedRetry: automatedRetry)
     }
 
-    func hasFailedMedia() -> Bool {
-        return mediaCoordinator.hasFailedMedia(for: post)
-    }
-
     func insert(exportableAsset: ExportableAsset, source: MediaSource) -> Media? {
         let info = MediaAnalyticsInfo(origin: .editor(source), selectionMethod: mediaSelectionMethod)
         return mediaCoordinator.addMedia(from: exportableAsset, to: self.post, analyticsInfo: info)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -7,16 +7,13 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
 
     let post: Post
 
-    private let isInternetReachable: Bool
     private let isJetpackFeaturesEnabled: Bool
     private let isBlazeFlagEnabled: Bool
 
     init(post: Post,
-         isInternetReachable: Bool = ReachabilityUtils.isInternetReachable(),
          isJetpackFeaturesEnabled: Bool = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(),
          isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled()) {
         self.post = post
-        self.isInternetReachable = isInternetReachable
         self.isJetpackFeaturesEnabled = isJetpackFeaturesEnabled
         self.isBlazeFlagEnabled = isBlazeFlagEnabled
         super.init()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -22,8 +22,6 @@ protocol PublishingEditor where Self: UIViewController {
     /// Title of the post
     var postTitle: String { get set }
 
-    var prepublishingSourceView: UIView? { get }
-
     var alertBarButtonItem: UIBarButtonItem? { get }
 
     /// Closure to be executed when the editor gets closed.
@@ -37,8 +35,6 @@ protocol PublishingEditor where Self: UIViewController {
 
     /// When the Prepublishing sheet or Prepublishing alert is dismissed, this is called.
     func publishingDismissed()
-
-    func removeFailedMedia()
 
     /// Returns the word counts of the content in the editor.
     var wordCount: UInt { get }
@@ -57,10 +53,6 @@ extension PublishingEditor {
 
     func emitPostSaveEvent() {
         // Default implementation is empty, can be optionally implemented by other classes.
-    }
-
-    func removeFailedMedia() {
-        // TODO: we can only implement this when GB bridge allows removal of blocks
     }
 
     // The debouncer will perform this callback every 500ms in order to save the post locally with a delay.

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -49,10 +49,6 @@ protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
     ///
     func cancelUploadOfAllMedia(for post: AbstractPost)
 
-    /// Whether the editor has failed media or not
-    ///
-    var hasFailedMedia: Bool { get }
-
     var isUploadingMedia: Bool { get }
 
     /// Verification prompt helper
@@ -72,9 +68,6 @@ protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
 
     /// Describes the editor type to be used in analytics reporting
     var analyticsEditorSource: String { get }
-
-    /// Error domain used when reporting error to Crash Logger
-    var errorDomain: String { get }
 
     /// Navigation bar manager for this post editor
     var navigationBarManager: PostEditorNavigationBarManager { get }
@@ -110,20 +103,8 @@ extension PostEditor {
         postEditorStateContext.updated(hasChanges: editorHasChanges)
     }
 
-    var mainContext: NSManagedObjectContext {
-        return ContextManager.sharedInstance().mainContext
-    }
-
-    var currentBlogCount: Int {
-        return postIsReblogged ? BlogQuery().hostedByWPCom(true).count(in: mainContext) : Blog.count(in: mainContext)
-    }
-
     var alertBarButtonItem: UIBarButtonItem? {
         return navigationBarManager.closeBarButtonItem
-    }
-
-    var prepublishingSourceView: UIView? {
-        return navigationBarManager.publishButton
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -60,19 +60,6 @@ struct PostEditorAnalyticsSession {
         WPAppAnalytics.track(.editorSessionSwitchEditor, withProperties: commonProperties)
     }
 
-    mutating func forceOutcome(_ newOutcome: Outcome) {
-        // We're allowing an outcome to be force in a few specific cases:
-        // - If a post was published, that should be the outcome no matter what happens later
-        // - If a post is saved, that should be the outcome unless it's published later
-        // - Otherwise, we'll use whatever outcome is set when the session ends
-        switch (outcome, newOutcome) {
-        case (_, .publish), (nil, .save):
-            self.outcome = newOutcome
-        default:
-            break
-        }
-    }
-
     func end(outcome endOutcome: Outcome) {
         let outcome = self.outcome ?? endOutcome
         let properties: [String: Any] = [

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -68,10 +68,6 @@ public class PostEditorStateContext {
         }
     }
 
-    fileprivate var originalPostStatus: BasePost.Status?
-    fileprivate var currentPostStatus: BasePost.Status?
-    fileprivate var currentPublishDate: Date?
-    fileprivate var userCanPublish: Bool
     private weak var delegate: PostEditorStateContextDelegate?
 
     fileprivate var hasContent = false {
@@ -115,7 +111,6 @@ public class PostEditorStateContext {
 
         self.init(originalPostStatus: originalPostStatus,
                   userCanPublish: userCanPublish,
-                  publishDate: post.dateCreated,
                   delegate: delegate)
 
         if let action = action {
@@ -126,16 +121,9 @@ public class PostEditorStateContext {
     /// The default initializer
     ///
     /// - Parameters:
-    ///   - originalPostStatus: If the post was already published (saved to the server) what is the status
-    ///   - userCanPublish: Does the user have permission to publish posts or merely create drafts
-    ///   - publishDate: The post publish date
     ///   - delegate: Delegate for listening to change in state for the editor
     ///
-    required init(originalPostStatus: BasePost.Status? = nil, userCanPublish: Bool = true, publishDate: Date? = nil, delegate: PostEditorStateContextDelegate) {
-        self.originalPostStatus = originalPostStatus
-        self.currentPostStatus = originalPostStatus
-        self.userCanPublish = userCanPublish
-        self.currentPublishDate = publishDate
+    required init(originalPostStatus: BasePost.Status? = nil, userCanPublish: Bool = true, delegate: PostEditorStateContextDelegate) {
         self.delegate = delegate
         self.action = PostEditorStateContext.initialAction(for: originalPostStatus, userCanPublish: userCanPublish)
     }
@@ -155,18 +143,6 @@ public class PostEditorStateContext {
         case .trash, .deleted:
             return .update // Should never happen (trashed posts are not be editable)
         }
-    }
-
-    /// Call when the post status has changed due to a remote operation
-    ///
-    func updated(postStatus: BasePost.Status) {
-        currentPostStatus = postStatus
-    }
-
-    /// Call when the publish date has changed (picked a future date) or nil if publish immediately selected
-    ///
-    func updated(publishDate: Date?) {
-        currentPublishDate = publishDate
     }
 
     /// Call whenever the post content is not empty - title or content body

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -7,8 +7,6 @@ protocol AbstractPostListCell {
 }
 
 final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResultCell, Reusable {
-    var isEnabled = true
-
     // MARK: - Views
 
     private lazy var mainStackView: UIStackView = {

--- a/WordPress/Classes/ViewRelated/Post/PostMediaUploadsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostMediaUploadsView.swift
@@ -105,18 +105,6 @@ private struct PostMediaUploadItemView: View {
         }
     }
 
-    struct HostDetailsView: UIViewControllerRepresentable {
-        let media: Media
-
-        func makeUIViewController(context: Context) -> MediaItemViewController {
-            MediaItemViewController(media: media)
-        }
-
-        func updateUIViewController(_ uiViewController: MediaItemViewController, context: Context) {
-            // Do nothing
-        }
-    }
-
     private var menu: some View {
         Menu {
             menuItems
@@ -177,7 +165,6 @@ private struct MediaThubmnailImageView: View {
 private enum Strings {
     static let title = NSLocalizedString("postMediaUploadStatusView.title", value: "Media Uploads", comment: "Title for post media upload status view")
     static let empty = NSLocalizedString("postMediaUploadStatusView.noPendingUploads", value: "No pending uploads", comment: "Placeholder text in postMediaUploadStatusView when no uploads remain")
-    static let close = NSLocalizedString("postMediaUploadStatusView.close", value: "Close", comment: "Close button in postMediaUploadStatusView")
     static let retryUpload = NSLocalizedString("postMediaUploadStatusView.retryUpload", value: "Retry Upload", comment: "Retry (single) upload button in postMediaUploadStatusView")
     static let cancelUpload = NSLocalizedString("postMediaUploadStatusView.cancelUpload", value: "Cancel Upload", comment: "Cancel (single) upload button in postMediaUploadStatusView")
     static let retryUploads = NSLocalizedString("postMediaUploadStatusView.retryUploads", value: "Retry Uploads", comment: "Retry upload button in postMediaUploadStatusView")

--- a/WordPress/Classes/ViewRelated/Post/PostNoticePublishSuccessView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticePublishSuccessView.swift
@@ -145,7 +145,6 @@ struct PostNoticePublishSuccessView: View {
 
 private enum Strings {
     static let title = NSLocalizedString("publishSuccessView.title", value: "Post published!", comment: "Post publish success view: title")
-    static let trafficSectionTitle = NSLocalizedString("publishSuccessView.trafficSectionTitle", value: "Get more traffic:", comment: "Post publish success view: section 'Get more traffic:' title")
     static let view = NSLocalizedString("publishSuccessView.view", value: "View post", comment: "Post publish success view: button 'View post'")
     static let share = NSLocalizedString("publishSuccessView.share", value: "Share post", comment: "Post publish success view: button 'Share post'")
     static let promoteWithBlaze = NSLocalizedString("publishSuccessView.promoteWithBlaze", value: "Promote with Blaze", comment: "Post publish success view: button 'Promote with Blaze'")

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -345,9 +345,6 @@ private extension PrepublishingSocialAccountsViewController {
         static let cellImageSize = CGSize(width: 28.0, height: 28.0)
 
         static let tableTopPadding: CGFloat = 16.0
-        static let minContentHeight: CGFloat = 300.0
-        static let defaultBottomInset: CGFloat = 34.0
-        static let additionalBottomInset: CGFloat = 16.0
 
         static let accountCellIdentifier = "AccountCell"
         static let messageCellIdentifier = "MessageCell"

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -43,6 +43,10 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
     private var cancellables: [AnyCancellable] = []
 
+    deinit {
+        mediaPollingTimer?.invalidate()
+    }
+
     init(post: AbstractPost,
          isStandalone: Bool,
          completion: @escaping (PrepublishingSheetResult) -> (),
@@ -480,7 +484,6 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
 
     fileprivate enum Constants {
         static let reuseIdentifier = "wpTableViewCell"
-        static let nuxButtonInsets = UIEdgeInsets(top: 16, left: 20, bottom: 16, right: 20)
         static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]
     }
 }
@@ -512,13 +515,6 @@ enum PrepublishingIdentifier {
     case tags
     case categories
     case autoSharing
-
-    static var defaultIdentifiers: [PrepublishingIdentifier] {
-        if RemoteFeatureFlag.jetpackSocialImprovements.enabled() {
-            return [.visibility, .schedule, .tags, .categories, .autoSharing]
-        }
-        return [.visibility, .schedule, .tags, .categories]
-    }
 }
 
 extension PrepublishingOption {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishDatePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishDatePickerViewController.swift
@@ -173,8 +173,6 @@ private enum Strings {
     static let date = NSLocalizedString("publishDatePicker.date", value: "Publish Date", comment: "Post publish date picker title for date cell")
     static let immediately = NSLocalizedString("publishDatePicker.immediately", value: "Immediately", comment: "Post publish date picker: selected value placeholder when no date is selected and the post will be published immediately")
     static let timeZone = NSLocalizedString("publishDatePicker.timeZone", value: "Time Zone", comment: "Post publish time zone cell title")
-    static let removePublishDate = NSLocalizedString("publishDatePicker.removePublishDate", value: "Remove Publish Date", comment: "Title for button in publish date picker")
-    static let selectPublishDate = NSLocalizedString("publishDatePicker.selectPublishDate", value: "Select Publish Date", comment: "Title for button in publish date picker")
     static let footerCurrentTimezone = NSLocalizedString("publishDatePicker.footerCurrentTimezone", value: "The date in your current time zone:", comment: "Post publish date picker footer view when the selected date time zone is different from your current time zone; followed by the time in the current time zone.")
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -1,7 +1,5 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
-import WordPressFlux
 
 struct PublishSettingsViewModel {
     enum State {
@@ -20,33 +18,16 @@ struct PublishSettingsViewModel {
 
     private(set) var state: State
     let timeZone: TimeZone
-    let title: String?
-
-    var detailString: String {
-        switch state {
-        case .scheduled(let date), .published(let date):
-            return dateTimeFormatter.string(from: date)
-        case .immediately:
-            return NSLocalizedString("Immediately", comment: "Undated post time label")
-        }
-    }
 
     private let post: AbstractPost
 
     var isRequired: Bool { post.original().isStatus(in: [.publish, .scheduled]) }
-    let dateFormatter: DateFormatter
-    let dateTimeFormatter: DateFormatter
 
-    init(post: AbstractPost, context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+    init(post: AbstractPost) {
         state = State(post: post)
 
         self.post = post
-
-        title = post.postTitle
         timeZone = post.blog.timeZone ?? TimeZone.current
-
-        dateFormatter = SiteDateFormatters.dateFormatter(for: timeZone, dateStyle: .long, timeStyle: .none)
-        dateTimeFormatter = SiteDateFormatters.dateFormatter(for: timeZone, dateStyle: .medium, timeStyle: .short)
     }
 
     var date: Date? {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchSuggestionsService.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchSuggestionsService.swift
@@ -92,6 +92,9 @@ actor PostSearchSuggestionsService {
     }
 
     private func getAllTagTokens() async -> [PostSearchTagToken] {
+        if let tags = cachedTags {
+            return tags
+        }
         let tags = try? await coreData.performQuery { [blogID] context in
             let blog = try context.existingObject(with: blogID)
             let tags = (blog.tags as? Set<PostTag>) ?? []

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -10,10 +10,6 @@ extension WPStyleGuide {
         cell.contentView.backgroundColor = .listBackground
     }
 
-    class func applyPostTitleStyle(_ label: UILabel) {
-        label.textColor = .text
-    }
-
     class func applyBorderStyle(_ view: UIView) {
         view.updateConstraint(for: .height, withRelation: .equal, setConstant: .hairlineBorderWidth, setActive: true)
         view.backgroundColor = .divider

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
@@ -71,37 +71,6 @@ class PublishSettingsViewControllerTests: CoreDataTestCase {
             XCTFail("View model should be published instead of \(viewModel.state)")
         }
     }
-
-    /// Tests that our display date is properly formatted and converted
-    func testDisplayDate() {
-
-        let timeZoneOffset = -1
-
-        let testDate = Date(timeIntervalSinceReferenceDate: 0)
-
-        let post = PostBuilder(mainContext).with(dateCreated: testDate).drafted().withRemote().build()
-
-        // Set our blog's time zone slightly offset from UTC
-        let newValue = OffsetTimeZone(offset: Float(timeZoneOffset))
-
-        // Need to use options here instead of blog.settings because BlogService uses those instead of the properties. No idea why.
-        post.blog.options = ["timezone": ["value": newValue.timezoneString], "gmt_offset": ["value": newValue.gmtOffset as NSNumber? ]]
-
-        let viewModel = PublishSettingsViewModel(post: post, context: self.mainContext)
-
-        // Create a date formatter that converts to the original UTC date
-        let adjustedFormatter = viewModel.dateTimeFormatter.copy() as! DateFormatter
-        adjustedFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-
-        // Generate formatted string and check that converting straight from that string is NOT the same as original date (should be earlier)
-        let formattedString = viewModel.dateTimeFormatter.string(from: post.dateCreated!)
-        let date = adjustedFormatter.date(from: formattedString)
-        XCTAssertNotEqual(date, testDate, "Dates should not be equal")
-
-        // Adjust the original date and check that it matches, thus verifying that our formatter is properly formatting
-        let timeZoneAdjustedDate = testDate.addingTimeInterval(TimeInterval(timeZoneOffset * 60 * 60))
-        XCTAssertEqual(timeZoneAdjustedDate, date, "Formatted date string should equal the adjusted date object")
-    }
 }
 
 extension PublishSettingsViewControllerTests {


### PR DESCRIPTION
I used Periphery to identify the remaining unused bits – stuff that wasn't explicitly annotated but is unused now.

## To test:

- Smoke test the editor
- Open "Post List" / "Search" and ✅ verify that you can still search by tags (just start typing)

## Regression Notes
1. Potential unintended areas of impact: Post 
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
