### PR TITLE
Use oslog instead of stdout during development

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -1,6 +1,5 @@
 import Foundation
 import CoreData
-import CocoaLumberjack
 import WordPressKit
 
 // MARK: - Notification Entity

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -1,6 +1,5 @@
 import Foundation
 import CoreData
-import CocoaLumberjack
 
 @objc(Post)
 class Post: AbstractPost {

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import Reachability
 import WordPressKit
 

--- a/WordPress/Classes/Services/BlogJetpackSettingsService.swift
+++ b/WordPress/Classes/Services/BlogJetpackSettingsService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 
 struct BlogJetpackSettingsService {

--- a/WordPress/Classes/Services/Domains/DomainsService.swift
+++ b/WordPress/Classes/Services/Domains/DomainsService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 import CoreData
 

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 import Gravatar
 

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import PhotosUI
 
 /// Encapsulates importing assets such as images, videos, or files at URLs to Media objects.

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 
 /// This service encapsulates all of the Actions that can be performed with a NotificationBlock
 ///

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 
 /// This service encapsulates the Restful API related to WordPress Notifications.

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 
 /// Notes:

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 
 enum PeopleServiceError: Error {

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 
 open class PlanService: NSObject {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -2,7 +2,6 @@ import Aztec
 import Foundation
 import WordPressKit
 import WordPressFlux
-import CocoaLumberjack
 import Combine
 import AutomatticTracks
 

--- a/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
+++ b/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 
 /// Provides functionality for fetching, saving, and deleting search phrases
 /// used to search for content in the reader.

--- a/WordPress/Classes/Services/ReaderSiteSearchService.swift
+++ b/WordPress/Classes/Services/ReaderSiteSearchService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 
 typealias ReaderSiteSearchSuccessBlock = (_ feeds: [ReaderFeed], _ hasMore: Bool, _ feedCount: Int) -> Void
 typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 import WordPressKit
 

--- a/WordPress/Classes/Services/SharingSyncService.swift
+++ b/WordPress/Classes/Services/SharingSyncService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 import WordPressKit
 

--- a/WordPress/Classes/Stores/StatsInsightsCache.swift
+++ b/WordPress/Classes/Stores/StatsInsightsCache.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressKit
-import CocoaLumberjack
 
 final class StatsInsightsCache {
     static let shared = StatsInsightsCache()

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import CoreData
 
 // MARK: - NSManagedObject Default entityName Helper

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import UserNotifications
 import WordPressFlux
 

--- a/WordPress/Classes/Utility/KeychainTools.swift
+++ b/WordPress/Classes/Utility/KeychainTools.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Security
-import CocoaLumberjack
 
 private let keychainDebugWipeArgument = "WipeKeychainItem"
 

--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -54,7 +54,7 @@ void SetCocoaLumberjackObjCLogLevel(NSUInteger ddLogLevelRawValue)
     
     // Sets up the CocoaLumberjack logging; debug output to console and file
 #ifdef DEBUG
-    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    [DDLog addLogger:[DDOSLogger sharedInstance]];
 #endif
     [DDLog addLogger:self.fileLogger];
 

--- a/WordPress/Classes/Utility/Logging/WordPressLibraryLogger.swift
+++ b/WordPress/Classes/Utility/Logging/WordPressLibraryLogger.swift
@@ -1,4 +1,3 @@
-import CocoaLumberjack
 import AutomatticTracks
 import WordPressShared
 import WordPressKit

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 
 /// Type of the local Media directory URL in implementation.
 ///

--- a/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
+++ b/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Foundation
-import CocoaLumberjack
 
 /// Note:
 /// This migration policy handles database migration from WPiOS 4.3 to 4.4

--- a/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
+++ b/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
@@ -1,6 +1,5 @@
 import UIKit
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /// Note:

--- a/WordPress/Classes/Utility/Migrations/BlogToBlog32to33.swift
+++ b/WordPress/Classes/Utility/Migrations/BlogToBlog32to33.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 
 class BlogToBlog32to33: NSEntityMigrationPolicy {
 

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import Reachability
 
 // This is added as a top level function to avoid cluttering PingHubManager.init

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -2,7 +2,6 @@ import Foundation
 import WordPressShared
 import NSObject_SafeExpectations
 import UserNotifications
-import CocoaLumberjack
 
 /// The purpose of this helper is to encapsulate all the tasks related to Push Notifications Registration + Handling,
 /// including iOS "Actionable" Notifications.

--- a/WordPress/Classes/Utility/WPContentSyncHelper.swift
+++ b/WordPress/Classes/Utility/WPContentSyncHelper.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 
 @objc protocol WPContentSyncHelperDelegate: NSObjectProtocol {
     func syncHelper(_ syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((_ hasMore: Bool) -> Void)?, failure: ((_ error: NSError) -> Void)?)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import SVProgressHUD
 import WordPressShared
 import WordPressFlux

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 import PDFKit
 import Aztec
-import CocoaLumberjack
 import Gridicons
 import WordPressShared
 import MobileCoreServices

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 
 /// Manages which sharing button are displayed, their order, and other settings

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import SVProgressHUD
 import WordPressShared
 import Gridicons

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteSettingsViewController+SiteManagement.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import SVProgressHUD
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /// This class will display the Blog's date and time settings, and will allow the user to modify them.

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /// The purpose of this class is to render the Discussion Settings associated to a site, and

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/BaseRestoreCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/BaseRestoreCompleteViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 struct JetpackRestoreCompleteConfiguration {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressFlux
 import WordPressShared
 import WordPressUI

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreCompleteViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressFlux
 import WordPressShared
 import WordPressUI

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreFailedViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreFailedViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 typealias HighlightedText = (substring: String, string: String)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import Gridicons
 import WordPressFlux
 import WordPressUI

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import Gridicons
 import WordPressUI
 import WordPressShared

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status Failed/JetpackBackupStatusFailedViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status Failed/JetpackBackupStatusFailedViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status Failed/JetpackRestoreStatusFailedViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status Failed/JetpackRestoreStatusFailedViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/BaseRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/BaseRestoreStatusViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 struct JetpackRestoreStatusConfiguration {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressFlux
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /// The purpose of this class is to render and modify the Jetpack Settings associated to a site.

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /// This class will display the Blog's "Speed you site" settings, and will allow the user to modify them.

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressAuthenticator
 import AutomatticAbout

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -2,7 +2,6 @@ import UIKit
 import PhotosUI
 import UniformTypeIdentifiers
 import AVFoundation
-import CocoaLumberjack
 
 /// A convenience API for creating actions for picking media from different
 /// source supported by the app: Photos library, Camera, Media library.

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Combine
 import CoreData
-import CocoaLumberjack
 import WordPressShared
 import WordPressAuthenticator
 import Gridicons

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 import WordPressFlux
 import UIKit

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 import Combine
 
-import CocoaLumberjack
 import WordPressShared
 
 // MARK: - PeopleViewController

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 import Gravatar

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 
 class PlanDetailViewController: UIViewController {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import CoreData
 import Gridicons
-import CocoaLumberjack
 import WordPressShared
 import WordPressFlux
 import WordPressUI

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 import Gridicons
 import UIKit

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressShared
-import CocoaLumberjack
 import WordPressFlux
 import Gridicons
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /// Defines methods that a delegate should implement for clearing suggestions

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-import CocoaLumberjack
 import SVProgressHUD
 import WordPressShared
 import WordPressFlux

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressShared
-import CocoaLumberjack
 
 /// Actions provided in cell button triggered action sheet
 ///

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 /**

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -1,7 +1,6 @@
 import UIKit
 import WordPressFlux
 import WordPressKit
-import CocoaLumberjack
 
 protocol SettingsController: ImmuTableController {
     var trackingKey: String { get }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import CocoaLumberjack
 import WordPressShared
 
 @objc protocol WPRichContentViewDelegate: UITextViewDelegate {

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WebKit
 
 class WPRichTextEmbed: UIView, WPRichTextMediaAttachment {

--- a/WordPress/WordPressShareExtension/ShareCategoriesPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareCategoriesPickerViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 import WordPressShared
 

--- a/WordPress/WordPressShareExtension/SharePostTypePickerViewController.swift
+++ b/WordPress/WordPressShareExtension/SharePostTypePickerViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressKit
 import WordPressShared
 

--- a/WordPress/WordPressShareExtension/ShareTagsPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareTagsPickerViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CocoaLumberjack
 import WordPressShared
 
 class ShareTagsPickerViewController: UIViewController {


### PR DESCRIPTION
It'd be much easier to filter logs in Xcode console.


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
