### PR TITLE
Fix an issue where sidebar reload when it does not need to

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -317,6 +317,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     [self observeManagedObjectContextObjectsDidChangeNotification];
 
     [self observeGravatarImageUpdate];
+
+    if (@available(iOS 17.0, *)) {
+        [self registerForTraitChanges:@[[UITraitHorizontalSizeClass self]] withAction:@selector(handleTraitChanges)];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -368,6 +372,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 {
     [super traitCollectionDidChange:previousTraitCollection];
 
+    if (@available(iOS 17.0, *)) {
+        // Do nothing. `handleTraitChanges` is registered using iOS 17 API.
+    } else {
+        [self handleTraitChanges];
+    }
+}
+
+- (void)handleTraitChanges
+{
     // Required to add / remove "Home" section when switching between regular and compact width
     [self configureTableViewData];
 


### PR DESCRIPTION
To reproduce the issue:
1. Launch the app with sidebar enabled.
2. Sign in WordPress.com.
3. Click the profile view on the sidebar to show the "Me" modal.
4. Dismiss the modal.
5. Repeat 3 and 4 and you'll notice there is reloading animation in the sidebar menu list.

This PR fixes the issue by using an iOS 17 API to only reload the sidebar menu list when horizontal size classes changes.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
