### PR TITLE
Reader: Fix crash in Discover stream due to unregistered cell types

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -27,6 +27,9 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         super.init(nibName: nil, bundle: nil)
 
         // register table view cells specific to this controller as early as possible.
+        // the superclass might trigger `layoutIfNeeded` from its `viewDidLoad`, and we want to make sure that
+        // all the cell types have been registered by that time.
+        // see: https://github.com/wordpress-mobile/WordPress-iOS/pull/23368
         tableView.register(ReaderTopicsCardCell.defaultNib, forCellReuseIdentifier: readerCardTopicsIdentifier)
         tableView.register(ReaderSitesCardCell.self, forCellReuseIdentifier: readerCardSitesIdentifier)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -23,12 +23,20 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         return isViewLoaded && view.window != nil
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    init() {
+        super.init(nibName: nil, bundle: nil)
 
+        // register table view cells specific to this controller as early as possible.
         tableView.register(ReaderTopicsCardCell.defaultNib, forCellReuseIdentifier: readerCardTopicsIdentifier)
         tableView.register(ReaderSitesCardCell.self, forCellReuseIdentifier: readerCardSitesIdentifier)
+    }
 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
         addObservers()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -109,7 +109,7 @@ extension ReaderTabView {
 
     private func addContentToContainerView(index: Int) {
         guard let controller = self.next as? UIViewController,
-            let childController = viewModel.makeChildContentViewController(at: index) else {
+              let childController = viewModel.makeChildContentViewController(at: index) else {
                 return
         }
 


### PR DESCRIPTION
Fixes #23351 

This addresses an issue where the `ReaderCardsStreamViewController` (i.e., the Discover stream) could crash due to loading an unregistered cell.

https://github.com/wordpress-mobile/WordPress-iOS/blob/ea97aa6c2d24bb22aeb38b57a20072b19fec3efd/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift#L26-L30

Even though the cell registration was done in `viewDidLoad`, the `super.viewDidLoad()` leads to calling `refreshTableViewHeaderLayout()`, which could trigger `layoutIfNeeded()` on the table view under certain conditions. This issue started happening in 25.0 due to several reasons:

1. Before 25.0, the Discover stream never displays the table header view. In 25.0, we introduced an announcement card in the form of a table header view, and made it eligible to display in the Discover stream. This opened up a path to this issue. Refer to [this diff](https://github.com/wordpress-mobile/WordPress-iOS/compare/24.9.1...25.0#diff-7cc79c8a9ebb1582022da45d82c189f9e8512a97bd9b4ee38b8ad9196c055cadL702-R662):
    ```diff
    -   if readerTopic != nil {
    -       configureStreamHeader()
    -   } else {
    -       tableView.tableHeaderView = nil
    -   }
    +   configureStreamHeader()
    ```
2. In the `refreshTableViewHeaderLayout()` method, `layoutIfNeeded()` is only called when there is a concrete table header view. Now that it's possible to display a table header view, it's possible for the `layoutIfNeeded()` to be called.

  https://github.com/wordpress-mobile/WordPress-iOS/blob/ea97aa6c2d24bb22aeb38b57a20072b19fec3efd/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift#L736-L743

3. The `ReaderCardsStreamViewController` registers two additional cell types specific to this controller's use case. The app crashes 💥  when `layoutIfNeeded()` is called, and there happens to be cell data requiring either one of these specific cell types because we're still executing `super.viewDidLoad()` and haven't registered the cells yet.

4. After observing the remote request, there are instances where the recommendation data is returned as the first or second entry in the response, which causes the table to request for the unregistered cell type. Although not specifically introduced in 25.0, the unpredictable response makes this issue more intermittent and harder to reproduce.

### Resolution

To resolve this, the cell registration is moved to the `init` method to ensure these specific cell types are ready when the table view asks for them.

Note that the problem is a bit more deeply rooted. For example, in the stack trace, you'll notice that the `viewDidLoad` gets triggered due to access to the `view` property in the `addContentToContainerView` method. This early trigger of `viewDidLoad`, leading to an early `layoutIfNeeded` call, may cause an incorrect cell sizing calculation. You might sometimes notice the recommendation cells being truncated due to incorrect height, despite having its constraints set up properly. Addressing this is out of scope of this PR.

## To test

<details>

<summary>Testing pre-requisites</summary>

To reproduce this issue, you need to be lucky and hit certain conditions: display the announcement card and have a site (or tag) recommendation card in the first or second row. To make this easy, I'd suggest making these temporary edits:

```diff
--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -64,7 +64,7 @@ class ReaderCardService {
                 let isCardSites = updatedCards.first?.type == .sites
                 if isFirstPage && (isCardTags || isCardSites) && updatedCards.count > 2 {
                     // Move the first tags recommendation card to a lower position
-                    updatedCards.move(fromOffsets: IndexSet(integer: 0), toOffset: 3)
+                    updatedCards.move(fromOffsets: IndexSet(integer: 0), toOffset: 0) // DEBUG
                 }
```

This ensures that the recommendation card will be displayed in the first row if it exists.

```diff
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -185,8 +185,9 @@ extension ReaderStreamViewController {

         guard readerAnnouncementCoordinator.canShowAnnouncement,
               tableView.tableHeaderView == nil,
-              !isContentFiltered,
-              !contentIsEmpty() else {
+              // DEBUG: Remove this later.
+              !isContentFiltered else {
+//              !contentIsEmpty() else {
             return nil
         }
```

This relaxes the condition, making it easier for the announcement card to be displayed.

</details>

- Ensure that you've applied the pre-requisites above. 
- Do a fresh install of the Jetpack app. 
- Log in to your WP.com account. 
- Navigate to the Reader tab.
- Refresh until you see a 'Blogs to subscribe to' row in the feed.
- Tap the Reader navigation button.
- Tap Discover.
- 🔎 **Verify that the app does NOT crash.**

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
