### PR TITLE
Disable outdated Reader announcements 

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderAnnouncementHeaderView.swift
@@ -172,7 +172,8 @@ class ReaderAnnouncementCoordinator {
     let repository: UserPersistentRepository = UserPersistentStoreFactory.instance()
 
     var canShowAnnouncement: Bool {
-        return !isDismissed && RemoteFeatureFlag.readerAnnouncementCard.enabled()
+        false
+        // return !isDismissed && RemoteFeatureFlag.readerAnnouncementCard.enabled()
     }
 
     var isDismissed: Bool {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23650.

We might need to remove this feature entirely in `trunk` because we have many other ways to announce stuff already.

To test:

On fresh install, verify that the announcement is not shown.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
