### PR TITLE
Move using stored credentials prompt to the WP.com sign in flow

### DIFF
--- a/WordPressAuthenticator/Sources/Signin/LoginPrologueViewController.swift
+++ b/WordPressAuthenticator/Sources/Signin/LoginPrologueViewController.swift
@@ -32,11 +32,6 @@ class LoginPrologueViewController: LoginViewController {
     private let configuration = WordPressAuthenticator.shared.configuration
     private let style = WordPressAuthenticator.shared.style
 
-    private lazy var storedCredentialsAuthenticator = StoredCredentialsAuthenticator(onCancel: { [weak self] in
-        // Since the authenticator has its own flow
-        self?.tracker.resetState()
-    })
-
     /// We can't rely on `isMovingToParent` to know if we need to track the `.prologue` step
     /// because for the root view in an App, it's always `false`.  We're relying this variiable
     /// instead, since the `.prologue` step only needs to be tracked once.
@@ -116,11 +111,6 @@ class LoginPrologueViewController: LoginViewController {
         } else {
             tracker.set(step: .prologue)
         }
-
-        // Only enable auto fill if WPCom login is available
-        if configuration.enableSiteAddressLoginOnlyInPrologue == false {
-            showiCloudKeychainLoginFlow()
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -141,19 +131,6 @@ class LoginPrologueViewController: LoginViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         setButtonViewMargins(forWidth: size.width)
-    }
-
-    // MARK: - iCloud Keychain Login
-
-    /// Starts the iCloud Keychain login flow if the conditions are given.
-    ///
-    private func showiCloudKeychainLoginFlow() {
-        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-              let navigationController = navigationController else {
-                  return
-        }
-
-        storedCredentialsAuthenticator.showPicker(from: navigationController)
     }
 
     private func configureButtonVC() {

--- a/WordPressAuthenticator/Sources/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WordPressAuthenticator/Sources/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -88,6 +88,11 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
 
     private var passwordCoordinator: PasswordCoordinator?
 
+    private lazy var storedCredentialsAuthenticator = StoredCredentialsAuthenticator(onCancel: { [weak self] in
+        // Since the authenticator has its own flow
+        self?.tracker.resetState()
+    })
+
     /// Sign in with site credentials button will be displayed based on the `screenMode`
     ///
     private var screenMode: ScreenMode {
@@ -181,6 +186,21 @@ class GetStartedViewController: LoginViewController, NUXKeyboardResponder {
             registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                       keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         }
+
+        if screenMode == .signInUsingWordPressComOrSocialAccounts && isMovingToParent {
+            showiCloudKeychainLoginFlow()
+        }
+    }
+
+    /// Starts the iCloud Keychain login flow if the conditions are given.
+    ///
+    private func showiCloudKeychainLoginFlow() {
+        guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
+              let navigationController = navigationController else {
+                  return
+        }
+
+        storedCredentialsAuthenticator.showPicker(from: navigationController)
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/23675.

When launching the app without logging in, the app immediately prompts for sign in to WP.com using a stored credential. This PR moves the prompt to the "Get Started" screen, which is the screen after user taps "Continue with WP.com"

The main reason for this change is that the prompt is not applicable for the web login flow (https://github.com/wordpress-mobile/WordPress-iOS/pull/23675). But we can't simply disable it because the web login flow will be hidden behind a remote feature toggle.

Also, it _feels_ more appropriate to prompt for a WP.com sign-in _after_ user selects "Continue with WP.com".

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
