### PR TITLE
Refresh stats after switching back to the app

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -86,7 +86,7 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
         viewModel?.removeListeners()
     }
 
-    private func refreshInsights(forceRefresh: Bool = false) {
+    func refreshInsights(forceRefresh: Bool = false) {
         viewModel?.refreshInsights(forceRefresh: forceRefresh)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -135,6 +135,15 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
         }
     }
 
+    func refreshData() {
+        guard viewIsVisible() else {
+            refreshControl.endRefreshing()
+            return
+        }
+        addViewModelListeners()
+        viewModel.refreshTrafficOverviewData(withDate: datePickerViewModel.date, forPeriod: datePickerViewModel.period)
+    }
+
 }
 
 // MARK: - Private Extension
@@ -188,15 +197,6 @@ private extension SiteStatsPeriodTableViewController {
         clearExpandedRows()
         refreshControl.beginRefreshing()
         refreshData()
-    }
-
-    func refreshData() {
-        guard viewIsVisible() else {
-            refreshControl.endRefreshing()
-            return
-        }
-        addViewModelListeners()
-        viewModel.refreshTrafficOverviewData(withDate: datePickerViewModel.date, forPeriod: datePickerViewModel.period)
     }
 
     func applyTableUpdates() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -44,11 +44,11 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         initViewModel()
         trackAccessEvent()
-        addWillEnterForegroundObserver()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        addWillEnterForegroundObserver()
         JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .stats)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -52,6 +52,10 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         tableView.register(SiteStatsTableHeaderView.defaultNib,
                            forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         addWillEnterForegroundObserver()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -34,6 +34,10 @@ class SiteStatsInsightsDetailsTableViewController: SiteStatsBaseTableViewControl
         refreshControl.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         addWillEnterForegroundObserver()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -104,13 +104,13 @@ class SiteStatsDashboardViewController: UIViewController {
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
         restoreSelectedTabFromUserDefaults()
-        addWillEnterForegroundObserver()
         configureNavBar()
         view.accessibilityIdentifier = "stats-dashboard"
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        addWillEnterForegroundObserver()
         JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .stats)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -244,18 +244,24 @@ private extension SiteStatsDashboardViewController {
                 pageViewController?.setViewControllers([insightsTableViewController],
                                                        direction: .forward,
                                                        animated: false)
+            } else {
+                insightsTableViewController.refreshInsights()
             }
         case .traffic:
             if oldSelectedTab != .traffic || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([trafficTableViewController],
                                                        direction: .forward,
                                                        animated: false)
+            } else {
+                trafficTableViewController.refreshData()
             }
         case .subscribers:
             if oldSelectedTab != .subscribers || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([subscribersViewController],
                                                        direction: .forward,
                                                        animated: false)
+            } else {
+                subscribersViewController.refreshData()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -58,7 +58,7 @@ final class StatsSubscribersViewController: SiteStatsBaseTableViewController {
         cancellables = []
     }
 
-    @objc private func refreshData() {
+    @objc func refreshData() {
         viewModel.refreshData()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {


### PR DESCRIPTION
Fixes #23604.

There are two issues involved.

The first issue is simple: Stats data is not refreshed after switching back, even though we have observer in place for it. This is fixed in `SiteStatsDashboardViewController.updatePeriodView(oldSelectedTab:)` changes.

The second issue is pretty weird. When sending the app to background, it appears iOS would collapse split view and then switching back to its original state. This causes view controller to be removed and re-added to the window, which means `viewWillDispappear`, `viewWillAppear`, and other functions will be called when sending the app to background. However, in most places, the "app will enter foreground" observer in Stats is added in `viewDidLoad` and removed in `viewWillDisappear`. The fix here is adding observer in `viewWillAppear` to match the removing code.

To test, verify #23604 is fixed on both iPhone and iPad.

## Regression Notes
1. Potential unintended areas of impact


3. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
