### PR TITLE
[Gutenberg] - Gallery block - Fix getMediaItems 

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: f65a69019e6634e8277fb0861b7cd7d2f4442d73
+  commit: 25a28edbafe8bb8895436c9cc3df48c51367465d
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 0239a7b2494802dfff1e9d8faa486efdf0885631
+  commit: f65a69019e6634e8277fb0861b7cd7d2f4442d73
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-25a28edbafe8bb8895436c9cc3df48c51367465d.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-25a28edbafe8bb8895436c9cc3df48c51367465d.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 21e8eb074e7da51aaf7c9dd2165d3ebfd5481088
+  Gutenberg: 568ec44e90c660516b2021235c8d3c0975981243
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-0239a7b2494802dfff1e9d8faa486efdf0885631.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-0239a7b2494802dfff1e9d8faa486efdf0885631.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-f65a69019e6634e8277fb0861b7cd7d2f4442d73.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 187b75f69ee51b81347329df29d3a7d78bda032c
+  Gutenberg: 21e8eb074e7da51aaf7c9dd2165d3ebfd5481088
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c


### PR DESCRIPTION
**Related PRs:**
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/6978
- https://github.com/WordPress/gutenberg/pull/63426
- https://github.com/wordpress-mobile/WordPress-Android/pull/21053

Fixes an issue with the Gallery block displaying an invalid type error when adding images.

## To Test:

Check the Gutenberg PR description.

## Regression Notes
1. Potential unintended areas of impact

It affects only the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing.

3. What automated tests I added (or what prevented me from doing so)

No new tests were added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
