### PR TITLE
Fix flaky Blogging Prompts Tests

### DIFF
--- a/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
@@ -57,6 +57,12 @@ public class BloggingPrompt: NSManagedObject {
     func inSameDay(as dateToCompare: Date) -> Bool {
         return DateFormatters.utc.string(from: date) == DateFormatters.local.string(from: dateToCompare)
     }
+
+    /// Used for comparison on upsert  – there can't be two `BloggingPrompt` objects with the same date, so we can use it as a unique identifier
+    @objc
+    var dateString: String {
+        DateFormatters.local.string(from: date)
+    }
 }
 
 // MARK: - Notification Payload

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Encapsulates a single blogging prompt object from the v3 API.
 struct BloggingPromptRemoteObject {
     let promptID: Int
@@ -10,6 +12,11 @@ struct BloggingPromptRemoteObject {
     let answeredLink: URL?
     let answeredLinkText: String
     let bloganuaryId: String?
+
+    /// Used for comparison on import
+    var dateString: String {
+        Self.dateFormatter.string(from: date)
+    }
 }
 
 // MARK: - Decodable

--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -27,7 +27,9 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
     }()
 
     private static var calendar: Calendar = {
-        .init(identifier: .gregorian)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .gmt
+        return calendar
     }()
 
     private var api: MockWordPressComRestApi!

--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -10,13 +10,10 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
     private let fetchPromptsResponseFileName = "blogging-prompts-fetch-success"
     private let bloganuaryPromptsResponseFileName = "blogging-prompts-bloganuary"
 
-    private static let utcTimeZone = TimeZone(secondsFromGMT: 0)!
-
-    private static var dateFormatter: DateFormatter = {
+    private var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = .init(identifier: "en_US_POSIX")
-        formatter.timeZone = utcTimeZone
         return formatter
     }()
 
@@ -26,11 +23,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         return decoder
     }()
 
-    private static var calendar: Calendar = {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = .gmt
-        return calendar
-    }()
+    private let calendar = Calendar(identifier: .gregorian)
 
     private var api: MockWordPressComRestApi!
     private var remote: BloggingPromptsServiceRemoteMock!
@@ -100,7 +93,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
     func test_fetchPrompts_shouldExcludePromptsOutsideGivenDate() throws {
         // this should exclude the second prompt dated 2021-09-12.
         // the remote may return multiple prompts, but there should be a client-side filtering for the prompt dates.
-        let dateParam = try XCTUnwrap(Self.dateFormatter.date(from: "2022-01-01"))
+        let dateParam = try XCTUnwrap(dateFormatter.date(from: "2022-01-01"))
 
         // use actual remote object so the request can be intercepted by HTTPStubs.
         service = BloggingPromptsService(contextManager: contextManager, blog: blog)
@@ -140,16 +133,14 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
     }
 
     func test_fetchPrompts_givenNoParameters_assignsDefaultValue() throws {
-        let expectedDifferenceInDays = 10
         let expectedNumber = 25
 
         // call the fetch just to trigger default parameter assignment. the completion blocks can be ignored.
         service.fetchPrompts(success: { _ in }, failure: { _ in })
 
         // calculate the difference and ensure that the passed date is 10 days ago.
-        let date = try passedDate()
-        let differenceInDays = try XCTUnwrap(Self.calendar.dateComponents([.day], from: date, to: Date()).day)
-        XCTAssertEqual(differenceInDays, expectedDifferenceInDays)
+        let expectedDate = dateFormatter.string(from: service.defaultStartDate)
+        XCTAssertEqual(expectedDate, try passedDate())
 
         // ensure that the passed number parameter is correct.
         let numberParameter = try XCTUnwrap(passedNumber())
@@ -157,32 +148,13 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
     }
 
     func test_fetchPrompts_passesTheDateCorrectly() throws {
-        // with the v3 implementation, we no longer have access to intercept at the method level.
-        // this means, we lose the time information of the passed date.
-        // In this case, we can only compare the year, month, and day components.
-        let expectedDate = try XCTUnwrap(BloggingPromptsServiceRemoteMock.dateFormatter.date(from: "2022-01-02"))
-        let expectedDateComponents = Self.calendar.dateComponents(in: Self.utcTimeZone, from: expectedDate)
-        let expectedNumber = 10
+        let expectedDate = try XCTUnwrap(dateFormatter.date(from: "2022-01-02"))
 
         // call the fetch just to trigger default parameter assignment. the completion blocks can be ignored.
-        service.fetchPrompts(from: expectedDate, number: expectedNumber, success: { _ in }, failure: { _ in })
+        service.fetchPrompts(from: expectedDate, number: 10, success: { _ in }, failure: { _ in })
 
-        // ensure that we compare the date components in UTC timezone to prevent possible day differences.
-        // e.g. edge cases such as `2023-01-02 22:00 -0500` or `2023-01-02 05:00 +0700`.
         let date = try passedDate()
-        let dateComponents = Self.calendar.dateComponents(in: Self.utcTimeZone, from: date)
-        let year = try passedParameter("force_year") as? Int
-        XCTAssertEqual(year, expectedDateComponents.year)
-
-        // FIXME: This needs to be addressed at the root but that requires more work than we have time for considering we want to support Xcode 15.1 ASAP.
-        // Tracked in https://github.com/wordpress-mobile/WordPress-iOS/issues/22323
-        XCTExpectFailure("The date conversion may fail at times, likely due to an underlying time zone inconsistency") {
-            XCTAssertEqual(dateComponents.month, expectedDateComponents.month)
-            XCTAssertEqual(dateComponents.day, expectedDateComponents.day)
-        }
-
-        let numberParameter = try XCTUnwrap(passedNumber())
-        XCTAssertEqual(numberParameter, expectedNumber)
+        XCTAssertEqual("2022-01-02", try passedDate())
     }
 
     // MARK: - Upsert Tests
@@ -198,8 +170,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         let expectedPromptIDs = Set(testPrompts.map(\.promptID))
 
         // insert existing prompts.
-        let date = try XCTUnwrap(Self.dateFormatter.date(from: "2022-05-03"))
-        makeBloggingPrompt(siteID: siteID, promptID: 1000, date: date)
+        try makeBloggingPrompt(siteID: siteID, promptID: 1000, date: testPrompts.last!.dateString)
         contextManager.save(contextManager.mainContext)
 
         let expectation = expectation(description: "Fetch prompts should succeed")
@@ -230,9 +201,8 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         let expectedPromptIDs = Set(testPrompts.map(\.promptID))
 
         // add 5 existing prompts having the same dates before calling `fetchPrompts`.
-        let date = try XCTUnwrap(Self.dateFormatter.date(from: "2022-05-03"))
         for existingID in 1...5 {
-            makeBloggingPrompt(siteID: siteID, promptID: existingID, date: date)
+            try makeBloggingPrompt(siteID: siteID, promptID: existingID, date: "2022-05-03")
         }
         contextManager.save(contextManager.mainContext)
 
@@ -268,8 +238,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         let expectedPromptIDs = Set(testPrompts.map(\.promptID) + [otherPromptID])
 
         // insert existing prompts.
-        let date = try XCTUnwrap(Self.dateFormatter.date(from: "2022-05-03"))
-        makeBloggingPrompt(siteID: otherSiteID, promptID: otherPromptID, date: date)
+        try makeBloggingPrompt(siteID: otherSiteID, promptID: otherPromptID, date: "2022-05-03")
         contextManager.save(contextManager.mainContext)
 
         let expectation = expectation(description: "Fetch prompts should succeed")
@@ -298,11 +267,10 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
         service = BloggingPromptsService(contextManager: contextManager, blog: blog)
         stubFetchPromptsResponse()
 
-        let date = try XCTUnwrap(Self.dateFormatter.date(from: "2021-05-03")) // one year before 2022-05-03.
         let promptID = try XCTUnwrap(testPrompts.first).promptID // same promptID as 2022-05-03 from the test data.
 
         // insert existing prompts.
-        makeBloggingPrompt(siteID: siteID, promptID: promptID, date: date)
+        try makeBloggingPrompt(siteID: siteID, promptID: promptID, date: "2021-05-03") // one year before 2022-05-03
         contextManager.save(contextManager.mainContext)
 
         let expectation = expectation(description: "Fetch prompts should succeed")
@@ -389,11 +357,11 @@ private extension BloggingPromptsServiceTests {
     }
 
     @discardableResult
-    func makeBloggingPrompt(siteID: Int, promptID: Int, date: Date) -> BloggingPrompt {
+    func makeBloggingPrompt(siteID: Int, promptID: Int, date: String) throws -> BloggingPrompt {
         let prompt = BloggingPrompt.newObject(in: contextManager.mainContext)!
         prompt.siteID = Int32(siteID)
         prompt.promptID = Int32(promptID)
-        prompt.date = date
+        prompt.date = try XCTUnwrap(dateFormatter.date(from: date))
 
         return prompt
     }
@@ -405,11 +373,11 @@ private extension BloggingPromptsServiceTests {
         return try XCTUnwrap(passedParameters[key], "Param not found for \(key)")
     }
 
-    func passedNumber() throws -> Int? {
-        return try passedParameter("per_page") as? Int
+    func passedNumber() throws -> Int {
+        return try XCTUnwrap(passedParameter("per_page") as? Int)
     }
 
-    func passedDate() throws -> Date {
+    func passedDate() throws -> String {
         // assumes that `ignoresYear` parameter is enabled.
         // get the month and day components.
         let dateString = try XCTUnwrap(passedParameter("after") as? String)
@@ -417,19 +385,15 @@ private extension BloggingPromptsServiceTests {
         XCTAssertEqual(components.count, 2)
 
         // build a date based on the passed values.
-        let forcedYear = try passedParameter("force_year") as? Int
+        let forcedYear = try XCTUnwrap(passedParameter("force_year") as? Int)
         let month = try XCTUnwrap(Int(components.first ?? ""))
         let day = try XCTUnwrap(Int(components.last ?? ""))
 
-        var dateComponents = DateComponents()
-        dateComponents.year = forcedYear
-        dateComponents.month = month
-        dateComponents.day = day
-        dateComponents.hour = 0
-        dateComponents.minute = 0
-        dateComponents.second = 0
-
-        return try XCTUnwrap(Self.calendar.date(from: dateComponents))
+        return [
+            String(forcedYear),
+            String(format: "%02d", month),
+            String(format: "%02d", day),
+        ].joined(separator: "-")
     }
 
     // MARK: Test Prompts
@@ -460,7 +424,6 @@ class BloggingPromptsServiceRemoteMock: BloggingPromptsServiceRemote {
         let formatter = DateFormatter()
         formatter.locale = .init(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(abbreviation: "UTC")!
 
         return formatter
     }()


### PR DESCRIPTION
Fixes #22323 

The tests here were more complex than they needed to be – this PR:

- Simplifies the test suite
- Simplifies the logic by not using a `Date` as a Dictionary key

To test:
- Ensure tests pass – I ran the `BloggingPromptsServiceTests` 100 times in a row without failure, then tested them twice in CI. Feel free to re-run them as many times as you'd like in CI to be confident that the issue is addressed!

## Regression Notes
1. Potential unintended areas of impact
Could cause issues with downloading Blogging Prompts from the server

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The existing test suite should cover this.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
