### PR TITLE
Bump Fastlane `xcodebuild -showBuildSettings` interval to try avoid timeouts

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -267,6 +267,14 @@ import 'lanes/release_management_in_ci.rb'
 default_platform(:ios)
 
 before_all do |lane|
+  # Various actions run 'xcodebuild -showBuildSettings ...' which can at times fail, possibly due to networking and SPM resolution.
+  # See for example this failure https://buildkite.com/automattic/wordpress-ios/builds/22979#01906bdc-3077-4d17-b742-a55c9a9db4b4
+  #
+  # Bumping the interval Fastlane waits for xcodebuild to provide output before retrying seems to be an effective workaround.
+  #
+  # See also https://github.com/fastlane/fastlane/issues/20919
+  ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
+
   # Skip these checks/steps for test lane (not needed for testing)
   next if lane == :test_without_building
 


### PR DESCRIPTION
I got a UI test failure timeout in https://github.com/wordpress-mobile/WordPress-iOS/pull/23402 during the `xcodebuild- showBuildSettings` step.

I thought using the newer Simulator in #23259 was the fix for this issue, but clearly that was a false positive.

In one of our apps that are not (yet?) open source and therefore can't be linked here, we had luck using `ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'` (as per https://github.com/fastlane/fastlane/issues/20919).

I replicated the setting here, but I won't stress test it because: 1) running tens of UI tests would clog our queue for hours, 2) I already did so in the other app, running the same step 50 times, twice.