### PR TITLE
Improve "Submit Feedback" Flow

### DIFF
--- a/WordPress/Classes/Extensions/View+Helpers.swift
+++ b/WordPress/Classes/Extensions/View+Helpers.swift
@@ -4,13 +4,4 @@ extension View {
     func apply<T>(_ closure: (Self) -> T) -> T {
         closure(self)
     }
-
-    @ViewBuilder
-    func listSectionCompactSpacing() -> some View {
-        if #available(iOS 17, *) {
-            listSectionSpacing(.compact)
-        } else {
-            self
-        }
-    }
 }

--- a/WordPress/Classes/Extensions/View+Helpers.swift
+++ b/WordPress/Classes/Extensions/View+Helpers.swift
@@ -4,4 +4,13 @@ extension View {
     func apply<T>(_ closure: (Self) -> T) -> T {
         closure(self)
     }
+
+    @ViewBuilder
+    func listSectionCompactSpacing() -> some View {
+        if #available(iOS 17, *) {
+            listSectionSpacing(.compact)
+        } else {
+            self
+        }
+    }
 }

--- a/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
@@ -78,7 +78,7 @@ final class InAppFeedbackPromptCoordinator: InAppFeedbackPromptPresenting {
             preferredStyle: .alert
         )
         let yes = UIAlertAction(title: Strings.NegativeFeedbackAlert.yes, style: .default) { _ in
-            let destination = UINavigationController(rootViewController: SubmitFeedbackViewController())
+            let destination = UINavigationController(rootViewController: SubmitFeedbackViewController(source: "in_app_feedback"))
             controller.present(destination, animated: true)
         }
         let no = UIAlertAction(title: Strings.NegativeFeedbackAlert.no, style: .default) { _ in

--- a/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
@@ -78,7 +78,7 @@ final class InAppFeedbackPromptCoordinator: InAppFeedbackPromptPresenting {
             preferredStyle: .alert
         )
         let yes = UIAlertAction(title: Strings.NegativeFeedbackAlert.yes, style: .default) { _ in
-            let destination = UINavigationController(rootViewController: self.submitFeedbackViewController(in: controller))
+            let destination = UINavigationController(rootViewController: SubmitFeedbackViewController())
             controller.present(destination, animated: true)
         }
         let no = UIAlertAction(title: Strings.NegativeFeedbackAlert.no, style: .default) { _ in
@@ -91,18 +91,6 @@ final class InAppFeedbackPromptCoordinator: InAppFeedbackPromptPresenting {
         WPAnalytics.track(.appReviewsDidntLikeApp)
         appRatingUtility.dislikedCurrentVersion()
     }
-
-    private func submitFeedbackViewController(in controller: UIViewController) -> SubmitFeedbackViewController {
-        let destination = SubmitFeedbackViewController()
-        destination.onFeedbackSubmitted = { [weak controller] _, _ in
-            controller?.displayNotice(
-                title: Strings.ConfirmationNotice.title,
-                message: Strings.ConfirmationNotice.message
-            )
-        }
-        return destination
-    }
-
 }
 
 // MARK: - Strings
@@ -132,6 +120,7 @@ extension InAppFeedbackPromptCoordinator {
                 comment: "The 'no' button title for the first feedback alert"
             )
         }
+
         enum NegativeFeedbackAlert {
             static let title = NSLocalizedString(
                 "in-app.feedback.negative.alert.title",
@@ -152,18 +141,6 @@ extension InAppFeedbackPromptCoordinator {
                 "in-app.feedback.negative.alert.no",
                 value: "Not now",
                 comment: "The 'no' button for the negative feedback alert"
-            )
-        }
-        enum ConfirmationNotice {
-            static let title = NSLocalizedString(
-                "in-app.feedback.confirmation.notice.title",
-                value: "Feedback sent",
-                comment: ""
-            )
-            static let message = NSLocalizedString(
-                "in-app.feedback.confirmation.notice.message",
-                value: "Thanks for helping us improve the app.",
-                comment: ""
             )
         }
     }

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -1,96 +1,120 @@
 import Foundation
-import Combine
-import DesignSystem
+import SwiftUI
+import WordPressShared
 
 final class SubmitFeedbackViewController: UIViewController {
-
-    // MARK: - Public Properties
-
-    private(set) var feedbackWasSubmitted = false
-
-    var onFeedbackSubmitted: ((SubmitFeedbackViewController, String) -> Void)?
-
-    // MARK: - Private Properties
-
-    private let textView: UITextView = {
-        let textView = UITextView()
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        textView.font = WPStyleGuide.fontForTextStyle(.body)
-        textView.textContainer.lineFragmentPadding = 0
-        textView.textContainerInset = .init(allEdges: .DS.Padding.double)
-        return textView
-    }()
-
-    private var cancellables = Set<AnyCancellable>()
-
-    // MARK: - View Lifecycle
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .systemBackground
-        self.setupSubviews()
-        self.textView.becomeFirstResponder()
-        WPAnalytics.track(.appReviewsOpenedFeedbackScreen)
+
+        let viewController = UIHostingController(rootView: SubmitFeedbackView(presentingViewController: self))
+        viewController.configureDefaultNavigationBarAppearance()
+
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.navigationBar.isTranslucent = true // Reset to default
+
+        addChild(navigationController)
+        view.addSubview(navigationController.view)
+        navigationController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(navigationController.view)
+        navigationController.didMove(toParent: self)
+    }
+}
+
+private struct SubmitFeedbackView: View {
+    weak var presentingViewController: UIViewController?
+
+    @State private var subject = ""
+    @State private var text = ""
+    @State private var isProcessing = false
+    @State private var isShowingCancellationConfirmation = false
+
+    @FocusState private var isSubjectFieldFocused: Bool
+
+    private let textLimit = 500
+
+    var isInputEmpty: Bool {
+        text.trim().isEmpty && subject.trim().isEmpty
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        guard !feedbackWasSubmitted else {
-            return
+    var body: some View {
+        Form {
+            Section(header: Spacer(minLength: 0)) {
+                TextField(Strings.subject, text: $subject)
+                    .focused($isSubjectFieldFocused)
+            }
+            Section {
+                TextEditor(text: $text)
+                    .frame(height: 170)
+                    .accessibilityLabel(Strings.details)
+            } header: {
+                Text(Strings.details)
+            } footer: {
+                HStack {
+                    Spacer()
+                    Text(max(0, textLimit - text.count).description)
+                        .monospacedDigit()
+                        .foregroundStyle(text.count >= textLimit ? .red : .secondary)
+                }
+            }
         }
-        WPAnalytics.track(.appReviewsCanceledFeedbackScreen)
-    }
+        .listSectionCompactSpacing()
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(Strings.cancel) {
+                    if isInputEmpty {
+                        dismiss()
+                    } else {
+                        isShowingCancellationConfirmation = true
+                    }
+                }
+            }
 
-    // MARK: - Setup Views
-
-    private func setupSubviews() {
-        self.setupNavigationItems()
-        self.setupTextView()
-    }
-
-    private func setupNavigationItems() {
-        let navBarAppearance = self.navigationController?.navigationBar.standardAppearance
-        let cancel = UIAction { [weak self] _ in
-            self?.dismiss(animated: true)
+            ToolbarItem(placement: .confirmationAction) {
+                if isProcessing {
+                    ProgressView()
+                } else {
+                    Button(Strings.submit, action: submit)
+                        .disabled(isInputEmpty)
+                }
+            }
         }
-        self.navigationItem.rightBarButtonItem = .init(
-            title: Strings.submit,
-            style: .done,
-            target: self,
-            action: #selector(didTapSubmit)
-        )
-        self.navigationItem.leftBarButtonItem = .init(systemItem: .cancel, primaryAction: cancel)
-        self.navigationItem.title = Strings.title
-        self.navigationItem.scrollEdgeAppearance = navBarAppearance
-        self.navigationItem.compactScrollEdgeAppearance = navBarAppearance
+        .onAppear {
+            WPAnalytics.track(.appReviewsOpenedFeedbackScreen)
+            isSubjectFieldFocused = true
+        }
+        .disabled(isProcessing)
+        .confirmationDialog(Strings.cancellationAlertTitle, isPresented: $isShowingCancellationConfirmation) {
+            Button(Strings.cancellationAlertContinueEditing, role: .cancel) {}
+            Button(Strings.cancellationAlertDiscardFeedbackButton, role: .destructive) {
+                dismiss()
+            }
+        }
+        .onChange(of: isInputEmpty) {
+            presentingViewController?.isModalInPresentation = !$0
+        }
+        .onChange(of: text) { text in
+            if text.count > textLimit {
+                self.text = String(text.prefix(textLimit))
+            }
+        }
+        .navigationTitle(Strings.title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func setupTextView() {
-        self.textView.delegate = self
-        self.view.addSubview(textView)
-        NSLayoutConstraint.activate([
-            self.textView.topAnchor.constraint(equalTo: view.topAnchor),
-            self.textView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            self.textView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            self.textView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor)
-        ])
-        self.updateSubmitNavigationItem(text: textView.text)
-    }
+    private func submit() {
+        wpAssert(!text.isEmpty)
 
-    // MARK: - Updating UI
+        guard let presentingViewController else {
+            return wpAssertionFailure("presentingViewController missing")
+        }
 
-    func updateSubmitNavigationItem(text: String?) {
-        let text = text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        self.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
-    }
+        isProcessing = true
 
-    // MARK: - User Interaction
-
-    @objc private func didTapSubmit() {
-        let text = textView.text ?? ""
+        let subject = subject.trim().nonEmptyString()
+        let text = text.trim()
         let tags = ["appreview_jetpack", "in_app_feedback"]
 
-        let options = ZendeskUtils.IdentityAlertOptions(
+        let identityAlertOptions = ZendeskUtils.IdentityAlertOptions(
             optionalIdentity: true,
             includesName: true,
             title: Strings.identityAlertTitle,
@@ -101,106 +125,66 @@ final class SubmitFeedbackViewController: UIViewController {
             namePlaceholder: Strings.identityAlertEmptyName
         )
 
-        let loadingStatus = { (status: ZendeskRequestLoadingStatus) in
-            switch status {
-            case .creatingTicket:
-                SVProgressHUD.show(withStatus: Strings.submitLoadingMessage)
-            case .creatingTicketAnonymously:
-                SVProgressHUD.show(withStatus: Strings.submitLoadingAnonymouslyMessage)
-            default:
-                break
-            }
-        }
-
-        ZendeskUtils.sharedInstance.createNewRequest(in: self, description: text, tags: tags, alertOptions: options, status: loadingStatus) { [weak self] result in
-            guard let self else { return }
-
-            let completion = {
-                DispatchQueue.main.async {
-                    SVProgressHUD.dismiss()
-                    WPAnalytics.track(.appReviewsSentFeedback, withProperties: ["feedback": text])
-                    self.feedbackWasSubmitted = true
-                    self.view.endEditing(true)
-                    self.dismiss(animated: true) {
-                        self.onFeedbackSubmitted?(self, text)
-                    }
-                }
-            }
-
-            switch result {
-            case .success:
-                completion()
-            case .failure(let error):
-                DDLogError("Submitting feedback failed: \(error)")
-                completion()
+        ZendeskUtils.sharedInstance.createNewRequest(
+            in: presentingViewController,
+            subject: subject,
+            description: text,
+            tags: tags,
+            alertOptions: identityAlertOptions
+        ) { result in
+            DispatchQueue.main.async {
+                didSubmitFeedback(with: result.map { _ in () })
             }
         }
     }
-}
 
-extension SubmitFeedbackViewController: UITextViewDelegate {
+    private func didSubmitFeedback(with result: Result<Void, ZendeskRequestError>) {
+        switch result {
+        case .success:
+            WPAnalytics.track(.appReviewsSentFeedback, withProperties: ["feedback": text])
 
-    func textViewDidChange(_ textView: UITextView) {
-        updateSubmitNavigationItem(text: textView.text)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            let notice = Notice(title: Strings.successNoticeTitle, message: Strings.successNoticeMessage)
+            ActionDispatcherFacade().dispatch(NoticeAction.post(notice))
+
+            dismiss()
+        case .failure(let error):
+            DDLogError("Submitting feedback failed: \(error)")
+
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            WPError.showAlert(withTitle: Strings.failureAlertTitle, message: error.localizedDescription)
+            isProcessing = false
+        }
+    }
+
+    private func dismiss() {
+        presentingViewController?.presentingViewController?.dismiss(animated: true)
     }
 }
 
-// MARK: - Strings
+private enum Strings {
+    static let cancel = NSLocalizedString("submit.feedback.buttonCancel", value: "Cancel", comment: "The button title for the Cancel button in the In-App Feedback screen")
+    static let submit = NSLocalizedString("submit.feedback.submit.button", value: "Submit", comment: "The button title for the Submit button in the In-App Feedback screen")
+    static let title = NSLocalizedString("submit.feedback.title", value: "Feedback", comment: "The title for the the In-App Feedback screen")
+    static let subject = NSLocalizedString("submit.feedback.subjectPlaceholder", value: "Subject", comment: "The section title and or placeholder")
+    static let details = NSLocalizedString("submit.feedback.subjectPlaceholder", value: "Details", comment: "The section title and or placeholder")
 
-private extension SubmitFeedbackViewController {
+    static let identityAlertTitle = NSLocalizedString("submit.feedback.alert.title", value: "Thanks for your feedback", comment: "Alert users are shown when submtiting their feedback.")
+    static let identityAlertDescription = NSLocalizedString("submit.feedback.alert.description", value: "You can optionally include your email and username to help us understand your experience.", comment: "Alert users are shown when submtiting their feedback.")
+    static let identityAlertSubmit = NSLocalizedString("submit.feedback.alert.submit", value: "Done", comment: "Alert submit option for users to accept sharing their email and name when submitting feedback.")
+    static let identityAlertEmptyEmail = NSLocalizedString("submit.feedback.alert.empty.email", value: "no email entered", comment: "Label we show on an email input field")
+    static let identityAlertEmptyName = NSLocalizedString("submit.feedback.alert.empty.username", value: "no username entered", comment: "Label we show on an name input field")
 
-    enum Strings {
-        static let submit = NSLocalizedString(
-            "submit.feedback.submit.button",
-            value: "Submit",
-            comment: "The button title for the Submit button in the In-App Feedback screen"
-        )
-        static let title = NSLocalizedString(
-            "submit.feedback.title",
-            value: "Feedback",
-            comment: "The title for the the In-App Feedback screen"
-        )
+    static let cancellationAlertTitle = NSLocalizedString("submitFeedback.cancellationAlertTitle", value: "Are you sure you want to discard the feedback", comment: "Submit feedback screen cancellation confirmation alert title")
+    static let cancellationAlertContinueEditing = NSLocalizedString("submitFeedback.cancellationAlertContinueEditing", value: "Continue Editing", comment: "Submit feedback screen cancellation confirmation alert action")
+    static let cancellationAlertDiscardFeedbackButton = NSLocalizedString("submitFeedback.cancellationAlertDiscardFeedbackButton", value: "Discard Feedback", comment: "Submit feedback screen cancellation confirmation alert action")
+    static let failureAlertTitle = NSLocalizedString("submitFeedback.failureAlertTitle", value: "Failed to submit feedback", comment: "Submit feedback screen failure alert title")
+    static let successNoticeTitle = NSLocalizedString("submitFeedback.successNoticeTitle", value: "Feedback sent", comment: "Submit feedback screen submit fsuccess notice title")
+    static let successNoticeMessage = NSLocalizedString("submitFeedback.successNoticeMessage", value: "Thank you for helping us improve the app", comment: "Submit feedback screen submit success notice messages")
+}
 
-        static let submitLoadingMessage = NSLocalizedString(
-            "submit.feedback.submit.loading",
-            value: "Sending",
-            comment: "Notice informing user that their feedback is being submitted."
-        )
-
-        static let submitLoadingAnonymouslyMessage = NSLocalizedString(
-            "submit.feedback.submitAnonymously.loading",
-            value: "Sending anonymously",
-            comment: "Notice informing user that their feedback is being submitted anonymously."
-        )
-
-        static let identityAlertTitle = NSLocalizedString(
-            "submit.feedback.alert.title",
-            value: "Thanks for your feedback",
-            comment: "Alert users are shown when submtiting their feedback."
-        )
-
-        static let identityAlertDescription = NSLocalizedString(
-            "submit.feedback.alert.description",
-            value: "You can optionally include your email and username to help us understand your experience.",
-            comment: "Alert users are shown when submtiting their feedback."
-        )
-
-        static let identityAlertSubmit = NSLocalizedString(
-            "submit.feedback.alert.submit",
-            value: "Done",
-            comment: "Alert submit option for users to accept sharing their email and name when submitting feedback."
-        )
-
-        static let identityAlertEmptyEmail = NSLocalizedString(
-            "submit.feedback.alert.empty.email",
-            value: "no email entered",
-            comment: "Label we show on an email input field"
-        )
-
-        static let identityAlertEmptyName = NSLocalizedString(
-            "submit.feedback.alert.empty.username",
-            value: "no username entered",
-            comment: "Label we show on an name input field"
-        )
+#Preview {
+    NavigationView {
+        SubmitFeedbackView()
     }
 }

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -3,10 +3,21 @@ import SwiftUI
 import WordPressShared
 
 final class SubmitFeedbackViewController: UIViewController {
+    private var source: String
+
+    init(source: String) {
+        self.source = source
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewController = UIHostingController(rootView: SubmitFeedbackView(presentingViewController: self))
+        let viewController = UIHostingController(rootView: SubmitFeedbackView(presentingViewController: self, source: source))
         viewController.configureDefaultNavigationBarAppearance()
 
         let navigationController = UINavigationController(rootViewController: viewController)
@@ -22,6 +33,7 @@ final class SubmitFeedbackViewController: UIViewController {
 
 private struct SubmitFeedbackView: View {
     weak var presentingViewController: UIViewController?
+    let source: String
 
     @State private var subject = ""
     @State private var text = ""
@@ -66,7 +78,7 @@ private struct SubmitFeedbackView: View {
             }
         }
         .onAppear {
-            WPAnalytics.track(.appReviewsOpenedFeedbackScreen)
+            WPAnalytics.track(.appReviewsOpenedFeedbackScreen, withProperties: ["source": source])
             isSubjectFieldFocused = true
         }
         .disabled(isSubmitting)
@@ -165,7 +177,7 @@ private struct SubmitFeedbackView: View {
     private func didSubmitFeedback(with result: Result<Void, ZendeskRequestError>) {
         switch result {
         case .success:
-            WPAnalytics.track(.appReviewsSentFeedback, withProperties: ["feedback": text])
+            WPAnalytics.track(.appReviewsSentFeedback, withProperties: ["feedback": text, "source": source])
 
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             let notice = Notice(title: Strings.successNoticeTitle, message: Strings.successNoticeMessage)
@@ -211,6 +223,6 @@ private enum Strings {
 
 #Preview {
     NavigationView {
-        SubmitFeedbackView()
+        SubmitFeedbackView(source: "preview")
     }
 }

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -147,7 +147,7 @@ private struct SubmitFeedbackView: View {
 
         let subject = subject.trim().nonEmptyString()
         let text = text.trim()
-        let tags = ["appreview_jetpack", "in_app_feedback", AppConstants.eventNamePrefix]
+        let tags = ["appreview_jetpack", "in_app_feedback"]
 
         let identityAlertOptions = ZendeskUtils.IdentityAlertOptions(
             optionalIdentity: true,

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -8,6 +8,7 @@ final class SubmitFeedbackViewController: UIViewController {
     init(source: String) {
         self.source = source
         super.init(nibName: nil, bundle: nil)
+        self.modalPresentationStyle = .formSheet
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
@@ -133,7 +133,7 @@ final class ZendeskAttachmentViewModel: ObservableObject, Identifiable {
 
     var isUploaded: Bool { response != nil }
 
-    static let attachmentSizeLimit: Int64 = 10_000_000
+    static let attachmentSizeLimit: Int64 = 8_000_000
 
     var response: ZDKUploadResponse? {
         guard case .uploaded(let response) = status else { return nil }

--- a/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+import Photos
+import PhotosUI
+import SupportProvidersSDK
+import UniformTypeIdentifiers
+
+@available(iOS 16, *)
+struct ZendeskAttachmentsSection: View {
+    @ObservedObject var viewModel: ZendeskAttachmentsSectionViewModel
+
+    @State private var selection: [PhotosPickerItem] = []
+    @State private var previewURL: URL?
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 16) {
+                if !viewModel.attachments.isEmpty {
+                    attachmentsStack
+                }
+                photosPicker
+            }
+            .padding(.vertical, 8)
+        }
+        .listRowBackground(Color.clear)
+        .onDisappear(perform: viewModel.onDisappear)
+    }
+
+    private var attachmentsStack: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(viewModel.attachments) { attachment in
+                    ZendeskAttachmentView(viewModel: attachment, onRemoveTapped: {
+                        if  let item = attachment.id as? PhotosPickerItem,
+                            let index = selection.firstIndex(of: item) {
+                            selection.remove(at: index)
+                        }
+                    })
+                }
+            }
+        }._scrollClipDisabled()
+    }
+
+    private var photosPicker: some View {
+        PhotosPicker(selection: $selection, maxSelectionCount: 5, matching: .images, preferredItemEncoding: .compatible) {
+            HStack {
+                Image(systemName: "paperclip")
+                Text(Strings.addAttachment)
+            }
+            .foregroundStyle(Color(uiColor: .brand))
+        }
+        .onChange(of: selection, perform: viewModel.process)
+    }
+}
+
+@MainActor
+final class ZendeskAttachmentsSectionViewModel: ObservableObject {
+    @Published private(set) var attachments: [ZendeskAttachmentViewModel] = []
+
+    @available(iOS 16, *)
+    func process(selection: [PhotosPickerItem]) {
+        var previous = Dictionary(uniqueKeysWithValues: attachments.map { ($0.id, $0) })
+        self.attachments = selection.map {
+            previous.removeValue(forKey: $0) ?? ZendeskAttachmentViewModel(item: $0)
+        }
+        previous.values.forEach { $0.cancel() } // Cancel remaining
+    }
+
+    func onDisappear() {
+        attachments.forEach { $0.cancel() }
+    }
+}
+
+@available(iOS 16, *)
+private struct ZendeskAttachmentView: View {
+    @ObservedObject var viewModel: ZendeskAttachmentViewModel
+    var onRemoveTapped: () -> Void
+
+    static let previewMaxWidth: CGFloat = 120
+
+    var body: some View {
+        Menu {
+            Section {
+                Button(role: .destructive, action: onRemoveTapped) {
+                    Label(Strings.removeAttachment, systemImage: "trash")
+                }
+            } header: {
+                if case .failed(let error) = viewModel.status {
+                    Text(error.localizedDescription)
+                }
+            }
+        } label: {
+            contents
+        }
+    }
+
+    var contents: some View {
+        ZStack {
+            Rectangle()
+                .foregroundStyle(Color(uiColor: .secondarySystemBackground))
+
+            viewModel.preview?
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+
+            switch viewModel.status {
+            case .uploading:
+                Rectangle()
+                    .foregroundStyle(Color(uiColor: .systemBackground).opacity(0.75))
+                ProgressView()
+            case .failed:
+                Rectangle()
+                    .foregroundStyle(Color(uiColor: .systemBackground).opacity(0.75))
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.white, .red)
+                    .font(.system(size: 22))
+            case .uploaded:
+                EmptyView()
+            }
+        }
+        .frame(minWidth: viewModel.preview == nil ? 100 : 44, maxWidth: ZendeskAttachmentView.previewMaxWidth)
+        .frame(height: 80)
+        .cornerRadius(8)
+    }
+}
+
+final class ZendeskAttachmentViewModel: ObservableObject, Identifiable {
+    let id: AnyHashable
+
+    @Published private(set) var preview: Image?
+    @Published private(set) var status: Status = .uploading
+
+    private var task: Task<Void, Never>?
+
+    var isUploaded: Bool { response != nil }
+
+    static let attachmentSizeLimit: Int64 = 10_000_000
+
+    var response: ZDKUploadResponse? {
+        guard case .uploaded(let response) = status else { return nil }
+        return response
+    }
+
+    enum Status {
+        case uploading
+        case failed(Error)
+        case uploaded(ZDKUploadResponse)
+    }
+
+    @available(iOS 16, *)
+    init(item: PhotosPickerItem) {
+        self.id = item
+        self.preview = preview
+        self.task = Task {
+            await self.process(item: item)
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+
+    @available(iOS 16, *)
+    @MainActor private func process(item: PhotosPickerItem) async {
+        status = .uploading
+        do {
+            let previewSize = CGSize(width: ZendeskAttachmentView.previewMaxWidth, height: ZendeskAttachmentView.previewMaxWidth)
+                .scaled(by: UITraitCollection.current.displayScale)
+            let contentType = preferredExportContentType(for: item)
+            let (data, preview) = try await export(item, contentType: contentType, previewSize: previewSize)
+            self.preview = preview
+
+            // Checking the limit _after_ displaying the review
+            guard data.count < ZendeskAttachmentViewModel.attachmentSizeLimit else {
+                throw SubmitFeedbackAttachmentError.attachmentTooLarge
+            }
+
+            let response = try await ZendeskUtils.sharedInstance.uploadAttachment(data, contentType: contentType.preferredMIMEType ?? "image/jpeg")
+            status = .uploaded(response)
+        } catch {
+            status = .failed(error)
+        }
+    }
+
+    @available(iOS 16, *)
+    private func preferredExportContentType(for item: PhotosPickerItem) -> UTType {
+        let supportedImageTypes: Set<UTType> = [UTType.png, UTType.jpeg, UTType.gif]
+        if let type = item.supportedContentTypes.first, supportedImageTypes.contains(type) {
+            return type
+        }
+        return UTType.jpeg
+    }
+
+    @available(iOS 16, *)
+    private func export(_ item: PhotosPickerItem, contentType: UTType, previewSize: CGSize) async throws -> (Data, Image) {
+        guard let rawData = try await item.loadTransferable(type: Data.self) else {
+            throw SubmitFeedbackAttachmentError.invalidAttachment
+        }
+
+        let exporter = MediaImageExporter(data: rawData, filename: nil, typeHint: item.supportedContentTypes.first?.identifier)
+        exporter.options.maximumImageSize = 1024
+        exporter.options.imageCompressionQuality = 0.7
+        exporter.mediaDirectoryType = .temporary
+        exporter.options.stripsGeoLocationIfNeeded = true
+        exporter.options.exportImageType = contentType.identifier
+
+        let export = try await exporter.export()
+        let data = try Data(contentsOf: export.url)
+        try FileManager.default.removeItem(at: export.url)
+
+        guard let image = UIImage(data: data),
+              let preview = await image.byPreparingThumbnail(ofSize: previewSize) else {
+            throw SubmitFeedbackAttachmentError.invalidAttachment
+        }
+        return (data, Image(uiImage: preview))
+    }
+}
+
+private enum SubmitFeedbackAttachmentError: Error, LocalizedError {
+    case invalidAttachment
+    case attachmentTooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAttachment:
+            return NSLocalizedString("zendeskAttachmentsSection.unsupportedAttachmentErrorMessage", value: "Unsupported attachment", comment: "Managing Zendesk attachments")
+        case .attachmentTooLarge:
+            let format = NSLocalizedString("zendeskAttachmentsSection.unsupportedAttachmentErrorMessage", value: "The attachment is too large. The maximum allowed size is %@.", comment: "Managing Zendesk attachments")
+            return String(format: format, ByteCountFormatter().string(fromByteCount: ZendeskAttachmentViewModel.attachmentSizeLimit))
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func _scrollClipDisabled() -> some View {
+        if #available(iOS 17, *) {
+            self.scrollClipDisabled()
+        } else {
+            self
+        }
+    }
+}
+
+private enum Strings {
+    static let addAttachment = NSLocalizedString("zendeskAttachmentsSection.addAttachment", value: "Add Attachments", comment: "Managing Zendesk attachments")
+    static let removeAttachment = NSLocalizedString("zendeskAttachmentsSection.removeAttachment", value: "Remove Attachment", comment: "Managing Zendesk attachments")
+    static let unsupportedAttachmentErrorMessage = NSLocalizedString("zendeskAttachmentsSection.unsupportedAttachmentErrorMessage", value: "Unsupported attachment", comment: "Managing Zendesk attachments")
+}

--- a/WordPress/Classes/Utility/Media/MediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaExporter.swift
@@ -120,6 +120,12 @@ extension MediaExporter {
             return MediaExportSystemError.failedWith(systemError: error)
         }
     }
+
+    func export() async throws -> MediaExport {
+        try await withUnsafeThrowingContinuation { continuation in
+            export(onCompletion: continuation.resume(returning:), onError: continuation.resume(throwing:))
+        }
+    }
 }
 
 /// Protocol of general options available for an export, typically corresponding to a user setting.

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -346,6 +346,7 @@ extension ZendeskUtils {
 
     func createNewRequest(
         in viewController: UIViewController,
+        subject: String? = nil,
         description: String,
         tags: [String],
         alertOptions: IdentityAlertOptions,
@@ -364,7 +365,7 @@ extension ZendeskUtils {
                 request.customFields = requestConfig.customFields
                 request.tags = requestConfig.tags
                 request.ticketFormId = requestConfig.ticketFormID
-                request.subject = requestConfig.subject
+                request.subject = subject ?? requestConfig.subject
                 request.requestDescription = description
 
                 provider.createRequest(request) { response, error in

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -200,8 +200,13 @@ class MeViewController: UITableViewController {
             ImmuTableSection(rows: {
                 var rows: [ImmuTableRow] = [helpAndSupportIndicator]
 
+                rows.append(NavigationItemRow(title: Strings.submitFeedback,
+                                              icon: UIImage.gridicon(.pencil),
+                                              accessoryType: accessoryType,
+                                              action: showFeedbackView()))
+
                 rows.append(NavigationItemRow(title: ShareAppContentPresenter.RowConstants.buttonTitle,
-                                              icon: ShareAppContentPresenter.RowConstants.buttonIconImage,
+                                              icon: UIImage.gridicon(.shareiOS),
                                               accessoryType: accessoryType,
                                               action: displayShareFlow(),
                                               loading: sharePresenter.isLoading))
@@ -322,6 +327,15 @@ class MeViewController: UITableViewController {
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)
             }
+        }
+    }
+
+    func showFeedbackView() -> ImmuTableAction {
+        return { [weak self] row in
+            defer {
+                self?.tableView.deselectSelectedRowWithAnimation(true)
+            }
+            self?.present(SubmitFeedbackViewController(source: "me_menu"), animated: true)
         }
     }
 
@@ -650,4 +664,8 @@ extension MeViewController {
         JetpackBrandingCoordinator.presentOverlay(from: self)
         JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .me)
     }
+}
+
+private enum Strings {
+    static let submitFeedback = NSLocalizedString("meMenu.submitFeedback", value: "Submit Feedback", comment: "Me tab menu items")
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -623,6 +623,8 @@
 		0CE783422B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
 		0CEA55522BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
 		0CEA55532BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
+		0CEA84CF2C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */; };
+		0CEA84D02C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */; };
 		0CED1FED2B61AAF600E6DD52 /* AtomicSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */; };
 		0CED1FEE2B61AAF600E6DD52 /* AtomicSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */; };
 		0CED20002B6809CB00E6DD52 /* FilterCompactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */; };
@@ -4809,8 +4811,6 @@
 		F4FB0ACD292587D500F651F9 /* MeHeaderViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB0ACC292587D500F651F9 /* MeHeaderViewConfiguration.swift */; };
 		F4FE743429C3767300AC2729 /* AddressTableViewCell+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE743329C3767300AC2729 /* AddressTableViewCell+ViewModel.swift */; };
 		F4FE743529C3767300AC2729 /* AddressTableViewCell+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE743329C3767300AC2729 /* AddressTableViewCell+ViewModel.swift */; };
-		F4FF50E72B4D7D590076DB0C /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF50E52B4D7D590076DB0C /* SubmitFeedbackViewController.swift */; };
-		F4FF50E82B4D7D590076DB0C /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF50E52B4D7D590076DB0C /* SubmitFeedbackViewController.swift */; };
 		F4FF50E92B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF50E62B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift */; };
 		F4FF50EA2B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF50E62B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift */; };
 		F4FF50EC2B4ECE320076DB0C /* MySiteOverlaysCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF50EB2B4ECE320076DB0C /* MySiteOverlaysCoordinator.swift */; };
@@ -7485,6 +7485,7 @@
 		0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerViewController.swift; sourceTree = "<group>"; };
 		0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerCollectionCell.swift; sourceTree = "<group>"; };
 		0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPInstrumentation.swift; sourceTree = "<group>"; };
+		0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitFeedbackViewController.swift; sourceTree = "<group>"; };
 		0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicSiteService.swift; sourceTree = "<group>"; };
 		0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactButton.swift; sourceTree = "<group>"; };
 		0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactDatePicker.swift; sourceTree = "<group>"; };
@@ -11273,7 +11274,6 @@
 		F4F9D5F32909B7C100502576 /* MigrationWelcomeBlogTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationWelcomeBlogTableViewCell.swift; sourceTree = "<group>"; };
 		F4FB0ACC292587D500F651F9 /* MeHeaderViewConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeHeaderViewConfiguration.swift; sourceTree = "<group>"; };
 		F4FE743329C3767300AC2729 /* AddressTableViewCell+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressTableViewCell+ViewModel.swift"; sourceTree = "<group>"; };
-		F4FF50E52B4D7D590076DB0C /* SubmitFeedbackViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubmitFeedbackViewController.swift; sourceTree = "<group>"; };
 		F4FF50E62B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppFeedbackPromptCoordinator.swift; sourceTree = "<group>"; };
 		F4FF50EB2B4ECE320076DB0C /* MySiteOverlaysCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySiteOverlaysCoordinator.swift; sourceTree = "<group>"; };
 		F50B0E7A246212B8006601DD /* NoticeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAnimator.swift; sourceTree = "<group>"; };
@@ -21557,7 +21557,7 @@
 			isa = PBXGroup;
 			children = (
 				E14A52361E39F43E00EE203E /* AppRatingsUtility.swift */,
-				F4FF50E52B4D7D590076DB0C /* SubmitFeedbackViewController.swift */,
+				0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */,
 				F4FF50E62B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift */,
 			);
 			path = "In-App Feedback";
@@ -25417,6 +25417,7 @@
 				0C23F33E2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift in Sources */,
 				F1E72EBA267790110066FF91 /* UIViewController+Dismissal.swift in Sources */,
 				E1ECE34F1FA88DA2007FA37A /* StoreContainer.swift in Sources */,
+				0CEA84CF2C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */,
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				0A3FCA1D28B71CBD00499A15 /* FullScreenCommentReplyViewModel.swift in Sources */,
 				1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */,
@@ -26094,7 +26095,6 @@
 				17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */,
 				F4FF50EC2B4ECE320076DB0C /* MySiteOverlaysCoordinator.swift in Sources */,
 				F1E3536B25B9F74C00992E3A /* WindowManager.swift in Sources */,
-				F4FF50E72B4D7D590076DB0C /* SubmitFeedbackViewController.swift in Sources */,
 				FF0148E51DFABBC9001AD265 /* NSFileManager+FolderSize.swift in Sources */,
 				731E88CB21C9A10B0055C014 /* ErrorStateViewController.swift in Sources */,
 				BE87E1A01BD4054F0075D45B /* WP3DTouchShortcutCreator.swift in Sources */,
@@ -29134,6 +29134,7 @@
 				FABB23382602FC2C00C8785C /* WordPress-22-23.xcmappingmodel in Sources */,
 				01C4472D2BE4F8560006F787 /* StatsGhostLineChartCell.swift in Sources */,
 				FED65D79293511E4008071BF /* SharedDataIssueSolver.swift in Sources */,
+				0CEA84D02C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */,
 				FABB23392602FC2C00C8785C /* CountriesMap.swift in Sources */,
 				F45EB50C2B883E6E004E9053 /* CommentNotification.swift in Sources */,
 				98BC522527F6245700D6E8C2 /* BloggingPromptsFeatureIntroduction.swift in Sources */,
@@ -29381,7 +29382,6 @@
 				FABB23F02602FC2C00C8785C /* TitleSubtitleTextfieldHeader.swift in Sources */,
 				FABB23F12602FC2C00C8785C /* DefaultStockPhotosService.swift in Sources */,
 				FABB23F22602FC2C00C8785C /* Animator.swift in Sources */,
-				F4FF50E82B4D7D590076DB0C /* SubmitFeedbackViewController.swift in Sources */,
 				FABB23F32602FC2C00C8785C /* SiteStatsDashboardViewController.swift in Sources */,
 				F4141EEC2AE945C7000D2AAE /* AllDomainsListItemViewModel.swift in Sources */,
 				9895401226C1F39300EDEB5A /* EditCommentTableViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -625,6 +625,8 @@
 		0CEA55532BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
 		0CEA84CF2C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */; };
 		0CEA84D02C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */; };
+		0CEA84D52C3EE0E2008E0B06 /* ZendeskAttachmentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84D42C3EE0E1008E0B06 /* ZendeskAttachmentsSection.swift */; };
+		0CEA84D62C3EE0E2008E0B06 /* ZendeskAttachmentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84D42C3EE0E1008E0B06 /* ZendeskAttachmentsSection.swift */; };
 		0CED1FED2B61AAF600E6DD52 /* AtomicSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */; };
 		0CED1FEE2B61AAF600E6DD52 /* AtomicSiteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */; };
 		0CED20002B6809CB00E6DD52 /* FilterCompactButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */; };
@@ -7486,6 +7488,7 @@
 		0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerCollectionCell.swift; sourceTree = "<group>"; };
 		0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPInstrumentation.swift; sourceTree = "<group>"; };
 		0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitFeedbackViewController.swift; sourceTree = "<group>"; };
+		0CEA84D42C3EE0E1008E0B06 /* ZendeskAttachmentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskAttachmentsSection.swift; sourceTree = "<group>"; };
 		0CED1FEC2B61AAF600E6DD52 /* AtomicSiteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicSiteService.swift; sourceTree = "<group>"; };
 		0CED1FFF2B6809CB00E6DD52 /* FilterCompactButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactButton.swift; sourceTree = "<group>"; };
 		0CED20012B6809D600E6DD52 /* FilterCompactDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterCompactDatePicker.swift; sourceTree = "<group>"; };
@@ -21558,6 +21561,7 @@
 			children = (
 				E14A52361E39F43E00EE203E /* AppRatingsUtility.swift */,
 				0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */,
+				0CEA84D42C3EE0E1008E0B06 /* ZendeskAttachmentsSection.swift */,
 				F4FF50E62B4D7D590076DB0C /* InAppFeedbackPromptCoordinator.swift */,
 			);
 			path = "In-App Feedback";
@@ -26269,6 +26273,7 @@
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,
 				46183CF5251BD658004F9AFD /* PageTemplateLayout+CoreDataProperties.swift in Sources */,
 				FA20751427A86B73001A644D /* UIScrollView+Helpers.swift in Sources */,
+				0CEA84D52C3EE0E2008E0B06 /* ZendeskAttachmentsSection.swift in Sources */,
 				981D464825B0D4E7000AA65C /* ReaderSeenAction.swift in Sources */,
 				FE34ACDC2B17AA9400108B3C /* BloganuaryOverlayViewController.swift in Sources */,
 				F57402A7235FF9C300374346 /* SchedulingDate+Helpers.swift in Sources */,
@@ -29330,6 +29335,7 @@
 				FABB23C42602FC2C00C8785C /* MenuItemsVisualOrderingView.m in Sources */,
 				FABB23C52602FC2C00C8785C /* JetpackScanViewController.swift in Sources */,
 				FABB23C62602FC2C00C8785C /* ReaderSubscribingNotificationAction.swift in Sources */,
+				0CEA84D62C3EE0E2008E0B06 /* ZendeskAttachmentsSection.swift in Sources */,
 				FABB23C72602FC2C00C8785C /* GutenbergMediaInserterHelper.swift in Sources */,
 				4AFB1A822A9C08CE007CE165 /* StoppableProgressIndicatorView.swift in Sources */,
 				FABB23C92602FC2C00C8785C /* JetpackState.swift in Sources */,


### PR DESCRIPTION
## Changes

- Add "Submit Feedback" button to the "Me" menu so that users can submit feedback at any time
- Add an optional "Subject" field to the form. Currently all requests have the default subject "Jetpack for iOS Support" A custom subject will make it easier to navigate these. The limit is 100 characters.
- Add 500 character limit to the "Details" field – this should be enough and limiting it will reduce the time needed to go through the feedbacks.
- Add support for adding basic image and GIF attachments. The limit 5 attachments, the maximum size is 8 MB. The app uses the existing `MediaImageExporter` infra to downscale the attachments to 1024×1024 pixels and remove location data.
- Stop asking to confirm your email and name when submitting feedbacks – there are supposed to be one-way interactions
- Add a confirmation dialog on "Cancel" and disable interactive dismiss when non-empty
- Add haptics on submit success and failure
- (Unrelated) Update the "Share Jetpack" Me menu icon to match the style of other icons

Example feedback with attachments created using the new form: 8465509-zd-a8c.

## Screenshots

**Notes on design**

- Using `.plain` list style to make sure there is enough space on smaller devices to fit the form. This is a common design for these types of screens on iOS, so nobody should be confused.
- `TextEditor` doesn't support placeholders, so it'll have to be like this – should be fine
- On iPad, it is presented in a [sheet](https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/0775d305-0615-4416-b2fc-da62c59acfca)

<img width="240" alt="Screenshot 2024-07-10 at 2 10 07 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/d0260642-dcf1-41b4-af2e-107b7317ef04">
<img width="240" alt="Screenshot 2024-07-10 at 1 15 47 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/c4fefbdf-c13f-48e2-a236-49d4809f8c61">
<img width="240" alt="Screenshot 2024-07-10 at 1 33 28 PM" src="https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/066fcf08-78e4-43d4-acc5-d086224451ae">

https://github.com/wordpress-mobile/WordPress-iOS/assets/1567433/bd5cd6df-3284-4816-9e45-26bf6933f2d8

## To test:

- Verify that you can submit a feedback with and without the attachments
- Check the acceptable criteria based on the "Changes" list

**No Prior Support Interactions**

- Login in the app for the first time
- Tap "Submit Feedback"
- Verify that you can upload attachments
- Submit a feedback
- Verify that the feedback was uploaded and reached Zendesk
- Verify that no prompts to confirm your email and/or name were shown
- Open "Help & Support" / "Tickets" and verify that now it asks to confirm your email and name

## Regression Notes
1. Potential unintended areas of impact: "Submit Feedback"
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
