### PR TITLE
Sidebar: State restoration when switching to a split view mode

### DIFF
--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -9,7 +9,7 @@ import WordPressUI
 final class SplitViewRootPresenter: RootViewPresenter {
     private let sidebarViewModel = SidebarViewModel()
     private let splitVC = UISplitViewController(style: .tripleColumn)
-    private let tabBarViewController: WPTabBarController
+    private let tabBarVC: WPTabBarController
     private weak var sitePickerPopoverVC: UIViewController?
     private var cancellables: [AnyCancellable] = []
 
@@ -32,7 +32,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
     /// Is the app displaying tab bar UI instead of the full split view UI (with sidebar).
     private var isDisplayingTabBar: Bool {
         if splitVC.isCollapsed {
-            wpAssert(splitVC.viewController(for: .compact) == tabBarViewController, "Split view is collapsed, but is not displaying the tab bar view controller")
+            wpAssert(splitVC.viewController(for: .compact) == tabBarVC, "Split view is collapsed, but is not displaying the tab bar view controller")
             return true
         }
 
@@ -40,7 +40,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
     }
 
     init() {
-        tabBarViewController = WPTabBarController(staticScreens: false)
+        tabBarVC = WPTabBarController(staticScreens: false)
 
         splitVC.delegate = self
 
@@ -48,7 +48,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
         let navigationVC = makeRootNavigationController(with: sidebarVC)
         splitVC.setViewController(navigationVC, for: .primary)
 
-        splitVC.setViewController(tabBarViewController, for: .compact)
+        splitVC.setViewController(tabBarVC, for: .compact)
 
         NotificationCenter.default.publisher(for: MySiteViewController.didPickSiteNotification).sink { [weak self] in
             guard let site = $0.userInfo?[MySiteViewController.siteUserInfoKey] as? Blog else {
@@ -240,7 +240,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
     func currentlySelectedScreen() -> String {
         if splitVC.isCollapsed {
-            return tabBarViewController.currentlySelectedScreen()
+            return tabBarVC.currentlySelectedScreen()
         } else {
             switch sidebarViewModel.selection {
             case .welcome: return "Welcome"
@@ -261,7 +261,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection?, userInfo: [AnyHashable: Any]) {
         if splitVC.isCollapsed {
-            tabBarViewController.showBlogDetails(for: blog, then: subsection, userInfo: userInfo)
+            tabBarVC.showBlogDetails(for: blog, then: subsection, userInfo: userInfo)
         } else {
             sidebarViewModel.selection = .blog(TaggedManagedObjectID(blog))
             if let subsection {
@@ -304,7 +304,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
     func showMeScreen(completion: ((MeViewController) -> Void)?) {
         if isDisplayingTabBar {
-            tabBarViewController.showMeScreen(completion: completion)
+            tabBarVC.showMeScreen(completion: completion)
             return
         }
 

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -333,10 +333,12 @@ extension SplitViewRootPresenter: UISplitViewControllerDelegate {
         }
     }
 
+    // TODO: refactor this
     func splitViewControllerDidCollapse(_ svc: UISplitViewController) {
+        let mainContext = ContextManager.shared.mainContext
         switch sidebarViewModel.selection {
         case .blog(let objectID):
-            guard let blog = try? ContextManager.shared.mainContext.existingObject(with: objectID) else {
+            guard let blog = try? mainContext.existingObject(with: objectID) else {
                 return
             }
             if let navigationVC = svc.viewController(for: .supplementary) as? UINavigationController,
@@ -346,6 +348,25 @@ extension SplitViewRootPresenter: UISplitViewControllerDelegate {
             } else {
                 tabBarVC.showBlogDetails(for: blog)
             }
+        case .reader:
+            if let selection = readerContent?.sidebar.viewModel.selection {
+                switch selection {
+                case .main(let readerStaticScreen):
+                    switch readerStaticScreen {
+                    case .recent: tabBarVC.showReader(path: .recent)
+                    case .discover: tabBarVC.showReader(path: .discover)
+                    case .saved: tabBarVC.showReader()
+                    case .likes: tabBarVC.showReader(path: .likes)
+                    case .search: tabBarVC.showReader(path: .search)
+                    }
+                case .allSubscriptions:
+                    tabBarVC.showReader(path: .subscriptions)
+                default:
+                    tabBarVC.showReader()
+                }
+            }
+        case .notifications:
+            tabBarVC.showNotificationsTab()
         default:
             break
         }

--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -280,7 +280,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
     func showReader(path: ReaderNavigationPath?) {
         if splitVC.isCollapsed {
-            tabBarViewController.showReader(path: path)
+            tabBarVC.showReader(path: path)
         } else {
             sidebarViewModel.selection = .reader
             if let path {
@@ -330,6 +330,24 @@ extension SplitViewRootPresenter: UISplitViewControllerDelegate {
     func splitViewController(_ svc: UISplitViewController, willHide column: UISplitViewController.Column) {
         if column == .primary {
             sitePickerPopoverVC?.presentingViewController?.dismiss(animated: true)
+        }
+    }
+
+    func splitViewControllerDidCollapse(_ svc: UISplitViewController) {
+        switch sidebarViewModel.selection {
+        case .blog(let objectID):
+            guard let blog = try? ContextManager.shared.mainContext.existingObject(with: objectID) else {
+                return
+            }
+            if let navigationVC = svc.viewController(for: .supplementary) as? UINavigationController,
+               let menuVC = navigationVC.viewControllers.first as? SiteMenuViewController,
+               let subsection = menuVC.selectedSubsection, subsection != .home {
+                tabBarVC.showBlogDetails(for: blog, then: subsection, userInfo: [:])
+            } else {
+                tabBarVC.showBlogDetails(for: blog)
+            }
+        default:
+            break
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -89,6 +89,9 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 @property (nonatomic) BOOL showsDisclosureIndicator;
 @property (nonatomic, copy, nullable) void (^callback)(void);
 
+/// - warning: This property is not specified for every row.
+@property (nonatomic, readonly) BlogDetailsSubsection subsection;
+
 - (instancetype _Nonnull)initWithTitle:(NSString * __nonnull)title
                             identifier:(NSString * __nonnull)identifier
                accessibilityIdentifier:(NSString *__nullable)accessibilityIdentifier
@@ -115,6 +118,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
                          renderingMode:(UIImageRenderingMode)renderingMode
                               callback:(void(^_Nullable)(void))callback;
 
+- (BlogDetailsRow * _Nonnull)withSubsection:(BlogDetailsSubsection)subsection;
+
 @end
 
 @protocol ScenePresenter;
@@ -134,6 +139,9 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 /// A new display mode for the displaying it as part of the site menu.
 @property (nonatomic) BOOL isSidebarModeEnabled;
+
+/// - warning: A temporary solution for restoring selection on iPad – imprecise!
+@property (nonatomic, readonly) BlogDetailsSubsection selectedSubsection;
 
 - (id _Nonnull)init;
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -195,7 +195,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
         _accessibilityHint = accessibilityHint;
         _showsSelectionState = YES;
         _showsDisclosureIndicator = YES;
+        _subsection = NSNotFound;
     }
+    return self;
+}
+
+- (BlogDetailsRow *)withSubsection:(BlogDetailsSubsection)subsection {
+    _subsection = subsection;
     return self;
 }
 
@@ -640,6 +646,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     return _siteIconPickerPresenter;
 }
 
+- (BlogDetailsSubsection)selectedSubsection {
+    NSIndexPath *indexPath = self.tableView.indexPathForSelectedRow;
+    if (!indexPath) {
+        return NSNotFound;
+    }
+    BlogDetailsSection *section = [self.tableSections objectAtIndex:indexPath.section];
+    BlogDetailsRow *row = [section.rows objectAtIndex:indexPath.row];
+    return row.subsection;
+}
+
 #pragma mark - iOS 10 bottom padding
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)sectionNum {
@@ -684,59 +700,59 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 - (BlogDetailsRow *)postsRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Posts", @"Noun. Title. Links to the blog's Posts screen.")
-                                        accessibilityIdentifier:@"Blog Post Row"
-                                                          image:[[UIImage imageNamed:@"site-menu-posts"] imageFlippedForRightToLeftLayoutDirection]
-                                                       callback:^{
-        [weakSelf showPostListFromSource:BlogDetailsNavigationSourceRow];
-    }];
+    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Posts", @"Noun. Title. Links to the blog's Posts screen.")
+                                         accessibilityIdentifier:@"Blog Post Row"
+                                                           image:[[UIImage imageNamed:@"site-menu-posts"] imageFlippedForRightToLeftLayoutDirection]
+                                                        callback:^{
+         [weakSelf showPostListFromSource:BlogDetailsNavigationSourceRow];
+     }] withSubsection:BlogDetailsSubsectionPosts];
     return row;
 }
 
 - (BlogDetailsRow *)pagesRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
-                                        accessibilityIdentifier:@"Site Pages Row"
-                                                          image:[UIImage imageNamed:@"site-menu-pages"]
-                                                       callback:^{
-        [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
-    }];
+    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
+                                         accessibilityIdentifier:@"Site Pages Row"
+                                                           image:[UIImage imageNamed:@"site-menu-pages"]
+                                                        callback:^{
+         [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
+    }] withSubsection:BlogDetailsSubsectionPages];
     return row;
 }
 
 - (BlogDetailsRow *)mediaRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
-                                        accessibilityIdentifier:@"Media Row"
-                                                          image:[UIImage imageNamed:@"site-menu-media"]
-                                                       callback:^{
-        [weakSelf showMediaLibraryFromSource:BlogDetailsNavigationSourceRow];
-    }];
+    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
+                                         accessibilityIdentifier:@"Media Row"
+                                                           image:[UIImage imageNamed:@"site-menu-media"]
+                                                        callback:^{
+         [weakSelf showMediaLibraryFromSource:BlogDetailsNavigationSourceRow];
+     }] withSubsection:BlogDetailsSubsectionMedia];
     return row;
 }
 
 - (BlogDetailsRow *)commentsRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
-                                                          image:[[UIImage imageNamed:@"site-menu-comments"] imageFlippedForRightToLeftLayoutDirection]
-                                                       callback:^{
-        [weakSelf showCommentsFromSource:BlogDetailsNavigationSourceRow];
-    }];
+    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
+                                                           image:[[UIImage imageNamed:@"site-menu-comments"] imageFlippedForRightToLeftLayoutDirection]
+                                                        callback:^{
+         [weakSelf showCommentsFromSource:BlogDetailsNavigationSourceRow];
+     }] withSubsection:BlogDetailsSubsectionComments];
     return row;
 }
 
 - (BlogDetailsRow *)statsRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
-                                             accessibilityIdentifier:@"Stats Row"
-                                                               image:[UIImage imageNamed:@"site-menu-stats"]
-                                                            callback:^{
-        [weakSelf showStatsFromSource:BlogDetailsNavigationSourceRow];
-    }];
+    BlogDetailsRow *statsRow = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
+                                              accessibilityIdentifier:@"Stats Row"
+                                                                image:[UIImage imageNamed:@"site-menu-stats"]
+                                                             callback:^{
+         [weakSelf showStatsFromSource:BlogDetailsNavigationSourceRow];
+     }] withSubsection:BlogDetailsSubsectionStats];
     return statsRow;
 }
 
@@ -1170,13 +1186,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
     
-    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
+    [rows addObject:[[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
                                   accessibilityIdentifier:@"Home Row"
                                                     image:[UIImage imageNamed:@"site-menu-home"]
                                                  callback:^{
                                                     [weakSelf showDashboard];
-                                                 }]];
-    
+    }] withSubsection: BlogDetailsSubsectionHome]];
+
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows category:BlogDetailsSectionCategoryHome];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Navigation/ReaderNavigationPath.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum ReaderNavigationPath: Hashable {
+    case recent
     case discover
     case likes
     case search

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -123,6 +123,8 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
 
     func navigate(to path: ReaderNavigationPath) {
         switch path {
+        case .recent:
+            viewModel.selection = .main(.recent)
         case .discover:
             viewModel.selection = .main(.discover)
         case .likes:

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -50,6 +50,8 @@ extension WPTabBarController {
 
     private func navigate(to path: ReaderNavigationPath) {
         switch path {
+        case .recent:
+            readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsFollowing)
         case .discover:
             readerTabViewModel.switchToTab(where: ReaderHelpers.topicIsDiscover)
         case .likes:

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -11,6 +11,12 @@ final class SiteMenuViewController: UIViewController {
 
     weak var delegate: SiteMenuViewControllerDelegate?
 
+    /// - warning: Temporary code. Avoid using it!
+    var selectedSubsection: BlogDetailsSubsection? {
+        let subsection = blogDetailsVC.selectedSubsection
+        return subsection.rawValue == NSNotFound ? nil : subsection
+    }
+
     init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
This PR introduces a temporary solution for restoring at least some of the navigation state when switching to the split view mode. Of course, this solution is not scalable. To implement it correctly, the iPhone part of the app needs to be updated and the design needs to be simplified and brought closer to what the app does.

The prototype demonstrates how it successfully preserves the selected blog and the selected main blog navigation (posts):

https://github.com/user-attachments/assets/b5a13ccd-9938-4352-9677-ba461d5e61e7

I encountered two other major issues when working on it:

- `BlogDetailsViewController` doesn't provide any good ways to determine which item is currently selected
- `WPTabBarViewController` that is used for `.compact` mode creates its entire UI in the `init` method instead of `viewDidLoad`. There is another hurdle that, unlike every other view controller, `UITabBarViewController` calls `viewDidLoad` in its init, so simply making this stuff lazy won't work. To be fair, I don't think this is a major problem, but I would like to avoid it.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
