### PR TITLE
Disable Photon for P2 sites

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -108,7 +108,7 @@ extension UIImageView {
         imageSize: CGSize = SiteIconDefaults.imageSize,
         placeholderImage: UIImage? = .siteIconPlaceholder
     ) {
-        guard let siteIconPath = blog.icon, let siteIconURL = SiteIconViewModel.optimizedURL(for: siteIconPath, imageSize: imageSize) else {
+        guard let siteIconPath = blog.icon, let siteIconURL = SiteIconViewModel.optimizedURL(for: siteIconPath, imageSize: imageSize, isP2: blog.isAutomatticP2) else {
 
             if blog.isWPForTeams() && placeholderImage == .siteIconPlaceholder {
                 image = UIImage.gridicon(.p2, size: imageSize)

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -30,7 +30,7 @@ struct SiteIconViewModel {
         self.firstLetter = blog.title?.first
 
         if blog.hasIcon, let icon = blog.icon {
-            self.imageURL = SiteIconViewModel.optimizedURL(for: icon, imageSize: size.size)
+            self.imageURL = SiteIconViewModel.optimizedURL(for: icon, imageSize: size.size, isP2: blog.isAutomatticP2)
             self.host = MediaHost(with: blog)
         }
     }
@@ -38,8 +38,8 @@ struct SiteIconViewModel {
 
 extension SiteIconViewModel {
     /// Returns the Size Optimized URL for a given Path.
-    static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size) -> URL? {
-        if isPhotonURL(path) || isDotcomURL(path) {
+    static func optimizedURL(for path: String, imageSize: CGSize = SiteIconViewModel.Size.regular.size, isP2: Bool = false) -> URL? {
+        if isPhotonURL(path) || isDotcomURL(path) || isP2 {
             return optimizedDotcomURL(from: path, imageSize: imageSize)
         }
         if isBlavatarURL(path) {


### PR DESCRIPTION
Fixes loading of site icons for Automattic sites. This is a stopgap solution.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
