### PR TITLE
Integrate SiteIconView in NotificationSettingsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -1,4 +1,3 @@
-import DesignSystem
 import SwiftUI
 import WordPressShared
 
@@ -6,19 +5,18 @@ struct BlogListSiteView: View {
     let site: BlogListSiteViewModel
 
     var body: some View {
-        HStack(alignment: .center, spacing: .DS.Padding.double) {
+        HStack(alignment: .center, spacing: 16) {
             SiteIconView(viewModel: site.icon)
                 .frame(width: 40, height: 40)
 
             VStack(alignment: .leading) {
                 Text(site.title)
                     .font(.callout.weight(.medium))
-                    .foregroundStyle(Color.DS.Foreground.primary)
                     .lineLimit(2)
 
                 Text(site.domain)
                     .font(.footnote)
-                    .foregroundStyle(Color.DS.Foreground.secondary)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -34,6 +34,12 @@ struct SiteIconViewModel {
             self.host = MediaHost(with: blog)
         }
     }
+
+    init(readerSiteTopic: ReaderSiteTopic, size: Size = .regular) {
+        self.size = size
+        self.firstLetter = readerSiteTopic.title.first
+        self.imageURL = SiteIconViewModel.optimizedBlavatarURL(from: readerSiteTopic.siteBlavatar, imageSize: size.size)
+    }
 }
 
 extension SiteIconViewModel {
@@ -54,7 +60,7 @@ extension SiteIconViewModel {
         return parseURL(path: path, query: query)
     }
 
-    private static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
+    static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
         return parseURL(path: path, query: query)

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NotificationSettingsSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NotificationSettingsSiteView.swift
@@ -1,0 +1,42 @@
+import Foundation
+import SwiftUI
+
+struct NotificationSettingsSiteView: View {
+    let viewModel: NotificationSettingsSiteViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            SiteIconView(viewModel: viewModel.icon)
+                .frame(width: 32, height: 32)
+
+            VStack(alignment: .leading) {
+                Text(viewModel.title)
+                    .font(.body)
+                    .lineLimit(1)
+
+                Text(viewModel.details)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+struct NotificationSettingsSiteViewModel {
+    let title: String
+    let details: String
+    let icon: SiteIconViewModel
+
+    init(blog: Blog) {
+        self.title = blog.title ?? "–"
+        self.details = blog.displayURL as String? ?? ""
+        self.icon = SiteIconViewModel(blog: blog)
+    }
+
+    init(topic: ReaderSiteTopic) {
+        self.title = topic.title
+        self.details = URL(string: topic.siteURL)?.host(percentEncoded: false) ?? ""
+        self.icon = SiteIconViewModel(readerSiteTopic: topic)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -474,6 +474,8 @@
 		0C23F33E2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23F33D2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift */; };
 		0C23F33F2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C23F33D2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift */; };
 		0C2518AE2ABE1F2800381D31 /* iphone-photo.heic in Resources */ = {isa = PBXBuildFile; fileRef = 0C2518AD2ABE1EA000381D31 /* iphone-photo.heic */; };
+		0C27CEAB2C6137C3002E3F05 /* NotificationSettingsSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27CEAA2C6137C2002E3F05 /* NotificationSettingsSiteView.swift */; };
+		0C27CEAC2C6137C3002E3F05 /* NotificationSettingsSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C27CEAA2C6137C2002E3F05 /* NotificationSettingsSiteView.swift */; };
 		0C2C83FA2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */; };
 		0C2C83FB2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */; };
 		0C2C83FD2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C2C83FC2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift */; };
@@ -6534,6 +6536,7 @@
 		0C23F3352AC4AD3400EE6117 /* SiteMediaSelectionTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaSelectionTitleView.swift; sourceTree = "<group>"; };
 		0C23F33D2AC4AEF600EE6117 /* SiteMediaPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaPickerViewController.swift; sourceTree = "<group>"; };
 		0C2518AD2ABE1EA000381D31 /* iphone-photo.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iphone-photo.heic"; sourceTree = "<group>"; };
+		0C27CEAA2C6137C2002E3F05 /* NotificationSettingsSiteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsSiteView.swift; sourceTree = "<group>"; };
 		0C2C83F92A6EABF300A3ACD9 /* StatsPeriodCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodCache.swift; sourceTree = "<group>"; };
 		0C2C83FC2A6EBD3F00A3ACD9 /* StatsInsightsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsInsightsCache.swift; sourceTree = "<group>"; };
 		0C308FFD2B1234E70071C551 /* SiteMediaFilterButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaFilterButtonView.swift; sourceTree = "<group>"; };
@@ -16661,6 +16664,7 @@
 				B52C4C7C199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift */,
 				B5C66B791ACF074600F68370 /* NoteBlockUserTableViewCell.xib */,
 				FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */,
+				0C27CEAA2C6137C2002E3F05 /* NotificationSettingsSiteView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -23016,6 +23020,7 @@
 				176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */,
 				400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */,
 				9A8ECE0E2254A3260043C8DA /* JetpackConnectionWebViewController.swift in Sources */,
+				0C27CEAB2C6137C3002E3F05 /* NotificationSettingsSiteView.swift in Sources */,
 				B06378C1253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift in Sources */,
 				0C2C83FA2A6EABF300A3ACD9 /* StatsPeriodCache.swift in Sources */,
 				4353BFB221A376BF0009CED3 /* UntouchableWindow.swift in Sources */,
@@ -26199,6 +26204,7 @@
 				FABB25452602FC2C00C8785C /* Blog+Interface.swift in Sources */,
 				FABB25462602FC2C00C8785C /* PostFeaturedImageCell.m in Sources */,
 				FABB25472602FC2C00C8785C /* WPException.m in Sources */,
+				0C27CEAC2C6137C3002E3F05 /* NotificationSettingsSiteView.swift in Sources */,
 				FABB25482602FC2C00C8785C /* StatsGhostCells.swift in Sources */,
 				FABB25492602FC2C00C8785C /* NotificationCenter+ObserveOnce.swift in Sources */,
 				FABB254A2602FC2C00C8785C /* SharePost.swift in Sources */,


### PR DESCRIPTION
This PR removes one more use of `WPBlogTableViewCell` and two uses of `downloadSiteIcon` in Notifications / More / Notifications Settings.

I also slightly updated the design of the cells. The previous style from `WPBlogTableViewCell` didn't fit the form. In a form, you have to use `body` with `regular` weight to match other fields. The images and the insets were also too large for this long list.

Before → After.

<img width="320" alt="before" src="https://github.com/user-attachments/assets/ccc8acd6-a85c-42c9-b84d-e4002d34f43f">

<img width="320" alt="after" src="https://github.com/user-attachments/assets/933693f0-6675-42c3-af49-7505620a3dde">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
