### PR TITLE
Update `SwiftSoup` to address privacy manifest warning

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/kaishin/Gifu", from: "3.4.1"),
         .package(url: "https://github.com/patchthecode/JTAppleCalendar", from: "8.0.5"),
         .package(url: "https://github.com/Quick/Nimble", from: "10.0.0"),
-        .package(url: "https://github.com/scinfu/SwiftSoup", exact: "2.7.1"),
+        .package(url: "https://github.com/scinfu/SwiftSoup", exact: "2.7.5"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.3.0"),
         .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", from: "2.3.1"),
         .package(url: "https://github.com/tonymillion/Reachability", from: "3.7.5"),

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -328,8 +328,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scinfu/SwiftSoup.git",
       "state" : {
-        "revision" : "1d39e56d364cba79ce43b341f9661b534cccb18d",
-        "version" : "2.7.1"
+        "revision" : "3c2c7e1e72b8abd96eafbae80323c5c1e5317437",
+        "version" : "2.7.5"
       }
     },
     {


### PR DESCRIPTION
We received the following email from Apple after the `25.3.0.1` build was uploaded to App Store Connect today: 
 

> We noticed one or more issues with a recent submission for App Store review for the following app:
> 
> WordPress – Website Builder
> Version 25.3
> Build 25.3.0.1
> Although submission for App Store review was successful, you may want to correct the following issues in your next submission for App Store review. Once you've corrected the issues, upload a new binary to App Store Connect.
> 
> ITMS-91108: Invalid privacy manifest - The PrivacyInfo.xcprivacy file from the following path is invalid: “SwiftSoup_SwiftSoup.bundle/PrivacyInfo.xcprivacy”. In addition to the privacy manifest files in the locations outlined in the documentation, starting November 12, 2024, all privacy manifests you submit must have valid content. Keys and values in any privacy manifest must be in a valid format. For more details about privacy manifest files, visit: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files and https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/adding_a_privacy_manifest_to_your_app_or_third-party_sdk.
> 
> Apple Developer Relations

The version of `SwiftSoup` currently being used is `2.7.1`, which was [released on February 15, 2024](https://github.com/scinfu/SwiftSoup/tags). A [fix for the privacy manifest](https://github.com/scinfu/SwiftSoup/pull/264) was merged on March 18, 2024. This PR updates `SwiftSoup` to the latest version, `2.7.5`, so that the updated privacy manifest will be included with the next upload. 

To test:

## Regression Notes
1. Potential unintended areas of impact
I am not familiar with the areas of the app that could be affected by upgrading `SwiftSoup`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I would love some help from the reviewer to know whether this upgrade could have unintended consequences within the app. 

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding unit tests for my changes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
