### PR TITLE
Sidebar: Remove isFollowingReaderGuide

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -170,7 +170,6 @@ class AbstractPostListViewController: UIViewController,
     private func configureFilterBar() {
         WPStyleGuide.configureFilterTabBar(filterTabBar)
         filterTabBar.isAutomaticTabSizingStyleEnabled = true
-        filterTabBar.isFollowingReaderGuide = true
         filterTabBar.backgroundColor = .clear
         filterTabBar.items = filterSettings.availablePostListFilters()
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -187,7 +187,6 @@ private extension SiteStatsDashboardViewController {
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
         filterTabBar.isAutomaticTabSizingStyleEnabled = true
-        filterTabBar.isFollowingReaderGuide = true
         filterTabBar.items = displayedTabs
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         filterTabBar.accessibilityIdentifier = "site-stats-dashboard-filter-bar"

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -564,19 +564,6 @@ class FilterTabBar: UIControl {
 
     private func updateForCurrentEnvironment() {
         tabSizingStyle = traitCollection.horizontalSizeClass == .regular ? .equalWidths : .fitting
-
-        if isFollowingReaderGuide {
-            switch tabSizingStyle {
-            case .equalWidths:
-                let readableFrame = readableContentGuide.layoutFrame
-                let inset = readableFrame.minX
-                scrollView.contentInset = UIEdgeInsets(top: 0, left: inset, bottom: 0, right: -inset)
-                stackViewWidthConstraint.constant = -(2 * inset)
-            case .fitting:
-                scrollView.contentInset = .zero
-                stackViewWidthConstraint.constant = 0
-            }
-        }
     }
 }
 


### PR DESCRIPTION
I added it but decided to remove it because I think it looked a bit off and it was a bit too complicated.


before → after

<img width="400" alt="Screenshot 2024-09-11 at 2 31 38 PM" src="https://github.com/user-attachments/assets/2edb9ec4-2da1-4f42-85a5-414e4004230a"> <img width="400" alt="Screenshot 2024-09-11 at 2 32 50 PM" src="https://github.com/user-attachments/assets/6518e04c-f727-4b97-adaa-fe8a3ce22643">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
