### PR TITLE
[Tooling] Don't cancel in-progress Issue Validation GitHub Action jobs

### DIFF
--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -14,5 +14,6 @@ jobs:
       ]'
       label-error-message: '🚫 Please add a type label (e.g. **[Type] Enhancement**) and a feature label (e.g. **Stats**) to this issue.'
       label-success-message: 'Thanks for reporting! 👍'
+      cancel-running-jobs: false
     secrets:
       github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-labels-on-issues:
-    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.0.0
+    uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.1.2.1
     with:
       label-format-list: '[
         "^\[.+\]",


### PR DESCRIPTION
This PR depends on https://github.com/Automattic/dangermattic/pull/82

This PR is an update to the `validate-issues.yml` workflow, using the new parameter `cancel-running-jobs` to prevent GitHub Actions to cancel currently running jobs in the same concurrency group.