### PR TITLE
Integrate gutenberg-mobile release v1.121.0

### DIFF
--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  tag: v1.121.0-alpha2
+  commit: 2ec1f526f28da566370a7b705176f6e9c0054c30
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Gutenberg/config.yml
+++ b/Gutenberg/config.yml
@@ -9,6 +9,6 @@
  #
  #   LOCAL_GUTENBERG=../my-gutenberg-fork bundle exec pod install
 ref:
-  commit: 2ec1f526f28da566370a7b705176f6e9c0054c30
+  tag: v1.121.0
 github_org: wordpress-mobile
 repo_name: gutenberg-mobile

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Gutenberg (1.120.1)
+  - Gutenberg (1.121.0)
   - SwiftLint (0.54.0)
   - WordPress-Aztec-iOS (1.19.11)
   - WordPress-Editor-iOS (1.19.11):
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.121.0-alpha2.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-2ec1f526f28da566370a7b705176f6e9c0054c30.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.121.0-alpha2.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-2ec1f526f28da566370a7b705176f6e9c0054c30.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: ff2d4988d208440f35c1554ef457fca86abf99a9
+  Gutenberg: 157d0c4d3e096bcb8624aa75dea21a8c6a1944fe
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
     - WordPress-Aztec-iOS (= 1.19.11)
 
 DEPENDENCIES:
-  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-2ec1f526f28da566370a7b705176f6e9c0054c30.podspec`)
+  - Gutenberg (from `https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.121.0.podspec`)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19.11)
 
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Gutenberg:
-    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-2ec1f526f28da566370a7b705176f6e9c0054c30.podspec
+    :podspec: https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-v1.121.0.podspec
 
 SPEC CHECKSUMS:
-  Gutenberg: 157d0c4d3e096bcb8624aa75dea21a8c6a1944fe
+  Gutenberg: 3e8f78cbb35f0572a696ac55bafac3aec5d0fc2e
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   WordPress-Aztec-iOS: 3732c6d865a5c9f35788377bdeda8a80ea10d0a1
   WordPress-Editor-iOS: 453345420ced3d3ef20f0051b3df46ff10281e0c

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,8 @@
 * [*] Fix an issue with incorrect snackbar shown when saving drafts manually [#23358]
 * [**] Support editing media metadata for sites not powered by Jetpack and reliant on XML-RPC [#23316]
 * [*] Fix rare crash in the unsupported block editor [#23379]
+* [**] Block editor: Fixed an issue preventing some users from editing or creating content [https://github.com/wordpress-mobile/gutenberg-mobile/pull/6967]
+* [*] Block editor: Added partial prefix support for creating Headings, List, and Quote blocks [https://github.com/WordPress/gutenberg/pull/62576]
 
 25.1
 -----


### PR DESCRIPTION
## Description
This PR incorporates the 1.121.0 release of gutenberg-mobile.
For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/6992

Release Submission Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.