### PR TITLE
Sidebar: Reader selection

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -15,6 +15,7 @@ private enum UPRUConstants {
     static let isJPContentImportCompleteKey = "jetpackContentImportComplete"
     static let jetpackContentMigrationStateKey = "jetpackContentMigrationState"
     static let mediaAspectRatioModeEnabledKey = "mediaAspectRatioModeEnabled"
+    static let readerSidebarSelectionKey = "readerSidebarSelectionKey"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -153,6 +154,18 @@ extension UserPersistentRepositoryUtility {
         }
         set {
             UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.mediaAspectRatioModeEnabledKey)
+        }
+    }
+
+    var readerSidebarSelection: ReaderStaticScreen? {
+        get {
+            let repository = UserPersistentStoreFactory.instance()
+            return repository.string(forKey: UPRUConstants.readerSidebarSelectionKey)
+                .flatMap(ReaderStaticScreen.init)
+        }
+        set {
+            let repository = UserPersistentStoreFactory.instance()
+            repository.set(newValue?.rawValue, forKey: UPRUConstants.readerSidebarSelectionKey)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -17,6 +17,12 @@ final class ReaderSidebarViewController: UIHostingController<ReaderSidebarView> 
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel.onAppear()
+    }
+
     func showInitialSelection() {
         cancellables = []
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -3,7 +3,9 @@ import UIKit
 import WordPressUI
 
 final class ReaderSidebarViewModel: ObservableObject {
-    @Published var selection: ReaderSidebarItem?
+    @Published var selection: ReaderSidebarItem? {
+        didSet { persistenSelection() }
+    }
 
     private let tabItemsStore: ReaderTabItemsStoreProtocol
     private let contextManager: CoreDataStackSwift
@@ -13,7 +15,8 @@ final class ReaderSidebarViewModel: ObservableObject {
          contextManager: CoreDataStackSwift = ContextManager.shared) {
         self.tabItemsStore = tabItemsStore
         self.contextManager = contextManager
-        self.selection = .main(.recent)
+        let selection = UserDefaults.standard.readerSidebarSelection
+        self.selection = .main(selection ?? .recent)
         self.reloadMenuIfNeeded()
     }
 
@@ -33,6 +36,13 @@ final class ReaderSidebarViewModel: ObservableObject {
             tabItemsStore.getItems()
         }
     }
+
+    private func persistenSelection() {
+        if case .main(let screen)? = selection,
+           screen == .recent || screen == .discover {
+            UserDefaults.standard.readerSidebarSelection = screen
+        }
+    }
 }
 
 enum ReaderSidebarItem: Identifiable, Hashable {
@@ -46,7 +56,7 @@ enum ReaderSidebarItem: Identifiable, Hashable {
 
 /// One of the predefined main navigation areas in the reader. The app displays
 /// these even if the respective "topics" were not loaded yet.
-enum ReaderStaticScreen: CaseIterable, Identifiable, Hashable {
+enum ReaderStaticScreen: String, CaseIterable, Identifiable, Hashable {
     case recent
     case discover
     case saved

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -7,21 +7,30 @@ final class ReaderSidebarViewModel: ObservableObject {
 
     private let tabItemsStore: ReaderTabItemsStoreProtocol
     private let contextManager: CoreDataStackSwift
+    private var previousReloadTimestamp: Date?
 
     init(tabItemsStore: ReaderTabItemsStoreProtocol = ReaderTabItemsStore(),
          contextManager: CoreDataStackSwift = ContextManager.shared) {
         self.tabItemsStore = tabItemsStore
         self.contextManager = contextManager
-
-        // TODO: (wpsidebar) reload when appropriate
-        tabItemsStore.getItems()
-
         self.selection = .main(.recent)
+        self.reloadMenuIfNeeded()
     }
 
     func getTopic(for topicType: ReaderTopicType) -> ReaderAbstractTopic? {
         return try? ReaderAbstractTopic.lookupAllMenus(in: contextManager.mainContext).first {
             ReaderHelpers.topicType($0) == topicType
+        }
+    }
+
+    func onAppear() {
+        reloadMenuIfNeeded()
+    }
+
+    private func reloadMenuIfNeeded() {
+        if Date.now.timeIntervalSince(previousReloadTimestamp ?? .distantPast) > 60 {
+            previousReloadTimestamp = .now
+            tabItemsStore.getItems()
         }
     }
 }


### PR DESCRIPTION
-  Saves sidebar selection persistently. It only "Recent" vs "Discover" for now because I'm not sure it's worth saving other items persistently, but everything is there to do it if there is a need for it later
- Refresh the sidebar menu when it appears, but with a bit of throttling so it doesn't happen too often

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
