### PR TITLE
[Tooling] `finalize_release` lane: Add back hotfix validation and remove unused lane parameter

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,7 +126,7 @@ def release_version_next
   VERSION_FORMATTER.release_version(next_calculated_release_version)
 end
 
-def release_is_hotfix?
+def current_version_hotfix?
   # Read the current release version from the .xcconfig file and parse it into an AppVersion object
   current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
   # Calculate and return whether the release version is a hotfix

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,9 +51,6 @@ Dotenv.load(PROJECT_ENV_FILE_PATH)
 GITHUB_REPO = 'wordpress-mobile/wordpress-iOS'
 DEFAULT_BRANCH = 'trunk'
 PUBLIC_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.public.xcconfig')
-# Unfortunately, ios_current_branch_is_hotfix relies on this ENV var under the hood.
-# We can't get rid of it just yet.
-ENV['PUBLIC_CONFIG_FILE'] = PUBLIC_CONFIG_FILE
 INTERNAL_CONFIG_FILE = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.internal.xcconfig')
 ENV['FASTLANE_WWDR_USE_HTTP1_AND_RETRIES'] = 'true'
 
@@ -127,6 +124,13 @@ def release_version_next
   next_calculated_release_version = VERSION_CALCULATOR.next_release_version(version: current_version)
   # Return the formatted release version
   VERSION_FORMATTER.release_version(next_calculated_release_version)
+end
+
+def release_is_hotfix?
+  # Read the current release version from the .xcconfig file and parse it into an AppVersion object
+  current_version = VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
+  # Calculate and return whether the release version is a hotfix
+  VERSION_CALCULATOR.release_is_hotfix?(version: current_version)
 end
 
 # Returns the current build code of the app

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -232,7 +232,7 @@ platform :ios do
     UI.user_error!('Aborted by user request') unless skip_user_confirmation || UI.confirm('Do you want to continue?')
 
     generate_strings_file_for_glotpress
-    download_localized_strings_and_metadata(options)
+    download_localized_strings_and_metadata
     lint_localizations(allow_retry: skip_user_confirmation == false)
 
     bump_build_codes
@@ -381,17 +381,19 @@ platform :ios do
     end
   end
 
-  # Finalizes a release at the end of a sprint to submit to the App Store
+  # Finalizes a release at the end of a sprint to submit to the App Store, triggering the final release build on CI
   #
-  #  - Updates store metadata
-  #  - Bumps final version number
-  #  - Removes branch protection and close milestone
-  #  - Triggers the final release on CI
+  # This lane performs the following actions:
+  # - Updates store metadata
+  # - Bumps final version number
+  # - Removes branch protection and closes milestone
+  # - Triggers the final release on CI
   #
-  # @option [Boolean] skip_confirm (default: false) If true, avoids any interactive prompt
+  # @param skip_confirm [Boolean] Whether to skip confirmation prompts
   #
-  desc 'Trigger the final release build on CI'
-  lane :finalize_release do |options, skip_confirm: false|
+  lane :finalize_release do |skip_confirm: false|
+    UI.user_error!('To finalize a hotfix, please use the `finalize_hotfix_release` lane instead') if release_is_hotfix?
+
     ensure_git_branch_is_release_branch!
     ensure_git_status_clean
 
@@ -400,7 +402,7 @@ platform :ios do
 
     check_all_translations(interactive: skip_confirm == false)
 
-    download_localized_strings_and_metadata(options)
+    download_localized_strings_and_metadata
     lint_localizations(allow_retry: skip_confirm == false)
 
     bump_build_codes

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -392,7 +392,7 @@ platform :ios do
   # @param skip_confirm [Boolean] Whether to skip confirmation prompts
   #
   lane :finalize_release do |skip_confirm: false|
-    UI.user_error!('To finalize a hotfix, please use the `finalize_hotfix_release` lane instead') if release_is_hotfix?
+    UI.user_error!('To finalize a hotfix, please use the `finalize_hotfix_release` lane instead') if current_version_hotfix?
 
     ensure_git_branch_is_release_branch!
     ensure_git_status_clean


### PR DESCRIPTION
Follow up to the release backmerge #23673, where a couple of errors had to be fixed after running `finalize_release`: the lane `ios_current_branch_is_hotfix` was removed from `release-toolkit` but was still being used, and the `options` parameter  was removed while still being passed to `download_localized_strings_and_metadata` (though not used).

This PR adds back the hotfix validation and properly removes the `options` parameter.