### PR TITLE
Add a missing call to failure block

### DIFF
--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -35,6 +35,7 @@ import WordPressKit
     @objc func syncPublicizeServicesForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         guard let remote = remoteForBlog(blog),
               let blogID = blog.dotComID else {
+            failure?(nil)
             return
         }
 


### PR DESCRIPTION
This PR fixes an issue where pull to refresh in "My Sites" home screen won't finish loading.

To test:

Select a self-hosted site, go to My Sites home screen, pull to refresh, observe the pull to refresh spinner.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verify the issue has been fixed.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
