### PR TITLE
Show "All Domains" in split view's details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -227,8 +227,8 @@ class MeViewController: UITableViewController {
                     title: AllDomainsListViewController.Strings.title,
                     icon: UIImage(systemName: "globe"),
                     accessoryType: accessoryType,
-                    action: { action in
-                        self.navigationController?.pushViewController(AllDomainsListViewController(), animated: true)
+                    action: { [weak self] action in
+                        self?.showOrPushController(AllDomainsListViewController())
                         WPAnalytics.track(.meDomainsTapped)
                     },
                     accessibilityIdentifier: "myDomains"


### PR DESCRIPTION
On iPad, "All Domains" screen in "Me" tab is pushed onto the split view's left side. The correct behaviour should be presenting on the right side as details.

| Before | After |
| ------ | ----- |
| ![IMG_5582](https://github.com/user-attachments/assets/915d9cf5-48d7-4b81-80ea-7ff62fb7ad67) | ![IMG_5583](https://github.com/user-attachments/assets/ad4d9c1e-6c66-4a76-aaa6-a63f1670aac0) |

## Test Instructions

On iPad, verify "All Domains" screen is presented on the right side. On iPhone, verify "All Domains" screen can be pushed as usual.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the Test Instructions.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
