### PR TITLE
Fix image resizing

### DIFF
--- a/Modules/Sources/WordPressUI/Extensions/UIImage+Scale.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImage+Scale.swift
@@ -15,6 +15,7 @@ public extension UIImage {
 
         return UIGraphicsImageRenderer(size: newSize, format: renderFormat).image { context in
             context.cgContext.concatenate(transform(forSuggestedSize: newSize))
+            self.draw(in: CGRect(origin: .zero, size: newSize))
         }
     }
 


### PR DESCRIPTION
Fixes #23494.

Image wasn't drawn in `UIGraphicsImageRenderer`.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
