### PR TITLE
Update dark mode color

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -91,7 +91,7 @@ struct UIAppColor {
 
 #if IS_JETPACK
     static let tint = UIColor.label
-    static let brand = CSColor.JetpackGreen.base
+    static let brand = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
 #endif
 
 #if IS_WORDPRESS


### PR DESCRIPTION
I cherry-picked the change from https://github.com/wordpress-mobile/WordPress-iOS/pull/23587, but only for Jetpack for now. I've been testing the dark mode version extensively on my personal devices, and the current green does appear too dark and it not legible. You typically want to use colors that are slightly lighter in dark mode, so this PR does that.

<img width="1316" alt="Screenshot 2024-09-19 at 9 29 31 PM" src="https://github.com/user-attachments/assets/c72aa3fb-27a8-4de7-87a4-b01f8dc97dba">

The color in light mode is unchanged.

<img width="1316" alt="Screenshot 2024-09-19 at 9 29 16 PM" src="https://github.com/user-attachments/assets/a7ca24b1-c409-4d9c-bdb1-be698e559e1c">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
