### PR TITLE
Remove unused code

### DIFF
--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -232,10 +232,6 @@ extension StoryEditor: PublishingEditor {
         return post.content ?? ""
     }
 
-    func cancelUploadOfAllMedia(for post: AbstractPost) {
-
-    }
-
     func publishingDismissed() {
         hideLoading()
     }

--- a/WordPress/Classes/System/RootViewPresenter+EditorNavigation.swift
+++ b/WordPress/Classes/System/RootViewPresenter+EditorNavigation.swift
@@ -81,7 +81,7 @@ extension RootViewPresenter {
         }
         guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
         guard content == nil else {
-            showEditor(blog: blog, title: title, content: content, templateKey: nil)
+            showEditor(blog: blog, title: title, content: content)
             return
         }
 
@@ -89,12 +89,12 @@ extension RootViewPresenter {
                           properties: [WPAppAnalyticsKeyTapSource: source],
                           blog: blog)
         PageCoordinator.showLayoutPickerIfNeeded(from: rootViewController, forBlog: blog) { [weak self] (selectedLayout) in
-            self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content, templateKey: selectedLayout?.slug)
+            self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content)
         }
     }
 
-    private func showEditor(blog: Blog, title: String?, content: String?, templateKey: String?) {
-        let editorViewController = EditPageViewController(blog: blog, postTitle: title, content: content, appliedTemplate: templateKey)
+    private func showEditor(blog: Blog, title: String?, content: String?) {
+        let editorViewController = EditPageViewController(blog: blog, postTitle: title, content: content)
         rootViewController.present(editorViewController, animated: false)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -61,10 +61,6 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     let mediaUtility = EditorMediaUtility()
 
-    func cancelUploadOfAllMedia(for post: AbstractPost) {
-        mediaCoordinator.cancelUploadOfAllMedia(for: post)
-    }
-
     var entryPoint: PostEditorEntryPoint = .unknown {
         didSet {
             editorSession.entryPoint = entryPoint

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/PagesCardViewModel.swift
@@ -109,7 +109,7 @@ class PagesCardViewModel: NSObject {
             guard let blog = self?.blog else {
                 return
             }
-            let editorViewController = EditPageViewController(blog: blog, postTitle: selectedLayout?.title, content: selectedLayout?.content, appliedTemplate: selectedLayout?.slug)
+            let editorViewController = EditPageViewController(blog: blog, postTitle: selectedLayout?.title, content: selectedLayout?.content)
             viewController.present(editorViewController, animated: false)
         }
         trackCreateSectionTapped()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -112,10 +112,6 @@ class GutenbergMediaInserterHelper: NSObject {
         return mediaCoordinator.isUploadingMedia(for: post)
     }
 
-    func cancelUploadOfAllMedia() {
-        mediaCoordinator.cancelUploadOfAllMedia(for: post)
-    }
-
     func cancelUploadOf(media: Media) {
         mediaCoordinator.cancelUploadAndDeleteMedia(media)
         gutenberg.mediaUploadUpdate(id: media.gutenbergUploadID, state: .reset, progress: 0, url: nil, serverID: nil)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -100,10 +100,6 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         return mediaInserterHelper.isUploadingMedia()
     }
 
-    func cancelUploadOfAllMedia(for post: AbstractPost) {
-        return mediaInserterHelper.cancelUploadOfAllMedia()
-    }
-
     var mediaToInsertOnPost = [Media]()
 
     func prepopulateMediaItems(_ media: [Media]) {

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
@@ -10,14 +10,14 @@ class EditPageViewController: UIViewController {
     var onClose: (() -> Void)?
 
     convenience init(page: Page) {
-        self.init(page: page, blog: page.blog, postTitle: nil, content: nil, appliedTemplate: nil)
+        self.init(page: page, blog: page.blog, postTitle: nil, content: nil)
     }
 
-    convenience init(blog: Blog, postTitle: String?, content: String?, appliedTemplate: String?) {
-        self.init(page: nil, blog: blog, postTitle: postTitle, content: content, appliedTemplate: appliedTemplate)
+    convenience init(blog: Blog, postTitle: String?, content: String?) {
+        self.init(page: nil, blog: blog, postTitle: postTitle, content: content)
     }
 
-    fileprivate init(page: Page?, blog: Blog, postTitle: String?, content: String?, appliedTemplate: String?) {
+    fileprivate init(page: Page?, blog: Blog, postTitle: String?, content: String?) {
         self.page = page
         self.blog = blog
         self.postTitle = postTitle

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -113,6 +113,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         setupLabels()
         setupFeaturedImageView()
         setupEllipsisButton()
+        setupIcon()
 
         indentationIconView.tintColor = .secondaryLabel
         indentationIconView.image = UIImage(named: "subdirectory")

--- a/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListItemViewModel.swift
@@ -6,7 +6,6 @@ final class PageListItemViewModel {
     let badgeIcon: UIImage?
     let badges: NSAttributedString
     let imageURL: URL?
-    let accessibilityIdentifier: String?
     let syncStateViewModel: PostSyncStateViewModel
 
     init(page: Page) {
@@ -15,7 +14,6 @@ final class PageListItemViewModel {
         self.badgeIcon = makeBadgeIcon(for: page)
         self.badges = makeBadgesString(for: page)
         self.imageURL = page.featuredImageURL
-        self.accessibilityIdentifier = page.slugForDisplay()
         self.syncStateViewModel = PostSyncStateViewModel(post: page)
     }
 }
@@ -69,5 +67,4 @@ private enum Strings {
     static let badgePosts = NSLocalizedString("pageList.badgePosts", value: "Posts page", comment: "Badge for page cells")
     static let badgePrivatePage = NSLocalizedString("pageList.badgePrivate", value: "Private", comment: "Badge for page cells")
     static let badgePendingReview = NSLocalizedString("pageList.badgePendingReview", value: "Pending review", comment: "Badge for page cells")
-    static let badgeLocalChanges = NSLocalizedString("pageList.badgeLocalChanges", value: "Local changes", comment: "Badge for page cells")
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -398,7 +398,7 @@ final class PageListViewController: AbstractPostListViewController {
     }
 
     private func createPage(_ starterLayout: PageTemplateLayout?) {
-        let editorViewController = EditPageViewController(blog: blog, postTitle: starterLayout?.title, content: starterLayout?.content, appliedTemplate: starterLayout?.slug)
+        let editorViewController = EditPageViewController(blog: blog, postTitle: starterLayout?.title, content: starterLayout?.content)
         present(editorViewController, animated: false)
 
         QuickStartTourGuide.shared.visited(.newPage)

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -33,8 +33,6 @@ private struct Row: ImmuTableRow {
 }
 
 class ParentPageSettingsViewController: UIViewController {
-    var onClose: (() -> Void)?
-
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var searchBar: UISearchBar!
 
@@ -142,23 +140,6 @@ class ParentPageSettingsViewController: UIViewController {
         return view.convert(keyboardFrame, from: nil)
     }
 
-    private func reloadData(at section: Int, animation: UITableView.RowAnimation = .none) {
-        let sections = IndexSet(integer: section)
-        tableView.reloadSections(sections, with: animation)
-    }
-
-    private func originalRow(with pages: [Page]) -> Row? {
-        if selectedPage.isTopLevelPage {
-            return Row()
-        }
-
-        guard let parent = (pages.first { $0.postID == selectedPage.parentID }) else {
-            return nil
-        }
-
-        return Row(page: parent, type: .child)
-    }
-
     private func triggerNoResults(display: Bool) {
         if display {
             if noResultsViewController.view.superview != nil {
@@ -229,13 +210,12 @@ extension ParentPageSettingsViewController: UITableViewDelegate {
 /// ParentPageSettingsViewController class constructor
 //
 extension ParentPageSettingsViewController {
-    class func make(with pages: [Page], selectedPage: Page, onClose: @escaping () -> Void) -> UIViewController {
+    class func make(with pages: [Page], selectedPage: Page) -> UIViewController {
         let storyboard = UIStoryboard(name: "Pages", bundle: Bundle.main)
         guard let viewController = storyboard.instantiateViewController(withIdentifier: "ParentPageSettings") as? ParentPageSettingsViewController else {
             fatalError("A ParentPageSettingsViewController view controller is required for Parent Page Settings")
         }
         viewController.set(pages: pages, for: selectedPage)
-        viewController.onClose = onClose
         return viewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostAuthorSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostAuthorSelectorViewController.swift
@@ -1,9 +1,6 @@
 import UIKit
 
 @objc class PostAuthorSelectorViewController: SettingsSelectionViewController {
-    /// The post to change the author.
-    private var post: AbstractPost!
-
     /// A completion block that is called after the user selects an option.
     @objc var completion: (() -> Void)?
 
@@ -13,8 +10,6 @@ import UIKit
     // MARK: - Constructors
 
     @objc init(_ post: AbstractPost) {
-        self.post = post
-
         let authors = PostAuthorSelectorViewController.sortedActiveAuthors(for: post.blog)
 
         guard !authors.isEmpty, let currentAuthorID = post.authorID else {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -34,10 +34,6 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
         return author
     }
 
-    private var postStatus: BasePost.Status? {
-        return post.status
-    }
-
     var statusColor: UIColor {
         if post.isLegacyUnsavedRevision {
             return .warning

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -30,9 +30,6 @@ protocol PublishingEditor where Self: UIViewController {
     /// Return the current html in the editor
     func getHTML() -> String
 
-    /// Cancels all ongoing uploads
-    func cancelUploadOfAllMedia(for post: AbstractPost)
-
     /// When the Prepublishing sheet or Prepublishing alert is dismissed, this is called.
     func publishingDismissed()
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -27,27 +27,11 @@ protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
     ///
     var post: AbstractPost { get set }
 
-    /// Initializer
-    ///
-    /// - Parameters:
-    ///     - post: the post to edit. Must be already assigned to a `ManagedObjectContext` since
-    ///     that's necessary for the edits to be saved.
-    ///     - replaceEditor: a closure that handles switching from one editor to another
-    ///     - editorSession: post editor analytics session
-    init(
-        post: AbstractPost,
-        replaceEditor: @escaping ReplaceEditorCallback,
-        editorSession: PostEditorAnalyticsSession?)
-
     /// Media items to be inserted on the post after creation
     ///
     /// - Parameter media: the media items to add
     ///
     func prepopulateMediaItems(_ media: [Media])
-
-    /// Cancels all ongoing uploads
-    ///
-    func cancelUploadOfAllMedia(for post: AbstractPost)
 
     var isUploadingMedia: Bool { get }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListHeaderView.swift
@@ -9,11 +9,6 @@ final class PostListHeaderView: UIView {
     private let indicator = UIActivityIndicatorView(style: .medium)
     private let ellipsisButton = UIButton(type: .custom)
 
-    // MARK: - Properties
-
-    private var post: Post?
-    private var viewModel: PostListItemViewModel?
-
     // MARK: - Initializer
 
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -223,10 +223,7 @@ extension PostSettingsViewController {
             if let index = pages.firstIndex(of: page) {
                 pages = pages.remove(from: index)
             }
-            let viewController = ParentPageSettingsViewController.make(with: pages, selectedPage: page) { [weak self] in
-                self?.navigationController?.popViewController(animated: true)
-                self?.tableView.reloadData()
-            }
+            let viewController = ParentPageSettingsViewController.make(with: pages, selectedPage: page)
             viewController.isModalInPresentation = true
             navigationController?.pushViewController(viewController, animated: true)
         } catch {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -23,8 +23,6 @@ final class PrepublishingViewController: UIViewController, UITableViewDataSource
         post.blog.dotComID?.intValue
     }
 
-    private lazy var publishSettingsViewModel = PublishSettingsViewModel(post: post)
-
     private var completion: ((PrepublishingSheetResult) -> ())?
 
     /// The data source for the table rows, based on the filtered `identifiers`.


### PR DESCRIPTION
This is one more sweep with Periphery, removing leftover code from the "Offline Mode" project and other unused code.

To test: n/a

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
