### PR TITLE
Fix crash in TipKit

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController.swift
@@ -55,8 +55,7 @@ final class HomeSiteHeaderViewController: UIViewController {
         super.viewDidAppear(animated)
 
         if #available(iOS 17, *) {
-            AppTips.SitePickerTip.blogCount = blog.account?.blogs.count ?? 0
-            if sitePickerTipObserver == nil, traitCollection.horizontalSizeClass == .compact {
+            if sitePickerTipObserver == nil, traitCollection.horizontalSizeClass == .compact, blog.account?.blogs.isEmpty == false {
                 sitePickerTipObserver = registerTipPopover(
                     AppTips.SitePickerTip(),
                     sourceItem: blogDetailHeaderView.titleView.siteSwitcherButton,

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -29,13 +29,6 @@ enum AppTips {
             Image(systemName: "rectangle.stack.badge.plus")
         }
 
-        @Parameter(.transient)
-        static var blogCount: Int = 0
-
-        var rules: [Rule] {
-            #Rule(Self.$blogCount) { $0 > 1 }
-        }
-
         var options: [any TipOption] {
             MaxDisplayCount(1)
         }


### PR DESCRIPTION
Crash: https://a8c.sentry.io/issues/5872820860/?environment=appStore&project=5716771&query=release%3Acom.automattic.jetpack%4025.3%2B25.3.0.1&referrer=release-issue-stream

There seems to be an issue with the way parameters for tips are designed/implementd and how they interact with the `#available` check. I'm removing this code just to be safe.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
