### PR TITLE
Fix an issue where you could remove the scheduled date on a scheduled post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] If draft sync fails, the app will now show the "Retry" button in the context menu along with the error message [#23355]
 * [*] Fix an issue with post content structure not loading in some scenarios [#23347]
 * [*] Fix a rare crash when updating posts with categories [#23354]
+* [*] Fix an issue where you could remove the scheduled date on a scheduled post [#23360]
 
 
 25.0

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -33,7 +33,7 @@ struct PublishSettingsViewModel {
 
     private let post: AbstractPost
 
-    var isRequired: Bool { (post.original ?? post).status == .publish }
+    var isRequired: Bool { post.original().isStatus(in: [.publish, .scheduled]) }
     let dateFormatter: DateFormatter
     let dateTimeFormatter: DateFormatter
 


### PR DESCRIPTION
It was not working as originally planned and removing the "Publish Date" would not do anything.

## To test:

- Create a scheduled post
- Open Post List / Scheduled / Context Menu / Post Settings / Publish Date
- ✅ Verify that the "xmark" button is not visible and you have to select a date if you want to publish the post at a different time

## Regression Notes
1. Potential unintended areas of impact: Post Settings
2. What I did to test those areas of impact (or what existing automated tests I relied on): manual
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
