### PR TITLE
Cache authToken in WPAccount instances

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -4,7 +4,7 @@
 @interface WPAccount ()
 
 @property (nonatomic, strong, readwrite) WordPressComRestApi *wordPressComRestApi;
-
+@property (nonatomic, strong, readwrite) NSString *cachedToken;
 
 @end
 
@@ -23,6 +23,7 @@
 @dynamic avatarURL;
 @dynamic settings;
 @synthesize wordPressComRestApi = _wordPressComRestApi;
+@synthesize cachedToken;
 
 #pragma mark - NSManagedObject subclass methods
 
@@ -42,6 +43,7 @@
 {
     [super didTurnIntoFault];
     _wordPressComRestApi = nil;
+    self.cachedToken = nil;
 }
 
 + (NSString *)entityName
@@ -74,11 +76,19 @@
 
 - (NSString *)authToken
 {
-    return [WPAccount tokenForUsername:self.username];
+    if (self.cachedToken != nil) {
+        return self.cachedToken;
+    }
+
+    NSString *token = [WPAccount tokenForUsername:self.username];
+    self.cachedToken = token;
+    return token;
 }
 
 - (void)setAuthToken:(NSString *)authToken
 {
+    self.cachedToken = nil;
+
     if (authToken) {
         NSError *error = nil;
         [SFHFKeychainUtils storeUsername:self.username


### PR DESCRIPTION
In accounts that have many sites (like a8c accounts), there are performance issues in the site picker and sidebar, where we display or query all sites.

I can reproduce the issue pretty easily on an iPad with my a8c account, when switching site from the sidebar. You can also use Instruments to profile the app by simplying switching sites from the sidebar: there is about 400 - 800 ms hang on the main thread.

The root cause is the keychain query at `WPAccount.authToken`, which is used during creating `SiteIconViewModel` instances. The query will be executed repeatedly for each `Blog` instances, even though they share the same `WPAccount` instance.

This PR simply caches the `authToken` query result within `WPAccount` instances. The app kinda already does that implicitly, because the `wordPressComApi` instance also has a copy of the `authToken`.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
