### PR TITLE
Update site picker button

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -158,7 +158,7 @@ class BlogDetailHeaderView: UIView {
         return [
             titleView.topAnchor.constraint(equalTo: topAnchor, constant: LayoutSpacing.top),
             titleView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: LayoutSpacing.atSides),
-            titleView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -LayoutSpacing.atSides),
+            titleView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -10),
             titleView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ]
     }
@@ -201,8 +201,8 @@ class BlogDetailHeaderView: UIView {
 extension BlogDetailHeaderView {
     class TitleView: UIView {
         private enum Dimensions {
-            static let siteSwitcherHeight: CGFloat = 36
-            static let siteSwitcherWidth: CGFloat = 32
+            static let siteSwitcherHeight: CGFloat = 44
+            static let siteSwitcherWidth: CGFloat = 44
         }
 
         // MARK: - Child Views
@@ -217,7 +217,7 @@ extension BlogDetailHeaderView {
             stackView.alignment = .center
             stackView.spacing = 12
             stackView.translatesAutoresizingMaskIntoConstraints = false
-            stackView.setCustomSpacing(4, after: titleStackView)
+            stackView.setCustomSpacing(2, after: titleStackView)
 
             return stackView
         }()
@@ -278,13 +278,14 @@ extension BlogDetailHeaderView {
         }()
 
         let siteSwitcherButton: UIButton = {
-            let button = UIButton(frame: .zero)
-            let image = UIImage(named: "chevron-down-slim")?.withRenderingMode(.alwaysTemplate)
+            var configuration = UIButton.Configuration.plain()
+            configuration.image = UIImage(systemName: "chevron.down.circle.fill")?.withBaselineOffset(fromBottom: 4)
+            configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [.secondaryLabel, .secondarySystemFill])
+                .applying(UIImage.SymbolConfiguration(font: WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)))
+            configuration.baseForegroundColor = .label
 
-            button.setImage(image, for: .normal)
-            button.contentMode = .center
+            let button = UIButton(configuration: configuration)
             button.translatesAutoresizingMaskIntoConstraints = false
-            button.tintColor = .secondaryLabel
             button.accessibilityLabel = NSLocalizedString("mySite.siteActions.button", value: "Site Actions", comment: "Button that reveals more site actions")
             button.accessibilityHint = NSLocalizedString("mySite.siteActions.hint", value: "Tap to show more site actions", comment: "Accessibility hint for button used to show more site actions")
             button.accessibilityIdentifier = .switchSiteAccessibilityId


### PR DESCRIPTION
A couple of small changes to the site picker button:

- Increase the size 36×32 to the recommended 44×44 to make sure it's easy to tap
- Visually align with the disclosure indicators in the list
- Use the native "title menu view" style

<img width="298" alt="Screenshot 2024-08-12 at 7 18 59 PM" src="https://github.com/user-attachments/assets/8a1f55ff-9f09-417e-ab42-41a4ae54a560">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
