### PR TITLE
Revert "Enable performance monitoring"

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -55,16 +55,6 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
         return !UserSettings.userHasOptedOutOfCrashLogging
     }
 
-    let performanceTracking: PerformanceTracking = {
-        let config = PerformanceTracking.Configuration(
-            sampler: { 0.005 },
-            profilingRate: 0.01,
-            trackCoreData: true,
-            trackNetwork: false
-        )
-        return .enabled(config)
-    }()
-
     var currentUser: TracksUser? {
         return contextManager.performQuery { context -> TracksUser? in
             guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context) else {


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-iOS#23201

This feature is currently not used, so there's no point to use organization limits and risk unwanted behavior. See: https://github.com/wordpress-mobile/WordPress-iOS/pull/23201#issuecomment-2166369408