### PR TITLE
Fix an issue with invalid popover placement when creating new site

### DIFF
--- a/Modules/Sources/DesignSystem/Components/FAB.swift
+++ b/Modules/Sources/DesignSystem/Components/FAB.swift
@@ -2,25 +2,34 @@ import SwiftUI
 
 public struct FAB: View {
     let image: Image
-    let action: () -> Void
+    let action: (() -> Void)?
 
-    public init(image: Image = Image(systemName: "plus"), action: @escaping () -> Void) {
+    public init(image: Image = Image(systemName: "plus"), action: (() -> Void)? = nil) {
         self.image = image
         self.action = action
     }
 
     public var body: some View {
-        Button(action: action) {
+        content
+            .dynamicTypeSize(...DynamicTypeSize.accessibility1) // important to be attached from the outside
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let action {
+            Button(action: action) {
+                FABContentView(image: image)
+            }
+        } else {
             FABContentView(image: image)
         }
-        .dynamicTypeSize(...DynamicTypeSize.accessibility1) // important to be attached from the outside
     }
 }
 
 private struct FABContentView: View {
     let image: Image
 
-    @ScaledMetric(relativeTo: .title2) private var size = 50.0
+    @ScaledMetric(relativeTo: .title2) private var size = 54.0
     @ScaledMetric(relativeTo: .title2) private var shadowRadios = 4.0
     @Environment(\.colorScheme) var colorScheme
 

--- a/WordPress/Classes/ViewRelated/Blog/Add Site/AddSiteAlertFactory.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Add Site/AddSiteAlertFactory.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// This class takes care of constructing our "Add Site" action sheets.  It does not handle any presentation logic and does
 /// not know any external data sources - all of the data is received as parameters.
@@ -34,7 +35,7 @@ class AddSiteAlertFactory: NSObject {
 
     private func addSelfHostedSiteAction(handler: @escaping () -> Void) -> UIAlertAction {
         return UIAlertAction(
-            title: NSLocalizedString("Add self-hosted site", comment: "Add self-hosted site button"),
+            title: Strings.addSelfHostedSite,
             style: .default,
             handler: { _ in
                 handler()
@@ -49,10 +50,50 @@ class AddSiteAlertFactory: NSObject {
 
     private func createWPComSiteAction(handler: @escaping () -> Void) -> UIAlertAction {
         return UIAlertAction(
-            title: NSLocalizedString("Create WordPress.com site", comment: "Create WordPress.com site button"),
+            title: Strings.createDotComSite,
             style: .default,
             handler: { _ in
                 handler()
             })
     }
+}
+
+struct AddSiteAlertViewModel {
+    let actions: [Action]
+
+    enum Selection: String {
+        case dotCom
+        case selfHosted
+    }
+
+    struct Action: Identifiable {
+        let id = UUID()
+        let title: String
+        let handler: () -> Void
+    }
+
+    init(context: ContextManager = .shared, onSelection: @escaping (Selection) -> Void) {
+        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: context.mainContext)
+        let canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton
+
+        var actions: [Action] = []
+        if defaultAccount != nil {
+            actions.append(Action(title: Strings.createDotComSite) {
+                onSelection(.dotCom)
+            })
+        }
+
+        if canAddSelfHostedSite {
+            actions.append(Action(title: Strings.addSelfHostedSite) {
+                onSelection(.selfHosted)
+            })
+        }
+
+        self.actions = actions
+    }
+}
+
+private enum Strings {
+    static let createDotComSite = NSLocalizedString("button.createDotCoSite", value: "Create WordPress.com site", comment: "Create WordPress.com site button")
+    static let addSelfHostedSite = NSLocalizedString("button.addSelfHostedSite", value: "Add self-hosted site", comment: "Add self-hosted site button")
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteActions.swift
@@ -25,7 +25,6 @@ extension SitePickerViewController {
         let menuItems = [
             MenuItem.visitSite({ [weak self] in self?.visitSiteTapped() }),
             MenuItem.shareSite { [weak self] in self?.buttonShareSiteTapped() },
-            MenuItem.addSite({ [weak self] in self?.addSiteTapped()} ),
             MenuItem.switchSite({ [weak self] in self?.siteSwitcherTapped() })
         ]
         return UIMenu(options: .displayInline, children: menuItems.map { $0.toAction })
@@ -73,37 +72,13 @@ extension SitePickerViewController {
 
     // MARK: - Add site
 
-    func addSiteTapped() {
-        let canCreateWPComSite = defaultAccount() != nil
-        let canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton
+    func addSiteTapped(siteType: AddSiteAlertViewModel.Selection) {
+        WPAnalytics.trackEvent(.mySiteHeaderAddSiteTapped, properties: ["siteType": siteType.rawValue])
 
-        // Launch wp.com site creation if the user can't add self-hosted sites
-        if canCreateWPComSite && !canAddSelfHostedSite {
-            launchSiteCreation()
-            return
+        switch siteType {
+        case .dotCom: launchSiteCreation()
+        case .selfHosted: launchLoginForSelfHostedSite()
         }
-
-        showAddSiteActionSheet(from: blogDetailHeaderView.titleView.siteSwitcherButton,
-                               canCreateWPComSite: canCreateWPComSite,
-                               canAddSelfHostedSite: canAddSelfHostedSite)
-
-        WPAnalytics.trackEvent(.mySiteHeaderAddSiteTapped)
-    }
-
-    private func showAddSiteActionSheet(from sourceView: UIView, canCreateWPComSite: Bool, canAddSelfHostedSite: Bool) {
-        let actionSheet = AddSiteAlertFactory().makeAddSiteAlert(
-            source: "my_site",
-            canCreateWPComSite: canCreateWPComSite,
-            createWPComSite: { [weak self] in self?.launchSiteCreation() },
-            canAddSelfHostedSite: canAddSelfHostedSite,
-            addSelfHostedSite: { [weak self] in self?.launchLoginForSelfHostedSite() }
-        )
-
-        actionSheet.popoverPresentationController?.sourceView = sourceView
-        actionSheet.popoverPresentationController?.sourceRect = sourceView.bounds
-        actionSheet.popoverPresentationController?.permittedArrowDirections = .up
-
-        presentedViewController?.present(actionSheet, animated: true)
     }
 
     private func launchSiteCreation() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -105,7 +105,7 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
     private func presentNewSiteSwitcher() {
         let viewController = SiteSwitcherViewController(
             addSiteAction: { [weak self] in
-                self?.addSiteTapped()
+                self?.addSiteTapped(siteType: $0)
             },
             onSiteSelected: { [weak self] site in
                 self?.switchToBlog(site)

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 import DesignSystem
 
 final class SiteSwitcherViewController: UIViewController {
-    private let addSiteAction: (() -> Void)
+    private let addSiteAction: ((AddSiteAlertViewModel.Selection) -> Void)
     private let onSiteSelected: ((Blog) -> Void)
 
-    init(addSiteAction: @escaping (() -> Void),
+    init(addSiteAction: @escaping ((AddSiteAlertViewModel.Selection) -> Void),
          onSiteSelected: @escaping ((Blog) -> Void)) {
         self.addSiteAction = addSiteAction
         self.onSiteSelected = onSiteSelected
@@ -40,7 +40,7 @@ final class SiteSwitcherViewController: UIViewController {
 }
 
 private struct SiteSwitcherView: View {
-    let addSiteAction: (() -> Void)
+    let addSiteAction: ((AddSiteAlertViewModel.Selection) -> Void)
     let onSiteSelected: ((Blog) -> Void)
 
     @StateObject private var viewModel = BlogListViewModel()
@@ -57,7 +57,7 @@ private struct SiteSwitcherView: View {
 }
 
 private struct SiteSwitcherToolbarView: View {
-    let addSiteAction: (() -> Void)
+    let addSiteAction: ((AddSiteAlertViewModel.Selection) -> Void)
 
     /// - warning: It has to be defined in a view "below" the .searchable
     @Environment(\.isSearching) var isSearching
@@ -66,9 +66,29 @@ private struct SiteSwitcherToolbarView: View {
         if !isSearching {
             HStack {
                 Spacer()
-                FAB(action: addSiteAction)
+                button
                     .padding(.trailing, 20)
                     .padding(.bottom, UIDevice.current.userInterfaceIdiom == .pad ? 20 : 0)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var button: some View {
+        let viewModel = AddSiteAlertViewModel(onSelection: addSiteAction)
+        switch viewModel.actions.count {
+        case 0:
+            EmptyView()
+        case 1:
+            FAB(action: viewModel.actions[0].handler)
+        default:
+            Menu {
+                // Menu reverses actions by default
+                ForEach(viewModel.actions.reversed()) { action in
+                    Button(action.title, action: action.handler)
+                }
+            } label: {
+                FAB()
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23451.

I missed that when testing – it was part of the old code.

<img width="600" alt="Screenshot 2024-07-30 at 10 08 15 AM" src="https://github.com/user-attachments/assets/940ac5e6-cd84-4602-922a-ea403c9714e3">


## Alternatives Considered

I initially implemented it as a nice SwiftUI-based popover with wp.com as a primary button, but you quickly run into issues with SwiftUI and UIKit interop. The popover is presented on top of the site picker as a separate view controller, and there doesn't seem to be any clear way to dismiss it from SwiftUI and guarantee that by the time the site picker tries to present something on top of `presentedViewController`, the popover will actually be dismissed. So you get a "attempting to present on top of the view controller that's already presenting (a popover)" error. Maybe next time.

<img width="600" alt="Screenshot 2024-07-30 at 9 29 22 AM" src="https://github.com/user-attachments/assets/f469891d-2b41-439e-8f0d-d227b5e3fa48">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
