### PR TITLE
Add support for opening detail for individual posts in Stats / Authors

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -567,13 +567,25 @@ private extension SiteStatsPeriodViewModel {
     func authorsDataRows() -> [StatsTotalRowData] {
         let authors = store.getTopAuthors()?.topAuthors.prefix(10) ?? []
 
-        return authors.map { StatsTotalRowData(name: $0.name,
-                                               data: $0.viewsCount.abbreviatedString(),
-                                               dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
-                                               userIconURL: $0.iconURL,
-                                               showDisclosure: true,
-                                               childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
-                                               statSection: .periodAuthors)
+        return authors.map {
+            StatsTotalRowData(
+                name: $0.name,
+                data: $0.viewsCount.abbreviatedString(),
+                dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
+                userIconURL: $0.iconURL,
+                showDisclosure: true,
+                childRows: $0.posts.map {
+                    StatsTotalRowData(
+                        name: $0.title,
+                        data: $0.viewsCount.abbreviatedString(),
+                        postID: $0.postID,
+                        showDisclosure: true,
+                        disclosureURL: $0.postURL,
+                        statSection: .periodAuthors
+                    )
+                },
+                statSection: .periodAuthors
+            )
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -446,7 +446,7 @@ private extension StatsTotalRow {
 
         if let disclosureURL = rowData?.disclosureURL {
             if let statSection = rowData?.statSection,
-               statSection == .periodPostsAndPages {
+               statSection == .periodPostsAndPages || statSection == .periodAuthors {
                 guard let postID = rowData?.postID else {
                     DDLogInfo("No postID available to show Post Stats.")
                     return


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23684

To test:

The "Authors" section in "Traffic" now shows disclosure for individual posts and you can tap to see the post stats.

<img src="https://github.com/user-attachments/assets/7e66eed2-4447-49ad-a470-ac9ea2227ed9" width="320px">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
