### PR TITLE
Site List – Replace

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
@@ -3,16 +3,13 @@ import DesignSystem
 import WordPressUI
 
 struct BlogListView: View {
-    @StateObject var viewModel = BlogListViewModel()
-
-    @Binding var isSearching: Bool
-    @Binding var searchText: String
+    @ObservedObject var viewModel: BlogListViewModel
 
     let onSiteSelected: ((Blog) -> Void)
 
     var body: some View {
         List {
-            if !searchText.isEmpty {
+            if !viewModel.searchText.isEmpty {
                 makeSiteList(with: viewModel.searchResults)
             } else {
                 listContent
@@ -23,9 +20,6 @@ struct BlogListView: View {
         }
         .environment(\.defaultMinListRowHeight, 30) // For custom section headers
         .listStyle(.plain)
-        .onChange(of: searchText) { newValue in
-            viewModel.searchQueryChanged(newValue)
-        }
         .onAppear(perform: viewModel.onAppear)
         .onDisappear(perform: viewModel.onDisappear)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -2,12 +2,15 @@ import CoreData
 import SwiftUI
 
 final class BlogListViewModel: NSObject, ObservableObject {
+    @Published var searchText = "" {
+        didSet { updateSearchResults() }
+    }
+
     @Published private(set) var recentSites: [BlogListSiteViewModel] = []
     @Published private(set) var allSites: [BlogListSiteViewModel] = []
     @Published private(set) var searchResults: [BlogListSiteViewModel] = []
 
     private var rawSites: [Blog] = []
-    private var searchText: String = ""
     private let fetchedResultsController: NSFetchedResultsController<Blog>
     private let contextManager: ContextManager
     private let blogService: BlogService
@@ -22,11 +25,6 @@ final class BlogListViewModel: NSObject, ObservableObject {
         self.fetchedResultsController = createFetchedResultsController(in: contextManager.mainContext)
         super.init()
         setupFetchedResultsController()
-    }
-
-    func searchQueryChanged(_ newText: String) {
-        searchText = newText
-        updateSearchResults()
     }
 
     func didSelectSite(withSiteID siteID: NSNumber) -> Blog? {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -42,8 +42,6 @@ final class SiteSwitcherViewController: UIViewController {
 }
 
 private struct SiteSwitcherView: View {
-    @State private var isSearching = false
-
     let addSiteAction: (() -> Void)
     let onSiteSelected: ((Blog) -> Void)
 
@@ -51,7 +49,6 @@ private struct SiteSwitcherView: View {
 
     var body: some View {
         BlogListView(viewModel: viewModel, onSiteSelected: onSiteSelected)
-            /// - warning: The order is important for `isSearching` to work.
             .safeAreaInset(edge: .bottom) {
                 SiteSwitcherToolbarView(addSiteAction: addSiteAction)
             }
@@ -64,6 +61,7 @@ private struct SiteSwitcherView: View {
 private struct SiteSwitcherToolbarView: View {
     let addSiteAction: (() -> Void)
 
+    /// - warning: It has to be defined in a view "below" the .searchable
     @Environment(\.isSearching) var isSearching
 
     var body: some View {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -42,51 +42,39 @@ final class SiteSwitcherViewController: UIViewController {
 }
 
 private struct SiteSwitcherView: View {
-    @State private var searchText = ""
     @State private var isSearching = false
 
     let addSiteAction: (() -> Void)
     let onSiteSelected: ((Blog) -> Void)
-    var eventTracker: EventTracker = DefaultEventTracker()
+
+    @StateObject private var viewModel = BlogListViewModel()
 
     var body: some View {
-        if #available(iOS 17.0, *) {
-            blogListView
-                .searchable(
-                    text: $searchText,
-                    isPresented: $isSearching,
-                    placement: .navigationBarDrawer(displayMode: .always)
-                )
-        } else {
-            blogListView
-                .searchable(
-                    text: $searchText,
-                    placement: .navigationBarDrawer(displayMode: .always)
-                )
-                .onChange(of: searchText) { newValue in
-                    isSearching = !newValue.isEmpty
-                }
-        }
+        BlogListView(viewModel: viewModel, onSiteSelected: onSiteSelected)
+            /// - warning: The order is important for `isSearching` to work.
+            .safeAreaInset(edge: .bottom) {
+                SiteSwitcherToolbarView(addSiteAction: addSiteAction)
+            }
+            .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always))
+            .navigationTitle(Strings.navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
     }
+}
 
-    private var blogListView: some View {
-        BlogListView(
-            isSearching: $isSearching,
-            searchText: $searchText,
-            onSiteSelected: onSiteSelected
-        )
-        .safeAreaInset(edge: .bottom) {
-            if !isSearching {
-                HStack {
-                    Spacer()
-                    FAB(action: addSiteAction)
-                        .padding(.trailing, 20)
-                        .padding(.bottom, UIDevice.current.userInterfaceIdiom == .pad ? 20 : 0)
-                }
+private struct SiteSwitcherToolbarView: View {
+    let addSiteAction: (() -> Void)
+
+    @Environment(\.isSearching) var isSearching
+
+    var body: some View {
+        if !isSearching {
+            HStack {
+                Spacer()
+                FAB(action: addSiteAction)
+                    .padding(.trailing, 20)
+                    .padding(.bottom, UIDevice.current.userInterfaceIdiom == .pad ? 20 : 0)
             }
         }
-        .navigationTitle(Strings.navigationTitle)
-        .navigationBarTitleDisplayMode(.inline)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/Views/RegisterDomainSitePickerView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/Views/RegisterDomainSitePickerView.swift
@@ -1,0 +1,12 @@
+import Foundation
+import SwiftUI
+
+struct RegisterDomainSitePickerView: View {
+    @StateObject var viewModel: BlogListViewModel
+    let onSiteSelected: (Blog) -> Void
+
+    var body: some View {
+        BlogListView(viewModel: viewModel, onSiteSelected: onSiteSelected)
+            .searchable(text: $viewModel.searchText)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -495,6 +495,8 @@
 		0C4CE8492C2F418000B9EEAC /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 433840C622C2BA5B00CB13F8 /* AppImages.xcassets */; };
 		0C5751102B011468001074E5 /* RemoteConfigDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */; };
 		0C5751112B011468001074E5 /* RemoteConfigDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */; };
+		0C5F19D02C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5F19CF2C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift */; };
+		0C5F19D12C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5F19CF2C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift */; };
 		0C63266F2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */; };
 		0C6AC6122C364A2800BF7600 /* XcodeTarget_App in Frameworks */ = {isa = PBXBuildFile; productRef = 0C6AC6112C364A2800BF7600 /* XcodeTarget_App */; };
 		0C6AC6142C364A3100BF7600 /* XcodeTarget_ShareExtension in Frameworks */ = {isa = PBXBuildFile; productRef = 0C6AC6132C364A3100BF7600 /* XcodeTarget_ShareExtension */; };
@@ -6570,6 +6572,7 @@
 		0C3C50412BA3A024002A37B4 /* PostNoticePublishSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticePublishSuccessView.swift; sourceTree = "<group>"; };
 		0C43FF802C3601770084B698 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/System/iOSSupport/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigDebugView.swift; sourceTree = "<group>"; };
+		0C5F19CF2C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDomainSitePickerView.swift; sourceTree = "<group>"; };
 		0C63266E2A3D1305000B8C57 /* GutenbergFilesAppMediaSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergFilesAppMediaSourceTests.swift; sourceTree = "<group>"; };
 		0C6C4CCF2A4F0A000049E762 /* BlazeCampaignsStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStreamTests.swift; sourceTree = "<group>"; };
 		0C6C4CD32A4F0AD80049E762 /* blaze-search-page-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-search-page-1.json"; sourceTree = "<group>"; };
@@ -12675,6 +12678,7 @@
 			children = (
 				43D74AD520FB5AD5004AD934 /* RegisterDomainSectionHeaderView.swift */,
 				43D74AD320FB5ABA004AD934 /* RegisterDomainSectionHeaderView.xib */,
+				0C5F19CF2C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -22397,6 +22401,7 @@
 				016231502B3B3CAD0010E377 /* PrimaryDomainView.swift in Sources */,
 				8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */,
 				3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */,
+				0C5F19D02C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift in Sources */,
 				FE7FAABE299A998E0032A6F2 /* EventTracker.swift in Sources */,
 				7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */,
 				321955C324BF77E400E3F316 /* ReaderTopicService+FollowedInterests.swift in Sources */,
@@ -24724,6 +24729,7 @@
 				FABB20F12602FC2C00C8785C /* RecentSitesService.swift in Sources */,
 				FA332AD129C1F97A00182FBB /* MovedToJetpackViewController.swift in Sources */,
 				8BD66ED52787530C00CCD95A /* PostsCardViewModel.swift in Sources */,
+				0C5F19D12C4F1800000A1AD0 /* RegisterDomainSitePickerView.swift in Sources */,
 				FABB20F22602FC2C00C8785C /* PlanService.swift in Sources */,
 				FABB20F32602FC2C00C8785C /* Routes+Mbar.swift in Sources */,
 				B038BD162BE1A37D009FD7E9 /* SubscribersChartMarker.swift in Sources */,


### PR DESCRIPTION
- Simplify `BlogListView` to make it easier to reuse
- Update the "Purchase Domain" flow to use the new site picker

## To test:

- Open Me / All Domains / "+"/ and add a domain
- Verify that the picker was displayed and you can select a site

https://github.com/user-attachments/assets/e7b35e1b-a906-4489-8208-8ec4e050cae4


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
