### PR TITLE
Reader: simplified ghost cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
@@ -51,24 +51,21 @@ private final class ReaderGhostCell: UITableViewCell {
                 view.widthAnchor.constraint(equalToConstant: width).withPriority(.defaultLow),
                 view.heightAnchor.constraint(equalToConstant: height).withPriority(.defaultHigh),
             ])
+            view.layer.cornerRadius = 4
+            view.layer.masksToBounds = true
             return view
         }
 
         let imageView = makeLeafView(height: 320, width: 1200)
         imageView.layer.cornerRadius = 8
-        imageView.layer.masksToBounds = true
         imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 0.5).isActive = true
 
         let insets = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
-        let stackView = UIStackView(axis: .vertical, alignment: .leading, spacing: 14, insets: insets, [
-            makeLeafView(height: 10, width: .random(in: 140...200)),
-            makeLeafView(height: 18, width: .random(in: 160...320)),
-            UIStackView(axis: .vertical, alignment: .leading, spacing: 4, [
-                makeLeafView(height: 10, width: 2000),
-                makeLeafView(height: 10, width: .random(in: 200...600))
-            ]),
+        let stackView = UIStackView(axis: .vertical, alignment: .leading, spacing: 16, insets: insets, [
+            makeLeafView(height: 16, width: .random(in: 140...200)),
+            makeLeafView(height: 24, width: .random(in: 200...600)),
             imageView,
-            makeLeafView(height: 10, width: .random(in: 200...240))
+            makeLeafView(height: 16, width: .random(in: 200...240))
         ])
         contentView.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
I recently [replaced](https://github.com/wordpress-mobile/WordPress-iOS/pull/23529) the ghost cells in Reader to remove the legacy code for cells. The new version turned out a bit too complex, so I made it more abstract.

Before → After

<img width="340" alt="Screenshot 2024-09-13 at 12 55 36 PM" src="https://github.com/user-attachments/assets/132966f9-4ec6-4df4-9b36-1bd030c866c7"> <img width="340" alt="Screenshot 2024-09-13 at 1 04 32 PM" src="https://github.com/user-attachments/assets/252d0eaf-bef7-44cb-a5c2-fe1e124b5361">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
