### PR TITLE
Sidebar: Global Reader Navigation

### DIFF
--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -32,10 +32,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func navigateToReaderSite(_ topic: ReaderSiteTopic) {
-        unsupportedFeatureFallback()
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -32,10 +32,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func switchToMyLikes() {
-        unsupportedFeatureFallback()
-    }
-
     func switchToFollowedSites() {
         unsupportedFeatureFallback()
     }

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -24,10 +24,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
-        unsupportedFeatureFallback()
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -28,10 +28,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func switchToFollowedSites() {
-        unsupportedFeatureFallback()
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -20,7 +20,7 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func switchToDiscover() {
+    func showReader(path: ReaderNavigationPath) {
         unsupportedFeatureFallback()
     }
 

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -44,15 +44,7 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
-        unsupportedFeatureFallback()
-    }
-
     // MARK: My Site
-
-    var mySitesCoordinator: MySitesCoordinator {
-        return self
-    }
 
     func showMySitesTab() {
         // Do nothing
@@ -69,13 +61,13 @@ extension MySitesCoordinator: RootViewPresenter {
 
     var meViewController: MeViewController? {
         /// On iPhone, the My Sites root view controller is a navigation controller, and Me is pushed onto the stack
-        if let navigationController = mySitesCoordinator.rootViewController as? UINavigationController,
+        if let navigationController = rootViewController as? UINavigationController,
            let controller = navigationController.viewControllers.compactMap({ $0 as? MeViewController }).first {
                return controller
            }
 
         /// On iPad, the My Sites root view controller is a split view controller, and Me is shown in the detail view controller
-        if let splitViewController = mySitesCoordinator.rootViewController as? WPSplitViewController,
+        if let splitViewController = rootViewController as? WPSplitViewController,
            let detailNavigationController = splitViewController.viewControllers.last as? UINavigationController,
            let controller = detailNavigationController.viewControllers.compactMap({ $0 as? MeViewController }).first {
             return controller
@@ -87,10 +79,10 @@ extension MySitesCoordinator: RootViewPresenter {
     func showMeScreen(completion: ((MeViewController) -> Void)?) {
         guard let meViewController else {
             /// In order to show the Me screen, the My Sites screen must be visible (see: MySitesCoordinator.showMe)
-            if let navigationController = mySitesCoordinator.rootViewController as? UINavigationController {
+            if let navigationController = rootViewController as? UINavigationController {
                 navigationController.popToRootViewController(animated: false)
             }
-            if let viewController = mySitesCoordinator.showMe() {
+            if let viewController = showMe() {
                 completion?(viewController)
             }
             return

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -36,10 +36,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func navigateToReaderTag(_ tagSlug: String) {
-        unsupportedFeatureFallback()
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -16,11 +16,7 @@ extension MySitesCoordinator: RootViewPresenter {
 
     // MARK: Reader
 
-    func showReaderTab() {
-        unsupportedFeatureFallback()
-    }
-
-    func showReader(path: ReaderNavigationPath) {
+    func showReader(path: ReaderNavigationPath?) {
         unsupportedFeatureFallback()
     }
 

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -24,10 +24,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func navigateToReaderSearch() {
-        unsupportedFeatureFallback()
-    }
-
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
         unsupportedFeatureFallback()
     }

--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -40,10 +40,6 @@ extension MySitesCoordinator: RootViewPresenter {
         unsupportedFeatureFallback()
     }
 
-    func navigateToReader(_ pushControlller: UIViewController?) {
-        unsupportedFeatureFallback()
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -10,20 +10,10 @@ protocol RootViewPresenter: AnyObject {
     // MARK: Sites
 
     func currentlyVisibleBlog() -> Blog?
-    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection?, userInfo: [AnyHashable: Any])
     func showMySitesTab()
-
-    // MARK: Reader
-
-    func showReaderTab()
-    func showReader(path: ReaderNavigationPath)
-
-    // MARK: Notifications
-
+    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection?, userInfo: [AnyHashable: Any])
+    func showReader(path: ReaderNavigationPath?)
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?)
-
-    // MARK: Me
-
     func showMeScreen(completion: ((MeViewController) -> Void)?)
 }
 
@@ -71,6 +61,12 @@ extension RootViewPresenter {
             userInfo[BlogDetailsViewController.userInfoSourceKey()] = NSNumber(value: source.rawValue)
         }
         showBlogDetails(for: blog, then: .stats)
+    }
+
+    // MARK: Reader
+
+    func showReader() {
+        showReader(path: nil)
     }
 
     // MARK: Notifications

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -1,19 +1,17 @@
 import Foundation
 
 protocol RootViewPresenter: AnyObject {
-
-    // MARK: General
-
     var rootViewController: UIViewController { get }
     func currentlySelectedScreen() -> String
-
-    // MARK: Sites
 
     func currentlyVisibleBlog() -> Blog?
     func showMySitesTab()
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection?, userInfo: [AnyHashable: Any])
+
     func showReader(path: ReaderNavigationPath?)
+
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?)
+
     func showMeScreen(completion: ((MeViewController) -> Void)?)
 }
 

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -29,18 +29,6 @@ extension RootViewPresenter {
         showBlogDetails(for: blog, then: subsection, userInfo: [:])
     }
 
-    func showMediaPicker(for blog: Blog) {
-        showBlogDetails(for: blog, then: .media, userInfo: [
-            BlogDetailsViewController.userInfoShowPickerKey(): true
-        ])
-    }
-
-    func showSiteMonitoring(for blog: Blog, selectedTab: SiteMonitoringTab) {
-        showBlogDetails(for: blog, then: .siteMonitoring, userInfo: [
-            BlogDetailsViewController.userInfoSiteMonitoringTabKey(): selectedTab.rawValue
-        ])
-    }
-
     func showStats(for blog: Blog, source: BlogDetailsNavigationSource? = nil, tab: StatsTabType? = nil, unit: StatsPeriodUnit? = nil, date: Date? = nil) {
         guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return showJetpackOverlayForDisabledEntryPoint()

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -16,8 +16,8 @@ protocol RootViewPresenter: AnyObject {
     // MARK: Reader
 
     func showReaderTab()
+    func showReader(path: ReaderNavigationPath)
     func showReaderTab(forPost: NSNumber, onBlog: NSNumber)
-    func switchToDiscover()
     func navigateToReaderSearch()
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
     func switchToMyLikes()

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -19,7 +19,6 @@ protocol RootViewPresenter: AnyObject {
     func showReader(path: ReaderNavigationPath)
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
     func switchToFollowedSites()
-    func navigateToReaderSite(_ topic: ReaderSiteTopic)
 
     // MARK: Notifications
 

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -18,7 +18,6 @@ protocol RootViewPresenter: AnyObject {
     func showReaderTab()
     func showReader(path: ReaderNavigationPath)
     func showReaderTab(forPost: NSNumber, onBlog: NSNumber)
-    func navigateToReaderSearch()
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
     func switchToFollowedSites()
     func navigateToReaderSite(_ topic: ReaderSiteTopic)

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -20,7 +20,6 @@ protocol RootViewPresenter: AnyObject {
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
     func switchToFollowedSites()
     func navigateToReaderSite(_ topic: ReaderSiteTopic)
-    func navigateToReaderTag(_ tagSlug: String)
 
     // MARK: Notifications
 

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -21,7 +21,6 @@ protocol RootViewPresenter: AnyObject {
     func switchToFollowedSites()
     func navigateToReaderSite(_ topic: ReaderSiteTopic)
     func navigateToReaderTag(_ tagSlug: String)
-    func navigateToReader(_ pushControlller: UIViewController?)
 
     // MARK: Notifications
 

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -20,7 +20,6 @@ protocol RootViewPresenter: AnyObject {
     func showReaderTab(forPost: NSNumber, onBlog: NSNumber)
     func navigateToReaderSearch()
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
-    func switchToMyLikes()
     func switchToFollowedSites()
     func navigateToReaderSite(_ topic: ReaderSiteTopic)
     func navigateToReaderTag(_ tagSlug: String)

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -17,7 +17,6 @@ protocol RootViewPresenter: AnyObject {
 
     func showReaderTab()
     func showReader(path: ReaderNavigationPath)
-    func showReaderTab(forPost: NSNumber, onBlog: NSNumber)
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
     func switchToFollowedSites()
     func navigateToReaderSite(_ topic: ReaderSiteTopic)

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -18,7 +18,6 @@ protocol RootViewPresenter: AnyObject {
     func showReaderTab()
     func showReader(path: ReaderNavigationPath)
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
-    func switchToFollowedSites()
 
     // MARK: Notifications
 

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -17,7 +17,6 @@ protocol RootViewPresenter: AnyObject {
 
     func showReaderTab()
     func showReader(path: ReaderNavigationPath)
-    func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool)
 
     // MARK: Notifications
 

--- a/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
@@ -26,6 +26,8 @@ class ReaderSplitViewContent: SplitViewDisplayable {
         switch path {
         case .discover:
             viewModel.selection = .main(.discover)
+        case .likes:
+            viewModel.selection = .main(.likes)
         }
     }
 }

--- a/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
@@ -6,10 +6,9 @@ class ReaderSplitViewContent: SplitViewDisplayable {
     let supplementary: UINavigationController
     var secondary: UINavigationController
 
-    private let viewModel = ReaderSidebarViewModel()
-
     init() {
         secondary = UINavigationController()
+        let viewModel = ReaderSidebarViewModel()
         sidebar = ReaderSidebarViewController(viewModel: viewModel)
         sidebar.navigationItem.largeTitleDisplayMode = .automatic
         supplementary = UINavigationController(rootViewController: sidebar)
@@ -23,13 +22,6 @@ class ReaderSplitViewContent: SplitViewDisplayable {
     }
 
     func navigate(to path: ReaderNavigationPath) {
-        switch path {
-        case .discover:
-            viewModel.selection = .main(.discover)
-        case .likes:
-            viewModel.selection = .main(.likes)
-        case .search:
-            viewModel.selection = .main(.search)
-        }
+        sidebar.navigate(to: path)
     }
 }

--- a/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
@@ -28,6 +28,8 @@ class ReaderSplitViewContent: SplitViewDisplayable {
             viewModel.selection = .main(.discover)
         case .likes:
             viewModel.selection = .main(.likes)
+        case .search:
+            viewModel.selection = .main(.search)
         }
     }
 }

--- a/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter+Reader.swift
@@ -6,9 +6,10 @@ class ReaderSplitViewContent: SplitViewDisplayable {
     let supplementary: UINavigationController
     var secondary: UINavigationController
 
+    private let viewModel = ReaderSidebarViewModel()
+
     init() {
         secondary = UINavigationController()
-        let viewModel = ReaderSidebarViewModel()
         sidebar = ReaderSidebarViewController(viewModel: viewModel)
         sidebar.navigationItem.largeTitleDisplayMode = .automatic
         supplementary = UINavigationController(rootViewController: sidebar)
@@ -18,6 +19,13 @@ class ReaderSplitViewContent: SplitViewDisplayable {
     func displayed(in splitVC: UISplitViewController) {
         if secondary.viewControllers.isEmpty {
             sidebar.showInitialSelection()
+        }
+    }
+
+    func navigate(to path: ReaderNavigationPath) {
+        switch path {
+        case .discover:
+            viewModel.selection = .main(.discover)
         }
     }
 }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -308,10 +308,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    func navigateToReader(_ pushControlller: UIViewController?) {
-        fatalError()
-    }
-
     // MARK: Notifications
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -296,10 +296,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    func navigateToReaderSearch() {
-        fatalError()
-    }
-
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
         fatalError()
     }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -304,10 +304,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    func switchToMyLikes() {
-        fatalError()
-    }
-
     func switchToFollowedSites() {
         fatalError()
     }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -300,10 +300,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    func navigateToReaderSite(_ topic: ReaderSiteTopic) {
-        fatalError()
-    }
-
     // MARK: Notifications
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -282,11 +282,17 @@ final class SplitViewRootPresenter: RootViewPresenter {
         sidebarViewModel.selection = .reader
     }
 
-    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
-        fatalError()
+    func showReader(path: ReaderNavigationPath) {
+        if splitVC.isCollapsed {
+            tabBarViewController.showReader(path: path)
+        } else {
+            sidebarViewModel.selection = .reader
+            wpAssert(readerContent != nil)
+            readerContent?.navigate(to: path)
+        }
     }
 
-    func switchToDiscover() {
+    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
         fatalError()
     }
 

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -292,10 +292,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         }
     }
 
-    func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
-        fatalError()
-    }
-
     // MARK: Notifications
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -292,10 +292,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         }
     }
 
-    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
-        fatalError()
-    }
-
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
         fatalError()
     }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -296,10 +296,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    func switchToFollowedSites() {
-        fatalError()
-    }
-
     // MARK: Notifications
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -278,17 +278,15 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
     // MARK: RootViewPresenter (Reader)
 
-    func showReaderTab() {
-        sidebarViewModel.selection = .reader
-    }
-
-    func showReader(path: ReaderNavigationPath) {
+    func showReader(path: ReaderNavigationPath?) {
         if splitVC.isCollapsed {
             tabBarViewController.showReader(path: path)
         } else {
             sidebarViewModel.selection = .reader
-            wpAssert(readerContent != nil)
-            readerContent?.navigate(to: path)
+            if let path {
+                wpAssert(readerContent != nil)
+                readerContent?.navigate(to: path)
+            }
         }
     }
 

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -290,7 +290,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
         }
     }
 
-    // MARK: Notifications
+    // MARK: RootViewPresenter (Notifications)
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
         sidebarViewModel.selection = .notifications
@@ -300,7 +300,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
         }
     }
 
-    // MARK: Me
+    // MARK: RootViewPresenter (Me)
 
     func showMeScreen(completion: ((MeViewController) -> Void)?) {
         if isDisplayingTabBar {

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -304,10 +304,6 @@ final class SplitViewRootPresenter: RootViewPresenter {
         fatalError()
     }
 
-    func navigateToReaderTag(_ tagSlug: String) {
-        fatalError()
-    }
-
     // MARK: Notifications
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -49,10 +49,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func navigateToReaderTag(_ tagSlug: String) {
-        // Do nothing
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -41,10 +41,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func navigateToReaderSearch() {
-        // Do nothing
-    }
-
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
         // Do nothing
     }

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -37,10 +37,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
-        // Do nothing
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -37,10 +37,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
-        // Do nothing
-    }
-
     func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
         // Do nothing
     }

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -41,10 +41,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func switchToFollowedSites() {
-        // Do nothing
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -45,10 +45,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func navigateToReaderSite(_ topic: ReaderSiteTopic) {
-        // Do nothing
-    }
-
     // MARK: My Site
 
     func showMySitesTab() {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -29,12 +29,8 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
 
     // MARK: Reader
 
-    func showReaderTab() {
-        tabBarController.showReaderTab()
-    }
-
-    func showReader(path: ReaderNavigationPath) {
-        // Do nothing
+    func showReader(path: ReaderNavigationPath?) {
+        tabBarController.showReader()
     }
 
     // MARK: My Site

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -33,11 +33,11 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         tabBarController.showReaderTab()
     }
 
-    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
+    func showReader(path: ReaderNavigationPath) {
         // Do nothing
     }
 
-    func switchToDiscover() {
+    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
         // Do nothing
     }
 

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -53,15 +53,7 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func navigateToReader(_ pushControlller: UIViewController?) {
-        // Do nothing
-    }
-
     // MARK: My Site
-
-    var mySitesCoordinator: MySitesCoordinator {
-        return tabBarController.mySitesCoordinator
-    }
 
     func showMySitesTab() {
         tabBarController.showMySitesTab()

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -49,10 +49,6 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
         // Do nothing
     }
 
-    func switchToMyLikes() {
-        // Do nothing
-    }
-
     func switchToFollowedSites() {
         // Do nothing
     }

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -73,8 +73,7 @@ import AutomatticTracks
             let postId = params.intValue(of: "postId") else {
             return false
         }
-
-        RootViewCoordinator.sharedPresenter.showReaderTab(forPost: NSNumber(value: postId), onBlog: NSNumber(value: blogId))
+        RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postId, siteID: blogId))
 
         return true
     }

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -330,7 +330,7 @@ fileprivate extension SearchManager {
     // MARK: Reader Tab Navigation
 
     func openReaderTab() -> Bool {
-        RootViewCoordinator.sharedPresenter.showReaderTab()
+        RootViewCoordinator.sharedPresenter.showReader()
         return true
     }
 

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -420,7 +420,7 @@ fileprivate extension SearchManager {
                 onFailure()
                 return
         }
-        RootViewCoordinator.sharedPresenter.showReaderTab(forPost: postID, onBlog: blogID)
+        RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID.intValue, siteID: blogID.intValue))
     }
 
     func openReader(for postID: NSNumber, siteID: NSNumber, onFailure: () -> Void) {
@@ -429,7 +429,7 @@ fileprivate extension SearchManager {
             onFailure()
             return
         }
-        RootViewCoordinator.sharedPresenter.showReaderTab(forPost: postID, onBlog: siteID)
+        RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID.intValue, siteID: siteID.intValue))
     }
 
     // MARK: - Editor

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -139,6 +139,20 @@ extension MySitesRoute: NavigationAction {
     }
 }
 
+private extension RootViewPresenter {
+    func showMediaPicker(for blog: Blog) {
+        showBlogDetails(for: blog, then: .media, userInfo: [
+            BlogDetailsViewController.userInfoShowPickerKey(): true
+        ])
+    }
+
+    func showSiteMonitoring(for blog: Blog, selectedTab: SiteMonitoringTab) {
+        showBlogDetails(for: blog, then: .siteMonitoring, userInfo: [
+            BlogDetailsViewController.userInfoSiteMonitoringTabKey(): selectedTab.rawValue
+        ])
+    }
+}
+
 private enum Strings {
     static let siteNotFound = NSLocalizedString(
         "universalLink.qrCodeMedia.error.title",

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -76,7 +76,7 @@ extension ReaderRoute: NavigationAction {
         case .root:
             coordinator.showReaderTab()
         case .discover:
-            coordinator.showDiscover()
+            coordinator.showReader(path: .discover)
         case .search:
             coordinator.showSearch()
         case .a8c:

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -87,7 +87,7 @@ extension ReaderRoute: NavigationAction {
         case .likes:
             presenter.showReader(path: .likes)
         case .manageFollowing:
-            coordinator.showManageFollowing()
+            presenter.showReader(path: .subscriptions)
         case .list:
             if let username = values["username"],
                 let listName = values["list_name"] {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -67,14 +67,14 @@ extension ReaderRoute: Route {
 extension ReaderRoute: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
-            RootViewCoordinator.sharedPresenter.showReaderTab() // Show static reader tab
+            RootViewCoordinator.sharedPresenter.showReader() // Show static reader tab
             return
         }
         let presenter = RootViewCoordinator.sharedPresenter
 
         switch self {
         case .root:
-            presenter.showReaderTab()
+            presenter.showReader()
         case .discover:
             presenter.showReader(path: .discover)
         case .search:

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -81,17 +81,16 @@ extension ReaderRoute: NavigationAction {
         case .search:
             presenter.showReader(path: .search)
         case .a8c:
-            coordinator.showA8C()
+            presenter.showReaderTeam(named: ReaderTeamTopic.a8cSlug)
         case .p2:
-            coordinator.showP2()
+            presenter.showReaderTeam(named: ReaderTeamTopic.p2Slug)
         case .likes:
             presenter.showReader(path: .likes)
         case .manageFollowing:
             presenter.showReader(path: .subscriptions)
         case .list:
-            if let username = values["username"],
-                let listName = values["list_name"] {
-                coordinator.showList(named: listName, forUser: username)
+            if let username = values["username"], let list = values["list_name"] {
+                presenter.showReaderList(named: list, forUser: username)
             }
         case .tag:
             if let tagName = values["tag_name"] {
@@ -166,7 +165,26 @@ extension ReaderRoute: NavigationAction {
     }
 }
 
+// MARK: - RootViewPresenter (Extensions)
+
 private extension RootViewPresenter {
+    func showReaderTeam(named teamName: String) {
+        let topic = ContextManager.shared.mainContext.firstObject(
+            ofType: ReaderTeamTopic.self,
+            matching: NSPredicate(format: "slug = %@", teamName)
+        )
+        if let topic {
+            showReader(path: .topic(topic))
+        }
+    }
+
+    func showReaderList(named listName: String, forUser user: String) {
+        let context = ContextManager.sharedInstance().mainContext
+        if let topic = ReaderListTopic.named(listName, forUser: user, in: context) {
+            showReader(path: .topic(topic))
+        }
+    }
+
     /// - warning: This method performs the navigation asyncronously after
     /// fetching the information about the stream from the backend.
     func showReaderStream(with siteID: Int, isFeed: Bool) {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -71,12 +71,13 @@ extension ReaderRoute: NavigationAction {
             return
         }
         let coordinator = ReaderCoordinator()
+        let presenter = RootViewCoordinator.sharedPresenter
 
         switch self {
         case .root:
             coordinator.showReaderTab()
         case .discover:
-            coordinator.showReader(path: .discover)
+            presenter.showReader(path: .discover)
         case .search:
             coordinator.showSearch()
         case .a8c:
@@ -84,7 +85,7 @@ extension ReaderRoute: NavigationAction {
         case .p2:
             coordinator.showP2()
         case .likes:
-            coordinator.showMyLikes()
+            presenter.showReader(path: .likes)
         case .manageFollowing:
             coordinator.showManageFollowing()
         case .list:

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -70,12 +70,11 @@ extension ReaderRoute: NavigationAction {
             RootViewCoordinator.sharedPresenter.showReaderTab() // Show static reader tab
             return
         }
-        let coordinator = ReaderCoordinator()
         let presenter = RootViewCoordinator.sharedPresenter
 
         switch self {
         case .root:
-            coordinator.showReaderTab()
+            presenter.showReaderTab()
         case .discover:
             presenter.showReader(path: .discover)
         case .search:

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -109,11 +109,11 @@ extension ReaderRoute: NavigationAction {
             }
         case .feedsPost:
             if let (feedID, postID) = feedAndPostID(from: values) {
-                coordinator.showPost(with: postID, for: feedID, isFeed: true)
+                presenter.showReader(path: .post(postID: postID, siteID: feedID, isFeed: true))
             }
         case .blogsPost:
             if let (blogID, postID) = blogAndPostID(from: values) {
-                coordinator.showPost(with: postID, for: blogID, isFeed: false)
+                presenter.showReader(path: .post(postID: postID, siteID: blogID))
             }
         case .wpcomPost:
             if let urlString = values[MatchedRouteURLComponentKey.url.rawValue],

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -79,7 +79,7 @@ extension ReaderRoute: NavigationAction {
         case .discover:
             presenter.showReader(path: .discover)
         case .search:
-            coordinator.showSearch()
+            presenter.showReader(path: .search)
         case .a8c:
             coordinator.showA8C()
         case .p2:

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -95,7 +95,7 @@ extension ReaderRoute: NavigationAction {
             }
         case .tag:
             if let tagName = values["tag_name"] {
-                coordinator.showTag(named: tagName)
+                presenter.showReader(path: .makeWithTagName(tagName))
             }
         case .feed:
             if let feedIDValue = values["feed_id"],

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -119,8 +119,7 @@ extension ReaderRoute: NavigationAction {
             if let urlString = values[MatchedRouteURLComponentKey.url.rawValue],
                let url = URL(string: urlString),
                isValidWpcomUrl(values) {
-
-                coordinator.showPost(with: url)
+                presenter.showReader(path: .postURL(url))
             }
         }
     }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -73,6 +73,7 @@ struct UniversalLinkRouter: LinkRouter {
         ReaderRoute.a8c,
         ReaderRoute.p2,
         ReaderRoute.likes,
+        ReaderRoute.manageFollowing,
         ReaderRoute.list,
         ReaderRoute.tag,
         ReaderRoute.feed,

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -73,7 +73,6 @@ struct UniversalLinkRouter: LinkRouter {
         ReaderRoute.a8c,
         ReaderRoute.p2,
         ReaderRoute.likes,
-        ReaderRoute.subscriptions,
         ReaderRoute.list,
         ReaderRoute.tag,
         ReaderRoute.feed,

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -73,7 +73,7 @@ struct UniversalLinkRouter: LinkRouter {
         ReaderRoute.a8c,
         ReaderRoute.p2,
         ReaderRoute.likes,
-        ReaderRoute.manageFollowing,
+        ReaderRoute.subscriptions,
         ReaderRoute.list,
         ReaderRoute.tag,
         ReaderRoute.feed,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -179,7 +179,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
               let promptID = prompt?.promptID else {
             return
         }
-        ReaderCoordinator().showTag(named: "\(Constants.dailyPromptTag)-\(promptID)")
+        let tagName = "\(Constants.dailyPromptTag)-\(promptID)"
+        RootViewCoordinator.sharedPresenter.showReader(path: .makeWithTagName(tagName))
         WPAnalytics.track(.promptsOtherAnswersTapped)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -1635,7 +1635,7 @@ extension NotificationsViewController: NoResultsViewControllerDelegate {
              .follow,
              .like:
             WPAnalytics.track(.notificationsTappedViewReader, withProperties: properties)
-            RootViewCoordinator.sharedPresenter.showReaderTab()
+            RootViewCoordinator.sharedPresenter.showReader()
         case .unread:
             WPAnalytics.track(.notificationsTappedNewPost, withProperties: properties)
             RootViewCoordinator.sharedPresenter.showPostTab()

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -6,4 +6,13 @@ enum ReaderNavigationPath: Hashable {
     case search
     case post(postID: Int, siteID: Int, isFeed: Bool = false)
     case postURL(URL)
+    case tag(String)
+}
+
+extension ReaderNavigationPath {
+    static func makeWithTagName(_ name: String) -> ReaderNavigationPath {
+        let remote = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress()))
+        let slug = remote.slug(forTopicName: name) ?? name.lowercased()
+        return ReaderNavigationPath.tag(slug)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -6,6 +6,7 @@ enum ReaderNavigationPath: Hashable {
     case search
     case post(postID: Int, siteID: Int, isFeed: Bool = false)
     case postURL(URL)
+    case topic(ReaderSiteTopic)
     case tag(String)
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum ReaderNavigationPath: Hashable {
+    case discover
+}

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -3,4 +3,5 @@ import Foundation
 enum ReaderNavigationPath: Hashable {
     case discover
     case likes
+    case search
 }

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -7,7 +7,7 @@ enum ReaderNavigationPath: Hashable {
     case subscriptions
     case post(postID: Int, siteID: Int, isFeed: Bool = false)
     case postURL(URL)
-    case topic(ReaderSiteTopic)
+    case topic(ReaderAbstractTopic)
     case tag(String)
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -2,4 +2,5 @@ import Foundation
 
 enum ReaderNavigationPath: Hashable {
     case discover
+    case likes
 }

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -5,4 +5,5 @@ enum ReaderNavigationPath: Hashable {
     case likes
     case search
     case post(postID: Int, siteID: Int, isFeed: Bool = false)
+    case postURL(URL)
 }

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -4,4 +4,5 @@ enum ReaderNavigationPath: Hashable {
     case discover
     case likes
     case search
+    case post(postID: Int, siteID: Int, isFeed: Bool = false)
 }

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -4,6 +4,7 @@ enum ReaderNavigationPath: Hashable {
     case discover
     case likes
     case search
+    case subscriptions
     case post(postID: Int, siteID: Int, isFeed: Bool = false)
     case postURL(URL)
     case topic(ReaderSiteTopic)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -132,12 +132,16 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
         case .subscriptions:
             viewModel.selection = .allSubscriptions
         case let .post(postID, siteID, isFeed):
+            viewModel.selection = nil
             showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
+            viewModel.selection = nil
             showSecondary(ReaderDetailViewController.controllerWithPostURL(url))
         case let .topic(topic):
+            viewModel.selection = nil
             showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
         case let .tag(slug):
+            viewModel.selection = nil
             showSecondary(ReaderStreamViewController.controllerWithTagSlug(slug))
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -133,6 +133,8 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
             showSecondary(ReaderDetailViewController.controllerWithPostURL(url))
+        case let .topic(topic):
+            showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
         case let .tag(slug):
             showSecondary(ReaderStreamViewController.controllerWithTagSlug(slug))
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -129,6 +129,8 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             viewModel.selection = .main(.likes)
         case .search:
             viewModel.selection = .main(.search)
+        case .subscriptions:
+            viewModel.selection = .allSubscriptions
         case let .post(postID, siteID, isFeed):
             showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -55,7 +55,6 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             showSecondary(makeViewController(withTopicID: objectID))
         case .organization(let objectID):
             showSecondary(makeViewController(withTopicID: objectID))
-
         }
     }
 
@@ -119,6 +118,19 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             let navigationVC = UINavigationController(rootViewController: interestsVC)
             navigationVC.modalPresentationStyle = .formSheet
             present(navigationVC, animated: true, completion: nil)
+        }
+    }
+
+    func navigate(to path: ReaderNavigationPath) {
+        switch path {
+        case .discover:
+            viewModel.selection = .main(.discover)
+        case .likes:
+            viewModel.selection = .main(.likes)
+        case .search:
+            viewModel.selection = .main(.search)
+        case let .post(postID, siteID, isFeed):
+            showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -131,6 +131,8 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             viewModel.selection = .main(.search)
         case let .post(postID, siteID, isFeed):
             showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
+        case let .postURL(url):
+            showSecondary(ReaderDetailViewController.controllerWithPostURL(url))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -133,6 +133,8 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
             showSecondary(ReaderDetailViewController.controllerWithPostURL(url))
+        case let .tag(slug):
+            showSecondary(ReaderStreamViewController.controllerWithTagSlug(slug))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -830,10 +830,6 @@ import AutomatticTracks
         navigationController?.pushViewController(controller, animated: animated)
     }
 
-    private func showFollowing() {
-        RootViewCoordinator.sharedPresenter.switchToFollowedSites()
-    }
-
     // MARK: - Blocking
 
     /// Update the post card when a site is blocked from post details.
@@ -1963,7 +1959,7 @@ extension ReaderStreamViewController: NoResultsViewControllerDelegate {
         }
 
         if ReaderHelpers.topicIsLiked(topic) {
-            showFollowing()
+            RootViewCoordinator.sharedPresenter.showReader(path: .subscriptions)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -52,6 +52,8 @@ extension WPTabBarController {
             showReaderDetails(ReaderSearchViewController.controller())
         case let .post(postID, siteID, isFeed):
             showReaderDetails(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
+        case let .postURL(url):
+            showReaderDetails(ReaderDetailViewController.controllerWithPostURL(url))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -26,10 +26,7 @@ extension WPTabBarController {
                 }
             },
             searchNavigationFactory: { [weak self] in
-                guard let self else {
-                    return
-                }
-                self.navigateToReaderSearch()
+                self?.showReader(path: .search)
             },
             tabItemsStore: ReaderTabItemsStore(),
             settingsPresenter: ReaderManageScenePresenter()
@@ -51,13 +48,9 @@ extension WPTabBarController {
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsDiscover)
         case .likes:
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsLiked)
+        case .search:
+            showReaderDetails(ReaderSearchViewController.controller())
         }
-    }
-
-    /// reader navigation methods
-    func navigateToReaderSearch() {
-        let searchController = ReaderSearchViewController.controller()
-        navigateToReader(searchController)
     }
 
     func navigateToReaderSite(_ topic: ReaderSiteTopic) {
@@ -70,13 +63,16 @@ extension WPTabBarController {
         navigateToReader(contentController)
     }
 
-    func navigateToReader(_ pushControlller: UIViewController? = nil) {
+    func navigateToReader(_ viewController: UIViewController? = nil) {
         showReaderTab()
-        readerNavigationController?.popToRootViewController(animated: false)
-        guard let controller = pushControlller else {
-            return
+        if let viewController {
+            showReaderDetails(viewController)
         }
-        readerNavigationController?.pushViewController(controller, animated: true)
+    }
+
+    private func showReaderDetails(_ viewController: UIViewController) {
+        readerNavigationController?.popToRootViewController(animated: false)
+        readerNavigationController?.pushViewController(viewController, animated: true)
     }
 
     func switchToFollowedSites() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -67,7 +67,7 @@ extension WPTabBarController {
         navigateToReader(contentController)
     }
 
-    func navigateToReader(_ viewController: UIViewController? = nil) {
+    private func navigateToReader(_ viewController: UIViewController? = nil) {
         showReaderTab()
         if let viewController {
             showReaderDetails(viewController)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -54,16 +54,13 @@ extension WPTabBarController {
             showReaderDetails(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
             showReaderDetails(ReaderDetailViewController.controllerWithPostURL(url))
+        case let .tag(slug):
+            showReaderDetails(ReaderStreamViewController.controllerWithTagSlug(slug))
         }
     }
 
     func navigateToReaderSite(_ topic: ReaderSiteTopic) {
         let contentController = ReaderStreamViewController.controllerWithTopic(topic)
-        navigateToReader(contentController)
-    }
-
-    func navigateToReaderTag(_ tagSlug: String) {
-        let contentController = ReaderStreamViewController.controllerWithTagSlug(tagSlug)
         navigateToReader(contentController)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -74,10 +74,4 @@ extension WPTabBarController {
         readerNavigationController?.popToRootViewController(animated: false)
         readerNavigationController?.pushViewController(viewController, animated: true)
     }
-
-    /// switches to a menu item topic that satisfies the given predicate with a topic value
-    func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
-        navigateToReader()
-        readerTabViewModel.switchToTab(where: predicate)
-    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -56,12 +56,9 @@ extension WPTabBarController {
             showReaderDetails(ReaderDetailViewController.controllerWithPostURL(url))
         case let .tag(slug):
             showReaderDetails(ReaderStreamViewController.controllerWithTagSlug(slug))
+        case let .topic(topic):
+            showReaderDetails(ReaderStreamViewController.controllerWithTopic(topic))
         }
-    }
-
-    func navigateToReaderSite(_ topic: ReaderSiteTopic) {
-        let contentController = ReaderStreamViewController.controllerWithTopic(topic)
-        navigateToReader(contentController)
     }
 
     private func navigateToReader(_ viewController: UIViewController? = nil) {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -41,8 +41,14 @@ extension WPTabBarController {
 
 // MARK: - Reader Navigation
 extension WPTabBarController {
-    func showReader(path: ReaderNavigationPath) {
-        navigateToReader()
+    func showReader(path: ReaderNavigationPath?) {
+        showReaderTab()
+        if let path {
+            navigate(to: path)
+        }
+    }
+
+    private func navigate(to path: ReaderNavigationPath) {
         switch path {
         case .discover:
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsDiscover)
@@ -60,13 +66,6 @@ extension WPTabBarController {
             showReaderDetails(ReaderStreamViewController.controllerWithTagSlug(slug))
         case let .topic(topic):
             showReaderDetails(ReaderStreamViewController.controllerWithTopic(topic))
-        }
-    }
-
-    private func navigateToReader(_ viewController: UIViewController? = nil) {
-        showReaderTab()
-        if let viewController {
-            showReaderDetails(viewController)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -50,6 +50,8 @@ extension WPTabBarController {
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsLiked)
         case .search:
             showReaderDetails(ReaderSearchViewController.controller())
+        case .subscriptions:
+            ReaderManageScenePresenter().present(on: self, selectedSection: .sites, animated: true, completion: nil)
         case let .post(postID, siteID, isFeed):
             showReaderDetails(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
@@ -71,13 +73,6 @@ extension WPTabBarController {
     private func showReaderDetails(_ viewController: UIViewController) {
         readerNavigationController?.popToRootViewController(animated: false)
         readerNavigationController?.pushViewController(viewController, animated: true)
-    }
-
-    func switchToFollowedSites() {
-        navigateToReader()
-        readerTabViewModel.switchToTab(where: {
-            ReaderHelpers.topicIsFollowing($0)
-        })
     }
 
     /// switches to a menu item topic that satisfies the given predicate with a topic value

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -44,6 +44,13 @@ extension WPTabBarController {
 
 // MARK: - Reader Navigation
 extension WPTabBarController {
+    func showReader(path: ReaderNavigationPath) {
+        navigateToReader()
+        switch path {
+        case .discover:
+            readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsDiscover)
+        }
+    }
 
     /// reader navigation methods
     func navigateToReaderSearch() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -49,6 +49,8 @@ extension WPTabBarController {
         switch path {
         case .discover:
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsDiscover)
+        case .likes:
+            readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsLiked)
         }
     }
 
@@ -81,20 +83,6 @@ extension WPTabBarController {
         navigateToReader()
         readerTabViewModel.switchToTab(where: {
             ReaderHelpers.topicIsFollowing($0)
-        })
-    }
-
-    func switchToDiscover() {
-        navigateToReader()
-        readerTabViewModel.switchToTab(where: {
-            ReaderHelpers.topicIsDiscover($0)
-        })
-    }
-
-    func switchToMyLikes() {
-        navigateToReader()
-        readerTabViewModel.switchToTab(where: {
-            ReaderHelpers.topicIsLiked($0)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -50,6 +50,8 @@ extension WPTabBarController {
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsLiked)
         case .search:
             showReaderDetails(ReaderSearchViewController.controller())
+        case let .post(postID, siteID, isFeed):
+            showReaderDetails(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -524,7 +524,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             }
 
             self.navigationController?.popToRootViewController(animated: false)
-            RootViewCoordinator.sharedPresenter.switchToDiscover()
+            RootViewCoordinator.sharedPresenter.showReader(path: .discover)
 
             Notice(title: NSLocalizedString("Comment to start making connections.", comment: "Hint for users to grow their audience by commenting on other blogs.")).post()
         }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -66,9 +66,4 @@ struct ReaderCoordinator {
             completion(.failure(error ?? defaultError))
         })
     }
-
-    private func showPost(in detailViewController: ReaderDetailViewController) {
-        RootViewCoordinator.sharedPresenter.navigateToReader(detailViewController)
-    }
-
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -4,25 +4,4 @@ struct ReaderCoordinator {
     func showReaderTab() {
         RootViewCoordinator.sharedPresenter.showReaderTab()
     }
-
-    func showA8C() {
-        RootViewCoordinator.sharedPresenter.switchToTopic(where: { topic in
-            return (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.a8cSlug
-        })
-    }
-
-    func showP2() {
-        RootViewCoordinator.sharedPresenter.switchToTopic(where: { topic in
-            return (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.p2Slug
-        })
-    }
-
-    func showList(named listName: String, forUser user: String) {
-        let context = ContextManager.sharedInstance().mainContext
-        guard let topic = ReaderListTopic.named(listName, forUser: user, in: context) else {
-            return
-        }
-
-        RootViewCoordinator.sharedPresenter.switchToTopic(where: { $0 == topic })
-    }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -67,17 +67,6 @@ struct ReaderCoordinator {
         })
     }
 
-    func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
-        showPost(in: ReaderDetailViewController
-                    .controllerWithPostID(postID as NSNumber,
-                                          siteID: feedID as NSNumber,
-                                          isFeed: isFeed))
-    }
-
-    func showPost(with url: URL) {
-        showPost(in: ReaderDetailViewController.controllerWithPostURL(url))
-    }
-
     private func showPost(in detailViewController: ReaderDetailViewController) {
         RootViewCoordinator.sharedPresenter.navigateToReader(detailViewController)
     }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -5,10 +5,6 @@ struct ReaderCoordinator {
         RootViewCoordinator.sharedPresenter.showReaderTab()
     }
 
-    func showReader(path: ReaderNavigationPath) {
-        RootViewCoordinator.sharedPresenter.showReader(path: path)
-    }
-
     func showSearch() {
         RootViewCoordinator.sharedPresenter.navigateToReaderSearch()
     }
@@ -23,10 +19,6 @@ struct ReaderCoordinator {
         RootViewCoordinator.sharedPresenter.switchToTopic(where: { topic in
             return (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.p2Slug
         })
-    }
-
-    func showMyLikes() {
-        RootViewCoordinator.sharedPresenter.switchToMyLikes()
     }
 
     func showManageFollowing() {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -5,8 +5,8 @@ struct ReaderCoordinator {
         RootViewCoordinator.sharedPresenter.showReaderTab()
     }
 
-    func showDiscover() {
-        RootViewCoordinator.sharedPresenter.switchToDiscover()
+    func showReader(path: ReaderNavigationPath) {
+        RootViewCoordinator.sharedPresenter.showReader(path: path)
     }
 
     func showSearch() {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -1,7 +1,0 @@
-import UIKit
-
-struct ReaderCoordinator {
-    func showReaderTab() {
-        RootViewCoordinator.sharedPresenter.showReaderTab()
-    }
-}

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -29,34 +29,4 @@ struct ReaderCoordinator {
 
         RootViewCoordinator.sharedPresenter.switchToTopic(where: { $0 == topic })
     }
-
-    func showStream(with siteID: Int, isFeed: Bool) {
-        getSiteTopic(siteID: NSNumber(value: siteID), isFeed: isFeed) { result in
-            guard let topic = try? result.get() else {
-                return
-            }
-
-            RootViewCoordinator.sharedPresenter.navigateToReaderSite(topic)
-        }
-    }
-
-    private func getSiteTopic(siteID: NSNumber, isFeed: Bool, completion: @escaping (Result<ReaderSiteTopic, Error>) -> Void) {
-        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
-        service.siteTopicForSite(withID: siteID,
-        isFeed: isFeed,
-        success: { objectID, isFollowing in
-
-            guard let objectID = objectID,
-                let topic = try? ContextManager.sharedInstance().mainContext.existingObject(with: objectID) as? ReaderSiteTopic else {
-                DDLogError("Reader: Error retriving site topic - invalid Site Id")
-                return
-            }
-            completion(.success(topic))
-        },
-        failure: { error in
-            let defaultError = NSError(domain: "readerSiteTopicError", code: -1, userInfo: nil)
-            DDLogError("Reader: Error retriving site topic - " + (error?.localizedDescription ?? "unknown failure reason"))
-            completion(.failure(error ?? defaultError))
-        })
-    }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -30,13 +30,6 @@ struct ReaderCoordinator {
         RootViewCoordinator.sharedPresenter.switchToTopic(where: { $0 == topic })
     }
 
-    func showTag(named tagName: String) {
-        let remote = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress()))
-        let slug = remote.slug(forTopicName: tagName) ?? tagName.lowercased()
-
-        RootViewCoordinator.sharedPresenter.navigateToReaderTag(slug)
-    }
-
     func showStream(with siteID: Int, isFeed: Bool) {
         getSiteTopic(siteID: NSNumber(value: siteID), isFeed: isFeed) { result in
             guard let topic = try? result.get() else {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -5,10 +5,6 @@ struct ReaderCoordinator {
         RootViewCoordinator.sharedPresenter.showReaderTab()
     }
 
-    func showSearch() {
-        RootViewCoordinator.sharedPresenter.navigateToReaderSearch()
-    }
-
     func showA8C() {
         RootViewCoordinator.sharedPresenter.switchToTopic(where: { topic in
             return (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.a8cSlug

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -17,10 +17,6 @@ struct ReaderCoordinator {
         })
     }
 
-    func showManageFollowing() {
-        RootViewCoordinator.sharedPresenter.switchToFollowedSites()
-    }
-
     func showList(named listName: String, forUser user: String) {
         let context = ContextManager.sharedInstance().mainContext
         guard let topic = ReaderListTopic.named(listName, forUser: user, in: context) else {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -35,7 +35,6 @@ extern NSNotificationName const WPTabBarHeightChangedNotification;
 
 - (void)showMySitesTab;
 - (void)showReaderTab;
-- (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
 - (void)showMeTab;
 - (void)reloadSplitViewControllers;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -315,25 +315,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [self setSelectedIndex:WPTabMe];
 }
 
-- (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId
-{
-    [self showReaderTab];
-    UIViewController *topDetailVC = (UIViewController *)self.readerNavigationController.topViewController;
-
-    // TODO: needed?
-    if ([topDetailVC isKindOfClass:[ReaderDetailViewController class]]) {
-        ReaderDetailViewController *readerDetailVC = (ReaderDetailViewController *)topDetailVC;
-        ReaderPost *readerPost = readerDetailVC.post;
-        if ([readerPost.postID isEqual:postId] && [readerPost.siteID isEqual: blogId]) {
-         // The desired reader detail VC is already the top VC for the tab. Move along.
-            return;
-        }
-    }
-    
-    UIViewController *readerPostDetailVC = [ReaderDetailViewController controllerWithPostID:postId siteID:blogId isFeed:NO];
-    [self.readerNavigationController pushFullscreenViewController:readerPostDetailVC animated:YES];
-}
-
 - (void)popNotificationsTabToRoot
 {
     [self.notificationsNavigationController popToRootViewControllerAnimated:NO];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -586,6 +586,8 @@
 		0CAFFD7F2C7D0CEC00DBF5C3 /* AddSiteController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD7D2C7D0CEC00DBF5C3 /* AddSiteController.swift */; };
 		0CAFFD812C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */; };
 		0CAFFD822C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */; };
+		0CB1D6B02C99A7520020766E /* ReaderNavigationPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB1D6AF2C99A7520020766E /* ReaderNavigationPath.swift */; };
+		0CB1D6B12C99A7520020766E /* ReaderNavigationPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB1D6AF2C99A7520020766E /* ReaderNavigationPath.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -6518,6 +6520,7 @@
 		0CAE8EF52A9E9EE30073EEB9 /* SiteMediaCollectionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteMediaCollectionCellViewModel.swift; sourceTree = "<group>"; };
 		0CAFFD7D2C7D0CEC00DBF5C3 /* AddSiteController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSiteController.swift; sourceTree = "<group>"; };
 		0CAFFD802C7E2AD100DBF5C3 /* NotificationsButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsButtonViewModel.swift; sourceTree = "<group>"; };
+		0CB1D6AF2C99A7520020766E /* ReaderNavigationPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNavigationPath.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
@@ -10792,6 +10795,14 @@
 				FA73D7E827987BA500DF24B3 /* HomeSiteHeaderViewController+SiteIcon.swift */,
 			);
 			path = Header;
+			sourceTree = "<group>";
+		};
+		0CB1D6AE2C99A7380020766E /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				0CB1D6AF2C99A7520020766E /* ReaderNavigationPath.swift */,
+			);
+			path = Navigation;
 			sourceTree = "<group>";
 		};
 		0CB4056F29C8DCD7008EED0A /* BlogPersonalization */ = {
@@ -17084,6 +17095,7 @@
 		CCB3A03814C8DD5100D43C3F /* Reader */ = {
 			isa = PBXGroup;
 			children = (
+				0CB1D6AE2C99A7380020766E /* Navigation */,
 				FE6BF4DC2BA5C86A0040A190 /* Theme */,
 				8B7F51C724EED488008CF5B5 /* Analytics */,
 				5D5A6E901B613C1800DAF819 /* Cards */,
@@ -21820,6 +21832,7 @@
 				0C13ACC72BF406CB00FF7405 /* VoiceToContentView.swift in Sources */,
 				3FAF9CC526D03C7400268EA2 /* DomainSuggestionViewControllerWrapper.swift in Sources */,
 				F4D140202AFD9B9700961797 /* TransferDomainsWebViewController.swift in Sources */,
+				0CB1D6B12C99A7520020766E /* ReaderNavigationPath.swift in Sources */,
 				FE4DC5A7293A79F1008F322F /* WordPressExportRoute.swift in Sources */,
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
 				FFD12D5E1FE1998D00F20A00 /* Progress+Helpers.swift in Sources */,
@@ -26258,6 +26271,7 @@
 				FADC40AF2A8D2E8D00C19997 /* ImageDownloader+Gravatar.swift in Sources */,
 				4AA33EFC2999AE3B005B6E23 /* ReaderListTopic+Creation.swift in Sources */,
 				F10D635026F0B78E00E46CC7 /* Blog+Organization.swift in Sources */,
+				0CB1D6B02C99A7520020766E /* ReaderNavigationPath.swift in Sources */,
 				FABB26122602FC2C00C8785C /* ActivityRangesFactory.swift in Sources */,
 				08A4E12D289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */,
 				FEA1124029964BCA008097B0 /* WPComJetpackRemoteInstallViewModel.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -883,7 +883,6 @@
 		17A28DC52050404C00EA6D9E /* AuthorFilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A28DC42050404C00EA6D9E /* AuthorFilterButton.swift */; };
 		17A28DCB2052FB5D00EA6D9E /* AuthorFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A28DCA2052FB5D00EA6D9E /* AuthorFilterViewController.swift */; };
 		17A4A36920EE51870071C2CA /* Routes+Reader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4A36820EE51870071C2CA /* Routes+Reader.swift */; };
-		17A4A36C20EE55320071C2CA /* ReaderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4A36B20EE55320071C2CA /* ReaderCoordinator.swift */; };
 		17ABD3522811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */; };
 		17ABD3532811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
@@ -5037,7 +5036,6 @@
 		FABB23E42602FC2C00C8785C /* ReaderPostService.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D3D559618F88C3500782892 /* ReaderPostService.m */; };
 		FABB23E52602FC2C00C8785C /* EditorMediaUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA30DB321ADA20F0092F894 /* EditorMediaUtility.swift */; };
 		FABB23E62602FC2C00C8785C /* ShareMediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7430C4481F97F23600E2673E /* ShareMediaFileManager.swift */; };
-		FABB23E82602FC2C00C8785C /* ReaderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A4A36B20EE55320071C2CA /* ReaderCoordinator.swift */; };
 		FABB23E92602FC2C00C8785C /* RestoreCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB800B125AEE3C600D5D54A /* RestoreCompleteView.swift */; };
 		FABB23EA2602FC2C00C8785C /* NoteBlockImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B532D4ED199D4418006E4DF6 /* NoteBlockImageTableViewCell.swift */; };
 		FABB23EB2602FC2C00C8785C /* PostCategoryService.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FA59DC18D88C1C001446BC /* PostCategoryService.m */; };
@@ -6736,7 +6734,6 @@
 		17A28DC42050404C00EA6D9E /* AuthorFilterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorFilterButton.swift; sourceTree = "<group>"; };
 		17A28DCA2052FB5D00EA6D9E /* AuthorFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorFilterViewController.swift; sourceTree = "<group>"; };
 		17A4A36820EE51870071C2CA /* Routes+Reader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Reader.swift"; sourceTree = "<group>"; };
-		17A4A36B20EE55320071C2CA /* ReaderCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCoordinator.swift; sourceTree = "<group>"; };
 		17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsMostPopularTimeInsightsCell.swift; sourceTree = "<group>"; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
 		17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkRouter.swift; sourceTree = "<group>"; };
@@ -11203,7 +11200,6 @@
 		17A4A36A20EE551F0071C2CA /* Coordinators */ = {
 			isa = PBXGroup;
 			children = (
-				17A4A36B20EE55320071C2CA /* ReaderCoordinator.swift */,
 				1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */,
 			);
 			path = Coordinators;
@@ -22530,7 +22526,6 @@
 				C35D4FF1280077F100DB90B5 /* SiteCreationStep.swift in Sources */,
 				7492F78E1F9BD94500B5A04A /* ShareMediaFileManager.swift in Sources */,
 				8379669C299C0C44004A92B9 /* JetpackRemoteInstallTableViewCell.swift in Sources */,
-				17A4A36C20EE55320071C2CA /* ReaderCoordinator.swift in Sources */,
 				FAB800B225AEE3C600D5D54A /* RestoreCompleteView.swift in Sources */,
 				B532D4EE199D4418006E4DF6 /* NoteBlockImageTableViewCell.swift in Sources */,
 				0CD9CCA32AD831590044A33C /* PostSearchViewModel.swift in Sources */,
@@ -25491,7 +25486,6 @@
 				FABB23E42602FC2C00C8785C /* ReaderPostService.m in Sources */,
 				FABB23E52602FC2C00C8785C /* EditorMediaUtility.swift in Sources */,
 				FABB23E62602FC2C00C8785C /* ShareMediaFileManager.swift in Sources */,
-				FABB23E82602FC2C00C8785C /* ReaderCoordinator.swift in Sources */,
 				8332D7462ADF263500EB97EF /* UIConfigurationTextAttributesTransformer+Font.swift in Sources */,
 				FABB23E92602FC2C00C8785C /* RestoreCompleteView.swift in Sources */,
 				FABB23EA2602FC2C00C8785C /* NoteBlockImageTableViewCell.swift in Sources */,


### PR DESCRIPTION
Reader required similar design as `BlogDetailsSubsection` for representing its paths, so I added `ReaderNavigationPath`:

```swift
enum ReaderNavigationPath: Hashable {
    case discover
    // ...
}

// In RootViewPresenter
func showReader(path: ReaderNavigationPath?)
```

Every single Reader navigation is now handled by this one method.

## Changes

Unlike the [previous PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/23602), I won't cover every change because most of it is just moving code around. But here are some of the more important ones: 

- https://github.com/wordpress-mobile/WordPress-iOS/pull/23605/commits/6454b2e53769a16a9ee2824e4fa2048c92ec76c2 adds `ReaderNavigationPath` initially only for `.discover`. Here it is in action (invoked programmatically): [iPhone](https://github.com/user-attachments/assets/81037e64-e277-4d6d-81a7-92318f39c51c), [iPad](https://github.com/user-attachments/assets/f2ebcda0-2f4d-4728-97ab-d06cf0c6ed54), [iPad Split View](https://github.com/user-attachments/assets/99057ac2-8dc0-42fa-88d0-cdf9c28a5677),  [iPad link from Insights](https://github.com/user-attachments/assets/8c6b2e30-62fb-4001-b0ac-4bfd44198578)
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23605/commits/3a0c7b709f5aeea839fbb78d346cded71651b20b adds `ReaderNavigationPath.post(postID:siteID:)`. Recording: [iPhone](https://github.com/user-attachments/assets/b453ce31-982e-4c9a-8598-cce0cfd28d4a) and [iPad](https://github.com/user-attachments/assets/2cf62c23-2b6f-4bef-ae31-13be6864f1b6).
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23605/commits/97fafef42674e3ba48fef7f6bb1b74022d2e59bc replaces `navigateToReader` site and brings us closer to removing `ReaderCoordinator`.  I wanted to note that it fetches the topics are fetched async when using deep links. It seems to work OK in practice, but it's not great. Recording: [iPad](https://github.com/user-attachments/assets/9e98d589-c578-4a3c-977d-6a1630794d8b), [Split View](https://github.com/user-attachments/assets/13665b23-e810-49e8-9dba-5d2d33ad17b6)
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23605/commits/057dc5f8090a861ada17580fa820438dab0f34f5 adds the link to subscriptions and fixes part of [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/23606) I found – it now opens "Manage" instead of just your subscriptions: [recording](https://github.com/user-attachments/assets/5831a6a7-6d4b-4255-bf01-765138bf5633).
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23605/commits/83e166eedf354b5ab627866658caf773eb5f5991 removes `switchToTopic(where:)`. For simplicity, for deep links it will replace the `.secondary` column but won't show any selection in the sidebar, which I think is completely acceptable. It might be improved in the future Reader project.
- https://github.com/wordpress-mobile/WordPress-iOS/pull/23605/commits/69f521f48483c8f02b4cb9ddb64b80af692c5f83 finally removes `ReaderCoordinator` 🥳 

## To test:

- Follow the steps from the videos

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
