### PR TITLE
Sidebar: Reader Subscriptions

### DIFF
--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -74,6 +74,12 @@ extension Notice: Equatable {
     }
 }
 
+extension Notice {
+    func post() {
+        ActionDispatcher.dispatch(NoticeAction.post(self))
+    }
+}
+
 struct NoticeNotificationInfo {
     /// Unique identifier for this notice. When displayed as a system notification,
     /// this value will be used as the `UNNotificationRequest`'s identifier.

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -59,7 +59,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
             do {
                 let site = try ContextManager.shared.mainContext.existingObject(with: objectID)
                 showDetails(for: site)
-                splitVC.hide(.primary)
             } catch {
                 // TODO: (wpsidebar) show empty state
             }
@@ -76,6 +75,8 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
             sidebarVC.showInitialSelection()
         }
+
+        splitVC.hide(.primary)
     }
 
     private func showDetails(for site: Blog) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -205,11 +205,7 @@ class ReaderFollowedSitesViewController: UIViewController {
         }, failure: { [weak self] (follow, error) in
             DDLogError("Could not unfollow site: \(String(describing: error))")
 
-            let notice = Notice(title: NSLocalizedString("reader.notice.blog.unsubscribed.error",
-                                                         value: "Could not unsubscribe from blog",
-                                                         comment: "Title of a prompt."),
-                                message: error?.localizedDescription,
-                                feedbackType: .error)
+            let notice = Notice(title: Strings.failedToUnfollow, message: error?.localizedDescription, feedbackType: .error)
             self?.post(notice)
         })
     }
@@ -521,5 +517,11 @@ extension ReaderFollowedSitesViewController: UISearchBarDelegate {
         }
         searchBar.text = nil
         searchBar.resignFirstResponder()
+    }
+}
+
+extension ReaderFollowedSitesViewController {
+    enum Strings {
+        static let failedToUnfollow =  NSLocalizedString("reader.notice.blog.unsubscribed.error", value: "Could not unsubscribe from blog", comment: "Title of a prompt.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -6,6 +6,7 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
     let viewModel: ReaderSidebarViewModel
 
     private var cancellables: [AnyCancellable] = []
+    private var viewContext: NSManagedObjectContext { ContextManager.shared.mainContext }
 
     init(viewModel: ReaderSidebarViewModel) {
         self.viewModel = viewModel
@@ -30,9 +31,16 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
         }
         switch selection {
         case .main(let screen):
-            let screenVC = makeViewController(for: screen)
-            let navigationVC = UINavigationController(rootViewController: screenVC)
-            splitViewController?.setViewController(navigationVC, for: .secondary)
+            showSecondary(makeViewController(for: screen))
+        case .allSubscriptions:
+            showSecondary(ReaderFollowedSitesViewController.controller())
+        case .subscription(let objectID):
+            do {
+                let site = try viewContext.existingObject(with: objectID)
+                showSecondary(ReaderStreamViewController.controllerWithTopic(site))
+            } catch {
+                wpAssertionFailure("site missing", userInfo: ["error": "\(error)"])
+            }
         }
     }
 
@@ -46,7 +54,7 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
                     return ReaderStreamViewController.controllerWithTopic(topic)
                 }
             } else {
-                // TODO: (wpsidebar) add error handling (hardcode lunks to topics?)
+                // TODO: (wpsidebar) add error handling (hardcode links to topics?)
                 return UIViewController()
             }
         case .saved:
@@ -55,10 +63,17 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
             return ReaderSearchViewController.controller(withSearchText: "")
         }
     }
+
+    private func showSecondary(_ viewController: UIViewController) {
+        let navigationVC = UINavigationController(rootViewController: viewController)
+        splitViewController?.setViewController(navigationVC, for: .secondary)
+    }
 }
 
 struct ReaderSidebarView: View {
     @ObservedObject var viewModel: ReaderSidebarViewModel
+
+    @AppStorage("reader_sidebar_subscriptions_expanded") var isSectionSubscriptionsExpanded = true
 
     var body: some View {
         List(selection: $viewModel.selection) {
@@ -66,14 +81,95 @@ struct ReaderSidebarView: View {
                 ForEach(ReaderStaticScreen.allCases) {
                     Label($0.localizedTitle, systemImage: $0.systemImage)
                         .tag(ReaderSidebarItem.main($0))
+                        .lineLimit(1)
                 }
+            }
+            makeSection(Strings.subscriptions, isExpanded: $isSectionSubscriptionsExpanded) {
+                ReaderSidebarSubscriptionsSection(viewModel: viewModel)
             }
         }
         .listStyle(.sidebar)
         .navigationTitle(Strings.reader)
+        .toolbar {
+            EditButton()
+        }
+        .environment(\.managedObjectContext, ContextManager.shared.mainContext)
+    }
+
+    @ViewBuilder
+    private func makeSection<Content: View>(_ title: String, isExpanded: Binding<Bool>, @ViewBuilder content: () -> Content) -> some View {
+        if #available(iOS 17, *) {
+            Section(title, isExpanded: isExpanded) {
+                content()
+            }
+        } else {
+            Section(title) {
+                content()
+            }
+        }
+    }
+}
+
+// TODO: (wpsidebar) Add button to add subscription (how should it work?)
+private struct ReaderSidebarSubscriptionsSection: View {
+    let viewModel: ReaderSidebarViewModel
+
+    @FetchRequest(
+        sortDescriptors: [SortDescriptor(\.title, order: .forward)],
+        predicate: NSPredicate(format: "following = YES")
+    )
+    private var subscriptions: FetchedResults<ReaderSiteTopic>
+
+    @State private var isShowingAll = false
+
+    var body: some View {
+        Label(Strings.allSubscriptions, systemImage: "checkmark.rectangle.stack")
+            .tag(ReaderSidebarItem.allSubscriptions)
+
+        ForEach(subscriptions, id: \.self) { site in
+            Label {
+                Text(site.title)
+            } icon: {
+                SiteIconView(viewModel: SiteIconViewModel(readerSiteTopic: site, size: .small))
+                    .frame(width: 28, height: 28)
+            }
+            .lineLimit(1)
+            .tag(ReaderSidebarItem.subscription(TaggedManagedObjectID(site)))
+            .swipeActions(edge: .trailing) {
+                Button(role: .destructive) {
+                    unfollow(site)
+                } label: {
+                    Text(Strings.unfollow)
+                }
+            }
+        }
+        .onDelete(perform: delete)
+    }
+
+    func delete(at offsets: IndexSet) {
+        let sites = offsets.map { subscriptions[$0] }
+        for site in sites {
+            unfollow(site)
+        }
+    }
+
+    private func unfollow(_ site: ReaderSiteTopic) {
+        NotificationCenter.default.post(name: .ReaderTopicUnfollowed, object: nil, userInfo: [ReaderNotificationKeys.topic: site])
+
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
+        service.toggleFollowing(forSite: site, success: { _ in
+            // Do nothing
+        }, failure: { _, error in
+            DDLogError("Could not unfollow site: \(String(describing: error))")
+            Notice(title: ReaderFollowedSitesViewController.Strings.failedToUnfollow, message: error?.localizedDescription, feedbackType: .error).post()
+        })
     }
 }
 
 private struct Strings {
-    static let reader = NSLocalizedString("reader.sidebar.navigationTitle", value: "Reader", comment: "Reader sidebar title on iPad")
+    static let reader = NSLocalizedString("reader.sidebar.navigationTitle", value: "Reader", comment: "Reader sidebar title")
+    static let allSubscriptions = NSLocalizedString("reader.sidebar.allSubscriptions", value: "All Subscriptions", comment: "Reader sidebar button title")
+    static let addSubscription = NSLocalizedString("reader.sidebar.addSubscription", value: "Add Subscription", comment: "Reader sidebar button title")
+    static let subscriptions = NSLocalizedString("reader.sidebar.sectionSubscriptionsTitle", value: "Subscriptions", comment: "Reader sidebar section title")
+    static let unfollow = NSLocalizedString("reader.sidebar.unfollow", value: "Unfollow", comment: "Reader sidebar button title")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -20,7 +20,7 @@ final class ReaderSidebarViewModel: ObservableObject {
     }
 
     func getTopic(for topicType: ReaderTopicType) -> ReaderAbstractTopic? {
-        return try? ReaderAbstractTopic.lookupAll(in: contextManager.mainContext).first {
+        return try? ReaderAbstractTopic.lookupAllMenus(in: contextManager.mainContext).first {
             ReaderHelpers.topicType($0) == topicType
         }
     }
@@ -29,6 +29,8 @@ final class ReaderSidebarViewModel: ObservableObject {
 enum ReaderSidebarItem: Identifiable, Hashable {
     /// One of the main navigation areas.
     case main(ReaderStaticScreen)
+    case allSubscriptions
+    case subscription(TaggedManagedObjectID<ReaderSiteTopic>)
 
     var id: ReaderSidebarItem { self }
 }

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -92,13 +92,7 @@ private struct SidebarView: View {
         let viewModel = AddSiteMenuViewModel(onSelection: { [weak viewModel] in
             viewModel?.navigate(.addSite(selection: $0))
         })
-        let label = Label {
-            Text(Strings.addSite)
-        } icon: {
-            Image(systemName: "plus.square.fill")
-                .foregroundStyle(Color(UIAppColor.brand), Color(.secondarySystemFill))
-                .font(.title2)
-        }
+        let label = SidebarAddButtonLabel(title: Strings.addSite)
         switch viewModel.actions.count {
         case 0:
             EmptyView()
@@ -220,6 +214,20 @@ private extension BlogListViewModel {
             topSites.append(site)
         }
         return Array(topSites).sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+        }
+    }
+}
+
+struct SidebarAddButtonLabel: View {
+    let title: String
+
+    var body: some View {
+        Label {
+            Text(title)
+        } icon: {
+            Image(systemName: "plus.square.fill")
+                .foregroundStyle(AppColor.brand, Color(.secondarySystemFill))
+                .font(.title2)
         }
     }
 }


### PR DESCRIPTION
This PR add the "Subcriptions" section to the new Reader sidebar (you can find notes about it in the #wpmobile-ios-18 channel).

<img width="1316" alt="Screenshot 2024-09-04 at 2 56 28 PM" src="https://github.com/user-attachments/assets/aef3033f-937d-4b55-a250-25c09c2a040c">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
