### PR TITLE
Fix an issue with recent sites showing site that were never open

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -81,6 +81,7 @@ final class BlogListViewModel: NSObject, ObservableObject {
         rawSites = getFilteredSites(from: fetchedResultsController)
 
         recentSites = rawSites
+            .filter { $0.lastUsed != nil }
             .sorted { ($0.lastUsed ?? .distantPast) > ($1.lastUsed ?? .distantPast) }
             .prefix(5)
             .map(BlogListSiteViewModel.init)


### PR DESCRIPTION
The previous implementation was showing the five most recent sites, but that also included sites that were never open and had `site.lastUsed = nil` resulting in issue with unstable ordering:

https://github.com/user-attachments/assets/4c6c2f60-0375-470a-805b-b4dc681d2998


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
