### PR TITLE
Explicitly set mac queue in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# Most of the steps need to run on a macOS agent, so let's define it as a root property.
+agents:
+  queue: mac
 env:
   IMAGE_ID: $IMAGE_ID
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,5 +1,7 @@
 # This pipeline is meant to be run via the Buildkite API, and is only used for release builds
 
+agents:
+  queue: mac
 env:
   IMAGE_ID: $IMAGE_ID
 


### PR DESCRIPTION
We are DRYing the pipeline upload step in our internal Infrastructure as Code (IaC) setup, see https://github.com/Automattic/buildkite-ci/pull/452/files#r1652113066, which in turns will allow us to do some useful things with metadata, see https://github.com/Automattic/buildkite-ci/pull/459.

However, some pipeline, such as the one here, were configured to set `agents: queue: mac` at upload time, blocking them from adopting the DRY upload step.

This is PR sets the queue at the pipeline level, making it safe to adopt the standard upload step.

Notice that the the only pipeline file to change is `pipeline.yml`. The other one already had to explicitly set their `agents` value because they are all started via API, thus bypassing the default upload step and not inheriting the `agents` value set in it.

## Testing

If CI is green, then we're good.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.
