### PR TITLE
Site List – Features

### DIFF
--- a/Modules/Sources/WordPressUI/Views/WebView.swift
+++ b/Modules/Sources/WordPressUI/Views/WebView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import WebKit
+
+public struct WebView: UIViewRepresentable {
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func makeUIView(context: Context) -> WKWebView {
+        let wkwebView = WKWebView()
+        let request = URLRequest(url: url)
+        wkwebView.load(request)
+        return wkwebView
+    }
+
+    public func updateUIView(_ uiView: WKWebView, context: Context) {
+        // Do nothing
+    }
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -288,6 +288,11 @@ import Foundation
     case siteSwitcherToggleBlogVisible
     case siteSwitcherSiteTapped
 
+    // Site List
+    case siteListViewTapped
+    case siteListShareTapped
+    case siteListCopyLinktapped
+
     // Post List
     case postListItemSelected
     case postListShareAction
@@ -1128,6 +1133,14 @@ import Foundation
             return "site_switcher_toggle_blog_visible"
         case .siteSwitcherSiteTapped:
             return "site_switcher_site_tapped"
+
+        // Site List
+        case .siteListViewTapped:
+            return "site_list_view_tapped"
+        case .siteListShareTapped:
+            return "site_list_share_tapped"
+        case .siteListCopyLinktapped:
+            return "site_list_copy_link_tapped"
 
         // Post List
         case .postListItemSelected:

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -10,5 +10,9 @@ enum SharedStrings {
         static let add = NSLocalizedString("shared.button.add", value: "Add", comment: "A shared button title used in different contexts")
         static let remove = NSLocalizedString("shared.button.remove", value: "Remove", comment: "A shared button title used in different contexts")
         static let save = NSLocalizedString("shared.button.save", value: "Save", comment: "A shared button title used in different contexts")
+        static let view = NSLocalizedString("shared.button.view", value: "View", comment: "A shared button title used in different contexts")
+        static let share = NSLocalizedString("shared.button.share", value: "Share", comment: "A shared button title used in different contexts")
+        static let copy = NSLocalizedString("shared.button.copy", value: "Copy", comment: "A shared button title used in different contexts")
+        static let copyLink = NSLocalizedString("shared.button.copyLink", value: "Copy Link", comment: "A shared button title used in different contexts")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -103,19 +103,17 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
     }
 
     private func presentNewSiteSwitcher() {
-        let viewController = UIHostingController(
-            rootView: SiteSwitcherView(
-                addSiteAction: { [weak self] in
-                    self?.addSiteTapped()
-                },
-                onSiteSelected: { [weak self] site in
-                    self?.switchToBlog(site)
-                    RecentSitesService().touch(blog: site)
-                    self?.dismiss(animated: true) { [weak self] in
-                        self?.onBlogListDismiss?()
-                    }
+        let viewController = SiteSwitcherViewController(
+            addSiteAction: { [weak self] in
+                self?.addSiteTapped()
+            },
+            onSiteSelected: { [weak self] site in
+                self?.switchToBlog(site)
+                RecentSitesService().touch(blog: site)
+                self?.dismiss(animated: true) { [weak self] in
+                    self?.onBlogListDismiss?()
                 }
-            )
+            }
         )
         present(viewController, animated: true)
         WPAnalytics.track(.mySiteSiteSwitcherTapped)

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -1,46 +1,71 @@
 import SwiftUI
 import DesignSystem
 
-struct SiteSwitcherView: View {
+final class SiteSwitcherViewController: UIViewController {
+    private let addSiteAction: (() -> Void)
+    private let onSiteSelected: ((Blog) -> Void)
+
+    init(addSiteAction: @escaping (() -> Void),
+         onSiteSelected: @escaping ((Blog) -> Void)) {
+        self.addSiteAction = addSiteAction
+        self.onSiteSelected = onSiteSelected
+
+        super.init(nibName: nil, bundle: nil)
+        self.modalPresentationStyle = .formSheet
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let viewController = UIHostingController(rootView: SiteSwitcherView(addSiteAction: addSiteAction, onSiteSelected: onSiteSelected))
+        viewController.configureDefaultNavigationBarAppearance() // Importanat
+
+        viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.close, style: .plain, target: self, action: #selector(buttonCloseTapped))
+
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.navigationBar.isTranslucent = true // Reset to default
+
+        addChild(navigationController)
+        view.addSubview(navigationController.view)
+        navigationController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(navigationController.view)
+        navigationController.didMove(toParent: self)
+    }
+
+    @objc private func buttonCloseTapped() {
+        presentingViewController?.dismiss(animated: true)
+    }
+}
+
+private struct SiteSwitcherView: View {
     @State private var searchText = ""
     @State private var isSearching = false
 
-    @Environment(\.dismiss) private var dismiss
-
-    private let onSiteSelected: ((Blog) -> Void)
-    private let addSiteAction: (() -> Void)
-    private let eventTracker: EventTracker
-
-    init(addSiteAction: @escaping (() -> Void),
-         onSiteSelected: @escaping ((Blog) -> Void),
-         eventTracker: EventTracker = DefaultEventTracker()
-    ) {
-        self.addSiteAction = addSiteAction
-        self.onSiteSelected = onSiteSelected
-        self.eventTracker = eventTracker
-    }
+    let addSiteAction: (() -> Void)
+    let onSiteSelected: ((Blog) -> Void)
+    var eventTracker: EventTracker = DefaultEventTracker()
 
     var body: some View {
         if #available(iOS 17.0, *) {
-            NavigationStack {
-                blogListView
-            }
-            .searchable(
-                text: $searchText,
-                isPresented: $isSearching,
-                placement: .navigationBarDrawer(displayMode: .always)
-            )
+            blogListView
+                .searchable(
+                    text: $searchText,
+                    isPresented: $isSearching,
+                    placement: .navigationBarDrawer(displayMode: .always)
+                )
         } else {
-            NavigationView {
-                blogListView
-                    .searchable(
-                        text: $searchText,
-                        placement: .navigationBarDrawer(displayMode: .always)
-                    )
-                    .onChange(of: searchText) { newValue in
-                        isSearching = !newValue.isEmpty
-                    }
-            }
+            blogListView
+                .searchable(
+                    text: $searchText,
+                    placement: .navigationBarDrawer(displayMode: .always)
+                )
+                .onChange(of: searchText) { newValue in
+                    isSearching = !newValue.isEmpty
+                }
         }
     }
 
@@ -56,14 +81,8 @@ struct SiteSwitcherView: View {
                     Spacer()
                     FAB(action: addSiteAction)
                         .padding(.trailing, 20)
+                        .padding(.bottom, UIDevice.current.userInterfaceIdiom == .pad ? 20 : 0)
                 }
-            }
-        }
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                Button(SharedStrings.Button.close) {
-                    dismiss()
-                }.tint(Color.DS.Foreground.primary)
             }
         }
         .navigationTitle(Strings.navigationTitle)


### PR DESCRIPTION
## Changes

- Add context menu with a preview
- Add swipe actions
- Add iPad support
- Show placeholder with a first letter of the site name when the icon isn't set
- Add pull-to-refresh
- Add post sync call on view appear
- Add integration with the stats widget (should ideally be extracted to a server in the future)
- Fix navigation bar style in dark mode (required UIKit changes)

## Next Steps

- Integrate the new screen in the domain picker (PR#3)
- Remove the old code (PR#4)

I'm not sure it's worth adding any more features from wp.com. 

Adding filters is not a very compelling features considering most users have only have a handful of sites. If we were to add filters, I'm not sure the ones on wp.com are the right ones. Why would you want to filter by the visibility? It would probably make some sense to separate self-hosted and wp.com sites. Maybe it should be done by default using list sections, wdyt, @jkmassel ?

It's also hard to imagine a scenario where anyone would use these navigation actions on mobile. It's also just going to duplicate the home page.

<img width="200" alt="Screenshot 2024-07-19 at 7 30 47 PM" src="https://github.com/user-attachments/assets/4c748b3e-137e-4505-b640-ae67f6bf576c">

Is there anything else worth adding?

## Screenshots

<img width="320" alt="Screenshot 2024-07-19 at 7 12 27 PM" src="https://github.com/user-attachments/assets/e94438cc-2ef8-473b-84b4-36d9b4cb6638">
<img width="320" alt="Screenshot 2024-07-19 at 7 12 51 PM" src="https://github.com/user-attachments/assets/97f58931-8aaa-4a5a-914d-4c8b6625eb1d">
<img width="460" alt="Screenshot 2024-07-19 at 7 23 54 PM" src="https://github.com/user-attachments/assets/b9f79180-b1fa-4049-8759-af710969de0d">
<img width="320" alt="Screenshot 2024-07-19 at 7 26 41 PM" src="https://github.com/user-attachments/assets/c9b52c61-3de6-4497-8c49-ecf36c204091">
<img width="320" alt="Screenshot 2024-07-19 at 7 26 46 PM" src="https://github.com/user-attachments/assets/bc3989bf-7db6-417c-8bf3-5035d7d769bf">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
