### PR TITLE
Remove WPGUIConstants

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -79,7 +79,7 @@ extension UIView {
 
         UIView.animate(withDuration: UIView.blankingSnapshotFadeDuration,
                        animations: {
-                        blankingView.alpha = WPAlphaZero
+                        blankingView.alpha = 0
         }, completion: { _ in
             blankingView.removeFromSuperview()
         })
@@ -201,7 +201,7 @@ class WPFullscreenNavigationTransition: NSObject, UIViewControllerAnimatedTransi
             toView.layer.addSublayer(shadowLayer)
             toView.addSubview(dimmingView)
         } else {
-            fromView.alpha = WPAlphaZero
+            fromView.alpha = 0
 
             containerView.insertSubview(toView, at: 0)
 
@@ -318,8 +318,8 @@ private struct WPFullscreenNavigationTransitionViewModel {
 
         let dimmingViewXOffset = (isRTLLayout) ? fromFrame.width : -fromFrame.width
         dimmingViewFrame = CGRect(x: dimmingViewXOffset, y: 0, width: fromFrame.width, height: fromFrame.height)
-        dimmingViewInitialAlpha = (operation == .push) ? WPAlphaZero : WPAlphaFull
-        dimmingViewFinalAlpha =   (operation == .push) ? WPAlphaFull : WPAlphaZero
+        dimmingViewInitialAlpha = (operation == .push) ? 0 : 1
+        dimmingViewFinalAlpha =   (operation == .push) ? 1 : 0
     }
 }
 

--- a/WordPress/Classes/System/WPGUIConstants.h
+++ b/WordPress/Classes/System/WPGUIConstants.h
@@ -1,8 +1,0 @@
-#import <Foundation/Foundation.h>
-
-extern const CGFloat WPAlphaFull;
-extern const CGFloat WPAlphaZero;
-
-extern const NSTimeInterval WPAnimationDurationDefault;
-
-extern const CGFloat WPTableViewDefaultRowHeight;

--- a/WordPress/Classes/System/WPGUIConstants.m
+++ b/WordPress/Classes/System/WPGUIConstants.m
@@ -1,8 +1,0 @@
-#import "WPGUIConstants.h"
-
-const CGFloat WPAlphaFull                       = 1.0;
-const CGFloat WPAlphaZero                       = 0.0;
-
-const NSTimeInterval WPAnimationDurationDefault = 0.33;
-
-const CGFloat WPTableViewDefaultRowHeight       = 44.0;

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -99,7 +99,7 @@ class WindowManager: NSObject {
 
         UIView.transition(
             with: window,
-            duration: WPAnimationDurationDefault,
+            duration: 0.33,
             options: .transitionCrossDissolve,
             animations: nil,
             completion: { _ in

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -88,7 +88,6 @@
 #import "WPAuthTokenIssueSolver.h"
 #import "WPUploadStatusButton.h"
 #import "WPError.h"
-#import "WPGUIConstants.h"
 #import "WPImageViewController.h"
 #import "WPScrollableViewController.h"
 #import "WPStyleGuide+Pages.h"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -10,7 +10,6 @@
 #import "StatsViewController.h"
 #import "WPAccount.h"
 #import "WPAppAnalytics.h"
-#import "WPGUIConstants.h"
 #import "WordPress-Swift.h"
 #import "MenusViewController.h"
 #import "NSMutableArray+NullableObjects.h"

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SettingsTitleSubtitleController.swift
@@ -57,9 +57,9 @@ final class SettingsTitleSubtitleController: UITableViewController {
         var height: CGFloat {
             switch self {
             case .name:
-                return WPTableViewDefaultRowHeight
+                return 44
             case .description:
-                return WPTableViewDefaultRowHeight * 3
+                return 44 * 3
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Domains/DomainSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainSelectionViewController.swift
@@ -790,7 +790,7 @@ private extension DomainSelectionViewController {
         }
 
         let constraints = transferFooterViewConstraints
-        let duration = animated ? WPAnimationDurationDefault : 0
+        let duration = animated ? 0.33 : 0
 
         NSLayoutConstraint.deactivate(hidden ? constraints.visible : constraints.hidden)
         NSLayoutConstraint.activate(hidden ? constraints.hidden : constraints.visible)

--- a/WordPress/Classes/ViewRelated/Me/Help & Support/Activity Logs/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/Help & Support/Activity Logs/ActivityLogViewController.m
@@ -3,7 +3,6 @@
 #import <CocoaLumberjack/DDFileLogger.h>
 #import "WordPress-Swift.h"
 #import "WPLogger.h"
-#import "WPGUIConstants.h"
 
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -7,7 +7,6 @@
 #import "MenuItemsVisualOrderingView.h"
 #import "CoreDataStack.h"
 #import "Menu+ViewDesign.h"
-#import "WPGUIConstants.h"
 #import "WordPress-Swift.h"
 
 @import WordPressShared;
@@ -235,13 +234,13 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
 
     for (MenuItemInsertionView *insertionView in self.insertionViews) {
         insertionView.hidden = YES;
-        insertionView.alpha = WPAlphaZero;
+        insertionView.alpha = 0;
     }
-    [UIView animateWithDuration:WPAnimationDurationDefault animations:^{
+    [UIView animateWithDuration:0.33 animations:^{
 
         for (MenuItemInsertionView *insertionView in self.insertionViews) {
             insertionView.hidden = NO;
-            insertionView.alpha = WPAlphaFull;
+            insertionView.alpha = 1;
         }
         // inform the delegate to handle this content change based on the rect we are focused on
         // a delegate will likely scroll the content with the size change
@@ -279,11 +278,11 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
     // since we are removing content above the toggledItemView, the toggledItemView (focus) will move upwards with the updated content size
     updatedRect.origin.y -= MenuItemsStackableViewDefaultHeight;
 
-    [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:0 animations:^{
+    [UIView animateWithDuration:0.33 delay:0.0 options:0 animations:^{
 
         for (MenuItemInsertionView *insertionView in self.insertionViews) {
             insertionView.hidden = YES;
-            insertionView.alpha = WPAlphaZero;
+            insertionView.alpha = 0;
         }
         // inform the delegate to handle this content change based on the rect we are focused on
         // a delegate will likely scroll the content with the size change

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -561,7 +561,7 @@ private extension NotificationsViewController {
     func setupInlinePrompt() {
         precondition(inlinePromptView != nil)
 
-        inlinePromptView.alpha = WPAlphaZero
+        inlinePromptView.alpha = 0
 
         inlinePromptView.isHidden = true
     }
@@ -1483,7 +1483,7 @@ private extension NotificationsViewController {
             return
         }
 
-        UIView.animate(withDuration: WPAnimationDurationDefault, animations: {
+        UIView.animate(withDuration: 0.33, animations: {
             self.filterTabBar.isHidden = false
         })
     }
@@ -1575,7 +1575,7 @@ private extension NotificationsViewController {
         }
 
         if columnWidth == .default {
-            splitViewController.dimDetailViewController(shouldDimDetailViewController, withAlpha: WPAlphaZero)
+            splitViewController.dimDetailViewController(shouldDimDetailViewController, withAlpha: 0)
         }
     }
 
@@ -1640,27 +1640,27 @@ extension NotificationsViewController: NoResultsViewControllerDelegate {
 //
 internal extension NotificationsViewController {
     func showInlinePrompt() {
-        guard inlinePromptView.alpha != WPAlphaFull,
+        guard inlinePromptView.alpha != 1,
             userDefaults.notificationPrimerAlertWasDisplayed,
             userDefaults.notificationsTabAccessCount >= Constants.inlineTabAccessCount else {
             return
         }
 
-        UIView.animate(withDuration: WPAnimationDurationDefault, delay: 0, options: .curveEaseIn, animations: {
+        UIView.animate(withDuration: 0.33, delay: 0, options: .curveEaseIn, animations: {
             self.inlinePromptView.isHidden = false
         })
 
-        UIView.animate(withDuration: WPAnimationDurationDefault * 0.5, delay: WPAnimationDurationDefault * 0.75, options: .curveEaseIn, animations: {
-            self.inlinePromptView.alpha = WPAlphaFull
+        UIView.animate(withDuration: 0.33 * 0.5, delay: 0.33 * 0.75, options: .curveEaseIn, animations: {
+            self.inlinePromptView.alpha = 1
         })
     }
 
     func hideInlinePrompt(delay: TimeInterval) {
-        UIView.animate(withDuration: WPAnimationDurationDefault * 0.75, delay: delay, animations: {
-            self.inlinePromptView.alpha = WPAlphaZero
+        UIView.animate(withDuration: 0.33 * 0.75, delay: delay, animations: {
+            self.inlinePromptView.alpha = 0
         })
 
-        UIView.animate(withDuration: WPAnimationDurationDefault, delay: delay + WPAnimationDurationDefault * 0.5, animations: {
+        UIView.animate(withDuration: 0.33, delay: delay + 0.33 * 0.5, animations: {
             self.inlinePromptView.isHidden = true
         })
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -11,7 +11,6 @@
 #import "WPProgressTableViewCell.h"
 #import <Photos/Photos.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-#import "WPGUIConstants.h"
 #import "WordPress-Swift.h"
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -97,8 +97,8 @@ private extension ReaderCrossPostCell {
 
     func applyHighlightedEffect(_ highlighted: Bool, animated: Bool) {
         func updateBorder() {
-            label.alpha = highlighted ? 0.50 : WPAlphaFull
-            titleLabel.alpha = highlighted ? 0.50 : WPAlphaFull
+            label.alpha = highlighted ? 0.50 : 1
+            titleLabel.alpha = highlighted ? 0.50 : 1
         }
         guard animated else {
             updateBorder()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -40,7 +40,7 @@ open class ReaderGapMarkerCell: UITableViewCell {
     }
 
     @objc open func animateActivityView(_ animate: Bool) {
-        button.alpha = animate ? WPAlphaZero : WPAlphaFull
+        button.alpha = animate ? 0 : 1
         if animate {
             activityView.startAnimating()
         } else {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeAnimator.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeAnimator.swift
@@ -41,7 +41,7 @@ public struct NoticeAnimator {
     }
 
     func animate(noticeContainer: NoticeContainerView, completion: (() -> Void)? = nil) {
-        noticeContainer.noticeView.alpha = WPAlphaZero
+        noticeContainer.noticeView.alpha = 0
 
         let fromState = state(for: noticeContainer, withTransition: .offscreen)
         let toState = state(for: noticeContainer, withTransition: .onscreen)
@@ -57,9 +57,9 @@ public struct NoticeAnimator {
             let alpha: CGFloat
             switch transition {
             case .onscreen:
-                alpha = WPAlphaFull
+                alpha = 1
             case .offscreen:
-                alpha = WPAlphaZero
+                alpha = 0
             }
 
             noticeContainer.noticeView.alpha = alpha

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -297,7 +297,7 @@ class NoticePresenter {
                            initialSpringVelocity: Animations.appearanceSpringVelocity,
                            options: [],
                            animations: {
-                    container.noticeView.alpha = WPAlphaZero
+                    container.noticeView.alpha = 0
             },
                            completion: { _ in
                     container.removeFromSuperview()

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -201,7 +201,7 @@ class WPSplitViewController: UISplitViewController {
             if dimmingView.superview == nil {
                 view.addSubview(dimmingView)
                 updateDimmingViewFrame()
-                dimmingView.alpha = WPAlphaZero
+                dimmingView.alpha = 0
 
                 // Dismiss the keyboard from the detail view controller if active
                 topDetailViewController?.navigationController?.view.endEditing(true)
@@ -211,7 +211,7 @@ class WPSplitViewController: UISplitViewController {
             }
         } else if dimmingView.superview != nil {
             UIView.animate(withDuration: dimmingViewAnimationDuration, animations: {
-                self.dimmingView.alpha = WPAlphaZero
+                self.dimmingView.alpha = 0
                 }, completion: { _ in
                     self.dimmingView.removeFromSuperview()
             })

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1629,7 +1629,6 @@
 		57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D6C83D22945A10003DDC7E /* PostCompactCellTests.swift */; };
 		590E873B1CB8205700D1B734 /* PostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590E873A1CB8205700D1B734 /* PostListViewController.swift */; };
 		591232691CCEAA5100B86207 /* AbstractPostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591232681CCEAA5100B86207 /* AbstractPostListViewController.swift */; };
-		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
 		591AA5011CEF9BF20074934F /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591AA4FF1CEF9BF20074934F /* Post.swift */; };
 		591AA5021CEF9BF20074934F /* Post+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591AA5001CEF9BF20074934F /* Post+CoreDataProperties.swift */; };
 		593F26611CAB00CA00F14073 /* PostSharingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593F26601CAB00CA00F14073 /* PostSharingController.swift */; };
@@ -5440,7 +5439,6 @@
 		FABB25E12602FC2C00C8785C /* WPActivityDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D95EB717A28F5E00A3E9F3 /* WPActivityDefaults.m */; };
 		FABB25E22602FC2C00C8785C /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436D562F2117410C00CEAA33 /* RegisterDomainDetailsViewModel+CellIndex.swift */; };
 		FABB25E32602FC2C00C8785C /* RouteMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */; };
-		FABB25E42602FC2C00C8785C /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
 		FABB25E52602FC2C00C8785C /* UIColor+Notice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD272DF24CF8F270021F0C8 /* UIColor+Notice.swift */; };
 		FABB25E62602FC2C00C8785C /* JetpackBackupOptionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */; };
 		FABB25E72602FC2C00C8785C /* PluginStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0A6B1FA73053004C4BBE /* PluginStore.swift */; };
@@ -7478,8 +7476,6 @@
 		57E15BC2269B6B7419464B6F /* Pods_Apps_Jetpack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Apps_Jetpack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		590E873A1CB8205700D1B734 /* PostListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListViewController.swift; sourceTree = "<group>"; };
 		591232681CCEAA5100B86207 /* AbstractPostListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AbstractPostListViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPGUIConstants.h; sourceTree = "<group>"; };
-		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
 		591AA4FF1CEF9BF20074934F /* Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		591AA5001CEF9BF20074934F /* Post+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Post+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		593F26601CAB00CA00F14073 /* PostSharingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostSharingController.swift; sourceTree = "<group>"; };
@@ -14659,8 +14655,6 @@
 				0CB54F562AEC320700582080 /* WordPressAppDelegate+PostCoordinatorDelegate.swift */,
 				43B0BA952229927F00328C69 /* WordPressAppDelegate+openURL.swift */,
 				F1E3536A25B9F74C00992E3A /* WindowManager.swift */,
-				591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */,
-				591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */,
 				17F7C24822770B68002E5C2E /* main.swift */,
 			);
 			path = System;
@@ -23170,7 +23164,6 @@
 				436D56302117410C00CEAA33 /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */,
 				C39ABBAE294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift in Sources */,
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
-				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				3FD272E024CF8F270021F0C8 /* UIColor+Notice.swift in Sources */,
 				98830A922747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */,
 				FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */,
@@ -26124,7 +26117,6 @@
 				FABB25E12602FC2C00C8785C /* WPActivityDefaults.m in Sources */,
 				FABB25E22602FC2C00C8785C /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */,
 				FABB25E32602FC2C00C8785C /* RouteMatcher.swift in Sources */,
-				FABB25E42602FC2C00C8785C /* WPGUIConstants.m in Sources */,
 				FABB25E52602FC2C00C8785C /* UIColor+Notice.swift in Sources */,
 				0147D64F294B1E1600AA6410 /* StatsRevampStore.swift in Sources */,
 				FABB25E62602FC2C00C8785C /* JetpackBackupOptionsCoordinator.swift in Sources */,


### PR DESCRIPTION
I'm reviewing `WordPressAppDelegate` and the related global navigation code. This file was next to the app delegate sources, so I decided to remove it.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
