### PR TITLE
Remove UIDeviceIdentifier dependency from WordPressKit 

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -85,7 +85,6 @@ enum XcodeSupport {
     static let targets: [Target] = {
         let wordPressKitDependencies: [Target.Dependency] = [
             .product(name: "NSObject-SafeExpectations", package: "NSObject-SafeExpectations"),
-            .product(name: "UIDeviceIdentifier", package: "UIDeviceIdentifier"),
             .product(name: "WordPressShared", package: "WordPress-iOS-Shared"),
             .product(name: "wpxmlrpc", package: "wpxmlrpc"),
         ]

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		0C0AD10B2B0CCFA400EC06E6 /* MediaPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AD1092B0CCFA400EC06E6 /* MediaPreviewController.swift */; };
 		0C0AE7592A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
 		0C0AE75A2A8FAD6A007D9D6C /* MediaPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */; };
+		0C0B34DC2C38ADC3005CB484 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0B34DB2C38ADC3005CB484 /* UIDevice+Extensions.swift */; };
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C0D3B0E2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C0DF8812C2DDE7900011B7D /* WordPressKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A98A2F42C22736F00A2CE58 /* WordPressKit.framework */; };
@@ -7476,6 +7477,7 @@
 		0C0AD1052B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaSelectionTitleView.swift; sourceTree = "<group>"; };
 		0C0AD1092B0CCFA400EC06E6 /* MediaPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewController.swift; sourceTree = "<group>"; };
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
+		0C0B34DB2C38ADC3005CB484 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C0DF8932C2DF12A00011B7D /* LoginFacadeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoginFacadeTests.m; sourceTree = "<group>"; };
 		0C13ACC62BF406CB00FF7405 /* VoiceToContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceToContentView.swift; sourceTree = "<group>"; };
@@ -15209,6 +15211,7 @@
 				4A98A4452C22741500A2CE58 /* NSString+MD5.m */,
 				4A98A4462C22741500A2CE58 /* ObjectValidation.swift */,
 				4A98A4472C22741500A2CE58 /* ZendeskMetadata.swift */,
+				0C0B34DB2C38ADC3005CB484 /* UIDevice+Extensions.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -27408,6 +27411,7 @@
 				4A98A4C72C22741500A2CE58 /* RemotePostParameters.swift in Sources */,
 				4A98A4F52C22741500A2CE58 /* QRLoginServiceRemote.swift in Sources */,
 				4A98A4FD2C22741500A2CE58 /* ActivityServiceRemote.swift in Sources */,
+				0C0B34DC2C38ADC3005CB484 /* UIDevice+Extensions.swift in Sources */,
 				4A98A5542C22741600A2CE58 /* TaxonomyServiceRemoteREST.m in Sources */,
 				4A98A5392C22741600A2CE58 /* ReaderPostServiceRemote.m in Sources */,
 				4A98A4922C22741500A2CE58 /* StatsSearchTermTimeIntervalData.swift in Sources */,

--- a/WordPressKit/Sources/WordPressKit/Services/NotificationSettingsServiceRemote.swift
+++ b/WordPressKit/Sources/WordPressKit/Services/NotificationSettingsServiceRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIDeviceIdentifier
 import WordPressShared
 
 /// The purpose of this class is to encapsulate all of the interaction with the Notifications REST endpoints.
@@ -77,7 +76,7 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
             "device_family": "apple",
             "app_secret_key": pushNotificationAppId,
             "device_name": device.name,
-            "device_model": UIDeviceHardware.platform(),
+            "device_model": device.platform,
             "os_version": device.systemVersion,
             "app_version": Bundle.main.bundleVersion(),
             "device_uuid": device.wordPressIdentifier()

--- a/WordPressKit/Sources/WordPressKit/Utility/UIDevice+Extensions.swift
+++ b/WordPressKit/Sources/WordPressKit/Utility/UIDevice+Extensions.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UIDevice {
+    var platform: String {
+        var size = 0
+        sysctlbyname("hw.machine", nil, &size, nil, 0)
+        var machine = [CChar](repeating: 0, count: size)
+        sysctlbyname("hw.machine", &machine, &size, nil, 0)
+        return String(cString: machine)
+    }
+}


### PR DESCRIPTION
The dependency was used in a single line: `UIDeviceHardware.platform()`, so it wasn't worth requiring it in the framework. Instead, I added it directly to the app.

I tested the before/after on a physical device, and the value was unchanged, so no manual testing needed.

`UIDeviceIdentifier` was also a _transient_ dependency, so I moved it to the Podfile to fix it for now. The only remaining place that uses it is `Automattic-Tracks-iOS`.

```
  - Automattic-Tracks-iOS (3.3.0):
    - Sentry (~> 8.0)
    - Sodium (>= 0.9.1)
    - UIDeviceIdentifier (~> 2.0)
```

`Automattic-Tracks-iOS` _seems_ to support SPM, so WPKit should no longer block us from adding `Automattic-Tracks-iOS` as a Swift package.

## Regression Notes
1. Potential unintended areas of impact:
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
