### PR TITLE
Add Not Now to review prompt

### DIFF
--- a/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
@@ -112,7 +112,7 @@ class AppRatingUtility: NSObject {
     ///
     @objc func declinedToRateCurrentVersion() {
         defaults.set(true, forKey: Key.declinedToRateCurrentVersion)
-        defaults.set(2, forKey: Key.numberOfVersionsToSkipPrompting)
+        defaults.set(3, forKey: Key.numberOfVersionsToSkipPrompting)
     }
 
     /// Indicates that the user decided to give feedback for this version.
@@ -132,7 +132,7 @@ class AppRatingUtility: NSObject {
     @objc func dislikedCurrentVersion() {
         incrementStoredValue(key: Key.userDislikeCount)
         defaults.set(true, forKey: Key.dislikedCurrentVersion)
-        defaults.set(2, forKey: Key.numberOfVersionsToSkipPrompting)
+        defaults.set(4, forKey: Key.numberOfVersionsToSkipPrompting)
     }
 
     /// Indicates the user did like the current version of the app.

--- a/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
@@ -112,7 +112,7 @@ class AppRatingUtility: NSObject {
     ///
     @objc func declinedToRateCurrentVersion() {
         defaults.set(true, forKey: Key.declinedToRateCurrentVersion)
-        defaults.set(3, forKey: Key.numberOfVersionsToSkipPrompting)
+        defaults.set(2, forKey: Key.numberOfVersionsToSkipPrompting)
     }
 
     /// Indicates that the user decided to give feedback for this version.
@@ -132,7 +132,7 @@ class AppRatingUtility: NSObject {
     @objc func dislikedCurrentVersion() {
         incrementStoredValue(key: Key.userDislikeCount)
         defaults.set(true, forKey: Key.dislikedCurrentVersion)
-        defaults.set(4, forKey: Key.numberOfVersionsToSkipPrompting)
+        defaults.set(2, forKey: Key.numberOfVersionsToSkipPrompting)
     }
 
     /// Indicates the user did like the current version of the app.

--- a/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
@@ -46,8 +46,13 @@ final class InAppFeedbackPromptCoordinator: InAppFeedbackPromptPresenting {
         let no = UIAlertAction(title: Strings.FeedbackAlert.no, style: .default) { _ in
             self.handleNegativeFeedback(in: controller)
         }
-        alert.addAction(no)
+        let notNow = UIAlertAction(title: Strings.FeedbackAlert.notNow, style: .cancel) { [weak self] _ in
+            WPAnalytics.track(.appReviewsDeclinedToRateApp)
+            self?.appRatingUtility.declinedToRateCurrentVersion()
+        }
         alert.addAction(yes)
+        alert.addAction(no)
+        alert.addAction(notNow)
         return alert
     }
 
@@ -118,6 +123,11 @@ extension InAppFeedbackPromptCoordinator {
                 "in-app.feedback.alert.no",
                 value: "Not really",
                 comment: "The 'no' button title for the first feedback alert"
+            )
+            static let notNow = NSLocalizedString(
+                "in-app.feedback.alert.notNow",
+                value: "Not Now",
+                comment: "The 'Not Now' button title for the first feedback alert"
             )
         }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23505.

There've been a few more feedbacks about it. It seems like a no-brainer to add. It's much nicer to be able to tap "Not Now".

<img width="280" alt="Screenshot 2024-09-30 at 3 39 04 PM" src="https://github.com/user-attachments/assets/788067a4-b6b0-4b26-9eb2-c6a556e1a58a">



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
