### PR TITLE
Remove BottomSheetViewController usages – #1

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailInfoViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailInfoViewController.swift
@@ -54,9 +54,7 @@ final class CommentDetailInfoViewController: UIViewController {
     private func setPreferredContentSize() {
         tableView.layoutIfNeeded()
 
-        if UIDevice.isPad() {
-            preferredContentSize = CGSize(width: 320, height: tableView.contentSize.height)
-        }
+        preferredContentSize = CGSize(width: 320, height: tableView.contentSize.height)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailInfoViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailInfoViewController.swift
@@ -8,15 +8,13 @@ protocol CommentDetailInfoView: AnyObject {
 
 final class CommentDetailInfoViewController: UIViewController {
     private static let cellReuseIdentifier = "infoCell"
-    private let tableView: UITableView = {
-        $0.translatesAutoresizingMaskIntoConstraints = false
-        return $0
-    }(UITableView())
+    private let tableView = UITableView(frame: .zero, style: .plain)
 
     private let viewModel: CommentDetailInfoViewModelType
 
     init(viewModel: CommentDetailInfoViewModelType) {
         self.viewModel = viewModel
+
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -26,12 +24,14 @@ final class CommentDetailInfoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         configureTableView()
         addTableViewConstraints()
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+
         setPreferredContentSize()
     }
 
@@ -42,6 +42,7 @@ final class CommentDetailInfoViewController: UIViewController {
     }
 
     private func addTableViewConstraints() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             view.trailingAnchor.constraint(equalTo: tableView.trailingAnchor),
@@ -52,7 +53,10 @@ final class CommentDetailInfoViewController: UIViewController {
 
     private func setPreferredContentSize() {
         tableView.layoutIfNeeded()
-        preferredContentSize = tableView.contentSize
+
+        if UIDevice.isPad() {
+            preferredContentSize = CGSize(width: 320, height: tableView.contentSize.height)
+        }
     }
 }
 
@@ -100,24 +104,23 @@ extension CommentDetailInfoViewController: UITableViewDelegate {
     }
 }
 
-// MARK: - DrawerPresentable
-extension CommentDetailInfoViewController: DrawerPresentable {
-    var collapsedHeight: DrawerHeight {
-        .intrinsicHeight
-    }
-
-    var allowsUserTransition: Bool {
-        false
-    }
-
-    var compactWidth: DrawerWidth {
-        .maxWidth
-    }
-}
-
-// MARK: - ChildDrawerPositionable
-extension CommentDetailInfoViewController: ChildDrawerPositionable {
-    var preferredDrawerPosition: DrawerPosition {
-        .collapsed
+extension CommentDetailInfoViewController {
+    func show(from presentingViewController: UIViewController, sourceView: UIView) {
+        let navigationController = UINavigationController(rootViewController: self)
+        if presentingViewController.traitCollection.horizontalSizeClass == .regular {
+            navigationController.modalPresentationStyle = .popover
+            navigationController.popoverPresentationController?.sourceView = sourceView
+            navigationController.popoverPresentationController?.permittedArrowDirections = [.up]
+        } else {
+            self.navigationItem.leftBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.close, primaryAction: UIAction { [weak presentingViewController] _ in
+                presentingViewController?.dismiss(animated: true)
+            })
+            if let sheet = navigationController.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+                sheet.prefersGrabberVisible = true
+                navigationController.additionalSafeAreaInsets = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0) // For grabber
+            }
+        }
+        presentingViewController.present(navigationController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -703,9 +703,9 @@ private extension CommentDetailViewController {
             isAdmin: comment.allowsModeration()
         )
         let viewController = CommentDetailInfoViewController(viewModel: viewModel)
+        viewController.title = comment.authorForDisplay()
         viewModel.view = viewController
-        let bottomSheet = BottomSheetViewController(childViewController: viewController, customHeaderSpacing: 0)
-        bottomSheet.show(from: self)
+        viewController.show(from: self, sourceView: senderView)
     }
 }
 


### PR DESCRIPTION
This is some background work to remove `BottomSheetViewController`, which is a quite large class that also has a couple of warnings. We don't want to maintain that, and the UIKit components do the same but better now.

## Before → After (iPhone)

The new version is better for accessibility with a visible close button.

<img width="320" alt="Screenshot 2024-07-29 at 3 02 03 PM" src="https://github.com/user-attachments/assets/1d17c829-7f85-4b57-a440-f046cc05e8a9">

<img width="320" alt="Screenshot 2024-07-29 at 3 01 32 PM" src="https://github.com/user-attachments/assets/7ef080fa-5e12-402f-be41-640cb92f110f">

## Before → After (iPad)

On iPad, you should just use a popover for this scenarios. It a much quicker and lighter interaction. There are many other cases where we could take some quick wins by simply using popovers on iPad.

<img width="500" alt="Screenshot 2024-07-29 at 2 25 19 PM" src="https://github.com/user-attachments/assets/ff9a3b40-e1f3-456e-9104-05d07d5999a7">

<img width="500" alt="Screenshot 2024-07-29 at 2 56 05 PM" src="https://github.com/user-attachments/assets/3ecbe5bc-1486-4717-8c9f-1517e7071b8f">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
