### PR TITLE
Replace a couple of Aztec API usages

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
@@ -120,7 +120,17 @@ class SharingAuthorizationWebViewController: WPWebViewController {
 
 extension SharingAuthorizationWebViewController {
 
+#if compiler(>=6)
+    override func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void) {
+        decidePolicy(webView: webView, navigationAction: navigationAction, decisionHandler: decisionHandler)
+    }
+#else
     override func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        decidePolicy(webView: webView, navigationAction: navigationAction) { decisionHandler($0) }
+    }
+#endif
+
+    private func decidePolicy(webView: WKWebView, navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void) {
 
         // Prevent a second verify load by someone happy clicking.
         guard !loadingVerify,

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import CoreData
 import WordPressUI
-import Aztec
 
 // Notification sent when a Comment is permanently deleted so the Notifications list (NotificationsViewController) is immediately updated.
 extension NSNotification.Name {
@@ -85,8 +84,9 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
         iconAttachment.image = Style.ReplyIndicator.iconImage
 
         let attributedString = NSMutableAttributedString()
-        attributedString.append(.init(attachment: iconAttachment, attributes: Style.ReplyIndicator.textAttributes))
-        attributedString.append(.init(string: " " + .replyIndicatorLabelText, attributes: Style.ReplyIndicator.textAttributes))
+        attributedString.append(NSAttributedString(attachment: iconAttachment))
+        attributedString.append(.init(string: " " + .replyIndicatorLabelText))
+        attributedString.addAttributes(Style.ReplyIndicator.textAttributes, range: NSMakeRange(0, attributedString.length))
 
         // reverse the attributed strings in RTL direction.
         if view.effectiveUserInterfaceLayoutDirection == .rightToLeft {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CoreData
 import WordPressUI
+import Aztec
 
 // Notification sent when a Comment is permanently deleted so the Notifications list (NotificationsViewController) is immediately updated.
 extension NSNotification.Name {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellSelectionOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellSelectionOverlayView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Aztec
 
 final class SiteMediaCollectionCellSelectionOverlayView: UIView {
     private let overlayView = UIView()

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellSelectionOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellSelectionOverlayView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import Aztec
 
 final class SiteMediaCollectionCellSelectionOverlayView: UIView {
     private let overlayView = UIView()
@@ -28,14 +27,7 @@ final class SiteMediaCollectionCellSelectionOverlayView: UIView {
     func setBadge(_ badge: SiteMediaCollectionCellViewModel.BadgeType) {
         switch badge {
         case .unordered:
-            badgeView.textLabel.attributedText = NSAttributedString(attachment: {
-                let attachment = NSTextAttachment()
-                let configuration = UIImage.SymbolConfiguration(font: UIFont.systemFont(ofSize: 11, weight: .semibold))
-                attachment.image = UIImage(systemName: "checkmark", withConfiguration: configuration)?.withTintColor(.white, renderingMode: .alwaysTemplate)
-                return attachment
-            }(), attributes: [
-                NSAttributedString.Key.baselineOffset: 1 // It doesn't appear visually centered othwerwise
-            ])
+            badgeView.textLabel.text = "✓"
         case .ordered(let index):
             badgeView.textLabel.text = (index + 1).description
         }

--- a/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
+++ b/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
@@ -14,6 +14,10 @@ final class SharedPersistentContainer: NSPersistentContainer {
     }
 }
 
+#if compiler(>=6)
+extension SharedPersistentContainer: @unchecked Sendable {}
+#endif
+
 class SharedCoreDataStack {
 
     // MARK: - Private Properties

--- a/WordPressAuthenticator/Sources/Email Client Picker/URLHandler.swift
+++ b/WordPressAuthenticator/Sources/Email Client Picker/URLHandler.swift
@@ -2,10 +2,18 @@
 public protocol URLHandler {
     /// checks if the specified URL can be opened
     func canOpenURL(_ url: URL) -> Bool
+
+#if compiler(>=6)
+    /// opens the specified URL
+    func open(_ url: URL,
+              options: [UIApplication.OpenExternalURLOptionsKey: Any],
+              completionHandler completion: (@MainActor @Sendable (Bool) -> Void)?)
+#else
     /// opens the specified URL
     func open(_ url: URL,
               options: [UIApplication.OpenExternalURLOptionsKey: Any],
               completionHandler completion: ((Bool) -> Void)?)
+#endif
 }
 
 /// conforms UIApplication to URLHandler to allow dependency injection


### PR DESCRIPTION
This is a follow-up PR for https://github.com/wordpress-mobile/WordPress-iOS/pull/23497#discussion_r1717340159

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
