### PR TITLE
Site List – Refactor & Redesign

### DIFF
--- a/Modules/Sources/DesignSystem/Components/FAB.swift
+++ b/Modules/Sources/DesignSystem/Components/FAB.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+public struct FAB: View {
+    let image: Image
+    let action: () -> Void
+
+    public init(image: Image = Image(systemName: "plus"), action: @escaping () -> Void) {
+        self.image = image
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            FABContentView(image: image)
+        }
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1) // important to be attached from the outside
+    }
+}
+
+private struct FABContentView: View {
+    let image: Image
+
+    @ScaledMetric(relativeTo: .title2) private var size = 50.0
+    @ScaledMetric(relativeTo: .title2) private var shadowRadios = 4.0
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        image
+            .font(.title2)
+            .foregroundStyle(Color.white)
+            .frame(width: size, height: size)
+            .background(colorScheme == .light ? Color(.label) : Color(.systemGray2))
+            .cornerRadius(size / 2)
+            .shadow(radius: shadowRadios)
+    }
+}
+
+@available(iOS 17, *)
+#Preview(traits: .fixedLayout(width: 200, height: 200)) {
+    FAB(action: {})
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -286,8 +286,6 @@ import Foundation
     case siteSwitcherAddSiteTapped
     case siteSwitcherSearchPerformed
     case siteSwitcherToggleBlogVisible
-    case siteSwitcherToggledPinTapped
-    case siteSwitcherPinUpdated
     case siteSwitcherSiteTapped
 
     // Post List
@@ -1128,10 +1126,6 @@ import Foundation
             return "site_switcher_search_performed"
         case .siteSwitcherToggleBlogVisible:
             return "site_switcher_toggle_blog_visible"
-        case .siteSwitcherToggledPinTapped:
-            return "site_switcher_toggled_pin_tapped"
-        case .siteSwitcherPinUpdated:
-            return "site_switcher_pin_updated"
         case .siteSwitcherSiteTapped:
             return "site_switcher_site_tapped"
 

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Shared localizable strings that can be used in different contexts.
+enum SharedStrings {
+    enum Button {
+        static let cancel = NSLocalizedString("shared.button.cancel", value: "Cancel", comment: "A shared button title used in different contexts")
+        static let close = NSLocalizedString("shared.button.close", value: "Close", comment: "A shared button title used in different contexts")
+        static let done = NSLocalizedString("shared.button.done", value: "Done", comment: "A shared button title used in different contexts")
+        static let edit = NSLocalizedString("shared.button.edit", value: "Edit", comment: "A shared button title used in different contexts")
+        static let add = NSLocalizedString("shared.button.add", value: "Add", comment: "A shared button title used in different contexts")
+        static let remove = NSLocalizedString("shared.button.remove", value: "Remove", comment: "A shared button title used in different contexts")
+        static let save = NSLocalizedString("shared.button.save", value: "Save", comment: "A shared button title used in different contexts")
+    }
+}

--- a/WordPress/Classes/Utility/StringRankedSearch.swift
+++ b/WordPress/Classes/Utility/StringRankedSearch.swift
@@ -101,3 +101,22 @@ struct StringRankedSearch {
         return score
     }
 }
+
+extension StringRankedSearch {
+    /// Returns the top matching results for the given items.
+    ///
+    /// - parameter input: Returns the input for the search algorithm to match against.
+    func search<S: Sequence>(
+        in items: S,
+        minScore: Double = 0.7,
+        input: (S.Element) -> String
+    ) -> [S.Element] {
+        items.compactMap { item -> (S.Element, Double)? in
+            let score = score(for: input(item))
+            guard score > minScore else { return nil }
+            return (item, score)
+        }
+        .sorted { $0.1 > $1.1 }
+        .map(\.0)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -1,0 +1,56 @@
+import DesignSystem
+import SwiftUI
+
+struct BlogListSiteView: View {
+    let site: BlogListSiteViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: .DS.Padding.double) {
+            CachedAsyncImage(url: site.imageURL) { image in
+                image.resizable().aspectRatio(contentMode: .fit)
+            } placeholder: {
+                Color.DS.Background.secondary
+                    .overlay {
+                        Image.DS.icon(named: .vector)
+                            .resizable()
+                            .frame(width: 18, height: 18)
+                            .tint(.DS.Foreground.tertiary)
+                    }
+            }
+            .frame(width: 40, height: 40)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading) {
+                Text(site.title)
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(Color.DS.Foreground.primary)
+                    .lineLimit(2)
+
+                Text(site.domain)
+                    .font(.footnote)
+                    .foregroundStyle(Color.DS.Foreground.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+final class BlogListSiteViewModel: Identifiable {
+    let id: NSNumber
+    let title: String
+    let domain: String
+    let imageURL: URL?
+    let searchTags: String
+
+    init(blog: Blog) {
+        self.id = blog.dotComID ?? 0
+        self.title = blog.title ?? "–"
+        self.domain = blog.displayURL as String? ?? ""
+        self.imageURL = blog.hasIcon ? blog.icon.flatMap(URL.init) : nil
+
+        NSLog(blog.icon ?? "")
+
+        // By adding displayURL _after_ the title, it loweres its weight in search
+        self.searchTags = "\(title) \(domain)"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
@@ -2,240 +2,94 @@ import SwiftUI
 import DesignSystem
 
 struct BlogListView: View {
-    private enum Constants {
-        static let imageDiameter: CGFloat = 40
-        static let sectionInsets = EdgeInsets(
-            top: .DS.Padding.half,
-            leading: .DS.Padding.double,
-            bottom: -.DS.Padding.half,
-            trailing: .DS.Padding.double
-        )
-    }
+    @StateObject var viewModel = BlogListViewModel()
 
-    struct Site: Equatable {
-        let id: NSNumber
-        let title: String
-        let domain: String
-        let imageURL: URL?
-
-        static func ==(lhs: Site, rhs: Site) -> Bool {
-            return lhs.id == rhs.id
-        }
-    }
-
-    @Binding private var isEditing: Bool
     @Binding private var isSearching: Bool
     @Binding private var searchText: String
-    @StateObject var viewModel: BlogListViewModel = BlogListViewModel()
-    @State private var pressedDomains: Set<String> = []
-    private let selectionCallback: ((NSNumber) -> Void)
+
+    private let onSiteSelected: ((Blog) -> Void)
 
     init(
-        isEditing: Binding<Bool>,
         isSearching: Binding<Bool>,
         searchText: Binding<String>,
-        selectionCallback: @escaping ((NSNumber) -> Void)
+        onSiteSelected: @escaping ((Blog) -> Void)
     ) {
-        self._isEditing = isEditing
         self._isSearching = isSearching
         self._searchText = searchText
-        self.selectionCallback = selectionCallback
+        self.onSiteSelected = onSiteSelected
     }
 
     var body: some View {
-        if #available(iOS 16.0, *) {
-            contentList
-                .scrollContentBackground(.hidden)
-        } else {
-            contentList
-        }
-    }
-
-    @ViewBuilder
-    private var contentList: some View {
-        let list = List {
-            if isSearching {
-                ForEach(viewModel.searchSites, id: \.id) { site in
-                    siteButton(site: site)
-                }
-                .onChange(of: searchText) { newValue in
-                    viewModel.searchQueryChanged(newValue)
-                }
+        List {
+            if !searchText.isEmpty {
+                makeSiteList(with: viewModel.searchResults)
             } else {
-                pinnedSection
-                recentsSection
-                allRemainingSitesSection
+                listContent
             }
-        }.onAppear {
+        }
+        .environment(\.defaultMinListRowHeight, 30) // For custom section headers
+        .listStyle(.plain)
+        .onChange(of: searchText) { newValue in
+            viewModel.searchQueryChanged(newValue)
+        }
+        .onAppear {
             viewModel.viewAppeared()
         }
+    }
 
-        if isSearching {
-            list.listStyle(.plain)
+    @ViewBuilder
+    private var listContent: some View {
+        if viewModel.allSites.count > 12 {
+            if !viewModel.recentSites.isEmpty {
+                makeSection(title: Strings.recentsSectionTitle, sites: viewModel.recentSites)
+            }
+            if !viewModel.allSites.isEmpty {
+                makeSection(title: Strings.allSitesSectionTitle, sites: viewModel.allSites, spacing: viewModel.recentSites.isEmpty ? 0 : 16)
+            }
         } else {
-            list.listStyle(.grouped)
+            // Too few sites to bother with "Recent"
+            makeSiteList(with: viewModel.allSites)
         }
     }
 
-    private func sectionHeader(title: String) -> some View {
+    @ViewBuilder
+    private func makeSection(title: String, sites: [BlogListSiteViewModel], spacing: CGFloat = 0) -> some View {
+        // We don't want these to be sticky, so titles are rendered as regular cells
         Text(title)
-            .style(.bodyLarge(.emphasized))
-            .foregroundStyle(Color.DS.Foreground.primary)
+            .font(.headline)
             .listRowSeparator(.hidden)
+            .padding(.top, spacing)
+
+        makeSiteList(with: sites)
     }
 
-    @ViewBuilder
-    private var pinnedSection: some View {
-        if !viewModel.pinnedSites.isEmpty {
-            Section {
-                ForEach(viewModel.pinnedSites, id: \.domain) { site in
-                    siteButton(site: site)
+    private func makeSiteList(with sites: [BlogListSiteViewModel]) -> some View {
+        ForEach(sites) { site in
+            Button {
+                if let site = viewModel.didSelectSite(withSiteID: site.id) {
+                    onSiteSelected(site)
                 }
-            } header: {
-                sectionHeader(
-                    title: Strings.pinnedSectionTitle
-                )
-                .listRowInsets(Constants.sectionInsets)
+            } label: {
+                BlogListSiteView(site: site)
             }
+            .listRowSeparator(site.id == sites.first?.id ? .hidden : .automatic, edges: .top)
+            .listRowSeparator(site.id == sites.last?.id ? .hidden : .automatic, edges: .bottom)
         }
     }
-
-    @ViewBuilder
-    private var allRemainingSitesSection: some View {
-        if !viewModel.allRemainingSites.isEmpty {
-            Section {
-                ForEach(viewModel.allRemainingSites, id: \.domain) { site in
-                    siteButton(site: site)
-                }
-            } header: {
-                sectionHeader(
-                    title: Strings.allRemainingSitesSectionTitle
-                )
-                .listRowInsets(Constants.sectionInsets)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var recentsSection: some View {
-        if !viewModel.recentSites.isEmpty {
-            Section {
-                ForEach(viewModel.recentSites, id: \.domain) { site in
-                    siteButton(site: site)
-                }
-            } header: {
-                sectionHeader(
-                    title: Strings.recentsSectionTitle
-                )
-                .listRowInsets(Constants.sectionInsets)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func siteButton(site: Site) -> some View {
-        Button {
-            if isEditing {
-                withAnimation {
-                    viewModel.togglePinnedSite(siteID: site.id)
-                }
-            } else {
-                viewModel.siteSelected(siteID: site.id)
-                selectionCallback(site.id)
-            }
-        } label: {
-            siteHStack(site: site)
-        }
-        .listRowSeparator(.hidden)
-        .buttonStyle(SelectedButtonStyle(onPress: { isPressed in
-            pressedDomains = pressedDomains.symmetricDifference([site.domain])
-        }))
-        .listRowBackground(
-            pressedDomains.contains(
-                site.domain
-            ) ? Color.DS.Background.secondary : Color.DS.Background.primary
-        )
-    }
-
-    private func siteHStack(site: Site) -> some View {
-        HStack(spacing: 0) {
-            AvatarsView(
-                avatarShape: RoundedRectangle(cornerRadius: 5),
-                style: .single(site.imageURL)
-            )
-            .padding(.trailing, .DS.Padding.split)
-
-            textsVStack(title: site.title, domain: site.domain)
-
-            Spacer()
-
-            if isEditing {
-                pinIcon(site: site)
-                    .padding(.leading, .DS.Padding.single)
-            }
-        }
-    }
-
-    private func textsVStack(title: String, domain: String) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .style(.bodySmall(.regular))
-                .foregroundStyle(Color.DS.Foreground.primary)
-                .layoutPriority(1)
-                .lineLimit(2)
-
-            Text(domain)
-                .style(.bodySmall(.regular))
-                .foregroundStyle(Color.DS.Foreground.secondary)
-                .layoutPriority(2)
-                .lineLimit(1)
-                .padding(.top, .DS.Padding.half)
-        }
-    }
-
-    private func pinIcon(site: Site) -> some View {
-        if viewModel.pinnedSites.contains(site) {
-            Image(systemName: "pin.fill")
-                .foregroundStyle(Color.DS.Background.brand(isJetpack: true))
-                .rotationEffect(.degrees(45))
-        } else {
-            Image(systemName: "pin")
-                .foregroundStyle(Color.DS.Foreground.secondary)
-                .rotationEffect(.degrees(45))
-        }
-    }
-
 }
 
 private extension BlogListView {
     enum Strings {
-        static let pinnedSectionTitle = NSLocalizedString(
-            "site_switcher.pinned_section.title",
-            value: "Pinned sites",
-            comment: "Pinned section title for site switcher."
-        )
-
         static let recentsSectionTitle = NSLocalizedString(
-            "site_switcher.recents_section.title",
+            "sitePicker.recentSitesSectionTitle",
             value: "Recent sites",
             comment: "Recents section title for site switcher."
         )
 
-        static let allRemainingSitesSectionTitle = NSLocalizedString(
-            "site_switcher.all_sites_section.title",
+        static let allSitesSectionTitle = NSLocalizedString(
+            "sitePicker.allSitesSectionTitle",
             value: "All sites",
             comment: "All sites section title for site switcher."
         )
-    }
-}
-
-private struct SelectedButtonStyle: ButtonStyle {
-    var onPress: (Bool) -> Void
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .onChange(of: configuration.isPressed) { newValue in
-                onPress(newValue)
-            }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -103,29 +103,22 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
     }
 
     private func presentNewSiteSwitcher() {
-        var dismissAction: (() -> Void)? = nil
-        let hostingController = UIHostingController(
+        let viewController = UIHostingController(
             rootView: SiteSwitcherView(
-                selectionCallback: { [weak self] siteID in
-                    guard let selectedBlog = BlogListViewModel().allBlogs.first(where: { $0.dotComID == siteID }) else {
-                        return
-                    }
-                    self?.switchToBlog(selectedBlog)
-                    RecentSitesService().touch(blog: selectedBlog)
-                    // Dismiss hosting controller with completion block
-                    dismissAction?()
-                }, addSiteCallback: { [weak self] in
+                addSiteAction: { [weak self] in
                     self?.addSiteTapped()
+                },
+                onSiteSelected: { [weak self] site in
+                    self?.switchToBlog(site)
+                    RecentSitesService().touch(blog: site)
+                    self?.dismiss(animated: true) { [weak self] in
+                        self?.onBlogListDismiss?()
+                    }
                 }
             )
         )
-        dismissAction = {
-            hostingController.dismiss(animated: true) { [weak self] in
-                self?.onBlogListDismiss?()
-            }
-        }
-        present(hostingController, animated: true)
-        WPAnalytics.track(.siteSwitcherAddSiteTapped)
+        present(viewController, animated: true)
+        WPAnalytics.track(.mySiteSiteSwitcherTapped)
     }
 
     private func presentLegacySiteSwitcher() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -2,27 +2,28 @@ import SwiftUI
 import DesignSystem
 
 struct SiteSwitcherView: View {
-    @State private var isEditing: Bool = false
-    private let selectionCallback: ((NSNumber) -> Void)
-    private let addSiteCallback: (() -> Void)
-    private let eventTracker: EventTracker
     @State private var searchText = ""
     @State private var isSearching = false
+
     @Environment(\.dismiss) private var dismiss
 
-    init(selectionCallback: @escaping ((NSNumber) -> Void),
-         addSiteCallback: @escaping (() -> Void),
+    private let onSiteSelected: ((Blog) -> Void)
+    private let addSiteAction: (() -> Void)
+    private let eventTracker: EventTracker
+
+    init(addSiteAction: @escaping (() -> Void),
+         onSiteSelected: @escaping ((Blog) -> Void),
          eventTracker: EventTracker = DefaultEventTracker()
     ) {
-        self.selectionCallback = selectionCallback
-        self.addSiteCallback = addSiteCallback
+        self.addSiteAction = addSiteAction
+        self.onSiteSelected = onSiteSelected
         self.eventTracker = eventTracker
     }
 
     var body: some View {
         if #available(iOS 17.0, *) {
             NavigationStack {
-                blogListVStack
+                blogListView
             }
             .searchable(
                 text: $searchText,
@@ -31,8 +32,7 @@ struct SiteSwitcherView: View {
             )
         } else {
             NavigationView {
-                blogListVStack
-                    .navigationBarTitleDisplayMode(.inline)
+                blogListView
                     .searchable(
                         text: $searchText,
                         placement: .navigationBarDrawer(displayMode: .always)
@@ -44,103 +44,37 @@ struct SiteSwitcherView: View {
         }
     }
 
-    private var blogListVStack: some View {
-        VStack(spacing: 0) {
-            blogListView
-            if !isSearching {
-                addSiteButtonVStack
-            }
-        }
-    }
-
     private var blogListView: some View {
         BlogListView(
-            isEditing: $isEditing,
             isSearching: $isSearching,
             searchText: $searchText,
-            selectionCallback: selectionCallback
+            onSiteSelected: onSiteSelected
         )
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                cancelButton
+        .safeAreaInset(edge: .bottom) {
+            if !isSearching {
+                HStack {
+                    Spacer()
+                    FAB(action: addSiteAction)
+                        .padding(.trailing, 20)
+                }
             }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                editButton
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(SharedStrings.Button.close) {
+                    dismiss()
+                }.tint(Color.DS.Foreground.primary)
             }
         }
         .navigationTitle(Strings.navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
     }
-
-    private var cancelButton: some View {
-        Button(action: {
-            dismiss()
-        }, label: {
-            Text(Strings.navigationDismissButtonTitle)
-                .style(.bodyLarge(.regular))
-                .foregroundStyle(
-                    Color.DS.Foreground.primary
-                )
-        })
-    }
-
-    private var editButton: some View {
-        Button(action: {
-            isEditing.toggle()
-            eventTracker.track(.siteSwitcherToggledPinTapped, properties: ["state": isEditing ? "edit" : "done"])
-        }, label: {
-            Text(isEditing ? Strings.navigationDoneButtonTitle: Strings.navigationEditButtonTitle)
-                .style(.bodyLarge(.regular))
-                .foregroundStyle(
-                    Color.DS.Foreground.primary
-                )
-        })
-    }
-
-    private var addSiteButtonVStack: some View {
-        VStack(spacing: .DS.Padding.medium) {
-            Divider()
-                .background(Color.DS.Foreground.secondary)
-            DSButton(title: Strings.addSiteButtonTitle, style: .init(emphasis: .primary, size: .large)) {
-                addSiteCallback()
-            }
-            .accessibilityIdentifier("add-site-button")
-            .padding(.horizontal, .DS.Padding.medium)
-        }
-        .background(Color.DS.Background.primary)
-    }
 }
 
-private extension SiteSwitcherView {
-    enum Strings {
-        static let navigationTitle = NSLocalizedString(
-            "site_switcher_title",
-            value: "Choose a site",
-            comment: "Title for site switcher screen."
-        )
-
-        static let navigationDismissButtonTitle = NSLocalizedString(
-            "site_switcher_dismiss_button_title",
-            value: "Cancel",
-            comment: "Dismiss button title above the search."
-        )
-
-        static let navigationEditButtonTitle = NSLocalizedString(
-            "site_switcher_edit_button_title",
-            value: "Edit",
-            comment: "Edit button title above the search."
-        )
-
-        static let navigationDoneButtonTitle = NSLocalizedString(
-            "site_switcher_done_button_title",
-            value: "Done",
-            comment: "Done button title above the search."
-        )
-
-        static let addSiteButtonTitle = NSLocalizedString(
-            "site_switcher_cta_title",
-            value: "Add a site",
-            comment: "CTA title for the site switcher screen."
-        )
-    }
+private enum Strings {
+    static let navigationTitle = NSLocalizedString(
+        "sitePicker.title",
+        value: "My Sites",
+        comment: "Title for site switcher screen"
+    )
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -1,5 +1,8 @@
+import UIKit
+import Gridicons
+
 /// A rounded button with a shadow intended for use as a "Floating Action Button"
-class FloatingActionButton: UIButton {
+final class FloatingActionButton: UIButton {
 
     private enum Constants {
         static let shadowColor: UIColor = UIColor.gray(.shade20)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -432,6 +432,10 @@
 		0C02E6C62BE3B6E30055F0F6 /* PostTrashedOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C02E6C42BE3B6E30055F0F6 /* PostTrashedOverlayView.swift */; };
 		0C03AECA2B7D995F00B64A25 /* PublishButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03AEC92B7D995F00B64A25 /* PublishButton.swift */; };
 		0C03AECB2B7D995F00B64A25 /* PublishButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03AEC92B7D995F00B64A25 /* PublishButton.swift */; };
+		0C03EF9F2C495D2E00B7F828 /* SharedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03EF9E2C495D2E00B7F828 /* SharedStrings.swift */; };
+		0C03EFA02C495D2E00B7F828 /* SharedStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03EF9E2C495D2E00B7F828 /* SharedStrings.swift */; };
+		0C03EFA22C498B3D00B7F828 /* BlogListSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03EFA12C498B3D00B7F828 /* BlogListSiteView.swift */; };
+		0C03EFA32C498B3D00B7F828 /* BlogListSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C03EFA12C498B3D00B7F828 /* BlogListSiteView.swift */; };
 		0C0453282AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C0453292AC73343003079C8 /* SiteMediaVideoDurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */; };
 		0C04532B2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */; };
@@ -6533,6 +6537,8 @@
 		0C01A6E92AB37F0F009F7145 /* SiteMediaCollectionCellSelectionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellSelectionOverlayView.swift; sourceTree = "<group>"; };
 		0C02E6C42BE3B6E30055F0F6 /* PostTrashedOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTrashedOverlayView.swift; sourceTree = "<group>"; };
 		0C03AEC92B7D995F00B64A25 /* PublishButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishButton.swift; sourceTree = "<group>"; };
+		0C03EF9E2C495D2E00B7F828 /* SharedStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStrings.swift; sourceTree = "<group>"; };
+		0C03EFA12C498B3D00B7F828 /* BlogListSiteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogListSiteView.swift; sourceTree = "<group>"; };
 		0C0453272AC73343003079C8 /* SiteMediaVideoDurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaVideoDurationView.swift; sourceTree = "<group>"; };
 		0C04532A2AC77245003079C8 /* SiteMediaDocumentInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaDocumentInfoView.swift; sourceTree = "<group>"; };
 		0C0AD1052B0C483F00EC06E6 /* ExternalMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaSelectionTitleView.swift; sourceTree = "<group>"; };
@@ -10562,6 +10568,7 @@
 			isa = PBXGroup;
 			children = (
 				0822C3F22BA1EA2000C53B50 /* BlogListView.swift */,
+				0C03EFA12C498B3D00B7F828 /* BlogListSiteView.swift */,
 				08C6FB482BC6E8530037457C /* BlogListViewModel.swift */,
 			);
 			path = BlogList;
@@ -14846,6 +14853,7 @@
 				0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */,
 				4A5DE7372B0D511900363171 /* PageTree.swift */,
 				FA87A22D2BF798E40062154A /* Version.swift */,
+				0C03EF9E2C495D2E00B7F828 /* SharedStrings.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -22050,6 +22058,7 @@
 				3F8513DF260D091500A4B938 /* RoundRectangleView.swift in Sources */,
 				8B4EDADD27DF9D5E004073B6 /* Blog+MySite.swift in Sources */,
 				D8071631203DA23700B32FD9 /* Accessible.swift in Sources */,
+				0C03EF9F2C495D2E00B7F828 /* SharedStrings.swift in Sources */,
 				9826AE9021B5D3CD00C851FA /* PostingActivityCell.swift in Sources */,
 				934098C02719577D00B3E77E /* InsightType.swift in Sources */,
 				98077B5A2075561800109F95 /* SupportTableViewController.swift in Sources */,
@@ -23354,6 +23363,7 @@
 				FA4F65A72594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift in Sources */,
 				F4DD58322A095210009A772D /* DataMigrationError.swift in Sources */,
 				08F8CD2A1EBD22EF0049D0C0 /* MediaExporter.swift in Sources */,
+				0C03EFA22C498B3D00B7F828 /* BlogListSiteView.swift in Sources */,
 				FAC086D725EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift in Sources */,
 				324780E1247F2E2A00987525 /* NoResultsViewController+FollowedSites.swift in Sources */,
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
@@ -24735,6 +24745,7 @@
 				FABB21002602FC2C00C8785C /* WordPress-91-92.xcmappingmodel in Sources */,
 				FABB21012602FC2C00C8785C /* ReaderCardDiscoverAttributionView.swift in Sources */,
 				FABB21022602FC2C00C8785C /* Plugin.swift in Sources */,
+				0C03EFA02C495D2E00B7F828 /* SharedStrings.swift in Sources */,
 				FABB21032602FC2C00C8785C /* JetpackActivityLogViewController.swift in Sources */,
 				17870A712816F2A000D1C627 /* StatsLatestPostSummaryInsightsCell.swift in Sources */,
 				C33A5ADC2935848F00961E3A /* MigrationAppDetection.swift in Sources */,
@@ -24795,6 +24806,7 @@
 				0189AF062ACAD89700F63393 /* ShoppingCartService.swift in Sources */,
 				FABB21262602FC2C00C8785C /* UIViewController+ChildViewController.swift in Sources */,
 				FABB21272602FC2C00C8785C /* Media+Blog.swift in Sources */,
+				0C03EFA32C498B3D00B7F828 /* BlogListSiteView.swift in Sources */,
 				FABB21282602FC2C00C8785C /* MenuItemEditingHeaderView.m in Sources */,
 				0CED20072B681EB100E6DD52 /* FilterCompactButton.swift in Sources */,
 				3F8B45AB292C42CC00730FA4 /* MigrationSuccessCell.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -75,6 +75,14 @@ final class BlogBuilder {
         return self
     }
 
+    func with(siteName: String) -> Self {
+        if blog.settings == nil {
+            blog.settings =  NSEntityDescription.insertNewObject(forEntityName: BlogSettings.entityName(), into: context) as! BlogSettings
+        }
+        blog.settings?.name = siteName
+        return self
+    }
+
     func with(siteVisibility: SiteVisibility) -> Self {
         blog.siteVisibility = siteVisibility
 

--- a/WordPress/WordPressTest/BlogListViewModelTests.swift
+++ b/WordPress/WordPressTest/BlogListViewModelTests.swift
@@ -11,22 +11,6 @@ final class BlogListViewModelTests: CoreDataTestCase {
     }
 
     // MARK: - Tests for Retrieval Functions
-    func testPinnedSitesWithNoData() {
-        XCTAssertTrue(viewModel.pinnedSites.isEmpty)
-    }
-
-    func testPinnedSitesWithValidData() throws {
-        let siteID = 34984
-        let _ = BlogBuilder(mainContext)
-            .with(dotComID: siteID)
-            .with(pinnedDate: Date())
-            .build()
-        try mainContext.save()
-
-        viewModel = BlogListViewModel(contextManager: contextManager)
-
-        XCTAssertEqual(viewModel.pinnedSites.first?.id, 34984)
-    }
 
     func testRecentSitesWithNoData() {
         XCTAssertTrue(viewModel.recentSites.isEmpty)
@@ -37,7 +21,6 @@ final class BlogListViewModelTests: CoreDataTestCase {
         let _ = BlogBuilder(mainContext)
             .with(dotComID: siteID)
             .with(lastUsed: Date())
-            .with(pinnedDate: nil)
             .build()
         try mainContext.save()
 
@@ -47,46 +30,47 @@ final class BlogListViewModelTests: CoreDataTestCase {
         XCTAssertEqual(viewModel.recentSites.count, 1)
     }
 
-    func testAllRemainingSitesWithNoData() {
-        XCTAssertTrue(viewModel.allRemainingSites.isEmpty)
-    }
-
-    func testAllRemainingSitesWithValidData() throws {
+    func testAllSitesAreDisplayedAndSortedByName() throws {
         let siteID1 = 34984
         let _ = BlogBuilder(mainContext)
+            .with(siteName: "A")
             .with(dotComID: siteID1)
             .with(lastUsed: Date())
             .build()
 
-        let siteID2 = 13287
+        let siteID2 = 54317
         let _ = BlogBuilder(mainContext)
+            .with(siteName: "51 Zone")
             .with(dotComID: siteID2)
             .with(pinnedDate: Date())
             .build()
 
-        let siteID3 = 43788
+        let siteID3 = 13287
         let _ = BlogBuilder(mainContext)
+            .with(siteName: "a")
             .with(dotComID: siteID3)
+            .with(pinnedDate: Date())
             .build()
+
+        let siteID4 = 54317
+        let _ = BlogBuilder(mainContext)
+            .with(siteName: ".Org")
+            .with(dotComID: siteID4)
+            .with(pinnedDate: Date())
+            .build()
+
+        let siteID5 = 43788
+        let _ = BlogBuilder(mainContext)
+            .with(siteName: "C")
+            .with(dotComID: siteID5)
+            .build()
+
         try mainContext.save()
 
         viewModel = BlogListViewModel(contextManager: contextManager)
 
-        XCTAssertEqual(viewModel.allRemainingSites.first?.id, siteID3 as NSNumber)
-        XCTAssertEqual(viewModel.allRemainingSites.count, 1)
-    }
-
-    func testTogglePinnedSiteUpdatesPinnedSites() throws {
-        let id = 23948
-        let blog = BlogBuilder(mainContext)
-            .with(dotComID: id)
-            .build()
-        try mainContext.save()
-
-        viewModel.togglePinnedSite(siteID: blog.dotComID)
-
-        XCTAssertEqual(viewModel.pinnedSites.first?.id, id as NSNumber)
-        XCTAssertEqual(viewModel.pinnedSites.count, 1)
+        let displayedNames = viewModel.allSites.map(\.title)
+        XCTAssertEqual(displayedNames, [".Org", "51 Zone", "a", "A", "C"])
     }
 
     func testSiteSelectedUpdatesLastUsedDate() throws {
@@ -97,7 +81,7 @@ final class BlogListViewModelTests: CoreDataTestCase {
             .build()
         try mainContext.save()
 
-        viewModel.siteSelected(siteID: siteID as NSNumber)
+        _ = viewModel.didSelectSite(withSiteID: siteID as NSNumber)
 
         XCTAssertEqual(viewModel.recentSites.first?.id, siteID as NSNumber)
     }

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -74,18 +74,18 @@ Do not use variables as the argument of `NSLocalizedString()` (neither for the k
 
 ```swift
 // Do
-let myText = NSLocalizedString("some.place.title", value: "This is the text I want to translate.", comment: "Put a meaningful comment here.")
+let myText = NSLocalizedString("someScreen.title", value: "This is the text I want to translate.", comment: "Put a meaningful comment here.")
 myTextLabel?.text = myText
 ```
 
 ```swift
 // Don't
 let myText = "This is the text I want to translate."
-myTextLabel?.text = NSLocalizedString("some.place.title", value: myText, comment: "Put a meaningful comment here.")
+myTextLabel?.text = NSLocalizedString("someScreen.title", value: myText, comment: "Put a meaningful comment here.")
 let myKey = "some.place.title"
 myTextLabel?.text = NSLocalizedString(myKey, value: "This is the text I want to translate.", comment: "Put a meaningful comment here.")
 let comment = "Put a meaningful comment here."
-myTextLabel?.text = NSLocalizedString("some.place.title", value: "This is the text I want to translate.", comment: comment)
+myTextLabel?.text = NSLocalizedString("someScreen.title", value: "This is the text I want to translate.", comment: comment)
 ```
 
 ### Do not use Interpolated Strings
@@ -97,14 +97,14 @@ Use [`String.localizedStringWithFormat`](https://developer.apple.com/documentati
 ```swift
 // Do
 let year = 2019
-let template = NSLocalizedString("mysite.copyrightNotice.title", value: "© %d Acme, Inc.", comment: "Copyright Notice")
+let template = NSLocalizedString("mySite.copyrightNotice.title", value: "© %d Acme, Inc.", comment: "Copyright Notice")
 let str = String.localizeStringWithFormat(template, year)
 ```
 
 ```swift
 // Don't
 let year = 2019
-let str = NSLocalizedString("mysite.copyrightNotice.title", value: "© \(year) Acme, Inc.", comment: "Copyright Notice")
+let str = NSLocalizedString("mySite.copyrightNotice.title", value: "© \(year) Acme, Inc.", comment: "Copyright Notice")
 ```
 
 ### Multiline Strings
@@ -114,7 +114,7 @@ For readability, you can split the string and concatenate the parts using the pl
 ```swift
 // Okay
 NSLocalizedString(
-    "some.place.concatenatedDescription",
+    "someScreen.concatenatedDescription",
     value: "Take some long text here " +
     "and then concatenate it using the '+' symbol."
     comment: "You can even use this form of concatenation " +
@@ -128,11 +128,15 @@ Do not use extended delimiters (e.g. triple quotes). They are not automatically 
 ```swift
 // Don't
 NSLocalizedString(
-    "some.place.tripleQuotedDescription",
+    "someScreen.tripleQuotedDescription",
     """Triple-quoted text, when used in NSLocalizedString, is Not OK. Our scripts break when you use this."""
     comment: """Triple-quoted text, when used in NSLocalizedString, is Not OK."""
 )
 ```
+
+### Shared Strings
+
+Use `SharedStrings` for localizable strings used across many screens like button title "Cancel". 
 
 ### Pluralization
 


### PR DESCRIPTION
This PR covers the first part of preparing the new Site List for production by refactoring the existing implementation and improving its core design and features.

## What Changed

- Simpler and bolder design optimized for a small number of sites – the vast majority of users have under three. 
- Remove the new "Pins" feature. Most users have too few sites to justify adding it. If you have a lot of sites (more than 12), the "Recent" section solves the same issue without you having to manage the pins manually. If that doesn't work, you have search. The "Pins" feature is also not available on wp.com, and if we were to add it without syncing with other devices, it would appear broken.
- Add a new `SharedStrings` enum so we could stop redefining the same basic localizable strings over and over
- Add FAB, which is used consistently across the app, for better or worse. Here, it is for better because the fullscreen button has too much visual weight for this context. Fullscreen CTA should be used where you generally _have_ to tap it to proceed.
- Integrate `StringRankedSearch` for better local search. It's an existing system added during Post List rewrite, which uses a scoring system, supports fuzzy search, and works well with multi-word searches
- Reduce the number of recent sites to 5
- Update "All Sites" to now display _all_ your sites and not just remaining after "recent" (note: not entirely sure this is good yet)
- Add stable ordering (by name) for recent sites so that you can memorize the position in the list
- Change title to "My Sites" (old title)
- Fix the transition to the "Searching" state
- Fix domain presentation – show without "https://"

## Next Steps

- Review the production version and check what else is missing
- Add pull-to-refresh
- Add filters
- Add quick actions and context menus
- Add "Deleted" sites support
- Add P2 badges
- Check iPad support 
- See what else is missing from wp.com – make sure we are consistent with their features
- And more

I think this is out of the scope, but this should be a custom view with wp.com as a CTA and not just a standard sheet:

<img width="320" src="https://github.com/user-attachments/assets/7ce62d73-6ab1-40f2-8997-dc09b44d89b0">

## Notes 

- The use of fonts needs to be reviews across the app. The app should generally default to 17px (body) for content. Everything else looks too small when testing on a physical device. It looks OK only in a simulator or on screenshots.
- The app needs to get rid of all the navigation bar and tab bar customizations to embrace the new native features like scroll edge appearance 

## Screenshots

### Production

<img width="320" alt="Screenshot 2024-07-18 at 7 30 37 PM" src="https://github.com/user-attachments/assets/21efeb7f-be19-4224-ba98-7a9fd2d6d81a">

### Previous Iteration

<img width="320" alt="Screenshot 2024-07-18 at 8 15 23 PM" src="https://github.com/user-attachments/assets/41091ea2-67ba-4e3d-b655-99599ea68294">

<img width="320" alt="Screenshot 2024-07-18 at 8 12 43 PM" src="https://github.com/user-attachments/assets/6e909ed4-1246-4a9b-934a-6b54eb218a8e">

### Latest Iteration

<img width="320" alt="Screenshot 2024-07-18 at 9 05 06 PM" src="https://github.com/user-attachments/assets/6b2bb1bd-0155-4127-88c0-6d9334e78172">

<img width="320" alt="Screenshot 2024-07-18 at 9 03 57 PM" src="https://github.com/user-attachments/assets/1c622f54-8f52-43d5-9d8a-1a6f14510337">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
