### PR TITLE
Address a build failure in the tests because of unhandled `XCTSkip`

### DIFF
--- a/WordPress/WordPressTest/MediaURLExporterTests.swift
+++ b/WordPress/WordPressTest/MediaURLExporterTests.swift
@@ -31,15 +31,15 @@ class MediaURLExporterTests: XCTestCase {
         waitForExpectations(timeout: 2.0, handler: nil)
     }
 
-    func testThatURLExportingVideoWorks() {
-        exportTestVideo(removingGPS: false)
+    func testThatURLExportingVideoWorks() throws {
+        try exportTestVideo(removingGPS: false)
     }
 
     func testThatURLExportingVideoWithoutGPSWorks() throws {
-        exportTestVideo(removingGPS: true)
+        try exportTestVideo(removingGPS: true)
     }
 
-    fileprivate func exportTestVideo(removingGPS: Bool) {
+    fileprivate func exportTestVideo(removingGPS: Bool) throws {
         throw XCTSkip("This test became too flaky in iOS 18")
 
         guard let mediaPath = OHPathForFile(testDeviceVideoName, type(of: self)) else {


### PR DESCRIPTION
CI should be green.

**[Before](https://buildkite.com/automattic/wordpress-ios/builds/24054#_)** — I haven't tracked down the PR/commit that introduced this (how did it pass CI?) the link there is just the first build I noticed.

![image](https://github.com/user-attachments/assets/8b537670-a2d1-4f91-be29-a844dfd7c6df)

**After**
<img width="632" alt="image" src="https://github.com/user-attachments/assets/ae200699-bf78-4255-a7dd-979e555e752d">
