### PR TITLE
Add SiteIconView and SiteIconHostingView

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -41,7 +41,7 @@ extension UIImageView {
         imageSize: CGSize = SiteIconDefaults.imageSize,
         placeholderImage: UIImage?
     ) {
-        guard let siteIconURL = optimizedURL(for: path, imageSize: imageSize) else {
+        guard let siteIconURL = SiteIconViewModel.optimizedURL(for: path, imageSize: imageSize) else {
             image = placeholderImage
             return
         }
@@ -85,7 +85,7 @@ extension UIImageView {
                     self.image = image
                 }
 
-                self.removePlaceholderBorder()
+                self.layer.borderColor = UIColor.clear.cgColor
             case .failure(let error):
                 if case .requestCancelled = error {
                     // Do not log intentionally cancelled requests as errors.
@@ -108,7 +108,7 @@ extension UIImageView {
         imageSize: CGSize = SiteIconDefaults.imageSize,
         placeholderImage: UIImage? = .siteIconPlaceholder
     ) {
-        guard let siteIconPath = blog.icon, let siteIconURL = optimizedURL(for: siteIconPath, imageSize: imageSize) else {
+        guard let siteIconPath = blog.icon, let siteIconURL = SiteIconViewModel.optimizedURL(for: siteIconPath, imageSize: imageSize) else {
 
             if blog.isWPForTeams() && placeholderImage == .siteIconPlaceholder {
                 image = UIImage.gridicon(.p2, size: imageSize)
@@ -138,101 +138,6 @@ extension UIImageView {
     }
 }
 
-// MARK: - Private Methods
-//
-extension UIImageView {
-    /// Returns the Size Optimized URL for a given Path.
-    ///
-    func optimizedURL(for path: String, imageSize: CGSize = SiteIconDefaults.imageSize) -> URL? {
-        if isPhotonURL(path) || isDotcomURL(path) {
-            return optimizedDotcomURL(from: path, imageSize: imageSize)
-        }
-
-        if isBlavatarURL(path) {
-            return optimizedBlavatarURL(from: path, imageSize: imageSize)
-        }
-
-        return optimizedPhotonURL(from: path, imageSize: imageSize)
-    }
-
-    // MARK: - Private Helpers
-
-    /// Returns the download URL for a square icon with a size of `imageSize` in pixels.
-    ///
-    /// - Parameter path: SiteIcon URL (string encoded).
-    ///
-    private func optimizedDotcomURL(from path: String, imageSize: CGSize = SiteIconDefaults.imageSize) -> URL? {
-        let size = imageSize.toPixels()
-        let query = String(format: "w=%d&h=%d", Int(size.width), Int(size.height))
-
-        return parseURL(path: path, query: query)
-    }
-
-    /// Returns the icon URL corresponding to the provided path
-    ///
-    /// - Parameter path: Blavatar URL (string encoded).
-    ///
-    private func optimizedBlavatarURL(from path: String, imageSize: CGSize = SiteIconDefaults.imageSize) -> URL? {
-        let size = imageSize.toPixels()
-        let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
-
-        return parseURL(path: path, query: query)
-    }
-
-    /// Returs the photon URL for the provided path
-    ///
-    /// - Parameter siteIconPath: SiteIcon URL (string encoded).
-    ///
-    private func optimizedPhotonURL(from path: String, imageSize: CGSize = SiteIconDefaults.imageSize) -> URL? {
-        guard let url = URL(string: path) else {
-            return nil
-        }
-
-        return PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
-    }
-
-    /// Indicates if the received URL is hosted at WordPress.com
-    ///
-    private func isDotcomURL(_ path: String) -> Bool {
-        return path.contains(".files.wordpress.com")
-    }
-
-    /// Indicates if the received URL is hosted at Gravatar.com
-    ///
-    private func isBlavatarURL(_ path: String) -> Bool {
-        return path.contains("gravatar.com/blavatar")
-    }
-
-    /// Indicates if the received URL is a Photon Endpoint
-    /// Possible matches are "i0.wp.com", "i1.wp.com" & "i2.wp.com" -> https://developer.wordpress.com/docs/photon/
-    ///
-    private func isPhotonURL(_ path: String) -> Bool {
-        return path.contains(".wp.com")
-    }
-
-    /// Attempts to parse the URL contained within a Path, with a given query. Returns nil on failure.
-    ///
-    private func parseURL(path: String, query: String) -> URL? {
-        guard var components = URLComponents(string: path) else {
-            return nil
-        }
-
-        components.query = query
-
-        return components.url
-    }
-}
-
-// MARK: - Border handling
-
-@objc
-extension UIImageView {
-
-    func removePlaceholderBorder() {
-        layer.borderColor = UIColor.clear.cgColor
-    }
-}
-
 // MARK: - Logging Support
 
 /// This is just a temporary extension to try and narrow down the caused behind this issue: https://sentry.io/share/issue/3da4662c65224346bb3a731c131df13d/
@@ -252,21 +157,5 @@ private extension UIImageView {
         }
 
         DDLogInfo("URL optimized from \(original) to \(optimized.absoluteString) for blog \(blogInfo)")
-    }
-}
-
-// MARK: - CGFloat Extension
-
-private extension CGSize {
-
-    func toPixels() -> CGSize {
-        return CGSize(width: width.toPixels(), height: height.toPixels())
-    }
-}
-
-private extension CGFloat {
-
-    func toPixels() -> CGFloat {
-        return self * UIScreen.main.scale
     }
 }

--- a/WordPress/Classes/Utility/Media/CachedAsyncImage.swift
+++ b/WordPress/Classes/Utility/Media/CachedAsyncImage.swift
@@ -4,10 +4,11 @@ import DesignSystem
 /// Asynchronous Image View that replicates the public API of `SwiftUI.AsyncImage`.
 /// It uses `ImageDownloader` to fetch and cache the images.
 struct CachedAsyncImage<Content>: View where Content: View {
-    @State private var phase: AsyncImagePhase
+    @State private var phase: AsyncImagePhase = .empty
     private let url: URL?
     private let content: (AsyncImagePhase) -> Content
     private let imageDownloader: ImageDownloader
+    private let host: MediaHost?
 
     public var body: some View {
         content(phase)
@@ -30,8 +31,8 @@ struct CachedAsyncImage<Content>: View where Content: View {
 
     /// Allows content customization and providing a placeholder that will be shown
     /// until the image download is finalized.
-    init<I, P>(url: URL?, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P) where Content == _ConditionalContent<I, P>, I: View, P: View {
-        self.init(url: url) { phase in
+    init<I, P>(url: URL?, host: MediaHost? = nil, @ViewBuilder content: @escaping (Image) -> I, @ViewBuilder placeholder: @escaping () -> P) where Content == _ConditionalContent<I, P>, I: View, P: View {
+        self.init(url: url, host: host) { phase in
             if let image = phase.image {
                 content(image)
             } else {
@@ -42,39 +43,37 @@ struct CachedAsyncImage<Content>: View where Content: View {
 
     init(
         url: URL?,
+        host: MediaHost? = nil,
         imageDownloader: ImageDownloader = .shared,
         @ViewBuilder content: @escaping (AsyncImagePhase) -> Content
     ) {
         self.url = url
+        self.host = host
         self.imageDownloader = imageDownloader
         self.content = content
-
-        self._phase = State(wrappedValue: .empty)
-        if let url, let image = cachedImage(from: url) {
-            self._phase = State(wrappedValue: .success(image))
-        }
     }
 
     // MARK: - Helpers
 
     private func fetchImage() async {
         do {
-            if let url {
-                let image = try await Image(uiImage: imageDownloader.image(from: url))
-                phase = .success(image)
-            } else {
+            guard let url else {
                 phase = .empty
+                return
+            }
+            if let image = imageDownloader.cachedImage(for: url) {
+                phase = .success(Image(uiImage: image))
+            } else {
+                let image: UIImage
+                if let host {
+                    image = try await imageDownloader.image(from: url, host: host)
+                } else {
+                    image = try await imageDownloader.image(from: url)
+                }
+                phase = .success(Image(uiImage: image))
             }
         } catch {
             phase = .failure(error)
         }
-    }
-
-    private func cachedImage(from url: URL?) -> Image? {
-        guard let url, let uiImage = imageDownloader.cachedImage(for: url) else {
-            return nil
-        }
-
-        return Image(uiImage: uiImage)
     }
 }

--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -62,13 +62,13 @@ actor ImageDownloader {
     // MARK: - Images (Blog)
 
     /// Returns image for the given URL authenticated for the given host.
-    func image(from imageURL: URL, host: MediaHost, options: ImageRequestOptions) async throws -> UIImage {
+    func image(from imageURL: URL, host: MediaHost, options: ImageRequestOptions = .init()) async throws -> UIImage {
         let request = try await authenticatedRequest(for: imageURL, host: host)
         return try await image(from: request, options: options)
     }
 
     /// Returns data for the given URL authenticated for the given host.
-    func data(from imageURL: URL, host: MediaHost, options: ImageRequestOptions) async throws -> Data {
+    func data(from imageURL: URL, host: MediaHost, options: ImageRequestOptions = .init()) async throws -> Data {
         let request = try await authenticatedRequest(for: imageURL, host: host)
         return try await data(for: request, options: options)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -1,6 +1,7 @@
 import Gridicons
 import UIKit
 import DesignSystem
+import SwiftUI
 
 @objc protocol BlogDetailHeaderViewDelegate {
     func makeSiteIconMenu() -> UIMenu?
@@ -25,6 +26,7 @@ class BlogDetailHeaderView: UIView {
 
     @objc var updatingIcon: Bool = false {
         didSet {
+            titleView.siteIconView.imageView.isHidden = updatingIcon
             if updatingIcon {
                 titleView.siteIconView.activityIndicator.startAnimating()
             } else {
@@ -33,7 +35,7 @@ class BlogDetailHeaderView: UIView {
         }
     }
 
-    @objc var blavatarImageView: UIImageView {
+    @objc var blavatarImageView: UIView {
         return titleView.siteIconView.imageView
     }
 
@@ -53,16 +55,11 @@ class BlogDetailHeaderView: UIView {
     }
 
     @objc func refreshIconImage() {
-        if let blog = blog,
-            blog.hasIcon == true {
-            titleView.siteIconView.imageView.downloadSiteIcon(for: blog)
-        } else if let blog = blog,
-            blog.isWPForTeams() {
-            titleView.siteIconView.imageView.tintColor = UIColor.listIcon
-            titleView.siteIconView.imageView.image = UIImage.gridicon(.p2)
-        } else {
-            titleView.siteIconView.imageView.image = UIImage.siteIconPlaceholder
-        }
+        guard let blog else { return }
+
+        var viewModel = SiteIconViewModel(blog: blog)
+        viewModel.background = Color(.systemBackground)
+        titleView.siteIconView.imageView.setIcon(with: viewModel)
 
         toggleSpotlightOnSiteIcon()
     }
@@ -225,8 +222,8 @@ extension BlogDetailHeaderView {
             return stackView
         }()
 
-        let siteIconView: SiteIconView = {
-            let siteIconView = SiteIconView(frame: .zero)
+        let siteIconView: SiteDetailsSiteIconView = {
+            let siteIconView = SiteDetailsSiteIconView(frame: .zero)
             siteIconView.translatesAutoresizingMaskIntoConstraints = false
             return siteIconView
         }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
@@ -1,9 +1,9 @@
-class SiteIconView: UIView {
+import UIKit
+
+final class SiteDetailsSiteIconView: UIView {
 
     private enum Constants {
-        static let imageSize: CGFloat = 40
-        static let borderRadius: CGFloat = 4
-        static let imageRadius: CGFloat = 2
+        static var imageSize: CGFloat { SiteIconViewModel.Size.regular.width }
         static let spotlightOffset: CGFloat = 8
     }
 
@@ -20,11 +20,10 @@ class SiteIconView: UIView {
     /// A block to be called when an image is dropped on to the view.
     var dropped: (([UIImage]) -> Void)?
 
-    let imageView: UIImageView = {
-        let imageView = UIImageView(frame: .zero)
+    let imageView: SiteIconHostingView = {
+        let imageView = SiteIconHostingView(frame: .zero)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.clipsToBounds = true
-        imageView.layer.cornerRadius = Constants.imageRadius
         NSLayoutConstraint.activate([
             imageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
             imageView.heightAnchor.constraint(equalToConstant: Constants.imageSize)
@@ -34,7 +33,6 @@ class SiteIconView: UIView {
 
     let activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
-        indicatorView.color = .white
         indicatorView.translatesAutoresizingMaskIntoConstraints = false
         return indicatorView
     }()
@@ -51,11 +49,8 @@ class SiteIconView: UIView {
 
     private let button: UIButton = {
         let button = UIButton(frame: .zero)
-        button.backgroundColor = UIColor(light: .white, dark: .systemGray5)
+        button.backgroundColor = UIColor.clear
         button.clipsToBounds = true
-        button.layer.borderColor = UIColor.systemGray3.cgColor
-        button.layer.borderWidth = 1
-        button.layer.cornerRadius = Constants.borderRadius
         return button
     }()
 
@@ -121,7 +116,7 @@ class SiteIconView: UIView {
     }
 }
 
-extension SiteIconView: UIDropInteractionDelegate {
+extension SiteDetailsSiteIconView: UIDropInteractionDelegate {
     func dropInteraction(_ interaction: UIDropInteraction, sessionDidEnter session: UIDropSession) {
         imageView.depressSpringAnimation()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -1,14 +1,14 @@
 import DesignSystem
 import SwiftUI
+import WordPressShared
 
 struct BlogListSiteView: View {
     let site: BlogListSiteViewModel
 
     var body: some View {
         HStack(alignment: .center, spacing: .DS.Padding.double) {
-            siteIconView
+            SiteIconView(viewModel: site.icon)
                 .frame(width: 40, height: 40)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
 
             VStack(alignment: .leading) {
                 Text(site.title)
@@ -23,42 +23,14 @@ struct BlogListSiteView: View {
             }
         }
     }
-
-    @ViewBuilder
-    private var siteIconView: some View {
-        if let imageURL = site.imageURL {
-            CachedAsyncImage(url: imageURL) { image in
-                image.resizable().aspectRatio(contentMode: .fit)
-            } placeholder: {
-                Color.DS.Background.secondary
-                    .overlay {
-                        Image.DS.icon(named: .vector)
-                            .resizable()
-                            .frame(width: 18, height: 18)
-                            .tint(.DS.Foreground.tertiary)
-                    }
-            }
-        } else {
-            Color(.secondarySystemBackground)
-                .overlay {
-                    Text(site.firstLetter?.uppercased() ?? "@")
-                        .font(.system(size: 22, weight: .medium, design: .rounded))
-                        .foregroundStyle(.secondary.opacity(0.8))
-                }
-        }
-    }
 }
 
 final class BlogListSiteViewModel: Identifiable {
     var id: NSManagedObjectID { blog.objectID }
     let title: String
     let domain: String
-    let imageURL: URL?
+    let icon: SiteIconViewModel
     let searchTags: String
-
-    var firstLetter: Character? {
-        title.first ?? domain.first
-    }
 
     var siteURL: URL? {
         blog.url.flatMap(URL.init)
@@ -70,7 +42,7 @@ final class BlogListSiteViewModel: Identifiable {
         self.blog = blog
         self.title = blog.title ?? "–"
         self.domain = blog.displayURL as String? ?? ""
-        self.imageURL = blog.hasIcon ? blog.icon.flatMap(URL.init) : nil
+        self.icon = SiteIconViewModel(blog: blog)
 
         // By adding displayURL _after_ the title, it loweres its weight in search
         self.searchTags = "\(title) \(domain)"

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -14,7 +14,7 @@ struct SiteIconView: View {
     @ViewBuilder
     private var contents: some View {
         if let imageURL = viewModel.imageURL {
-            CachedAsyncImage(url: imageURL) { image in
+            CachedAsyncImage(url: imageURL, host: viewModel.host) { image in
                 image.resizable().aspectRatio(contentMode: .fit)
             } placeholder: {
                 viewModel.background

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -14,10 +14,15 @@ struct SiteIconView: View {
     @ViewBuilder
     private var contents: some View {
         if let imageURL = viewModel.imageURL {
-            CachedAsyncImage(url: imageURL, host: viewModel.host) { image in
-                image.resizable().aspectRatio(contentMode: .fit)
-            } placeholder: {
-                viewModel.background
+            CachedAsyncImage(url: imageURL, host: viewModel.host) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().aspectRatio(contentMode: .fit)
+                case .failure:
+                    failureStateView
+                default:
+                    viewModel.background
+                }
             }
         } else {
             noIconView
@@ -31,11 +36,17 @@ struct SiteIconView: View {
                     .font(.system(size: 24, weight: .medium, design: .rounded))
                     .foregroundStyle(.secondary.opacity(0.8))
             } else {
-                Image.DS.icon(named: .vector)
-                    .resizable()
-                    .frame(width: 18, height: 18)
-                    .tint(.DS.Foreground.tertiary)
+                failureStateView
             }
+        }
+    }
+
+    private var failureStateView: some View {
+        viewModel.background.overlay {
+            Image.DS.icon(named: .vector)
+                .resizable()
+                .frame(width: 18, height: 18)
+                .tint(.DS.Foreground.tertiary)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -1,0 +1,109 @@
+import UIKit
+import SwiftUI
+import DesignSystem
+import WordPressShared
+
+struct SiteIconView: View {
+    let viewModel: SiteIconViewModel
+
+    var body: some View {
+        contents
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private var contents: some View {
+        if let imageURL = viewModel.imageURL {
+            CachedAsyncImage(url: imageURL) { image in
+                image.resizable().aspectRatio(contentMode: .fit)
+            } placeholder: {
+                viewModel.background
+            }
+        } else {
+            noIconView
+        }
+    }
+
+    private var noIconView: some View {
+        viewModel.background.overlay {
+            if let firstLetter = viewModel.firstLetter {
+                Text(firstLetter.uppercased())
+                    .font(.system(size: 24, weight: .medium, design: .rounded))
+                    .foregroundStyle(.secondary.opacity(0.8))
+            } else {
+                Image.DS.icon(named: .vector)
+                    .resizable()
+                    .frame(width: 18, height: 18)
+                    .tint(.DS.Foreground.tertiary)
+            }
+        }
+    }
+}
+
+struct SiteIconViewModel {
+    let imageURL: URL?
+    let firstLetter: Character?
+    let size: Size
+    var background = Color(.secondarySystemBackground)
+
+    enum Size {
+        case small
+        case regular
+
+        var width: CGFloat {
+            switch self {
+            case .small: 24
+            case .regular: 40
+            }
+        }
+    }
+
+    init(blog: Blog, size: Size = .regular) {
+        self.size = size
+        self.firstLetter = blog.title?.first
+
+        if blog.hasIcon, let iconURL = blog.icon.flatMap(URL.init) {
+            let targetSize = CGSize(width: size.width, height: size.width)
+                .scaled(by: UITraitCollection.current.displayScale)
+            self.imageURL = WPImageURLHelper.imageURLWithSize(targetSize, forImageURL: iconURL)
+        } else {
+            self.imageURL = nil
+        }
+    }
+}
+
+// MARK: - SiteIconHostingView (UIKit)
+
+final class SiteIconHostingView: UIView {
+    private let viewModel = SiteIconHostingViewModel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        let host = UIHostingController(rootView: _SiteIconHostingView(viewModel: viewModel))
+        addSubview(host.view)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        host.view.backgroundColor = .clear // important
+        host.view.pinSubviewToAllEdges(self)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setIcon(with viewModel: SiteIconViewModel) {
+        self.viewModel.icon = viewModel
+    }
+}
+
+private final class SiteIconHostingViewModel: ObservableObject {
+    @Published var icon: SiteIconViewModel?
+}
+
+private struct _SiteIconHostingView: View {
+    @ObservedObject var viewModel: SiteIconHostingViewModel
+
+    var body: some View {
+        viewModel.icon.map(SiteIconView.init)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -40,38 +40,6 @@ struct SiteIconView: View {
     }
 }
 
-struct SiteIconViewModel {
-    let imageURL: URL?
-    let firstLetter: Character?
-    let size: Size
-    var background = Color(.secondarySystemBackground)
-
-    enum Size {
-        case small
-        case regular
-
-        var width: CGFloat {
-            switch self {
-            case .small: 24
-            case .regular: 40
-            }
-        }
-    }
-
-    init(blog: Blog, size: Size = .regular) {
-        self.size = size
-        self.firstLetter = blog.title?.first
-
-        if blog.hasIcon, let iconURL = blog.icon.flatMap(URL.init) {
-            let targetSize = CGSize(width: size.width, height: size.width)
-                .scaled(by: UITraitCollection.current.displayScale)
-            self.imageURL = WPImageURLHelper.imageURLWithSize(targetSize, forImageURL: iconURL)
-        } else {
-            self.imageURL = nil
-        }
-    }
-}
-
 // MARK: - SiteIconHostingView (UIKit)
 
 final class SiteIconHostingView: UIView {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+import SwiftUI
+import WordPressShared
+
+struct SiteIconViewModel {
+    let imageURL: URL?
+    let firstLetter: Character?
+    let size: Size
+    var background = Color(.secondarySystemBackground)
+
+    enum Size {
+        case small
+        case regular
+
+        var width: CGFloat {
+            switch self {
+            case .small: 24
+            case .regular: 40
+            }
+        }
+
+        var size: CGSize {
+            CGSize(width: width, height: width)
+        }
+    }
+
+    init(blog: Blog, size: Size = .regular) {
+        self.size = size
+        self.firstLetter = blog.title?.first
+
+        if blog.hasIcon, let iconURL = blog.icon.flatMap(URL.init) {
+            let targetSize = CGSize(width: size.width, height: size.width)
+                .scaled(by: UITraitCollection.current.displayScale)
+            self.imageURL = WPImageURLHelper.imageURLWithSize(targetSize, forImageURL: iconURL)
+        } else {
+            self.imageURL = nil
+        }
+    }
+}
+
+extension SiteIconViewModel {
+    /// Returns the Size Optimized URL for a given Path.
+    static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size) -> URL? {
+        if isPhotonURL(path) || isDotcomURL(path) {
+            return optimizedDotcomURL(from: path, imageSize: imageSize)
+        }
+        if isBlavatarURL(path) {
+            return optimizedBlavatarURL(from: path, imageSize: imageSize)
+        }
+        return optimizedPhotonURL(from: path, imageSize: imageSize)
+    }
+
+    private static func optimizedDotcomURL(from path: String, imageSize: CGSize) -> URL? {
+        let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
+        let query = String(format: "w=%d&h=%d", Int(size.width), Int(size.height))
+        return parseURL(path: path, query: query)
+    }
+
+    private static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
+        let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
+        let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
+        return parseURL(path: path, query: query)
+    }
+
+    private static func optimizedPhotonURL(from path: String, imageSize: CGSize) -> URL? {
+        guard let url = URL(string: path) else { return nil }
+        return PhotonImageURLHelper.photonURL(with: imageSize, forImageURL: url)
+    }
+
+    /// Indicates if the received URL is hosted at WordPress.com
+    ///
+    private static func isDotcomURL(_ path: String) -> Bool {
+        path.contains(".files.wordpress.com")
+    }
+
+    /// Indicates if the received URL is hosted at Gravatar.com
+    ///
+    private static func isBlavatarURL(_ path: String) -> Bool {
+        path.contains("gravatar.com/blavatar")
+    }
+
+    /// Indicates if the received URL is a Photon Endpoint
+    /// Possible matches are "i0.wp.com", "i1.wp.com" & "i2.wp.com" -> https://developer.wordpress.com/docs/photon/
+    ///
+    private static func isPhotonURL(_ path: String) -> Bool {
+        path.contains(".wp.com")
+    }
+
+    /// Attempts to parse the URL contained within a Path, with a given query. Returns nil on failure.
+    private static func parseURL(path: String, query: String) -> URL? {
+        guard var components = URLComponents(string: path) else {
+            return nil
+        }
+        components.query = query
+        return components.url
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -3,10 +3,11 @@ import SwiftUI
 import WordPressShared
 
 struct SiteIconViewModel {
-    let imageURL: URL?
-    let firstLetter: Character?
-    let size: Size
+    var imageURL: URL?
+    var firstLetter: Character?
+    var size: Size
     var background = Color(.secondarySystemBackground)
+    var host: MediaHost?
 
     enum Size {
         case small
@@ -28,12 +29,9 @@ struct SiteIconViewModel {
         self.size = size
         self.firstLetter = blog.title?.first
 
-        if blog.hasIcon, let iconURL = blog.icon.flatMap(URL.init) {
-            let targetSize = CGSize(width: size.width, height: size.width)
-                .scaled(by: UITraitCollection.current.displayScale)
-            self.imageURL = WPImageURLHelper.imageURLWithSize(targetSize, forImageURL: iconURL)
-        } else {
-            self.imageURL = nil
+        if blog.hasIcon, let icon = blog.icon {
+            self.imageURL = SiteIconViewModel.optimizedURL(for: icon, imageSize: size.size)
+            self.host = MediaHost(with: blog)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
@@ -180,7 +180,6 @@ extension SitePickerViewController {
         imageCropController.onCompletion = { [weak self] image, modified in
             self?.dismiss(animated: true)
             self?.uploadDroppedSiteIcon(image, completion: {
-                self?.blogDetailHeaderView.blavatarImageView.image = image
                 self?.blogDetailHeaderView.updatingIcon = false
             })
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -440,17 +440,8 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
     }
 
     private func reloadBlogIconView() {
-        let blog = post.blog
-
-        if blog.hasIcon == true {
-            let size = CGSize(width: 24, height: 24)
-            navigationBarManager.siteIconView.imageView.downloadSiteIcon(for: blog, imageSize: size)
-        } else if blog.isWPForTeams() {
-            navigationBarManager.siteIconView.imageView.tintColor = UIColor.listIcon
-            navigationBarManager.siteIconView.imageView.image = UIImage.gridicon(.p2)
-        } else {
-            navigationBarManager.siteIconView.imageView.image = UIImage.siteIconPlaceholder
-        }
+        let viewModel = SiteIconViewModel(blog: post.blog, size: .small)
+        navigationBarManager.siteIconView.imageView.setIcon(with: viewModel)
     }
 
     private func reloadEditorContents() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -40,8 +40,8 @@ class PostEditorNavigationBarManager {
 
     /// Dismiss Button
     ///
-    let siteIconView: SiteIconView = {
-        let siteIconView = SiteIconView(frame: .zero)
+    let siteIconView: SiteDetailsSiteIconView = {
+        let siteIconView = SiteDetailsSiteIconView(frame: .zero)
         siteIconView.translatesAutoresizingMaskIntoConstraints = false
         siteIconView.imageView.sizeToFit()
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -571,6 +571,8 @@
 		0CA15B4E2BB2128800518D6E /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA15B4D2BB2128800518D6E /* PostCoordinatorTests.swift */; };
 		0CA1C8C12A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
 		0CA1C8C22A940EE300F691EE /* AvatarMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */; };
+		0CA3A4A22C5C371E00269EFC /* SiteIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA3A4A12C5C371E00269EFC /* SiteIconViewModel.swift */; };
+		0CA3A4A32C5C371E00269EFC /* SiteIconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA3A4A12C5C371E00269EFC /* SiteIconViewModel.swift */; };
 		0CAE8EF22A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */; };
 		0CAE8EF32A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */; };
 		0CAE8EF62A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */; };
@@ -4049,7 +4051,7 @@
 		F4EDAA4C29A516EA00622D3D /* ReaderPostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */; };
 		F4EDAA4D29A516EA00622D3D /* ReaderPostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */; };
 		F4EDAA5129A795C600622D3D /* BlockedAuthor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42A1D9629928B360059CC70 /* BlockedAuthor.swift */; };
-		F4EF4BAB291D3D4700147B61 /* SiteIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EF4BAA291D3D4700147B61 /* SiteIconTests.swift */; };
+		F4EF4BAB291D3D4700147B61 /* SiteIconViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EF4BAA291D3D4700147B61 /* SiteIconViewModelTests.swift */; };
 		F4F7B2512AF8EF2C00207282 /* DomainDetailsWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F7B2502AF8EBDB00207282 /* DomainDetailsWebViewController.swift */; };
 		F4F7B2532AFA585700207282 /* DomainDetailsWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F7B2522AFA585700207282 /* DomainDetailsWebViewControllerTests.swift */; };
 		F4F7B2542AFA5D8600207282 /* AllDomainsListCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08240C2D2AB8A2DD00E7AEA8 /* AllDomainsListCardView.swift */; };
@@ -6598,6 +6600,7 @@
 		0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchService.swift; sourceTree = "<group>"; };
 		0CA15B4D2BB2128800518D6E /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarMenuController.swift; sourceTree = "<group>"; };
+		0CA3A4A12C5C371E00269EFC /* SiteIconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconViewModel.swift; sourceTree = "<group>"; };
 		0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCell.swift; sourceTree = "<group>"; };
 		0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
@@ -9666,7 +9669,7 @@
 		F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashLogging+Singleton.swift"; sourceTree = "<group>"; };
 		F4E79300296EEE320025E8E0 /* MigrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationState.swift; sourceTree = "<group>"; };
 		F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostService.swift; sourceTree = "<group>"; };
-		F4EF4BAA291D3D4700147B61 /* SiteIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconTests.swift; sourceTree = "<group>"; };
+		F4EF4BAA291D3D4700147B61 /* SiteIconViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconViewModelTests.swift; sourceTree = "<group>"; };
 		F4F09CCB2989BF5B00A5F420 /* ReaderSiteService_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReaderSiteService_Internal.h; sourceTree = "<group>"; };
 		F4F7B2502AF8EBDB00207282 /* DomainDetailsWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainDetailsWebViewController.swift; sourceTree = "<group>"; };
 		F4F7B2522AFA585700207282 /* DomainDetailsWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainDetailsWebViewControllerTests.swift; sourceTree = "<group>"; };
@@ -10551,6 +10554,7 @@
 				0C03EFA12C498B3D00B7F828 /* BlogListSiteView.swift */,
 				08C6FB482BC6E8530037457C /* BlogListViewModel.swift */,
 				0CE7C8E72C4FF58900800A43 /* SiteIconView.swift */,
+				0CA3A4A12C5C371E00269EFC /* SiteIconViewModel.swift */,
 			);
 			path = BlogList;
 			sourceTree = "<group>";
@@ -14678,7 +14682,7 @@
 				FAE8EE9B273AD0A800A65307 /* QuickStartSettingsTests.swift */,
 				803DE81828FFB7B5007D4E9C /* RemoteParameterTests.swift */,
 				24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */,
-				F4EF4BAA291D3D4700147B61 /* SiteIconTests.swift */,
+				F4EF4BAA291D3D4700147B61 /* SiteIconViewModelTests.swift */,
 				F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */,
 				FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */,
 				0C896DE62A3A832B00D7D4E7 /* SiteVisibilityTests.swift */,
@@ -23249,6 +23253,7 @@
 				E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */,
 				FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */,
 				FAE4CA682732C094003BFDFE /* QuickStartPromptViewController.swift in Sources */,
+				0CA3A4A22C5C371E00269EFC /* SiteIconViewModel.swift in Sources */,
 				73C8F06321BEEF2F00DDDF7E /* SiteAssembly.swift in Sources */,
 				326E281B250AC4A50029EBF0 /* ImageDimensionFetcher.swift in Sources */,
 				7435CE7320A4B9170075A1B9 /* AnimatedImageCache.swift in Sources */,
@@ -24413,7 +24418,7 @@
 				73178C2A21BEE09300E37C9A /* SiteSegmentsCellTests.swift in Sources */,
 				B5416CFE1C1756B900006DD8 /* PushNotificationsManagerTests.m in Sources */,
 				321955C124BE4EBF00E3F316 /* ReaderSelectInterestsCoordinatorTests.swift in Sources */,
-				F4EF4BAB291D3D4700147B61 /* SiteIconTests.swift in Sources */,
+				F4EF4BAB291D3D4700147B61 /* SiteIconViewModelTests.swift in Sources */,
 				FA6C32C02BF255FA00BBDDB4 /* AppUpdateCoordinatorTests.swift in Sources */,
 				59B48B621B99E132008EBB84 /* JSONObject.swift in Sources */,
 				3F82310F24564A870086E9B8 /* ReaderTabViewTests.swift in Sources */,
@@ -24754,6 +24759,7 @@
 				FABB21192602FC2C00C8785C /* NotificationContentRangeFactory.swift in Sources */,
 				011F52C12A1538EC00B04114 /* FreeToPaidPlansDashboardCardCell.swift in Sources */,
 				FABB211A2602FC2C00C8785C /* SiteInfo.swift in Sources */,
+				0CA3A4A32C5C371E00269EFC /* SiteIconViewModel.swift in Sources */,
 				011F52BE2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
 				FABB211B2602FC2C00C8785C /* CredentialsService.swift in Sources */,
 				3F5AAC242877791900AEF5DD /* JetpackButton.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -625,6 +625,8 @@
 		0CE7833E2B08F3C300B114EB /* ExternalMediaPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */; };
 		0CE783412B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
 		0CE783422B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */; };
+		0CE7C8E82C4FF58900800A43 /* SiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7C8E72C4FF58900800A43 /* SiteIconView.swift */; };
+		0CE7C8E92C4FF58900800A43 /* SiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE7C8E72C4FF58900800A43 /* SiteIconView.swift */; };
 		0CEA55522BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
 		0CEA55532BC55940008D0FE5 /* WPInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */; };
 		0CEA84CF2C3DD619008E0B06 /* SubmitFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */; };
@@ -4070,7 +4072,7 @@
 		F515E9672654312200848251 /* Noticons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F5A34D0C25DF2F7700C9654B /* Noticons.ttf */; };
 		F52CACCA244FA7AA00661380 /* ReaderManageScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */; };
 		F532AE1C253E55D40013B42E /* CreateButtonActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F532AE1B253E55D40013B42E /* CreateButtonActionSheet.swift */; };
-		F53FF3AA23EA725C001AD596 /* SiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A923EA725C001AD596 /* SiteIconView.swift */; };
+		F53FF3AA23EA725C001AD596 /* SiteDetailsSiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A923EA725C001AD596 /* SiteDetailsSiteIconView.swift */; };
 		F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5623A84E4D0022F595 /* PublishSettingsControllerTests.swift */; };
 		F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F423F6EA3100751212 /* FloatingActionButton.swift */; };
 		F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */; };
@@ -5257,7 +5259,7 @@
 		FABB24A22602FC2C00C8785C /* WPAnalyticsTrackerAutomatticTracks.m in Sources */ = {isa = PBXBuildFile; fileRef = 937F3E311AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m */; };
 		FABB24A32602FC2C00C8785C /* CollapsableHeaderCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469CE06F24BCFB04003BDC8B /* CollapsableHeaderCollectionViewCell.swift */; };
 		FABB24A42602FC2C00C8785C /* NotificationContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB5824620EC41B200002702 /* NotificationContentFactory.swift */; };
-		FABB24A52602FC2C00C8785C /* SiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A923EA725C001AD596 /* SiteIconView.swift */; };
+		FABB24A52602FC2C00C8785C /* SiteDetailsSiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A923EA725C001AD596 /* SiteDetailsSiteIconView.swift */; };
 		FABB24A62602FC2C00C8785C /* JetpackRestoreCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */; };
 		FABB24A72602FC2C00C8785C /* FormattableNoticonRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7947AC210BAC7B005BB851 /* FormattableNoticonRange.swift */; };
 		FABB24AA2602FC2C00C8785C /* ActivityListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */; };
@@ -6625,6 +6627,7 @@
 		0CE58A2C2B35C91900E87D1E /* SiteMediaPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPreviewViewController.swift; sourceTree = "<group>"; };
 		0CE7833C2B08F3C300B114EB /* ExternalMediaPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerViewController.swift; sourceTree = "<group>"; };
 		0CE783402B08FB2E00B114EB /* ExternalMediaPickerCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaPickerCollectionCell.swift; sourceTree = "<group>"; };
+		0CE7C8E72C4FF58900800A43 /* SiteIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconView.swift; sourceTree = "<group>"; };
 		0CEA55512BC55940008D0FE5 /* WPInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPInstrumentation.swift; sourceTree = "<group>"; };
 		0CEA84CE2C3DD619008E0B06 /* SubmitFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitFeedbackViewController.swift; sourceTree = "<group>"; };
 		0CEA84D42C3EE0E1008E0B06 /* ZendeskAttachmentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskAttachmentsSection.swift; sourceTree = "<group>"; };
@@ -9679,7 +9682,7 @@
 		F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsViewController.swift; sourceTree = "<group>"; };
 		F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderManageScenePresenter.swift; sourceTree = "<group>"; };
 		F532AE1B253E55D40013B42E /* CreateButtonActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateButtonActionSheet.swift; sourceTree = "<group>"; };
-		F53FF3A923EA725C001AD596 /* SiteIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconView.swift; sourceTree = "<group>"; };
+		F53FF3A923EA725C001AD596 /* SiteDetailsSiteIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDetailsSiteIconView.swift; sourceTree = "<group>"; };
 		F543AF5623A84E4D0022F595 /* PublishSettingsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsControllerTests.swift; sourceTree = "<group>"; };
 		F551E7F423F6EA3100751212 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
 		F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+RotateTests.swift"; sourceTree = "<group>"; };
@@ -10547,6 +10550,7 @@
 				0822C3F22BA1EA2000C53B50 /* BlogListView.swift */,
 				0C03EFA12C498B3D00B7F828 /* BlogListSiteView.swift */,
 				08C6FB482BC6E8530037457C /* BlogListViewModel.swift */,
+				0CE7C8E72C4FF58900800A43 /* SiteIconView.swift */,
 			);
 			path = BlogList;
 			sourceTree = "<group>";
@@ -18795,7 +18799,7 @@
 			isa = PBXGroup;
 			children = (
 				F1112AB1255C2D4600F1F746 /* BlogDetailHeaderView.swift */,
-				F53FF3A923EA725C001AD596 /* SiteIconView.swift */,
+				F53FF3A923EA725C001AD596 /* SiteDetailsSiteIconView.swift */,
 			);
 			path = "Detail Header";
 			sourceTree = "<group>";
@@ -23029,7 +23033,7 @@
 				469CE07124BCFB04003BDC8B /* CollapsableHeaderCollectionViewCell.swift in Sources */,
 				7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */,
 				80535DBE294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift in Sources */,
-				F53FF3AA23EA725C001AD596 /* SiteIconView.swift in Sources */,
+				F53FF3AA23EA725C001AD596 /* SiteDetailsSiteIconView.swift in Sources */,
 				FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */,
 				7E7947AD210BAC7B005BB851 /* FormattableNoticonRange.swift in Sources */,
 				46F583AB2624CE790010A723 /* BlockEditorSettings+CoreDataProperties.swift in Sources */,
@@ -23234,6 +23238,7 @@
 				C81CCD83243BF7A600A83E27 /* TenorDataLoader.swift in Sources */,
 				F4D140222AFE794300961797 /* RegisterDomainTransferFooterView.swift in Sources */,
 				98797DBC222F434500128C21 /* OverviewCell.swift in Sources */,
+				0CE7C8E82C4FF58900800A43 /* SiteIconView.swift in Sources */,
 				F484D4ED2A32C4520050BE15 /* CATransaction+Extension.swift in Sources */,
 				C3BC86F629528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift in Sources */,
 				1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */,
@@ -25622,6 +25627,7 @@
 				FABB23822602FC2C00C8785C /* FooterContentGroup.swift in Sources */,
 				F163541726DE2ECE008B625B /* NotificationEventTracker.swift in Sources */,
 				0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */,
+				0CE7C8E92C4FF58900800A43 /* SiteIconView.swift in Sources */,
 				80C740FC2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift in Sources */,
 				83914BD52A2EA03A0017A588 /* PostSettingsViewController+JetpackSocial.swift in Sources */,
 				F46546312AF2F8D30017E3D1 /* DomainsStateViewModel.swift in Sources */,
@@ -26032,7 +26038,7 @@
 				0822C3F62BA1EA2100C53B50 /* BlogListView.swift in Sources */,
 				C3643AD028AC049D00FC5FD3 /* SharingViewController.swift in Sources */,
 				FABB24A42602FC2C00C8785C /* NotificationContentFactory.swift in Sources */,
-				FABB24A52602FC2C00C8785C /* SiteIconView.swift in Sources */,
+				FABB24A52602FC2C00C8785C /* SiteDetailsSiteIconView.swift in Sources */,
 				3FF15A56291B4EEA00E1B4E5 /* MigrationCenterView.swift in Sources */,
 				FABB24A62602FC2C00C8785C /* JetpackRestoreCompleteViewController.swift in Sources */,
 				FABB24A72602FC2C00C8785C /* FormattableNoticonRange.swift in Sources */,

--- a/WordPress/WordPressTest/SiteIconViewModelTests.swift
+++ b/WordPress/WordPressTest/SiteIconViewModelTests.swift
@@ -3,12 +3,7 @@ import XCTest
 
 @testable import WordPress
 
-final class SiteIconTests: XCTestCase {
-
-    /// Instance to access the extension methods declared in `UIImageView+SiteIcon.swift`.
-    /// Perhaps those methods should be static.
-    let imageView = UIImageView()
-
+final class SiteIconViewModelTests: XCTestCase {
     // MARK: - Test `optimizedURL(for:)`
 
     /// Tests that a dotcom image URL with default image size is valid.
@@ -17,7 +12,7 @@ final class SiteIconTests: XCTestCase {
         let path =  Constants.dotcomPath
 
         // When
-        let optimizedURL = imageView.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
@@ -31,7 +26,7 @@ final class SiteIconTests: XCTestCase {
         let path = Constants.gravatarPath
 
         // When
-        let optimizedURL = imageView.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
@@ -45,7 +40,7 @@ final class SiteIconTests: XCTestCase {
         let path = Constants.photonPath
 
         // When
-        let optimizedURL = imageView.optimizedURL(for: path)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path)
 
         // Then
         let size = 40 * Int(UIScreen.main.scale)
@@ -60,7 +55,7 @@ final class SiteIconTests: XCTestCase {
         let path = Constants.dotcomPath
 
         // When
-        let optimizedURL = imageView.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
@@ -75,7 +70,7 @@ final class SiteIconTests: XCTestCase {
         let path = Constants.gravatarPath
 
         // When
-        let optimizedURL = imageView.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)
@@ -90,7 +85,7 @@ final class SiteIconTests: XCTestCase {
         let path = Constants.photonPath
 
         // When
-        let optimizedURL = imageView.optimizedURL(for: path, imageSize: sizeInPoints)
+        let optimizedURL = SiteIconViewModel.optimizedURL(for: path, imageSize: sizeInPoints)
 
         // Then
         let size = Int(sizeInPoints.width) * Int(UIScreen.main.scale)


### PR DESCRIPTION
## Changes

- Extract new site icon code in `SiteIconView` and add a UIKit counterpart – `SiteIconHostingView`
- Integrate the new views on dashboard and site editor
- Increase the quality of the images – fetch 120×120px images on @3 screens

**Note**: the images without the "photon" loads just fine ... not sure if we are missing something.  

## Screenshots

<img width="340" alt="Screenshot 2024-07-23 at 4 41 02 PM" src="https://github.com/user-attachments/assets/2ad51bcd-420d-43de-beea-a33b8b311ad1">
<img width="340" alt="Screenshot 2024-07-23 at 5 17 33 PM" src="https://github.com/user-attachments/assets/e9f0b4c2-a536-400e-bd1b-38f776882db8">



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
