### PR TITLE
Add TipKit for Sidebar

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController.swift
@@ -56,11 +56,10 @@ final class HomeSiteHeaderViewController: UIViewController {
 
         if #available(iOS 17, *) {
             AppTips.SitePickerTip.blogCount = blog.account?.blogs.count ?? 0
-
-            if sitePickerTipObserver == nil {
+            if sitePickerTipObserver == nil, traitCollection.horizontalSizeClass == .compact {
                 sitePickerTipObserver = registerTipPopover(
                     AppTips.SitePickerTip(),
-                    sourceView: blogDetailHeaderView.titleView.siteSwitcherButton,
+                    sourceItem: blogDetailHeaderView.titleView.siteSwitcherButton,
                     arrowDirection: [.up]
                 )
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -8,6 +8,7 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
 
     private var cancellables: [AnyCancellable] = []
     private var viewContext: NSManagedObjectContext { ContextManager.shared.mainContext }
+    private var didAppear = false
 
     init(viewModel: ReaderSidebarViewModel) {
         self.viewModel = viewModel
@@ -28,6 +29,12 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
         super.viewWillAppear(animated)
 
         viewModel.onAppear()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        didAppear = true
     }
 
     func showInitialSelection() {
@@ -60,7 +67,7 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
             showSecondary(makeViewController(withTopicID: objectID))
         }
 
-        if let splitVC = splitViewController, splitVC.splitBehavior == .overlay {
+        if didAppear, let splitVC = splitViewController, splitVC.splitBehavior == .overlay {
             DispatchQueue.main.async {
                 splitVC.hide(.supplementary)
             }

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -11,6 +11,10 @@ final class SiteMenuViewController: UIViewController {
 
     weak var delegate: SiteMenuViewControllerDelegate?
 
+    private var tipObserver: TipObserver?
+    private var didAppear = false
+    private let tipAnchor = UIView()
+
     /// - warning: Temporary code. Avoid using it!
     var selectedSubsection: BlogDetailsSubsection? {
         let subsection = blogDetailsVC.selectedSubsection
@@ -42,6 +46,42 @@ final class SiteMenuViewController: UIViewController {
         blogDetailsVC.showInitialDetailsForBlog()
 
         navigationItem.title = blog.settings?.name ?? (blog.displayURL as String?) ?? ""
+    }
+
+    private func getTipAnchor() -> UIView {
+        if tipAnchor.superview != nil {
+            return tipAnchor
+        }
+        guard let navigationBar = navigationController?.navigationBar else {
+            return view // fallback
+        }
+        navigationBar.addSubview(tipAnchor)
+        tipAnchor.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tipAnchor.widthAnchor.constraint(equalToConstant: 0),
+            tipAnchor.heightAnchor.constraint(equalToConstant: 0),
+            tipAnchor.leadingAnchor.constraint(equalTo: navigationBar.safeAreaLayoutGuide.leadingAnchor, constant: 8),
+            tipAnchor.topAnchor.constraint(equalTo: navigationBar.safeAreaLayoutGuide.topAnchor, constant: 40)
+        ])
+        return tipAnchor
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if #available(iOS 17, *) {
+            if tipObserver == nil {
+                tipObserver = registerTipPopover(AppTips.SidebarTip(), sourceItem: getTipAnchor(), arrowDirection: [.up])
+            }
+        }
+
+        didAppear = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        tipObserver = nil
     }
 
     func showSubsection(_ subsection: BlogDetailsSubsection, userInfo: [AnyHashable: Any]) {
@@ -103,7 +143,8 @@ extension SiteMenuViewController: BlogDetailsPresentationDelegate {
     func presentBlogDetailsViewController(_ viewController: UIViewController) {
         delegate?.siteMenuViewController(self, showDetailsViewController: viewController)
 
-        if let splitVC = splitViewController, splitVC.splitBehavior == .overlay {
+        // didAppear prevents it from being hidden on first show
+        if didAppear, let splitVC = splitViewController, splitVC.splitBehavior == .overlay {
             DispatchQueue.main.async {
                 splitVC.hide(.supplementary)
             }

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -40,6 +40,27 @@ enum AppTips {
             MaxDisplayCount(1)
         }
     }
+
+    @available(iOS 17, *)
+    struct SidebarTip: Tip {
+        let id = "sidebar_tip"
+
+        var title: Text {
+            Text(NSLocalizedString("tips.sidebar.title", value: "Sidebar", comment: "Tip for sidebar"))
+        }
+
+        var message: Text? {
+            Text(NSLocalizedString("tips.sidebar.message", value: "Swipe right to access your sites, Reader, notifications, and profile", comment: "Tip for sidebar"))
+        }
+
+        var image: Image? {
+            Image(systemName: "sidebar.left")
+        }
+
+        var options: [any TipOption] {
+            MaxDisplayCount(1)
+        }
+    }
 }
 
 extension UIViewController {
@@ -47,7 +68,7 @@ extension UIViewController {
     @available(iOS 17, *)
     func registerTipPopover(
         _ tip: some Tip,
-        sourceView: UIView,
+        sourceItem: any UIPopoverPresentationControllerSourceItem,
         arrowDirection: UIPopoverArrowDirection? = nil,
         actionHandler: ((Tips.Action) -> Void)? = nil
     ) -> TipObserver? {
@@ -57,7 +78,7 @@ extension UIViewController {
         let task = Task { @MainActor [weak self] in
             for await shouldDisplay in tip.shouldDisplayUpdates {
                 if shouldDisplay {
-                    let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceView, actionHandler: actionHandler ?? { _ in })
+                    let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceItem, actionHandler: actionHandler ?? { _ in })
                     popoverController.view.tintColor = .secondaryLabel
                     if let arrowDirection {
                         popoverController.popoverPresentationController?.permittedArrowDirections = arrowDirection


### PR DESCRIPTION
This PR has two changes:

- Add a new tip for the sidebar for iPad and disable the previous iPhone tip for site switcher
- Fix an issue where `splitVC.hide(.supplementary)` would hide the column on app launch

<img width="400" alt="Screenshot 2024-10-01 at 1 39 35 PM" src="https://github.com/user-attachments/assets/f26e5ce4-6bd9-49af-b5c4-fa66b37a27c1">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
