### PR TITLE
Update `complete_code_freeze` to use named block arguments

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -151,7 +151,7 @@ platform :ios do
   # @option [Boolean] skip_confirm (default: false) If true, avoids any interactive prompt
   #
   desc 'Completes the final steps for the code freeze'
-  lane :complete_code_freeze do |options|
+  lane :complete_code_freeze do |skip_confirm: false|
     ensure_git_branch_is_release_branch
 
     # Verify that there's nothing in progress in the working copy
@@ -161,13 +161,11 @@ platform :ios do
 
     UI.important("Completing code freeze for: #{version}")
 
-    skip_user_confirmation = options[:skip_confirm]
-
-    UI.user_error!('Aborted by user request') unless skip_user_confirmation || UI.confirm('Do you want to continue?')
+    UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
     generate_strings_file_for_glotpress
 
-    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote and trigger the beta build?')
+    unless skip_confirm || UI.confirm('Ready to push changes to remote and trigger the beta build?')
       UI.message("Terminating as requested. Don't forget to run the remainder of this automation manually.")
       next
     end


### PR DESCRIPTION
Noticed this while reading the lane as a reference for https://github.com/Automattic/simplenote-ios/pull/1646

 ## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.