### PR TITLE
Fix a crash which may be caused by a nil WPAccount.email

### DIFF
--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -4,7 +4,7 @@ import Network
 
 struct WordPressSite {
     enum SiteType {
-        case dotCom(emailAddress: String, authToken: String)
+        case dotCom(authToken: String)
         case selfHosted(username: String, authToken: String)
     }
 
@@ -19,10 +19,7 @@ struct WordPressSite {
     static func from(blog: Blog) throws -> WordPressSite {
         let url = try ParsedUrl.parse(input: blog.getUrlString())
         if let account = blog.account {
-            return WordPressSite(baseUrl: url, type: .dotCom(
-                emailAddress: account.email,
-                authToken: account.authToken
-            ))
+            return WordPressSite(baseUrl: url, type: .dotCom(authToken: account.authToken))
         } else {
             return WordPressSite(baseUrl: url, type: .selfHosted(
                 username: try blog.getUsername(),
@@ -52,7 +49,7 @@ actor WordPressClient {
         let parsedUrl = try ParsedUrl.parse(input: site.baseUrl)
 
         switch site.type {
-        case let .dotCom(_, authToken):
+        case let .dotCom(authToken):
             let api = WordPressAPI(urlSession: session, baseUrl: parsedUrl, authenticationStategy: .authorizationHeader(token: authToken))
             return WordPressClient(api: api, rootUrl: parsedUrl)
         case .selfHosted(let username, let authToken):


### PR DESCRIPTION
Not exactly sure how, but the `WPAccount.email` could be nil. This PR removes the non-null property since it's not used anyway.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
