### PR TITLE
Change BlogListViewModel type from class to struct

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -53,6 +53,7 @@ struct BlogListSiteViewModel: Identifiable {
     let searchTags: String
     let siteURL: URL?
     let badge: Badge?
+    let blog: Blog
 
     struct Badge {
         let title: String
@@ -60,13 +61,11 @@ struct BlogListSiteViewModel: Identifiable {
     }
 
     func makeIcon(with size: SiteIconViewModel.Size) -> SiteIconViewModel {
-        let context = ContextManager.shared.mainContext
-        guard let blog = try? context.existingObject(with: id) else { return icon }
-
-        return SiteIconViewModel(blog: blog, size: size)
+        SiteIconViewModel(blog: blog, size: size)
     }
 
     init(blog: Blog) {
+        self.blog = blog
         self.id = TaggedManagedObjectID(blog)
         self.title = blog.title ?? "–"
         self.domain = blog.displayURL as String? ?? ""


### PR DESCRIPTION
This PR makes two changes to `BlogListViewModel`:
1. Remove the `blog: Blog` instance from it, to make it a plain object.
2. Declare it as a `struct`, instead of class. I don't think it needs to be a reference type.

## Regression Notes
1. Potential unintended areas of impact


3. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
