### PR TITLE
Sidebar: Fix styles in Me screen

### DIFF
--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -42,8 +42,7 @@ struct NavigationItemRow: ImmuTableRow {
 
         WPStyleGuide.configureTableViewCell(cell)
 
-        cell.imageView?.tintColor = tintColor
-        cell.textLabel?.textColor = tintColor
+        cell.imageView?.tintColor = tintColor ?? .secondaryLabel
     }
 }
 
@@ -52,13 +51,15 @@ struct IndicatorNavigationItemRow: ImmuTableRow {
 
     let title: String
     let icon: UIImage?
+    let tintColor: UIColor?
     let showIndicator: Bool
     let accessoryType: UITableViewCell.AccessoryType
     let action: ImmuTableAction?
 
-    init(title: String, icon: UIImage? = nil, showIndicator: Bool = false, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, action: @escaping ImmuTableAction) {
+    init(title: String, icon: UIImage? = nil, tintColor: UIColor?, showIndicator: Bool = false, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, action: @escaping ImmuTableAction) {
         self.title = title
         self.icon = icon
+        self.tintColor = tintColor
         self.showIndicator = showIndicator
         self.accessoryType = accessoryType
         self.action = action
@@ -73,6 +74,8 @@ struct IndicatorNavigationItemRow: ImmuTableRow {
         cell.showIndicator = showIndicator
 
         WPStyleGuide.configureTableViewCell(cell)
+
+        cell.imageView?.tintColor = tintColor ?? .secondaryLabel
     }
 }
 
@@ -273,7 +276,10 @@ struct ButtonRow: ImmuTableRow {
     static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
 
     let title: String
+    var textAlignment: NSTextAlignment = .center
+    var isLoading = false
     let action: ImmuTableAction?
+    var accessibilityIdentifier: String?
 
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -281,7 +287,18 @@ struct ButtonRow: ImmuTableRow {
         cell.textLabel?.lineBreakMode = .byWordWrapping
 
         WPStyleGuide.configureTableViewActionCell(cell)
-        cell.textLabel?.textAlignment = .center
+        cell.textLabel?.textAlignment = textAlignment
+
+        if isLoading {
+            let indicator: UIActivityIndicatorView
+            indicator = UIActivityIndicatorView(style: .medium)
+            indicator.startAnimating()
+            cell.accessoryView = indicator
+        } else {
+            cell.accessoryView = nil
+        }
+
+        cell.accessibilityIdentifier = accessibilityIdentifier
     }
 }
 

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -32,8 +32,7 @@ struct NavigationItemRow: ImmuTableRow {
         cell.accessibilityIdentifier = accessibilityIdentifier
 
         if loading {
-            let indicator: UIActivityIndicatorView
-            indicator = UIActivityIndicatorView(style: .medium)
+            let indicator = UIActivityIndicatorView(style: .medium)
             indicator.startAnimating()
             cell.accessoryView = indicator
         } else {
@@ -290,8 +289,7 @@ struct ButtonRow: ImmuTableRow {
         cell.textLabel?.textAlignment = textAlignment
 
         if isLoading {
-            let indicator: UIActivityIndicatorView
-            indicator = UIActivityIndicatorView(style: .medium)
+            let indicator = UIActivityIndicatorView(style: .medium)
             indicator.startAnimating()
             cell.accessoryView = indicator
         } else {

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -128,7 +128,8 @@ class MeViewController: UITableViewController {
 
         return NavigationItemRow(
             title: RowTitles.appSettings,
-            icon: UIImage(named: "wpl-tablet"),
+            icon: UIImage(named: "wpl-tablet")?.withRenderingMode(.alwaysTemplate),
+            tintColor: .label,
             accessoryType: accessoryType,
             action: pushAppSettings(),
             accessibilityIdentifier: "appSettings"
@@ -142,28 +143,32 @@ class MeViewController: UITableViewController {
 
         let myProfile = NavigationItemRow(
             title: RowTitles.myProfile,
-            icon: UIImage(named: "site-menu-people"),
+            icon: UIImage(named: "site-menu-people")?.withRenderingMode(.alwaysTemplate),
+            tintColor: .label,
             accessoryType: accessoryType,
             action: pushMyProfile(),
             accessibilityIdentifier: "myProfile")
 
         let qrLogin = NavigationItemRow(
             title: RowTitles.qrLogin,
-            icon: UIImage(named: "wpl-capture-photo"),
+            icon: UIImage(named: "wpl-capture-photo")?.withRenderingMode(.alwaysTemplate),
+            tintColor: .label,
             accessoryType: accessoryType,
             action: presentQRLogin(),
             accessibilityIdentifier: "qrLogin")
 
         let accountSettings = NavigationItemRow(
             title: RowTitles.accountSettings,
-            icon: UIImage(named: "wpl-gearshape"),
+            icon: UIImage(named: "wpl-gearshape")?.withRenderingMode(.alwaysTemplate),
+            tintColor: .label,
             accessoryType: accessoryType,
             action: pushAccountSettings(),
             accessibilityIdentifier: "accountSettings")
 
         let helpAndSupportIndicator = IndicatorNavigationItemRow(
             title: RowTitles.support,
-            icon: UIImage(named: "wpl-help"),
+            icon: UIImage(named: "wpl-help")?.withRenderingMode(.alwaysTemplate),
+            tintColor: .label,
             showIndicator: ZendeskUtils.showSupportNotificationIndicator,
             accessoryType: accessoryType,
             action: pushHelp())
@@ -198,25 +203,22 @@ class MeViewController: UITableViewController {
             ImmuTableSection(rows: {
                 var rows: [ImmuTableRow] = []
 
-                rows.append(NavigationItemRow(
+                rows.append(ButtonRow(
                     title: Strings.submitFeedback,
-                    tintColor: .brand,
-                    accessoryType: .none,
+                    textAlignment: .left,
                     action: showFeedbackView())
                 )
 
-                rows.append(NavigationItemRow(
+                rows.append(ButtonRow(
                     title: ShareAppContentPresenter.RowConstants.buttonTitle,
-                    tintColor: .brand,
-                    accessoryType: .none,
-                    action: displayShareFlow(),
-                    loading: sharePresenter.isLoading)
+                    textAlignment: .left,
+                    isLoading: sharePresenter.isLoading,
+                    action: displayShareFlow())
                 )
 
-                rows.append(NavigationItemRow(
+                rows.append(ButtonRow(
                     title: RowTitles.about,
-                    tintColor: .brand,
-                    accessoryType: .none,
+                    textAlignment: .left,
                     action: pushAbout(),
                     accessibilityIdentifier: "About")
                 )
@@ -229,7 +231,8 @@ class MeViewController: UITableViewController {
             sections.append(.init(rows: [
                 NavigationItemRow(
                     title: AllDomainsListViewController.Strings.title,
-                    icon: UIImage(named: "wpl-globe"),
+                    icon: UIImage(named: "wpl-globe")?.withRenderingMode(.alwaysTemplate),
+                    tintColor: .label,
                     accessoryType: accessoryType,
                     action: { [weak self] action in
                         self?.showOrPushController(AllDomainsListViewController())


### PR DESCRIPTION
Fix the color of images in the dark mode and more.

<img width="1316" alt="Screenshot 2024-09-03 at 8 30 44 AM" src="https://github.com/user-attachments/assets/ac3eec0c-79b1-4d54-8268-f2250688981b">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
