### PR TITLE
Fix issue in signing into another WP.com account

### DIFF
--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -78,7 +78,7 @@ struct WordPressDotComAuthenticator {
         }
 
         do {
-            let urlSession = URLSession(configuration: .default)
+            let urlSession = URLSession.shared
             let (data, _) = try await urlSession.data(for: tokenRequest)
 
             struct Response: Decodable {

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -156,7 +156,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 {
     NSManagedObjectID * __block accountObjectID = nil;
     [self.coreDataStack.mainContext performBlockAndWait:^{
-        accountObjectID = [[WPAccount lookupDefaultWordPressComAccountInContext:self.coreDataStack.mainContext] objectID];
+        accountObjectID = [[WPAccount lookupWithUsername:remoteUser.username context:self.coreDataStack.mainContext] objectID];
     }];
 
     if (accountObjectID) {

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptsService.swift
@@ -207,7 +207,7 @@ class BloggingPromptsService {
             }
 
             // fetch the default account and fall back to default values as needed.
-            guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: mainContext) else {
+            guard let account = blogInContext?.account else {
                 return (
                     blogInContext?.dotComID,
                     remote,


### PR DESCRIPTION
This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/23644.

This PR fixes an issue with having multiple WP.com accounts in the app. Here are steps to reproduce the issue.

1. Create a self-hosted site and connect it to WP.com account A.
1. Open Jetpack app and sign in using WP.com account B.
1. Add the self-hosted site in step 1.
1. Tap "Stats" of the self-hosted site. You'll see a "Log in" button here.
1. Tap the Log in button to sign in with WP.com account A.

Expected behaviour: the app displays Stats content after successful login.

Actual behaviour: the app is kind of messed up, because it incorrectly saves the second WP.com account as the default account.

## Regression Notes
1. Potential unintended areas of impact


3. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
