### PR TITLE
Add tracking for post sync errors

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -317,6 +317,7 @@ import Foundation
     case postRepositoryPostUpdated
     case postRepositoryPatchStarted
     case postRepositoryConflictEncountered
+    case postRepositoryPostsFetchFailed
 
     // Reader: Filter Sheet
     case readerFilterSheetDisplayed
@@ -1191,6 +1192,8 @@ import Foundation
             return "post_repository_patch_started"
         case .postRepositoryConflictEncountered:
             return "post_repository_conflict_encountered"
+        case .postRepositoryPostsFetchFailed:
+            return "post_repository_posts_fetch_failed"
 
         // Reader: Filter Sheet
         case .readerFilterSheetDisplayed:

--- a/WordPress/Classes/Utility/WPInstrumentation.swift
+++ b/WordPress/Classes/Utility/WPInstrumentation.swift
@@ -93,6 +93,20 @@ extension WordPressAPIError: TrackableErrorProtocol {
     }
 }
 
+extension WPAnalyticsEvent {
+    static func makeUserInfo(for error: Error) -> [String: String] {
+        if let error = error as? TrackableErrorProtocol, let userInfo = error.getTrackingUserInfo() {
+            return userInfo
+        }
+        let nsError = error as NSError
+        return [
+            "category": "other",
+            "error_code": nsError.code.description,
+            "error_domain": nsError.domain
+        ]
+    }
+}
+
 private func getUserInfo(for error: Error, category: String) -> [String: String] {
     return [
         "category": category,

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -546,6 +546,7 @@ class AbstractPostListViewController: UIViewController,
             } catch {
                 guard let self else { return }
 
+                self.logSyncError(error)
                 failure?(error as NSError)
 
                 if userInteraction == true {
@@ -575,6 +576,7 @@ class AbstractPostListViewController: UIViewController,
 
                 success?(filter.hasMore)
             } catch {
+                self?.logSyncError(error)
                 failure?(error as NSError)
             }
         }
@@ -625,6 +627,12 @@ class AbstractPostListViewController: UIViewController,
             let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
             WPError.showNetworkingNotice(title: title, error: error)
         }
+    }
+
+    private func logSyncError(_ error: Error) {
+        guard let blog else { return }
+        let userInfo = WPAnalyticsEvent.makeUserInfo(for: error)
+        WPAnalytics.track(.postRepositoryPostsFetchFailed, properties: userInfo, blog: blog)
     }
 
     // MARK: - Actions


### PR DESCRIPTION
Related: https://github.com/wordpress-mobile/WordPress-iOS/issues/23639. I saw a few reports about posts not being loaded, so I'm adding tracking to determine if there is anything the app could do to help.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
