### PR TITLE
Fix rare crash in GutenbergWebViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Simplify post list context menu sections [#23356]
 * [*] Fix an issue with incorrect snackbar shown when saving drafts manually [#23358]
+* [*] Fix rare crash in the unsupported block editor [#23379]
 
 25.1
 -----


### PR DESCRIPTION
I've been reviewing Sentry in the scope of the release rotation. This [issue](https://a8c.sentry.io/issues/5257376344/?environment=appStore&project=5716771&query=release%3Acom.automattic.jetpack%4025.0%2B25.0.0.2&referrer=release-issue-stream) because since the web-based editor became more discoverable, more people started using it.

I'm not sure how to reproduce it exactly, but I replaced the legacy KVO APIs with the new safe ones.

## To test:

- Open a post with an unsupported block
- Tap the block to edit it
- ✅ Verify that the progress view reaches 100% and gets dismissed

## Regression Notes
1. Potential unintended areas of impact: Gutenberg web-based block editor
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
