### PR TITLE
feat: Remote editor

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "8d5bfdf0742a54e6f2b0a109a260f40fc2441905"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "27896c967511a595d9dfc5efdda0ed2416318cfe"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "add/swift-file-output"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "da722c56773fdbf40648a914275ffb8316c1c84c"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "83b757bf22390fdf8c840236f5d77ca1b3517c6f"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "add/swift-file-output"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "179c3e7868212faca4b55b7c94998ed0be796c9f"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "0987aa05587342f531b646dbb36d5622df12cfea"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "add/swift-file-output"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "27896c967511a595d9dfc5efdda0ed2416318cfe"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "179c3e7868212faca4b55b7c94998ed0be796c9f"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "add/swift-file-output"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "83b757bf22390fdf8c840236f5d77ca1b3517c6f"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "8d5bfdf0742a54e6f2b0a109a260f40fc2441905"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "add/swift-file-output"),
     ],
     targets: XcodeSupport.targets + [

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "179c3e7868212faca4b55b7c94998ed0be796c9f"
+        "revision" : "0987aa05587342f531b646dbb36d5622df12cfea"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "da722c56773fdbf40648a914275ffb8316c1c84c"
+        "revision" : "83b757bf22390fdf8c840236f5d77ca1b3517c6f"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "8d5bfdf0742a54e6f2b0a109a260f40fc2441905"
+        "revision" : "27896c967511a595d9dfc5efdda0ed2416318cfe"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "83b757bf22390fdf8c840236f5d77ca1b3517c6f"
+        "revision" : "8d5bfdf0742a54e6f2b0a109a260f40fc2441905"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "27896c967511a595d9dfc5efdda0ed2416318cfe"
+        "revision" : "179c3e7868212faca4b55b7c94998ed0be796c9f"
       }
     },
     {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -16,6 +16,7 @@ enum FeatureFlag: Int, CaseIterable {
     case sidebar
     case newGutenberg
     case newGutenbergThemeStyles
+    case newGutenbergPlugins
     case serif
 
     /// Returns a boolean indicating if the feature is enabled
@@ -52,6 +53,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .newGutenberg:
             return false
         case .newGutenbergThemeStyles:
+            return false
+        case .newGutenbergPlugins:
             return false
         case .serif:
             return false
@@ -91,6 +94,7 @@ extension FeatureFlag {
         case .sidebar: "Sidebar"
         case .newGutenberg: "Experimental Block Editor"
         case .newGutenbergThemeStyles: "Experimental Block Editor Styles"
+        case .newGutenbergPlugins: "Experimental Block Editor Plugins"
         case .serif: "Serif"
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -134,7 +134,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let networkClient = NewGutenbergNetworkClient(blog: post.blog)
 
         let selfHostedApiUrl = post.blog.url(withPath: "wp-json/")
-        let siteApiRoot = post.blog.isAccessibleThroughWPCom() ? post.blog.wordPressComRestApi()?.baseURL.absoluteString : selfHostedApiUrl
+        let siteApiRoot = post.blog.isAccessibleThroughWPCom() && post.blog.isHostedAtWPcom ? post.blog.wordPressComRestApi()?.baseURL.absoluteString : selfHostedApiUrl
         let siteId = post.blog.dotComID?.stringValue
         let authToken = post.blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
@@ -149,7 +149,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             }
         }
 
-        let siteApiNamespace = post.blog.dotComID != nil && applicationPassword == nil ? "sites/\(siteId ?? "")" : ""
+        let siteApiNamespace = post.blog.dotComID != nil && post.blog.isHostedAtWPcom && applicationPassword == nil ? "sites/\(siteId ?? "")" : ""
         let postType = post is Page ? "page" : "post"
         let postId: Int? = post.postID?.intValue != -1 ? post.postID?.intValue : nil
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -140,8 +140,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let authToken = post.blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
 
-        // TODO: Reinstate the application password token getter once supported
-        let applicationPassword = try? post.blog.getPassword()
+        let applicationPassword = try? post.blog.getApplicationToken()
 
         if let appPassword = applicationPassword, let username = post.blog.username {
             let credentials = "\(username):\(appPassword)"

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -160,6 +160,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             content: post.content ?? "",
             service: GutenbergKit.EditorService(client: networkClient),
             themeStyles: FeatureFlag.newGutenbergThemeStyles.enabled,
+            plugins: FeatureFlag.newGutenbergPlugins.enabled,
             siteURL: post.blog.url ?? "",
             siteApiRoot: siteApiRoot!,
             siteApiNamespace: siteApiNamespace,

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -139,7 +139,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let authToken = post.blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
 
-        let applicationPassword = try? post.blog.getApplicationToken()
+        // TODO: Reinstate the application password token getter once supported
+        let applicationPassword = try? post.blog.getPassword()
 
         if let appPassword = applicationPassword, let username = post.blog.username {
             let credentials = "\(username):\(appPassword)"

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -134,7 +134,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let networkClient = NewGutenbergNetworkClient(blog: post.blog)
 
         let selfHostedApiUrl = post.blog.url(withPath: "wp-json/")
-        let siteApiRoot = post.blog.isAccessibleThroughWPCom() && post.blog.isHostedAtWPcom ? post.blog.wordPressComRestApi()?.baseURL.absoluteString : selfHostedApiUrl
+        let isSelfHosted = !post.blog.isHostedAtWPcom && !post.blog.isAtomic()
+        let siteApiRoot = post.blog.isAccessibleThroughWPCom() && !isSelfHosted ? post.blog.wordPressComRestApi()?.baseURL.absoluteString : selfHostedApiUrl
         let siteId = post.blog.dotComID?.stringValue
         let authToken = post.blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
@@ -150,7 +151,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             }
         }
 
-        let siteApiNamespace = post.blog.dotComID != nil && post.blog.isHostedAtWPcom && applicationPassword == nil ? "sites/\(siteId ?? "")" : ""
+        let siteApiNamespace = post.blog.dotComID != nil && !isSelfHosted && applicationPassword == nil ? "sites/\(siteId ?? "")" : ""
         let postType = post is Page ? "page" : "post"
         let postId: Int? = post.postID?.intValue != -1 ? post.postID?.intValue : nil
 
@@ -161,7 +162,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             content: post.content ?? "",
             service: GutenbergKit.EditorService(client: networkClient),
             themeStyles: FeatureFlag.newGutenbergThemeStyles.enabled,
-            plugins: FeatureFlag.newGutenbergPlugins.enabled,
+            plugins: FeatureFlag.newGutenbergPlugins.enabled && isSelfHosted,
             siteURL: post.blog.url ?? "",
             siteApiRoot: siteApiRoot!,
             siteApiNamespace: siteApiNamespace,

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -160,6 +160,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             content: post.content ?? "",
             service: GutenbergKit.EditorService(client: networkClient),
             themeStyles: FeatureFlag.newGutenbergThemeStyles.enabled,
+            siteURL: post.blog.url ?? "",
             siteApiRoot: siteApiRoot!,
             siteApiNamespace: siteApiNamespace,
             authHeader: authHeader


### PR DESCRIPTION
Add experimental editor relying upon editor assets fetch from the remote WordPress site, enabling the ability to utilize third-party blocks.

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/22. 

## Regression Notes
1. Potential unintended areas of impact
  None, changed confined to feature hidden behind a disabled feature flag. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
  Verified previous editor worked as expected. 
4. What automated tests I added (or what prevented me from doing so)
  Deemed unnecessary. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
