### PR TITLE
Sidebar: Reader Lists and Organization

### DIFF
--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -10,6 +10,7 @@ enum SharedStrings {
         static let edit = NSLocalizedString("shared.button.edit", value: "Edit", comment: "A shared button title used in different contexts")
         static let add = NSLocalizedString("shared.button.add", value: "Add", comment: "A shared button title used in different contexts")
         static let remove = NSLocalizedString("shared.button.remove", value: "Remove", comment: "A shared button title used in different contexts")
+        static let delete = NSLocalizedString("shared.button.remove", value: "Delete", comment: "A shared button title used in different contexts")
         static let save = NSLocalizedString("shared.button.save", value: "Save", comment: "A shared button title used in different contexts")
         static let retry = NSLocalizedString("shared.button.retry", value: "Retry", comment: "A shared button title used in different contexts")
         static let view = NSLocalizedString("shared.button.view", value: "View", comment: "A shared button title used in different contexts")

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -10,7 +10,7 @@ enum SharedStrings {
         static let edit = NSLocalizedString("shared.button.edit", value: "Edit", comment: "A shared button title used in different contexts")
         static let add = NSLocalizedString("shared.button.add", value: "Add", comment: "A shared button title used in different contexts")
         static let remove = NSLocalizedString("shared.button.remove", value: "Remove", comment: "A shared button title used in different contexts")
-        static let delete = NSLocalizedString("shared.button.remove", value: "Delete", comment: "A shared button title used in different contexts")
+        static let delete = NSLocalizedString("shared.button.delete", value: "Delete", comment: "A shared button title used in different contexts")
         static let save = NSLocalizedString("shared.button.save", value: "Save", comment: "A shared button title used in different contexts")
         static let retry = NSLocalizedString("shared.button.retry", value: "Retry", comment: "A shared button title used in different contexts")
         static let view = NSLocalizedString("shared.button.view", value: "View", comment: "A shared button title used in different contexts")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarListsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarListsSection.swift
@@ -1,0 +1,26 @@
+import UIKit
+import SwiftUI
+import Combine
+import WordPressUI
+
+struct ReaderSidebarListsSection: View {
+    let viewModel: ReaderSidebarViewModel
+
+    @FetchRequest(
+        sortDescriptors: [SortDescriptor(\.title, order: .forward)]
+    )
+    private var lists: FetchedResults<ReaderListTopic>
+
+    var body: some View {
+        ForEach(lists, id: \.self) { list in
+            Label {
+                Text(list.title)
+                    .lineLimit(1)
+            } icon: {
+                Image(systemName: "list.star")
+                    .foregroundStyle(.secondary)
+            }
+            .tag(ReaderSidebarItem.list(TaggedManagedObjectID(list)))
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -50,6 +50,13 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
             } catch {
                 wpAssertionFailure("site missing", userInfo: ["error": "\(error)"])
             }
+        case .list(let objectID):
+            do {
+                let topic = try viewContext.existingObject(with: objectID)
+                showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
+            } catch {
+                wpAssertionFailure("list missing", userInfo: ["error": "\(error)"])
+            }
         case .tag(let objectID):
             do {
                 let topic = try viewContext.existingObject(with: objectID)
@@ -130,6 +137,7 @@ struct ReaderSidebarView: View {
     @ObservedObject var viewModel: ReaderSidebarViewModel
 
     @AppStorage("reader_sidebar_subscriptions_expanded") var isSectionSubscriptionsExpanded = true
+    @AppStorage("reader_sidebar_lists_expanded") var isSectionListsExpanded = true
     @AppStorage("reader_sidebar_tags_expanded") var isSectionTagsExpanded = true
 
     var body: some View {
@@ -143,6 +151,9 @@ struct ReaderSidebarView: View {
             }
             makeSection(Strings.subscriptions, isExpanded: $isSectionSubscriptionsExpanded) {
                 ReaderSidebarSubscriptionsSection(viewModel: viewModel)
+            }
+            makeSection(Strings.lists, isExpanded: $isSectionListsExpanded) {
+                ReaderSidebarListsSection(viewModel: viewModel)
             }
             makeSection(Strings.tags, isExpanded: $isSectionTagsExpanded) {
                 ReaderSidebarTagsSection(viewModel: viewModel)
@@ -174,5 +185,6 @@ struct ReaderSidebarView: View {
 private struct Strings {
     static let reader = NSLocalizedString("reader.sidebar.navigationTitle", value: "Reader", comment: "Reader sidebar title")
     static let subscriptions = NSLocalizedString("reader.sidebar.section.subscriptions.tTitle", value: "Subscriptions", comment: "Reader sidebar section title")
+    static let lists = NSLocalizedString("reader.sidebar.section.lists.title", value: "Lists", comment: "Reader sidebar section title")
     static let tags = NSLocalizedString("reader.sidebar.section.tags.title", value: "Tags", comment: "Reader sidebar section title")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import Combine
 import WordPressUI
 
-final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> {
+final class ReaderSidebarViewController: UIHostingController<AnyView> {
     let viewModel: ReaderSidebarViewModel
 
     private var cancellables: [AnyCancellable] = []
@@ -11,7 +11,11 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
 
     init(viewModel: ReaderSidebarViewModel) {
         self.viewModel = viewModel
-        super.init(rootView: ReaderSidebarView(viewModel: viewModel))
+        // - warning: The `managedObjectContext` has to be set here in order for
+        // `ReaderSidebarView` to eb able to access it
+        let view = ReaderSidebarView(viewModel: viewModel)
+            .environment(\.managedObjectContext, ContextManager.shared.mainContext)
+        super.init(rootView: AnyView(view))
 
         viewModel.navigate = { [weak self] in self?.navigate(to: $0) }
     }
@@ -44,26 +48,24 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
         case .allSubscriptions:
             showSecondary(makeAllSubscriptionsViewController(), isLargeTitle: true)
         case .subscription(let objectID):
-            do {
-                let topic = try viewContext.existingObject(with: objectID)
-                showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
-            } catch {
-                wpAssertionFailure("site missing", userInfo: ["error": "\(error)"])
-            }
+            showSecondary(makeViewController(withTopicID: objectID))
         case .list(let objectID):
-            do {
-                let topic = try viewContext.existingObject(with: objectID)
-                showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
-            } catch {
-                wpAssertionFailure("list missing", userInfo: ["error": "\(error)"])
-            }
+            showSecondary(makeViewController(withTopicID: objectID))
         case .tag(let objectID):
-            do {
-                let topic = try viewContext.existingObject(with: objectID)
-                showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
-            } catch {
-                wpAssertionFailure("tag missing", userInfo: ["error": "\(error)"])
-            }
+            showSecondary(makeViewController(withTopicID: objectID))
+        case .organization(let objectID):
+            showSecondary(makeViewController(withTopicID: objectID))
+
+        }
+    }
+
+    private func makeViewController<T: ReaderAbstractTopic>(withTopicID objectID: TaggedManagedObjectID<T>) -> UIViewController {
+        do {
+            let topic = try viewContext.existingObject(with: objectID)
+            return ReaderStreamViewController.controllerWithTopic(topic)
+        } catch {
+            wpAssertionFailure("tag missing", userInfo: ["error": "\(error)"])
+            return makeErrorViewController()
         }
     }
 
@@ -133,12 +135,16 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
     }
 }
 
-struct ReaderSidebarView: View {
+private struct ReaderSidebarView: View {
     @ObservedObject var viewModel: ReaderSidebarViewModel
 
+    @AppStorage("reader_sidebar_organization_expanded") var isSectionOrganizationExpanded = true
     @AppStorage("reader_sidebar_subscriptions_expanded") var isSectionSubscriptionsExpanded = true
     @AppStorage("reader_sidebar_lists_expanded") var isSectionListsExpanded = true
     @AppStorage("reader_sidebar_tags_expanded") var isSectionTagsExpanded = true
+
+    @FetchRequest(sortDescriptors: [SortDescriptor(\.title, order: .forward)])
+    private var teams: FetchedResults<ReaderTeamTopic>
 
     var body: some View {
         List(selection: $viewModel.selection) {
@@ -147,6 +153,11 @@ struct ReaderSidebarView: View {
                     Label($0.localizedTitle, systemImage: $0.systemImage)
                         .tag(ReaderSidebarItem.main($0))
                         .lineLimit(1)
+                }
+            }
+            if !teams.isEmpty {
+                makeSection(Strings.organization, isExpanded: $isSectionOrganizationExpanded) {
+                    ReaderSidebarOrganizationSection(viewModel: viewModel, teams: teams)
                 }
             }
             makeSection(Strings.subscriptions, isExpanded: $isSectionSubscriptionsExpanded) {
@@ -165,7 +176,6 @@ struct ReaderSidebarView: View {
             EditButton()
         }
         .tint(Color(UIAppColor.primary))
-        .environment(\.managedObjectContext, ContextManager.shared.mainContext)
     }
 
     @ViewBuilder
@@ -187,4 +197,5 @@ private struct Strings {
     static let subscriptions = NSLocalizedString("reader.sidebar.section.subscriptions.tTitle", value: "Subscriptions", comment: "Reader sidebar section title")
     static let lists = NSLocalizedString("reader.sidebar.section.lists.title", value: "Lists", comment: "Reader sidebar section title")
     static let tags = NSLocalizedString("reader.sidebar.section.tags.title", value: "Tags", comment: "Reader sidebar section title")
+    static let organization = NSLocalizedString("reader.sidebar.section.organization.title", value: "Organization", comment: "Reader sidebar section title")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -52,6 +52,7 @@ enum ReaderSidebarItem: Identifiable, Hashable {
     case main(ReaderStaticScreen)
     case allSubscriptions
     case subscription(TaggedManagedObjectID<ReaderSiteTopic>)
+    case list(TaggedManagedObjectID<ReaderListTopic>)
     case tag(TaggedManagedObjectID<ReaderTagTopic>)
 
     var id: ReaderSidebarItem { self }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -54,6 +54,7 @@ enum ReaderSidebarItem: Identifiable, Hashable {
     case subscription(TaggedManagedObjectID<ReaderSiteTopic>)
     case list(TaggedManagedObjectID<ReaderListTopic>)
     case tag(TaggedManagedObjectID<ReaderTagTopic>)
+    case organization(TaggedManagedObjectID<ReaderTeamTopic>)
 
     var id: ReaderSidebarItem { self }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarOrganizationSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarOrganizationSection.swift
@@ -1,0 +1,23 @@
+import UIKit
+import SwiftUI
+import Combine
+import WordPressUI
+
+struct ReaderSidebarOrganizationSection: View {
+    let viewModel: ReaderSidebarViewModel
+    var teams: FetchedResults<ReaderTeamTopic>
+
+    var body: some View {
+        ForEach(teams, id: \.self) { list in
+            Label {
+                Text(list.title)
+                    .lineLimit(1)
+            } icon: {
+                // TODO: update icon
+                Image(systemName: "list.star")
+                    .foregroundStyle(.secondary)
+            }
+            .tag(ReaderSidebarItem.organization(TaggedManagedObjectID(list)))
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -648,6 +648,8 @@
 		0CDDCA092C8F4126005AACA3 /* ReaderTagsAddTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA072C8F4126005AACA3 /* ReaderTagsAddTagView.swift */; };
 		0CDDCA0B2C8F4990005AACA3 /* ReaderTagsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0A2C8F4990005AACA3 /* ReaderTagsHelper.swift */; };
 		0CDDCA0C2C8F4990005AACA3 /* ReaderTagsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0A2C8F4990005AACA3 /* ReaderTagsHelper.swift */; };
+		0CDDCA102C8F9528005AACA3 /* ReaderSidebarListsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */; };
+		0CDDCA112C8F9528005AACA3 /* ReaderSidebarListsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CE538CA2B0D6E0000834BA2 /* ExternalMediaDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */; };
@@ -6547,6 +6549,7 @@
 		0CDDCA032C8F3F6E005AACA3 /* ReaderSidebarTagsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSidebarTagsSection.swift; sourceTree = "<group>"; };
 		0CDDCA072C8F4126005AACA3 /* ReaderTagsAddTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagsAddTagView.swift; sourceTree = "<group>"; };
 		0CDDCA0A2C8F4990005AACA3 /* ReaderTagsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagsHelper.swift; sourceTree = "<group>"; };
+		0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSidebarListsSection.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaDataSource.swift; sourceTree = "<group>"; };
 		0CE538CF2B0E317000834BA2 /* StockPhotosWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosWelcomeView.swift; sourceTree = "<group>"; };
@@ -10759,6 +10762,7 @@
 				0CAC10932C876E47003AB1BC /* ReaderSidebarViewModel.swift */,
 				0CDDCA002C8F3F34005AACA3 /* ReaderSidebarSubscriptionsSection.swift */,
 				0CDDCA032C8F3F6E005AACA3 /* ReaderSidebarTagsSection.swift */,
+				0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */,
 			);
 			name = Sidebar;
 			sourceTree = "<group>";
@@ -21645,6 +21649,7 @@
 				8313B9EE298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */,
 				E15644F11CE0E56600D96E64 /* FeatureItemCell.swift in Sources */,
 				8BAC9D9E27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */,
+				0CDDCA102C8F9528005AACA3 /* ReaderSidebarListsSection.swift in Sources */,
 				E62AFB6B1DC8E593007484FC /* WPRichContentView.swift in Sources */,
 				9856A39D261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
 				08B6E51A1F036CAD00268F57 /* MediaFileManager.swift in Sources */,
@@ -24505,6 +24510,7 @@
 				FABB21232602FC2C00C8785C /* InteractivePostViewDelegate.swift in Sources */,
 				FABB21252602FC2C00C8785C /* ActivityLogViewController.m in Sources */,
 				0189AF062ACAD89700F63393 /* ShoppingCartService.swift in Sources */,
+				0CDDCA112C8F9528005AACA3 /* ReaderSidebarListsSection.swift in Sources */,
 				FABB21262602FC2C00C8785C /* UIViewController+ChildViewController.swift in Sources */,
 				FABB21272602FC2C00C8785C /* Media+Blog.swift in Sources */,
 				0C03EFA32C498B3D00B7F828 /* BlogListSiteView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -650,6 +650,8 @@
 		0CDDCA0C2C8F4990005AACA3 /* ReaderTagsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0A2C8F4990005AACA3 /* ReaderTagsHelper.swift */; };
 		0CDDCA102C8F9528005AACA3 /* ReaderSidebarListsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */; };
 		0CDDCA112C8F9528005AACA3 /* ReaderSidebarListsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */; };
+		0CDDCA132C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA122C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift */; };
+		0CDDCA142C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDDCA122C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift */; };
 		0CDEC40C2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CDEC40D2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */; };
 		0CE538CA2B0D6E0000834BA2 /* ExternalMediaDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */; };
@@ -6550,6 +6552,7 @@
 		0CDDCA072C8F4126005AACA3 /* ReaderTagsAddTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagsAddTagView.swift; sourceTree = "<group>"; };
 		0CDDCA0A2C8F4990005AACA3 /* ReaderTagsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagsHelper.swift; sourceTree = "<group>"; };
 		0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSidebarListsSection.swift; sourceTree = "<group>"; };
+		0CDDCA122C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReaderSidebarOrganizationSection.swift; path = Sidebar/ReaderSidebarOrganizationSection.swift; sourceTree = "<group>"; };
 		0CDEC40B2A2FAF0500BB3A91 /* DashboardBlazeCampaignsCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardBlazeCampaignsCardView.swift; sourceTree = "<group>"; };
 		0CE538C92B0D6E0000834BA2 /* ExternalMediaDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalMediaDataSource.swift; sourceTree = "<group>"; };
 		0CE538CF2B0E317000834BA2 /* StockPhotosWelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosWelcomeView.swift; sourceTree = "<group>"; };
@@ -10763,6 +10766,7 @@
 				0CDDCA002C8F3F34005AACA3 /* ReaderSidebarSubscriptionsSection.swift */,
 				0CDDCA032C8F3F6E005AACA3 /* ReaderSidebarTagsSection.swift */,
 				0CDDCA0F2C8F9528005AACA3 /* ReaderSidebarListsSection.swift */,
+				0CDDCA122C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift */,
 			);
 			name = Sidebar;
 			sourceTree = "<group>";
@@ -22873,6 +22877,7 @@
 				17F7C24922770B68002E5C2E /* main.swift in Sources */,
 				9A4E939F2268D9B400E14823 /* UIViewController+NoResults.swift in Sources */,
 				E1CB6DA3200F376400945457 /* TimeZoneStore.swift in Sources */,
+				0CDDCA132C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift in Sources */,
 				0C9434D62B687E38006AA6BC /* SiteMonitoringEntryDetailsView.swift in Sources */,
 				B0B68A9C252FA91E0001B28C /* UserSuggestion+CoreDataClass.swift in Sources */,
 				46F583D42624D0BC0010A723 /* Blog+BlockEditorSettings.swift in Sources */,
@@ -24810,6 +24815,7 @@
 				FABB22012602FC2C00C8785C /* RevisionDiff.swift in Sources */,
 				FABB22032602FC2C00C8785C /* RevisionDiffsPageManager.swift in Sources */,
 				FABB22042602FC2C00C8785C /* CalendarCollectionView.swift in Sources */,
+				0CDDCA142C907C7E005AACA3 /* ReaderSidebarOrganizationSection.swift in Sources */,
 				3F946C5A2684DD8E00B946F6 /* BloggingRemindersActions.swift in Sources */,
 				F48D44BC2989AA8A0051EAA6 /* ReaderSiteService.m in Sources */,
 				C387B7A22638D66F00BDEF86 /* PostAuthorSelectorViewController.swift in Sources */,


### PR DESCRIPTION
This PR adds "Lists" and "Organization" sections to the Reader sidebar, which were the only remaining items.

**Note**: the icons for the "organization" lists are no there yet. I'll update both the app sidebar and the Reader sidebar with the icons from the WordPress Design Library separately.

For both "Lists" and "Organization" you can't yet see what's in there. This will need to be implemented separately.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
