### PR TITLE
Integrate SiteIconView in ReaderSiteSearchViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import WordPressShared
+import WordPressKit
 
 struct SiteIconViewModel {
     var imageURL: URL?
@@ -54,7 +55,7 @@ extension SiteIconViewModel {
         return parseURL(path: path, query: query)
     }
 
-    private static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
+    static func optimizedBlavatarURL(from path: String, imageSize: CGSize) -> URL? {
         let size = imageSize.scaled(by: UITraitCollection.current.displayScale)
         let query = String(format: "d=404&s=%d", Int(max(size.width, size.height)))
         return parseURL(path: path, query: query)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFeedCell.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import WordPressKit
+
+struct ReaderFeedCell: View {
+    let feed: ReaderFeed
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 16) {
+            SiteIconView(viewModel: .init(feed: feed))
+                .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading) {
+                Text(feed.title)
+                    .font(.body)
+                    .lineLimit(1)
+
+                Text(feed.urlForDisplay)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+extension SiteIconViewModel {
+    init(feed: ReaderFeed, size: Size = .regular) {
+        self.size = size
+        if let iconURL = feed.blavatarURL {
+            self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL.absoluteString, imageSize: size.size)
+        }
+    }
+}
+
+private extension ReaderFeed {
+    /// Strips the protocol and query from the URL.
+    ///
+    var urlForDisplay: String {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let host = components.host else {
+            return url.absoluteString
+        }
+
+        let path = components.path
+        if path.isEmpty && path != "/" {
+            return host + path
+        } else {
+            return host
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -451,6 +451,8 @@
 		0C0D3B0D2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C0D3B0E2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */; };
 		0C0DF8942C2DF14600011B7D /* LoginFacadeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0C0DF8932C2DF12A00011B7D /* LoginFacadeTests.m */; };
+		0C0F05532C6290670040390D /* ReaderFeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F05522C6290670040390D /* ReaderFeedCell.swift */; };
+		0C0F05542C6290670040390D /* ReaderFeedCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0F05522C6290670040390D /* ReaderFeedCell.swift */; };
 		0C13ACC72BF406CB00FF7405 /* VoiceToContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C13ACC62BF406CB00FF7405 /* VoiceToContentView.swift */; };
 		0C13ACC92BF406E700FF7405 /* VoiceToContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C13ACC82BF406E700FF7405 /* VoiceToContentViewModel.swift */; };
 		0C13ACCA2BF4084400FF7405 /* VoiceToContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C13ACC62BF406CB00FF7405 /* VoiceToContentView.swift */; };
@@ -6522,6 +6524,7 @@
 		0C0AE7582A8FAD6A007D9D6C /* MediaPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerMenu.swift; sourceTree = "<group>"; };
 		0C0D3B0C2A4C79DE0050A00D /* BlazeCampaignsStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignsStream.swift; sourceTree = "<group>"; };
 		0C0DF8932C2DF12A00011B7D /* LoginFacadeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoginFacadeTests.m; sourceTree = "<group>"; };
+		0C0F05522C6290670040390D /* ReaderFeedCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFeedCell.swift; sourceTree = "<group>"; };
 		0C13ACC62BF406CB00FF7405 /* VoiceToContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceToContentView.swift; sourceTree = "<group>"; };
 		0C13ACC82BF406E700FF7405 /* VoiceToContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceToContentViewModel.swift; sourceTree = "<group>"; };
 		0C1531FD2AE17140003CDE13 /* PostSearchViewModel+Highlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSearchViewModel+Highlighter.swift"; sourceTree = "<group>"; };
@@ -13409,6 +13412,7 @@
 				E6DAABDC1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift */,
 				E64ECA4C1CE62041000188A0 /* ReaderSearchViewController.swift */,
 				17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */,
+				0C0F05522C6290670040390D /* ReaderFeedCell.swift */,
 				5D1D04741B7A50B100CDE646 /* ReaderStreamViewController.swift */,
 				8BCB83D024C21063001581BD /* ReaderStreamViewController+Ghost.swift */,
 				8BB185D024B63D1600A4CCE8 /* ReaderCardsStreamViewController.swift */,
@@ -22739,6 +22743,7 @@
 				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
 				8352AC712B2A185A00F8492C /* ReaderNavigationButton.swift in Sources */,
 				80EF672527F3D63B0063B138 /* DashboardStatsStackView.swift in Sources */,
+				0C0F05532C6290670040390D /* ReaderFeedCell.swift in Sources */,
 				0CDA09032BD022130032D123 /* PostMediaUploadsView.swift in Sources */,
 				E1D0D81616D3B86800E33F4C /* SafariActivity.m in Sources */,
 				E603C7701BC94AED00AD49D7 /* WordPress-37-38.xcmappingmodel in Sources */,
@@ -25052,6 +25057,7 @@
 				FABB22192602FC2C00C8785C /* ReaderInterestsCollectionViewFlowLayout.swift in Sources */,
 				FABB221B2602FC2C00C8785C /* Theme.m in Sources */,
 				FABB221D2602FC2C00C8785C /* DefaultFormattableContentAction.swift in Sources */,
+				0C0F05542C6290670040390D /* ReaderFeedCell.swift in Sources */,
 				80D9CFF529DD314600FE3400 /* DashboardPagesListCardCell.swift in Sources */,
 				FABB221E2602FC2C00C8785C /* PostEditorNavigationBarManager.swift in Sources */,
 				FABB221F2602FC2C00C8785C /* Charts+LargeValueFormatter.swift in Sources */,


### PR DESCRIPTION
This change removes the last remaining use of `WPBlogTableViewCell`. Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/23480, it needed a dedicated cell, and, fortunately, these are extremely easy to make in SwiftUI. I also removed the weird borders likely form the ancient versions of this screen.

Update: added disclosure indicator (not shown on screenshots).

Before → After.

<img width="320" alt="reader-before" src="https://github.com/user-attachments/assets/0157458f-d118-4a25-afab-3674c6bfee33">

<img width="320" alt="reader-after" src="https://github.com/user-attachments/assets/9dcf2dcd-98ac-4df2-9473-26cb15b86b3a">



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
