### PR TITLE
Fix an issue with Me header view alignment

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
@@ -15,7 +15,7 @@ final class MeHeaderView: UIView {
         [iconView, infoStackView]
     )
 
-    private lazy var infoStackView = UIStackView(axis: .vertical, spacing: 2, [titleLabel, detailsLabel])
+    private lazy var infoStackView = UIStackView(axis: .vertical, alignment: .center, spacing: 2, [titleLabel, detailsLabel])
 
     private lazy var iconSizeConstraints = [
         iconView.widthAnchor.constraint(equalToConstant: 0),
@@ -86,6 +86,7 @@ final class MeHeaderView: UIView {
         stackView.axis = .horizontal
         stackView.spacing = 16
         stackView.layoutMargins = UIEdgeInsets(horizontal: 30, vertical: 6)
+        infoStackView.alignment = .leading
         setIconSize(40)
     }
 }


### PR DESCRIPTION
Fixes a small regression introduced during the iPad rework.

Before -> After

<img width="280" alt="Screenshot 2024-10-01 at 11 48 29 AM" src="https://github.com/user-attachments/assets/4c0f8bc1-c69b-4c5f-b98d-a3a8de01a0bb"> <img width="280" alt="Screenshot 2024-10-01 at 11 52 59 AM" src="https://github.com/user-attachments/assets/2478ab0a-99ae-4a89-bc39-38079f345ec4">

iPad still works:

<img width="600" alt="Screenshot 2024-10-01 at 11 53 47 AM" src="https://github.com/user-attachments/assets/939a88a9-8f33-4386-8a4b-46157ba81f84">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
