### PR TITLE
Remove some OS version checks

### DIFF
--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -106,10 +106,7 @@ public class BottomSheetViewController: UIViewController {
     private var stackView: UIStackView!
 
     private var defaultBrackgroundColor: UIColor {
-        if #available(iOS 13, *) {
-            return .systemBackground
-        }
-        return .white
+        return .systemBackground
     }
 
     @objc func buttonPressed() {

--- a/Modules/Sources/WordPressUI/BottomSheet/GripButton.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/GripButton.swift
@@ -10,14 +10,10 @@ public class GripButton: UIButton {
     }
 
     private var color: UIColor {
-        if #available(iOS 13, *) {
-            if traitCollection.userInterfaceStyle == .dark {
-                return .systemGray4
-            } else {
-                return .systemGray5
-            }
+        if traitCollection.userInterfaceStyle == .dark {
+            return .systemGray4
         } else {
-            return UIColor(red: 0.764706, green: 0.768627, blue: 0.780392, alpha: 1)
+            return .systemGray5
         }
     }
 

--- a/Modules/Sources/WordPressUI/Extensions/UIControl+Helpers.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIControl+Helpers.swift
@@ -28,17 +28,9 @@ extension UIControl {
         set(alignment) {
             switch alignment {
             case .leading:
-                if #available(iOS 11.0, *) {
-                    contentHorizontalAlignment = .leading
-                } else {
-                    contentHorizontalAlignment = userInterfaceLayoutDirection() == .leftToRight ? .left : .right
-                }
+                contentHorizontalAlignment = .leading
             case .trailing:
-                if #available(iOS 11.0, *) {
-                    contentHorizontalAlignment = .trailing
-                } else {
-                    contentHorizontalAlignment = userInterfaceLayoutDirection() == .leftToRight ? .right : .left
-                }
+                contentHorizontalAlignment = .trailing
             case .center:
                 fallthrough
             default:

--- a/Modules/Sources/WordPressUI/Extensions/UIView+Helpers.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIView+Helpers.swift
@@ -58,14 +58,12 @@ extension UIView {
     ///   - subview: a subview to be pinned to self's safe area.
     ///   - insets: spacing between each subview edge to self's safe area. A positive value for an edge indicates that the subview is inside safe area on that edge.
     @objc public func pinSubviewToSafeArea(_ subview: UIView, insets: UIEdgeInsets) {
-        if #available(iOS 11.0, *) {
-            NSLayoutConstraint.activate([
-                safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: subview.leadingAnchor, constant: -insets.left),
-                safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
-                safeAreaLayoutGuide.topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
-                safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom)
-                ])
-        }
+        NSLayoutConstraint.activate([
+            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: subview.leadingAnchor, constant: -insets.left),
+            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
+            safeAreaLayoutGuide.topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom)
+        ])
     }
 
     @objc public func findFirstResponder() -> UIView? {

--- a/Modules/Sources/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/Modules/Sources/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -211,12 +211,10 @@ open class FancyAlertView: UIView {
     }
 
     func preferredContentSizeDidChange() {
-        if #available(iOS 11.0, *) {
-            if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-                bottomSwitchStackView.axis = .vertical
-            } else {
-                bottomSwitchStackView.axis = .horizontal
-            }
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            bottomSwitchStackView.axis = .vertical
+        } else {
+            bottomSwitchStackView.axis = .horizontal
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsRelatedPostsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsRelatedPostsView.swift
@@ -46,11 +46,7 @@ struct RelatedPostsSettingsView: View {
         } footer: {
             Text(Strings.optionsFooter)
         }
-        if #available(iOS 15, *) {
-            return section.tint(Color(UIColor.jetpackGreen))
-        } else {
-            return section.toggleStyle(SwitchToggleStyle(tint: Color(UIColor.jetpackGreen)))
-        }
+        return section.tint(Color(UIColor.jetpackGreen))
     }
 
     private var previewsSection: some View {

--- a/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
+++ b/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
@@ -196,15 +196,11 @@ open class Snapshot: NSObject {
         #if os(watchOS)
             return image
         #else
-            if #available(iOS 10.0, *) {
-                let format = UIGraphicsImageRendererFormat()
-                format.scale = image.scale
-                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-                return renderer.image { context in
-                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-                }
-            } else {
-                return image
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = image.scale
+            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+            return renderer.image { context in
+                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
             }
         #endif
     }

--- a/WordPressAuthenticator/Sources/Signin/Login2FAViewController.swift
+++ b/WordPressAuthenticator/Sources/Signin/Login2FAViewController.swift
@@ -272,18 +272,12 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
                 return
         }
 
-        if #available(iOS 14.0, *) {
-            UIPasteboard.general.detectAuthenticatorCode { [weak self] result in
-                switch result {
-                    case .success(let authenticatorCode):
-                        self?.handle(code: authenticatorCode)
-                    case .failure:
-                        break
-                }
-            }
-        } else {
-            if let pasteString = UIPasteboard.general.string {
-                handle(code: pasteString)
+        UIPasteboard.general.detectAuthenticatorCode { [weak self] result in
+            switch result {
+                case .success(let authenticatorCode):
+                    self?.handle(code: authenticatorCode)
+                case .failure:
+                    break
             }
         }
     }

--- a/WordPressAuthenticator/Sources/Signin/LoginNavigationController.swift
+++ b/WordPressAuthenticator/Sources/Signin/LoginNavigationController.swift
@@ -10,11 +10,7 @@ public class LoginNavigationController: RotationAwareNavigationViewController {
     public override func pushViewController(_ viewController: UIViewController, animated: Bool) {
         // By default, the back button label uses the previous view's title.
         // To override that, reset the label when pushing a new view controller.
-        if #available(iOS 14.0, *) {
-            self.viewControllers.last?.navigationItem.backButtonDisplayMode = .minimal
-        } else {
-            self.viewControllers.last?.navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(), style: .plain, target: nil, action: nil)
-        }
+        self.viewControllers.last?.navigationItem.backButtonDisplayMode = .minimal
 
         super.pushViewController(viewController, animated: animated)
     }

--- a/WordPressAuthenticator/Sources/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WordPressAuthenticator/Sources/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -423,18 +423,12 @@ private extension TwoFAViewController {
                 return
         }
 
-        if #available(iOS 14.0, *) {
-            UIPasteboard.general.detectAuthenticatorCode { [weak self] result in
-                switch result {
-                    case .success(let authenticatorCode):
-                        self?.handle(code: authenticatorCode, textField: codeField)
-                    case .failure:
-                        break
-                }
-            }
-        } else {
-            if let pasteString = UIPasteboard.general.string {
-                handle(code: pasteString, textField: codeField)
+        UIPasteboard.general.detectAuthenticatorCode { [weak self] result in
+            switch result {
+                case .success(let authenticatorCode):
+                    self?.handle(code: authenticatorCode, textField: codeField)
+                case .failure:
+                    break
             }
         }
     }


### PR DESCRIPTION
The removed checks are redundant, because the app runs on iOS 16 or above.

> [!NOTE]
> It's much easier to review [with the "Hide whitespace" option on](https://github.com/wordpress-mobile/WordPress-iOS/pull/23514/files?diff=unified&w=1).

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
