### PR TITLE
Fix some warnings

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CoreTelephony
 import WordPressAuthenticator
 import WordPressKit
 import WordPressShared
@@ -215,7 +214,6 @@ protocol ZendeskUtilsProtocol {
         ticketFields.append(CustomField(fieldId: TicketFieldIDs.appVersion, value: ZendeskUtils.appVersion))
         ticketFields.append(CustomField(fieldId: TicketFieldIDs.allBlogs, value: ZendeskUtils.getBlogInformation()))
         ticketFields.append(CustomField(fieldId: TicketFieldIDs.deviceFreeSpace, value: ZendeskUtils.getDeviceFreeSpace()))
-        ticketFields.append(CustomField(fieldId: TicketFieldIDs.networkInformation, value: ZendeskUtils.getNetworkInformation()))
         ticketFields.append(CustomField(fieldId: TicketFieldIDs.logs, value: ZendeskUtils.getEncryptedLogUUID()))
         ticketFields.append(CustomField(fieldId: TicketFieldIDs.currentSite, value: ZendeskUtils.getCurrentSiteDescription()))
         ticketFields.append(CustomField(fieldId: TicketFieldIDs.sourcePlatform, value: Constants.sourcePlatform))
@@ -817,34 +815,6 @@ private extension ZendeskUtils {
         return tags
     }
 
-    static func getNetworkInformation() -> String {
-
-        var networkInformation = [String]()
-
-        let reachibilityStatus = ZDKReachability.forInternetConnection().currentReachabilityStatus()
-
-        let networkType: String = {
-            switch reachibilityStatus {
-            case .reachableViaWiFi:
-                return Constants.networkWiFi
-            case .reachableViaWWAN:
-                return Constants.networkWWAN
-            default:
-                return Constants.unknownValue
-            }
-        }()
-
-        let networkCarrier = CTTelephonyNetworkInfo().serviceSubscriberCellularProviders?.values.first
-        let carrierName = networkCarrier?.carrierName ?? Constants.unknownValue
-        let carrierCountryCode = networkCarrier?.isoCountryCode ?? Constants.unknownValue
-
-        networkInformation.append("\(Constants.networkTypeLabel) \(networkType)")
-        networkInformation.append("\(Constants.networkCarrierLabel) \(carrierName)")
-        networkInformation.append("\(Constants.networkCountryCodeLabel) \(carrierCountryCode)")
-
-        return networkInformation.joined(separator: "\n")
-    }
-
     func trackSourceEvent(_ event: WPAnalyticsStat) {
         guard let sourceTag = sourceTag else {
             WPAnalytics.track(event)
@@ -1136,9 +1106,6 @@ private extension ZendeskUtils {
         static let wpComTag = "wpcom"
         static let networkWiFi = "WiFi"
         static let networkWWAN = "Mobile"
-        static let networkTypeLabel = "Network Type:"
-        static let networkCarrierLabel = "Carrier:"
-        static let networkCountryCodeLabel = "Country Code:"
         static let zendeskProfileUDKey = "wp_zendesk_profile"
         static let profileEmailKey = "email"
         static let profileNameKey = "name"
@@ -1157,7 +1124,6 @@ private extension ZendeskUtils {
         static let appVersion: Int64 = 360000086866
         static let allBlogs: Int64 = 360000087183
         static let deviceFreeSpace: Int64 = 360000089123
-        static let networkInformation: Int64 = 360000086966
         static let logs: Int64 = 22871957
         static let currentSite: Int64 = 360000103103
         static let sourcePlatform: Int64 = 360009311651

--- a/WordPressAuthenticator/Sources/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPressAuthenticator/Sources/Services/WordPressXMLRPCAPIFacade.m
@@ -68,7 +68,7 @@ NSString *const XMLRPCOriginalErrorKey = @"XMLRPCOriginalErrorKey";
 {
     
     WordPressOrgXMLRPCApi *api = [[WordPressOrgXMLRPCApi alloc] initWithEndpoint:xmlrpc userAgent:self.userAgent];
-    [api checkCredentials:username password:password success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [api checkCredentials:username password:password success:^(id responseObject, NSHTTPURLResponse *httpResponse __unused) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (![responseObject isKindOfClass:[NSDictionary class]]) {
                 if (failure) {
@@ -83,7 +83,7 @@ NSString *const XMLRPCOriginalErrorKey = @"XMLRPCOriginalErrorKey";
             }
         });
 
-    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse __unused) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (failure) {
                 failure(error);


### PR DESCRIPTION
There are a couple of new warnings on iOS 16+. This PR fixes some of them.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
