### PR TITLE
Add missing Site Switcher features

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -50,7 +50,7 @@ struct BlogListSiteView: View {
 }
 
 final class BlogListSiteViewModel: Identifiable {
-    let id: NSNumber
+    var id: NSManagedObjectID { blog.objectID }
     let title: String
     let domain: String
     let imageURL: URL?
@@ -68,12 +68,9 @@ final class BlogListSiteViewModel: Identifiable {
 
     init(blog: Blog) {
         self.blog = blog
-        self.id = blog.dotComID ?? 0
         self.title = blog.title ?? "–"
         self.domain = blog.displayURL as String? ?? ""
         self.imageURL = blog.hasIcon ? blog.icon.flatMap(URL.init) : nil
-
-        NSLog(blog.icon ?? "")
 
         // By adding displayURL _after_ the title, it loweres its weight in search
         self.searchTags = "\(title) \(domain)"

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListView.swift
@@ -61,7 +61,7 @@ struct BlogListView: View {
     @ViewBuilder
     private func makeSiteView(with site: BlogListSiteViewModel) -> some View {
         let view = Button {
-            if let site = viewModel.didSelectSite(withSiteID: site.id) {
+            if let site = viewModel.didSelectSite(withID: site.id) {
                 onSiteSelected(site)
             }
         } label: {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -30,9 +30,12 @@ final class BlogListViewModel: NSObject, ObservableObject {
         setupFetchedResultsController()
     }
 
-    func didSelectSite(withSiteID siteID: NSNumber) -> Blog? {
-        guard let blog = rawSites.first(where: { $0.dotComID == siteID }) else {
+    func didSelectSite(withID objectID: NSManagedObjectID) -> Blog? {
+        guard let blog = rawSites.first(where: { $0.objectID == objectID }) else {
             return nil
+        }
+        if selectedBlog() != blog {
+            PushNotificationsManager.shared.deletePendingLocalNotifications()
         }
         eventTracker.track(.siteSwitcherSiteTapped, properties: [
             "section": blog.lastUsed != nil ? "recent" : "all"

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -37,6 +37,18 @@ final class SiteSwitcherViewController: UIViewController {
     @objc private func buttonCloseTapped() {
         presentingViewController?.dismiss(animated: true)
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        WPAnalytics.track(.siteSwitcherDisplayed)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        WPAnalytics.track(.siteSwitcherDismissed)
+    }
 }
 
 private struct SiteSwitcherView: View {

--- a/WordPress/WordPressTest/BlogListViewModelTests.swift
+++ b/WordPress/WordPressTest/BlogListViewModelTests.swift
@@ -18,7 +18,7 @@ final class BlogListViewModelTests: CoreDataTestCase {
 
     func testRecentSitesWithValidData() throws {
         let siteID = 34984
-        let _ = BlogBuilder(mainContext)
+        let site = BlogBuilder(mainContext)
             .with(dotComID: siteID)
             .with(lastUsed: Date())
             .build()
@@ -26,7 +26,7 @@ final class BlogListViewModelTests: CoreDataTestCase {
 
         viewModel = BlogListViewModel(contextManager: contextManager)
 
-        XCTAssertEqual(viewModel.recentSites.first?.id, siteID as NSNumber)
+        XCTAssertEqual(viewModel.recentSites.first?.id, site.objectID)
         XCTAssertEqual(viewModel.recentSites.count, 1)
     }
 
@@ -71,18 +71,5 @@ final class BlogListViewModelTests: CoreDataTestCase {
 
         let displayedNames = viewModel.allSites.map(\.title)
         XCTAssertEqual(displayedNames, [".Org", "51 Zone", "a", "A", "C"])
-    }
-
-    func testSiteSelectedUpdatesLastUsedDate() throws {
-        let siteID = 4839
-        let _ = BlogBuilder(mainContext)
-            .with(dotComID: siteID)
-            .with(lastUsed: nil)
-            .build()
-        try mainContext.save()
-
-        _ = viewModel.didSelectSite(withSiteID: siteID as NSNumber)
-
-        XCTAssertEqual(viewModel.recentSites.first?.id, siteID as NSNumber)
     }
 }

--- a/WordPress/WordPressTest/WordPressUnitTests.xctestplan
+++ b/WordPress/WordPressTest/WordPressUnitTests.xctestplan
@@ -54,13 +54,6 @@
     },
     {
       "target" : {
-        "containerPath" : "container:WordPress.xcodeproj",
-        "identifier" : "4A98A2FA2C22736F00A2CE58",
-        "name" : "WordPressKitTests"
-      }
-    },
-    {
-      "target" : {
         "containerPath" : "container:..\/Modules",
         "identifier" : "DesignSystemTests",
         "name" : "DesignSystemTests"


### PR DESCRIPTION
A small PR addressing Tony's feedback for https://github.com/wordpress-mobile/WordPress-iOS/pull/23439.

- Add missing analytics events
- Fix the identifier used for cells so that it works if you have more than on self-hosted site
- Remove unwanted `NSLog`
- Add missing `deletePendingLocalNotification` call

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
