### PR TITLE
Sidebar: Fix an issue with SidebarProfileView not reloading

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarProfileView.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarProfileView.swift
@@ -2,20 +2,23 @@ import SwiftUI
 import WordPressUI
 
 struct SidebarProfileView: View {
-    var username: String
-    var displayName: String
-    var avatar: URL?
+    @ObservedObject var account: WPAccount
 
     var body: some View {
         HStack {
-            AvatarView<Circle>(style: .single(avatar), diameter: 30)
+            let avatarURL = account.avatarURL.flatMap(URL.init(string:))
+            AvatarView<Circle>(style: .single(avatarURL), diameter: 30)
 
             VStack(alignment: .leading, spacing: 0) {
-                Text(displayName)
-                    .font(.subheadline.weight(.medium))
-                Text("@\(username)")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                if let displayName = account.displayName {
+                    Text(displayName)
+                        .font(.subheadline.weight(.medium))
+                }
+                if let username = account.username {
+                    Text("@\(username)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Spacer()

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -161,11 +161,7 @@ private struct SidebarProfileContainerView: View {
     var content: some View {
         if let account = viewModel.account {
             Button(action: { viewModel.navigate(.profile) }) {
-                SidebarProfileView(
-                    username: account.username,
-                    displayName: account.displayName,
-                    avatar: account.avatarURL.flatMap(URL.init(string:))
-                )
+                SidebarProfileView(account: account)
             }
             .containerShape(Rectangle())
             .buttonStyle(.plain)

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewModel.swift
@@ -54,7 +54,6 @@ final class SidebarViewModel: ObservableObject {
 
         NotificationCenter.default
             .publisher(for: .WPAccountDefaultWordPressComAccountChanged)
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.account = try? WPAccount.lookupDefaultWordPressComAccount(in: self.contextManager.mainContext)


### PR DESCRIPTION
(see title)

## To test:

**Test 1**

- Login with a wp.com account
- Open the account and change the display name
- Verify that the display name was updated in the sidebar profile view

**Test 2**

- Logout
- Verify that the is not crash and the sidebar shows the "Sign in" button

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
