### PR TITLE
Remove unused willDisplayPostSignupFlow

### DIFF
--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -10,7 +10,6 @@ protocol RootViewPresenter: AnyObject {
     func getMeScenePresenter() -> ScenePresenter
     func currentlySelectedScreen() -> String
     func currentlyVisibleBlog() -> Blog?
-    func willDisplayPostSignupFlow()
 
     // MARK: Reader
 

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -257,10 +257,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         return try? ContextManager.shared.mainContext.existingObject(with: id)
     }
 
-    func willDisplayPostSignupFlow() {
-        fatalError()
-    }
-
     var readerTabViewController: ReaderTabViewController?
 
     var readerCoordinator: ReaderCoordinator?

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -35,10 +35,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         tabBarController.currentlyVisibleBlog()
     }
 
-    func willDisplayPostSignupFlow() {
-        tabBarController.willDisplayPostSignupFlow()
-    }
-
     // MARK: Reader
 
     var readerTabViewController: ReaderTabViewController? {

--- a/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
+++ b/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
@@ -29,10 +29,6 @@ extension WPTabBarController: RootViewPresenter {
         return mySitesCoordinator.currentBlog
     }
 
-    func willDisplayPostSignupFlow() {
-        mySitesCoordinator.willDisplayPostSignupFlow()
-    }
-
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
         self.selectedIndex = WPTab.notifications.rawValue
         completion?(self.notificationsViewController!)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -57,9 +57,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         return refreshControl
     }()
 
-    /// A boolean indicating whether a site creation or adding self-hosted site flow has been initiated but not yet displayed.
-    var willDisplayPostSignupFlow: Bool = false
-
     private var isSidebarModeEnabled = false
 
     private var createButtonCoordinator: CreateButtonCoordinator?
@@ -607,12 +604,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         WordPressAuthenticator.showLoginForSelfHostedSite(self)
     }
 
-    @objc
-    func launchSiteCreationFromNotification() {
-        self.launchSiteCreation(source: "signup_epilogue")
-        willDisplayPostSignupFlow = false
-    }
-
     func launchSiteCreation(source: String) {
         JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self, source: source, onDidDismiss: {
             guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
@@ -633,7 +624,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     @objc
     private func showAddSelfHostedSite() {
         WordPressAuthenticator.showLoginForSelfHostedSite(self)
-        willDisplayPostSignupFlow = false
     }
 
     // MARK: - Blog Details UI Logic
@@ -946,7 +936,7 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
 
 private extension MySiteViewController {
     @objc func displayOverlayIfNeeded() {
-        if isViewOnScreen() && !willDisplayPostSignupFlow && !RootViewCoordinator.shared.isSiteCreationActive {
+        if isViewOnScreen() && !RootViewCoordinator.shared.isSiteCreationActive {
             let didReloadUI = RootViewCoordinator.shared.reloadUIIfNeeded(blog: self.blog)
             if !didReloadUI {
                 let phase = JetpackFeaturesRemovalCoordinator.generalPhase()

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -151,10 +151,6 @@ class MySitesCoordinator: NSObject {
 
     // MARK: - Adding a new site
 
-    func willDisplayPostSignupFlow() {
-        mySiteViewController.willDisplayPostSignupFlow = true
-    }
-
     func showSiteCreation() {
         showRootViewController()
         mySiteViewController.launchSiteCreation(source: "my_site")


### PR DESCRIPTION
With the removal of https://github.com/wordpress-mobile/WordPress-iOS/pull/23459, `willDisplayPostSignupFlow` is now also no longer needed – one less thing in the root presenter protocol.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
