### PR TITLE
Fix bar chart colors

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -87,11 +87,14 @@ struct UIAppColor {
 
 #if IS_JETPACK
     static let tint = UIColor.label
+
     static let brand = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
 
     static func brand(_ shade: ColorStudioShade) -> UIColor {
         CSColor.JetpackGreen.shade(shade)
     }
+
+    static let primary = CSColor.JetpackGreen.base
 
     static func primary(_ shade: ColorStudioShade) -> UIColor {
         CSColor.JetpackGreen.shade(shade)
@@ -100,11 +103,14 @@ struct UIAppColor {
 
 #if IS_WORDPRESS
     static let tint = brand
+
     static let brand = CSColor.WordPressBlue.base
 
     static func brand(_ shade: ColorStudioShade) -> UIColor {
         CSColor.WordPressBlue.shade(shade)
     }
+
+    static let primary = CSColor.Blue.base
 
     static func primary(_ shade: ColorStudioShade) -> UIColor {
         CSColor.Blue.shade(shade)
@@ -115,9 +121,6 @@ struct UIAppColor {
     static let error = CSColor.Red.base
     static let gray = CSColor.Gray.base
     static let blue = CSColor.Blue.base
-
-    /// - warning: soft-deprecated, use `UIAppColor.tint`.
-    static let primary = brand
 
     static let success = CSColor.Green.base
     static let text = CSColor.Gray.shade(.shade80)

--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -3,10 +3,6 @@ import ColorStudio
 import SwiftUI
 
 struct UIAppColor {
-    static func primary(_ shade: ColorStudioShade) -> UIColor {
-        CSColor.Blue.shade(shade)
-    }
-
     static func accent(_ shade: ColorStudioShade) -> UIColor {
         CSColor.Pink.shade(shade)
     }
@@ -96,6 +92,10 @@ struct UIAppColor {
     static func brand(_ shade: ColorStudioShade) -> UIColor {
         CSColor.JetpackGreen.shade(shade)
     }
+
+    static func primary(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.JetpackGreen.shade(shade)
+    }
 #endif
 
 #if IS_WORDPRESS
@@ -104,6 +104,10 @@ struct UIAppColor {
 
     static func brand(_ shade: ColorStudioShade) -> UIColor {
         CSColor.WordPressBlue.shade(shade)
+    }
+
+    static func primary(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.Blue.shade(shade)
     }
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23709

<img width="320" alt="Screenshot 2024-10-28 at 1 55 02 PM" src="https://github.com/user-attachments/assets/051a0441-c116-43a3-a827-02bf848c0cad">
<img width="320" alt="Screenshot 2024-10-28 at 1 54 58 PM" src="https://github.com/user-attachments/assets/310cb5a4-c90b-42d6-a848-039e161ab3f1">

## RCA

In one of the previous releases, `func primary` was moved to `UIColor` without implementing a Jetpack-specific variant.

In the previous versions, these would map to:

```swift
// wp
static let primary = MurielColor(name: .blue)
// jp
static let primary = MurielColor(name: .jetpackGreen)
```

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
