### PR TITLE
Remove Alamofire dependency from WordPressKit

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -149,9 +149,7 @@ enum XcodeSupport {
                 .product(name: "WordPressShared", package: "WordPress-iOS-Shared"),
             ]),
             .xcodeTarget("XcodeTarget_WordPressKit", dependencies: wordPressKitDependencies),
-            .xcodeTarget("XcodeTarget_WordPressKitTests", dependencies: wordPressKitDependencies + testDependencies + [
-                .product(name: "Alamofire", package: "Alamofire"),
-            ]),
+            .xcodeTarget("XcodeTarget_WordPressKitTests", dependencies: wordPressKitDependencies + testDependencies),
             .xcodeTarget("XcodeTarget_WordPressAuthentificator", dependencies: wordPresAuthentificatorDependencies),
             .xcodeTarget("XcodeTarget_WordPressAuthentificatorTests", dependencies: wordPresAuthentificatorDependencies + testDependencies),
             .xcodeTarget("XcodeTarget_ShareExtension", dependencies: shareAndDraftExtensionsDependencies),

--- a/WordPressKit/Tests/WordPressKitTests/Tests/Models/Stats/V2/Insights/StatsDotComFollowersInsightTests.swift
+++ b/WordPressKit/Tests/WordPressKitTests/Tests/Models/Stats/V2/Insights/StatsDotComFollowersInsightTests.swift
@@ -115,7 +115,7 @@ private extension StatsDotComFollowersInsightTests {
         guard var components = URLComponents(string: urlString) else { return nil }
         components.query = "d=mm&s=60"
 
-        return try? components.asURL()
+        return components.url
     }
 
 }


### PR DESCRIPTION
It was "needed" for tests.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
