### PR TITLE
Find the right WP.com account for Jetpack connected sites

### DIFF
--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -69,7 +69,7 @@
             NSString *dotcomUsername = [blog getOptionValue:@"jetpack_user_login"];
             if (dotcomUsername) {
                 // Search for a matching .com account
-                WPAccount *account = [WPAccount lookupDefaultWordPressComAccountInContext:context];
+                WPAccount *account = [WPAccount lookupWithUsername:dotcomUsername context:context];
                 if (account) {
                     blog.account = account;
                     [WPAppAnalytics track:WPAnalyticsStatSignedInToJetpack withBlog:blog];


### PR DESCRIPTION
## Issue

Jetpack connected sites can't be added to the app if the app is signed in using a different WP.com account.

Here are steps (taken from a internal discussion p1727463794673359-slack-C06S1QS55K9) to reproduce the bug:
1. Create a site, connect Jetpack to WPCOM Account A.
1. Log into the Jetpack mobile app with WPCOM Account B.
1. Add the targeted self-hosted site.
1. :boom: All site requests are sent to [public-api.wordpress.com](http://public-api.wordpress.com/) and fail to locate the site.

## Changes

The current app WP.com account is incorrectly assigned to the self-hosted site. The fix is simply lookup the right account for the added site.

~However, the account look up will always results in nil though, because we only have one account in the app.~ Users can log in to another account by going to the Stats screen in the new self-hosted site. This flow is broken at the moment though. I'm looking into the issue, but any change would result in a separate PR.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)