### PR TITLE
Remove direct wpxmlrpc usages from the app

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -139,7 +139,6 @@ enum XcodeSupport {
                 .product(name: "UIDeviceIdentifier", package: "UIDeviceIdentifier"),
                 .product(name: "WordPressShared", package: "WordPress-iOS-Shared"),
                 .product(name: "WordPressUI", package: "WordPressUI-iOS"),
-                .product(name: "wpxmlrpc", package: "wpxmlrpc"),
                 .product(name: "ZendeskSupportSDK", package: "support_sdk_ios"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ]),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -94,7 +94,8 @@ enum XcodeSupport {
             .product(name: "Gridicons", package: "Gridicons-iOS"),
             .product(name: "SVProgressHUD", package: "SVProgressHUD"),
             .product(name: "WordPressUI", package: "WordPressUI-iOS"),
-        ] + wordPressKitDependencies
+            .product(name: "WordPressShared", package: "WordPress-iOS-Shared"),
+        ]
 
         let shareAndDraftExtensionsDependencies: [Target.Dependency] = [
             .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -6,7 +6,6 @@
 #import "Blog.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "WordPress-Swift.h"
-#import "WPXMLRPCDecoder.h"
 
 @import WordPressKit;
 @import WordPressUI;

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -7,6 +7,8 @@
 
 NSInteger const SupportButtonIndex = 0;
 
+@import WordPressKit;
+
 @interface WPError ()
 
 @property (nonatomic, assign) BOOL alertShowing;
@@ -48,7 +50,7 @@ NSInteger const SupportButtonIndex = 0;
 {
     NSString *cleanedErrorMsg = [error localizedDescription];
 
-    if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain] && error.code == 401) {
+    if ([error.domain isEqualToString:WordPressOrgXMLRPCApi.errorDomain] && error.code == 401) {
         cleanedErrorMsg = NSLocalizedString(@"Sorry, you cannot access this feature. Please check your User Role on this site.", @"");
     }
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -3,7 +3,6 @@
 #import "WordPress-Swift.h"
 
 @import WordPressShared;
-@import wpxmlrpc;
 
 NSInteger const SupportButtonIndex = 0;
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -16,7 +16,6 @@
 
 @import WordPressKit;
 @import WordPressShared;
-@import wpxmlrpc;
 @import NSURL_IDN;
 
 NS_ENUM(NSInteger, SiteSettingsAccount) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -3,9 +3,9 @@ import CoreData
 import Gridicons
 import CocoaLumberjack
 import WordPressShared
-import wpxmlrpc
 import WordPressFlux
 import WordPressUI
+import WordPressKit
 import Combine
 
 class AbstractPostListViewController: UIViewController,
@@ -618,8 +618,8 @@ class AbstractPostListViewController: UIViewController,
     }
 
     @objc func handleSyncFailure(_ error: NSError) {
-        if error.domain == WPXMLRPCFaultErrorDomain
-            && error.code == type(of: self).httpErrorCodeForbidden {
+        if error.domain == WordPressOrgXMLRPCApi.errorDomain &&
+            error.code == type(of: self).httpErrorCodeForbidden {
             WordPressAppDelegate.shared?.showPasswordInvalidPrompt(for: blog)
             return
         }

--- a/WordPressAuthenticator/Sources/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WordPressAuthenticator/Sources/Extensions/FancyAlertViewController+LoginError.swift
@@ -1,7 +1,7 @@
 import UIKit
-import wpxmlrpc
 import SafariServices
 import WordPressUI
+import WordPressKit
 
 extension FancyAlertViewController {
     private struct Strings {
@@ -88,7 +88,7 @@ extension FancyAlertViewController {
             }
         }
 
-        if error.domain != WPXMLRPCFaultErrorDomain && error.code != NSURLErrorBadURL {
+        if error.domain != WordPressOrgXMLRPCApi.errorDomain && error.code != NSURLErrorBadURL {
             if WordPressAuthenticator.shared.delegate?.supportEnabled == true {
                 return alertForGenericErrorMessageWithHelpButton(message, loginFields: loginFields, sourceTag: sourceTag)
             }

--- a/WordPressAuthenticator/Sources/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPressAuthenticator/Sources/Services/WordPressXMLRPCAPIFacade.m
@@ -2,8 +2,6 @@
 #import "WPAuthenticator-Swift.h"
 
 @import WordPressKit;
-@import wpxmlrpc;
-
 
 @interface WordPressXMLRPCAPIFacade ()
 

--- a/WordPressKit/Sources/CoreAPI/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/Sources/CoreAPI/WordPressOrgXMLRPCApi.swift
@@ -29,6 +29,10 @@ open class WordPressOrgXMLRPCApi: NSObject {
     ///
     @objc public static let minimumSupportedVersion = "4.0"
 
+    @objc public static var errorDomain: String {
+        wpxmlrpc.WPXMLRPCFaultErrorDomain
+    }
+
     private lazy var urlSession: URLSession = makeSession(configuration: .default)
     private lazy var uploadURLSession: URLSession = {
         backgroundUploads


### PR DESCRIPTION
The `wpxmlrpc` was another transient dependency declared in `WordPressKit.podspec` but used directly from the app. `WordPressKit` now re-export the only property from `wpxmlrpc` that was used by the app. 

~~If we end up using Xcode targets to define `WordPressKit`, we'll include it as a Swift package and link it statically in `WordPressKit`. Either way, it's one less dependency to worry about.~~

Update: I had to also update  `WordPressAuthentificator` to remove the direct `wpxmlrpc` usage, so it is now linked statically in `WordPressKit` and doesn't leak from its interface.

## To test:

Just to make sure it works, I span a local WP instance and changes a password:

Not sure what's up with "Updating..." in the background. I left a note to check it later.

<img width="340" alt="Screenshot 2024-06-26 at 3 26 50 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/b279757e-7850-4c0a-a1cc-3dd74b2e3e4b">



## Regression Notes
1. Potential unintended areas of impact
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
