### PR TITLE
Do not store Core Data objects in MediaHost error types

### DIFF
--- a/WordPress/Classes/Networking/MediaHost+AbstractPost.swift
+++ b/WordPress/Classes/Networking/MediaHost+AbstractPost.swift
@@ -5,17 +5,17 @@ import Foundation
 ///
 extension MediaHost {
     enum AbstractPostError: Swift.Error {
-        case baseInitializerError(error: BlogError, post: AbstractPost)
+        case baseInitializerError(error: BlogError)
     }
 
     init(with post: AbstractPost, failure: (AbstractPostError) -> ()) {
+        let postId = TaggedManagedObjectID(post)
         self.init(
             with: post.blog,
             failure: { error in
                 // We just associate a post with the underlying error for simpler debugging.
-                failure(AbstractPostError.baseInitializerError(
-                    error: error,
-                    post: post))
-        })
+                failure(AbstractPostError.baseInitializerError(error: error))
+            }
+        )
    }
 }

--- a/WordPress/Classes/Networking/MediaHost+Blog.swift
+++ b/WordPress/Classes/Networking/MediaHost+Blog.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 extension MediaHost {
     enum BlogError: Swift.Error {
-        case baseInitializerError(error: Error, blog: Blog)
+        case baseInitializerError(error: Error)
     }
 
     init(with blog: Blog) {
@@ -21,7 +21,8 @@ extension MediaHost {
     }
 
     init(with blog: Blog, isAtomic: Bool, failure: (BlogError) -> ()) {
-        self.init(isAccessibleThroughWPCom: blog.isAccessibleThroughWPCom(),
+        self.init(
+            isAccessibleThroughWPCom: blog.isAccessibleThroughWPCom(),
             isPrivate: blog.isPrivate(),
             isAtomic: isAtomic,
             siteID: blog.dotComID?.intValue,
@@ -29,9 +30,8 @@ extension MediaHost {
             authToken: blog.authToken,
             failure: { error in
                 // We just associate a blog with the underlying error for simpler debugging.
-                failure(BlogError.baseInitializerError(
-                    error: error,
-                    blog: blog))
-        })
+                failure(BlogError.baseInitializerError(error: error))
+            }
+        )
    }
 }

--- a/WordPress/Classes/Networking/MediaHost+ReaderPostContentProvider.swift
+++ b/WordPress/Classes/Networking/MediaHost+ReaderPostContentProvider.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 extension MediaHost {
     enum ReaderPostContentProviderError: Swift.Error {
-        case baseInitializerError(error: Error, readerPostContentProvider: ReaderPostContentProvider)
+        case baseInitializerError(error: Error)
     }
 
     init(with readerPostContentProvider: ReaderPostContentProvider, failure: (ReaderPostContentProviderError) -> ()) {
@@ -20,7 +20,8 @@ extension MediaHost {
         let username = account?.username
         let authToken = account?.authToken
 
-        self.init(isAccessibleThroughWPCom: isAccessibleThroughWPCom,
+        self.init(
+            isAccessibleThroughWPCom: isAccessibleThroughWPCom,
             isPrivate: readerPostContentProvider.isPrivate(),
             isAtomic: readerPostContentProvider.isAtomic(),
             siteID: readerPostContentProvider.siteID()?.intValue,
@@ -28,9 +29,8 @@ extension MediaHost {
             authToken: authToken,
             failure: { error in
                 // We just associate a ReaderPostContentProvider with the underlying error for simpler debugging.
-                failure(ReaderPostContentProviderError.baseInitializerError(
-                    error: error,
-                    readerPostContentProvider: readerPostContentProvider))
-        })
+                failure(ReaderPostContentProviderError.baseInitializerError(error: error))
+            }
+        )
     }
 }


### PR DESCRIPTION
`MediaHost` itself is completely decoupled from Core Data objects. However, some error types in it still stores blog, post, etc. Since those objects are not used, this PR removes them to clean up the code.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
