### PR TITLE
Sidebar: Fixes and Improvements

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -164,7 +164,7 @@ extension WPStyleGuide {
     @objc
     class func configureTableViewActionCell(_ cell: UITableViewCell?) {
         configureTableViewCell(cell)
-        cell?.textLabel?.textColor = UIAppColor.primary
+        cell?.textLabel?.textColor = UIAppColor.brand
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -208,14 +208,16 @@ extension BlogDashboardViewController {
         let group = NSCollectionLayoutGroup.vertical(layoutSize: itemSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)
-        let isQuickActionSection = viewModel.isQuickActionsSection(sectionIndex)
-        let isMigrationSuccessCardSection = viewModel.isMigrationSuccessCardSection(sectionIndex)
         let horizontalInset = Constants.horizontalSectionInset
-        let bottomInset = isQuickActionSection || isMigrationSuccessCardSection ? 0 : Constants.bottomSectionInset
-        section.contentInsets = NSDirectionalEdgeInsets(top: Constants.verticalSectionInset,
-                                                        leading: horizontalInset,
-                                                        bottom: bottomInset,
-                                                        trailing: horizontalInset)
+        let isLast = (sectionIndex == collectionView.numberOfSections - 1)
+        // More on .compact to match the FAB.
+        let bottomInset = (isLast && traitCollection.horizontalSizeClass == .compact) ? 86 : 20
+        section.contentInsets = NSDirectionalEdgeInsets(
+            top: Constants.verticalSectionInset,
+            leading: horizontalInset,
+            bottom: CGFloat(bottomInset),
+            trailing: horizontalInset
+        )
 
         section.interGroupSpacing = Constants.cellSpacing
         section.contentInsetsReference = .readableContent
@@ -240,10 +242,6 @@ extension BlogDashboardViewController {
         static let estimatedHeight: CGFloat = 44
         static let horizontalSectionInset: CGFloat = 12
         static let verticalSectionInset: CGFloat = 20
-        static var bottomSectionInset: CGFloat {
-            // Make room for FAB on iPhone
-            WPDeviceIdentification.isiPad() ? verticalSectionInset : 86
-        }
         static let cellSpacing: CGFloat = 20
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -166,17 +166,6 @@ final class BlogDashboardViewModel {
         let cards = service.fetchLocal(blog: blog)
         updateCurrentCards(cards: cards)
     }
-
-    func isQuickActionsSection(_ sectionIndex: Int) -> Bool {
-        let showMigration = MigrationSuccessCardView.shouldShowMigrationSuccessCard && isShowingQuickActions
-        let targetIndex = showMigration ? DashboardSection.quickActions.rawValue : DashboardSection.quickActions.rawValue - 1
-        return sectionIndex == targetIndex
-    }
-
-    func isMigrationSuccessCardSection(_ sectionIndex: Int) -> Bool {
-        let showMigration = MigrationSuccessCardView.shouldShowMigrationSuccessCard && isShowingQuickActions
-        return showMigration ? sectionIndex == DashboardSection.migrationSuccess.rawValue : false
-    }
 }
 
 // MARK: - Private methods
@@ -214,6 +203,13 @@ private extension BlogDashboardViewModel {
     }
 
     func createSnapshot(from cards: [DashboardCardModel]) -> DashboardSnapshot {
+        let isShowingQuickActions: Bool = {
+            guard Feature.enabled(.sidebar) else {
+                return !WPDeviceIdentification.isiPad()
+            }
+            return viewController?.traitCollection.horizontalSizeClass == .compact
+        }()
+
         let items = cards.map { DashboardItem.cards($0) }
         let dotComID = blog.dotComID?.intValue ?? 0
         var snapshot = DashboardSnapshot()
@@ -228,13 +224,6 @@ private extension BlogDashboardViewModel {
         snapshot.appendSections([.cards])
         snapshot.appendItems(items, toSection: .cards)
         return snapshot
-    }
-
-    var isShowingQuickActions: Bool {
-        guard Feature.enabled(.sidebar) else {
-            return !WPDeviceIdentification.isiPad()
-        }
-        return viewController?.traitCollection.horizontalSizeClass == .compact
     }
 
     // In case a draft is saved and the drafts card

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -168,13 +168,13 @@ final class BlogDashboardViewModel {
     }
 
     func isQuickActionsSection(_ sectionIndex: Int) -> Bool {
-        let showMigration = MigrationSuccessCardView.shouldShowMigrationSuccessCard && !WPDeviceIdentification.isiPad()
+        let showMigration = MigrationSuccessCardView.shouldShowMigrationSuccessCard && isShowingQuickActions
         let targetIndex = showMigration ? DashboardSection.quickActions.rawValue : DashboardSection.quickActions.rawValue - 1
         return sectionIndex == targetIndex
     }
 
     func isMigrationSuccessCardSection(_ sectionIndex: Int) -> Bool {
-        let showMigration = MigrationSuccessCardView.shouldShowMigrationSuccessCard && !WPDeviceIdentification.isiPad()
+        let showMigration = MigrationSuccessCardView.shouldShowMigrationSuccessCard && isShowingQuickActions
         return showMigration ? sectionIndex == DashboardSection.migrationSuccess.rawValue : false
     }
 }
@@ -217,17 +217,24 @@ private extension BlogDashboardViewModel {
         let items = cards.map { DashboardItem.cards($0) }
         let dotComID = blog.dotComID?.intValue ?? 0
         var snapshot = DashboardSnapshot()
-        if MigrationSuccessCardView.shouldShowMigrationSuccessCard, !WPDeviceIdentification.isiPad() {
+        if MigrationSuccessCardView.shouldShowMigrationSuccessCard, isShowingQuickActions {
             snapshot.appendSections([.migrationSuccess])
             snapshot.appendItems([.migrationSuccess], toSection: .migrationSuccess)
         }
-        if !WPDeviceIdentification.isiPad() {
+        if isShowingQuickActions {
             snapshot.appendSections([.quickActions])
             snapshot.appendItems([.quickActions(dotComID)], toSection: .quickActions)
         }
         snapshot.appendSections([.cards])
         snapshot.appendItems(items, toSection: .cards)
         return snapshot
+    }
+
+    var isShowingQuickActions: Bool {
+        guard Feature.enabled(.sidebar) else {
+            return !WPDeviceIdentification.isiPad()
+        }
+        return viewController?.traitCollection.horizontalSizeClass == .compact
     }
 
     // In case a draft is saved and the drafts card

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1026,7 +1026,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     self.tableSections = [NSArray arrayWithArray:marr];
 }
 
-// TODO: (wpsidebar) Remove when WPSPlitViewController is removed on iPhone
 - (Boolean)isSplitViewDisplayed {
     if (self.isSidebarModeEnabled) {
         return true;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1549,12 +1549,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
         return cell;
     }
 
-        if (section.category == BlogDetailsSectionCategoryMigrationSuccess) {
+    if (section.category == BlogDetailsSectionCategoryMigrationSuccess) {
         MigrationSuccessCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsMigrationSuccessCellIdentifier];
+        if (self.isSidebarModeEnabled) {
+            [cell configureForSidebarMode];
+        }
         [cell configureWithViewController:self];
         return cell;
     }
-    
+
     if (section.category == BlogDetailsSectionCategoryJetpackBrandingCard) {
         JetpackBrandingMenuCardCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsJetpackBrandingCardCellIdentifier];
         [cell configureWithViewController:self];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -975,7 +975,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
         [marr addNullableObject:[self sotw2023SectionViewModel]];
     }
 
-    if (MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES) {
+    if (MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES && ![Feature enabled:FeatureFlagSidebar]) {
         [marr addNullableObject:[self migrationSuccessSectionViewModel]];
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -80,7 +80,7 @@ final class BlogListViewModel: NSObject, ObservableObject {
         updateDisplayedSites()
     }
 
-    private func updateDisplayedSites() {
+    func updateDisplayedSites() {
         rawSites = getFilteredSites(from: fetchedResultsController)
 
         var sitesByURL: [String: Blog] = [:]

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -36,7 +36,9 @@ struct SiteIconView: View {
             if let firstLetter = viewModel.firstLetter {
                 Text(firstLetter.uppercased())
                     .font(.system(size: iconFontSize(for: viewModel.size), weight: .medium, design: .rounded))
-                    .foregroundStyle(.secondary.opacity(0.8))
+                // - warning: important to use `.foregroundColor` and not
+                // `.foregroundStyle` to avoid it changing in sidebar on selection
+                    .foregroundColor(.secondary.opacity(0.8))
             } else {
                 failureStateView
             }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -34,10 +34,10 @@ struct SiteIconView: View {
     private var noIconView: some View {
         backgroundColor.overlay {
             if let firstLetter = viewModel.firstLetter {
-                Text(firstLetter.uppercased())
-                    .font(.system(size: iconFontSize(for: viewModel.size), weight: .medium, design: .rounded))
                 // - warning: important to use `.foregroundColor` and not
                 // `.foregroundStyle` to avoid it changing in sidebar on selection
+                Text(firstLetter.uppercased())
+                    .font(.system(size: iconFontSize(for: viewModel.size), weight: .medium, design: .rounded))
                     .foregroundColor(.secondary.opacity(0.8))
             } else {
                 failureStateView

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -129,7 +129,7 @@ class MeViewController: UITableViewController {
 
         return NavigationItemRow(
             title: RowTitles.appSettings,
-            icon: UIImage(named: "wpl-tablet")?.withRenderingMode(.alwaysTemplate),
+            icon: UIImage(named: UIDevice.isPad() ? "wpl-tablet" : "wpl-phone")?.withRenderingMode(.alwaysTemplate),
             tintColor: .label,
             accessoryType: accessoryType,
             action: pushAppSettings(),

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -87,7 +87,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
 
         let button = UIButton.makeMenu(title: Strings.title, menu: menu)
         self.buttonFilter = button
-        if UIDevice.isPad() {
+        if traitCollection.horizontalSizeClass == .regular {
             navigationItem.leftBarButtonItem = UIBarButtonItem(customView: button)
         } else {
             navigationItem.titleView = button

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -101,7 +101,9 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         configureNavBar()
+        WPStyleGuide.disableScrollEdgeAppearance(for: self)
         view.backgroundColor = .systemBackground
         loadComment()
     }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -463,17 +463,15 @@ private extension PeopleViewController {
         let accessoryView = isLoading ? NoResultsViewController.loadingAccessoryView() : nil
         noResultsViewController.configure(title: noResultsTitle(), accessoryView: accessoryView)
 
-        // Set the NRV top as the filterBar bottom so the NRV
-        // adjusts correctly when refreshControl is active.
-        let filterBarBottom = filterBar.frame.origin.y + filterBar.frame.size.height
-        noResultsViewController.view.frame.origin.y = filterBarBottom
-
         guard noResultsViewController.parent == nil else {
             noResultsViewController.updateView()
             return
         }
         addChild(noResultsViewController)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        noResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(noResultsViewController.view)
+
         noResultsViewController.didMove(toParent: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -175,7 +175,6 @@ private struct ReaderSidebarView: View {
         .toolbar {
             EditButton()
         }
-        .tint(Color(UIAppColor.primary))
     }
 
     @ViewBuilder

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -25,6 +25,7 @@ class SiteStatsBaseTableViewController: UIViewController {
 
     func initTableView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         view.addSubview(tableView)
         view.pinSubviewToAllEdges(tableView)
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -111,6 +111,7 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
         let controller = InsightsManagementViewController(insightsDelegate: self,
                 insightsManagementDelegate: self, insightsShown: insightsToShow.compactMap { $0.statSection })
         let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .formSheet // Has to be set before the delegate
         navigationController.presentationController?.delegate = self
         present(navigationController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -43,7 +43,11 @@ class MySitesCoordinator: NSObject {
     }
 
     @objc class var isSplitViewEnabled: Bool {
-        UIDevice.current.userInterfaceIdiom == .pad
+        if Feature.enabled(.sidebar) {
+            return false
+        } else {
+            return UIDevice.current.userInterfaceIdiom == .pad
+        }
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -5,7 +5,6 @@ import WordPressAuthenticator
 class MySitesCoordinator: NSObject {
     let meScenePresenter: ScenePresenter
 
-    // TODO: (wpsidebar) move logic to RootViewPresenter
     let becomeActiveTab: () -> Void
 
     @objc
@@ -43,7 +42,6 @@ class MySitesCoordinator: NSObject {
         }
     }
 
-    // TODO: (wpsidebar) remove
     @objc class var isSplitViewEnabled: Bool {
         UIDevice.current.userInterfaceIdiom == .pad
     }

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -6,19 +6,28 @@ import WordPressUI
 
 /// The sidebar for the iPad version of the app.
 final class SidebarViewController: UIHostingController<AnyView> {
+    private let viewModel: SidebarViewModel
+
     init(viewModel: SidebarViewModel) {
-        super.init(rootView: AnyView(SidebarView(viewModel: viewModel)))
+        self.viewModel = viewModel
+        super.init(rootView: AnyView(SidebarView(viewModel: viewModel, blogListViewModel: viewModel.blogListViewModel)))
         self.title = Strings.sectionMySites
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        viewModel.onAppear()
+    }
 }
 
 private struct SidebarView: View {
     @ObservedObject var viewModel: SidebarViewModel
-    @StateObject private var blogListViewModel = BlogListViewModel()
+    @ObservedObject var blogListViewModel: BlogListViewModel
     @StateObject private var notificationsButtonViewModel = NotificationsButtonViewModel()
 
     static let displayedSiteLimit = 4

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -82,7 +82,6 @@ private final class SiteMenuListViewController: BlogDetailsViewController {
             container.pinSubviewToAllEdges(backgroundView, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
             return container
         }()
-        cell.focusEffect = nil
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -82,6 +82,7 @@ private final class SiteMenuListViewController: BlogDetailsViewController {
             container.pinSubviewToAllEdges(backgroundView, insets: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
             return container
         }()
+        cell.focusEffect = nil
 
         return cell
     }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell.swift
@@ -4,6 +4,7 @@ import UIKit
 class MigrationSuccessCell: UITableViewCell {
 
     var onTap: (() -> Void)?
+    var cardView: MigrationSuccessCardView?
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -21,6 +22,11 @@ class MigrationSuccessCell: UITableViewCell {
         view.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(view)
         contentView.pinSubviewToAllEdges(view)
+        cardView = view
+    }
+
+    @objc func configureForSidebarMode() {
+        cardView?.backgroundColor = .clear
     }
 }
 


### PR DESCRIPTION
Please see the commit list for the full list of changes. I'm going to cover some of them in the description.

"Before" on the left. "After" always on the right.

**1. Fix button colors that became black since one of the previous PRs**

<img width="340" alt="buttons-01" src="https://github.com/user-attachments/assets/ed583ba9-c3e8-4b43-a11a-08c918b9410c"> <img width="340" alt="buttons-02" src="https://github.com/user-attachments/assets/e90c5592-b3f5-4147-880c-99674a2a5221">

**2. Fix empty state layout in "Loading People" (had no constraints)**

<img width="420" alt="loading-people" src="https://github.com/user-attachments/assets/41075f7b-1b95-4498-8e73-08de4aa37d1c">

**3. Update the design of the "Migration Success" card for the new Site Menu sidebar style**

<img width="340" alt="migration-card-01" src="https://github.com/user-attachments/assets/bd881855-964f-4953-a19c-56bece62aea3"> <img width="340" alt="migration-card-02" src="https://github.com/user-attachments/assets/28f5152e-01f4-4eec-a1f1-c6b6addf42a4">

**4. Fix transparent navigation bar in the Notifications / Reader Comment Details**

<img width="340" alt="notification-comments-01" src="https://github.com/user-attachments/assets/45c69628-d0ea-42ed-a203-861aa51304a9"> <img width="340" alt="notification-comments-02" src="https://github.com/user-attachments/assets/51c5a022-ea42-443d-9ebe-c42861b84376">

**5. Add Quick Actions  that were missing in Split View**

**Note:** there are a few other important Split View fixes.

<img width="500" alt="quick-actions" src="https://github.com/user-attachments/assets/21ffe1aa-b17c-49da-a8e8-b904e1bfeac4">

**6. Fix Reader sidebar tint color in dark mode**

I just removed the custom tint for now and use green.

<img width="340" alt="reader-sidebar-tint-01" src="https://github.com/user-attachments/assets/cac41fcd-63f5-4eea-8acb-639aed6ababc"> <img width="340" alt="reader-sidebar-tint-02" src="https://github.com/user-attachments/assets/3b9d13a8-358b-4ac1-9c95-cbc6dc23295e">

**7. Fix site icon placeholder in sidebars in dark mode**

<img width="172" alt="sidebar-selection-01" src="https://github.com/user-attachments/assets/b286922c-e6c3-4375-9295-9c8b6d5aca2b">
<img width="143" alt="sidebar-selection-02" src="https://github.com/user-attachments/assets/12df209f-8c56-49de-9a08-c0c567458cd3">



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
