### PR TITLE
Fix login background colors

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -59,6 +59,10 @@ struct UIAppColor {
         CSColor.Celadon.shade(shade)
     }
 
+    static func wordPressBlue(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.WordPressBlue.shade(shade)
+    }
+
     static func jetpackGreen(_ shade: ColorStudioShade) -> UIColor {
         CSColor.JetpackGreen.shade(shade)
     }
@@ -85,13 +89,13 @@ struct UIAppColor {
 
     static let accent = CSColor.Pink.base
 
-    #if IS_JETPACK
+#if IS_JETPACK
     static let brand = CSColor.JetpackGreen.base
-    #endif
+#endif
 
-    #if IS_WORDPRESS
+#if IS_WORDPRESS
     static let brand = CSColor.WordPressBlue.base
-    #endif
+#endif
 
     static let divider = CSColor.Gray.shade(.shade10)
     static let error = CSColor.Red.base
@@ -124,11 +128,11 @@ struct UIAppColor {
 }
 
 struct AppColor {
-    #if IS_JETPACK
+#if IS_JETPACK
     static let brand = Color(CSColor.JetpackGreen.base)
-    #endif
+#endif
 
-    #if IS_WORDPRESS
+#if IS_WORDPRESS
     static let brand = Color(CSColor.WordPressBlue.base)
-    #endif
+#endif
 }

--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/ViewModel/JetpackPromptsConfiguration.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/ViewModel/JetpackPromptsConfiguration.swift
@@ -6,7 +6,7 @@ struct JetpackPromptsConfiguration {
 
     enum Constants {
         // alternate colors in rows
-        static let evenColor = UIColor.systemBackground
+        static let evenColor = UIAppColor.wordPressBlue(.shade50)
         static let oddColor = UIAppColor.jetpackGreen(.shade40)
 
         static let basePrompts = [


### PR DESCRIPTION
**RCA**

This line

```swift
static let evenColor = UIColor.DS.Background.brand(isJetpack: false)
```

was replaced with this:

```swift
static let evenColor = UIColor.systemBackground
```

I couldn't find any other instances where `Background.brand` was replaced with an incorrect color.

<img width="1316" alt="Screenshot 2024-09-11 at 3 50 00 PM" src="https://github.com/user-attachments/assets/c0d77656-9889-4ee4-b176-34c71c9b9fd8">

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
