### PR TITLE
feat: Handle remote editor load failure

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "c31879b834ef3ca5ea6b09040c96093ef627e029"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "6e827cb1d932cc1fc3e7fec726549a4f69b0a309"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "6e827cb1d932cc1fc3e7fec726549a4f69b0a309"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cfc127351249c58ee3b2714e984429f74f434e5d"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cfc127351249c58ee3b2714e984429f74f434e5d"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "849118af582068f75807bc0f1265edeee4bf1b5e"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "c31879b834ef3ca5ea6b09040c96093ef627e029"
+        "revision" : "6e827cb1d932cc1fc3e7fec726549a4f69b0a309"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "cfc127351249c58ee3b2714e984429f74f434e5d"
+        "revision" : "849118af582068f75807bc0f1265edeee4bf1b5e"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "6e827cb1d932cc1fc3e7fec726549a4f69b0a309"
+        "revision" : "cfc127351249c58ee3b2714e984429f74f434e5d"
       }
     },
     {


### PR DESCRIPTION
## Description

Gracefully handle failed attempts to load a site's remote editor by falling back
to the local, default editor and displaying a notice to the user. 

**Related:**

* https://github.com/wordpress-mobile/GutenbergKit/pull/27
* https://github.com/Automattic/dotcom-forge/issues/9085

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/27.

## Regression Notes
1. Potential unintended areas of impact
  None, should be limited to the experimental editor.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
  N/A.
3. What automated tests I added (or what prevented me from doing so)
  None, we are not focused on automating tests for this experimental feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
