### PR TITLE
Fix concurrency warning in WordpressUICacheAdapter

### DIFF
--- a/WordPress/Classes/Utility/Media/MemoryCache.swift
+++ b/WordPress/Classes/Utility/Media/MemoryCache.swift
@@ -8,7 +8,8 @@ protocol MemoryCacheProtocol: AnyObject {
     subscript(key: String) -> UIImage? { get set }
 }
 
-final class MemoryCache: MemoryCacheProtocol {
+/// - note: The type is thread-safe because it uses thread-safe `NSCache`.
+final class MemoryCache: MemoryCacheProtocol, @unchecked Sendable {
     /// A shared image cache used by the entire system.
     static let shared = MemoryCache()
 


### PR DESCRIPTION
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
