### PR TITLE
Stop handling WordPress.com links in the WordPress app

### DIFF
--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -6,9 +6,6 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>webcredentials:*.wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:*.wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -8,9 +8,6 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>webcredentials:*.wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:*.wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -12,10 +12,6 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>webcredentials:*.wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:*.wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
-		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>

--- a/WordPress/WordPressTest/MediaURLExporterTests.swift
+++ b/WordPress/WordPressTest/MediaURLExporterTests.swift
@@ -31,15 +31,15 @@ class MediaURLExporterTests: XCTestCase {
         waitForExpectations(timeout: 2.0, handler: nil)
     }
 
-    func testThatURLExportingVideoWorks() {
-        exportTestVideo(removingGPS: false)
+    func testThatURLExportingVideoWorks() throws {
+        try exportTestVideo(removingGPS: false)
     }
 
     func testThatURLExportingVideoWithoutGPSWorks() throws {
-        exportTestVideo(removingGPS: true)
+        try exportTestVideo(removingGPS: true)
     }
 
-    fileprivate func exportTestVideo(removingGPS: Bool) {
+    fileprivate func exportTestVideo(removingGPS: Bool) throws {
         throw XCTSkip("This test became too flaky in iOS 18")
 
         guard let mediaPath = OHPathForFile(testDeviceVideoName, type(of: self)) else {


### PR DESCRIPTION
This PR prevents the following links from opening the WordPress app. Context: p1727802045578739-slack-C011BKNU1V5

Other than wordpress.com links, this PR also stops handling two specific URLs:
- `https://apps.wordpress.com/get`: the "Open in app" banner in wordpress.com site. See [the implementation](https://github.com/wordpress-mobile/WordPress-iOS/blob/release/25.4/WordPress/Classes/Utility/Universal%20Links/Routes%2BBanners.swift) for details.
- `https://public-api.wordpress.com/mbar`: marketing emails that are for mobile apps. See [the implementation](https://github.com/wordpress-mobile/WordPress-iOS/blob/release/25.4/WordPress/Classes/Utility/Universal%20Links/Routes%2BMbar.swift) for details.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)