### PR TITLE
Refactor: Rename showPostTab

### DIFF
--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -24,7 +24,7 @@ open class WP3DTouchShortcutHandler: NSObject {
                 return true
             case ShortcutIdentifier.NewPost.type:
                 WPAnalytics.track(.shortcutNewPost)
-                rootViewPresenter.showPostTab(animated: false)
+                rootViewPresenter.showPostEditor(animated: false)
                 return true
             case ShortcutIdentifier.Stats.type:
                 WPAnalytics.track(.shortcutStats)

--- a/WordPress/Classes/System/RootViewPresenter+EditorNavigation.swift
+++ b/WordPress/Classes/System/RootViewPresenter+EditorNavigation.swift
@@ -9,30 +9,12 @@ extension RootViewPresenter {
         return Blog.lastUsedOrFirst(in: context)
     }
 
-    func showPostTab() {
-        showPostTab(completion: nil)
-    }
-
-    func showPostTab(completion afterDismiss: (() -> Void)?) {
-        let context = ContextManager.shared.mainContext
-        // Ignore taps on the post tab and instead show the modal.
-        if Blog.count(in: context) > 0 {
-            showPostTab(animated: true, completion: afterDismiss)
-        }
-    }
-
-    func showPostTab(for blog: Blog) {
-        let context = ContextManager.shared.mainContext
-        if Blog.count(in: context) > 0 {
-            showPostTab(animated: true, blog: blog)
-        }
-    }
-
-    // TODO: rename
-    func showPostTab(animated: Bool,
-                     post: Post? = nil,
-                     blog: Blog? = nil,
-                     completion afterDismiss: (() -> Void)? = nil) {
+    func showPostEditor(
+        animated: Bool = true,
+        post: Post? = nil,
+        blog: Blog? = nil,
+        completion afterDismiss: (() -> Void)? = nil
+    ) {
         if rootViewController.presentedViewController != nil {
             rootViewController.dismiss(animated: false)
         }
@@ -56,22 +38,19 @@ extension RootViewPresenter {
         rootViewController.present(editor, animated: false)
     }
 
-    func showPageEditor(forBlog: Blog? = nil) {
-        showPageEditor(blog: forBlog)
-    }
-
-    /// Show the page tab
-    /// - Parameter blog: Blog to a add a page to. Uses the current or last blog if not provided
-    func showPageEditor(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
+    /// - parameter blog: Blog to a add a page to. Uses the current or last blog if not provided
+    func showPageEditor(blog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
 
         // If we are already showing a view controller, dismiss and show the editor afterward
         guard rootViewController.presentedViewController == nil else {
             rootViewController.dismiss(animated: true) { [weak self] in
-                self?.showPageEditor(blog: inBlog, title: title, content: content, source: source)
+                self?.showPageEditor(blog: blog, title: title, content: content, source: source)
             }
             return
         }
-        guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
+        guard let blog = blog ?? self.currentOrLastBlog() else {
+            return
+        }
         guard content == nil else {
             showEditor(blog: blog, title: title, content: content)
             return

--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -16,10 +16,6 @@ struct NewPageForSiteRoute: Route {
 
 struct NewPageNavigationAction: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
-        if let blog = blog(from: values) {
-            RootViewCoordinator.sharedPresenter.showPageEditor(forBlog: blog)
-        } else {
-            RootViewCoordinator.sharedPresenter.showPageEditor()
-        }
+        RootViewCoordinator.sharedPresenter.showPageEditor(blog: blog(from: values))
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -16,10 +16,6 @@ struct NewPostForSiteRoute: Route {
 
 struct NewPostNavigationAction: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
-        if let blog = blog(from: values) {
-            RootViewCoordinator.sharedPresenter.showPostTab(for: blog)
-        } else {
-            RootViewCoordinator.sharedPresenter.showPostTab()
-        }
+        RootViewCoordinator.sharedPresenter.showPostEditor(blog: blog(from: values))
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
@@ -8,14 +8,11 @@ extension MySiteViewController {
     @objc func makeCreateButtonCoordinator() -> CreateButtonCoordinator {
 
         let newPage = {
-            let presenter = RootViewCoordinator.sharedPresenter
-            let blog = presenter.currentOrLastBlog()
-            presenter.showPageEditor(forBlog: blog)
+            RootViewCoordinator.sharedPresenter.showPageEditor()
         }
 
         let newPost = {
-            let presenter = RootViewCoordinator.sharedPresenter
-            presenter.showPostTab(completion: {})
+            RootViewCoordinator.sharedPresenter.showPostEditor()
         }
 
         let source = "my_site"
@@ -50,7 +47,7 @@ extension MySiteViewController {
                 let presenter = RootViewCoordinator.sharedPresenter
                 let post = blog.createDraftPost()
                 post.voiceContent = transcription
-                presenter.showPostTab(animated: true, post: post)
+                presenter.showPostEditor(post: post)
             }
         }
         let view = VoiceToContentView(viewModel: viewModel)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -1638,7 +1638,7 @@ extension NotificationsViewController: NoResultsViewControllerDelegate {
             RootViewCoordinator.sharedPresenter.showReader()
         case .unread:
             WPAnalytics.track(.notificationsTappedNewPost, withProperties: properties)
-            RootViewCoordinator.sharedPresenter.showPostTab()
+            RootViewCoordinator.sharedPresenter.showPostEditor()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -126,7 +126,7 @@ class ReaderTabViewController: UIViewController {
 
         let postAction = PostAction(handler: {
             let presenter = RootViewCoordinator.sharedPresenter
-            presenter.showPostTab()
+            presenter.showPostEditor()
         }, source: source)
 
         return CreateButtonCoordinator(self, actions: [postAction], source: source, blog: blog)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -362,7 +362,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func showCreatePost() {
-        RootViewCoordinator.sharedPresenter.showPostTab { [weak self] in
+        RootViewCoordinator.sharedPresenter.showPostEditor { [weak self] in
             self?.refreshInsights()
         }
     }


### PR DESCRIPTION
It is not longer a tab, so the naming is confusing. I also removed the redundant variants.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
