### PR TITLE
Add loading indicator when refreshing cached data in post list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,7 +14,7 @@
 * [*] Fix a rare crash when updating posts with categories [#23354]
 * [*] Fix an issue where a Page editor will not close automatically after trying to update a permanently deleted post [#23363]
 * [*] Fix an issue where you could remove the scheduled date on a scheduled post [#23360]
-
+* [*] The Post List screen now fetches updates faster and shows a spinner when refreshing stale data [#23362]
 
 25.0
 -----

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -133,6 +133,7 @@ class AbstractPostListViewController: UIViewController,
         updateSelectedFilter()
 
         refreshResults()
+        automaticallySyncIfAppropriate()
 
         // Show it initially but allow the user to dismiss it by scrolling
         navigationItem.hidesSearchBarWhenScrolling = false
@@ -140,8 +141,6 @@ class AbstractPostListViewController: UIViewController,
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        automaticallySyncIfAppropriate()
 
         navigationItem.hidesSearchBarWhenScrolling = true
     }
@@ -467,12 +466,6 @@ class AbstractPostListViewController: UIViewController,
     // MARK: - Syncing
 
     private func automaticallySyncIfAppropriate() {
-        // Only automatically refresh if the view is loaded and visible on the screen
-        if !isViewLoaded || view.window == nil {
-            DDLogVerbose("View is not visible and will not check for auto refresh.")
-            return
-        }
-
         // Do not start auto-sync if connection is down
         let appDelegate = WordPressAppDelegate.shared
 
@@ -488,6 +481,9 @@ class AbstractPostListViewController: UIViewController,
     }
 
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
+        if !userInteraction {
+            showRefreshingIndicator()
+        }
         syncHelper.syncContentWithUserInteraction(userInteraction)
         refreshResults()
     }
@@ -605,6 +601,7 @@ class AbstractPostListViewController: UIViewController,
                 self.refreshControl.endRefreshing()
             }
         }
+        hideRefreshingIndicator()
         setFooterHidden(true)
         noResultsViewController.removeFromView()
 
@@ -627,6 +624,7 @@ class AbstractPostListViewController: UIViewController,
             return
         }
 
+        hideRefreshingIndicator()
         dismissAllNetworkErrorNotices()
 
         // If there is no internet connection, we'll show the specific error message defined in
@@ -831,6 +829,31 @@ class AbstractPostListViewController: UIViewController,
 
     // MARK: - Misc
 
+    private func showRefreshingIndicator() {
+        guard navigationItem.titleView == nil else {
+            return
+        }
+
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.startAnimating()
+        spinner.tintColor = .secondaryLabel
+        spinner.transform = .init(scaleX: 0.8, y: 0.8)
+
+        let titleView = UILabel()
+        titleView.text = Strings.updating + "..."
+        titleView.font = WPStyleGuide.navigationBarStandardFont
+        titleView.textColor = UIColor.secondaryLabel
+
+        let stack = UIStackView(arrangedSubviews: [spinner, titleView])
+        stack.spacing = 8
+
+        navigationItem.titleView = stack
+    }
+
+    private func hideRefreshingIndicator() {
+        navigationItem.titleView = nil
+    }
+
     private func setFooterHidden(_ isHidden: Bool) {
         if isHidden {
             tableView.tableFooterView = nil
@@ -851,6 +874,11 @@ class AbstractPostListViewController: UIViewController,
 
 extension AbstractPostListViewController: NetworkStatusDelegate {
     func networkStatusDidChange(active: Bool) {
+        // Only automatically refresh if the view is loaded and visible on the screen
+        if !isViewLoaded || view.window == nil {
+            DDLogVerbose("View is not visible and will not check for auto refresh.")
+            return
+        }
         automaticallySyncIfAppropriate()
     }
 }
@@ -868,6 +896,8 @@ extension AbstractPostListViewController: NoResultsViewControllerDelegate {
 
 private enum Strings {
     static let cancelText = NSLocalizedString("postList.cancel", value: "Cancel", comment: "Cancels an Action")
+    // TODO: Add namespace (kahu-offline-mode)
+    static let updating = NSLocalizedString("Updating", comment: "Updating label title")
 
     enum Trash {
         static let actionTitle = NSLocalizedString("postList.trash.actionTitle", value: "Move to Trash", comment: "Trash option in the trash post or page confirmation alert.")


### PR DESCRIPTION
In the current production version, there is no indicator when the cached data in the post list is updating. It can lead to a few issues:

- If you tap on a post before it finished updating, you’ll end up modifying an old version of the post, which will lead to a data conflict (a comprehensive way is to solve it is by refreshing the post right before opening it, which I'm working on for 25.2)
- If you tap the “More” menu on one of the posts, it’ll end up shifting around when the refresh finishes. You really don’t want to tap before it finishes, but there is no visual indication.
 
While both of these issues need other solutions, and there is already one in place, this change will hopefully significantly cut down on the number of occurrences of both issues, and we’ll track it in production. I worked on the design with Chris.

<img width="320" alt="Screenshot 2024-06-17 at 8 53 57 AM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/e5c22016-c1c6-4c2e-b8ba-b4b5d397b39c">


## Testing

- Open Post List with some cached data
- ✅ Verify that the loading indicator is shown and is hidden when the refresh finished
- Switch a tab
- ✅ Verify that the loading indicator is shown and is hidden when the refresh finished

**Alternative considered**: covering the entire view with an overlay and preventing any interactions until the data refreshes. This could lead to the app feeling slower, and we don’t want a compromise solutions. There are ways to implement it correctly while still marinating the sense of speed.

## Regression Notes
1. Potential unintended areas of impact
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
