### PR TITLE
Add a note about Feedback vs Support

### DIFF
--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -117,8 +117,14 @@ private struct SubmitFeedbackView: View {
                 }
                 .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
         }
+        Section {
+            Text(Strings.footer)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(4)
+        }
         ZendeskAttachmentsSection(viewModel: attachmentsViewModel)
-            .listRowSeparator(.hidden)
+            .listRowSeparator(.hidden, edges: .bottom)
     }
 
     private func submit() {
@@ -178,6 +184,7 @@ private enum Strings {
     static let submit = NSLocalizedString("submit.feedback.submit.button", value: "Submit", comment: "The button title for the Submit button in the In-App Feedback screen")
     static let title = NSLocalizedString("submit.feedback.title", value: "Feedback", comment: "The title for the the In-App Feedback screen")
     static let details = NSLocalizedString("submit.feedback.detailsPlaceholder", value: "Details", comment: "The section title and or placeholder")
+    static let footer = NSLocalizedString("submit.feedback.footer", value: "If you need support, please get in touch using the \"Help & Support\" screen", comment: "The footer in the Submit Feedback screen to clarify that it's not support")
 
     static let cancellationAlertTitle = NSLocalizedString("submitFeedback.cancellationAlertTitle", value: "Are you sure you want to discard the feedback", comment: "Submit feedback screen cancellation confirmation alert title")
     static let cancellationAlertContinueEditing = NSLocalizedString("submitFeedback.cancellationAlertContinueEditing", value: "Continue Editing", comment: "Submit feedback screen cancellation confirmation alert action")


### PR DESCRIPTION
This change was suggested by the HEs some time ago. The goal is to cut down on the number of feedback requests that were supposed to be support requests a bit.

<img width="320" alt="Screenshot 2024-10-03 at 10 31 04 AM" src="https://github.com/user-attachments/assets/6ba0ee97-cd23-4b09-b10e-b68dd10a024d">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
