### PR TITLE
Add support for staging sites

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -102,7 +102,7 @@
     {
       "identity" : "fsinteractivemap",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/wordpress-mobile/FSInteractiveMap",
+      "location" : "https://github.com/wordpress-mobile/FSInteractiveMap/",
       "state" : {
         "revision" : "3a05cd433c4f6bfe66f09253459cef2be058b3ec",
         "version" : "0.3.0"
@@ -365,7 +365,7 @@
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
         "branch" : "wpios-edition",
-        "revision" : "0583ccc9f1f6b748bab6a9242bbf585351d18caa"
+        "revision" : "c3eeb90e7a4f3664f85ff53f1fef009cda17d5b6"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -10,16 +10,30 @@ struct BlogListSiteView: View {
                 .frame(width: 40, height: 40)
 
             VStack(alignment: .leading) {
-                Text(site.title)
-                    .font(.callout.weight(.medium))
-                    .lineLimit(2)
+                HStack(alignment: .center) {
+                    Text(site.title)
+                        .font(.callout.weight(.medium))
 
+                    if let badge = site.badge {
+                        makeBadge(with: badge)
+                    }
+                }
                 Text(site.domain)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
             }
+            .lineLimit(1)
         }
+    }
+
+    func makeBadge(with viewModel: BlogListSiteViewModel.Badge) -> some View {
+        Text(viewModel.title.uppercased())
+            .lineLimit(1)
+            .font(.caption2.weight(.semibold))
+            .padding(EdgeInsets(top: 3, leading: 5, bottom: 3, trailing: 5))
+            .background(viewModel.color)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .frame(height: 10) // Make sure it doesn't affect the layout and spacing
     }
 }
 
@@ -29,9 +43,15 @@ final class BlogListSiteViewModel: Identifiable {
     let domain: String
     let icon: SiteIconViewModel
     let searchTags: String
+    var badge: Badge?
 
     var siteURL: URL? {
         blog.url.flatMap(URL.init)
+    }
+
+    struct Badge {
+        let title: String
+        let color: Color
     }
 
     private let blog: Blog
@@ -44,6 +64,10 @@ final class BlogListSiteViewModel: Identifiable {
 
         // By adding displayURL _after_ the title, it loweres its weight in search
         self.searchTags = "\(title) \(domain)"
+
+        if (blog.getOption(name: "is_wpcom_staging_site") as Bool?) == true {
+            badge = Badge(title: Strings.staging, color: Color.yellow.opacity(0.33))
+        }
     }
 
     func buttonViewTapped() {
@@ -58,4 +82,8 @@ final class BlogListSiteViewModel: Identifiable {
         UIPasteboard.general.string = siteURL?.absoluteString
         WPAnalytics.track(.siteListCopyLinktapped)
     }
+}
+
+private enum Strings {
+    static let staging = NSLocalizedString("blogList.siteBadge.staging", value: "Staging", comment: "Badge title in site list")
 }


### PR DESCRIPTION
- Integrates newest WPKit changes with support for staging sites and fewer Xcode warnings
- Add "Staging" badge to the new Site Picker

To test:

- Create a staging site and verify that it has a badge

<img width="320px" src="https://github.com/user-attachments/assets/fa5770c0-a3cb-4e9d-9bd6-5318f4330d37">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
