### PR TITLE
feat: GutenbergKit Media Library support

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "849118af582068f75807bc0f1265edeee4bf1b5e"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "e76e6f38641b886a85c470ded4cf816e161c50b1"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "65c9027f4f78d3478bbd90ee82c8bfd8d461259f"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "6cc307e7fc24910697be5f71b7d70f465a9c0f63"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "489659562215b00d20f3b0513bd8db7e40449fde"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "1dffd4d5ba053454e674a161738a987d530efc1e"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "e76e6f38641b886a85c470ded4cf816e161c50b1"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "489659562215b00d20f3b0513bd8db7e40449fde"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-swift-20240813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "1dffd4d5ba053454e674a161738a987d530efc1e"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "65c9027f4f78d3478bbd90ee82c8bfd8d461259f"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "1dffd4d5ba053454e674a161738a987d530efc1e"
+        "revision" : "65c9027f4f78d3478bbd90ee82c8bfd8d461259f"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "489659562215b00d20f3b0513bd8db7e40449fde"
+        "revision" : "1dffd4d5ba053454e674a161738a987d530efc1e"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "849118af582068f75807bc0f1265edeee4bf1b5e"
+        "revision" : "e76e6f38641b886a85c470ded4cf816e161c50b1"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "e76e6f38641b886a85c470ded4cf816e161c50b1"
+        "revision" : "489659562215b00d20f3b0513bd8db7e40449fde"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "65c9027f4f78d3478bbd90ee82c8bfd8d461259f"
+        "revision" : "6cc307e7fc24910697be5f71b7d70f465a9c0f63"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -46,6 +46,7 @@ final class GutenbergMediaPickerHelper: NSObject {
     }
 
     private func mapMediaIdsToMedia(_ mediaIds: [Int]) -> [Media] {
+        assert(Thread.isMainThread, "mapMediaIdsToMedia should only be called on the main thread")
         let context = ContextManager.shared.mainContext
         let request = NSFetchRequest<NSManagedObject>(entityName: "Media")
         request.predicate = NSPredicate(format: "mediaID IN %@", mediaIds.map { NSNumber(value: $0) })

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -47,11 +47,22 @@ final class GutenbergMediaPickerHelper: NSObject {
 
     private func mapMediaIdsToMedia(_ mediaIds: [Int]) -> [Media] {
         let context = ContextManager.shared.mainContext
-        let request: NSFetchRequest = Media.fetchRequest()
-        request.predicate = NSPredicate(format: "mediaID IN %@", mediaIds)
+        let request = NSFetchRequest<NSManagedObject>(entityName: "Media")
+        request.predicate = NSPredicate(format: "mediaID IN %@", mediaIds.map { NSNumber(value: $0) })
 
         do {
-            return try context.fetch(request) as? [Media] ?? []
+            let fetchedMedia = try context.fetch(request) as? [Media] ?? []
+
+            // Create a dictionary for quick lookup
+            let mediaDict = Dictionary(uniqueKeysWithValues: fetchedMedia.compactMap { media -> (Int, Media)? in
+                if let mediaID = media.mediaID?.intValue {
+                    return (mediaID, media)
+                }
+                return nil
+            })
+
+            // Map the original mediaIds to Media objects, preserving order
+            return mediaIds.compactMap { mediaDict[$0] }
         } catch {
             return []
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -41,7 +41,7 @@ final class GutenbergMediaPickerHelper: NSObject {
     func presentSiteMediaPicker(filter: WPMediaType, allowMultipleSelection: Bool, initialSelection: [Int] = [], preserveSelection: Bool = false, completion: @escaping GutenbergMediaPickerHelperCallback) {
         didPickMediaCallback = completion
         let initialMediaSelection = mapMediaIdsToMedia(initialSelection)
-        MediaPickerMenu(viewController: context, filter: .init(filter), isMultipleSelectionEnabled: allowMultipleSelection, initialSelection: initialMediaSelection, preserveSelection: preserveSelection)
+        MediaPickerMenu(viewController: context, filter: .init(filter), isMultipleSelectionEnabled: allowMultipleSelection, initialSelection: initialMediaSelection)
             .showSiteMediaPicker(blog: post.blog, delegate: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -38,10 +38,23 @@ final class GutenbergMediaPickerHelper: NSObject {
         context.present(picker, animated: true)
     }
 
-    func presentSiteMediaPicker(filter: WPMediaType, allowMultipleSelection: Bool, completion: @escaping GutenbergMediaPickerHelperCallback) {
+    func presentSiteMediaPicker(filter: WPMediaType, allowMultipleSelection: Bool, initialSelection: [Int] = [], preserveSelection: Bool = false, completion: @escaping GutenbergMediaPickerHelperCallback) {
         didPickMediaCallback = completion
-        MediaPickerMenu(viewController: context, filter: .init(filter), isMultipleSelectionEnabled: allowMultipleSelection)
+        let initialMediaSelection = mapMediaIdsToMedia(initialSelection)
+        MediaPickerMenu(viewController: context, filter: .init(filter), isMultipleSelectionEnabled: allowMultipleSelection, initialSelection: initialMediaSelection, preserveSelection: preserveSelection)
             .showSiteMediaPicker(blog: post.blog, delegate: self)
+    }
+
+    private func mapMediaIdsToMedia(_ mediaIds: [Int]) -> [Media] {
+        let context = ContextManager.shared.mainContext
+        let request: NSFetchRequest = Media.fetchRequest()
+        request.predicate = NSPredicate(format: "mediaID IN %@", mediaIds)
+
+        do {
+            return try context.fetch(request) as? [Media] ?? []
+        } catch {
+            return []
+        }
     }
 
     func presentCameraCaptureFullScreen(animated: Bool,

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -38,7 +38,7 @@ final class GutenbergMediaPickerHelper: NSObject {
         context.present(picker, animated: true)
     }
 
-    func presentSiteMediaPicker(filter: WPMediaType, allowMultipleSelection: Bool, initialSelection: [Int] = [], preserveSelection: Bool = false, completion: @escaping GutenbergMediaPickerHelperCallback) {
+    func presentSiteMediaPicker(filter: WPMediaType, allowMultipleSelection: Bool, initialSelection: [Int] = [], completion: @escaping GutenbergMediaPickerHelperCallback) {
         didPickMediaCallback = completion
         let initialMediaSelection = mapMediaIdsToMedia(initialSelection)
         MediaPickerMenu(viewController: context, filter: .init(filter), isMultipleSelectionEnabled: allowMultipleSelection, initialSelection: initialMediaSelection)

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -10,7 +10,6 @@ struct MediaPickerMenu {
     var filter: MediaFilter?
     var isMultipleSelectionEnabled: Bool
     var initialSelection: [Media]
-    var preserveSelection: Bool
 
     enum MediaFilter {
         case images
@@ -26,13 +25,11 @@ struct MediaPickerMenu {
     init(viewController: UIViewController,
          filter: MediaFilter? = nil,
          isMultipleSelectionEnabled: Bool = false,
-         initialSelection: [Media] = [],
-         preserveSelection: Bool = false) {
+         initialSelection: [Media] = []) {
         self.presentingViewController = viewController
         self.filter = filter
         self.isMultipleSelectionEnabled = isMultipleSelectionEnabled
         self.initialSelection = initialSelection
-        self.preserveSelection = preserveSelection
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -9,6 +9,8 @@ struct MediaPickerMenu {
     weak var presentingViewController: UIViewController?
     var filter: MediaFilter?
     var isMultipleSelectionEnabled: Bool
+    var initialSelection: [Media]
+    var preserveSelection: Bool
 
     enum MediaFilter {
         case images
@@ -23,10 +25,14 @@ struct MediaPickerMenu {
     ///   - isMultipleSelectionEnabled: By default, `false`.
     init(viewController: UIViewController,
          filter: MediaFilter? = nil,
-         isMultipleSelectionEnabled: Bool = false) {
+         isMultipleSelectionEnabled: Bool = false,
+         initialSelection: [Media] = [],
+         preserveSelection: Bool = false) {
         self.presentingViewController = viewController
         self.filter = filter
         self.isMultipleSelectionEnabled = isMultipleSelectionEnabled
+        self.initialSelection = initialSelection
+        self.preserveSelection = preserveSelection
     }
 }
 
@@ -185,7 +191,9 @@ extension MediaPickerMenu {
         let viewController = SiteMediaPickerViewController(
             blog: blog,
             filter: filter.map { [$0.mediaType] },
-            allowsMultipleSelection: isMultipleSelectionEnabled
+            allowsMultipleSelection: isMultipleSelectionEnabled,
+            initialSelection: initialSelection,
+            preserveSelection: preserveSelection
         )
         viewController.delegate = delegate
         let navigation = UINavigationController(rootViewController: viewController)

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -22,6 +22,7 @@ struct MediaPickerMenu {
     ///   - viewController: The view controller to use for presentation.
     ///   - filter: By default, `nil` – allow all content types.
     ///   - isMultipleSelectionEnabled: By default, `false`.
+    ///   - initialSelection: By default, `[]`.
     init(viewController: UIViewController,
          filter: MediaFilter? = nil,
          isMultipleSelectionEnabled: Bool = false,

--- a/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPickerMenu.swift
@@ -192,8 +192,7 @@ extension MediaPickerMenu {
             blog: blog,
             filter: filter.map { [$0.mediaType] },
             allowsMultipleSelection: isMultipleSelectionEnabled,
-            initialSelection: initialSelection,
-            preserveSelection: preserveSelection
+            initialSelection: initialSelection
         )
         viewController.delegate = delegate
         let navigation = UINavigationController(rootViewController: viewController)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -106,14 +106,6 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
 
         syncMedia()
         updateEmptyViewState()
-        applyInitialSelection()
-    }
-
-    private func applyInitialSelection() {
-        for media in selectedMedia {
-            getViewModel(for: media).badge = isSelectionOrdered ? .ordered(index: selection.index(of: media)) : .unordered
-        }
-        delegate?.siteMediaViewController(self, didUpdateSelection: selectedMedia)
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -62,13 +62,11 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         return selection
     }
 
-    init(blog: Blog, filter: Set<MediaType>? = nil, isShowingPendingUploads: Bool = true, initialSelection: [Media] = []) {
+    init(blog: Blog, filter: Set<MediaType>? = nil, isShowingPendingUploads: Bool = true) {
         self.blog = blog
         self.filter = filter
         self.isShowingPendingUploads = isShowingPendingUploads
         super.init(nibName: nil, bundle: nil)
-
-        setInitialSelection(initialSelection)
     }
 
     required init?(coder: NSCoder) {
@@ -178,14 +176,16 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         _ isEditing: Bool,
         allowsMultipleSelection: Bool = true,
         isSelectionOrdered: Bool = false,
-        preserveSelection: Bool = false
+        initialSelection: [Media]? = nil
     ) {
         guard self.isEditing != isEditing else { return }
         self.isEditing = isEditing
         self.allowsMultipleSelection = allowsMultipleSelection
         self.isSelectionOrdered = isSelectionOrdered
 
-        if !preserveSelection {
+        if let selectedMedia = initialSelection {
+            setInitialSelection(selectedMedia)
+        } else {
             deselectAll()
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -175,7 +175,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         self.allowsMultipleSelection = allowsMultipleSelection
         self.isSelectionOrdered = isSelectionOrdered
 
-        if let selectedMedia = initialSelection {
+        if let selectedMedia = initialSelection, allowsMultipleSelection {
             setInitialSelection(selectedMedia)
         } else {
             deselectAll()

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -214,11 +214,9 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
             }
         }
         delegate?.siteMediaViewController(self, didUpdateSelection: selectedMedia)
-        // TODO: Disabled to support preserving initial selection, but this
-        // likely introduces bugs and needs to be reinstated.
-//        if !allowsMultipleSelection {
-//            selection = []
-//        }
+        if !allowsMultipleSelection {
+            selection = []
+        }
     }
 
     func isSelected(_ media: Media) -> Bool {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -62,15 +62,25 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         return selection
     }
 
-    init(blog: Blog, filter: Set<MediaType>? = nil, isShowingPendingUploads: Bool = true) {
+    init(blog: Blog, filter: Set<MediaType>? = nil, isShowingPendingUploads: Bool = true, initialSelection: [Media] = []) {
         self.blog = blog
         self.filter = filter
         self.isShowingPendingUploads = isShowingPendingUploads
         super.init(nibName: nil, bundle: nil)
+
+        setInitialSelection(initialSelection)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setInitialSelection(_ media: [Media]) {
+        updateSelection {
+            for item in media {
+                selection.add(item)
+            }
+        }
     }
 
     func embed(in parentViewController: UIViewController) {
@@ -98,6 +108,14 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
 
         syncMedia()
         updateEmptyViewState()
+        applyInitialSelection()
+    }
+
+    private func applyInitialSelection() {
+        for media in selectedMedia {
+            getViewModel(for: media).badge = isSelectionOrdered ? .ordered(index: selection.index(of: media)) : .unordered
+        }
+        delegate?.siteMediaViewController(self, didUpdateSelection: selectedMedia)
     }
 
     override func viewDidLayoutSubviews() {
@@ -159,14 +177,17 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
     func setEditing(
         _ isEditing: Bool,
         allowsMultipleSelection: Bool = true,
-        isSelectionOrdered: Bool = false
+        isSelectionOrdered: Bool = false,
+        preserveSelection: Bool = false
     ) {
         guard self.isEditing != isEditing else { return }
         self.isEditing = isEditing
         self.allowsMultipleSelection = allowsMultipleSelection
         self.isSelectionOrdered = isSelectionOrdered
 
-        deselectAll()
+        if !preserveSelection {
+            deselectAll()
+        }
     }
 
     private func updateSelection(_ perform: () -> Void) {
@@ -193,9 +214,11 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
             }
         }
         delegate?.siteMediaViewController(self, didUpdateSelection: selectedMedia)
-        if !allowsMultipleSelection {
-            selection = []
-        }
+        // TODO: Disabled to support preserving initial selection, but this
+        // likely introduces bugs and needs to be reinstated.
+//        if !allowsMultipleSelection {
+//            selection = []
+//        }
     }
 
     func isSelected(_ media: Media) -> Bool {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -10,7 +10,6 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     private let blog: Blog
     private let allowsMultipleSelection: Bool
     private let initialSelection: [Media]
-    private let preserveSelection: Bool
 
     private let collectionViewController: SiteMediaCollectionViewController
     private let toolbarItemTitle = SiteMediaSelectionTitleView()
@@ -24,11 +23,10 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     ///   - blog: The site that contains the media
     ///   - filter: The types of media to display. By default, `nil` (show everything).
     ///   - allowsMultipleSelection: `false` by default.
-    init(blog: Blog, filter: Set<MediaType>? = nil, allowsMultipleSelection: Bool = false, initialSelection: [Media] = [], preserveSelection: Bool = false) {
+    init(blog: Blog, filter: Set<MediaType>? = nil, allowsMultipleSelection: Bool = false, initialSelection: [Media] = []) {
         self.blog = blog
         self.allowsMultipleSelection = allowsMultipleSelection
         self.initialSelection = initialSelection
-        self.preserveSelection = preserveSelection
         self.collectionViewController = SiteMediaCollectionViewController(blog: blog, filter: filter, isShowingPendingUploads: false)
 
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -29,7 +29,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
         self.allowsMultipleSelection = allowsMultipleSelection
         self.initialSelection = initialSelection
         self.preserveSelection = preserveSelection
-        self.collectionViewController = SiteMediaCollectionViewController(blog: blog, filter: filter, isShowingPendingUploads: false, initialSelection: initialSelection)
+        self.collectionViewController = SiteMediaCollectionViewController(blog: blog, filter: filter, isShowingPendingUploads: false)
 
         super.init(nibName: nil, bundle: nil)
 
@@ -79,7 +79,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     // MARK: - Selection
 
     private func startSelection() {
-        collectionViewController.setEditing(true, allowsMultipleSelection: allowsMultipleSelection, isSelectionOrdered: true, preserveSelection: preserveSelection)
+        collectionViewController.setEditing(true, allowsMultipleSelection: allowsMultipleSelection, isSelectionOrdered: true, initialSelection: initialSelection)
 
         if allowsMultipleSelection, toolbarItems == nil {
             var toolbarItems: [UIBarButtonItem] = []

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -67,7 +67,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     // MARK: - Actions
 
     private func buttonCancelTapped() {
-        delegate?.siteMediaPickerViewController(self, didFinishWithSelection: [])
+        delegate?.siteMediaPickerViewController(self, didFinishWithSelection: initialSelection)
     }
 
     @objc private func buttonDoneTapped() {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -23,6 +23,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     ///   - blog: The site that contains the media
     ///   - filter: The types of media to display. By default, `nil` (show everything).
     ///   - allowsMultipleSelection: `false` by default.
+    ///   - initialSelection: `[]` by default.
     init(blog: Blog, filter: Set<MediaType>? = nil, allowsMultipleSelection: Bool = false, initialSelection: [Media] = []) {
         self.blog = blog
         self.allowsMultipleSelection = allowsMultipleSelection

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPickerViewController.swift
@@ -9,6 +9,8 @@ protocol SiteMediaPickerViewControllerDelegate: AnyObject {
 final class SiteMediaPickerViewController: UIViewController, SiteMediaCollectionViewControllerDelegate {
     private let blog: Blog
     private let allowsMultipleSelection: Bool
+    private let initialSelection: [Media]
+    private let preserveSelection: Bool
 
     private let collectionViewController: SiteMediaCollectionViewController
     private let toolbarItemTitle = SiteMediaSelectionTitleView()
@@ -22,10 +24,12 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     ///   - blog: The site that contains the media
     ///   - filter: The types of media to display. By default, `nil` (show everything).
     ///   - allowsMultipleSelection: `false` by default.
-    init(blog: Blog, filter: Set<MediaType>? = nil, allowsMultipleSelection: Bool = false) {
+    init(blog: Blog, filter: Set<MediaType>? = nil, allowsMultipleSelection: Bool = false, initialSelection: [Media] = [], preserveSelection: Bool = false) {
         self.blog = blog
         self.allowsMultipleSelection = allowsMultipleSelection
-        self.collectionViewController = SiteMediaCollectionViewController(blog: blog, filter: filter, isShowingPendingUploads: false)
+        self.initialSelection = initialSelection
+        self.preserveSelection = preserveSelection
+        self.collectionViewController = SiteMediaCollectionViewController(blog: blog, filter: filter, isShowingPendingUploads: false, initialSelection: initialSelection)
 
         super.init(nibName: nil, bundle: nil)
 
@@ -75,7 +79,7 @@ final class SiteMediaPickerViewController: UIViewController, SiteMediaCollection
     // MARK: - Selection
 
     private func startSelection() {
-        collectionViewController.setEditing(true, allowsMultipleSelection: allowsMultipleSelection, isSelectionOrdered: true)
+        collectionViewController.setEditing(true, allowsMultipleSelection: allowsMultipleSelection, isSelectionOrdered: true, preserveSelection: preserveSelection)
 
         if allowsMultipleSelection, toolbarItems == nil {
             var toolbarItems: [UIBarButtonItem] = []

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -341,11 +341,10 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
     }
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibrary) {
-        print("[2] openMediaLibrary: \(config)")
         let flags = mediaFilterFlags(using: config.allowedTypes)
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
-                self?.editorViewController.receiveMedia("[]")
+                self?.editorViewController.receiveMedia(config.id, media: "[]")
                 return
             }
             let mediaInfos = media.map { item in
@@ -354,7 +353,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {
                 // Escape the string for JavaScript
                 let escapedJsonString = jsonString.replacingOccurrences(of: "'", with: "\\'")
-                editorViewController.receiveMedia(escapedJsonString)
+                editorViewController.receiveMedia(config.id, media: escapedJsonString)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -340,7 +340,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         throw URLError(.unknown)
     }
 
-    func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibrary) {
+    func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibraryAction) {
         let flags = mediaFilterFlags(using: config.allowedTypes)
 
         let initialSelectionArray: [Int]
@@ -381,7 +381,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         return nil
     }
 
-    private func mediaFilterFlags(using filterArray: [OpenMediaLibrary.MediaType]) -> WPMediaType {
+    private func mediaFilterFlags(using filterArray: [OpenMediaLibraryAction.MediaType]) -> WPMediaType {
         var mediaType: Int = 0
         for filter in filterArray {
             switch filter {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -344,7 +344,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         let flags = mediaFilterFlags(using: config.allowedTypes)
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
-                self?.editorViewController.receiveMedia(config.id, media: "[]")
+                self?.editorViewController.receiveMedia("[]")
                 return
             }
             let mediaInfos = media.map { item in
@@ -353,7 +353,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {
                 // Escape the string for JavaScript
                 let escapedJsonString = jsonString.replacingOccurrences(of: "'", with: "\\'")
-                editorViewController.receiveMedia(config.id, media: escapedJsonString)
+                editorViewController.receiveMedia(escapedJsonString)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -20,6 +20,10 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private lazy var coordinator: SupportCoordinator = {
         SupportCoordinator(controllerToShowFrom: topmostPresentedViewController, tag: .editorHelp)
     }()
+    
+    lazy var mediaPickerHelper: GutenbergMediaPickerHelper = {
+        return GutenbergMediaPickerHelper(context: self, post: post)
+    }()
 
     // MARK: - PostEditor
 
@@ -334,6 +338,44 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
 
     func editor(_ viewController: GutenbergKit.EditorViewController, performRequest: GutenbergKit.EditorNetworkRequest) async throws -> GutenbergKit.EditorNetworkResponse {
         throw URLError(.unknown)
+    }
+
+    func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibrary) {
+        print("[2] openMediaLibrary: \(config)")
+        let flags = mediaFilterFlags(using: config.allowedTypes)
+        mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple) { [weak self] assets in
+            guard let self, let media = assets as? [Media] else {
+                self?.editorViewController.receiveMedia(nil)
+                return
+            }
+            let formattedMedia = media.map { item in
+                let mediaInfo = MediaInfo(id: item.mediaID?.int32Value, url: item.remoteURL, type: item.mediaTypeString, caption: item.caption, title: item.filename, alt: item.alt, metadata: [:])
+                return mediaInfo.encodeForJS()
+            }
+            editorViewController.receiveMedia(formattedMedia)
+        }
+    }
+
+    private func mediaFilterFlags(using filterArray: [OpenMediaLibrary.MediaType]) -> WPMediaType {
+        var mediaType: Int = 0
+        for filter in filterArray {
+            switch filter {
+            case .image:
+                mediaType = mediaType | WPMediaType.image.rawValue
+            case .video:
+                mediaType = mediaType | WPMediaType.video.rawValue
+            case .audio:
+                mediaType = mediaType | WPMediaType.audio.rawValue
+            case .other:
+                mediaType = mediaType | WPMediaType.other.rawValue
+            case .any:
+                mediaType = mediaType | WPMediaType.all.rawValue
+            @unknown default:
+                fatalError()
+            }
+        }
+
+        return WPMediaType(rawValue: mediaType)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -345,15 +345,30 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         let flags = mediaFilterFlags(using: config.allowedTypes)
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
-                self?.editorViewController.receiveMedia(nil)
+                self?.editorViewController.receiveMedia("[]")
                 return
             }
-            let formattedMedia = media.map { item in
-                let mediaInfo = MediaInfo(id: item.mediaID?.int32Value, url: item.remoteURL, type: item.mediaTypeString, caption: item.caption, title: item.filename, alt: item.alt, metadata: [:])
-                return mediaInfo.encodeForJS()
+            let mediaInfos = media.map { item in
+                return MediaInfo(id: item.mediaID?.int32Value, url: item.remoteURL, type: item.mediaTypeString, caption: item.caption, title: item.filename, alt: item.alt, metadata: [:])
             }
-            editorViewController.receiveMedia(formattedMedia)
+            if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {
+                // Escape the string for JavaScript
+                let escapedJsonString = jsonString.replacingOccurrences(of: "'", with: "\\'")
+                editorViewController.receiveMedia(escapedJsonString)
+            }
         }
+    }
+
+    private func convertMediaInfoArrayToJSONString(_ mediaInfoArray: [MediaInfo]) -> String? {
+        do {
+            let jsonData = try JSONEncoder().encode(mediaInfoArray)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                return jsonString
+            }
+        } catch {
+            print("Error encoding MediaInfo array: \(error)")
+        }
+        return nil
     }
 
     private func mediaFilterFlags(using filterArray: [OpenMediaLibrary.MediaType]) -> WPMediaType {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -353,7 +353,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             initialSelectionArray = []
         }
 
-        mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray, preserveSelection: true) { [weak self] assets in
+        mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
                 self?.editorViewController.receiveMedia("[]")
                 return

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -341,7 +341,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
     }
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibraryAction) {
-        let flags = mediaFilterFlags(using: config.allowedTypes)
+        let flags = mediaFilterFlags(using: config.allowedTypes ?? [])
 
         let initialSelectionArray: [Int]
         switch config.value {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -342,7 +342,18 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibrary) {
         let flags = mediaFilterFlags(using: config.allowedTypes)
-        mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple) { [weak self] assets in
+
+        let initialSelectionArray: [Int]
+        switch config.value {
+        case .single(let id):
+            initialSelectionArray = [id]
+        case .multiple(let ids):
+            initialSelectionArray = ids
+        case .none:
+            initialSelectionArray = []
+        }
+
+        mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray, preserveSelection: true) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
                 self?.editorViewController.receiveMedia("[]")
                 return

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -355,7 +355,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
 
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
-                self?.editorViewController.receiveMedia("[]")
+                self?.editorViewController.setMediaUploadAttachment("[]")
                 return
             }
             let mediaInfos = media.map { item in
@@ -364,7 +364,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {
                 // Escape the string for JavaScript
                 let escapedJsonString = jsonString.replacingOccurrences(of: "'", with: "\\'")
-                editorViewController.receiveMedia(escapedJsonString)
+                editorViewController.setMediaUploadAttachment(escapedJsonString)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -20,7 +20,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private lazy var coordinator: SupportCoordinator = {
         SupportCoordinator(controllerToShowFrom: topmostPresentedViewController, tag: .editorHelp)
     }()
-    
+
     lazy var mediaPickerHelper: GutenbergMediaPickerHelper = {
         return GutenbergMediaPickerHelper(context: self, post: post)
     }()

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -359,6 +359,10 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
                 return
             }
             let mediaInfos = media.map { item in
+                var metadata: [String: String] = [:]
+                if let videopressGUID = item.videopressGUID {
+                    metadata["videopressGUID"] = videopressGUID
+                }
                 return MediaInfo(id: item.mediaID?.int32Value, url: item.remoteURL, type: item.mediaTypeString, caption: item.caption, title: item.filename, alt: item.alt, metadata: [:])
             }
             if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {


### PR DESCRIPTION
## Related 

- https://github.com/Automattic/dotcom-forge/issues/9086
- https://github.com/wordpress-mobile/GutenbergKit/pull/35

## Description
Enable attaching media selected from the Media Library.

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/35. 

## Regression Notes
1. Potential unintended areas of impact
    Existing Media Library support in Gutenberg Mobile, Aztec, etc. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested Media Library support in alternative editors. 
3. What automated tests I added (or what prevented me from doing so)
    Not a priority for this experimental editor. 

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
