### PR TITLE
Move StringRankedSearch to WordPressShared

### DIFF
--- a/Modules/Sources/WordPressShared/Utility/StringRankedSearch.swift
+++ b/Modules/Sources/WordPressShared/Utility/StringRankedSearch.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-struct StringRankedSearch {
+public struct StringRankedSearch {
     /// By default, `[.caseInsensitive, .diacriticInsensitive]`.
     var options: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
 
     private let term: String
     private let terms: [String]
 
-    init(searchTerm: String) {
+    public init(searchTerm: String) {
         self.term = searchTerm.trimmingCharacters(in: .whitespaces)
         self.terms = term.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
     }
 
     /// Returns a score in a `0.0...1.0` range where `1.0` is maximum confidence.
     /// Anything above `0.5` suggests a good probability of a match.
-    func score(for string: String?) -> Double {
+    public func score(for string: String?) -> Double {
         guard let string else {
             return 0
         }
@@ -106,7 +106,7 @@ extension StringRankedSearch {
     /// Returns the top matching results for the given items.
     ///
     /// - parameter input: Returns the input for the search algorithm to match against.
-    func search<S: Sequence>(
+    public func search<S: Sequence>(
         in items: S,
         minScore: Double = 0.7,
         input: (S.Element) -> String

--- a/Modules/Tests/WordPressSharedTests/StringRankedSearchTests.swift
+++ b/Modules/Tests/WordPressSharedTests/StringRankedSearchTests.swift
@@ -1,6 +1,5 @@
 import XCTest
-
-@testable import WordPress
+import WordPressShared
 
 final class StringRankedSearchTests: XCTestCase {
     func testScoreInRange() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -1,5 +1,6 @@
 import CoreData
 import SwiftUI
+import WordPressShared
 
 final class BlogListViewModel: NSObject, ObservableObject {
     @Published var searchText = "" {

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchSuggestionsService.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchSuggestionsService.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// Suggests search token for the given input and context. Performs all of the
 /// work in the background.

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WordPressUI
+import WordPressShared
 
 struct ReaderSubscriptionsView: View {
     @FetchRequest(

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -576,9 +576,6 @@
 		0C9CD7A02B9A6FDC0045BE03 /* remote-post.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C9CD79F2B9A6FDC0045BE03 /* remote-post.json */; };
 		0CA10F6D2ADAE86D00CE75AC /* PostSearchSuggestionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10F6C2ADAE86D00CE75AC /* PostSearchSuggestionsService.swift */; };
 		0CA10F6E2ADAE86E00CE75AC /* PostSearchSuggestionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10F6C2ADAE86D00CE75AC /* PostSearchSuggestionsService.swift */; };
-		0CA10F732ADB014C00CE75AC /* StringRankedSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */; };
-		0CA10F742ADB014C00CE75AC /* StringRankedSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */; };
-		0CA10FA52ADB286300CE75AC /* StringRankedSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */; };
 		0CA10FA82ADB7C5200CE75AC /* PostSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */; };
 		0CA10FA92ADB7C5300CE75AC /* PostSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */; };
 		0CA15B4E2BB2128800518D6E /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CA15B4D2BB2128800518D6E /* PostCoordinatorTests.swift */; };
@@ -6515,8 +6512,6 @@
 		0C9CD79C2B9A6ABF0045BE03 /* PostRepositorySaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRepositorySaveTests.swift; sourceTree = "<group>"; };
 		0C9CD79F2B9A6FDC0045BE03 /* remote-post.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "remote-post.json"; sourceTree = "<group>"; };
 		0CA10F6C2ADAE86D00CE75AC /* PostSearchSuggestionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchSuggestionsService.swift; sourceTree = "<group>"; };
-		0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRankedSearch.swift; sourceTree = "<group>"; };
-		0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRankedSearchTests.swift; sourceTree = "<group>"; };
 		0CA10FA62ADB76ED00CE75AC /* PostSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchService.swift; sourceTree = "<group>"; };
 		0CA15B4D2BB2128800518D6E /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		0CA1C8C02A940EE300F691EE /* AvatarMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarMenuController.swift; sourceTree = "<group>"; };
@@ -14565,7 +14560,6 @@
 				F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */,
 				FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */,
 				0C896DE62A3A832B00D7D4E7 /* SiteVisibilityTests.swift */,
-				0CA10FA42ADB286300CE75AC /* StringRankedSearchTests.swift */,
 				4AD862E42AFAEF1700A07557 /* PostsListAPIStub.swift */,
 				0C1DB60A2B0A9A570028F200 /* ImageDownloaderTests.swift */,
 				4A5598842B05AC180083C220 /* PagesListTests.swift */,
@@ -14709,7 +14703,6 @@
 				175721152754D31F00DE38BC /* AppIcon.swift */,
 				4A2172F728EAACFF0006F4F1 /* BlogQuery.swift */,
 				801D9519291AC0B00051993E /* OverlayFrequencyTracker.swift */,
-				0CA10F722ADB014C00CE75AC /* StringRankedSearch.swift */,
 				4A5DE7372B0D511900363171 /* PageTree.swift */,
 				FA87A22D2BF798E40062154A /* Version.swift */,
 				0C03EF9E2C495D2E00B7F828 /* SharedStrings.swift */,
@@ -23193,7 +23186,6 @@
 				241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */,
 				0815CF461E96F22600069916 /* MediaImportService.swift in Sources */,
 				B56F25881FBDE502005C33E4 /* NSAttributedStringKey+Conversion.swift in Sources */,
-				0CA10F732ADB014C00CE75AC /* StringRankedSearch.swift in Sources */,
 				08AA64052A84FFF40076E38D /* DashboardGoogleDomainsViewModel.swift in Sources */,
 				98E54FF2265C972900B4BE9A /* ReaderDetailLikesView.swift in Sources */,
 				FFABD80821370496003C65B6 /* SelectPostViewController.swift in Sources */,
@@ -24142,7 +24134,6 @@
 				0C8FC9AA2A8C57000059DCE4 /* ItemProviderMediaExporterTests.swift in Sources */,
 				4AD862E52AFAEF1700A07557 /* PostsListAPIStub.swift in Sources */,
 				0A69300B28B5AA5E00E98DE1 /* FullScreenCommentReplyViewModelTests.swift in Sources */,
-				0CA10FA52ADB286300CE75AC /* StringRankedSearchTests.swift in Sources */,
 				FF8032661EE9E22200861F28 /* MediaProgressCoordinatorTests.swift in Sources */,
 				173D82E7238EE2A7008432DA /* FeatureFlagTests.swift in Sources */,
 				3F4A4C212AD39CB100DE5DF8 /* TruthTable.swift in Sources */,
@@ -24993,7 +24984,6 @@
 				0C0D3B0E2A4C79DE0050A00D /* BlazeCampaignsStream.swift in Sources */,
 				FABB22792602FC2C00C8785C /* WPCrashLoggingProvider.swift in Sources */,
 				FA332AD529C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */,
-				0CA10F742ADB014C00CE75AC /* StringRankedSearch.swift in Sources */,
 				0CDDCA0C2C8F4990005AACA3 /* ReaderTagsHelper.swift in Sources */,
 				FABB227A2602FC2C00C8785C /* StockPhotosMedia.swift in Sources */,
 				FABB227B2602FC2C00C8785C /* FancyAlertViewController+SavedPosts.swift in Sources */,


### PR DESCRIPTION
This change is part of #23572. The `StringRankedSearch` will be used in searching WordPress site users locally.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
