### PR TITLE
Reader: Minor Improvements

### DIFF
--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -143,7 +143,11 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         case .addTag:
             let addTagVC = UIHostingController(rootView: ReaderTagsAddTagView())
             addTagVC.modalPresentationStyle = .formSheet
-            addTagVC.preferredContentSize = CGSize(width: 420, height: 124)
+            let preferredHeight: CGFloat = 124
+            addTagVC.sheetPresentationController?.detents = [.custom(resolver: { _ in
+                preferredHeight
+            })]
+            addTagVC.preferredContentSize = CGSize(width: 420, height: preferredHeight)
             sidebar.present(addTagVC, animated: true, completion: nil)
         case .discoverTags:
             let tags = viewContext.allObjects(

--- a/WordPress/Classes/Utility/Media/ImageView.swift
+++ b/WordPress/Classes/Utility/Media/ImageView.swift
@@ -19,6 +19,9 @@ final class ImageView: UIView {
     var isErrorViewEnabled = true
     var loadingStyle = LoadingStyle.background
 
+    /// The background color to use when the image is loaded.
+    var successBackgroundColor = UIColor.clear
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -69,7 +72,7 @@ final class ImageView: UIView {
         case .success(let image):
             imageView.configure(image: image)
             imageView.isHidden = false
-            backgroundColor = .clear
+            backgroundColor = successBackgroundColor
         case .failure:
             if isErrorViewEnabled {
                 makeErrorView().isHidden = false

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -27,5 +27,7 @@ enum SharedStrings {
 
     enum Reader {
         static let unfollow = NSLocalizedString("reader.button.unfollow", value: "Unfollow", comment: "Reader sidebar button title")
+        static let recent = NSLocalizedString("reader.recent.title", value: "Recent", comment: "Used in multiple contexts, usually as a screen title")
+        static let discover = NSLocalizedString("reader.discover.title", value: "Discover", comment: "Used in multiple contexts, usually as a screen title")
     }
 }

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -29,5 +29,7 @@ enum SharedStrings {
         static let unfollow = NSLocalizedString("reader.button.unfollow", value: "Unfollow", comment: "Reader sidebar button title")
         static let recent = NSLocalizedString("reader.recent.title", value: "Recent", comment: "Used in multiple contexts, usually as a screen title")
         static let discover = NSLocalizedString("reader.discover.title", value: "Discover", comment: "Used in multiple contexts, usually as a screen title")
+        static let saved = NSLocalizedString("reader.saved.title", value: "Saved", comment: "Used in multiple contexts, usually as a screen title")
+        static let likes = NSLocalizedString("reader.likes.title", value: "Likes", comment: "Used in multiple contexts, usually as a screen title")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDiscoverHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDiscoverHeaderView.swift
@@ -5,7 +5,7 @@ protocol ReaderDiscoverHeaderViewDelegate: AnyObject {
 }
 
 final class ReaderDiscoverHeaderView: UIView, UITextViewDelegate {
-    private let titleView = ReaderStreamTitleView()
+    private let titleView = ReaderStreamTitleView(insets: nil)
     private let channelsStackView = UIStackView(spacing: 8, [])
     private var channelViews: [ReaderDiscoverChannelView] = []
 
@@ -25,7 +25,7 @@ final class ReaderDiscoverHeaderView: UIView, UITextViewDelegate {
 
         let stackView = UIStackView(axis: .vertical, spacing: 8, [titleView, scrollView])
         addSubview(stackView)
-        stackView.pinEdges(insets: UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16))
+        stackView.pinEdges(insets: ReaderStreamTitleView.preferredInsets)
 
         titleView.titleLabel.text = Strings.title
         titleView.detailsTextView.attributedText = {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDiscoverHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDiscoverHeaderView.swift
@@ -27,7 +27,7 @@ final class ReaderDiscoverHeaderView: UIView, UITextViewDelegate {
         addSubview(stackView)
         stackView.pinEdges(insets: ReaderStreamTitleView.preferredInsets)
 
-        titleView.titleLabel.text = Strings.title
+        titleView.titleLabel.text = SharedStrings.Reader.discover
         titleView.detailsTextView.attributedText = {
             guard let details = try? NSMutableAttributedString(markdown: Strings.details) else {
                 return nil
@@ -204,7 +204,6 @@ enum ReaderDiscoverChannel: Hashable {
 }
 
 private enum Strings {
-    static let title = NSLocalizedString("reader.discover.header.title", value: "Discover", comment: "Header view title")
     static let details = NSLocalizedString("reader.discover.header.title", value: "Explore popular blogs that inspire, educate, and entertain based on your [interests](/interests).", comment: "Reader Discover header view details label. The text has a Markdown URL: [interests](/interests). Only the text in the square brackets needs to be translated: [<translate_this>](/interests).")
     static let editInterests = NSLocalizedString("reader.editInterests.title", value: "Edit Interests", comment: "Screen title")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDiscoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDiscoverViewController.swift
@@ -93,7 +93,7 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
 
         if FeatureFlag.readerReset.enabled {
             // Important to set before `viewDidLoad`
-            streamVC.isReaderResetDiscoverEnabled = true
+            streamVC.isEmbeddedInDiscover = true
             streamVC.setHeaderView(headerView)
         }
 
@@ -101,6 +101,8 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
         view.addSubview(streamVC.view)
         streamVC.view.pinEdges()
         streamVC.didMove(toParent: self)
+
+        navigationItem.titleView = streamVC.navigationItem.titleView // important
     }
 
     /// TODO: (tech-debt) the app currently stores the responses from the `/discover`

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCell.swift
@@ -299,6 +299,11 @@ private final class ReaderPostCellView: UIView {
             imageView.setImage(with: imageURL)
         }
 
+        configureToolbar(with: viewModel.toolbar)
+        configureToolbarAccessibility(with: viewModel.toolbar)
+    }
+
+    private func configureToolbar(with viewModel: ReaderPostToolbarViewModel) {
         buttons.bookmark.configuration = {
             var configuration = buttons.bookmark.configuration ?? .plain()
             configuration.image = UIImage(systemName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
@@ -320,8 +325,6 @@ private final class ReaderPostCellView: UIView {
                 return configuration
             }()
         }
-
-        configureAccessibility(with: viewModel)
     }
 
     private func setAvatar(with viewModel: ReaderPostCellViewModel) {
@@ -401,7 +404,7 @@ private extension ReaderPostCellView {
         buttons.like.accessibilityIdentifier = "reader-like-button"
     }
 
-    func configureAccessibility(with viewModel: ReaderPostCellViewModel) {
+    func configureToolbarAccessibility(with viewModel: ReaderPostToolbarViewModel) {
         buttons.bookmark.accessibilityLabel = viewModel.isBookmarked ? NSLocalizedString("reader.post.buttonRemoveBookmark.accessibilityLint", value: "Remove bookmark", comment: "Button accessibility label") : NSLocalizedString("reader.post.buttonBookmark.accessibilityLabel", value: "Bookmark", comment: "Button accessibility label")
         buttons.reblog.accessibilityLabel = NSLocalizedString("reader.post.buttonReblog.accessibilityLabel", value: "Reblog", comment: "Button accessibility label")
         buttons.comment.accessibilityLabel = {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCell.swift
@@ -132,6 +132,9 @@ private final class ReaderPostCellView: UIView {
     private func setupStyle() {
         avatarView.layer.cornerRadius = ReaderPostCell.avatarSize / 2
         avatarView.layer.masksToBounds = true
+        avatarView.successBackgroundColor = UIColor.white
+        avatarView.layer.borderWidth = 0.5
+        avatarView.layer.borderColor = UIColor.opaqueSeparator.withAlphaComponent(0.5).cgColor
         avatarView.isErrorViewEnabled = false
 
         buttonAuthor.maximumContentSizeCategory = .accessibilityLarge

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellViewModel.swift
@@ -12,12 +12,7 @@ final class ReaderPostCellViewModel {
     let imageURL: URL?
 
     // Footer (Buttons)
-    let isBookmarked: Bool
-    let isCommentsEnabled: Bool
-    let commentCount: Int
-    let isLikesEnabled: Bool
-    let likeCount: Int
-    let isLiked: Bool
+    let toolbar: ReaderPostToolbarViewModel
 
     weak var viewController: ReaderStreamViewController?
 
@@ -32,7 +27,6 @@ final class ReaderPostCellViewModel {
         self.post = post
 
         let isP2 = (topic as? ReaderSiteTopic)?.isP2Type == true
-
         if isP2 {
             self.author = post.authorDisplayName ?? ""
         } else {
@@ -42,15 +36,7 @@ final class ReaderPostCellViewModel {
         self.title = post.titleForDisplay() ?? ""
         self.details = post.contentPreviewForDisplay() ?? ""
         self.imageURL = post.featuredImageURLForDisplay()
-
-        self.isBookmarked = post.isSavedForLater
-
-        self.isCommentsEnabled = post.isCommentsEnabled
-        self.commentCount = post.commentCount?.intValue ?? 0
-
-        self.isLikesEnabled = post.isLikesEnabled()
-        self.likeCount = post.likeCount?.intValue ?? 0
-        self.isLiked = post.isLiked()
+        self.toolbar = ReaderPostToolbarViewModel.make(post: post)
 
         if isP2 {
             self.avatarURL = post.authorAvatarURL.flatMap(URL.init)
@@ -75,12 +61,14 @@ final class ReaderPostCellViewModel {
         self.title = "Discovering the Wonders of the Wild"
         self.details = "Lorem ipsum dolor sit amet. Non omnis quia et natus voluptatum et eligendi voluptate vel iusto fuga sit repellendus molestiae aut voluptatem blanditiis ad neque sapiente. Id galisum distinctio quo enim aperiam non veritatis vitae et ducimus rerum."
         self.imageURL = URL(string: "https://picsum.photos/1260/630.jpg")
-        self.isBookmarked = false
-        self.isLikesEnabled = true
-        self.likeCount = 9000
-        self.isCommentsEnabled = true
-        self.commentCount = 213
-        self.isLiked = true
+        self.toolbar = ReaderPostToolbarViewModel(
+            isBookmarked: false,
+            isCommentsEnabled: true,
+            commentCount: 9000,
+            isLikesEnabled: true,
+            likeCount: 213,
+            isLiked: true
+        )
     }
 
     static func mock() -> ReaderPostCellViewModel {
@@ -111,5 +99,25 @@ final class ReaderPostCellViewModel {
 
     func toggleLike() {
         ReaderLikeAction().execute(with: post)
+    }
+}
+
+struct ReaderPostToolbarViewModel {
+    let isBookmarked: Bool
+    let isCommentsEnabled: Bool
+    let commentCount: Int
+    let isLikesEnabled: Bool
+    let likeCount: Int
+    let isLiked: Bool
+
+    static func make(post: ReaderPost) -> ReaderPostToolbarViewModel {
+        ReaderPostToolbarViewModel(
+            isBookmarked: post.isSavedForLater,
+            isCommentsEnabled: post.isCommentsEnabled,
+            commentCount: post.commentCount?.intValue ?? 0,
+            isLikesEnabled: post.isLikesEnabled(),
+            likeCount: post.likeCount?.intValue ?? 0,
+            isLiked: post.isLiked()
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarSubscriptionsSection.swift
@@ -18,7 +18,6 @@ struct ReaderSidebarSubscriptionsSection: View {
                 Text(site.title)
             } icon: {
                 SiteIconView(viewModel: SiteIconViewModel(readerSiteTopic: site, size: .small))
-                    .environment(\.siteIconBackgroundColor, Color(.systemBackground))
                     .frame(width: 28, height: 28)
             }
             .lineLimit(1)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -161,7 +161,7 @@ private struct ReaderSidebarSection<Content: View>: View {
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.secondary)
                     Spacer()
-                    Image(systemName: "chevron.down")
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
                         .font(.system(size: 14).weight(.semibold))
                         .foregroundStyle(AppColor.brand)
                 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -108,6 +108,7 @@ private struct ReaderSidebarView: View {
         }
         makeSection(Strings.lists, isExpanded: $isSectionListsExpanded) {
             ReaderSidebarListsSection(viewModel: viewModel)
+                .environment(\.siteIconBackgroundColor, Color(viewModel.isCompact ? .secondarySystemBackground : .systemBackground))
         }
         makeSection(Strings.tags, isExpanded: $isSectionTagsExpanded) {
             ReaderSidebarTagsSection(viewModel: viewModel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteHeaderView.swift
@@ -94,7 +94,7 @@ struct ReaderSiteHeader: View {
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text(viewModel.title)
-                    .font(Font(WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)))
+                    .font(Font(WPStyleGuide.fontForTextStyle(.title1, fontWeight: .semibold)))
                 Text(viewModel.siteUrl)
                     .font(.subheadline)
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
@@ -22,18 +22,16 @@ final class ReaderStreamTitleView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    static let preferredInsets = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16)
+    static let preferredInsets = UIEdgeInsets(top: 4, left: 16, bottom: 8, right: 16)
 }
 
 extension ReaderStreamTitleView {
     static func makeForFollowing() -> ReaderStreamTitleView {
         let view = ReaderStreamTitleView()
-        view.titleLabel.text = Strings.followingTitle
+        view.titleLabel.text = SharedStrings.Reader.recent
         view.detailsTextView.text = Strings.followingDetails
         return view
     }
-
-    static var followingTitle: String { Strings.followingTitle }
 }
 
 final class ReaderNavigationCustomTitleView: UIView {
@@ -68,6 +66,5 @@ final class ReaderNavigationCustomTitleView: UIView {
 }
 
 private enum Strings {
-    static let followingTitle = NSLocalizedString("reader.following.header.title", value: "Following", comment: "Screen header title")
     static let followingDetails = NSLocalizedString("reader.following.header.details", value: "Stay current with the blogs you've subscribed to.", comment: "Screen header details")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
@@ -6,14 +6,14 @@ final class ReaderStreamTitleView: UIView {
     let titleLabel = UILabel()
     let detailsTextView = UITextView.makeLabel()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(insets: UIEdgeInsets? = ReaderStreamTitleView.preferredInsets) {
+        super.init(frame: .zero)
 
         titleLabel.font = UIFont.preferredFont(forTextStyle: .largeTitle).withWeight(.bold)
         detailsTextView.font = UIFont.preferredFont(forTextStyle: .subheadline)
         detailsTextView.textColor = .secondaryLabel
 
-        let stackView = UIStackView(axis: .vertical, alignment: .leading, [titleLabel, detailsTextView])
+        let stackView = UIStackView(axis: .vertical, alignment: .leading, insets: insets, [titleLabel, detailsTextView])
         addSubview(stackView)
         stackView.pinEdges()
     }
@@ -21,4 +21,20 @@ final class ReaderStreamTitleView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    static let preferredInsets = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16)
+}
+
+extension ReaderStreamTitleView {
+    static func makeForFollowing() -> ReaderStreamTitleView {
+        let view = ReaderStreamTitleView()
+        view.titleLabel.text = Strings.followingTitle
+        view.detailsTextView.text = Strings.followingDetails
+        return view
+    }
+}
+
+private enum Strings {
+    static let followingTitle = NSLocalizedString("reader.following.header.title", value: "Following", comment: "Screen header title")
+    static let followingDetails = NSLocalizedString("reader.following.header.details", value: "Stay current with the blogs you've subscribed to", comment: "Screen header details")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
@@ -69,5 +69,5 @@ final class ReaderNavigationCustomTitleView: UIView {
 
 private enum Strings {
     static let followingTitle = NSLocalizedString("reader.following.header.title", value: "Following", comment: "Screen header title")
-    static let followingDetails = NSLocalizedString("reader.following.header.details", value: "Stay current with the blogs you've subscribed to", comment: "Screen header details")
+    static let followingDetails = NSLocalizedString("reader.following.header.details", value: "Stay current with the blogs you've subscribed to.", comment: "Screen header details")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamTitleView.swift
@@ -32,6 +32,39 @@ extension ReaderStreamTitleView {
         view.detailsTextView.text = Strings.followingDetails
         return view
     }
+
+    static var followingTitle: String { Strings.followingTitle }
+}
+
+final class ReaderNavigationCustomTitleView: UIView {
+    let textLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        textLabel.font = WPStyleGuide.navigationBarStandardFont
+        textLabel.alpha = 0
+
+        // The label has to be a subview of the title view because
+        // navigation bar doesn't seem to allow you to change the alpha
+        // of `navigationItem.titleView` itself.
+        addSubview(textLabel)
+        textLabel.pinEdges()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateAlpha(in scrollView: UIScrollView) {
+        let offsetY = scrollView.contentOffset.y
+        if offsetY < 16 {
+            textLabel.alpha = 0
+        } else {
+            let alpha = (offsetY - 16) / 24
+            textLabel.alpha = max(0, min(1, alpha))
+        }
+    }
 }
 
 private enum Strings {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Ghost.swift
@@ -11,7 +11,7 @@ extension ReaderStreamViewController {
 
         ghostableTableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(ghostableTableView)
-        if isReaderResetDiscoverEnabled {
+        if isEmbeddedInDiscover {
             NSLayoutConstraint.activate([
                 ghostableTableView.topAnchor.constraint(equalTo: tableView.tableHeaderView?.bottomAnchor ?? view.topAnchor),
                 ghostableTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -11,6 +11,11 @@ extension ReaderStreamViewController {
     }
 
     func headerForStream(_ topic: ReaderAbstractTopic?, isLoggedIn: Bool, container: UITableViewController) -> UIView? {
+        if FeatureFlag.readerReset.enabled, let topic {
+            if ReaderHelpers.topicIsFollowing(topic) {
+                return ReaderStreamTitleView.makeForFollowing()
+            }
+        }
         if let topic,
            let header = headerForStream(topic) {
             configure(header, topic: topic, isLoggedIn: isLoggedIn, delegate: self)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -716,6 +716,10 @@ import AutomatticTracks
 
     /// Scrolls to the top of the list of posts.
     @objc func scrollViewToTop() {
+        guard !FeatureFlag.readerReset.enabled else {
+            return
+        }
+
         navigationMenuDelegate?.didScrollToTop()
         guard tableView.numberOfRows(inSection: .zero) > 0 else {
             tableView.setContentOffset(.zero, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -107,6 +107,7 @@ import AutomatticTracks
     private var indexPathForGapMarker: IndexPath?
     private var didSetupView = false
     private var didBumpStats = false
+    @Lazy private var titleView = ReaderNavigationCustomTitleView()
     internal let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     /// Content management
@@ -637,6 +638,14 @@ import AutomatticTracks
             title = ""
         } else {
             title = topic.title
+        }
+
+        if FeatureFlag.readerReset.enabled {
+            if ReaderHelpers.topicIsFollowing(topic) {
+                title = ReaderStreamTitleView.followingTitle
+                titleView.textLabel.text = ReaderStreamTitleView.followingTitle
+                navigationItem.titleView = titleView
+            }
         }
     }
 
@@ -2074,6 +2083,8 @@ extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate 
 
         let velocity = tableView.panGestureRecognizer.velocity(in: tableView)
         navigationMenuDelegate?.scrollViewDidScroll(scrollView, velocity: velocity)
+
+        $titleView.value?.updateAlpha(in: scrollView)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -646,15 +646,9 @@ import AutomatticTracks
     }
 
     private func configureCustomTitleView(for topic: ReaderAbstractTopic) {
-        var title: String?
         if ReaderHelpers.topicIsFollowing(topic) {
-            title = SharedStrings.Reader.recent
-        } else if ReaderHelpers.topicIsDiscover(topic) {
-            title = SharedStrings.Reader.discover
-        }
-        if let title {
-            self.title = title
-            titleView.textLabel.text = title
+            self.title = SharedStrings.Reader.recent
+            titleView.textLabel.text = SharedStrings.Reader.recent
             navigationItem.titleView = titleView
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -641,11 +641,21 @@ import AutomatticTracks
         }
 
         if FeatureFlag.readerReset.enabled {
-            if ReaderHelpers.topicIsFollowing(topic) {
-                title = ReaderStreamTitleView.followingTitle
-                titleView.textLabel.text = ReaderStreamTitleView.followingTitle
-                navigationItem.titleView = titleView
-            }
+            configureCustomTitleView(for: topic)
+        }
+    }
+
+    private func configureCustomTitleView(for topic: ReaderAbstractTopic) {
+        var title: String?
+        if ReaderHelpers.topicIsFollowing(topic) {
+            title = SharedStrings.Reader.recent
+        } else if ReaderHelpers.topicIsDiscover(topic) {
+            title = SharedStrings.Reader.discover
+        }
+        if let title {
+            self.title = title
+            titleView.textLabel.text = title
+            navigationItem.titleView = titleView
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -651,17 +651,18 @@ import AutomatticTracks
 
     private func configureNavigationTitle(for topic: ReaderAbstractTopic) {
         func setCustomTitleView(_ title: String) {
+            self.title = title
             titleView.textLabel.text = title
             navigationItem.titleView = titleView
         }
         if isEmbeddedInDiscover {
-            title = SharedStrings.Reader.discover
             setCustomTitleView(SharedStrings.Reader.discover)
         } else if ReaderHelpers.topicIsFollowing(topic) {
-            title = SharedStrings.Reader.recent
             setCustomTitleView(SharedStrings.Reader.recent)
         } else if ReaderHelpers.topicIsLiked(topic) {
             title = SharedStrings.Reader.likes
+        } else {
+            setCustomTitleView(topic.title)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -630,7 +630,11 @@ import AutomatticTracks
 
     private func configureTitleForTopic() {
         guard let topic = readerTopic else {
-            title = NSLocalizedString("Reader", comment: "The default title of the Reader")
+            if contentType == .saved {
+                title = SharedStrings.Reader.saved
+            } else {
+                title = NSLocalizedString("Reader", comment: "The default title of the Reader")
+            }
             return
         }
 
@@ -641,11 +645,11 @@ import AutomatticTracks
         }
 
         if FeatureFlag.readerReset.enabled {
-            configureCustomTitleView(for: topic)
+            configureNavigationTitle(for: topic)
         }
     }
 
-    private func configureCustomTitleView(for topic: ReaderAbstractTopic) {
+    private func configureNavigationTitle(for topic: ReaderAbstractTopic) {
         func setCustomTitleView(_ title: String) {
             titleView.textLabel.text = title
             navigationItem.titleView = titleView
@@ -656,6 +660,8 @@ import AutomatticTracks
         } else if ReaderHelpers.topicIsFollowing(topic) {
             title = SharedStrings.Reader.recent
             setCustomTitleView(SharedStrings.Reader.recent)
+        } else if ReaderHelpers.topicIsLiked(topic) {
+            title = SharedStrings.Reader.likes
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -261,7 +261,7 @@ import AutomatticTracks
 
     lazy var isSidebarModeEnabled = splitViewController?.isCollapsed == false
 
-    var isReaderResetDiscoverEnabled = false
+    var isEmbeddedInDiscover = false
 
     // MARK: - Factory Methods
 
@@ -543,7 +543,7 @@ import AutomatticTracks
     // MARK: - Configuration / Topic Presentation
 
     @objc private func configureStreamHeader() {
-        guard !isReaderResetDiscoverEnabled else {
+        guard !isEmbeddedInDiscover else {
             return
         }
         guard let headerView = headerForStream(readerTopic, isLoggedIn: isLoggedIn, container: tableViewController) else {
@@ -646,10 +646,16 @@ import AutomatticTracks
     }
 
     private func configureCustomTitleView(for topic: ReaderAbstractTopic) {
-        if ReaderHelpers.topicIsFollowing(topic) {
-            self.title = SharedStrings.Reader.recent
-            titleView.textLabel.text = SharedStrings.Reader.recent
+        func setCustomTitleView(_ title: String) {
+            titleView.textLabel.text = title
             navigationItem.titleView = titleView
+        }
+        if isEmbeddedInDiscover {
+            title = SharedStrings.Reader.discover
+            setCustomTitleView(SharedStrings.Reader.discover)
+        } else if ReaderHelpers.topicIsFollowing(topic) {
+            title = SharedStrings.Reader.recent
+            setCustomTitleView(SharedStrings.Reader.recent)
         }
     }
 
@@ -1740,7 +1746,7 @@ extension ReaderStreamViewController {
         if content.contentCount > 0 {
             return
         }
-        if !isReaderResetDiscoverEnabled {
+        if !isEmbeddedInDiscover {
             tableView.tableHeaderView?.isHidden = true
         }
         configureResultsStatus(title: ResultsStatusText.fetchingPostsTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
@@ -1762,7 +1768,7 @@ extension ReaderStreamViewController {
             return
         }
 
-        if !isReaderResetDiscoverEnabled {
+        if !isEmbeddedInDiscover {
             tableView.tableHeaderView?.isHidden = true
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -18,7 +18,7 @@ struct ReaderSubscriptionCell: View {
     }
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 0) {
             HStack(spacing: 16) {
                 let size = SiteIconViewModel.Size.regular
                 SiteIconView(viewModel: .init(readerSiteTopic: site, size: size))
@@ -65,7 +65,8 @@ struct ReaderSubscriptionCell: View {
                 }
             }
             .font(.subheadline)
-            .frame(width: 44, alignment: .center)
+            .frame(width: 34, alignment: .center)
+            .padding(.trailing, 6)
         }
         .buttonStyle(.plain)
         .popover(isPresented: $isShowingSettings) { settings }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -11,7 +11,7 @@ struct ReaderSubscriptionCell: View {
 
     private var details: String {
         let components = [
-            URL(string: site.siteURL)?.host,
+            horizontalSizeClass == .compact ? nil : URL(string: site.siteURL)?.host,
             Strings.numberOfSubscriptions(with: site.subscriberCount.intValue)
         ]
         return components.compactMap { $0 }.joined(separator: " · ")

--- a/WordPress/Classes/ViewRelated/Reader/Tags/ReaderTagsAddTagView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags/ReaderTagsAddTagView.swift
@@ -27,6 +27,7 @@ struct ReaderTagsAddTagView: View {
             }
         }
         .padding()
+        .frame(maxHeight: .infinity, alignment: .top)
         .onAppear {
             isFocused = true
         }


### PR DESCRIPTION
This PR contains multiple small improvements to the Reader
- Add custom title views for “Recent”, “Discover”, tags/lists/sites that are shown when the custom larger header disappears ([screenshot](https://github.com/user-attachments/assets/a8b9608a-2ad1-49eb-99a3-ac5721dc5f64), [video](https://github.com/user-attachments/assets/0547a95a-4504-4a0a-a38f-e56a2cd8847b))
- Fix an issue with feed scrolling to the wrong position after selecting interests after the initial prompt
- Fix navigation title for the “Saved” screen (was “Reader”)
- Fix background color for site icon placeholders in the Reader menu ([screenshot](https://github.com/user-attachments/assets/ff37c292-c2b9-40b1-a31d-f7d47a7744a6))
- Fix an issue with chevron in sidebar showing wrong icon when collapsed
- Remove Serif fonts from site header
- Add white background and border to avatars (the clear background doesn’t work for many images) ([screenshot](https://github.com/user-attachments/assets/dbe0a577-368d-4236-b94b-c9c4bf31768b))
- Fix how “Add Tag” modal is shown on iPhone ([screenshot](https://github.com/user-attachments/assets/18a3b0d3-07b0-48cc-8b39-a449a7cad7fc))
- Reduce spacing for buttons in Subscriptions view so more text fits
- Remove subscriptions URLs in compact mode as they don’t fit (you’ll need to open details)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
