### PR TITLE
Reader: Load Stream lazily

### DIFF
--- a/WordPress/Classes/System/ReaderPresenter.swift
+++ b/WordPress/Classes/System/ReaderPresenter.swift
@@ -14,7 +14,7 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
     var secondary: UINavigationController
 
     /// The navigation controller for the main content when shown using tabs.
-    private let mainNavigationController = UINavigationController()
+    private var mainNavigationController = UINavigationController()
     private var latestContentVC: UIViewController?
 
     private var viewContext: NSManagedObjectContext {
@@ -37,12 +37,14 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
 
     // TODO: (reader) update to allow seamless transitions between split view and tabs
     @objc func prepareForTabBarPresentation() -> UINavigationController {
+        sidebar.onViewDidLoad = { [weak self] in
+            self?.showInitialSelection()
+        }
         sidebarViewModel.isCompact = true
         sidebarViewModel.restoreSelection(defaultValue: nil)
         mainNavigationController.navigationBar.prefersLargeTitles = true
-        mainNavigationController.viewControllers = [sidebar]
+        mainNavigationController = UINavigationController(rootViewController: sidebar) // Loads sidebar lazily
         sidebar.navigationItem.backButtonDisplayMode = .minimal
-        showInitialSelection()
         return mainNavigationController
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSidebarViewController.swift
@@ -9,6 +9,8 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
     private var viewContext: NSManagedObjectContext { ContextManager.shared.mainContext }
     var didAppear = false
 
+    var onViewDidLoad: (() -> Void)?
+
     init(viewModel: ReaderSidebarViewModel) {
         self.viewModel = viewModel
         // - warning: The `managedObjectContext` has to be set here in order for
@@ -23,6 +25,12 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        onViewDidLoad?()
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes an issue where `ReaderStreamViewController` and `ReaderSidebarViewController` were loaded eagerly on app launch, even when the Reader was never selected.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
