### PR TITLE
Sidebar: Update Home

### DIFF
--- a/WordPress/Classes/Extensions/UIButton+Extensions.swift
+++ b/WordPress/Classes/Extensions/UIButton+Extensions.swift
@@ -4,12 +4,21 @@ extension UIButton {
     /// Creates a bar button item that looks like the native title menu
     /// (see `navigationItem.titleMenuProvider`, iOS 16+).
     static func makeMenu(title: String, menu: UIMenu) -> UIButton {
-        let button = UIButton(configuration: {
+        let button = makeMenuButton(title: title)
+        button.menu = menu
+        button.showsMenuAsPrimaryAction = true
+        return button
+    }
+
+    /// Creates a bar button item that looks like the native title menu
+    /// (see `navigationItem.titleMenuProvider`, iOS 16+).
+    static func makeMenuButton(title: String) -> UIButton {
+        UIButton(configuration: {
             var configuration = UIButton.Configuration.plain()
             configuration.title = title
             configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
                 var attributes = $0
-                attributes.font = WPStyleGuide.fontForTextStyle(.headline)
+                attributes.font = AppStyleGuide.navigationBarStandardFont
                 return attributes
             }
             configuration.image = UIImage(systemName: "chevron.down.circle.fill")?.withBaselineOffset(fromBottom: 4)
@@ -20,8 +29,5 @@ extension UIButton {
             configuration.baseForegroundColor = .label
             return configuration
         }())
-        button.menu = menu
-        button.showsMenuAsPrimaryAction = true
-        return button
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,6 +15,7 @@ enum FeatureFlag: Int, CaseIterable {
     case authenticateUsingApplicationPassword
     case tipKit
     case sidebar
+    case serif
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -48,6 +49,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .tipKit:
             return BuildConfiguration.current != .appStore
         case .sidebar:
+            return false
+        case .serif:
             return false
         }
     }
@@ -84,6 +87,7 @@ extension FeatureFlag {
         case .authenticateUsingApplicationPassword: "Application Passwords for self-hosted sites"
         case .tipKit: "TipKit"
         case .sidebar: "Sidebar"
+        case .serif: "Serif"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -122,7 +122,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)presentBlogDetailsViewController:(UIViewController * __nonnull)viewController;
 @end
 
-@interface BlogDetailsViewController : UIViewController <UIViewControllerTransitioningDelegate>
+@interface BlogDetailsViewController : UIViewController <UITableViewDelegate, UITableViewDataSource, UIViewControllerTransitioningDelegate>
 
 @property (nonatomic, strong, nonnull) Blog * blog;
 @property (nonatomic, strong, readonly) CreateButtonCoordinator * _Nullable createButtonCoordinator;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -227,7 +227,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 
 #pragma mark -
 
-@interface BlogDetailsViewController () <UIActionSheetDelegate, UIAlertViewDelegate, WPSplitViewControllerDetailProvider, UITableViewDelegate, UITableViewDataSource>
+@interface BlogDetailsViewController () <UIActionSheetDelegate, UIAlertViewDelegate, WPSplitViewControllerDetailProvider>
 
 @property (nonatomic, strong) NSArray *headerViewHorizontalConstraints;
 @property (nonatomic, strong) NSArray<BlogDetailsSection *> *tableSections;
@@ -264,7 +264,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 {
     [super viewDidLoad];
     
-    if (self.isScrollEnabled) {
+    if (self.isSidebarModeEnabled) {
+        _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
+    } else if (self.isScrollEnabled) {
         _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleInsetGrouped];
     } else {
         _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleInsetGrouped];
@@ -273,6 +275,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.translatesAutoresizingMaskIntoConstraints = false;
+    if (self.isSidebarModeEnabled) {
+        self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+        self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 8, 0, 0); // Left inset
+    }
     [self.view addSubview:self.tableView];
     [self.view pinSubviewToAllEdges:self.tableView];
     
@@ -1547,6 +1553,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     cell.accessibilityHint = row.accessibilityHint;
     cell.accessoryView = nil;
     cell.textLabel.textAlignment = NSTextAlignmentNatural;
+
     if (row.forDestructiveAction) {
         cell.accessoryType = UITableViewCellAccessoryNone;
         [WPStyleGuide configureTableViewDestructiveActionCell:cell];
@@ -1802,10 +1809,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 
 - (void)showDashboard
 {
-    BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog embeddedInScrollView:NO];
-    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    controller.extendedLayoutIncludesOpaqueBars = YES;
-    [self.presentationDelegate presentBlogDetailsViewController:controller];
+    if (self.isSidebarModeEnabled) {
+        MySiteViewController *controller = [MySiteViewController makeForBlog:self.blog isSidebarModeEnabled:true];
+        [self.presentationDelegate presentBlogDetailsViewController:controller];
+    } else {
+        BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog embeddedInScrollView:NO];
+        controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+        controller.extendedLayoutIncludesOpaqueBars = YES;
+        [self.presentationDelegate presentBlogDetailsViewController:controller];
+    }
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -73,15 +73,15 @@ class BlogDetailHeaderView: UIView {
         static let atSides: CGFloat = 20
         static let top: CGFloat = 10
         static let bottom: CGFloat = 16
-        static func betweenTitleViewAndActionRow(_ showsActionRow: Bool) -> CGFloat {
-            return showsActionRow ? 32 : 0
-        }
     }
+
+    private let isSidebarModeEnabled: Bool
 
     // MARK: - Initializers
 
-    required init(delegate: BlogDetailHeaderViewDelegate) {
-        titleView = TitleView(frame: .zero)
+    required init(delegate: BlogDetailHeaderViewDelegate, isSidebarModeEnabled: Bool) {
+        titleView = TitleView(isSidebarModeEnabled: isSidebarModeEnabled)
+        self.isSidebarModeEnabled = isSidebarModeEnabled
 
         super.init(frame: .zero)
 
@@ -107,7 +107,7 @@ class BlogDetailHeaderView: UIView {
         }
 
         if let siteIconMenu = delegate?.makeSiteIconMenu() {
-            titleView.siteIconView.setMenu(siteIconMenu) { [weak self] in
+            titleView.siteIconView.setMenu(siteIconMenu) {
                 WPAnalytics.track(.siteSettingsSiteIconTapped)
             }
         }
@@ -128,8 +128,6 @@ class BlogDetailHeaderView: UIView {
 
     // MARK: - Constraints
 
-    private var topActionRowConstraint: NSLayoutConstraint?
-
     private func setupConstraintsForChildViews() {
         let constraints = constraintsForTitleView()
         NSLayoutConstraint.activate(constraints)
@@ -137,7 +135,7 @@ class BlogDetailHeaderView: UIView {
 
     private func constraintsForTitleView() -> [NSLayoutConstraint] {
         return [
-            titleView.topAnchor.constraint(equalTo: topAnchor, constant: LayoutSpacing.top),
+            titleView.topAnchor.constraint(equalTo: topAnchor, constant: isSidebarModeEnabled ? 3 : LayoutSpacing.top),
             titleView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: LayoutSpacing.atSides),
             titleView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -10),
             titleView.bottomAnchor.constraint(equalTo: bottomAnchor)
@@ -160,20 +158,6 @@ class BlogDetailHeaderView: UIView {
     private func subtitleButtonTapped() {
         delegate?.visitSiteTapped()
     }
-
-    // MARK: - Accessibility
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        refreshStackViewVisibility()
-    }
-
-    private func refreshStackViewVisibility() {
-        let showsActionRow = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-
-        topActionRowConstraint?.constant = LayoutSpacing.betweenTitleViewAndActionRow(showsActionRow)
-    }
 }
 
 extension BlogDetailHeaderView {
@@ -193,7 +177,7 @@ extension BlogDetailHeaderView {
             ])
 
             stackView.alignment = .center
-            stackView.spacing = 12
+            stackView.spacing = isSidebarModeEnabled ? 20 : 12
             stackView.translatesAutoresizingMaskIntoConstraints = false
             stackView.setCustomSpacing(2, after: titleStackView)
 
@@ -206,7 +190,7 @@ extension BlogDetailHeaderView {
             return siteIconView
         }()
 
-        let subtitleButton: UIButton = {
+        private(set) lazy var subtitleButton: UIButton = {
             let button = UIButton(type: .custom)
 
             var configuration = UIButton.Configuration.plain()
@@ -216,7 +200,7 @@ extension BlogDetailHeaderView {
                 attributes.foregroundColor = .primary
                 return attributes
             }
-            configuration.contentInsets = NSDirectionalEdgeInsets(top: 2, leading: 0, bottom: 1, trailing: 0)
+            configuration.contentInsets = isSidebarModeEnabled ? NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 2, trailing: 0) : NSDirectionalEdgeInsets(top: 2, leading: 0, bottom: 1, trailing: 0)
             configuration.titleLineBreakMode = .byTruncatingTail
             button.configuration = configuration
 
@@ -234,17 +218,18 @@ extension BlogDetailHeaderView {
             return button
         }()
 
-        let titleButton: UIButton = {
+        private(set) lazy var titleButton: UIButton = {
             let button = UIButton(type: .custom)
 
             var configuration = UIButton.Configuration.plain()
+            let font = isSidebarModeEnabled ? AppStyleGuide.navigationBarLargeFont : WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
             configuration.titleTextAttributesTransformer = .init { attributes in
                 var attributes = attributes
-                attributes.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+                attributes.font = font
                 attributes.foregroundColor = UIColor.label
                 return attributes
             }
-            configuration.contentInsets = NSDirectionalEdgeInsets(top: 1, leading: 0, bottom: 1, trailing: 0)
+            configuration.contentInsets = isSidebarModeEnabled ? .zero : NSDirectionalEdgeInsets(top: 1, leading: 0, bottom: 1, trailing: 0)
             configuration.titleLineBreakMode = .byTruncatingTail
             button.configuration = configuration
 
@@ -283,12 +268,18 @@ extension BlogDetailHeaderView {
             return stackView
         }()
 
+        private let isSidebarModeEnabled: Bool
+
         // MARK: - Initializers
 
-        override init(frame: CGRect) {
-            super.init(frame: frame)
+        init(isSidebarModeEnabled: Bool) {
+            self.isSidebarModeEnabled = isSidebarModeEnabled
+            super.init(frame: .zero)
 
             setupChildViews()
+            if isSidebarModeEnabled {
+                configureLargeTitleMode()
+            }
         }
 
         required init?(coder: NSCoder) {
@@ -296,6 +287,19 @@ extension BlogDetailHeaderView {
         }
 
         // MARK: - Configuration
+
+        fileprivate func configureLargeTitleMode() {
+            siteIconView.setImageViewSize(50)
+
+            siteIconView.transform = CGAffineTransform(translationX: 0, y: 2) // Visually center vertically
+
+            siteSwitcherButton.removeFromSuperview()
+            mainStackView.addSubview(siteSwitcherButton)
+            NSLayoutConstraint.activate([
+                siteSwitcherButton.lastBaselineAnchor.constraint(equalTo: titleButton.lastBaselineAnchor, constant: -2),
+                siteSwitcherButton.leadingAnchor.constraint(equalTo: titleButton.trailingAnchor, constant: 2)
+            ])
+        }
 
         func set(url: String) {
             subtitleButton.setTitle(url, for: .normal)
@@ -317,7 +321,7 @@ extension BlogDetailHeaderView {
             addSubview(mainStackView)
 
             NSLayoutConstraint.activate([
-                mainStackView.topAnchor.constraint(equalTo: topAnchor, constant: .DS.Padding.double),
+                mainStackView.topAnchor.constraint(equalTo: topAnchor, constant: isSidebarModeEnabled ? 0 : .DS.Padding.double),
                 mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
                 mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
                 mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
@@ -12,16 +12,15 @@ final class SiteDetailsSiteIconView: UIView {
     /// A block to be called when an image is dropped on to the view.
     var dropped: (([UIImage]) -> Void)?
 
-    let imageView: SiteIconHostingView = {
-        let imageView = SiteIconHostingView(frame: .zero)
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.clipsToBounds = true
-        NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
-            imageView.heightAnchor.constraint(equalToConstant: Constants.imageSize)
-        ])
-        return imageView
-    }()
+    let imageView = SiteIconHostingView()
+
+    private let imageViewSizeConstraints: [NSLayoutConstraint]
+
+    func setImageViewSize(_ size: CGFloat) {
+        for constraint in imageViewSizeConstraints {
+            constraint.constant = size
+        }
+    }
 
     let activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
@@ -61,6 +60,14 @@ final class SiteDetailsSiteIconView: UIView {
     }
 
     init(frame: CGRect, insets: UIEdgeInsets = .zero) {
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageViewSizeConstraints = [
+            imageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
+            imageView.heightAnchor.constraint(equalToConstant: Constants.imageSize)
+        ]
+        NSLayoutConstraint.activate(imageViewSizeConstraints)
+
         super.init(frame: frame)
 
         button.addSubview(imageView)

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -21,19 +21,22 @@ final class SitePickerViewController: UIViewController {
     let mediaService: MediaService
 
     private(set) lazy var blogDetailHeaderView: BlogDetailHeaderView = {
-        let headerView = BlogDetailHeaderView(delegate: self)
+        let headerView = BlogDetailHeaderView(delegate: self, isSidebarModeEnabled: isSidebarModeEnabled)
         headerView.translatesAutoresizingMaskIntoConstraints = false
         return headerView
     }()
 
     private var sitePickerTipObserver: TipObserver?
+    private let isSidebarModeEnabled: Bool
 
     init(blog: Blog,
          blogService: BlogService? = nil,
-         mediaService: MediaService? = nil) {
+         mediaService: MediaService? = nil,
+         isSidebarModeEnabled: Bool) {
         self.blog = blog
         self.blogService = blogService ?? BlogService(coreDataStack: ContextManager.shared)
         self.mediaService = mediaService ?? MediaService(managedObjectContext: ContextManager.shared.mainContext)
+        self.isSidebarModeEnabled = isSidebarModeEnabled
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -73,7 +76,17 @@ final class SitePickerViewController: UIViewController {
     private func setupHeaderView() {
         blogDetailHeaderView.blog = blog
         view.addSubview(blogDetailHeaderView)
-        view.pinSubviewToAllEdges(blogDetailHeaderView)
+
+        if isSidebarModeEnabled {
+            NSLayoutConstraint.activate([
+                blogDetailHeaderView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
+                blogDetailHeaderView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
+                blogDetailHeaderView.topAnchor.constraint(equalTo: view.topAnchor),
+                blogDetailHeaderView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            ])
+        } else {
+            view.pinSubviewToAllEdges(blogDetailHeaderView)
+        }
     }
 
     private func startObservingTitleChanges() {

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -7,7 +7,7 @@ protocol SiteMenuViewControllerDelegate: AnyObject {
 /// The site menu for the split view navigation.
 final class SiteMenuViewController: UIViewController {
     private let blog: Blog
-    private let blogDetailsVC = BlogDetailsViewController()
+    private let blogDetailsVC = SiteMenuListViewController()
 
     weak var delegate: SiteMenuViewControllerDelegate?
 
@@ -36,6 +36,53 @@ final class SiteMenuViewController: UIViewController {
         blogDetailsVC.showInitialDetailsForBlog()
 
         navigationItem.title = blog.settings?.name ?? (blog.displayURL as String?) ?? ""
+    }
+}
+
+// Updates the `BlogDetailsViewController` style to match the native sidebar style.
+private final class SiteMenuListViewController: BlogDetailsViewController {
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        let title = super.tableView(tableView, titleForHeaderInSection: section)
+        return title == nil ? (section == 0 ? 0 : 20) : 52
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let title = super.tableView(tableView, titleForHeaderInSection: section) else {
+            return nil
+        }
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .headline)
+        label.text = title
+
+        let headerView = UIView()
+        headerView.addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 20),
+            label.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -10),
+            label.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: 20)
+        ])
+        return headerView
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = super.tableView(tableView, cellForRowAt: indexPath)
+
+        cell.backgroundColor = .clear
+        cell.selectedBackgroundView = {
+            let backgroundView = UIView()
+            backgroundView.backgroundColor = .systemFill
+            backgroundView.layer.cornerRadius = 10
+            backgroundView.layer.cornerCurve = .continuous
+
+            let container = UIView()
+            container.addSubview(backgroundView)
+            backgroundView.translatesAutoresizingMaskIntoConstraints = false
+            container.pinSubviewToAllEdges(backgroundView, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+            return container
+        }()
+
+        return cell
     }
 }
 

--- a/WordPress/Jetpack/AppStyleGuide.swift
+++ b/WordPress/Jetpack/AppStyleGuide.swift
@@ -6,9 +6,9 @@ import Gridicons
 /// This configuration struct has a **WordPress** counterpart in the WordPress bundle.
 /// Make sure to keep them in sync to avoid build errors when building the WordPress target.
 struct AppStyleGuide {
-    static let navigationBarStandardFont: UIFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
-    static let navigationBarLargeFont: UIFont = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
-    static let epilogueTitleFont: UIFont = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
+    static let navigationBarStandardFont: UIFont = Feature.enabled(.serif) ? WPStyleGuide.fixedSerifFontForTextStyle(.headline, fontWeight: .semibold) : WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+    static let navigationBarLargeFont: UIFont = Feature.enabled(.serif) ? WPStyleGuide.fixedSerifFontForTextStyle(.largeTitle, fontWeight: .semibold) : WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
+    static let epilogueTitleFont: UIFont = Feature.enabled(.serif) ? WPStyleGuide.fixedSerifFontForTextStyle(.largeTitle, fontWeight: .semibold) : WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
 }
 
 // MARK: - Colors


### PR DESCRIPTION
This PR updates the Home page and the Site Menu on iPad.

<img width="1316" alt="Screenshot 2024-08-23 at 11 55 00 AM" src="https://github.com/user-attachments/assets/1edd5a15-887d-48ba-bf14-6c96c2e23c87">

<img width="1316" alt="Screenshot 2024-08-23 at 11 54 35 AM" src="https://github.com/user-attachments/assets/abb5b669-106f-4429-bab8-5426be8d6270">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
