### PR TITLE
[Tooling] Do not cancel GitHub Actions running jobs

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,11 +7,12 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.0
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.2
     with:
-      org-slug: "automattic"
-      pipeline-slug: "wordpress-ios"
-      retry-step-key: "danger"
-      build-commit-sha: "${{ github.event.pull_request.head.sha }}"
+      org-slug: automattic
+      pipeline-slug: wordpress-ios
+      retry-step-key: danger
+      build-commit-sha: ${{ github.event.pull_request.head.sha }}
+      cancel-running-github-jobs: false
     secrets:
       buildkite-api-token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}


### PR DESCRIPTION
**Context**: currently, GHA jobs are grouped by branch and several jobs can be triggered in parallel based on PR events such as updating a label, a milestone and so on. If a newer jobs starts while a previous one is still running, GitHub will cancel it according to our [default settings](https://github.com/Automattic/dangermattic/blob/05f24612221a90310ec7552eb397f322a6318461/.github/workflows/reusable-retry-buildkite-step-on-events.yml#L20).

This PR updates the GHA Workflow concurrency setting to not cancel other currently running jobs.