### PR TITLE
Validate site icon URL

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -96,6 +96,11 @@ extension SiteIconViewModel {
             return nil
         }
         components.query = query
+
+        if components.host == nil {
+            return nil
+        }
+
         return components.url
     }
 }


### PR DESCRIPTION
I noticed there are many errors like this when navigating to the Reader.

```
Task <FF11E022-6F86-42FA-8041-1208EF01A307>.<10> finished with error [-1002] Error Domain=NSURLErrorDomain Code=-1002 "unsupported URL" UserInfo={NSLocalizedDescription=unsupported URL, NSErrorFailingURLStringKey=?d=404&s=80, NSErrorFailingURLKey=?d=404&s=80, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <FF11E022-6F86-42FA-8041-1208EF01A307>.<10>"
), _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <FF11E022-6F86-42FA-8041-1208EF01A307>.<10>, NSUnderlyingError=0x353ffa600 {Error Domain=kCFErrorDomainCFNetwork Code=-1002 "(null)"}}
```

The cause is URLSession fetches an incorrect URL `?d=404&s=80`. It turns out some site icon urls are malformed.

The root cause is that `readerSiteTopic.siteBlavatar` is an empty string, which is used as a full URL path to construct a URL, which ends up to be `?d=404&s=80`.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
