### PR TITLE
Add brand colors for dark mode

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -85,13 +85,13 @@ struct UIAppColor {
 
     static let accent = CSColor.Pink.base
 
-    #if IS_JETPACK
-    static let brand = CSColor.JetpackGreen.base
-    #endif
+#if IS_JETPACK
+    static let brand = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
+#endif
 
-    #if IS_WORDPRESS
-    static let brand = CSColor.WordPressBlue.base
-    #endif
+#if IS_WORDPRESS
+    static let brand = UIColor(light: CSColor.WordPressBlue.shade(.shade50), dark: CSColor.WordPressBlue.shade(.shade40))
+#endif
 
     static let divider = CSColor.Gray.shade(.shade10)
     static let error = CSColor.Red.base
@@ -124,11 +124,5 @@ struct UIAppColor {
 }
 
 struct AppColor {
-    #if IS_JETPACK
-    static let brand = Color(CSColor.JetpackGreen.base)
-    #endif
-
-    #if IS_WORDPRESS
-    static let brand = Color(CSColor.WordPressBlue.base)
-    #endif
+    static let brand = Color(UIAppColor.brand)
 }


### PR DESCRIPTION
The colors needs to be a tiny bit lighter in dark mode.

I'm not sure about the WordPress blue. Neither of these shades seem to work well in dark mode.

Before → After

<img width="800" alt="Screenshot 2024-09-11 at 3 57 42 PM" src="https://github.com/user-attachments/assets/eee1d623-0ad3-4430-b8e5-f347652f52de">

<img width="800" alt="Screenshot 2024-09-11 at 4 16 31 PM" src="https://github.com/user-attachments/assets/34ad62f4-0193-4c18-83b5-193540f9fa65">

<img width="800" alt="Screenshot 2024-09-11 at 4 27 22 PM" src="https://github.com/user-attachments/assets/6d2c208e-a85d-4ee1-874e-8b205d2eb1a0">

<img width="800" alt="Screenshot 2024-09-11 at 4 21 40 PM" src="https://github.com/user-attachments/assets/3f3720df-17b9-48bc-bba5-523ea76e9724">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
