### PR TITLE
Add support for video attachments in "Send Feedback" form

### DIFF
--- a/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
@@ -26,7 +26,6 @@ struct ZendeskAttachmentsSection: View {
         }
         .listRowBackground(Color.clear)
         .onDisappear(perform: viewModel.onDisappear)
-        .quickLookPreview($previewURL)
     }
 
     private var attachmentsStack: some View {
@@ -40,11 +39,6 @@ struct ZendeskAttachmentsSection: View {
     private func makeView(for attachment: ZendeskAttachmentViewModel) -> some View {
         ZendeskAttachmentView(viewModel: attachment) {
             Section {
-                if let export = attachment.export {
-                    Button(action: { previewURL = export.url }) {
-                        Label(Strings.previewAttachment, systemImage: "eye")
-                    }
-                }
                 Button(role: .destructive, action: { removeAttachment(attachment) }) {
                     Label(Strings.removeAttachment, systemImage: "trash")
                 }
@@ -279,7 +273,6 @@ private enum Constants {
 
 private enum Strings {
     static let addAttachment = NSLocalizedString("zendeskAttachmentsSection.addAttachment", value: "Add Attachments", comment: "Managing Zendesk attachments")
-    static let previewAttachment = NSLocalizedString("zendeskAttachmentsSection.previewAttachment", value: "Preview", comment: "Managing Zendesk attachments")
     static let removeAttachment = NSLocalizedString("zendeskAttachmentsSection.removeAttachment", value: "Remove Attachment", comment: "Managing Zendesk attachments")
     static let unsupportedAttachmentErrorMessage = NSLocalizedString("zendeskAttachmentsSection.unsupportedAttachmentErrorMessage", value: "Unsupported attachment", comment: "Managing Zendesk attachments")
 }

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -16,7 +16,7 @@ enum MediaDirectory {
 
     /// Returns the directory URL for the directory type.
     ///
-    fileprivate var url: URL {
+    var url: URL {
         let fileManager = FileManager.default
         // Get a parent directory, based on the type.
         let parentDirectory: URL

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -667,5 +667,5 @@ extension MeViewController {
 }
 
 private enum Strings {
-    static let submitFeedback = NSLocalizedString("meMenu.submitFeedback", value: "Submit Feedback", comment: "Me tab menu items")
+    static let submitFeedback = NSLocalizedString("meMenu.submitFeedback", value: "Send Feedback", comment: "Me tab menu items")
 }


### PR DESCRIPTION
- Add support for uploading video in the "Send Feedback" form
- Increase the upload limit to 32 MB
- Add "Preview" button to attachments – I added it for testing the upload quality, but I think it's worth keeping

## To test:

- Verify that you can upload video and that the quality is acceptable – looking for a good trade-off between size and quality

## Regression Notes
1. Potential unintended areas of impact: Send Feedback
2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
