### PR TITLE
Remove some Objective-C code from WordPressUIObjC

### DIFF
--- a/Modules/Sources/WordPressUIObjC/Categories/UIColor+Helpers.h
+++ b/Modules/Sources/WordPressUIObjC/Categories/UIColor+Helpers.h
@@ -2,10 +2,6 @@
 
 @interface UIColor (Helpers)
 
-// [UIColor UIColorFromRGBAColorWithRed:10 green:20 blue:30 alpha:0.8]
-+ (UIColor *)UIColorFromRGBColorWithRed:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b;
-+ (UIColor *)UIColorFromRGBAColorWithRed: (CGFloat)r green:(CGFloat)g blue:(CGFloat)b alpha:(CGFloat)a;
-
 // [UIColor UIColorFromHex:0xc5c5c5 alpha:0.8];
 + (UIColor *)UIColorFromHex:(NSUInteger)rgb alpha:(CGFloat)alpha;
 + (UIColor *)UIColorFromHex:(NSUInteger)rgb;

--- a/Modules/Sources/WordPressUIObjC/Categories/UIColor+Helpers.m
+++ b/Modules/Sources/WordPressUIObjC/Categories/UIColor+Helpers.m
@@ -2,16 +2,6 @@
 
 @implementation UIColor (Helpers)
 
-// [UIColor UIColorFromRGBAColorWithRed:10 green:20 blue:30 alpha:0.8]
-+ (UIColor *)UIColorFromRGBAColorWithRed: (CGFloat)r green:(CGFloat)g blue:(CGFloat)b alpha:(CGFloat)a {
-    return [UIColor colorWithRed: r/255.0 green: g/255.0 blue: b/255.0 alpha:a];
-}
-
-// [UIColor UIColorFromRGBColorWithRed:10 green:20 blue:30]
-+ (UIColor *)UIColorFromRGBColorWithRed:(CGFloat)r green:(CGFloat)g blue:(CGFloat)b {
-    return [UIColor colorWithRed: r/255.0 green: g/255.0 blue: b/255.0 alpha: 0.5];
-}
-
 // [UIColor UIColorFromHex:0xc5c5c5 alpha:0.8];
 + (UIColor *)UIColorFromHex:(NSUInteger)rgb alpha:(CGFloat)alpha {
     return [UIColor colorWithRed:((float)((rgb & 0xFF0000) >> 16))/255.0

--- a/Modules/Sources/WordPressUIObjC/Categories/UILabel+SuggestSize.h
+++ b/Modules/Sources/WordPressUIObjC/Categories/UILabel+SuggestSize.h
@@ -2,8 +2,6 @@
 
 @interface UILabel (SuggestSize)
 
-- (CGSize)suggestedSizeForWidth:(CGFloat)width;
-- (CGSize)suggestSizeForAttributedString:(NSAttributedString *)string width:(CGFloat)width;
 - (CGSize)suggestSizeForString:(NSString *)string width:(CGFloat)width;
 
 @end

--- a/Modules/Sources/WordPressUIObjC/Categories/UILabel+SuggestSize.m
+++ b/Modules/Sources/WordPressUIObjC/Categories/UILabel+SuggestSize.m
@@ -2,13 +2,12 @@
 
 @implementation UILabel (SuggestSize)
 
-- (CGSize)suggestedSizeForWidth:(CGFloat)width
+- (CGSize)suggestSizeForString:(NSString *)string width:(CGFloat)width
 {
-    if (self.attributedText) {
-        return [self suggestSizeForAttributedString:self.attributedText width:width];
+    if (!string) {
+        return CGSizeZero;
     }
-
-    return [self suggestSizeForString:self.text width:width];
+    return [self suggestSizeForAttributedString:[[NSAttributedString alloc] initWithString:string attributes:@{NSFontAttributeName: self.font}] width:width];
 }
 
 - (CGSize)suggestSizeForAttributedString:(NSAttributedString *)string width:(CGFloat)width
@@ -17,14 +16,6 @@
         return CGSizeZero;
     }
     return [string boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading context:nil].size;
-}
-
-- (CGSize)suggestSizeForString:(NSString *)string width:(CGFloat)width
-{
-    if (!string) {
-        return CGSizeZero;
-    }
-    return [self suggestSizeForAttributedString:[[NSAttributedString alloc] initWithString:string attributes:@{NSFontAttributeName: self.font}] width:width];
 }
 
 @end

--- a/Modules/Sources/WordPressUIObjC/include/NSString+Gravatar.h
+++ b/Modules/Sources/WordPressUIObjC/include/NSString+Gravatar.h
@@ -1,1 +1,0 @@
-../Extensions/NSString+Gravatar.h

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
@@ -69,48 +69,6 @@ extension WPStyleGuide {
     }
 
     @objc public class func socialIcon(for service: NSString) -> UIImage {
-        guard RemoteFeatureFlag.jetpackSocialImprovements.enabled() else {
-            return iconForService(service)
-        }
-
-        return UIImage(named: "icon-\(service)") ?? iconForService(service)
-    }
-
-    /// Get's the tint color to use for the specified service when it is connected.
-    ///
-    /// - Parameters:
-    ///     - service: The name of the service.
-    ///
-    /// - Returns: The tint color for the service, or the default color.
-    ///
-    @objc public class func tintColorForConnectedService(_ service: String) -> UIColor {
-        guard let name = SharingServiceNames(rawValue: service) else {
-            return .primary
-        }
-
-        switch name {
-        case .Facebook:
-            return UIColor(fromRGBAColorWithRed: 59.0, green: 89.0, blue: 152.0, alpha: 1)
-        case .Twitter:
-            return UIColor(fromRGBAColorWithRed: 85, green: 172, blue: 238, alpha: 1)
-        case .Google:
-            return UIColor(fromRGBAColorWithRed: 220, green: 78, blue: 65, alpha: 1)
-        case .LinkedIn:
-            return UIColor(fromRGBAColorWithRed: 0, green: 119, blue: 181, alpha: 1)
-        case .Tumblr:
-            return UIColor(fromRGBAColorWithRed: 53, green: 70, blue: 92, alpha: 1)
-        case .Path:
-            return UIColor(fromRGBAColorWithRed: 238, green: 52, blue: 35, alpha: 1)
-        }
-    }
-
-    // TODO: Remove this in favor of `PublicizeService.ServiceName` once `jetpackSocial` flag is removed.
-    enum SharingServiceNames: String {
-        case Facebook = "facebook"
-        case Twitter = "twitter"
-        case Google = "google_plus"
-        case LinkedIn = "linkedin"
-        case Tumblr = "tumblr"
-        case Path = "path"
+        UIImage(named: "icon-\(service)") ?? iconForService(service)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -863,19 +863,11 @@ FeaturedImageViewControllerDelegate>
                                       canEditSharing:(BOOL)canEditSharing
                                              section:(NSInteger)section
 {
-    BOOL isJetpackSocialEnabled = [RemoteFeature enabled:RemoteFeatureFlagJetpackSocialImprovements];
     UITableViewCell *cell = [self getWPTableViewImageAndAccessoryCell];
-    UIImage *image = [WPStyleGuide socialIconFor:connection.service];
-    if (isJetpackSocialEnabled) {
-        image = [image resizedImageWithContentMode:UIViewContentModeScaleAspectFill
-                                            bounds:CGSizeMake(28.0, 28.0)
-                              interpolationQuality:kCGInterpolationDefault];
-    }
+    UIImage *image = [[WPStyleGuide socialIconFor:connection.service] resizedImageWithContentMode:UIViewContentModeScaleAspectFill bounds:CGSizeMake(28.0, 28.0) interpolationQuality:kCGInterpolationDefault];
     [cell.imageView setImage:image];
     cell.imageView.alpha = 1.0;
-    if (canEditSharing && !isJetpackSocialEnabled) {
-        cell.imageView.tintColor = [WPStyleGuide tintColorForConnectedService: connection.service];
-    } else if (!canEditSharing && isJetpackSocialEnabled) {
+    if (!canEditSharing) {
         cell.imageView.alpha = 0.36;
     }
     cell.textLabel.text = connection.externalDisplay;

--- a/WordPressAuthenticator/Sources/Extensions/WPStyleGuide+Login.swift
+++ b/WordPressAuthenticator/Sources/Extensions/WPStyleGuide+Login.swift
@@ -48,14 +48,6 @@ extension WPStyleGuide {
     }
 
     ///
-    ///
-    class func colorForErrorView(_ opaque: Bool) -> UIColor {
-        let alpha: CGFloat = opaque ? 1.0 : 0.95
-        return UIColor(fromRGBAColorWithRed: 17.0, green: 17.0, blue: 17.0, alpha: alpha)
-    }
-
-    ///
-    ///
     class func edgeInsetForLoginTextFields() -> UIEdgeInsets {
         return UIEdgeInsets(top: 7, left: 20, bottom: 7, right: 20)
     }


### PR DESCRIPTION
The FF for social sharing improvements is free to remove. More discussion here https://github.com/wordpress-mobile/WordPress-iOS/pull/22730#discussion_r1507837534. I haven't remove it completely yet because in some scenarios it seems to be used to determinate if the app is a Jetpack app, but not in Objective-C.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
