### PR TITLE
Sidebar: Show Site Settings in modal on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -242,6 +242,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 
 @property (nonatomic) BOOL hasLoggedDomainCreditPromptShownEvent;
 
+@property (nonatomic, weak) UIViewController *presentedSiteSettingsViewController;
+
 @end
 
 @implementation BlogDetailsViewController
@@ -1807,6 +1809,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 #pragma clang diagnostic pop
         navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
         [self presentViewController:navigationController animated:YES completion:nil];
+        self.presentedSiteSettingsViewController = navigationController;
         navigationController.presentationController.delegate = self;
     } else {
         [self.presentationDelegate presentBlogDetailsViewController:controller];
@@ -2098,7 +2101,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 #pragma mark - UIAdaptivePresentationControllerDelegate
 
 - (void)presentationControllerWillDismiss:(UIPresentationController *)presentationController {
-    [self.tableView deselectSelectedRowWithAnimation:YES];
+    if (presentationController.presentedViewController == self.presentedSiteSettingsViewController) {
+        [self.tableView deselectSelectedRowWithAnimation:YES];
+    }
 }
 
 #pragma mark - Domain Registration


### PR DESCRIPTION
The app will now show "Site Settings" in a form modal like all other "Settings" pages. 

<img width="1316" alt="Screenshot 2024-09-11 at 3 14 25 PM" src="https://github.com/user-attachments/assets/f904d249-ada9-4ce6-99fc-b923c6c394c7">

There are multiple advantages to showing it in a modal:

- It makes sure all sub-screens look great, even if they are not designed yet to support readable content guide like "Site Privacy"
- It puts you into context. This looks disorienting:

<img width="1316" alt="Screenshot 2024-09-11 at 3 16 12 PM" src="https://github.com/user-attachments/assets/92615d2f-3c9d-4c88-8074-8d1eeff7e129">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
