### PR TITLE
Fix an issue with missing Sidebar button when you have no sites

### DIFF
--- a/WordPress/Classes/System/SplitViewRootPresenter+Welcome.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter+Welcome.swift
@@ -15,8 +15,6 @@ class WelcomeSplitViewContent: SplitViewDisplayable {
         let noSitesVC = UIHostingController(rootView: noSiteView)
         noSitesVC.view.backgroundColor = .systemBackground
         secondary = UINavigationController(rootViewController: noSitesVC)
-
-        supplementary.isNavigationBarHidden = true
     }
 
     func displayed(in splitVC: UISplitViewController) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23708

<img width="1316" alt="Screenshot 2024-10-28 at 12 35 31 PM" src="https://github.com/user-attachments/assets/abfb1ac0-aaa5-4458-b329-b72315a0ec38">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
