### PR TITLE
Sidebar: My Site

### DIFF
--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -275,6 +275,13 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
 extension SplitViewRootPresenter: SiteMenuViewControllerDelegate {
     func siteMenuViewController(_ siteMenuViewController: SiteMenuViewController, showDetailsViewController viewController: UIViewController) {
-        splitVC.setViewController(viewController, for: .secondary)
+        if viewController is UINavigationController ||
+            viewController is UISplitViewController {
+            splitVC.setViewController(viewController, for: .secondary)
+        } else {
+            // Reset previous navigation or split stack
+            let navigationVC = UINavigationController(rootViewController: viewController)
+            splitVC.setViewController(navigationVC, for: .secondary)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1692,9 +1692,28 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 - (void)showCommentsFromSource:(BlogDetailsNavigationSource)source
 {
     [self trackEvent:WPAnalyticsStatOpenedComments fromSource:source];
-    CommentsViewController *controller = [CommentsViewController controllerWithBlog:self.blog];
-    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self.presentationDelegate presentBlogDetailsViewController:controller];
+    CommentsViewController *commentsVC = [CommentsViewController controllerWithBlog:self.blog];
+    commentsVC.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+
+    if (self.isSidebarModeEnabled) {
+        commentsVC.isSidebarModeEnabled = YES;
+
+        UISplitViewController *splitVC = [[UISplitViewController alloc] initWithStyle:UISplitViewControllerStyleDoubleColumn];
+        splitVC.presentsWithGesture = NO;
+        splitVC.preferredDisplayMode = UISplitViewControllerDisplayModeOneBesideSecondary;
+        [splitVC setPreferredPrimaryColumnWidth:320];
+        [splitVC setMinimumPrimaryColumnWidth:375];
+        [splitVC setMaximumPrimaryColumnWidth:400];
+        [splitVC setViewController:commentsVC forColumn:UISplitViewControllerColumnPrimary];
+
+        UIViewController *noSelectionVC = [UIViewController new];
+        noSelectionVC.view.backgroundColor = [UIColor systemBackgroundColor];
+        [splitVC setViewController:noSelectionVC forColumn:UISplitViewControllerColumnSecondary];
+
+        [self.presentationDelegate presentBlogDetailsViewController:splitVC];
+    } else {
+        [self.presentationDelegate presentBlogDetailsViewController:commentsVC];
+    }
 }
 
 - (void)showPostListFromSource:(BlogDetailsNavigationSource)source

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -111,6 +111,7 @@ import WordPressShared
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         tableView.setEditing(true, animated: false)
         tableView.allowsSelectionDuringEditing = true
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     /// Sets up the sections for the table view and configures their starting state.

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -48,6 +48,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     self.navigationItem.title = self.publicizeService.label;
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+    self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:CellIdentifier];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -66,6 +66,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
                                                                                                action:@selector(doneButtonTapped)];
     }
 
+    self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.publicizeServicesState addInitialConnections:[self allConnections]];
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
@@ -47,6 +47,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
         title = NSLocalizedString("Date and Time Format", comment: "Title for the Date and Time Format Settings Screen")
         ImmuTable.registerRows([NavigationItemRow.self], tableView: tableView)
         WPStyleGuide.configureColors(view: view, tableView: tableView)
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         reloadViewModel()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -42,6 +42,7 @@ open class DiscussionSettingsViewController: UITableViewController {
     fileprivate func setupTableView() {
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         // Note: We really want to handle 'Unselect' manually.
         // Reason: we always reload previously selected rows.

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -64,6 +64,7 @@ import WordPressShared
         // Setup tableView
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         ImmuTable.registerRows([CheckmarkRow.self, NavigationItemRow.self, ActivityIndicatorRow.self], tableView: tableView)
         reloadViewModel()

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageViewController.swift
@@ -28,6 +28,7 @@ open class LanguageViewController: UITableViewController, LanguageSelectorDelega
         // Setup tableView
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     open override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -118,6 +118,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 {
     DDLogMethod();
     [super viewDidLoad];
+
+    self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
     [self.tableView registerClass:[SettingTableViewCell class] forCellReuseIdentifier:SettingsTableViewCellReuseIdentifier];
     [self.tableView registerNib:MediaQuotaCell.nib forCellReuseIdentifier:MediaQuotaCell.defaultReuseIdentifier];
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -194,7 +194,7 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
     private(set) lazy var shareBarButtonItem: UIBarButtonItem = {
         let button = UIBarButtonItem(
             image: comment.allowsModeration()
-            ? UIImage(systemName: Style.Content.ellipsisIconImageName)
+            ? UIImage(systemName: "ellipsis")
             : UIImage(systemName: Style.Content.shareIconImageName),
             style: .plain,
             target: self,
@@ -203,6 +203,8 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
         button.accessibilityLabel = NSLocalizedString("Share comment", comment: "Accessibility label for button to share a comment from a notification")
         return button
     }()
+
+    @objc var isSidebarModeEnabled = false
 
     // MARK: Initialization
 
@@ -597,7 +599,13 @@ private extension CommentDetailViewController {
         }
 
         let readerViewController = ReaderDetailViewController.controllerWithPostID(NSNumber(value: comment.postID), siteID: siteID, isFeed: false)
-        navigationController?.pushFullscreenViewController(readerViewController, animated: true)
+        if isSidebarModeEnabled {
+            let navigationController = UINavigationController(rootViewController: readerViewController)
+            navigationController.modalPresentationStyle = .pageSheet
+            present(navigationController, animated: true)
+        } else {
+            navigationController?.pushFullscreenViewController(readerViewController, animated: true)
+        }
     }
 
     func openWebView(for url: URL?) {
@@ -625,7 +633,6 @@ private extension CommentDetailViewController {
 
         CommentAnalytics.trackCommentEditorOpened(comment: comment)
         let navigationControllerToPresent = UINavigationController(rootViewController: editCommentTableViewController)
-        navigationControllerToPresent.modalPresentationStyle = .fullScreen
         present(navigationControllerToPresent, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.h
@@ -5,6 +5,8 @@
 
 @interface CommentsViewController : UIViewController
 
+@property (nonatomic) BOOL isSidebarModeEnabled;
+
 + (CommentsViewController *)controllerWithBlog:(Blog *)blog;
 - (void)refreshWithStatusFilter:(CommentStatusFilter)statusFilter;
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.swift
@@ -68,12 +68,11 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
             featuredImageView.setImage(with: thumbnailURL, host: host)
         }
 
-        separatorInset = UIEdgeInsets(top: 0, left: 16 + CGFloat(indentation) * 32, bottom: 0, right: 0)
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: 12,
-            leading: 16 + CGFloat(max(0, indentation - 1)) * 32,
-            bottom: 12,
-            trailing: 16
+            top: 0,
+            leading: CGFloat(max(0, indentation - 1)) * 32,
+            bottom: 0,
+            trailing: 0
         )
         indentationIconView.isHidden = indentation == 0
         indentationIconView.alpha = isFirstSubdirectory ? 1 : 0 // Still contribute to layout
@@ -148,7 +147,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
         contentView.addSubview(contentStackView)
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(contentStackView)
+        contentView.pinSubviewToAllEdgeMargins(contentStackView)
     }
 
     private func setupLabels() {

--- a/WordPress/Classes/ViewRelated/Pages/TemplatePageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/TemplatePageTableViewCell.swift
@@ -9,17 +9,11 @@ class TemplatePageTableViewCell: UITableViewCell {
         hostViewController.view.translatesAutoresizingMaskIntoConstraints = false
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.addSubview(hostViewController.view)
-        contentView.pinSubviewToAllEdges(hostViewController.view)
-        applyStyles()
+        contentView.pinSubviewToAllEdgeMargins(hostViewController.view)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func applyStyles() {
-        backgroundColor = .neutral(.shade5)
-        separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
     }
 }
 
@@ -29,8 +23,6 @@ private struct TemplatePageView: View {
             text
             icon
         }
-        .padding(EdgeInsets(top: 12.0, leading: 16.0, bottom: 12.0, trailing: 16.0))
-        .background(Color(UIColor.listForeground))
     }
 
     private var text: some View {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -164,11 +164,14 @@ class AbstractPostListViewController: UIViewController,
         tableView.estimatedRowHeight = 110
         tableView.rowHeight = UITableView.automaticDimension
         tableView.refreshControl = refreshControl
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
     }
 
     private func configureFilterBar() {
         WPStyleGuide.configureFilterTabBar(filterTabBar)
+        filterTabBar.isAutomaticTabSizingStyleEnabled = true
+        filterTabBar.isFollowingReaderGuide = true
         filterTabBar.backgroundColor = .clear
         filterTabBar.items = filterSettings.availablePostListFilters()
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
@@ -200,7 +203,6 @@ class AbstractPostListViewController: UIViewController,
 
         definesPresentationContext = true
         navigationItem.searchController = searchController
-        navigationItem.preferredSearchBarPlacement = .stacked
     }
 
     func propertiesForAnalytics() -> [String: AnyObject] {

--- a/WordPress/Classes/ViewRelated/Post/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListCell.swift
@@ -99,8 +99,6 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
     // MARK: - Setup
 
     private func setupViews() {
-        separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
-
         setupContentLabel()
         setupFeaturedImageView()
         setupStatusLabel()
@@ -120,11 +118,8 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
             statusLabel
         ])
         mainStackView.spacing = 4
-        mainStackView.isLayoutMarginsRelativeArrangement = true
-        mainStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
-
         contentView.addSubview(mainStackView)
-        contentView.pinSubviewToAllEdges(mainStackView)
+        contentView.pinSubviewToAllEdgeMargins(mainStackView)
     }
 
     private func setupContentLabel() {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -56,6 +56,7 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         tableView.dataSource = dataSource
         tableView.delegate = self
         tableView.sectionHeaderTopPadding = 0
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     private func bindViewModel() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -61,6 +61,7 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         tableView.estimatedRowHeight = 500
         tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         sendScrollEventsToBanner()
 
         viewModel = SiteStatsPeriodViewModel(store: store,
@@ -96,17 +97,31 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
     override func initTableView() {
         let embeddedDatePickerView = UIView.embedSwiftUIView(datePickerView)
         view.addSubview(embeddedDatePickerView)
-        tableView.translatesAutoresizingMaskIntoConstraints = false
+        embeddedDatePickerView.translatesAutoresizingMaskIntoConstraints = false
+
         view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             view.topAnchor.constraint(equalTo: embeddedDatePickerView.topAnchor, constant: 0),
-            view.leadingAnchor.constraint(equalTo: embeddedDatePickerView.leadingAnchor, constant: 0),
-            view.trailingAnchor.constraint(equalTo: embeddedDatePickerView.trailingAnchor, constant: 0),
+            view.readableContentGuide.leadingAnchor.constraint(equalTo: embeddedDatePickerView.leadingAnchor, constant: 0),
+            view.readableContentGuide.trailingAnchor.constraint(equalTo: embeddedDatePickerView.trailingAnchor, constant: 0),
             embeddedDatePickerView.bottomAnchor.constraint(equalTo: tableView.topAnchor, constant: 0),
             view.leadingAnchor.constraint(equalTo: tableView.leadingAnchor, constant: 0),
             view.trailingAnchor.constraint(equalTo: tableView.trailingAnchor, constant: 0),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
+        ])
+
+        let divider = UIView()
+        divider.backgroundColor = .separator
+
+        view.addSubview(divider)
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            divider.heightAnchor.constraint(equalToConstant: 0.5),
+            divider.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            divider.bottomAnchor.constraint(equalTo: embeddedDatePickerView.bottomAnchor)
         ])
 
         tableView.refreshControl = refreshControl

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -186,6 +186,8 @@ private extension SiteStatsDashboardViewController {
 
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
+        filterTabBar.isAutomaticTabSizingStyleEnabled = true
+        filterTabBar.isFollowingReaderGuide = true
         filterTabBar.items = displayedTabs
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         filterTabBar.accessibilityIdentifier = "site-stats-dashboard-filter-bar"

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -24,6 +24,7 @@ final class StatsSubscribersViewController: SiteStatsBaseTableViewController {
         super.viewDidLoad()
 
         viewModel.viewMoreDelegate = self
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         refreshControl.addTarget(self, action: #selector(refreshData), for: .valueChanged)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerView.swift
@@ -9,18 +9,12 @@ struct StatsTrafficDatePickerView: View {
     var body: some View {
         HStack {
             granularityPicker
-                .padding(.leading, 36) // Matching grouped table style
+                .padding(.leading, 16) // Matching grouped table style
             Spacer()
             periodPicker
-                .padding(.trailing, 20)
+                .padding(.trailing, 16)
         }
         .background(Color(.systemBackground))
-        .overlay(
-            Rectangle()
-                .frame(height: .DS.Border.thin)
-                .foregroundColor(Color.DS.Foreground.tertiary),
-            alignment: .bottom
-        )
     }
 
     @ViewBuilder

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -149,7 +149,15 @@ class FilterTabBar: UIControl {
         }
     }
 
+    var isFollowingReaderGuide = false {
+        didSet { updateForCurrentEnvironment() }
+    }
+
     // MARK: - Tab Sizing
+
+    var isAutomaticTabSizingStyleEnabled = false {
+        didSet { updateForCurrentEnvironment() }
+    }
 
     private var stackViewEdgeConstraints: [NSLayoutConstraint]! {
         didSet {
@@ -273,6 +281,12 @@ class FilterTabBar: UIControl {
         createTopTabSeparatorPlacementConstraints()
         createBottomTabSeparatorPlacementConstraints()
         activateTabSeparatorPlacementConstraints()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        updateForCurrentEnvironment()
     }
 
     // MARK: - Tabs
@@ -538,6 +552,31 @@ class FilterTabBar: UIControl {
         static let duration: TimeInterval = 0.3
         static let springDamping: CGFloat = 0.9
         static let initialVelocity: CGFloat = -0.5
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if isAutomaticTabSizingStyleEnabled {
+            updateForCurrentEnvironment()
+        }
+    }
+
+    private func updateForCurrentEnvironment() {
+        tabSizingStyle = traitCollection.horizontalSizeClass == .regular ? .equalWidths : .fitting
+
+        if isFollowingReaderGuide {
+            switch tabSizingStyle {
+            case .equalWidths:
+                let readableFrame = readableContentGuide.layoutFrame
+                let inset = readableFrame.minX
+                scrollView.contentInset = UIEdgeInsets(top: 0, left: inset, bottom: 0, right: -inset)
+                stackViewWidthConstraint.constant = -(2 * inset)
+            case .fitting:
+                scrollView.contentInset = .zero
+                stackViewWidthConstraint.constant = 0
+            }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -46,6 +46,7 @@ open class SettingsListEditorViewController: UITableViewController {
     fileprivate func setupTableView() {
         tableView.register(WPTableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
         WPStyleGuide.configureColors(view: view, tableView: tableView)
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     // MARK: - Button Handlers

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -57,6 +57,7 @@ open class SettingsPickerViewController: UITableViewController {
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         tableView.estimatedRowHeight = estimatedRowHeight
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     // MARK: - UITableViewDataSoutce Methods

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -105,6 +105,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     
     // Don't auto-size rows
     self.tableView.estimatedRowHeight = 0;
+    self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
 
     [self startListeningTextfieldChanges];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
@@ -218,11 +219,11 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     self.textField.translatesAutoresizingMaskIntoConstraints = NO;
     UILayoutGuide *readableGuide = _textFieldCell.contentView.readableContentGuide;
     [NSLayoutConstraint activateConstraints:@[
-                                               [self.textField.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
-                                               [self.textField.topAnchor constraintEqualToAnchor:_textFieldCell.contentView.topAnchor],
-                                               [self.textField.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
-                                               [self.textField.bottomAnchor constraintEqualToAnchor:_textFieldCell.contentView.bottomAnchor],
-                                               ]];
+        [self.textField.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+        [self.textField.topAnchor constraintEqualToAnchor:_textFieldCell.contentView.topAnchor],
+        [self.textField.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+        [self.textField.bottomAnchor constraintEqualToAnchor:_textFieldCell.contentView.bottomAnchor],
+    ]];
 
     return _textFieldCell;
 }


### PR DESCRIPTION
This PR slightly updates the design of some of the "My Sites" screens for iPad – only low-hanging fruits.

<img width="1316" alt="comments-after" src="https://github.com/user-attachments/assets/705717e9-f56d-490f-bac2-c42305156993">
<img width="1428" alt="posta-fter-2" src="https://github.com/user-attachments/assets/5cecda6d-4d31-4a8d-a703-32b62c20a6c5">
<img width="1316" alt="settings-after" src="https://github.com/user-attachments/assets/d2cd8b00-ea01-42df-8c5f-31150607048e">
<img width="1316" alt="social-after" src="https://github.com/user-attachments/assets/48538830-6a86-4862-94ec-cbff25b8c313">
<img width="1316" alt="stats-after" src="https://github.com/user-attachments/assets/87a5e8d3-8908-4207-a993-45ad89c6beb1">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
