### PR TITLE
Add WordPress REST API Helpers

### DIFF
--- a/WordPress/Classes/Models/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog+SelfHosted.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+extension Blog {
+
+    enum BlogCredentialsError: Error {
+        case blogUrlMissing
+        case blogUrlInvalid
+        case blogUsernameMissing
+        case blogPasswordMissing
+        case blogIdentifierMissing
+        case invalidCredentialsUrl
+        case invalidXmlRpcEndpoint
+    }
+
+    static func createRestApiBlog(
+        with details: SelfHostedLoginDetails,
+        in contextManager: ContextManager,
+        using keychainImplementation: KeychainAccessible = KeychainUtils()
+    ) async throws -> String {
+        try await contextManager.performAndSave { context in
+            let blog = Blog.createBlankBlog(in: context)
+            blog.setUrl(details.url)
+            blog.username = details.username
+            try blog.setPassword(to: details.password, using: keychainImplementation)
+            blog.setXMLRPCEndpoint(to: details.derivedXMLRPCRoot)
+            blog.setSiteIdentifier(details.derivedSiteId)
+
+            return details.derivedSiteId
+        }
+    }
+
+    static func lookupRestApiBlog(with id: SiteIdentifier, in context: NSManagedObjectContext) throws -> Blog? {
+        try BlogQuery().apiKey(is: id).blog(in: context)
+    }
+
+    static func hasRestApiBlog(with id: SiteIdentifier, in context: NSManagedObjectContext) throws -> Bool {
+        BlogQuery().apiKey(is: id).count(in: context) != 0
+    }
+
+    // MARK: Type-safe wrappers
+    // The underlying `Blog` object has lots of field nullability that doesn't provide guarantees about
+    // which fields are present. These wrappers will `throw` if the `Blog` is invalid, allowing any dependent
+    // code can be much simpler.
+
+    /// An alias for `getPassword` to make it obvious how to retrieve Application Tokens
+    ///
+    func getApplicationToken(using keychainImplementation: KeychainAccessible = KeychainUtils()) throws -> String {
+        try getPassword(using: keychainImplementation)
+    }
+
+    /// An alias for `setPassword` to make it obvious how to store Application Tokens
+    ///
+    func setApplicationToken(
+        _ newValue: String,
+        using keychainImplementation: KeychainAccessible = KeychainUtils()
+    ) throws {
+        try setPassword(to: newValue, using: keychainImplementation)
+    }
+
+    /// A null-safe wrapper for `Blog.username`
+    func getUsername() throws -> String {
+        guard let username = self.username else {
+            throw BlogCredentialsError.blogUsernameMissing
+        }
+
+        return username
+    }
+
+    /// A null-safe replacement for `Blog.password(get)`
+    func getPassword(using keychainImplementation: KeychainAccessible = KeychainUtils()) throws -> String {
+        try keychainImplementation.getPassword(for: self.getUsername(), serviceName: self.getUrlString())
+    }
+
+    /// A null-safe replacement for `Blog.password(set)`
+    func setPassword(to newValue: String, using keychainImplementation: KeychainAccessible = KeychainUtils()) throws {
+        try keychainImplementation.setPassword(for: self.getUsername(), to: newValue, serviceName: self.getUrlString())
+    }
+
+    /// A null-and-type-safe replacement for `Blog.url(get)`
+    func getUrl() throws -> URL {
+        guard let stringUrl = self.url else {
+            throw BlogCredentialsError.blogUrlMissing
+        }
+
+        guard let url = URL(string: stringUrl) else {
+            throw BlogCredentialsError.blogUrlInvalid
+        }
+
+        return url
+    }
+
+    /// A null-safe helper for `Blog.url(get)`, when what you really want is a String
+    func getUrlString() throws -> String {
+        try getUrl().absoluteString
+    }
+
+    /// A type-safe helper for `Blog.url(set)` that takes a URL directly (instead of a string)
+    func setUrl(_ newValue: URL) {
+        self.url = newValue.absoluteString
+    }
+
+    /// A null-and-type-safe replacement for `Blog.xmlrpc(get)`
+    func getXMLRPCEndpoint() throws -> URL {
+        guard let urlString = self.xmlrpc, let url = URL(string: urlString) else {
+            throw BlogCredentialsError.invalidXmlRpcEndpoint
+        }
+
+        return url
+    }
+
+    /// A type-safe helper for `Blog.xmlrpc(set)` that takes a URL directly (instead of a string)
+    func setXMLRPCEndpoint(to newValue: URL) {
+        self.xmlrpc = newValue.absoluteString
+    }
+
+    /// There's `dotComId` for WordPress.com blogs, but we don't have a good way to lookup REST API sites with a scalar value.
+    ///
+    /// This hack fixes that – we should never store API Keys in Core Data anyway, so we can (mis)use that field to add a unique identifier
+    typealias SiteIdentifier = String
+
+    func getSiteIdentifier() throws -> SiteIdentifier {
+        guard let identifier = self.apiKey else {
+            throw BlogCredentialsError.blogIdentifierMissing
+        }
+
+        return identifier
+    }
+
+    func setSiteIdentifier(_ newValue: SiteIdentifier) {
+        self.apiKey = newValue
+    }
+}

--- a/WordPress/Classes/Models/SelfHostedLoginDetails.swift
+++ b/WordPress/Classes/Models/SelfHostedLoginDetails.swift
@@ -1,0 +1,56 @@
+import Foundation
+import CryptoKit
+
+// TODO: The majority of this should probably be cross-platform code
+struct SelfHostedLoginDetails {
+    let url: URL
+    let username: String
+    let password: String
+    let XMLRPCEndpoint: URL?
+
+    var derivedXMLRPCRoot: URL {
+        url.appendingPathComponent("/xmlrpc.php")
+    }
+
+    var derivedSiteId: String {
+        SHA256.hash(data: Data(url.absoluteString.utf8))
+            .compactMap { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    static func fromApplicationPasswordResponse(_ url: URL) throws -> SelfHostedLoginDetails {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        guard let hashMap = components?.queryItems?.reduce(into: [String: String](), { partialResult, item in
+            partialResult[item.name] = item.value
+        }) else {
+            throw Blog.BlogCredentialsError.invalidCredentialsUrl
+        }
+
+        guard let stringUrl = hashMap["site_url"] else {
+            throw Blog.BlogCredentialsError.blogUrlMissing
+        }
+
+        guard let url = URL(string: stringUrl) else {
+            throw Blog.BlogCredentialsError.blogUrlInvalid
+        }
+
+        guard let username = hashMap["user_login"] else {
+            throw Blog.BlogCredentialsError.blogUsernameMissing
+        }
+
+        guard let password = hashMap["password"] else {
+            throw Blog.BlogCredentialsError.blogPasswordMissing
+        }
+
+        return SelfHostedLoginDetails(url: url, username: username, password: password, XMLRPCEndpoint: nil)
+    }
+
+    static func from(blog: Blog) throws -> SelfHostedLoginDetails {
+        return try SelfHostedLoginDetails(
+            url: blog.getUrl(),
+            username: blog.getUsername(),
+            password: blog.getPassword(),
+            XMLRPCEndpoint: try? blog.getXMLRPCEndpoint() // We're ok with this failing because it may not be needed
+        )
+    }
+}

--- a/WordPress/Classes/Models/SelfHostedLoginDetails.swift
+++ b/WordPress/Classes/Models/SelfHostedLoginDetails.swift
@@ -6,14 +6,14 @@ struct SelfHostedLoginDetails {
     let url: URL
     let username: String
     let password: String
-    let XMLRPCEndpoint: URL?
+    let xmlrpcEndpoint: URL?
 
     var derivedXMLRPCRoot: URL {
         url.appendingPathComponent("/xmlrpc.php")
     }
 
     var derivedSiteId: String {
-        SHA256.hash(data: Data(url.absoluteString.utf8))
+        SHA256.hash(data: Data(url.absoluteString.localizedLowercase.utf8))
             .compactMap { String(format: "%02x", $0) }
             .joined()
     }
@@ -42,7 +42,7 @@ struct SelfHostedLoginDetails {
             throw Blog.BlogCredentialsError.blogPasswordMissing
         }
 
-        return SelfHostedLoginDetails(url: url, username: username, password: password, XMLRPCEndpoint: nil)
+        return SelfHostedLoginDetails(url: url, username: username, password: password, xmlrpcEndpoint: nil)
     }
 
     static func from(blog: Blog) throws -> SelfHostedLoginDetails {
@@ -50,7 +50,7 @@ struct SelfHostedLoginDetails {
             url: blog.getUrl(),
             username: blog.getUsername(),
             password: blog.getPassword(),
-            XMLRPCEndpoint: try? blog.getXMLRPCEndpoint() // We're ok with this failing because it may not be needed
+            xmlrpcEndpoint: try? blog.getXMLRPCEndpoint() // We're ok with this failing because it may not be needed
         )
     }
 }

--- a/WordPress/Classes/Utility/BlogQuery.swift
+++ b/WordPress/Classes/Utility/BlogQuery.swift
@@ -48,6 +48,10 @@ struct BlogQuery {
         and(NSPredicate(format: "xmlrpc = %@", xmlrpc))
     }
 
+    func apiKey(is string: String) -> Self {
+        and(NSPredicate(format: "apiKey = %@", string))
+    }
+
     func count(in context: NSManagedObjectContext) -> Int {
         (try? context.count(for: buildFetchRequest())) ?? 0
     }

--- a/WordPress/Classes/Utility/KeychainUtils.swift
+++ b/WordPress/Classes/Utility/KeychainUtils.swift
@@ -35,3 +35,18 @@ class KeychainUtils: NSObject {
                                                updateExisting: updateExisting)
     }
 }
+
+extension KeychainUtils: KeychainAccessible {
+    func getPassword(for username: String, serviceName: String) throws -> String {
+        try self.keychainUtils.getPasswordForUsername(username, andServiceName: serviceName)
+    }
+
+    func setPassword(for username: String, to newValue: String, serviceName: String) throws {
+        try keychainUtils.storeUsername(username, andPassword: newValue, forServiceName: serviceName, updateExisting: true)
+    }
+}
+
+protocol KeychainAccessible {
+    func getPassword(for username: String, serviceName: String) throws -> String
+    func setPassword(for username: String, to newValue: String, serviceName: String) throws
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -908,6 +908,9 @@
 		223EA61E212A7C26A456C32C /* Pods_JetpackDraftActionExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 430F7B409FE22699ADB1A724 /* Pods_JetpackDraftActionExtension.framework */; };
 		241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E60B225CA0D2900912CEB /* UserSettings.swift */; };
 		2420BEF125D8DAB300966129 /* Blog+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2420BEF025D8DAB300966129 /* Blog+Lookup.swift */; };
+		2422A2C02C5846DB00402A81 /* Blog+RestAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2422A2BF2C5846DB00402A81 /* Blog+RestAPITests.swift */; };
+		2422A2C22C58470600402A81 /* Blog+SelfHosted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2422A2C12C58470600402A81 /* Blog+SelfHosted.swift */; };
+		2422A2C32C58470600402A81 /* Blog+SelfHosted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2422A2C12C58470600402A81 /* Blog+SelfHosted.swift */; };
 		24351254264DCA08009BB2B6 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24351253264DCA08009BB2B6 /* Secrets.swift */; };
 		24351255264DCA08009BB2B6 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24351253264DCA08009BB2B6 /* Secrets.swift */; };
 		246D0A0325E97D5D0028B83F /* Blog+ObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 246D0A0225E97D5D0028B83F /* Blog+ObjcTests.m */; };
@@ -922,6 +925,8 @@
 		24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C69A8A2612421900312D9A /* UserSettingsTests.swift */; };
 		24C69AC22612467C00312D9A /* UserSettingsTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */; };
 		24CDE3412C5863A1005E5E43 /* TestKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CDE3402C5863A1005E5E43 /* TestKeychain.swift */; };
+		24CDE3442C586A64005E5E43 /* SelfHostedLoginDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CDE3422C586A40005E5E43 /* SelfHostedLoginDetails.swift */; };
+		24CDE3452C586A66005E5E43 /* SelfHostedLoginDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CDE3422C586A40005E5E43 /* SelfHostedLoginDetails.swift */; };
 		24F3789825E6E62100A27BB7 /* NSManagedObject+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
@@ -6880,6 +6885,8 @@
 		23052F0F1F9B2503E33D0A26 /* Pods_JetpackShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_JetpackShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		241E60B225CA0D2900912CEB /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		2420BEF025D8DAB300966129 /* Blog+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Lookup.swift"; sourceTree = "<group>"; };
+		2422A2BF2C5846DB00402A81 /* Blog+RestAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+RestAPITests.swift"; sourceTree = "<group>"; };
+		2422A2C12C58470600402A81 /* Blog+SelfHosted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+SelfHosted.swift"; sourceTree = "<group>"; };
 		24350E7C264DB76E009BB2B6 /* Jetpack.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Jetpack.debug.xcconfig; sourceTree = "<group>"; };
 		24351059264DC1E2009BB2B6 /* Jetpack.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Jetpack.release.xcconfig; sourceTree = "<group>"; };
 		243511A4264DC2D9009BB2B6 /* Jetpack.internal.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Jetpack.internal.xcconfig; sourceTree = "<group>"; };
@@ -6935,6 +6942,7 @@
 		24C69A8A2612421900312D9A /* UserSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTests.swift; sourceTree = "<group>"; };
 		24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserSettingsTestsObjc.m; sourceTree = "<group>"; };
 		24CDE3402C5863A1005E5E43 /* TestKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestKeychain.swift; sourceTree = "<group>"; };
+		24CDE3422C586A40005E5E43 /* SelfHostedLoginDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfHostedLoginDetails.swift; sourceTree = "<group>"; };
 		24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Lookup.swift"; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -11679,6 +11687,7 @@
 				43AF2F962107D3800069C012 /* QuickStartTourState.swift */,
 				17EFD3732578201100AB753C /* ValueTransformers.swift */,
 				241E60B225CA0D2900912CEB /* UserSettings.swift */,
+				24CDE3422C586A40005E5E43 /* SelfHostedLoginDetails.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -13606,6 +13615,7 @@
 				3F759FB92A2DA93B0039A845 /* WPAccount+Fixture.swift */,
 				2481B1E7260D4EAC00AE59DB /* WPAccount+LookupTests.swift */,
 				2481B20B260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m */,
+				2422A2BF2C5846DB00402A81 /* Blog+RestAPITests.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -16180,6 +16190,7 @@
 				8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */,
 				4AD5656E28E413160054C676 /* Blog+History.swift */,
 				FEE48EFB2A4C8312008A48E0 /* Blog+JetpackSocial.swift */,
+				2422A2C12C58470600402A81 /* Blog+SelfHosted.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -22679,6 +22690,7 @@
 				014ACD142A1E5034008A706C /* WebKitViewController+SandboxStore.swift in Sources */,
 				B0960C8727D14BD400BC9717 /* SiteIntentStep.swift in Sources */,
 				9801E682274EEBC4002FDDB6 /* ReaderDetailCommentsHeader.swift in Sources */,
+				2422A2C22C58470600402A81 /* Blog+SelfHosted.swift in Sources */,
 				B5EFB1C21B31B98E007608A3 /* NotificationSettingsService.swift in Sources */,
 				011896A829D5BBB400D34BA9 /* DomainsDashboardFactory.swift in Sources */,
 				011F52BD2A15327700B04114 /* BaseDashboardDomainsCardCell.swift in Sources */,
@@ -22721,6 +22733,7 @@
 				E14DFAFB1E07E7C400494688 /* Data.swift in Sources */,
 				E14B40FD1C58B806005046F6 /* AccountSettingsViewController.swift in Sources */,
 				98B11B892216535100B7F2D7 /* StatsChildRowsView.swift in Sources */,
+				24CDE3442C586A64005E5E43 /* SelfHostedLoginDetails.swift in Sources */,
 				4A358DE929B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */,
 				08CC677F1C49B65A00153AD7 /* Menu.m in Sources */,
 				BE13B3E71B2B58D800A4211D /* BlogListViewController.m in Sources */,
@@ -24301,6 +24314,7 @@
 				D8BA274D20FDEA2E007A5C77 /* NotificationTextContentTests.swift in Sources */,
 				2481B1D5260D4E8B00AE59DB /* AccountBuilder.swift in Sources */,
 				E66969C81B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift in Sources */,
+				2422A2C02C5846DB00402A81 /* Blog+RestAPITests.swift in Sources */,
 				E1EBC3731C118ED200F638E0 /* ImmuTableTest.swift in Sources */,
 				F5C00EAE242179780047846F /* WeekdaysHeaderViewTests.swift in Sources */,
 				24C69AC22612467C00312D9A /* UserSettingsTestsObjc.m in Sources */,
@@ -24698,6 +24712,7 @@
 				FABB20DC2602FC2C00C8785C /* WPAppAnalytics+Media.swift in Sources */,
 				FE6BB144293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */,
 				FABB20DD2602FC2C00C8785C /* Post.swift in Sources */,
+				2422A2C32C58470600402A81 /* Blog+SelfHosted.swift in Sources */,
 				FA8E2FE127C6377000DA0982 /* DashboardQuickStartCardCell.swift in Sources */,
 				FABB20DE2602FC2C00C8785C /* GutenbergWebViewController.swift in Sources */,
 				FABB20E02602FC2C00C8785C /* CookieJar.swift in Sources */,
@@ -26447,6 +26462,7 @@
 				83F1BED32BA4D1190057BC0F /* ReaderTopicService+FollowedSites.swift in Sources */,
 				FABB25A82602FC2C00C8785C /* RichTextView.swift in Sources */,
 				FABB25A92602FC2C00C8785C /* ScenePresenter.swift in Sources */,
+				24CDE3452C586A66005E5E43 /* SelfHostedLoginDetails.swift in Sources */,
 				FABB25AA2602FC2C00C8785C /* AccountSettingsStore.swift in Sources */,
 				FABB25AB2602FC2C00C8785C /* FancyAlertViewController+NotificationPrimer.swift in Sources */,
 				FABB25AC2602FC2C00C8785C /* Charts+Support.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -921,6 +921,7 @@
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
 		24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C69A8A2612421900312D9A /* UserSettingsTests.swift */; };
 		24C69AC22612467C00312D9A /* UserSettingsTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */; };
+		24CDE3412C5863A1005E5E43 /* TestKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CDE3402C5863A1005E5E43 /* TestKeychain.swift */; };
 		24F3789825E6E62100A27BB7 /* NSManagedObject+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
@@ -6933,6 +6934,7 @@
 		24B54FB02624F8690041B18E /* JetpackDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = JetpackDebug.entitlements; sourceTree = "<group>"; };
 		24C69A8A2612421900312D9A /* UserSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTests.swift; sourceTree = "<group>"; };
 		24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserSettingsTestsObjc.m; sourceTree = "<group>"; };
+		24CDE3402C5863A1005E5E43 /* TestKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestKeychain.swift; sourceTree = "<group>"; };
 		24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Lookup.swift"; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -17634,6 +17636,7 @@
 				933D1F461EA64108009FB462 /* TestingAppDelegate.m */,
 				933D1F6B1EA7A3AB009FB462 /* TestingMode.storyboard */,
 				3F4A4C202AD39CB100DE5DF8 /* TruthTable.swift */,
+				24CDE3402C5863A1005E5E43 /* TestKeychain.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -24560,6 +24563,7 @@
 				F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */,
 				8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */,
 				8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */,
+				24CDE3412C5863A1005E5E43 /* TestKeychain.swift in Sources */,
 				3F28CEA52A4ABB8800B79686 /* PrivacySettingsAnalyticsTrackerTests.swift in Sources */,
 				325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */,
 				805CC0B9296680F7002941DC /* RemoteConfigStoreMock.swift in Sources */,

--- a/WordPress/WordPressTest/Blog+RestAPITests.swift
+++ b/WordPress/WordPressTest/Blog+RestAPITests.swift
@@ -6,7 +6,7 @@ final class Blog_RestAPITests: CoreDataTestCase {
         url: URL(string: "http://example.com")!,
         username: "test@example.com",
         password: "StrongPassword!",
-        XMLRPCEndpoint: nil
+        xmlrpcEndpoint: nil
     )
 
     let testKeychain = TestKeychain()

--- a/WordPress/WordPressTest/Blog+RestAPITests.swift
+++ b/WordPress/WordPressTest/Blog+RestAPITests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import WordPress
+
+final class Blog_RestAPITests: CoreDataTestCase {
+    let loginDetails = SelfHostedLoginDetails(
+        url: URL(string: "http://example.com")!,
+        username: "test@example.com",
+        password: "StrongPassword!",
+        XMLRPCEndpoint: nil
+    )
+
+    let testKeychain = TestKeychain()
+
+    private var blog: Blog!
+
+    override func setUp() async throws {
+        _ = try await Blog.createRestApiBlog(with: loginDetails, in: contextManager, using: testKeychain)
+        self.blog = try XCTUnwrap(contextManager.mainContext.fetch(NSFetchRequest<Blog>(entityName: "Blog")).first)
+    }
+
+    func testThatCreateRestApiBlogStoresUrl() throws {
+        XCTAssertEqual(try blog.getUrl(), loginDetails.url)
+    }
+
+    func testThatCreateRestApiBlogStoresUsername() throws {
+        XCTAssertEqual(try blog.getUsername(), loginDetails.username)
+    }
+
+    func testThatCreateRestApiBlogStoresPassword() throws {
+        XCTAssertEqual(try blog.getPassword(using: testKeychain), loginDetails.password)
+    }
+
+    func testThatCreateRestApiBlogStoresSiteIdentifier() throws {
+        XCTAssertEqual(try blog.getSiteIdentifier(), loginDetails.derivedSiteId)
+    }
+
+    func testThatCreateRestApiBlogStoresDerivedXMLRPCEndpoint() throws {
+        XCTAssertEqual(try blog.getXMLRPCEndpoint(), loginDetails.derivedXMLRPCRoot)
+    }
+
+    func testThatExistingBlogWithInvalidUrlThrowsErrorOnAccess() throws {
+        blog.url = ""
+        XCTAssertThrowsError(try blog.getUrl())
+    }
+
+    func testThatExistingBlogWithNoUrlThrowsErrorOnAccess() throws {
+        blog.url = nil
+        XCTAssertThrowsError(try blog.getUrl())
+    }
+
+    func testThatExistingBlogWithNoUsernameThrowsErrorOnAccess() throws {
+        blog.username = nil
+        XCTAssertThrowsError(try blog.getUsername())
+    }
+
+    func testThatExistingBlogWithNoSiteIdentifierThrowsErrorOnAccess() throws {
+        blog.apiKey = nil
+        XCTAssertThrowsError(try blog.getSiteIdentifier())
+    }
+
+    func testThatBlogWithNoXMLRPCEndpointThrowsErrorOnAccess() throws {
+        blog.xmlrpc = nil
+        XCTAssertThrowsError(try blog.getXMLRPCEndpoint())
+    }
+
+    func testThatBlogWithInvalidXMLRPCEndpointThrowsErrorOnAccess() throws {
+        blog.xmlrpc = ""
+        XCTAssertThrowsError(try blog.getXMLRPCEndpoint())
+    }
+
+    func testThatExistingBlogCanBeLookedUp() throws {
+        XCTAssertNotNil(try Blog.lookupRestApiBlog(with: blog.getSiteIdentifier(), in: mainContext))
+    }
+
+    func testThatExistingBlogCausesHasRestApiBlogToReturnTrue() throws {
+        XCTAssertTrue(try Blog.hasRestApiBlog(with: blog.getSiteIdentifier(), in: mainContext))
+    }
+
+    func testThatNoExistingBlogCausesHasRestApiBlogToReturnFalse() throws {
+        XCTAssertFalse(try Blog.hasRestApiBlog(with: "invalid identifier", in: mainContext))
+    }
+}

--- a/WordPress/WordPressTest/TestKeychain.swift
+++ b/WordPress/WordPressTest/TestKeychain.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import WordPress
+
+class TestKeychain: KeychainAccessible {
+    private var keychain = [String: KeychainItem]()
+
+    struct KeychainItem {
+        let username: String
+        let password: String
+    }
+
+    enum TestKeychainErrors: Error {
+        case keychainItemNotFound
+    }
+
+    func getPassword(for username: String, serviceName: String) throws -> String {
+        guard let keychainItem = keychain[serviceName], keychainItem.username == username else {
+            throw TestKeychainErrors.keychainItemNotFound
+        }
+
+        return keychainItem.password
+    }
+
+    func setPassword(for username: String, to newValue: String, serviceName: String) throws {
+        keychain[serviceName] = KeychainItem(username: username, password: newValue)
+    }
+}


### PR DESCRIPTION
Adds helpers that'll be used by #23412 – right now there's no centralized code for dealing with self-hosted sites, and this PR brings the implementation details together into a single extension.

We'll still be using XMLRPC for a little while, but I decided not to rewrite much of the existing handling for that code – partially because it would've required Objective-C bridging.

If needed, we can add more later.


To test:
- Ensure CI passes

## Regression Notes
1. Potential unintended areas of impact
n/a – this code isn't called from anywhere

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Code is covered by CI

3. What automated tests I added (or what prevented me from doing so)
See tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
n/a
