### PR TITLE
Introduce `ViewLayer`

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     ],
     products: XcodeSupport.products + [
         .library(name: "JetpackStatsWidgetsCore", targets: ["JetpackStatsWidgetsCore"]),
+        .library(name: "ViewLayer", targets: ["ViewLayer"]),
         .library(name: "DesignSystem", targets: ["DesignSystem"]),
         .library(name: "WordPressFlux", targets: ["WordPressFlux"]),
         .library(name: "WordPressShared", targets: ["WordPressShared"]),
@@ -50,6 +51,9 @@ let package = Package(
     targets: XcodeSupport.targets + [
         .target(name: "JetpackStatsWidgetsCore"),
         .target(name: "DesignSystem"),
+        .target(name: "ViewLayer", dependencies: [
+            .target(name: "DesignSystem")
+        ]),
         .target(name: "UITestsFoundation", dependencies: [
             .product(name: "ScreenObject", package: "ScreenObject"),
             .product(name: "XCUITestHelpers", package: "XCUITestHelpers"),

--- a/Modules/Sources/ViewLayer/ViewLayer.swift
+++ b/Modules/Sources/ViewLayer/ViewLayer.swift
@@ -1,0 +1,3 @@
+import SwiftUI
+
+// Package Stub

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -931,6 +931,8 @@
 		24CDE3452C586A66005E5E43 /* SelfHostedLoginDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CDE3422C586A40005E5E43 /* SelfHostedLoginDetails.swift */; };
 		24DB7C132C5AEF0600A0FE92 /* LoginClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB7C122C5AEF0500A0FE92 /* LoginClient.swift */; };
 		24DB7C142C5AEF0600A0FE92 /* LoginClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB7C122C5AEF0500A0FE92 /* LoginClient.swift */; };
+		24DB7C242C5BF12100A0FE92 /* ViewLayer in Frameworks */ = {isa = PBXBuildFile; productRef = 24DB7C232C5BF12100A0FE92 /* ViewLayer */; };
+		24DB7C262C5BF12700A0FE92 /* ViewLayer in Frameworks */ = {isa = PBXBuildFile; productRef = 24DB7C252C5BF12700A0FE92 /* ViewLayer */; };
 		24F3789825E6E62100A27BB7 /* NSManagedObject+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
@@ -10091,6 +10093,7 @@
 				E1A386CB14DB063800954CF8 /* MediaPlayer.framework in Frameworks */,
 				E1A386CA14DB05F700954CF8 /* CoreMedia.framework in Frameworks */,
 				E1A386C814DB05C300954CF8 /* AVFoundation.framework in Frameworks */,
+				24DB7C262C5BF12700A0FE92 /* ViewLayer in Frameworks */,
 				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
 				296890780FE971DC00770264 /* Security.framework in Frameworks */,
 				83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */,
@@ -10213,6 +10216,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FABB26202602FC2C00C8785C /* iAd.framework in Frameworks */,
+				24DB7C242C5BF12100A0FE92 /* ViewLayer in Frameworks */,
 				FABB26212602FC2C00C8785C /* StoreKit.framework in Frameworks */,
 				FABB26222602FC2C00C8785C /* CoreSpotlight.framework in Frameworks */,
 				FABB26232602FC2C00C8785C /* QuickLook.framework in Frameworks */,
@@ -19651,6 +19655,7 @@
 			name = WordPress;
 			packageProductDependencies = (
 				0C6AC6112C364A2800BF7600 /* XcodeTarget_App */,
+				24DB7C252C5BF12700A0FE92 /* ViewLayer */,
 			);
 			productName = WordPress;
 			productReference = 1D6058910D05DD3D006BFB54 /* WordPress.app */;
@@ -19945,6 +19950,7 @@
 			name = Jetpack;
 			packageProductDependencies = (
 				0C6AC61B2C364A6600BF7600 /* XcodeTarget_App */,
+				24DB7C232C5BF12100A0FE92 /* ViewLayer */,
 			);
 			productName = WordPress;
 			productReference = FABB26522602FC2C00C8785C /* Jetpack.app */;
@@ -31336,6 +31342,14 @@
 		0CFFFECA2C36F5760044709B /* XcodeTarget_WordPressAuthentificatorTests */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeTarget_WordPressAuthentificatorTests;
+		};
+		24DB7C232C5BF12100A0FE92 /* ViewLayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ViewLayer;
+		};
+		24DB7C252C5BF12700A0FE92 /* ViewLayer */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ViewLayer;
 		};
 /* End XCSwiftPackageProductDependency section */
 


### PR DESCRIPTION
Adds the `ViewLayer` target with a dedicated `UIHost` for building it as a preview.

You can test it by creating a new SwiftUI View in the `ViewLayer` target, switching to that target, then seeing the Swift Preview work.