### PR TITLE
Reader: Menu improvements

### DIFF
--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -64,17 +64,17 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
     private func configure(for selection: ReaderSidebarItem) {
         switch selection {
         case .main(let screen):
-            showSecondary(makeViewController(for: screen))
+            show(makeViewController(for: screen))
         case .allSubscriptions:
-            showSecondary(makeAllSubscriptionsViewController(), isLargeTitle: true)
+            show(makeAllSubscriptionsViewController(), isLargeTitle: true)
         case .subscription(let objectID):
-            showSecondary(makeViewController(withTopicID: objectID))
+            show(makeViewController(withTopicID: objectID))
         case .list(let objectID):
-            showSecondary(makeViewController(withTopicID: objectID))
+            show(makeViewController(withTopicID: objectID))
         case .tag(let objectID):
-            showSecondary(makeViewController(withTopicID: objectID))
+            show(makeViewController(withTopicID: objectID))
         case .organization(let objectID):
-            showSecondary(makeViewController(withTopicID: objectID))
+            show(makeViewController(withTopicID: objectID))
         }
     }
 
@@ -130,11 +130,8 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
 
     private func makeAllSubscriptionsViewController() -> UIViewController {
         let view = ReaderSubscriptionsView() { [weak self] selection in
-            guard let self else { return }
-            let navigationVC = self.splitViewController?.viewController(for: .secondary) as? UINavigationController
-            wpAssert(navigationVC != nil)
             let streamVC = ReaderStreamViewController.controllerWithTopic(selection)
-            navigationVC?.pushViewController(streamVC, animated: true)
+            self?.push(streamVC)
         }.environment(\.managedObjectContext, viewContext)
         let hostVC = UIHostingController(rootView: view)
         hostVC.title = ReaderSubscriptionsView.navigationTitle
@@ -171,7 +168,9 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         UIHostingController(rootView: EmptyStateView(SharedStrings.Error.generic, systemImage: "exclamationmark.circle"))
     }
 
-    private func showSecondary(_ viewController: UIViewController, isLargeTitle: Bool = false) {
+    /// Shows the given view controller by either displaying it in the `.secondary`
+    /// column (split view) or pushing to the navigation stack.
+    private func show(_ viewController: UIViewController, isLargeTitle: Bool = false) {
         if let splitViewController {
             let navigationVC = UINavigationController(rootViewController: viewController)
             if isLargeTitle {
@@ -180,6 +179,18 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
             splitViewController.setViewController(navigationVC, for: .secondary)
         } else {
             latestContentVC = viewController
+            mainNavigationController.pushViewController(viewController, animated: true)
+        }
+    }
+
+    /// Pushes the view controller to either the existing navigation stack in
+    /// the `.secondary` column (split view) or to the main navigation stack.
+    private func push(_ viewController: UIViewController) {
+        if let splitViewController {
+            let navigationVC = splitViewController.viewController(for: .secondary) as? UINavigationController
+            wpAssert(navigationVC != nil)
+            navigationVC?.pushViewController(viewController, animated: true)
+        } else {
             mainNavigationController.pushViewController(viewController, animated: true)
         }
     }
@@ -206,16 +217,16 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
             viewModel.selection = .allSubscriptions
         case let .post(postID, siteID, isFeed):
             viewModel.selection = nil
-            showSecondary(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
+            show(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
             viewModel.selection = nil
-            showSecondary(ReaderDetailViewController.controllerWithPostURL(url))
+            show(ReaderDetailViewController.controllerWithPostURL(url))
         case let .topic(topic):
             viewModel.selection = nil
-            showSecondary(ReaderStreamViewController.controllerWithTopic(topic))
+            show(ReaderStreamViewController.controllerWithTopic(topic))
         case let .tag(slug):
             viewModel.selection = nil
-            showSecondary(ReaderStreamViewController.controllerWithTagSlug(slug))
+            show(ReaderStreamViewController.controllerWithTagSlug(slug))
         }
     }
 

--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -40,9 +40,6 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         sidebarViewModel.isCompactStyleEnabled = true
         mainNavigationController.navigationBar.prefersLargeTitles = true
         mainNavigationController.viewControllers = [sidebar]
-//        sidebar.navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "sidebar.left"), primaryAction: UIAction { [weak self] _ in
-//            self?.mainNavigationController.popViewController(animated: true)
-//        })
         sidebar.navigationItem.backButtonDisplayMode = .minimal
         showInitialSelection()
         return mainNavigationController

--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -37,7 +37,7 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
 
     // TODO: (reader) update to allow seamless transitions between split view and tabs
     @objc func prepareForTabBarPresentation() -> UINavigationController {
-        sidebarViewModel.isCompactStyleEnabled = true
+        sidebarViewModel.isCompact = true
         mainNavigationController.navigationBar.prefersLargeTitles = true
         mainNavigationController.viewControllers = [sidebar]
         sidebar.navigationItem.backButtonDisplayMode = .minimal
@@ -135,7 +135,7 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         }.environment(\.managedObjectContext, viewContext)
         let hostVC = UIHostingController(rootView: view)
         hostVC.title = ReaderSubscriptionsView.navigationTitle
-        if sidebarViewModel.isCompactStyleEnabled {
+        if sidebarViewModel.isCompact {
             hostVC.navigationItem.largeTitleDisplayMode = .never
         }
         return hostVC

--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -136,7 +136,12 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
             let streamVC = ReaderStreamViewController.controllerWithTopic(selection)
             navigationVC?.pushViewController(streamVC, animated: true)
         }.environment(\.managedObjectContext, viewContext)
-        return UIHostingController(rootView: view)
+        let hostVC = UIHostingController(rootView: view)
+        hostVC.title = ReaderSubscriptionsView.navigationTitle
+        if sidebarViewModel.isCompactStyleEnabled {
+            hostVC.navigationItem.largeTitleDisplayMode = .never
+        }
+        return hostVC
     }
 
     private func navigate(to item: ReaderSidebarNavigation) {

--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -40,9 +40,9 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         sidebarViewModel.isCompactStyleEnabled = true
         mainNavigationController.navigationBar.prefersLargeTitles = true
         mainNavigationController.viewControllers = [sidebar]
-        sidebar.navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "sidebar.left"), primaryAction: UIAction { [weak self] _ in
-            self?.mainNavigationController.popViewController(animated: true)
-        })
+//        sidebar.navigationItem.backBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "sidebar.left"), primaryAction: UIAction { [weak self] _ in
+//            self?.mainNavigationController.popViewController(animated: true)
+//        })
         sidebar.navigationItem.backButtonDisplayMode = .minimal
         showInitialSelection()
         return mainNavigationController

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarSubscriptionsSection.swift
@@ -13,8 +13,9 @@ struct ReaderSidebarSubscriptionsSection: View {
     private var subscriptions: FetchedResults<ReaderSiteTopic>
 
     var body: some View {
-        Label(Strings.allSubscriptions, systemImage: "checkmark.rectangle.stack")
+        Label(Strings.subscriptions, systemImage: "checkmark.rectangle.stack")
             .tag(ReaderSidebarItem.allSubscriptions)
+            .listItemTint(AppColor.brand)
 
         ForEach(subscriptions, id: \.self) { site in
             Label {
@@ -44,5 +45,5 @@ struct ReaderSidebarSubscriptionsSection: View {
 }
 
 private struct Strings {
-    static let allSubscriptions = NSLocalizedString("reader.sidebar.allSubscriptions", value: "All Subscriptions", comment: "Reader sidebar button title")
+    static let subscriptions = NSLocalizedString("reader.sidebar.button.subscriptions", value: "Subscriptions", comment: "Reader sidebar button title")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarTagsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarTagsSection.swift
@@ -37,12 +37,14 @@ struct ReaderSidebarTagsSection: View {
         } label: {
             Label(Strings.addTag, systemImage: "plus.circle")
         }
+        .listItemTint(AppColor.brand)
 
         Button {
             viewModel.navigate(.discoverTags)
         } label: {
             Label(Strings.discoverTags, systemImage: "sparkle.magnifyingglass")
         }
+        .listItemTint(AppColor.brand)
     }
 
     func delete(at offsets: IndexSet) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -49,8 +49,6 @@ private struct ReaderSidebarView: View {
     @FetchRequest(sortDescriptors: [SortDescriptor(\.title, order: .forward)])
     private var teams: FetchedResults<ReaderTeamTopic>
 
-    @State private var searchText = ""
-
     var body: some View {
         list
             .toolbar {
@@ -79,7 +77,6 @@ private struct ReaderSidebarView: View {
             list
                 .listRowBackground(Color(.systemBackground))
                 .scrollContentBackground(.hidden)
-                .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: Strings.searchPlaceholder)
         } else {
             list
         }
@@ -88,8 +85,8 @@ private struct ReaderSidebarView: View {
     @ViewBuilder
     private var content: some View {
         Section {
-            let screens = allStaticScreens
-            ForEach(screens) {
+            let screens = ReaderStaticScreen.allCases
+            ForEach(ReaderStaticScreen.allCases) {
                 makePrimaryNavigationItem($0.localizedTitle, systemImage: $0.systemImage)
                     .tag(ReaderSidebarItem.main($0))
                     .lineLimit(1)
@@ -111,14 +108,6 @@ private struct ReaderSidebarView: View {
         makeSection(Strings.tags, isExpanded: $isSectionTagsExpanded) {
             ReaderSidebarTagsSection(viewModel: viewModel)
         }
-    }
-
-    private var allStaticScreens: [ReaderStaticScreen] {
-        var screens = ReaderStaticScreen.allCases
-        if viewModel.isCompactStyleEnabled, let index = screens.firstIndex(of: .search) {
-            screens.remove(at: index)
-        }
-        return screens
     }
 
     private func makePrimaryNavigationItem(_ title: String, systemImage: String) -> some View {
@@ -165,5 +154,4 @@ private struct Strings {
     static let lists = NSLocalizedString("reader.sidebar.section.lists.title", value: "Lists", comment: "Reader sidebar section title")
     static let tags = NSLocalizedString("reader.sidebar.section.tags.title", value: "Tags", comment: "Reader sidebar section title")
     static let organization = NSLocalizedString("reader.sidebar.section.organization.title", value: "Organization", comment: "Reader sidebar section title")
-    static let searchPlaceholder = NSLocalizedString("reader.sidebar.searchPlaceholder", value: "Blogs, Posts, and More", comment: "Reader sidebar search placeholder")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -89,7 +89,7 @@ enum ReaderStaticScreen: String, CaseIterable, Identifiable, Hashable {
 
     var systemImage: String {
         switch self {
-        case .recent: "newspaper"
+        case .recent: "checkmark.circle"
         case .discover: "safari"
         case .saved: "bookmark"
         case .likes: "star"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewModel.swift
@@ -11,7 +11,7 @@ final class ReaderSidebarViewModel: ObservableObject {
     private let contextManager: CoreDataStackSwift
     private var previousReloadTimestamp: Date?
 
-    @Published var isCompactStyleEnabled = false
+    @Published var isCompact = false
 
     var navigate: (ReaderSidebarNavigation) -> Void = { _ in }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -45,8 +45,6 @@ import AutomatticTracks
 
     weak var navigationMenuDelegate: ReaderNavigationMenuDelegate?
 
-    var jetpackBannerView: JetpackBannerView?
-
     private var syncHelpers: [ReaderAbstractTopic: WPContentSyncHelper] = [:]
 
     private var syncHelper: WPContentSyncHelper? {
@@ -358,7 +356,7 @@ import AutomatticTracks
         NotificationCenter.default.addObserver(self, selector: #selector(postSeenToggled(_:)), name: .ReaderPostSeenToggled, object: nil)
 
         configureCloseButtonIfNeeded()
-        setupStackView()
+        setupTableView()
         setupFooterView()
         setupContentHandler()
         setupResultsStatusView()
@@ -511,50 +509,12 @@ import AutomatticTracks
 
     // MARK: - Setup
 
-    private func setupStackView() {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-
-        setupTableView(stackView: stackView)
-        setupJetpackBanner(stackView: stackView)
-
-        view.addSubview(stackView)
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-
-    private func setupJetpackBanner(stackView: UIStackView) {
-        /// If being presented in a modal, don't show a Jetpack banner
-        if let nav = navigationController, nav.isModal() {
-            return
-        }
-
-        guard JetpackBrandingVisibility.all.enabled else {
-            return
-        }
-        let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.reader)
-        let bannerView = JetpackBannerView()
-        bannerView.configure(title: textProvider.brandingText()) { [weak self] in
-            guard let self else {
-                return
-            }
-            JetpackBrandingCoordinator.presentOverlay(from: self)
-            JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .reader)
-        }
-        jetpackBannerView = bannerView
-        addTranslationObserver(bannerView)
-        stackView.addArrangedSubview(bannerView)
-    }
-
-    private func setupTableView(stackView: UIStackView) {
+    private func setupTableView() {
         configureRefreshControl()
 
-        stackView.addArrangedSubview(tableViewController.view)
+        view.addSubview(tableViewController.view)
+        tableViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(tableViewController.view)
         tableViewController.didMove(toParent: self)
         tableConfiguration.setup(tableView)
         tableView.delegate = self

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -514,7 +514,7 @@ import AutomatticTracks
 
         view.addSubview(tableViewController.view)
         tableViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToAllEdges(tableViewController.view)
+        view.pinSubviewToSafeArea(tableViewController.view)
         tableViewController.didMove(toParent: self)
         tableConfiguration.setup(tableView)
         tableView.delegate = self

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionAddButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionAddButton.swift
@@ -12,7 +12,12 @@ struct ReaderSubscriptionAddButton: View {
 
     var body: some View {
         button.popover(isPresented: $isShowingPopover) {
-            ReaderSubscriptionAddView()
+            if #available(iOS 16.4, *) {
+                ReaderSubscriptionAddView()
+                    .presentationCompactAdaptation(.popover)
+            } else {
+                ReaderSubscriptionAddView()
+            }
         }
     }
 
@@ -62,7 +67,7 @@ private struct ReaderSubscriptionAddView: View {
         .onChange(of: siteURL) { _ in
             displayedError = nil
         }
-        .frame(width: 420)
+        .frame(idealWidth: 420)
         .interactiveDismissDisabled(!siteURL.isEmpty)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -5,6 +5,8 @@ struct ReaderSubscriptionCell: View {
 
     @State private var isShowingSettings = false
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     var onDelete: (ReaderSiteTopic) -> Void
 
     private var details: String {
@@ -66,7 +68,16 @@ struct ReaderSubscriptionCell: View {
             .frame(width: 44, alignment: .center)
         }
         .buttonStyle(.plain)
-        .popover(isPresented: $isShowingSettings) {
+        .popover(isPresented: $isShowingSettings) { settings }
+    }
+
+    @ViewBuilder
+    private var settings: some View {
+        if horizontalSizeClass == .compact {
+            ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue, isCompact: true)
+            .presentationDetents([.medium, .large])
+                .edgesIgnoringSafeArea(.all)
+        } else {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
@@ -42,7 +42,7 @@ struct ReaderSubscriptionHelper {
         NotificationCenter.default.post(name: .ReaderTopicUnfollowed, object: nil, userInfo: [ReaderNotificationKeys.topic: site])
         let service = ReaderTopicService(coreDataStack: contextManager)
         service.toggleFollowing(forSite: site, success: { _ in
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            // Do nothing
         }, failure: { _, error in
             DDLogError("Could not unfollow site: \(String(describing: error))")
             Notice(title: ReaderFollowedSitesViewController.Strings.failedToUnfollow, message: error?.localizedDescription, feedbackType: .error).post()

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsView.swift
@@ -3,16 +3,28 @@ import UIKit
 
 struct ReaderSubscriptionNotificationSettingsView: UIViewControllerRepresentable {
     let siteID: Int
+    var isCompact = false
 
-    func makeUIViewController(context: Context) -> NotificationSiteSubscriptionViewController {
-        NotificationSiteSubscriptionViewController(siteId: siteID)
+    @Environment(\.dismiss) var dismiss
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let vc = NotificationSiteSubscriptionViewController(siteId: siteID)
+        if isCompact {
+            vc.navigationItem.rightBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.done, primaryAction: .init { _ in
+                dismiss()
+            })
+            // - warning: UIKit is used to prevent the modifiers from the
+            // containing list to affect this screen/
+            return UINavigationController(rootViewController: vc)
+        }
+        return vc
     }
 
-    func updateUIViewController(_ uiViewController: NotificationSiteSubscriptionViewController, context: Context) {
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
         // Do nothing
     }
 
-    func sizeThatFits(_ proposal: ProposedViewSize, uiViewController: NotificationSiteSubscriptionViewController, context: Context) -> CGSize? {
-        return CGSize(width: 320, height: 434)
+    func sizeThatFits(_ proposal: ProposedViewSize, uiViewController: UIViewController, context: Context) -> CGSize? {
+        isCompact ? nil : CGSize(width: 320, height: 434)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionsView.swift
@@ -15,6 +15,8 @@ struct ReaderSubscriptionsView: View {
 
     @StateObject private var viewModel = ReaderSubscriptionsViewModel()
 
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
     var isShowingSearchResuts: Bool { !searchText.isEmpty }
 
     var onSelection: (_ subscription: ReaderSiteTopic) -> Void = { _ in }
@@ -129,6 +131,8 @@ struct ReaderSubscriptionsView: View {
         let ranking = StringRankedSearch(searchTerm: searchText)
         searchResults = ranking.search(in: subscriptions) { "\($0.title) \($0.siteURL)" }
     }
+
+    static var navigationTitle: String { Strings.title }
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Reader/Tags/ReaderTagsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags/ReaderTagsHelper.swift
@@ -28,7 +28,7 @@ struct ReaderTagsHelper {
     func unfollow(_ tag: ReaderTagTopic) {
         let service = ReaderTopicService(coreDataStack: contextManager)
         service.unfollowTag(tag, withSuccess: {
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            // Do nothing
         }, failure: { error in
             DDLogError("Could not unfollow topic \(tag), \(String(describing: error))")
             Notice(title: Strings.failedToUnfollow, message: error?.localizedDescription, feedbackType: .error).post()


### PR DESCRIPTION
This PR improves upon the initial implementation of the Reader menu:

- Fix "Subscriptions" screen ("Add", "Settings", etc)
- Fix an issue with subscriptions screen crashing when a site is selected
- Add separators and disclosure indicators to the make the main navigation stand out. With separators, the tap area feels much larger
- Implement search on iPhone inline. It pushes the main navigation a bit down to make it easier to reach.
- Standard primary (white) background instead of the gray-
- Add tint color to some of the actions
- Remove the “sidebar” icon (should be OK as is)
- Remove haptics when unfollowing
- Fix bottom inset in ReaderStreamVC
- Remove JetpackBanner to simplify view hierarchy (more stuff can be removed too later)
- Fix an issue with incorrect layout in "Edit" mode 
- Add selection highlight 
- Fix an issue with "Search" showing keyboard too early and breaking the menu and having choppy animations on presentation

<img width="240" alt="Screenshot 2024-10-10 at 8 19 46 AM" src="https://github.com/user-attachments/assets/773e77b4-709c-4aa0-9170-17f22569b180">
<img width="240" alt="subscriptions_add" src="https://github.com/user-attachments/assets/254591b4-2160-4e48-b712-e9b81393d5d4">
<img width="240" alt="subscriptions_edit_settings" src="https://github.com/user-attachments/assets/35def65b-30ca-4626-b9c8-550373adfcaf">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
