### PR TITLE
Update GlotPress localization generation to include new Swift Packages

### DIFF
--- a/.buildkite/commands/complete-code-freeze.sh
+++ b/.buildkite/commands/complete-code-freeze.sh
@@ -16,6 +16,9 @@ echo '--- :git: Checkout release branch'
 echo '--- :ruby: Setup Ruby tools'
 install_gems
 
+echo "--- :swift: Set up Swift Packages"
+install_swiftpm_dependencies
+
 echo '--- :closed_lock_with_key: Access secrets'
 bundle exec fastlane run configure_apply
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -317,13 +317,12 @@ platform :ios do
 
   lane :resolve_packages do |derived_data_path: DERIVED_DATA_PATH|
     sh(
-      command: <<~CMD
-        xcodebuild \
-          -resolvePackageDependencies \
-          -workspace #{File.join(PROJECT_ROOT_FOLDER, 'WordPress.xcworkspace')} \
-          -scheme WordPress \
-          -derivedDataPath #{derived_data_path}
-      CMD
+      'xcodebuild',
+      '-resolvePackageDependencies',
+      '-onlyUsePackageVersionsFromResolvedFile',
+      '-workspace', File.join(PROJECT_ROOT_FOLDER, 'WordPress.xcworkspace'),
+      '-scheme', 'WordPress',
+      '-derivedDataPath', derived_data_path
     )
   end
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -7,7 +7,7 @@ APPCENTER_OWNER_NAME = 'automattic'
 APPCENTER_OWNER_TYPE = 'organization'
 CONCURRENT_SIMULATORS = 2
 
-# Shared options to use when invoking `gym` / `build_app`.
+# Shared options to use when invoking `build_app` (`gym`).
 #
 # - `manageAppVersionAndBuildNumber: false` prevents `xcodebuild` from bumping
 #   the build number when extracting an archive into an IPA file. We want to
@@ -171,7 +171,7 @@ platform :ios do
 
     appstore_code_signing
 
-    gym(
+    build_app(
       scheme: 'WordPress',
       workspace: WORKSPACE_PATH,
       clean: true,
@@ -236,7 +236,7 @@ platform :ios do
 
     jetpack_appstore_code_signing
 
-    gym(
+    build_app(
       scheme: 'Jetpack',
       workspace: WORKSPACE_PATH,
       clean: true,
@@ -357,7 +357,7 @@ platform :ios do
     new_config.save_as(Pathname.new(version_config_path))
 
     # Build
-    gym(
+    build_app(
       scheme: scheme,
       workspace: WORKSPACE_PATH,
       configuration: configuration,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -315,6 +315,18 @@ platform :ios do
     )
   end
 
+  lane :resolve_packages do |derived_data_path: DERIVED_DATA_PATH|
+    sh(
+      command: <<~CMD
+        xcodebuild \
+          -resolvePackageDependencies \
+          -workspace #{File.join(PROJECT_ROOT_FOLDER, 'WordPress.xcworkspace')} \
+          -scheme WordPress \
+          -derivedDataPath #{derived_data_path}
+      CMD
+    )
+  end
+
   #################################################
   # Helper Functions
   #################################################

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -97,6 +97,11 @@ MANUALLY_MAINTAINED_STRINGS_FILES = {
   File.join('WordPress', 'JetpackIntents', 'en.lproj', 'Sites.strings') => 'ios-widget.' # Strings from the `.intentdefinition`, used for configuring the iOS Widget
 }.freeze
 
+# The names of the remote Swift Packages that we want to add to our localizations, as they'll be checked out during resolvePackageDependencies in the Derived Data folder
+REMOTE_SWIFT_PACKAGES_TO_LOCALIZE = %w[
+  WordPressKit-iOS
+].freeze
+
 # Application-agnostic settings for the `upload_to_app_store` action (also known as `deliver`).
 # Used in `update_*_metadata_on_app_store_connect` lanes.
 #
@@ -128,6 +133,10 @@ platform :ios do
       # Fetch fresh pods to read the latest localizations from them.
       # In CI, we expect the pods to be already available and up to date.
       cocoapods unless is_ci
+
+      # For the same reason, fetch fresh packages
+      # FIXME: We yet don't have an explicit way to set the derived data in CI, so we'll run it in CI, too
+      resolve_packages(derived_data_path: DERIVED_DATA_PATH)
 
       custom_gutenber_path = options[:gutenberg_path]
       if custom_gutenber_path
@@ -186,7 +195,8 @@ platform :ios do
           'Pods/WordPress*/',
           'Modules/Sources/',
           'WordPressAuthenticator/Sources/',
-          gutenberg_path
+          gutenberg_path,
+          *REMOTE_SWIFT_PACKAGES_TO_LOCALIZE.map { |name| File.join(DERIVED_DATA_PATH, 'SourcePackages', 'checkouts', name, 'Sources') }
         ],
         exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],
         routines: ['AppLocalizedString'],

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -182,6 +182,8 @@ platform :ios do
         paths: [
           'WordPress/',
           'Pods/WordPress*/',
+          'Modules/Sources/',
+          'WordPressAuthenticator/Sources/',
           gutenberg_path
         ],
         exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -125,7 +125,9 @@ platform :ios do
     # We jump in the tempdir immediately, even though we might not need it.
     # It's just simpler to rely on the Ruby block API for it than to manage it by hand.
     Dir.mktmpdir do |tempdir|
-      cocoapods
+      # Fetch fresh pods to read the latest localizations from them.
+      # In CI, we expect the pods to be already available and up to date.
+      cocoapods unless is_ci
 
       custom_gutenber_path = options[:gutenberg_path]
       if custom_gutenber_path

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -122,29 +122,31 @@ platform :ios do
   # @called_by complete_code_freeze
   #
   lane :generate_strings_file_for_glotpress do |options|
-    cocoapods
-
-    # On top of fetching the latest Pods, we also need to fetch the source for the Gutenberg code.
-    # To get it, we need to manually clone the repo, since Gutenberg is distributed via XCFramework.
-    # XCFrameworks are binary targets and cannot extract strings via genstrings from there.
-    config = gutenberg_config!
-
-    ref_node = config[:ref]
-    UI.user_error!('Could not find Gutenberg ref to clone the repository in order to access its strings.') if ref_node.nil?
-
-    ref = ref_node[:tag] || ref_node[:commit]
-    UI.user_error!('The ref to clone Gutenberg in order to access its strings has neither tag nor commit values.') if ref.nil?
-
-    github_org = config[:github_org]
-    UI.user_error!('Could not find GitHub organization name to clone Gutenberg in order to access its strings.') if github_org.nil?
-
-    repo_name = config[:repo_name]
-    UI.user_error!('Could not find GitHub repository name to clone Gutenberg in order to access its strings.') if repo_name.nil?
-
-    # Create a temporary directory to clone Gutenberg into.
-    # We'll run the rest of the automation from within the block, but notice that only the Gutenbreg cloning happens within the temporary directory.
-    gutenberg_clone_name = 'Gutenberg-Strings-Clone'
+    # We create the tempdir immediately, even though we might not need it.
+    # It's just simpler to rely on the Ruby block API for it than to manage it by hand.
     Dir.mktmpdir do |tempdir|
+      cocoapods
+
+      # On top of fetching the latest Pods, we also need to fetch the source for the Gutenberg code.
+      # To get it, we need to manually clone the repo, since Gutenberg is distributed via XCFramework.
+      # XCFrameworks are binary targets and cannot extract strings via genstrings from there.
+      config = gutenberg_config!
+
+      ref_node = config[:ref]
+      UI.user_error!('Could not find Gutenberg ref to clone the repository in order to access its strings.') if ref_node.nil?
+
+      ref = ref_node[:tag] || ref_node[:commit]
+      UI.user_error!('The ref to clone Gutenberg in order to access its strings has neither tag nor commit values.') if ref.nil?
+
+      github_org = config[:github_org]
+      UI.user_error!('Could not find GitHub organization name to clone Gutenberg in order to access its strings.') if github_org.nil?
+
+      repo_name = config[:repo_name]
+      UI.user_error!('Could not find GitHub repository name to clone Gutenberg in order to access its strings.') if repo_name.nil?
+
+      # Create a temporary directory to clone Gutenberg into.
+      # We'll run the rest of the automation from within the block, but notice that only the Gutenbreg cloning happens within the temporary directory.
+      gutenberg_clone_name = 'Gutenberg-Strings-Clone'
       Dir.chdir(tempdir) do
         repo_url = "https://github.com/#{github_org}/#{repo_name}"
         UI.message("Cloning Gutenberg from #{repo_url} into #{gutenberg_clone_name}. This might take a few minutes…")

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -164,7 +164,11 @@ platform :ios do
       # However, we are still in the tempdir block, so that once the automation is done, the tempdir will be automatically deleted.
       wordpress_en_lproj = File.join('WordPress', 'Resources', 'en.lproj')
       ios_generate_strings_file_from_code(
-        paths: ['WordPress/', 'Pods/WordPress*/', 'Pods/WPMediaPicker/', 'WordPressShared/WordPressShared/', File.join(tempdir, gutenberg_clone_name)],
+        paths: [
+          'WordPress/',
+          'Pods/WordPress*/',
+          File.join(tempdir, gutenberg_clone_name)
+        ],
         exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],
         routines: ['AppLocalizedString'],
         output_dir: wordpress_en_lproj

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -136,7 +136,8 @@ platform :ios do
 
       # For the same reason, fetch fresh packages
       # FIXME: We yet don't have an explicit way to set the derived data in CI, so we'll run it in CI, too
-      resolve_packages(derived_data_path: DERIVED_DATA_PATH)
+      derived_data_path = options[:derived_data_path] || DERIVED_DATA_PATH
+      resolve_packages(derived_data_path: derived_data_path)
 
       custom_gutenber_path = options[:gutenberg_path]
       if custom_gutenber_path
@@ -196,7 +197,7 @@ platform :ios do
           'Modules/Sources/',
           'WordPressAuthenticator/Sources/',
           gutenberg_path,
-          *REMOTE_SWIFT_PACKAGES_TO_LOCALIZE.map { |name| File.join(DERIVED_DATA_PATH, 'SourcePackages', 'checkouts', name, 'Sources') }
+          *REMOTE_SWIFT_PACKAGES_TO_LOCALIZE.map { |name| File.join(derived_data_path, 'SourcePackages', 'checkouts', name, 'Sources') }
         ],
         exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],
         routines: ['AppLocalizedString'],

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -136,7 +136,7 @@ platform :ios do
 
       # For the same reason, fetch fresh packages
       # FIXME: We yet don't have an explicit way to set the derived data in CI, so we'll run it in CI, too
-      derived_data_path = options[:derived_data_path] || DERIVED_DATA_PATH
+      derived_data_path = options.fetch(:derived_data_path, DERIVED_DATA_PATH)
       resolve_packages(derived_data_path: derived_data_path)
 
       custom_gutenber_path = options[:gutenberg_path]

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -122,44 +122,57 @@ platform :ios do
   # @called_by complete_code_freeze
   #
   lane :generate_strings_file_for_glotpress do |options|
-    # We create the tempdir immediately, even though we might not need it.
+    # We jump in the tempdir immediately, even though we might not need it.
     # It's just simpler to rely on the Ruby block API for it than to manage it by hand.
     Dir.mktmpdir do |tempdir|
       cocoapods
 
-      # On top of fetching the latest Pods, we also need to fetch the source for the Gutenberg code.
-      # To get it, we need to manually clone the repo, since Gutenberg is distributed via XCFramework.
-      # XCFrameworks are binary targets and cannot extract strings via genstrings from there.
-      config = gutenberg_config!
+      custom_gutenber_path = options[:gutenberg_path]
+      if custom_gutenber_path
+        # It's simpler to ask the caller to give an absolute path than to make it absolute ourselves be
+        # Given this is a debug option, it seems like an okay tradeoff.
+        UI.user_error!("Please provide gutenberg_path as an absolute path. Current value: #{custom_gutenber_path}") unless File.absolute_path?(custom_gutenber_path)
 
-      ref_node = config[:ref]
-      UI.user_error!('Could not find Gutenberg ref to clone the repository in order to access its strings.') if ref_node.nil?
+        UI.user_error!("Could not find Gutenber project at given path #{custom_gutenber_path}") unless Dir.exist?(custom_gutenber_path)
 
-      ref = ref_node[:tag] || ref_node[:commit]
-      UI.user_error!('The ref to clone Gutenberg in order to access its strings has neither tag nor commit values.') if ref.nil?
+        gutenberg_path = custom_gutenber_path
+        UI.message("Using Gutenberg from #{gutenberg_path} instead of cloing it...")
+      else
+        # On top of fetching the latest Pods, we also need to fetch the source for the Gutenberg code.
+        # To get it, we need to manually clone the repo, since Gutenberg is distributed via XCFramework.
+        # XCFrameworks are binary targets and cannot extract strings via genstrings from there.
+        config = gutenberg_config!
 
-      github_org = config[:github_org]
-      UI.user_error!('Could not find GitHub organization name to clone Gutenberg in order to access its strings.') if github_org.nil?
+        ref_node = config[:ref]
+        UI.user_error!('Could not find Gutenberg ref to clone the repository in order to access its strings.') if ref_node.nil?
 
-      repo_name = config[:repo_name]
-      UI.user_error!('Could not find GitHub repository name to clone Gutenberg in order to access its strings.') if repo_name.nil?
+        ref = ref_node[:tag] || ref_node[:commit]
+        UI.user_error!('The ref to clone Gutenberg in order to access its strings has neither tag nor commit values.') if ref.nil?
 
-      # Create a temporary directory to clone Gutenberg into.
-      # We'll run the rest of the automation from within the block, but notice that only the Gutenbreg cloning happens within the temporary directory.
-      gutenberg_clone_name = 'Gutenberg-Strings-Clone'
-      Dir.chdir(tempdir) do
-        repo_url = "https://github.com/#{github_org}/#{repo_name}"
-        UI.message("Cloning Gutenberg from #{repo_url} into #{gutenberg_clone_name}. This might take a few minutes…")
-        sh("git clone --depth 1 #{repo_url} #{gutenberg_clone_name}")
-        Dir.chdir(gutenberg_clone_name) do
-          if config[:ref][:tag]
-            sh("git fetch origin refs/tags/#{ref}:refs/tags/#{ref}")
-            sh("git checkout refs/tags/#{ref}")
-          else
-            sh("git fetch origin #{ref}")
-            sh("git checkout #{ref}")
+        github_org = config[:github_org]
+        UI.user_error!('Could not find GitHub organization name to clone Gutenberg in order to access its strings.') if github_org.nil?
+
+        repo_name = config[:repo_name]
+        UI.user_error!('Could not find GitHub repository name to clone Gutenberg in order to access its strings.') if repo_name.nil?
+
+        # Create a temporary directory to clone Gutenberg into.
+        # We'll run the rest of the automation from within the block, but notice that only the Gutenbreg cloning happens within the temporary directory.
+        gutenberg_clone_name = 'Gutenberg-Strings-Clone'
+        Dir.chdir(tempdir) do
+          repo_url = "https://github.com/#{github_org}/#{repo_name}"
+          UI.message("Cloning Gutenberg from #{repo_url} into #{gutenberg_clone_name}. This might take a few minutes…")
+          sh("git clone --depth 1 #{repo_url} #{gutenberg_clone_name}")
+          Dir.chdir(gutenberg_clone_name) do
+            if config[:ref][:tag]
+              sh("git fetch origin refs/tags/#{ref}:refs/tags/#{ref}")
+              sh("git checkout refs/tags/#{ref}")
+            else
+              sh("git fetch origin #{ref}")
+              sh("git checkout #{ref}")
+            end
           end
         end
+        gutenberg_path = File.join(tempdir, gutenberg_clone_name)
       end
 
       # Notice that we are no longer in the tempdir, so the paths below are back to being relative to the project root folder.
@@ -169,7 +182,7 @@ platform :ios do
         paths: [
           'WordPress/',
           'Pods/WordPress*/',
-          File.join(tempdir, gutenberg_clone_name)
+          gutenberg_path
         ],
         exclude: ['*Vendor*', 'WordPress/WordPressTest/**', '**/AppLocalizedString.swift'],
         routines: ['AppLocalizedString'],

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -148,7 +148,7 @@ platform :ios do
         UI.user_error!("Could not find Gutenber project at given path #{custom_gutenber_path}") unless Dir.exist?(custom_gutenber_path)
 
         gutenberg_path = custom_gutenber_path
-        UI.message("Using Gutenberg from #{gutenberg_path} instead of cloing it...")
+        UI.message("Using Gutenberg from #{gutenberg_path} instead of cloning it...")
       else
         # On top of fetching the latest Pods, we also need to fetch the source for the Gutenberg code.
         # To get it, we need to manually clone the repo, since Gutenberg is distributed via XCFramework.


### PR DESCRIPTION
Fixes an issue discovered by @crazytonyli where various entries had [disappeared from the `.strings` source of truth](https://github.com/wordpress-mobile/WordPress-iOS/commit/77eb1ad26ae6a0797671727ef950b520279847a9#diff-236a1390429e10f018cd3b7250bac8ce595acf8003dc42b43a01b034c485ca6e) during the 25.2 code freeze. This was due to moving the corresponding libraries from being fetched via CocoaPods to being local Swift Packages.

This PR address the issue by updating the localization automation configuration. 

Internal ref pdnsEh-1OV-p2

## Testing

To test these changes, I created a [test branch](https://github.com/wordpress-mobile/WordPress-iOS/compare/25.2.0.0...mokagio/test-update-localizations-on-25.2.0.0?expand=1) that cherry picks the commits from here on top of the 25.2.0.0 tag, then run the automation. 693d6f994880067e91f90fdb82d5c3e104c1b2b8 is the resulting commit where you can see the various strings that were removed in 77eb1ad26ae6a0797671727ef950b520279847a9 being reintroduced.

_I'll admit that I didn't check each individual edit. But here are a few random samples I took:_

![image](https://github.com/user-attachments/assets/a24ef8c9-00d0-42cd-8b54-8487b37fad05)

![image](https://github.com/user-attachments/assets/7380ab91-0cd4-4e25-b982-ba9dc2c77fda)

![image](https://github.com/user-attachments/assets/e96882ed-2ad7-448e-bd41-0209c7fc6a87)

_And here is a check for a string coming from the [WordPressKit repo](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/3832252c43c3710403ced45e7e2bc77f74add8e4/Sources/CoreAPI/WordPressOrgXMLRPCApi.swift#L213):_

![image](https://github.com/user-attachments/assets/66b6e44d-8835-4d54-9d20-18eadccfe6d1)


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.