### PR TITLE
Refresh post when it is opened

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 * [*] Fix an issue with a missing navigation bar background in Post Settings [#23334]
 * [*] Fix an issue where the app will sometimes save empty drafts [#23342]
 * [*] Add `.networkConnectionLost` to the list of "offline" scenarios so that the "offline changes" badge and fast retries work for this use case [#23348]
-
+* [*] Fix an issue with post content structure not loading in some scenarios [#23347]
 
 25.0
 -----

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -266,6 +266,14 @@ class PostCoordinator: NSObject {
         }
     }
 
+    /// Refreshes the post content if needed.
+    @MainActor
+    func refresh(_ post: AbstractPost) async throws -> Bool {
+        try await PostRepository().refresh(post)
+
+        // TODO: handle "not found"
+    }
+
     // MARK: - Sync
 
     /// Returns `true` if the post is eligible for syncing.

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -43,6 +43,7 @@ import Foundation
     case editorPostExcerptChanged
     case editorPostSiteChanged
     case editorPostLegacyMoreMenuShown
+    case editorPostRefreshed
 
     // Resolve post version conflict
     case resolveConflictScreenShown
@@ -700,6 +701,8 @@ import Foundation
             return "editor_post_site_changed"
         case .editorPostLegacyMoreMenuShown:
             return "editor_post_legacy_more_menu_shown"
+        case .editorPostRefreshed:
+            return "editor_post_refreshed"
         case .resolveConflictScreenShown:
             return "resolve_conflict_screen_shown"
         case .resolveConflictSaveTapped:


### PR DESCRIPTION
This PR introduces the “post refresh” mechanism that was cut from the original scope of 24.9 to reduce the complexity. When you open a post for editing the app will now fetch the latest version of the post. Now if you tap a cached post before the list finishes refreshing, the app will guarantee that you will still see the latest version of the post. We hope that it will reduce the number of data conflicts when saving posts (`post_repository_conflict_encountered`). 

There are a few caveats:
- Refreshing a post takes time (expected range is ~200-500ms) and we don’t want to slow down opening the editor. This means that refresh has to happen in parallel with the editor initialization. If the post is already up to date, the editor doesn’t even need to reload.
- You should be able to close the editor in case the refresh is taking too much time. If you do, and the request eventually fails, the app shouldn’t show the error snackbar.
- The “Autosave Available” dialog should be shown based on the latest post content and after the refresh completes
- The editor has it own loading animation. Ideally, we would tap into it, but with lack of an API, I ended up showing an overlay on top of it similar to what you find on [wp.com](http://wp.com/)

Out of the scope: adding support for “Not Found” scenario. It depends on fix/missing-original-assertion-when-updating-not-found-page, and I’d prefer to ship it in 25.2 once this change is proven.

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/e59ae2ea-b887-4a3a-9c1a-8ebf1ffc5dd6

*Scenario 1*

- (App) Open post list and wait until it fetches the latest posts
- (Web) Modify and save one of the posts
- (App) Select the modified post
- ✅ Verify that the post shows the latest data

Comments in code:
- This should be unreachable as [self] will be weak, but adding it just in case
    - We want to make sure that if you close the editor before the refresh finishes, it doesn’t affect other parts of that
- When the editor opens, it immediately creates a revision, so we have to add this, unfortunately. If we end up rethinking the editor, this will be one thing to refactor.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
