### PR TITLE
Revert 23201 enable performance monitoring

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -55,15 +55,7 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
         return !UserSettings.userHasOptedOutOfCrashLogging
     }
 
-    let performanceTracking: PerformanceTracking = {
-        let config = PerformanceTracking.Configuration(
-            sampler: { 0.005 },
-            profilingRate: 0.01,
-            trackCoreData: true,
-            trackNetwork: false
-        )
-        return .enabled(config)
-    }()
+    let performanceTracking: PerformanceTracking = .disabled
 
     var currentUser: TracksUser? {
         return contextManager.performQuery { context -> TracksUser? in


### PR DESCRIPTION
I don't think there was a demand for this  from the iOS team, and I've seen some odd crashes when debugging related to Sentry, which I suspect might be related.

We've disabled some of these problematic areas of Sentry before. It might be one of these too, and I'm not sure we want to deal with it right now if it turns out to be problematic.

## To test:

Smoke test: app still runs.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
