### PR TITLE
Integrate TipKit

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -113,6 +113,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         setupBackgroundRefresh(application)
         UITestConfigurator.prepareApplicationForUITests(application)
         DebugMenuViewController.configure(in: window)
+        AppTips.initialize()
 
         // This was necessary to properly load fonts for the Stories editor. I believe external libraries may require this call to access fonts.
         let fonts = Bundle.main.urls(forResourcesWithExtension: "ttf", subdirectory: nil)

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -14,6 +14,7 @@ enum FeatureFlag: Int, CaseIterable {
     case autoSaveDrafts
     case voiceToContent
     case authenticateUsingApplicationPassword
+    case tipKit
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -46,6 +47,8 @@ enum FeatureFlag: Int, CaseIterable {
             return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .authenticateUsingApplicationPassword:
             return false
+        case .tipKit:
+            return BuildConfiguration.current != .appStore
         }
     }
 
@@ -80,6 +83,7 @@ extension FeatureFlag {
         case .autoSaveDrafts: "Autosave Drafts"
         case .voiceToContent: "Voice to Content"
         case .authenticateUsingApplicationPassword: "Authenticate self-hosted sites using Application Password"
+        case .tipKit: "TipKit"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -201,7 +201,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         Task { @MainActor in
             await overlaysCoordinator.presentOverlayIfNeeded(in: self)
         }
-
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -131,6 +131,10 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
         navigationController.modalPresentationStyle = .formSheet
         present(navigationController, animated: true)
         WPAnalytics.track(.mySiteSiteSwitcherTapped)
+
+        if #available(iOS 17, *) {
+            AppTips.SitePickerTip().invalidate(reason: .actionPerformed)
+        }
     }
 
     func visitSiteTapped() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -4,6 +4,7 @@ import WordPressShared
 import SwiftUI
 import SVProgressHUD
 import DesignSystem
+import TipKit
 
 final class SitePickerViewController: UIViewController {
 
@@ -27,6 +28,10 @@ final class SitePickerViewController: UIViewController {
         return headerView
     }()
 
+    private var tipSitePicker = AppTips.SitePickerTip()
+    private var tipSitePickerTask: Task<Void, Never>?
+    private weak var tipPopoverController: UIViewController?
+
     init(blog: Blog,
          meScenePresenter: ScenePresenter,
          blogService: BlogService? = nil,
@@ -44,9 +49,24 @@ final class SitePickerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         setupHeaderView()
         startObservingQuickStart()
         startObservingTitleChanges()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if #available(iOS 17.0, *) {
+            startObservingTips()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        stopObservingTips()
     }
 
     private func setupHeaderView() {
@@ -63,6 +83,34 @@ final class SitePickerViewController: UIViewController {
         DispatchQueue.main.async {
             self.updateTitles()
         }
+    }
+
+    @available(iOS 17.0, *)
+    private func startObservingTips() {
+        guard Feature.enabled(.tipKit) else { return }
+
+        tipSitePickerTask = tipSitePickerTask ?? Task { @MainActor in
+            for await shouldDisplay in tipSitePicker.shouldDisplayUpdates {
+                if shouldDisplay {
+                    let popoverController = TipUIPopoverViewController(tipSitePicker, sourceItem: blogDetailHeaderView.titleView.siteSwitcherButton)
+                    popoverController.view.tintColor = .secondaryLabel
+                    popoverController.popoverPresentationController?.permittedArrowDirections = [.up]
+                    present(popoverController, animated: true)
+                    tipPopoverController = popoverController
+                }
+                else {
+                    if presentedViewController is TipUIPopoverViewController {
+                        dismiss(animated: true)
+                        tipPopoverController = nil
+                    }
+                }
+            }
+        }
+    }
+
+    private func stopObservingTips() {
+        tipSitePickerTask?.cancel()
+        tipSitePickerTask = nil
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -55,12 +55,16 @@ final class SitePickerViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if #available(iOS 17, *), sitePickerTipObserver == nil {
-            sitePickerTipObserver = registerTipPopover(
-                AppTips.SitePickerTip(),
-                sourceView: blogDetailHeaderView.titleView.siteSwitcherButton,
-                arrowDirection: [.up]
-            )
+        if #available(iOS 17, *) {
+            AppTips.SitePickerTip.blogCount = blog.account?.blogs.count ?? 0
+
+            if sitePickerTipObserver == nil {
+                sitePickerTipObserver = registerTipPopover(
+                    AppTips.SitePickerTip(),
+                    sourceView: blogDetailHeaderView.titleView.siteSwitcherButton,
+                    arrowDirection: [.up]
+                )
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import AutomatticTracks
 import SwiftUI
 import WordPressFlux
+import TipKit
 
 struct DebugMenuView: View {
     @StateObject private var viewModel = DebugMenuViewModel()
@@ -12,6 +13,9 @@ struct DebugMenuView: View {
         List {
             Section { main }
             Section(Strings.sectionSettings) { settings }
+            if #available(iOS 17, *) {
+                Section(Strings.sectionTipKit) { tipKit }
+            }
             if let blog = viewModel.blog {
                 Section(Strings.sectionQuickStart) { makeQuickStart(with: blog) }
             }
@@ -49,6 +53,22 @@ struct DebugMenuView: View {
         }
         NavigationLink(Strings.readerCssTitle) {
             readerSettings
+        }
+    }
+
+    @available(iOS 17, *)
+    @ViewBuilder private var tipKit: some View {
+        Button(Strings.showAllTips) {
+            Tips.showAllTipsForTesting()
+            showSuccessNotice()
+        }
+        Button(Strings.hideAllTips) {
+            Tips.hideAllTipsForTesting()
+            showSuccessNotice()
+        }
+        Button(Strings.resetTipKitData, role: .destructive) {
+            try? Tips.resetDatastore()
+            showSuccessNotice()
         }
     }
 
@@ -206,6 +226,7 @@ private enum Strings {
     static let sectionSettings = NSLocalizedString("debugMenu.section.settings", value: "Settings", comment: "Debug Menu section title")
     static let sectionLogging = NSLocalizedString("debugMenu.section.logging", value: "Logging", comment: "Debug Menu section title")
     static let sectionQuickStart = NSLocalizedString("debugMenu.section.quickStart", value: "Quick Start", comment: "Debug Menu section title")
+    static let sectionTipKit = NSLocalizedString("debugMenu.section.tipKit", value: "TipKit", comment: "Debug Menu section title")
     static let sandboxStoreCookieSecretRow = NSLocalizedString("Sandbox Store", comment: "Title of a row displayed on the debug screen used to configure the sandbox store use in the App.")
     static let quickStartForNewSiteRow = NSLocalizedString("Enable Quick Start for New Site", comment: "Title of a row displayed on the debug screen used in debug builds of the app")
     static let quickStartForExistingSiteRow = NSLocalizedString("Enable Quick Start for Existing Site", comment: "Title of a row displayed on the debug screen used in debug builds of the app")
@@ -222,4 +243,8 @@ private enum Strings {
     static let removeQuickStartRow = NSLocalizedString("debugMenu.removeQuickStart", value: "Remove Current Tour", comment: "Remove current quick start tour menu item")
     static let weeklyRoundup = NSLocalizedString("debugMenu.weeklyRoundup", value: "Weekly Roundup", comment: "Weekly Roundup debug menu item")
     static let booleanUserDefaults = NSLocalizedString("debugMenu.booleanUserDefaults", value: "Boolean User Defaults", comment: "Boolean User Defaults debug menu item")
+
+    static let showAllTips = NSLocalizedString("debugMenu.showAllTips", value: "Show All Tips", comment: "Debug Menu action for TipKit")
+    static let hideAllTips = NSLocalizedString("debugMenu.hideAllTips", value: "Hide All Tips", comment: "Debug Menu action for TipKit")
+    static let resetTipKitData = NSLocalizedString("debugMenu.resetTipKitData", value: "Reset Data", comment: "Debug Menu action for TipKit")
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -206,9 +206,11 @@ import WordPressUI
     }
 
     private func showCreateButton(notice: Notice) {
-        if !didDismissTooltip {
-            noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
-            shownTooltipCount += 1
+        if !Feature.enabled(.tipKit) {
+            if !didDismissTooltip {
+                noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
+                shownTooltipCount += 1
+            }
         }
 
         if UIAccessibility.isReduceMotionEnabled {

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import TipKit
+import Combine
 
 enum AppTips {
     static func initialize() {
@@ -12,10 +13,59 @@ enum AppTips {
         }
     }
 
+    @available(iOS 17, *)
     struct SitePickerTip: Tip {
         let id = "site_picker_tip"
-        let title = Text(NSLocalizedString("tips.sitePickerTip.title", value: "Your Sites", comment: "Tip for site picker"))
-        let message: Text? = Text(NSLocalizedString("tips.sitePickerTip.message", value: "Tap to select a different site or create a new one", comment: "Tip for site picker"))
-        let image: Image? = Image(systemName: "rectangle.stack.badge.plus")
+
+        var title: Text {
+            Text(NSLocalizedString("tips.sitePickerTip.title", value: "Your Sites", comment: "Tip for site picker"))
+        }
+
+        var message: Text? {
+            Text(NSLocalizedString("tips.sitePickerTip.message", value: "Tap to select a different site or create a new one", comment: "Tip for site picker"))
+        }
+
+        var image: Image? {
+            Image(systemName: "rectangle.stack.badge.plus")
+        }
+
+        var options: [any TipOption] {
+            MaxDisplayCount(1)
+        }
     }
 }
+
+extension UIViewController {
+    /// Registers a popover to be displayed for the given tip.
+    @available(iOS 17, *)
+    func registerTipPopover(
+        _ tip: some Tip,
+        sourceView: UIView,
+        arrowDirection: UIPopoverArrowDirection? = nil
+    ) -> TipObserver? {
+        guard Feature.enabled(.tipKit) else {
+            return nil
+        }
+        let task = Task { @MainActor [weak self] in
+            for await shouldDisplay in tip.shouldDisplayUpdates {
+                if shouldDisplay {
+                    let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceView)
+                    popoverController.view.tintColor = .secondaryLabel
+                    if let arrowDirection {
+                        popoverController.popoverPresentationController?.permittedArrowDirections = arrowDirection
+                    }
+                    self?.present(popoverController, animated: true)
+                } else {
+                    if self?.presentedViewController is TipUIPopoverViewController {
+                        self?.dismiss(animated: true)
+                    }
+                }
+            }
+        }
+        return TipObserver {
+            task.cancel()
+        }
+    }
+}
+
+typealias TipObserver = AnyCancellable

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -7,7 +7,7 @@ enum AppTips {
     static func initialize() {
         guard Feature.enabled(.tipKit), #available(iOS 17, *) else { return }
         do {
-            try Tips.configure([.displayFrequency(.daily)])
+            try Tips.configure()
         } catch {
             DDLogError("Error initializing tips: \(error)")
         }

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -41,7 +41,8 @@ extension UIViewController {
     func registerTipPopover(
         _ tip: some Tip,
         sourceView: UIView,
-        arrowDirection: UIPopoverArrowDirection? = nil
+        arrowDirection: UIPopoverArrowDirection? = nil,
+        actionHandler: ((Tips.Action) -> Void)? = nil
     ) -> TipObserver? {
         guard Feature.enabled(.tipKit) else {
             return nil
@@ -49,7 +50,7 @@ extension UIViewController {
         let task = Task { @MainActor [weak self] in
             for await shouldDisplay in tip.shouldDisplayUpdates {
                 if shouldDisplay {
-                    let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceView)
+                    let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceView, actionHandler: actionHandler ?? { _ in })
                     popoverController.view.tintColor = .secondaryLabel
                     if let arrowDirection {
                         popoverController.popoverPresentationController?.permittedArrowDirections = arrowDirection

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -6,7 +6,7 @@ enum AppTips {
     static func initialize() {
         guard Feature.enabled(.tipKit), #available(iOS 17, *) else { return }
         do {
-            try Tips.configure()
+            try Tips.configure([.displayFrequency(.daily)])
         } catch {
             DDLogError("Error initializing tips: \(error)")
         }

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftUI
+import TipKit
+
+enum AppTips {
+    static func initialize() {
+        guard Feature.enabled(.tipKit), #available(iOS 17, *) else { return }
+        do {
+            try Tips.configure()
+        } catch {
+            DDLogError("Error initializing tips: \(error)")
+        }
+    }
+
+    struct SitePickerTip: Tip {
+        let id = "site_picker_tip"
+        let title = Text(NSLocalizedString("tips.sitePickerTip.title", value: "Your Sites", comment: "Tip for site picker"))
+        let message: Text? = Text(NSLocalizedString("tips.sitePickerTip.message", value: "Tap to select a different site or create a new one", comment: "Tip for site picker"))
+        let image: Image? = Image(systemName: "rectangle.stack.badge.plus")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -29,6 +29,13 @@ enum AppTips {
             Image(systemName: "rectangle.stack.badge.plus")
         }
 
+        @Parameter(.transient)
+        static var blogCount: Int = 0
+
+        var rules: [Rule] {
+            #Rule(Self.$blogCount) { $0 > 1 }
+        }
+
         var options: [any TipOption] {
             MaxDisplayCount(1)
         }

--- a/WordPress/UITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/UITests/Utils/XCTest+Extensions.swift
@@ -42,6 +42,8 @@ extension XCTestCase {
             app.launchArguments.append(contentsOf: ["-ui-test-select-wpcom-site", selectWPComSite])
         }
 
+        app.launchArguments.append(contentsOf: ["-ff-override-TipKit", "false"])
+
         if removeBeforeLaunching {
             removeApp(app)
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -619,6 +619,8 @@
 		0CDA09042BD022130032D123 /* PostMediaUploadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA09022BD022130032D123 /* PostMediaUploadsView.swift */; };
 		0CDA090C2BD04B270032D123 /* PostMediaUploadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */; };
 		0CDA090D2BD04B270032D123 /* PostMediaUploadsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */; };
+		0CDB4CF42C5D6723001BE6D7 /* AppTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDB4CF32C5D6723001BE6D7 /* AppTips.swift */; };
+		0CDB4CF52C5D6863001BE6D7 /* AppTips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDB4CF32C5D6723001BE6D7 /* AppTips.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CE538CA2B0D6E0000834BA2 /* ExternalMediaDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */; };
@@ -6602,6 +6604,7 @@
 		0CD9FB8A2AFADAFE009D9C7A /* SiteMediaPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPageViewController.swift; sourceTree = "<group>"; };
 		0CDA09022BD022130032D123 /* PostMediaUploadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadsView.swift; sourceTree = "<group>"; };
 		0CDA090B2BD04B270032D123 /* PostMediaUploadsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMediaUploadsViewModel.swift; sourceTree = "<group>"; };
+		0CDB4CF32C5D6723001BE6D7 /* AppTips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTips.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaDataSource.swift; sourceTree = "<group>"; };
 		0CE538CF2B0E317000834BA2 /* StockPhotosWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosWelcomeView.swift; sourceTree = "<group>"; };
@@ -10906,6 +10909,14 @@
 			path = Search;
 			sourceTree = "<group>";
 		};
+		0CDB4CF22C5D6715001BE6D7 /* Tips */ = {
+			isa = PBXGroup;
+			children = (
+				0CDB4CF32C5D6723001BE6D7 /* AppTips.swift */,
+			);
+			path = Tips;
+			sourceTree = "<group>";
+		};
 		0CE7833F2B08FB1B00B114EB /* External */ = {
 			isa = PBXGroup;
 			children = (
@@ -14676,6 +14687,7 @@
 				D865720F21869C380023A99C /* Site Creation */,
 				3792259E12F6DBCC00F2176A /* Stats */,
 				319D6E8219E44C7B0013871C /* Suggestions */,
+				0CDB4CF22C5D6715001BE6D7 /* Tips */,
 				98077B58207555E400109F95 /* Support */,
 				8584FDB619243AC40019C02E /* System */,
 				5DA5BF4918E32DDB005F11F9 /* Themes */,
@@ -22106,6 +22118,7 @@
 				E6D3B1431D1C702600008D4B /* ReaderFollowedSitesViewController.swift in Sources */,
 				8BEE846427B1E05B0001A93C /* DashboardCardModel.swift in Sources */,
 				3F6AD0562502A91400080F3B /* AnnouncementsCache.swift in Sources */,
+				0CDB4CF42C5D6723001BE6D7 /* AppTips.swift in Sources */,
 				43FF64EF20DAA0840060A69A /* GravatarUploader.swift in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
 				D8A3A5AA2069E53900992576 /* AztecMediaPickingCoordinator.swift in Sources */,
@@ -26306,6 +26319,7 @@
 				FABB25A12602FC2C00C8785C /* QuickStartChecklistViewController.swift in Sources */,
 				FABB25A22602FC2C00C8785C /* MenuItemsViewController.m in Sources */,
 				FABB25A32602FC2C00C8785C /* ReachabilityUtils+OnlineActions.swift in Sources */,
+				0CDB4CF52C5D6863001BE6D7 /* AppTips.swift in Sources */,
 				FABB25A42602FC2C00C8785C /* TableViewKeyboardObserver.swift in Sources */,
 				FABB25A52602FC2C00C8785C /* BlogToJetpackAccount.m in Sources */,
 				FABB25A62602FC2C00C8785C /* NotificationSettingsViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -83,6 +83,18 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-com.apple.TipKit.ShowAllTips 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.HideAllTips 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.ResetDataStore 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-extra_debug 1"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -83,18 +83,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-com.apple.TipKit.ShowAllTips 1"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-com.apple.TipKit.HideAllTips 1"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-com.apple.TipKit.ResetDataStore 1"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "-extra_debug 1"
             isEnabled = "NO">
          </CommandLineArgument>
@@ -112,6 +100,18 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-debugJetpackConnectionFlow"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.ShowAllTips 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.HideAllTips 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.ResetDataStore 1"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -125,6 +125,18 @@
             argument = "-debugJetpackConnectionFlow"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.ShowAllTips 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.HideAllTips 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.TipKit.ResetDataStore 1"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable


### PR DESCRIPTION
## TipKit

In https://github.com/wordpress-mobile/WordPress-iOS/pull/23469, we removed the `LoginEpilogue` screen, and the app now automatically selects one of your sites after login, defaulting to your primary site. To make sure the users learn how to switch to a different site, this PR integrate Apple's TipKit.

The first time you log in with an existing account with two or more sites, the app will show the "Your Sites" tip. The tip is shown only once. If you log in on a different device with the same Apple ID, the previously shown tips are not shown again.

<img width="320" alt="Screenshot 2024-08-02 at 3 39 20 PM" src="https://github.com/user-attachments/assets/e8034b65-54d0-4524-b70d-6b97494af9b5">

### Resources

- [WWDC23: Make features discoverable with TipKit | Apple](https://www.youtube.com/watch?v=yppA9-n0fL4)
- [Sample code: Highlighting app features with TipKit](https://developer.apple.com/documentation/tipkit/highlightingappfeatureswithtipkit)

## Quick Start

TipKit will also be used as a replacement for the existing Quick Start tours.

This PR removes the "What would you like to focus on first?" screen. It was [added](https://github.com/wordpress-mobile/WordPress-iOS/pull/18385) for the following reasons:

```
[**] We'll now ask users logging in which area of the app they'd like to focus on to build towards a more personalized experience. [#18385]"
```

There was no follow-up, and this screen does nothing other than simply opening one of the selected primary areas in the app, but only after showing the "Enable Notifications?" screen.

<img width="300" alt="Screenshot 2024-08-12 at 1 29 09 PM" src="https://github.com/user-attachments/assets/9a389c7c-6e90-43a8-88de-1f01caa17592">

This screen is also the entry point for the "existing site" Quick Start tour – the "Not sure, show me around" option. By removing it, you can no longer initiate this tour.

<img width="300" alt="Screenshot 2024-08-12 at 1 40 48 PM" src="https://github.com/user-attachments/assets/cd329bf1-5ea1-4d3a-b5b1-7578afe66d71">

The next step would be to consider if there are any good candidates for being replaced with TipKit.

## Debug Options

I added the following launch arguments to the schemes.

<img width="320" alt="Screenshot 2024-08-12 at 10 07 47 AM" src="https://github.com/user-attachments/assets/c77f2d5f-fa73-4844-a506-6d2ef798d6ed">

The same options are also added to the Debug Menu.

<img width="320" alt="Screenshot 2024-08-12 at 1 27 49 PM" src="https://github.com/user-attachments/assets/75f7fb9c-4f72-4564-9704-25e2d7470950">

## Testing

- Verify that the "Enable Notifications" screen is shown on the first login. Noting that in the production version, if you tapped "Skip" on the "Onboarding Questions" screen, the app would never prompt you to enable notifications 😨 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
