### PR TITLE
Reader: Update cells for iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -264,6 +264,8 @@ import AutomatticTracks
     /// This is set to true after the Reader Manage view is dismissed
     var shouldForceRefresh = false
 
+    lazy var isSidebarModeEnabled = splitViewController?.isCollapsed == false
+
     // MARK: - Factory Methods
 
     /// Convenience method for instantiating an instance of ReaderStreamViewController
@@ -1570,6 +1572,10 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         }
 
         let cell = tableConfiguration.postCardCell(tableView)
+        if isSidebarModeEnabled {
+            cell.enableSidebarMode()
+        }
+
         let viewModel = ReaderPostCardCellViewModel(contentProvider: post,
                                                     isLoggedIn: isLoggedIn,
                                                     showsSeparator: showsSeparator,


### PR DESCRIPTION
This PR tweaks the design of the cells a bit for iPad (see iOS-18 channel for more details) and fixes an issue where the app was adding the same constraints over and over again to the cells as you scroll. This is not exactly the target design, but is already an improvement that makes the list usable as opposed to the current production design.

<img width="1316" alt="Screenshot 2024-09-10 at 3 21 52 PM" src="https://github.com/user-attachments/assets/ad2e5469-e6b7-4b66-ab43-5d90fdc5f7a6">

## To test:

Please, help run some more regression tests on iPhone.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
