### PR TITLE
Deprecate new Blog/lastUsed database field

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -173,10 +173,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, strong, readwrite, nullable) NSDictionary *capabilities;
 @property (nonatomic, strong, readwrite, nullable) NSSet<QuickStartTourState *> *quickStartTours;
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quickStartTypeValue;
-
-// Site Switcher Convenience Properties
-@property (nonatomic, strong, readwrite, nullable) NSDate *pinnedDate;
-@property (nonatomic, strong, readwrite, nullable) NSDate *lastUsed;
 /// The blog's user ID for the current user
 @property (nonatomic, strong, readwrite, nullable) NSNumber *userID;
 /// Disk quota for site, this is only available for WP.com sites

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -93,8 +93,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 @dynamic quotaSpaceUsed;
 @dynamic pageTemplateCategories;
 @dynamic publicizeInfo;
-@dynamic pinnedDate;
-@dynamic lastUsed;
 
 @synthesize isSyncingPosts;
 @synthesize isSyncingPages;

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -19,7 +19,7 @@ class RecentSitesService: NSObject {
 
     /// The maximum number of recent sites (read only)
     ///
-    @objc let maxSiteCount = 3
+    @objc let maxSiteCount = 4
 
     // MARK: - Initialization
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -16,14 +16,17 @@ final class BlogListViewModel: NSObject, ObservableObject {
     private let contextManager: ContextManager
     private let blogService: BlogService
     private let eventTracker: EventTracker
+    private let recentSitesService: RecentSitesService
     private var syncBlogsTask: Task<Void, Error>?
 
     init(configuration: BlogListConfiguration = .defaultConfig,
          contextManager: ContextManager = ContextManager.sharedInstance(),
+         recentSitesService: RecentSitesService = RecentSitesService(),
          eventTracker: EventTracker = DefaultEventTracker()) {
         self.configuration = configuration
         self.contextManager = contextManager
         self.blogService = BlogService(coreDataStack: contextManager)
+        self.recentSitesService = recentSitesService
         self.eventTracker = eventTracker
         self.fetchedResultsController = createFetchedResultsController(in: contextManager.mainContext)
         super.init()
@@ -37,18 +40,13 @@ final class BlogListViewModel: NSObject, ObservableObject {
         if selectedBlog() != blog {
             PushNotificationsManager.shared.deletePendingLocalNotifications()
         }
-        eventTracker.track(.siteSwitcherSiteTapped, properties: [
-            "section": blog.lastUsed != nil ? "recent" : "all"
-        ])
-        blog.lastUsed = Date()
+        eventTracker.track(.siteSwitcherSiteTapped)
+        recentSitesService.touch(blog: blog)
         contextManager.saveContextAndWait(contextManager.mainContext)
         return blog
     }
 
     func onAppear() {
-        if recentSites.isEmpty {
-            selectedBlog()?.lastUsed = Date()
-        }
         contextManager.save(contextManager.mainContext)
 
         Task {
@@ -80,19 +78,18 @@ final class BlogListViewModel: NSObject, ObservableObject {
     private func updateDisplayedSites() {
         rawSites = getFilteredSites(from: fetchedResultsController)
 
-        recentSites = rawSites
-            .filter { $0.lastUsed != nil }
-            .sorted { ($0.lastUsed ?? .distantPast) > ($1.lastUsed ?? .distantPast) }
-            .prefix(5)
+        var sitesByURL: [String: Blog] = [:]
+        for site in rawSites where site.url != nil {
+            sitesByURL[site.url!] = site
+        }
+
+        recentSites = recentSitesService.recentSites
+            .compactMap { sitesByURL[$0] }
             .map(BlogListSiteViewModel.init)
-            .sorted {
-                $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
-            }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
         allSites = rawSites.map(BlogListSiteViewModel.init)
-            .sorted {
-                $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
-            }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
 
         updateSearchResults()
     }
@@ -160,7 +157,7 @@ private func createFetchedResultsController(in context: NSManagedObjectContext) 
     let request = NSFetchRequest<Blog>(entityName: NSStringFromClass(Blog.self))
     /// - warning: sorting happens in the ViewModel. It's irrelevant what descriptor
     /// is provided here, but Core Data requires one.
-    request.sortDescriptors = [NSSortDescriptor(keyPath: \Blog.lastUsed, ascending: true)]
+    request.sortDescriptors = [NSSortDescriptor(keyPath: \Blog.url, ascending: true)]
     return NSFetchedResultsController(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
 }
 

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -144,16 +144,6 @@ final class BlogBuilder {
         return self
     }
 
-    func with(pinnedDate: Date?) -> Self {
-        blog.pinnedDate = pinnedDate
-        return self
-    }
-
-    func with(lastUsed: Date?) -> Self {
-        blog.lastUsed = lastUsed
-        return self
-    }
-
     func with(url: String) -> Self {
         blog.url = url
 

--- a/WordPress/WordPressTest/BlogListViewModelTests.swift
+++ b/WordPress/WordPressTest/BlogListViewModelTests.swift
@@ -3,11 +3,16 @@ import XCTest
 
 final class BlogListViewModelTests: CoreDataTestCase {
     private var viewModel: BlogListViewModel!
+    private let recentSitesService = RecentSitesService(database: EphemeralKeyValueDatabase())
 
     override func setUp() {
         super.setUp()
 
-        viewModel = BlogListViewModel(contextManager: contextManager)
+        setupViewModel()
+    }
+
+    private func setupViewModel() {
+        viewModel = BlogListViewModel(contextManager: contextManager, recentSitesService: recentSitesService)
     }
 
     // MARK: - Tests for Retrieval Functions
@@ -20,11 +25,13 @@ final class BlogListViewModelTests: CoreDataTestCase {
         let siteID = 34984
         let site = BlogBuilder(mainContext)
             .with(dotComID: siteID)
-            .with(lastUsed: Date())
+            .with(url: "test")
             .build()
         try mainContext.save()
 
-        viewModel = BlogListViewModel(contextManager: contextManager)
+        recentSitesService.touch(blog: site)
+
+        setupViewModel()
 
         XCTAssertEqual(viewModel.recentSites.first?.id, site.objectID)
         XCTAssertEqual(viewModel.recentSites.count, 1)
@@ -35,28 +42,24 @@ final class BlogListViewModelTests: CoreDataTestCase {
         let _ = BlogBuilder(mainContext)
             .with(siteName: "A")
             .with(dotComID: siteID1)
-            .with(lastUsed: Date())
             .build()
 
         let siteID2 = 54317
         let _ = BlogBuilder(mainContext)
             .with(siteName: "51 Zone")
             .with(dotComID: siteID2)
-            .with(pinnedDate: Date())
             .build()
 
         let siteID3 = 13287
         let _ = BlogBuilder(mainContext)
             .with(siteName: "a")
             .with(dotComID: siteID3)
-            .with(pinnedDate: Date())
             .build()
 
         let siteID4 = 54317
         let _ = BlogBuilder(mainContext)
             .with(siteName: ".Org")
             .with(dotComID: siteID4)
-            .with(pinnedDate: Date())
             .build()
 
         let siteID5 = 43788
@@ -67,7 +70,7 @@ final class BlogListViewModelTests: CoreDataTestCase {
 
         try mainContext.save()
 
-        viewModel = BlogListViewModel(contextManager: contextManager)
+        setupViewModel()
 
         let displayedNames = viewModel.allSites.map(\.title)
         XCTAssertEqual(displayedNames, [".Org", "51 Zone", "a", "A", "C"])

--- a/WordPress/WordPressTest/RecentSitesServiceTests.swift
+++ b/WordPress/WordPressTest/RecentSitesServiceTests.swift
@@ -13,7 +13,8 @@ class RecentSitesServiceTests: XCTestCase {
         service.touch(site: "site2")
         service.touch(site: "site3")
         service.touch(site: "site4")
-        XCTAssertEqual(service.recentSites, ["site4", "site3", "site2"])
+        service.touch(site: "site5")
+        XCTAssertEqual(service.recentSites, ["site5", "site4", "site3", "site2"])
     }
 
     func testDoesNotDuplicate() {


### PR DESCRIPTION
I've been reviewing the new implementation and noticed that it was using a new `blog.lastUsed` field, but the app already has a perfectly good `RecentSitesService` that is used across the app and its extension and is the key part of the some of the app features. It was uncalled for to add `blog.lastUsed`, so I deprecated it and make sure we still use `RecentSitesService`.

To test: check that "Recent Sites" section still works.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
