### PR TITLE
Sidebar: Notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1309,13 +1309,11 @@ extension NotificationDetailsViewController {
         }
 
         notificationCommentDetailCoordinator?.onSelectedNoteChange = self.onSelectedNoteChange
-        weak var navigationController = navigationController
 
-        dismiss(animated: true, completion: {
-            commentDetailViewController.navigationItem.largeTitleDisplayMode = .never
-            navigationController?.popViewController(animated: false)
-            navigationController?.pushViewController(commentDetailViewController, animated: false)
-        })
+        let navigationController = navigationController // important to keep reference
+        commentDetailViewController.navigationItem.largeTitleDisplayMode = .never
+        navigationController?.popViewController(animated: false)
+        navigationController?.pushViewController(commentDetailViewController, animated: false)
     }
 
     var shouldEnablePreviousButton: Bool {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsButtonViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsButtonViewModel.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Combine
+import UIKit
+import SwiftUI
+
+final class NotificationsButtonViewModel: ObservableObject {
+    @Published private(set) var counter = 0
+    @Published private(set) var image: UIImage?
+
+    private var cancellables: [AnyCancellable] = []
+
+    init() {
+        refresh()
+
+        NotificationCenter.default
+            .publisher(for: NSNotification.ZendeskPushNotificationReceivedNotification)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default
+            .publisher(for: NSNotification.ZendeskPushNotificationClearedNotification)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+
+        UIApplication.shared
+            .publisher(for: \.applicationIconBadgeNumber)
+            .sink { [weak self] _ in self?.refresh() }
+            .store(in: &cancellables)
+    }
+
+    private func refresh() {
+        counter = UIApplication.shared.applicationIconBadgeNumber - ZendeskUtils.unreadNotificationsCount
+
+        if counter > 0 {
+            image = UIImage(systemName: "bell.badge")?
+                .withConfiguration(UIImage.SymbolConfiguration(paletteColors: [.systemRed, .label]))
+        } else {
+            image = UIImage(systemName: "bell")
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -838,7 +838,11 @@ extension NotificationsViewController {
         if shouldPushDetailsViewController {
             navigationController?.pushViewController(controller, animated: true)
         } else if isSidebarModeEnabled {
-            splitViewController?.setViewController(controller, for: .secondary)
+            if let splitViewController {
+                splitViewController.setViewController(controller, for: .secondary)
+            } else {
+                navigationController?.pushViewController(controller, animated: true)
+            }
         } else {
             showDetailViewController(controller, sender: nil)
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -88,13 +88,10 @@ private extension NotificationCommentDetailCoordinator {
         notificationDetailsViewController.dataSource = notificationsNavigationDataSource
         notificationDetailsViewController.onSelectedNoteChange = onSelectedNoteChange
 
-        weak var navigationController = viewController.navigationController
-
-        viewController.dismiss(animated: true, completion: {
-            notificationDetailsViewController.navigationItem.largeTitleDisplayMode = .never
-            navigationController?.popViewController(animated: false)
-            navigationController?.pushViewController(notificationDetailsViewController, animated: false)
-        })
+        let navigationController = viewController.navigationController // important to keep reference
+        notificationDetailsViewController.navigationItem.largeTitleDisplayMode = .never
+        navigationController?.popViewController(animated: false)
+        navigationController?.pushViewController(notificationDetailsViewController, animated: false)
     }
 
     func refreshViewControllerWith(_ notification: Notification) {

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -19,6 +19,7 @@ final class SidebarViewController: UIHostingController<AnyView> {
 private struct SidebarView: View {
     @ObservedObject var viewModel: SidebarViewModel
     @StateObject private var blogListViewModel = BlogListViewModel()
+    @StateObject private var notificationsButtonViewModel = NotificationsButtonViewModel()
 
     static let displayedSiteLimit = 4
 
@@ -117,8 +118,18 @@ private struct SidebarView: View {
     @ViewBuilder
     private var more: some View {
 #if JETPACK
-        Label(Strings.notifications, systemImage: "bell")
-            .tag(SidebarSelection.notifications)
+        Label {
+            Text(Strings.notifications)
+        } icon: {
+            if notificationsButtonViewModel.counter > 0 {
+                Image(systemName: "bell.badge")
+                    .foregroundStyle(.red, Color(.brand))
+            } else {
+                Image(systemName: "bell")
+            }
+        }
+        .tag(SidebarSelection.notifications)
+
         Label(Strings.reader, systemImage: "eyeglasses")
             .tag(SidebarSelection.reader)
         if RemoteFeatureFlag.domainManagement.enabled() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -582,6 +582,8 @@
 		0CAE8EF72A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */; };
 		0CAFFD7E2C7D0CEC00DBF5C3 /* AddSiteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD7D2C7D0CEC00DBF5C3 /* AddSiteController.swift */; };
 		0CAFFD7F2C7D0CEC00DBF5C3 /* AddSiteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD7D2C7D0CEC00DBF5C3 /* AddSiteController.swift */; };
+		0CAFFD812C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */; };
+		0CAFFD822C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -6507,6 +6509,7 @@
 		0CAE8EF12A9E9E8D0073EEB9 /* SiteMediaCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCell.swift; sourceTree = "<group>"; };
 		0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
 		0CAFFD7D2C7D0CEC00DBF5C3 /* AddSiteController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSiteController.swift; sourceTree = "<group>"; };
+		0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsButtonViewModel.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
@@ -16537,6 +16540,7 @@
 				4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */,
 				8236EB4F2024ED8C007C7CF9 /* NotificationsViewController+JetpackPrompt.swift */,
 				4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */,
+				0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -23084,6 +23088,7 @@
 				C7234A3A2832BA240045C63F /* QRLoginCoordinator.swift in Sources */,
 				0C04532B2AC77245003079C8 /* SiteMediaDocumentInfoView.swift in Sources */,
 				9A341E5721997A340036662E /* Blog+BlogAuthors.swift in Sources */,
+				0CAFFD812C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift in Sources */,
 				F4D829702931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift in Sources */,
 				1DF7A0CF2BA099760003CBA3 /* GutenbergContentParser.swift in Sources */,
 				7E3AB3DB20F52654001F33B6 /* ActivityContentStyles.swift in Sources */,
@@ -25429,6 +25434,7 @@
 				FA0A1C372BBEB32F006A2D6F /* PostCoordinator+ResolveConflict.swift in Sources */,
 				0141929D2983F0A300CAEDB0 /* SupportConfiguration.swift in Sources */,
 				F484D4EB2A32B51C0050BE15 /* RootViewPresenter+AppSettingsNavigation.swift in Sources */,
+				0CAFFD822C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift in Sources */,
 				FABB23CB2602FC2C00C8785C /* PostListFilter.swift in Sources */,
 				FABB23CC2602FC2C00C8785C /* MediaThumbnailExporter.swift in Sources */,
 				C79C307C26EA915100E88514 /* ReferrerDetailsTableViewController.swift in Sources */,


### PR DESCRIPTION
- Add "Notifications" navigation item to the new Home page as a shortcut to quickly access your notifications and see if you have any new ones
- Implement notifications badge when you have new notifications

<img width="958" alt="Screenshot 2024-08-27 at 12 40 11 PM" src="https://github.com/user-attachments/assets/61f24ae8-7fb8-44b8-ba5f-e6cceb8f957b">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
