### PR TITLE
Revert split view changes

### DIFF
--- a/WordPress/Classes/System/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter.swift
@@ -342,19 +342,9 @@ extension SplitViewRootPresenter: UISplitViewControllerDelegate {
 
     // TODO: refactor this
     func splitViewControllerDidCollapse(_ svc: UISplitViewController) {
-        let mainContext = ContextManager.shared.mainContext
         switch sidebarViewModel.selection {
-        case .blog(let objectID):
-            guard let blog = try? mainContext.existingObject(with: objectID) else {
-                return
-            }
-            if let navigationVC = svc.viewController(for: .supplementary) as? UINavigationController,
-               let menuVC = navigationVC.viewControllers.first as? SiteMenuViewController,
-               let subsection = menuVC.selectedSubsection, subsection != .home {
-                tabBarVC.showBlogDetails(for: blog, then: subsection, userInfo: [:])
-            } else {
-                tabBarVC.showBlogDetails(for: blog)
-            }
+        case .blog:
+            break
         case .reader:
             if let selection = readerContent?.sidebar.viewModel.selection {
                 switch selection {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -89,9 +89,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 @property (nonatomic) BOOL showsDisclosureIndicator;
 @property (nonatomic, copy, nullable) void (^callback)(void);
 
-/// - warning: This property is not specified for every row.
-@property (nonatomic, readonly) BlogDetailsSubsection subsection;
-
 - (instancetype _Nonnull)initWithTitle:(NSString * __nonnull)title
                             identifier:(NSString * __nonnull)identifier
                accessibilityIdentifier:(NSString *__nullable)accessibilityIdentifier
@@ -118,8 +115,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
                          renderingMode:(UIImageRenderingMode)renderingMode
                               callback:(void(^_Nullable)(void))callback;
 
-- (BlogDetailsRow * _Nonnull)withSubsection:(BlogDetailsSubsection)subsection;
-
 @end
 
 @protocol ScenePresenter;
@@ -139,9 +134,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 /// A new display mode for the displaying it as part of the site menu.
 @property (nonatomic) BOOL isSidebarModeEnabled;
-
-/// - warning: A temporary solution for restoring selection on iPad – imprecise!
-@property (nonatomic, readonly) BlogDetailsSubsection selectedSubsection;
 
 - (id _Nonnull)init;
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -123,7 +123,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
                          image:image
                       callback:callback];
 }
-    
+
 - (instancetype)initWithTitle:(NSString *)title
       accessibilityIdentifier:(NSString *)accessibilityIdentifier
                         image:(UIImage *)image
@@ -195,13 +195,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
         _accessibilityHint = accessibilityHint;
         _showsSelectionState = YES;
         _showsDisclosureIndicator = YES;
-        _subsection = NSNotFound;
     }
-    return self;
-}
-
-- (BlogDetailsRow *)withSubsection:(BlogDetailsSubsection)subsection {
-    _subsection = subsection;
     return self;
 }
 
@@ -260,18 +254,18 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 - (instancetype)init
 {
     self = [super init];
-    
+
     if (self) {
         self.isScrollEnabled = false;
     }
-    
+
     return self;
 }
 
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     if (self.isSidebarModeEnabled) {
         _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     } else if (self.isScrollEnabled) {
@@ -289,7 +283,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     }
     [self.view addSubview:self.tableView];
     [self.view pinSubviewToAllEdges:self.tableView];
-    
+
     UIRefreshControl *refreshControl = [UIRefreshControl new];
     [refreshControl addTarget:self action:@selector(pulledToRefresh) forControlEvents:UIControlEventValueChanged];
     self.tableView.refreshControl = refreshControl;
@@ -359,7 +353,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
         [WPAnalytics trackEvent:WPAnalyticsEventJetpackInstallFullPluginCardViewed
                      properties:@{WPAppAnalyticsKeyTabSource: @"site_menu"}];
     }
-    
+
     if ([self shouldShowBlaze]) {
         [BlazeEventsTracker trackEntryPointDisplayedFor:BlazeSourceMenuItem];
     }
@@ -396,7 +390,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     [self reloadTableViewPreservingSelection];
 }
 
-- (void)showDetailViewForSubsection:(BlogDetailsSubsection)section 
+- (void)showDetailViewForSubsection:(BlogDetailsSubsection)section
 {
     [self showDetailViewForSubsection:section userInfo:@{}];
 }
@@ -646,16 +640,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     return _siteIconPickerPresenter;
 }
 
-- (BlogDetailsSubsection)selectedSubsection {
-    NSIndexPath *indexPath = self.tableView.indexPathForSelectedRow;
-    if (!indexPath) {
-        return NSNotFound;
-    }
-    BlogDetailsSection *section = [self.tableSections objectAtIndex:indexPath.section];
-    BlogDetailsRow *row = [section.rows objectAtIndex:indexPath.row];
-    return row.subsection;
-}
-
 #pragma mark - iOS 10 bottom padding
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)sectionNum {
@@ -700,59 +684,59 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 - (BlogDetailsRow *)postsRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Posts", @"Noun. Title. Links to the blog's Posts screen.")
-                                         accessibilityIdentifier:@"Blog Post Row"
-                                                           image:[[UIImage imageNamed:@"site-menu-posts"] imageFlippedForRightToLeftLayoutDirection]
-                                                        callback:^{
-         [weakSelf showPostListFromSource:BlogDetailsNavigationSourceRow];
-     }] withSubsection:BlogDetailsSubsectionPosts];
+    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Posts", @"Noun. Title. Links to the blog's Posts screen.")
+                                        accessibilityIdentifier:@"Blog Post Row"
+                                                          image:[[UIImage imageNamed:@"site-menu-posts"] imageFlippedForRightToLeftLayoutDirection]
+                                                       callback:^{
+        [weakSelf showPostListFromSource:BlogDetailsNavigationSourceRow];
+    }];
     return row;
 }
 
 - (BlogDetailsRow *)pagesRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
-                                         accessibilityIdentifier:@"Site Pages Row"
-                                                           image:[UIImage imageNamed:@"site-menu-pages"]
-                                                        callback:^{
-         [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
-    }] withSubsection:BlogDetailsSubsectionPages];
+    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
+                                        accessibilityIdentifier:@"Site Pages Row"
+                                                          image:[UIImage imageNamed:@"site-menu-pages"]
+                                                       callback:^{
+        [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
+    }];
     return row;
 }
 
 - (BlogDetailsRow *)mediaRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
-                                         accessibilityIdentifier:@"Media Row"
-                                                           image:[UIImage imageNamed:@"site-menu-media"]
-                                                        callback:^{
-         [weakSelf showMediaLibraryFromSource:BlogDetailsNavigationSourceRow];
-     }] withSubsection:BlogDetailsSubsectionMedia];
+    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
+                                        accessibilityIdentifier:@"Media Row"
+                                                          image:[UIImage imageNamed:@"site-menu-media"]
+                                                       callback:^{
+        [weakSelf showMediaLibraryFromSource:BlogDetailsNavigationSourceRow];
+    }];
     return row;
 }
 
 - (BlogDetailsRow *)commentsRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *row = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
-                                                           image:[[UIImage imageNamed:@"site-menu-comments"] imageFlippedForRightToLeftLayoutDirection]
-                                                        callback:^{
-         [weakSelf showCommentsFromSource:BlogDetailsNavigationSourceRow];
-     }] withSubsection:BlogDetailsSubsectionComments];
+    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
+                                                          image:[[UIImage imageNamed:@"site-menu-comments"] imageFlippedForRightToLeftLayoutDirection]
+                                                       callback:^{
+        [weakSelf showCommentsFromSource:BlogDetailsNavigationSourceRow];
+    }];
     return row;
 }
 
 - (BlogDetailsRow *)statsRow
 {
     __weak __typeof(self) weakSelf = self;
-    BlogDetailsRow *statsRow = [[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
-                                              accessibilityIdentifier:@"Stats Row"
-                                                                image:[UIImage imageNamed:@"site-menu-stats"]
-                                                             callback:^{
-         [weakSelf showStatsFromSource:BlogDetailsNavigationSourceRow];
-     }] withSubsection:BlogDetailsSubsectionStats];
+    BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
+                                             accessibilityIdentifier:@"Stats Row"
+                                                               image:[UIImage imageNamed:@"site-menu-stats"]
+                                                            callback:^{
+        [weakSelf showStatsFromSource:BlogDetailsNavigationSourceRow];
+    }];
     return statsRow;
 }
 
@@ -1040,7 +1024,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     if ([self.blog supports:BlogFeatureRemovable]) {
         [marr addNullableObject:[self removeSiteSectionViewModel]];
     }
-    
+
     if (self.shouldShowBottomJetpackBrandingMenuCard == YES) {
         [marr addNullableObject:[self jetpackCardSectionViewModel]];
     }
@@ -1185,13 +1169,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    
-    [rows addObject:[[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
+
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
                                   accessibilityIdentifier:@"Home Row"
                                                     image:[UIImage imageNamed:@"site-menu-home"]
                                                  callback:^{
                                                     [weakSelf showDashboard];
-    }] withSubsection: BlogDetailsSubsectionHome]];
+                                                 }]];
 
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows category:BlogDetailsSectionCategoryHome];
 }
@@ -1200,7 +1184,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    
+
     if ([self.blog isViewingStatsAllowed]) {
         [rows addObject:[self statsRow]];
     }
@@ -1212,7 +1196,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
                                                          [weakSelf showActivity];
                                                      }]];
     }
-    
+
     if ([self shouldShowBlaze]) {
         [rows addObject:[self blazeRow]];
     }
@@ -1233,7 +1217,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     if (rows.count == 0) {
         return nil;
     }
-    
+
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows category:BlogDetailsSectionCategoryGeneral];
 }
 
@@ -1241,7 +1225,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    
+
     if ([self.blog isViewingStatsAllowed]) {
         [rows addObject:[self statsRow]];
     }
@@ -1285,7 +1269,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 
         [rows addObject:settingsRow];
     }
-    
+
     if ([self shouldShowBlaze]) {
         [rows addObject:[self blazeRow]];
     }
@@ -1345,7 +1329,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    
+
     if ([self shouldAddMeRow]) {
         BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Me", @"Noun. Title. Links to the Me screen.")
                                         image:[UIImage gridiconOfType:GridiconTypeUserCircle]
@@ -1660,9 +1644,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 #pragma mark - Private methods
 
 - (void)trackEvent:(WPAnalyticsStat)event fromSource:(BlogDetailsNavigationSource)source {
-    
+
     NSString *sourceString = [self propertiesStringForSource:source];
-    
+
     [WPAppAnalytics track:event withProperties:@{WPAppAnalyticsKeyTapSource: sourceString, WPAppAnalyticsKeyTabSource: @"site_menu"} withBlog:self.blog];
 }
 
@@ -1956,7 +1940,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 - (void)showViewSiteFromSource:(BlogDetailsNavigationSource)source
 {
     [self trackEvent:WPAnalyticsStatOpenedViewSite fromSource:source];
-    
+
     NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
 
     UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL
@@ -2033,7 +2017,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     if ([AppConfiguration isWordPress]) {
         [ContentMigrationCoordinator.shared cleanupExportedDataIfNeeded];
     }
-    
+
     // Delete local data after removing the last site
     if (!AccountHelper.isLoggedIn) {
         [AccountHelper deleteAccountData];

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -15,12 +15,6 @@ final class SiteMenuViewController: UIViewController {
     private var didAppear = false
     private let tipAnchor = UIView()
 
-    /// - warning: Temporary code. Avoid using it!
-    var selectedSubsection: BlogDetailsSubsection? {
-        let subsection = blogDetailsVC.selectedSubsection
-        return subsection.rawValue == NSNotFound ? nil : subsection
-    }
-
     init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23686 and crash https://a8c.sentry.io/issues/5994956486/?project=5716771&query=release%3Acom.automattic.jetpack%4025.4%2B25.4.0.5&referrer=release-issue-stream.

This PR removes the buggy workaround introduced to implement partial Split View support. It's too risky to keep it because there might be causing more issues we don't know about.

## To test:

- Verify that https://github.com/wordpress-mobile/WordPress-iOS/issues/23686 no longer reproduces (see steps)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
