### PR TITLE
Fix an issue where a Page editor will not close automatically after trying to update a permanently deleted post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] If draft sync fails, the app will now show the "Retry" button in the context menu along with the error message [#23355]
 * [*] Fix an issue with post content structure not loading in some scenarios [#23347]
 * [*] Fix a rare crash when updating posts with categories [#23354]
+* [*] Fix an issue where a Page editor will not close automatically after trying to update a permanently deleted post [#23363]
 * [*] Fix an issue where you could remove the scheduled date on a scheduled post [#23360]
 
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -25,8 +25,6 @@ class EditPostViewController: UIViewController {
     @objc var onClose: ((_ changesSaved: Bool) -> ())?
     @objc var afterDismiss: (() -> Void)?
 
-    private var originalPostID: NSManagedObjectID?
-
     override var modalPresentationStyle: UIModalPresentationStyle {
         didSet(newValue) {
             // make sure this view is transparent with the previous VC visible
@@ -69,7 +67,6 @@ class EditPostViewController: UIViewController {
     /// - Note: it's preferable to use one of the convenience initializers
     fileprivate init(post: Post?, blog: Blog, prompt: BloggingPrompt? = nil) {
         self.post = post
-        self.originalPostID = post?.original().objectID
         if let post = post {
             if !post.originalIsDraft() {
                 editingExistingPost = true
@@ -82,8 +79,6 @@ class EditPostViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
         modalTransitionStyle = .coverVertical
-
-        NotificationCenter.default.addObserver(self, selector: #selector(didChangeObjects), name: NSManagedObjectContext.didChangeObjectsNotification, object: blog.managedObjectContext)
     }
 
     required init?(coder: NSCoder) {
@@ -118,15 +113,6 @@ class EditPostViewController: UIViewController {
             newPost.prepareForPrompt(prompt)
             post = newPost
             return newPost
-        }
-    }
-
-    @objc private func didChangeObjects(_ notification: Foundation.Notification) {
-        guard let userInfo = notification.userInfo else { return }
-
-        let deletedObjects = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
-        if deletedObjects.contains(where: { $0.objectID == originalPostID }) {
-            closeEditor()
         }
     }
 


### PR DESCRIPTION
Fix an issue where a Page editor will not close automatically after trying to update a permanently deleted post

This issue reproduces only for pages and not for posts. 

- (App) Open an existing published page for editing
- (Desktop) Delete the page permanently
- (App) Make some changes and tap “Update”
- ✅ Verify that the app shows an error alert saying that the page no longer exists
- Tap “OK”
- ✅ Verify the the editor closed automatically (in production it does not

Note: please, run the same test for a post for regression testing.

I hope, in the future iterations, we’ll consolidate EditPostViewController and EditrPageViewController as they do the same thing.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
