### PR TITLE
[Gutenberg] - Remove Gallery V1 and experimental flags

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 80c9f88a26f89804fbec0e929f24ac240dca38d4
+  commit: 0239a7b2494802dfff1e9d8faa486efdf0885631
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 25a28edbafe8bb8895436c9cc3df48c51367465d
+  tag: v1.121.0-alpha2
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: f65a69019e6634e8277fb0861b7cd7d2f4442d73
+  commit: 25a28edbafe8bb8895436c9cc3df48c51367465d
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 0239a7b2494802dfff1e9d8faa486efdf0885631
+  commit: f65a69019e6634e8277fb0861b7cd7d2f4442d73
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  tag: v1.120.1
+  commit: 80c9f88a26f89804fbec0e929f24ac240dca38d4
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-80c9f88a26f89804fbec0e929f24ac240dca38d4.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-0239a7b2494802dfff1e9d8faa486efdf0885631.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-80c9f88a26f89804fbec0e929f24ac240dca38d4.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-0239a7b2494802dfff1e9d8faa486efdf0885631.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 9a76b99b224d5d82ee3aadc0b418ac399c5c1e76
+  Gutenberg: 187b75f69ee51b81347329df29d3a7d78bda032c
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-25a28edbafe8bb8895436c9cc3df48c51367465d.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.121.0-alpha2.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-25a28edbafe8bb8895436c9cc3df48c51367465d.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.121.0-alpha2.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 568ec44e90c660516b2021235c8d3c0975981243
+  Gutenberg: ff2d4988d208440f35c1554ef457fca86abf99a9
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-25a28edbafe8bb8895436c9cc3df48c51367465d.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-25a28edbafe8bb8895436c9cc3df48c51367465d.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 21e8eb074e7da51aaf7c9dd2165d3ebfd5481088
+  Gutenberg: 568ec44e90c660516b2021235c8d3c0975981243
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.120.1.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-80c9f88a26f89804fbec0e929f24ac240dca38d4.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.120.1.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-80c9f88a26f89804fbec0e929f24ac240dca38d4.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 0699e7dd207afb591ccd5e81252a92e6e7781391
+  Gutenberg: 9a76b99b224d5d82ee3aadc0b418ac399c5c1e76
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-0239a7b2494802dfff1e9d8faa486efdf0885631.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-0239a7b2494802dfff1e9d8faa486efdf0885631.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 187b75f69ee51b81347329df29d3a7d78bda032c
+  Gutenberg: 21e8eb074e7da51aaf7c9dd2165d3ebfd5481088
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/WordPress/Classes/Models/BlockEditorSettingElement+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/BlockEditorSettingElement+CoreDataProperties.swift
@@ -11,12 +11,6 @@ enum BlockEditorSettingElementTypes: String {
     }
 }
 
-enum BlockEditorExperimentalFeatureKeys: String {
-    case galleryWithImageBlocks
-    case quoteBlockV2
-    case listBlockV2
-}
-
 extension BlockEditorSettingElement {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<BlockEditorSettingElement> {

--- a/WordPress/Classes/Models/BlockEditorSettings+GutenbergEditorSettings.swift
+++ b/WordPress/Classes/Models/BlockEditorSettings+GutenbergEditorSettings.swift
@@ -11,25 +11,6 @@ extension BlockEditorSettings: GutenbergEditorSettings {
         elementsByType(.gradient)
     }
 
-    public var galleryWithImageBlocks: Bool {
-        // If site is using WP 5.9+ then return true as galleryWithImageBlocks is supported in WP 5.9+.
-        // Once support for WP 5.8 is dropped, this can be removed.
-        // https://github.com/WordPress/gutenberg/issues/47782
-        if blog.hasRequiredWordPressVersion("5.9") {
-            return true
-        } else {
-            return experimentalFeature(.galleryWithImageBlocks)
-        }
-    }
-
-    public var quoteBlockV2: Bool {
-        return experimentalFeature(.quoteBlockV2)
-    }
-
-    public var listBlockV2: Bool {
-        return experimentalFeature(.listBlockV2)
-    }
-
     private func elementsByType(_ type: BlockEditorSettingElementTypes) -> [[String: String]]? {
         return elements?.sorted(by: { (lhs, rhs) -> Bool in
             return lhs.order >= rhs.order
@@ -37,15 +18,6 @@ extension BlockEditorSettings: GutenbergEditorSettings {
             guard element.type == type.rawValue else { return nil }
             return element.rawRepresentation
         })
-    }
-
-    private func experimentalFeature(_ feature: BlockEditorExperimentalFeatureKeys) -> Bool {
-        guard let experimentalFeature = elements?.first(where: { (element) -> Bool in
-            guard element.type == BlockEditorSettingElementTypes.experimentalFeatures.rawValue else { return false }
-            return element.slug == feature.rawValue
-        }) else { return false }
-
-        return Bool(experimentalFeature.value) ?? false
     }
 }
 
@@ -87,32 +59,6 @@ extension BlockEditorSettings {
         remoteSettings.gradients?.enumerated().forEach({ (index, gradient) in
             parsedElements.insert(BlockEditorSettingElement(fromRawRepresentation: gradient, type: .gradient, order: index, context: context))
         })
-
-        // Experimental Features
-        let galleryKey = BlockEditorExperimentalFeatureKeys.galleryWithImageBlocks.rawValue
-        let galleryRefactor = BlockEditorSettingElement(name: galleryKey,
-                                                         value: "\(remoteSettings.galleryWithImageBlocks)",
-                                                         slug: galleryKey,
-                                                         type: .experimentalFeatures,
-                                                         order: 0,
-                                                         context: context)
-        let quoteKey = BlockEditorExperimentalFeatureKeys.quoteBlockV2.rawValue
-        let quoteRefactor = BlockEditorSettingElement(name: quoteKey,
-                                                         value: "\(remoteSettings.quoteBlockV2)",
-                                                         slug: quoteKey,
-                                                         type: .experimentalFeatures,
-                                                         order: 1,
-                                                         context: context)
-        let listKey = BlockEditorExperimentalFeatureKeys.listBlockV2.rawValue
-        let listRefactor = BlockEditorSettingElement(name: listKey,
-                                                         value: "\(remoteSettings.listBlockV2)",
-                                                         slug: listKey,
-                                                         type: .experimentalFeatures,
-                                                         order: 2,
-                                                         context: context)
-        parsedElements.insert(galleryRefactor)
-        parsedElements.insert(quoteRefactor)
-        parsedElements.insert(listRefactor)
 
         self.elements = parsedElements
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -874,13 +874,11 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidMount(unsupportedBlockNames: [String]) {
         if !editorSession.started {
-            let galleryWithImageBlocks = gutenbergEditorSettings()?.galleryWithImageBlocks
-
             // Note that this method is also used to track startup performance
             // It assumes this is being called when the editor has finished loading
             // If you need to refactor this, please ensure that the startup_time_ms property
             // is still reflecting the actual startup time of the editor
-            editorSession.start(unsupportedBlocks: unsupportedBlockNames, galleryWithImageBlocks: galleryWithImageBlocks)
+            editorSession.start(unsupportedBlocks: unsupportedBlockNames)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -21,17 +21,17 @@ struct PostEditorAnalyticsSession {
         contentType = ContentType(post: post).rawValue
     }
 
-    mutating func start(unsupportedBlocks: [String] = [], galleryWithImageBlocks: Bool? = nil) {
+    mutating func start(unsupportedBlocks: [String] = []) {
         assert(!started, "An editor session was attempted to start more than once")
         hasUnsupportedBlocks = !unsupportedBlocks.isEmpty
 
-        let properties = startEventProperties(with: unsupportedBlocks, galleryWithImageBlocks: galleryWithImageBlocks)
+        let properties = startEventProperties(with: unsupportedBlocks)
 
         WPAppAnalytics.track(.editorSessionStart, withProperties: properties)
         started = true
     }
 
-    private func startEventProperties(with unsupportedBlocks: [String], galleryWithImageBlocks: Bool?) -> [String: Any] {
+    private func startEventProperties(with unsupportedBlocks: [String]) -> [String: Any] {
         // On Android, we are tracking this in milliseconds, which seems like a good enough time scale
         // Let's make sure to round the value and send an integer for consistency
         let startupTimeNanoseconds = DispatchTime.now().uptimeNanoseconds - startTime
@@ -42,12 +42,6 @@ struct PostEditorAnalyticsSession {
         if let data = try? JSONSerialization.data(withJSONObject: unsupportedBlocks, options: .fragmentsAllowed) {
             let blocksJSON = String(data: data, encoding: .utf8)
             properties[Property.unsupportedBlocks] = blocksJSON
-        }
-
-        if let galleryWithImageBlocks = galleryWithImageBlocks {
-            properties[Property.unstableGalleryWithImageBlocks] = "\(galleryWithImageBlocks)"
-        } else {
-            properties[Property.unstableGalleryWithImageBlocks] = "unknown"
         }
 
         properties[Property.entryPoint] = (entryPoint ?? .unknown).rawValue
@@ -84,7 +78,6 @@ private extension PostEditorAnalyticsSession {
         static let sessionId = "session_id"
         static let template = "template"
         static let startupTime = "startup_time_ms"
-        static let unstableGalleryWithImageBlocks = "unstable_gallery_with_image_blocks"
         static let entryPoint = "entry_point"
     }
 

--- a/WordPress/UITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/UITests/Tests/EditorGutenbergTests.swift
@@ -93,7 +93,7 @@ class EditorGutenbergTests: XCTestCase {
             .enterTextInTitle(text: postTitle)
             .addParagraphBlock(withText: postContent)
             .addImageGallery()
-            .verifyContentStructure(blocks: 2, words: postContent.components(separatedBy: " ").count, characters: postContent.count)
+            .verifyContentStructure(blocks: 5, words: postContent.components(separatedBy: " ").count, characters: postContent.count)
     }
 
     func testAddMediaBlocks() throws {

--- a/WordPressKit/Sources/WordPressKit/Models/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/Sources/WordPressKit/Models/RemoteBlockEditorSettings.swift
@@ -3,9 +3,6 @@ import Foundation
 public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
         case isFSETheme = "__unstableIsBlockBasedTheme"
-        case galleryWithImageBlocks = "__unstableGalleryWithImageBlocks"
-        case quoteBlockV2 = "__experimentalEnableQuoteBlockV2"
-        case listBlockV2 = "__experimentalEnableListBlockV2"
         case rawStyles = "__experimentalStyles"
         case rawFeatures = "__experimentalFeatures"
         case colors
@@ -13,9 +10,6 @@ public class RemoteBlockEditorSettings: Codable {
     }
 
     public let isFSETheme: Bool
-    public let galleryWithImageBlocks: Bool
-    public let quoteBlockV2: Bool
-    public let listBlockV2: Bool
     public let rawStyles: String?
     public let rawFeatures: String?
     public let colors: [[String: String]]?
@@ -40,9 +34,6 @@ public class RemoteBlockEditorSettings: Codable {
     required public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
-        self.galleryWithImageBlocks = (try? map.decode(Bool.self, forKey: .galleryWithImageBlocks)) ?? false
-        self.quoteBlockV2 = (try? map.decode(Bool.self, forKey: .quoteBlockV2)) ?? false
-        self.listBlockV2 = (try? map.decode(Bool.self, forKey: .listBlockV2)) ?? false
         self.rawStyles = RemoteBlockEditorSettings.parseToString(map, .rawStyles)
         self.rawFeatures = RemoteBlockEditorSettings.parseToString(map, .rawFeatures)
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6973
- https://github.com/WordPress/gutenberg/pull/63285

To test:

- Test adding a Gallery block to a post

## Regression Notes
1. Potential unintended areas of impact
It affects only the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and existing automated tests for the Gallery block.

3. What automated tests I added (or what prevented me from doing so)
No tests were added since this is only removing the old Gallery block format and a few experimental flags.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
