### PR TITLE
Remove an unused function in RootViewPresenter

### DIFF
--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -145,10 +145,6 @@ extension MySitesCoordinator: RootViewPresenter {
         meViewController.navigationController?.popToViewController(meViewController, animated: false)
     }
 
-    func popMeScreenToRoot() {
-        // Do nothing
-    }
-
     // MARK: Helpers
 
     /// Default implementation for functions that are not supported by the simplified UI.

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -48,5 +48,4 @@ protocol RootViewPresenter: AnyObject {
 
     var meViewController: MeViewController? { get }
     func showMeScreen()
-    func popMeScreenToRoot()
 }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -321,10 +321,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         navigationVC.modalPresentationStyle = .formSheet
         splitVC.present(navigationVC, animated: true)
     }
-
-    func popMeScreenToRoot() {
-        fatalError()
-    }
 }
 
 extension SplitViewRootPresenter: SiteMenuViewControllerDelegate {


### PR DESCRIPTION
`popMeScreenToRoot` doesn't need to be in `RootViewPresenter`. There are two places that calls this function. It's okay to remove the function from the protocol defination and  leave it in the concrete types.

https://github.com/wordpress-mobile/WordPress-iOS/blob/54788f1b34ac7da2eff5740a765c7bac505f2e41/WordPress/Classes/System/WPTabBarController%2BRootViewPresenter.swift#L52-L59

https://github.com/wordpress-mobile/WordPress-iOS/blob/54788f1b34ac7da2eff5740a765c7bac505f2e41/WordPress/Classes/System/StaticScreensTabBarWrapper.swift#L146-L153

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
