### PR TITLE
Fix UIColor primary

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -37,7 +37,7 @@ extension WPStyleGuide {
         configureSharedSettings(for: scrollEdgeAppearance)
 
         let appearance = UINavigationBar.appearance()
-        appearance.tintColor = UIAppColor.primary // Back button color
+        appearance.tintColor = UIAppColor.tint // Back button color
 
         appearance.standardAppearance = standardAppearance
         appearance.compactAppearance = standardAppearance
@@ -48,7 +48,7 @@ extension WPStyleGuide {
     private class func configureSharedSettings(for appearance: UINavigationBarAppearance) {
         appearance.titleTextAttributes = [
             .font: WPStyleGuide.navigationBarStandardFont,
-            .foregroundColor: UIAppColor.primary
+            .foregroundColor: UIColor.label
         ]
         appearance.largeTitleTextAttributes = [
             .font: AppStyleGuide.navigationBarLargeFont
@@ -65,7 +65,7 @@ extension WPStyleGuide {
     }
 
     @objc class func configureTabBar(_ tabBar: UITabBar) {
-        tabBar.tintColor = UIAppColor.primary
+        tabBar.tintColor = UIAppColor.tint
         tabBar.unselectedItemTintColor = UIColor(named: "TabUnselected")
     }
 

--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -92,11 +92,19 @@ struct UIAppColor {
 #if IS_JETPACK
     static let tint = UIColor.label
     static let brand = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
+
+    static func brand(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.JetpackGreen.shade(shade)
+    }
 #endif
 
 #if IS_WORDPRESS
     static let tint = brand
     static let brand = CSColor.WordPressBlue.base
+
+    static func brand(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.WordPressBlue.shade(shade)
+    }
 #endif
 
     static let divider = CSColor.Gray.shade(.shade10)

--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -104,7 +104,8 @@ struct UIAppColor {
     static let gray = CSColor.Gray.base
     static let blue = CSColor.Blue.base
 
-    static let primary = UIColor.label
+    /// - warning: soft-deprecated, use `UIAppColor.tint`.
+    static let primary = brand
 
     static let success = CSColor.Green.base
     static let text = CSColor.Gray.shade(.shade80)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -69,9 +69,9 @@ private extension CountriesMapView {
 
     func mapColors() -> [UIColor] {
         if traitCollection.userInterfaceStyle == .dark {
-            return [UIAppColor.primary(.shade90), UIAppColor.primary]
+            return [WPStyleGuide.Stats.mapBackground, UIAppColor.brand]
         } else {
-            return [UIAppColor.primary(.shade5), UIAppColor.primary]
+            return [WPStyleGuide.Stats.mapBackground, UIAppColor.brand]
         }
     }
 

--- a/WordPress/JetpackStatsWidgets/Views/Cards/ListRow.swift
+++ b/WordPress/JetpackStatsWidgets/Views/Cards/ListRow.swift
@@ -87,8 +87,8 @@ private extension ListRow {
 
     enum Constants {
         // difference view
-        static let positiveColor = Color("Green50")
-        static let negativeColor = Color("Red50")
+        static let positiveColor = Color(UIAppColor.jetpackGreen(.shade50))
+        static let negativeColor = Color(UIAppColor.red(.shade50))
         static let neutralColor = Color(UIColor.systemGray)
         static let differenceTextColor = Color.white
 


### PR DESCRIPTION
**RCA**

In the previous version, `UIColor.primary` (custom property) meant the same as `UIColor.brand` (blue/green). 

In the new version, `UIAppColor.primary` maps to `UIColor.label`, which is incorrect. In most places where `UIColor.primary` was replaced with `UIAppColor.primary`, the app now shows incorrect colors. For example, here are three areas I found during testing:

<img width="240" alt="Screenshot 2024-09-24 at 4 43 02 PM" src="https://github.com/user-attachments/assets/8e924216-4f0b-4419-a793-e43ed5cfb7d1">
<img width="240" alt="Screenshot 2024-09-24 at 5 54 20 PM" src="https://github.com/user-attachments/assets/16688bdd-d0c3-4b08-acbf-13fb14d53e17">
<img width="240" alt="Screenshot 2024-09-24 at 5 54 27 PM" src="https://github.com/user-attachments/assets/e0398c04-25c3-4602-891c-b64cd8c3bea7">

The fix isn't as straightforward because in some places – the ones I found so far – `UIAppColor.primary` replaced other colors like `UIColor.appBarText`. We don't want nav bar titles to be green or blue, so it had to be address it with more code changes.

## To test:

<img width="240" alt="Screenshot 2024-09-24 at 5 47 29 PM" src="https://github.com/user-attachments/assets/65c00043-de21-4c49-bb2a-fe7e2bf3ba15">

I've reviewed a bunch of scenarios that used `UIAppColor.primary`, but didn't have to time to check everything. I hope if there are any other issues, they will eventually bubble up. To the very least, this PR should reduce the number of issues.

## Future Changes

There is still a little bit of work left to review how the brand/tint/primary colors are used and how the colors are applied in the UI. 

For Jetpack, the rule of thumb should be to use green color (`UIAppColor.brand`) only in places where it would otherwise be hard or impossible to tell that the control is a control. The main tint color for the Jetpack app (`UIAppColor.tint`) is black (`UIColor.label`).

I would also recommend removing `UIAppColor.primary` as it can be confused with `Color.primary` from SwiftUI.


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
