### PR TITLE
T18442: Reevaluate site title font when button state changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -222,9 +222,10 @@ extension BlogDetailHeaderView {
             let button = UIButton(type: .custom)
 
             var configuration = UIButton.Configuration.plain()
-            let font = isSidebarModeEnabled ? AppStyleGuide.navigationBarLargeFont : WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
-            configuration.titleTextAttributesTransformer = .init { attributes in
+            configuration.titleTextAttributesTransformer = .init { [weak self] attributes in
+                guard let self else { return attributes }
                 var attributes = attributes
+                let font = isSidebarModeEnabled ? AppStyleGuide.navigationBarLargeFont : WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
                 attributes.font = font
                 attributes.foregroundColor = UIColor.label
                 return attributes


### PR DESCRIPTION
Evaluate which font to display every time the `titleTextAttributesTransformer` is executed. This way, if the font scale is changed in accessibility settings, the site title font will be updated with the right size upon reentering the app.

Fixes #18442

Before:

<img src="https://github.com/user-attachments/assets/a7358430-8cb2-4e38-a2c6-4441182d8a5a" width="20%">

After:

<img src="https://github.com/user-attachments/assets/bc1bc174-7b15-4589-a597-9a79622e95bd" width="20%">

## Regression Notes
1. Potential unintended areas of impact
- Appearance on iPhone & iPad
- Appearance in portrait or landscape

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- Tested on iPad, problem was not present in the sidebar (even before my changes):

<img width="20%" alt="Screenshot 2024-09-30 at 16 18 23" src="https://github.com/user-attachments/assets/746d5d33-c693-43d0-9e2c-20fdc429d736">

- Tested in landscape, looks good:

<img src="https://github.com/user-attachments/assets/2283d70f-0d0b-4c4c-b11c-c17294e2968c" width="20%">

3. What automated tests I added (or what prevented me from doing so)
Didn't find similar tests in codebase + impractical to test dynamic text size

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [x] WordPress.com sites and self-hosted Jetpack sites.
- [x] Portrait and landscape orientations.
- [x] Light and dark modes.
- [x] Fonts: Larger, smaller and bold text.
- [x] High contrast.
- [x] VoiceOver.
- [x] Languages with large words or with letters/accents not frequently used in English.
- [x] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [x] iPhone and iPad. 
- [x] Multi-tasking: Split view and Slide over. (iPad)
