### PR TITLE
Simplify navigating to the Notifications tab

### DIFF
--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -92,24 +92,7 @@ extension MySitesCoordinator: RootViewPresenter {
 
     // MARK: Notifications
 
-    var notificationsViewController: NotificationsViewController? {
-        unsupportedFeatureFallback()
-        return nil
-    }
-
-    func showNotificationsTab() {
-        unsupportedFeatureFallback()
-    }
-
-    func switchNotificationsTabToNotificationSettings() {
-        unsupportedFeatureFallback()
-    }
-
-    func showNotificationsTabForNote(withID notificationID: String) {
-        unsupportedFeatureFallback()
-    }
-
-    func popNotificationsTabToRoot() {
+    func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
         unsupportedFeatureFallback()
     }
 

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -38,13 +38,35 @@ protocol RootViewPresenter: AnyObject {
 
     // MARK: Notifications
 
-    var notificationsViewController: NotificationsViewController? { get }
-    func showNotificationsTab()
-    func showNotificationsTabForNote(withID notificationID: String)
-    func switchNotificationsTabToNotificationSettings()
-    func popNotificationsTabToRoot()
+    func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?)
 
     // MARK: Me
 
     func showMeScreen(completion: ((MeViewController) -> Void)?)
+}
+
+extension RootViewPresenter {
+
+    func showNotificationsTab() {
+        showNotificationsTab(completion: nil)
+    }
+
+    func showNotificationsTabForNote(withID notificationID: String) {
+        showNotificationsTab {
+            $0.showDetailsForNotificationWithID(notificationID)
+        }
+    }
+
+    func popNotificationsTabToRoot() {
+        showNotificationsTab {
+            $0.navigationController?.popToRootViewController(animated: false)
+        }
+    }
+
+    func switchNotificationsTabToNotificationSettings() {
+        showNotificationsTab {
+            $0.navigationController?.popToRootViewController(animated: false)
+            $0.showNotificationSettings()
+        }
+    }
 }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -11,6 +11,12 @@ final class SplitViewRootPresenter: RootViewPresenter {
     private weak var sitePickerPopoverVC: UIViewController?
     private var cancellables: [AnyCancellable] = []
 
+    private var notifications: UINavigationController? {
+        didSet {
+            assert(notifications == nil || notifications?.viewControllers.first is NotificationsViewController)
+        }
+    }
+
     /// Is the app displaying tab bar UI instead of the full split view UI (with sidebar).
     private var isDisplayingTabBar: Bool {
         if splitVC.isCollapsed {
@@ -77,11 +83,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
                 // TODO: (wpsidebar) show empty state
             }
         case .notifications:
-            // TODO: (wpsidebar) update tab bar item when new notifications arrive
-            let notificationsVC = UIStoryboard(name: "Notifications", bundle: nil).instantiateInitialViewController() as! NotificationsViewController
-            notificationsVC.isSidebarModeEnabled = true
-            let navigationVC = UINavigationController(rootViewController: notificationsVC)
-            splitVC.setViewController(navigationVC, for: .supplementary)
+            showNotificationsTab(completion: nil)
         case .reader:
             let viewModel = ReaderSidebarViewModel()
             let sidebarVC = ReaderSidebarViewController(viewModel: viewModel)
@@ -309,22 +311,22 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    var notificationsViewController: NotificationsViewController?
+    func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
+        // TODO: (wpsidebar) update tab bar item when new notifications arrive
+        let navigationController: UINavigationController
+        if let notifications = self.notifications {
+            navigationController = notifications
+        } else {
+            let notificationsVC = UIStoryboard(name: "Notifications", bundle: nil).instantiateInitialViewController() as! NotificationsViewController
+            notificationsVC.isSidebarModeEnabled = true
+            let navigationVC = UINavigationController(rootViewController: notificationsVC)
+            self.notifications = navigationVC
 
-    func showNotificationsTab() {
-        fatalError()
-    }
+            navigationController = navigationVC
+        }
 
-    func showNotificationsTabForNote(withID notificationID: String) {
-        fatalError()
-    }
-
-    func switchNotificationsTabToNotificationSettings() {
-        fatalError()
-    }
-
-    func popNotificationsTabToRoot() {
-        fatalError()
+        splitVC.setViewController(navigationController, for: .supplementary)
+        completion?(navigationController.viewControllers.first as! NotificationsViewController)
     }
 
     var meViewController: MeViewController?

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -117,24 +117,8 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
 
     // MARK: Notifications
 
-    var notificationsViewController: NotificationsViewController? {
-        return nil
-    }
-
-    func showNotificationsTab() {
-        tabBarController.showNotificationsTab()
-    }
-
-    func showNotificationsTabForNote(withID notificationID: String) {
-        tabBarController.showNotificationsTab()
-    }
-
-    func switchNotificationsTabToNotificationSettings() {
-        tabBarController.showNotificationsTab()
-    }
-
-    func popNotificationsTabToRoot() {
-        // Do nothing since static notification tab will never have a stack
+    func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
+        tabBarController.showNotificationsTab(completion: completion)
     }
 
     // MARK: Me

--- a/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
+++ b/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
@@ -33,6 +33,11 @@ extension WPTabBarController: RootViewPresenter {
         mySitesCoordinator.willDisplayPostSignupFlow()
     }
 
+    func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
+        self.selectedIndex = WPTab.notifications.rawValue
+        completion?(self.notificationsViewController!)
+    }
+
     // MARK: My Site
 
     func showPages(for blog: Blog) {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
@@ -9,7 +9,6 @@ struct NotificationsRoute: Route {
 
 struct NotificationsNavigationAction: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
-        RootViewCoordinator.sharedPresenter.showNotificationsTab()
         RootViewCoordinator.sharedPresenter.popNotificationsTabToRoot()
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -38,15 +38,10 @@ extern NSNotificationName const WPTabBarHeightChangedNotification;
 
 - (void)showMySitesTab;
 - (void)showReaderTab;
-- (void)showNotificationsTab;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
 - (void)showMeTab;
 - (void)reloadSplitViewControllers;
 
-- (void)popNotificationsTabToRoot;
-- (void)switchNotificationsTabToNotificationSettings;
-
-- (void)showNotificationsTabForNoteWithID:(NSString *)notificationID;
 - (void)updateNotificationBadgeVisibility;
 
 @end

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -398,12 +398,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     return YES;
 }
 
-- (void)showNotificationsTabForNoteWithID:(NSString *)notificationID
-{
-    [self setSelectedIndex:WPTabNotifications];
-    [self.notificationsViewController showDetailsForNotificationWithID:notificationID];
-}
-
 #pragma mark - UITabBarDelegate
 
 - (void)tabBar:(UITabBar *)tabBar didSelectItem:(UITabBarItem *)item


### PR DESCRIPTION
This PR moves a few functions from the `RootViewPresenter` protocol definition to its extension, so that we can have one implementation to be shared by different conformations.

There should be no changes to how the app behaves. You can test the changes by using the following universal links:
- https://wordpress.com/notifications takes the app to the root of navigation tab.
- https://wordpress.com/me/notifications takes the app to the notification settings modal.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
