### PR TITLE
Sidebar: Disable halo focus effect in Site Menu

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -83,6 +83,8 @@ private final class SiteMenuListViewController: BlogDetailsViewController {
             return container
         }()
 
+        cell.focusStyle = .custom
+        cell.focusEffect = nil
         return cell
     }
 }


### PR DESCRIPTION
I'm not sure I've done it correctly, but it disables this default focus halo effect on cells, but you can still navigate with the menu with the keyboard.

<img width="1316" alt="Screenshot 2024-09-11 at 2 31 38 PM" src="https://github.com/user-attachments/assets/35c719f8-1ba4-489c-aea0-f08eda056a03">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
