### PR TITLE
Reader: Fix announcement card keep showing up after tapping Done

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -171,9 +171,9 @@ class ReaderAnnouncementCoordinator {
 
     let repository: UserPersistentRepository = UserPersistentStoreFactory.instance()
 
-    lazy var canShowAnnouncement: Bool = {
+    var canShowAnnouncement: Bool {
         return !isDismissed && RemoteFeatureFlag.readerAnnouncementCard.enabled()
-    }()
+    }
 
     var isDismissed: Bool {
         get {


### PR DESCRIPTION
Fixes p1719277043323269-slack-C0180B5PRJ4

This fixes an issue where the Reader announcement card is not dismissed correctly. 

## To test

- Launch a fresh install of the Jetpack app.
- Log in to your WP.com account.
- Navigate to Reader.
- Tap 'Done' on the announcement card.
- Do a pull-to-refresh to refresh the stream.
- 🔎 Verify that the announcement card is NOT displayed.
- Kill the app and relaunch.
- Navigate to Reader.
- 🔎 Verify that the announcement card is NOT displayed.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)