### PR TITLE
Add Application Token Experimental Feature

### DIFF
--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
@@ -11,16 +11,7 @@ public struct ExperimentalFeaturesList: View {
 
     public var body: some View {
         List(viewModel.items) { item in
-            HStack {
-                Toggle(item.name, isOn: Binding<Bool>(
-                    get: {
-                        viewModel.dataProvider.value(for: item)
-                    },
-                    set: { newValue in
-                        viewModel.dataProvider.didChangeValue(for: item, to: newValue)
-                    }
-                ))
-            }
+            Toggle(item.name, isOn: viewModel.binding(for: item))
         }
         .navigationTitle(Strings.pageTitle)
         .task {

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
@@ -5,10 +5,6 @@ public struct ExperimentalFeaturesList: View {
     @ObservedObject
     var viewModel: ExperimentalFeaturesViewModel
 
-    public init(dataProvider: ExperimentalFeaturesViewModel.DataProvider) {
-        self.viewModel = ExperimentalFeaturesViewModel(dataProvider: dataProvider)
-    }
-
     package init(viewModel: ExperimentalFeaturesViewModel) {
         self.viewModel = viewModel
     }
@@ -26,10 +22,29 @@ public struct ExperimentalFeaturesList: View {
                 ))
             }
         }
-        .navigationTitle("Experimental Features")
+        .navigationTitle(Strings.pageTitle)
         .task {
             await viewModel.loadItems()
         }
+    }
+
+    public static func asViewController(
+        dataProvider: ExperimentalFeaturesViewModel.DataProvider
+    ) -> UIHostingController<Self> {
+        let viewModel = ExperimentalFeaturesViewModel(dataProvider: dataProvider)
+        let rootView  = ExperimentalFeaturesList(viewModel: viewModel)
+
+        let vc = UIHostingController(rootView: rootView)
+        vc.title = Strings.pageTitle
+        return vc
+    }
+
+    enum Strings {
+        static let pageTitle = NSLocalizedString(
+            "experimental-features-list.heading",
+            value: "Experimental Features",
+            comment: "The title for the experimental features list"
+        )
     }
 }
 

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
@@ -40,7 +40,7 @@ public struct ExperimentalFeaturesList: View {
 
     enum Strings {
         static let pageTitle = NSLocalizedString(
-            "experimental-features-list.heading",
+            "experimentalFeaturesList.heading",
             value: "Experimental Features",
             comment: "The title for the experimental features list"
         )

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
@@ -29,9 +29,8 @@ public struct ExperimentalFeaturesList: View {
     }
 
     public static func asViewController(
-        dataProvider: ExperimentalFeaturesViewModel.DataProvider
+        viewModel: ExperimentalFeaturesViewModel
     ) -> UIHostingController<Self> {
-        let viewModel = ExperimentalFeaturesViewModel(dataProvider: dataProvider)
         let rootView  = ExperimentalFeaturesList(viewModel: viewModel)
 
         let vc = UIHostingController(rootView: rootView)

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesList.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+public struct ExperimentalFeaturesList: View {
+
+    @ObservedObject
+    var viewModel: ExperimentalFeaturesViewModel
+
+    public init(dataProvider: ExperimentalFeaturesViewModel.DataProvider) {
+        self.viewModel = ExperimentalFeaturesViewModel(dataProvider: dataProvider)
+    }
+
+    package init(viewModel: ExperimentalFeaturesViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        List(viewModel.items) { item in
+            HStack {
+                Toggle(item.name, isOn: Binding<Bool>(
+                    get: {
+                        viewModel.dataProvider.value(for: item)
+                    },
+                    set: { newValue in
+                        viewModel.dataProvider.didChangeValue(for: item, to: newValue)
+                    }
+                ))
+            }
+        }
+        .navigationTitle("Experimental Features")
+        .task {
+            await viewModel.loadItems()
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        ExperimentalFeaturesList(viewModel: .withSampleData())
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 public class ExperimentalFeaturesViewModel: ObservableObject {
     public protocol DataProvider {
-        func loadItems() throws -> [Feature]
+        func loadItems() async throws -> [Feature]
         func value(for: Feature) -> Bool
         func didChangeValue(for feature: Feature, to newValue: Bool)
     }
@@ -36,15 +36,15 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
     }
 
     @Published
-    public var items: [Feature] = []
+    public private(set) var items: [Feature] = []
 
     @Published
-    public var isLoadingItems: Bool = true
+    public private(set) var isLoadingItems: Bool = true
 
     @Published
-    public var error: Error? = nil
+    public private(set) var error: Error? = nil
 
-    var dataProvider: DataProvider
+    private var dataProvider: DataProvider
 
     public init(dataProvider: DataProvider) {
         self.dataProvider = dataProvider

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+public class ExperimentalFeaturesViewModel: ObservableObject {
+    public protocol DataProvider {
+        func loadItems() throws -> [Feature]
+        func value(for: Feature) -> Bool
+        func didChangeValue(for feature: Feature, to newValue: Bool)
+    }
+
+    package class DefaultDataProvider: DataProvider {
+
+        let items: [Feature]
+
+        var values = [String: Bool]()
+
+        init(items: [Feature]) {
+            self.items = items
+        }
+
+        package func loadItems() throws -> [Feature] {
+            return items
+        }
+
+        package func value(for feature: Feature) -> Bool {
+            if let value = values[feature.id] {
+                return value
+            }
+
+            values[feature.id] = false
+            return value(for: feature)
+        }
+
+        package func didChangeValue(for feature: Feature, to newValue: Bool) {
+            values[feature.id] = newValue
+        }
+    }
+
+    @Published
+    public var items: [Feature] = []
+
+    @Published
+    public var isLoadingItems: Bool = true
+
+    @Published
+    public var error: Error? = nil
+
+    var dataProvider: DataProvider
+
+    init(dataProvider: DataProvider) {
+        self.dataProvider = dataProvider
+    }
+
+    @MainActor
+    func loadItems() async {
+        do {
+            let items = try dataProvider.loadItems()
+            self.items = items
+            self.isLoadingItems = false
+        } catch {
+            self.error = error
+            self.isLoadingItems = false
+        }
+    }
+
+    package static func withSampleData() -> ExperimentalFeaturesViewModel {
+        let dataProvider = DefaultDataProvider(items: Feature.SampleData)
+        return ExperimentalFeaturesViewModel(dataProvider: dataProvider)
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
@@ -46,7 +46,7 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
 
     var dataProvider: DataProvider
 
-    init(dataProvider: DataProvider) {
+    public init(dataProvider: DataProvider) {
         self.dataProvider = dataProvider
     }
 

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
@@ -62,6 +62,17 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
         }
     }
 
+    func binding(for item: Feature) -> Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                self.dataProvider.value(for: item)
+            },
+            set: { newValue in
+                self.objectWillChange.send()
+                self.dataProvider.didChangeValue(for: item, to: newValue)
+            }
+        )
+    }
     package static func withSampleData() -> ExperimentalFeaturesViewModel {
         let dataProvider = DefaultDataProvider(items: Feature.SampleData)
         return ExperimentalFeaturesViewModel(dataProvider: dataProvider)

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/ExperimentalFeaturesViewModel.swift
@@ -50,15 +50,15 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
         self.dataProvider = dataProvider
     }
 
-    @MainActor
     func loadItems() async {
+        isLoadingItems = true
+        defer { isLoadingItems = false }
+
         do {
-            let items = try dataProvider.loadItems()
+            let items = try await dataProvider.loadItems()
             self.items = items
-            self.isLoadingItems = false
         } catch {
             self.error = error
-            self.isLoadingItems = false
         }
     }
 
@@ -73,6 +73,7 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
             }
         )
     }
+
     package static func withSampleData() -> ExperimentalFeaturesViewModel {
         let dataProvider = DefaultDataProvider(items: Feature.SampleData)
         return ExperimentalFeaturesViewModel(dataProvider: dataProvider)

--- a/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/Feature.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/Experimental Features/Feature.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct Feature: Identifiable {
+    public let name: String
+    public let key: String
+
+    public var id: String { key }
+
+    public init(name: String, key: String) {
+        self.name = name
+        self.key = key
+    }
+
+    package static let SampleData: [Feature]  = [
+        Feature(name: "Stratify Ground Layers", key: "01"),
+        Feature(name: "Reticulate Splines", key: "02"),
+        Feature(name: "Obfuscate Quigley Matrix", key: "03"),
+    ]
+}

--- a/Modules/Tests/WordPressUITests/Extensions/UIImage+ScaleTests.swift
+++ b/Modules/Tests/WordPressUITests/Extensions/UIImage+ScaleTests.swift
@@ -1,9 +1,9 @@
 import XCTest
-@testable import WordPressUI
+import WordPressUI
 
 final class UIImage_ScaleTests: XCTestCase {
 
-    let originalImage = UIImage.from(color: .blue, havingSize: CGSize(width: 1024, height: 768))
+    let originalImage = UIImage(color: .blue, size: CGSize(width: 1024, height: 768))
 
     func testAspectFitIntoSquare() {
         let targetSize = CGSize(width: 1000, height: 1000)
@@ -43,7 +43,7 @@ final class UIImage_ScaleTests: XCTestCase {
 
     func testFoo() {
         let targetSize = CGSize(width: 0, height: 0)
-        let originalImage = UIImage.from(color: .blue, havingSize: CGSize(width: 1024, height: 680))
+        let originalImage = UIImage(color: .blue, size: CGSize(width: 1024, height: 680))
         let size = originalImage.dimensions(forSuggestedSize: targetSize, format: .scaleAspectFill)
     }
 }

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -173,7 +173,7 @@ private class WeeklyRoundupDataProvider {
     ///
     private func filterCandidateSites(_ sites: [Site], result: @escaping (Result<[Site], Error>) -> Void) {
         let administeredSites = sites.filter { site in
-            site.isAdmin && ((FeatureFlag.debugMenu.enabled && debugSettings.isEnabledForA8cP2s) || !site.isAutomatticP2)
+            site.isAdmin && !site.isAutomatticP2
         }
 
         guard administeredSites.count > 0 else {

--- a/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
+++ b/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
@@ -36,4 +36,8 @@ enum BuildConfiguration: String {
         BuildConfiguration.testingOverride = nil
     }
     #endif
+
+    var isInternal: Bool {
+        self ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+    }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -78,7 +78,7 @@ extension FeatureFlag {
         case .newTabIcons: "New Tab Icons"
         case .autoSaveDrafts: "Autosave Drafts"
         case .voiceToContent: "Voice to Content"
-        case .authenticateUsingApplicationPassword: "Authenticate self-hosted sites using Application Password"
+        case .authenticateUsingApplicationPassword: "Application Passwords for self-hosted sites"
         case .tipKit: "TipKit"
         }
     }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int, CaseIterable {
     case bloggingPrompts
     case jetpackDisconnect
-    case debugMenu
     case siteIconCreator
     case betaSiteDesigns
     case commentModerationUpdate
@@ -27,8 +26,6 @@ enum FeatureFlag: Int, CaseIterable {
             return AppConfiguration.isJetpack
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
-        case .debugMenu:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .siteIconCreator:
             return BuildConfiguration.current != .appStore
         case .betaSiteDesigns:
@@ -73,7 +70,6 @@ extension FeatureFlag {
         switch self {
         case .bloggingPrompts: "Blogging Prompts"
         case .jetpackDisconnect: "Jetpack disconnect"
-        case .debugMenu: "Debug menu"
         case .siteIconCreator: "Site Icon Creator"
         case .betaSiteDesigns: "Fetch Beta Site Designs"
         case .commentModerationUpdate: "Comments Moderation Update"
@@ -94,13 +90,8 @@ extension FeatureFlag: OverridableFlag {
         return enabled
     }
 
-    var canOverride: Bool {
-        switch self {
-        case .debugMenu:
-            return false
-        default:
-            return true
-        }
+    var key: String {
+        return "ff-override-\(String(describing: self))"
     }
 }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
@@ -5,7 +5,7 @@ import Foundation
 //
 protocol OverridableFlag: CustomStringConvertible {
     var originalValue: Bool { get }
-    var canOverride: Bool { get }
+    var key: String { get }
 }
 
 /// Used to override values for feature flags at runtime in debug builds
@@ -17,10 +17,6 @@ struct FeatureFlagOverrideStore {
         self.store = store
     }
 
-    private func key(for flag: OverridableFlag) -> String {
-        return "ff-override-\(String(describing: flag))"
-    }
-
     /// - returns: True if the specified feature flag is overridden
     ///
     func isOverridden(_ featureFlag: OverridableFlag) -> Bool {
@@ -29,12 +25,8 @@ struct FeatureFlagOverrideStore {
 
     /// Removes any existing overridden value and stores the new value
     ///
-    func override(_ featureFlag: OverridableFlag, withValue value: Bool) throws {
-        guard featureFlag.canOverride == true else {
-            throw FeatureFlagError.cannotBeOverridden
-        }
-
-        let key = self.key(for: featureFlag)
+    func override(_ featureFlag: OverridableFlag, withValue value: Bool) {
+        let key = featureFlag.key
 
         if isOverridden(featureFlag) {
             store.removeObject(forKey: key)
@@ -46,17 +38,17 @@ struct FeatureFlagOverrideStore {
     }
 
     func removeOverride(for featureFlag: OverridableFlag) {
-        store.removeObject(forKey: key(for: featureFlag))
+        store.removeObject(forKey: featureFlag.key)
     }
 
     /// - returns: The overridden value for the specified feature flag, if one exists.
     /// If no override exists, returns `nil`.
     ///
     func overriddenValue(for featureFlag: OverridableFlag) -> Bool? {
-        guard store.object(forKey: key(for: featureFlag)) != nil else {
+        guard store.object(forKey: featureFlag.key) != nil else {
             return nil
         }
-        return store.bool(forKey: key(for: featureFlag))
+        return store.bool(forKey: featureFlag.key)
     }
 }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -253,6 +253,10 @@ enum RemoteFeatureFlag: Int, CaseIterable {
 }
 
 extension RemoteFeatureFlag: OverridableFlag {
+    var key: String {
+        return "ff-override-\(String(describing: self))"
+    }
+
     var originalValue: Bool {
         return enabled()
     }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -6,6 +6,7 @@ import WordPressShared
 import SVProgressHUD
 import WordPressFlux
 import DesignSystem
+import WordPressUI
 
 class AppSettingsViewController: UITableViewController {
     fileprivate var handler: ImmuTableViewHandler!
@@ -376,6 +377,15 @@ class AppSettingsViewController: UITableViewController {
             RootViewCoordinator.shared.presentWhatIsNew(on: self)
         }
     }
+
+    func pushExperimentalFeatures() -> ImmuTableAction {
+        return { [weak self] row in
+            let dataProvider = ExperimentalFeaturesDataProvider()
+            let vc = UIHostingController(rootView: ExperimentalFeaturesList(dataProvider: dataProvider))
+            self?.tableView.deselectSelectedRowWithAnimation(true)
+            self?.navigationController?.pushViewController(vc, animated: true)
+        }
+    }
 }
 
 // MARK: - SearchableActivity Conformance
@@ -544,12 +554,18 @@ private extension AppSettingsViewController {
             action: pushAppIconSwitcher()
         )
 
+        let experimentalFeaturesRow = NavigationItemRow(
+            title: Strings.experimentalFeatures,
+            icon: UIImage(systemName: "testtube.2"),
+            action: pushExperimentalFeatures()
+        )
+
         let settingsRow = NavigationItemRow(
             title: NSLocalizedString("Open Device Settings", comment: "Opens iOS's Device Settings for WordPress App"),
             action: openApplicationSettings()
         )
 
-        var rows: [ImmuTableRow] = [settingsRow]
+        var rows: [ImmuTableRow] = [experimentalFeaturesRow, settingsRow]
 
         if AppConfiguration.allowsCustomAppIcons && UIApplication.shared.supportsAlternateIcons {
             // We don't show custom icons for Jetpack
@@ -599,5 +615,13 @@ extension AppSettingsViewController {
     @objc private func jetpackButtonTapped() {
         JetpackBrandingCoordinator.presentOverlay(from: self)
         JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .appSettings)
+    }
+
+    enum Strings {
+        static let experimentalFeatures = NSLocalizedString(
+            "application-settings.experimental-features",
+            value: "Experimental Features",
+            comment: "The list item of experimental features that users can choose to enable"
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -40,7 +40,7 @@ class AppSettingsViewController: UITableViewController {
             ImageSizingRow.self,
             SwitchRow.self,
             NavigationItemRow.self
-            ], tableView: self.tableView)
+        ], tableView: self.tableView)
 
         handler = ImmuTableViewHandler(takeOver: self)
         reloadViewModel()
@@ -551,6 +551,7 @@ private extension AppSettingsViewController {
 
         let iconRow = NavigationItemRow(
             title: NSLocalizedString("App Icon", comment: "Navigates to picker screen to change the app's icon"),
+            icon: UIImage(systemName: "app.dashed"),
             action: pushAppIconSwitcher()
         )
 
@@ -562,6 +563,7 @@ private extension AppSettingsViewController {
 
         let settingsRow = NavigationItemRow(
             title: NSLocalizedString("Open Device Settings", comment: "Opens iOS's Device Settings for WordPress App"),
+            icon: UIImage(systemName: "gear"),
             action: openApplicationSettings()
         )
 
@@ -572,7 +574,7 @@ private extension AppSettingsViewController {
             rows.insert(iconRow, at: 0)
         }
 
-        if FeatureFlag.debugMenu.enabled {
+        if BuildConfiguration.current.isInternal {
             rows.append(debugRow)
             rows.append(designSystem)
         }
@@ -585,7 +587,12 @@ private extension AppSettingsViewController {
             rows.append(whatIsNewRow)
         }
 
-        let appearanceRow = NavigationItemRow(title: NSLocalizedString("Appearance", comment: "The title of the app appearance settings screen"), detail: AppAppearance.current.appearanceDescription, action: pushAppearanceSettings())
+        let appearanceRow = NavigationItemRow(
+            title: NSLocalizedString("Appearance", comment: "The title of the app appearance settings screen"),
+            detail: AppAppearance.current.appearanceDescription,
+            icon: UIImage(systemName: "circle.lefthalf.filled"),
+            action: pushAppearanceSettings()
+        )
 
         rows.insert(appearanceRow, at: 0)
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -380,8 +380,7 @@ class AppSettingsViewController: UITableViewController {
 
     func pushExperimentalFeatures() -> ImmuTableAction {
         return { [weak self] row in
-            let dataProvider = ExperimentalFeaturesDataProvider()
-            let vc = UIHostingController(rootView: ExperimentalFeaturesList(dataProvider: dataProvider))
+            let vc = ExperimentalFeaturesList.asViewController(dataProvider: ExperimentalFeaturesDataProvider())
             self?.tableView.deselectSelectedRowWithAnimation(true)
             self?.navigationController?.pushViewController(vc, animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -378,11 +378,17 @@ class AppSettingsViewController: UITableViewController {
         }
     }
 
+    private let experimentalFeaturesVM = ExperimentalFeaturesViewModel(dataProvider: ExperimentalFeaturesDataProvider())
+
     func pushExperimentalFeatures() -> ImmuTableAction {
         return { [weak self] row in
-            let vc = ExperimentalFeaturesList.asViewController(dataProvider: ExperimentalFeaturesDataProvider())
-            self?.tableView.deselectSelectedRowWithAnimation(true)
-            self?.navigationController?.pushViewController(vc, animated: true)
+            guard let self else {
+                return
+            }
+
+            let vc = ExperimentalFeaturesList.asViewController(viewModel: self.experimentalFeaturesVM)
+            self.tableView.deselectSelectedRowWithAnimation(true)
+            self.navigationController?.pushViewController(vc, animated: true)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugFeatureFlagsView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugFeatureFlagsView.swift
@@ -81,7 +81,7 @@ private final class DebugFeatureFlagsViewModel: ObservableObject {
     private let overrideStore = FeatureFlagOverrideStore()
 
     private let allRemoteFlags = RemoteFeatureFlag.allCases.filter(\.canOverride)
-    private let allLocalFlags = FeatureFlag.allCases.filter(\.canOverride)
+    private let allLocalFlags = FeatureFlag.allCases
 
     @Published var filter: DebugFeatureFlagFilter = .all
     @Published var filterTerm = ""
@@ -115,7 +115,7 @@ private final class DebugFeatureFlagsViewModel: ObservableObject {
     }
 
     private func override(_ flag: OverridableFlag, withValue value: Bool) {
-        try? overrideStore.override(flag, withValue: value)
+        overrideStore.override(flag, withValue: value)
         objectWillChange.send()
     }
 
@@ -146,10 +146,10 @@ private final class DebugFeatureFlagsViewModel: ObservableObject {
 
     func enableAllFlags() {
         for flag in RemoteFeatureFlag.allCases where !flag.enabled() {
-            try? overrideStore.override(flag, withValue: true)
+            overrideStore.override(flag, withValue: true)
         }
         for flag in FeatureFlag.allCases where !flag.enabled {
-            try? overrideStore.override(flag, withValue: true)
+            overrideStore.override(flag, withValue: true)
         }
         objectWillChange.send()
     }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -157,9 +157,10 @@ final class DebugMenuViewController: UIHostingController<DebugMenuView> {
     }
 
     static func configure(in window: UIWindow?) {
-        guard FeatureFlag.debugMenu.enabled else {
+        guard BuildConfiguration.current.isInternal else {
             return
         }
+
         assert(window != nil)
 
         let gesture = UIScreenEdgePanGestureRecognizer(target: DebugMenuViewController.self, action: #selector(showDebugMenu))

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -1,0 +1,34 @@
+import Foundation
+import WordPressUI
+
+class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvider {
+
+    let flags: [OverridableFlag] = [
+        FeatureFlag.authenticateUsingApplicationPassword,
+    ]
+
+    private let flagStore = FeatureFlagOverrideStore()
+
+    func loadItems() throws -> [WordPressUI.Feature] {
+        flags.map { flag in
+            WordPressUI.Feature(name: flag.description, key: flag.key)
+        }
+    }
+
+    func value(for feature: WordPressUI.Feature) -> Bool {
+        let flag = flag(for: feature)
+        return flagStore.overriddenValue(for: flag) ?? flag.originalValue
+    }
+
+    func didChangeValue(for feature: WordPressUI.Feature, to newValue: Bool) {
+        flagStore.override(flag(for: feature), withValue: newValue)
+    }
+
+    private func flag(for feature: WordPressUI.Feature) -> OverridableFlag {
+        guard let flag = flags.first(where: { $0.key == feature.key }) else {
+            preconditionFailure("Invalid Feature Flag")
+        }
+
+        return flag
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -931,6 +931,8 @@
 		24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C69A8A2612421900312D9A /* UserSettingsTests.swift */; };
 		24C69AC22612467C00312D9A /* UserSettingsTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */; };
 		24CDE3412C5863A1005E5E43 /* TestKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CDE3402C5863A1005E5E43 /* TestKeychain.swift */; };
+		24CED4032C73E267005A1E1D /* ExperimentalFeaturesDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CED4022C73E266005A1E1D /* ExperimentalFeaturesDataProvider.swift */; };
+		24CED4042C73E267005A1E1D /* ExperimentalFeaturesDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CED4022C73E266005A1E1D /* ExperimentalFeaturesDataProvider.swift */; };
 		24DB7C132C5AEF0600A0FE92 /* LoginClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB7C122C5AEF0500A0FE92 /* LoginClient.swift */; };
 		24DB7C142C5AEF0600A0FE92 /* LoginClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB7C122C5AEF0500A0FE92 /* LoginClient.swift */; };
 		24DB7C162C5AFA7200A0FE92 /* WordPressClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB7C152C5AFA7200A0FE92 /* WordPressClient.swift */; };
@@ -6820,6 +6822,7 @@
 		24C69A8A2612421900312D9A /* UserSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTests.swift; sourceTree = "<group>"; };
 		24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserSettingsTestsObjc.m; sourceTree = "<group>"; };
 		24CDE3402C5863A1005E5E43 /* TestKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestKeychain.swift; sourceTree = "<group>"; };
+		24CED4022C73E266005A1E1D /* ExperimentalFeaturesDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentalFeaturesDataProvider.swift; sourceTree = "<group>"; };
 		24DB7C122C5AEF0500A0FE92 /* LoginClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginClient.swift; sourceTree = "<group>"; };
 		24DB7C152C5AFA7200A0FE92 /* WordPressClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressClient.swift; sourceTree = "<group>"; };
 		24DB7C182C5AFC0600A0FE92 /* ApplicationPasswordService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordService.swift; sourceTree = "<group>"; };
@@ -11787,6 +11790,7 @@
 				F9B862C82478170A008B093C /* EncryptedLogTableViewController.swift */,
 				CECEEB542823164800A28ADE /* MediaCacheSettingsViewController.swift */,
 				0C57510F2B011468001074E5 /* RemoteConfigDebugView.swift */,
+				24CED4022C73E266005A1E1D /* ExperimentalFeaturesDataProvider.swift */,
 			);
 			path = "App Settings";
 			sourceTree = "<group>";
@@ -21771,6 +21775,7 @@
 				C9B477B229CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */,
 				F4AA1E5E2AF66D3300EBA201 /* AllDomainsListItemViewModel.swift in Sources */,
 				4A2C73F42A95856000ACE79E /* PostRepository.swift in Sources */,
+				24CED4032C73E267005A1E1D /* ExperimentalFeaturesDataProvider.swift in Sources */,
 				F5B9D7F0245BA938002BB2C7 /* FancyAlertViewController+CreateButtonAnnouncement.swift in Sources */,
 				FF54D4641D6F3FA900A0DC4D /* GutenbergSettings.swift in Sources */,
 				0C13ACC72BF406CB00FF7405 /* VoiceToContentView.swift in Sources */,
@@ -24559,6 +24564,7 @@
 				FABB217B2602FC2C00C8785C /* WPAddPostCategoryViewController.m in Sources */,
 				FABB217C2602FC2C00C8785C /* ReaderSearchTopic.swift in Sources */,
 				3F2ABE1B277118C4005D8916 /* Blog+VideoLimits.swift in Sources */,
+				24CED4042C73E267005A1E1D /* ExperimentalFeaturesDataProvider.swift in Sources */,
 				805CC0BD29668987002941DC /* JetpackBrandedScreen.swift in Sources */,
 				FABB217E2602FC2C00C8785C /* JetpackInstallError+Blocking.swift in Sources */,
 				FABB217F2602FC2C00C8785C /* QuickStartTourState.swift in Sources */,

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -134,7 +134,7 @@ class FeatureFlagTests: XCTestCase {
         let flag = MockFeatureFlag.enabledFeature
 
         XCTAssertNil(store.overriddenValue(for: flag))
-        try? store.override(flag, withValue: false)
+        store.override(flag, withValue: false)
 
         let value = store.overriddenValue(for: flag)
         XCTAssertNotNil(value)
@@ -145,18 +145,11 @@ class FeatureFlagTests: XCTestCase {
         let flag = MockFeatureFlag.disabledFeature
 
         XCTAssertNil(store.overriddenValue(for: flag))
-        try? store.override(flag, withValue: true)
+        store.override(flag, withValue: true)
 
         let value = store.overriddenValue(for: flag)
         XCTAssertNotNil(value)
         XCTAssert(value == true)
-    }
-
-    func testNonOverrideableFeatureFlagCannotBeOverridden() {
-        let flag = MockFeatureFlag.nonOverrideableFeature
-
-        try? store.override(flag, withValue: false)
-        XCTAssertFalse(store.isOverridden(flag))
     }
 
     func testEnabledFeatureFlagValueIsNotOverriddenWhenResetToNormalState() {
@@ -164,10 +157,10 @@ class FeatureFlagTests: XCTestCase {
 
         XCTAssertFalse(store.isOverridden(flag))
 
-        try? store.override(flag, withValue: false)
+        store.override(flag, withValue: false)
         XCTAssertTrue(store.isOverridden(flag))
 
-        try? store.override(flag, withValue: true)
+        store.override(flag, withValue: true)
         XCTAssertFalse(store.isOverridden(flag))
     }
 
@@ -176,10 +169,10 @@ class FeatureFlagTests: XCTestCase {
 
         XCTAssertFalse(store.isOverridden(flag))
 
-        try? store.override(flag, withValue: true)
+        store.override(flag, withValue: true)
         XCTAssertTrue(store.isOverridden(flag))
 
-        try? store.override(flag, withValue: false)
+        store.override(flag, withValue: false)
         XCTAssertFalse(store.isOverridden(flag))
     }
 }

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -89,6 +89,10 @@ enum MockFeatureFlag: OverridableFlag {
         }
     }
 
+    var key: String {
+        "ff-override-\(String(describing: self))"
+    }
+
     var remoteValue: Bool? {
         switch self {
         case .remotelyEnabledLocallyEnabledFeature,


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/ee490cee-3911-4e8b-8623-581fadc3ae3f" width="320" />

To test:

1. Go to Me > App Settings > Experimental Features
2. Enable "Application Passwords for self-hosted sites"
3. Note that that flow is now enabled if you try to add a new self-hosted site
4. Note that In the "Debug" menu, the feature flag is now marked as "Overridden"
5. Turn it off, note that everything goes back to normal.

## Regression Notes
1. Potential unintended areas of impact
Other feature flags stuff could be weird – I simplified the implementation. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I checked the feature flag page and didn't see any issues – I figure they'd crop up there

3. What automated tests I added (or what prevented me from doing so)
I didn't add any new tests, because there's not really any logic to test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
