### PR TITLE
Rename Personalize home tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
@@ -87,6 +87,6 @@ final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
 
 private extension BlogDashboardPersonalizeCardCell {
     struct Strings {
-        static let buttonTitle = NSLocalizedString("dasboard.personalizeHomeButtonTitle", value: "Personalize your home tab", comment: "Personialize home tab button title")
+        static let buttonTitle = NSLocalizedString("dasboard.personalizeHomeButton", value: "Personalize your home screen", comment: "Personialize home screen button title")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogPersonalization/BlogDashboardPersonalizationView.swift
@@ -64,7 +64,7 @@ private struct BlogDashboardPersonalizationCardCell: View {
 
 private extension BlogDashboardPersonalizationView {
     struct Strings {
-        static let title = NSLocalizedString("personalizeHome.title", value: "Personalize Home Tab", comment: "Page title")
+        static let title = NSLocalizedString("personalizeHome.navigationTitle", value: "Personalize Home Screen", comment: "Page title")
         static let quickActionSectionHeader = NSLocalizedString("personalizeHome.shortcutsSectionHeader", value: "Show or hide shortcuts", comment: "Section header for shortcuts")
         static let cardSectionHeader = NSLocalizedString("personalizeHome.cardsSectionHeader", value: "Show or hide cards", comment: "Section header")
         static let cardSectionFooter = NSLocalizedString("personalizeHome.cardsSectionFooter", value: "Cards may show different content depending on what's happening on your site. We're working on more cards and controls.", comment: "Section footer displayed below the list of toggles")


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23651.

I'm changing it in `trunk` because I"m not sure there is enough time to localize it.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
