### PR TITLE
Remove saved credentials when removing self-hosted sites

### DIFF
--- a/WordPress/Classes/Models/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog+SelfHosted.swift
@@ -55,6 +55,18 @@ extension Blog {
         try keychainImplementation.getPassword(for: self.getUsername(), serviceName: self.getUrlString())
     }
 
+    /// Delete Application Token
+    ///
+    func deleteApplicationToken(using keychainImplementation: KeychainAccessible = KeychainUtils()) throws {
+        try? keychainImplementation.setPassword(for: self.getUsername(), to: nil, serviceName: self.getUrlString())
+    }
+
+    @available(swift, obsoleted: 1.0)
+    @objc(deleteApplicationToken)
+    func objc_deleteApplicationToken() {
+        _ = try? deleteApplicationToken()
+    }
+
     /// Store Application Tokens
     ///
     func setApplicationToken(

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -106,6 +106,10 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         self.password = nil;
     }
 
+    if (self.account == nil) {
+        [self deleteApplicationToken];
+    }
+
     [_xmlrpcApi invalidateAndCancelTasks];
     [_selfHostedSiteRestApi invalidateAndCancelTasks];
 }

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -112,6 +112,17 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
     [_xmlrpcApi invalidateAndCancelTasks];
     [_selfHostedSiteRestApi invalidateAndCancelTasks];
+
+    // Remove the self-hosted site cookies from the shared cookie storage.
+    if (self.account == nil && self.url != nil) {
+        NSURL *siteURL = [NSURL URLWithString:self.url];
+        if (siteURL != nil) {
+            NSHTTPCookieStorage *cookieJar = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+            for (NSHTTPCookie *cookie in [cookieJar cookiesForURL:siteURL]) {
+                [cookieJar deleteCookie:cookie];
+            }
+        }
+    }
 }
 
 - (void)didTurnIntoFault

--- a/WordPress/Classes/Utility/KeychainUtils.swift
+++ b/WordPress/Classes/Utility/KeychainUtils.swift
@@ -41,12 +41,16 @@ extension KeychainUtils: KeychainAccessible {
         try self.keychainUtils.getPasswordForUsername(username, andServiceName: serviceName)
     }
 
-    func setPassword(for username: String, to newValue: String, serviceName: String) throws {
-        try keychainUtils.storeUsername(username, andPassword: newValue, forServiceName: serviceName, updateExisting: true)
+    func setPassword(for username: String, to newValue: String?, serviceName: String) throws {
+        if let newValue {
+            try keychainUtils.storeUsername(username, andPassword: newValue, forServiceName: serviceName, updateExisting: true)
+        } else {
+            try keychainUtils.deleteItem(forUsername: username, andServiceName: serviceName)
+        }
     }
 }
 
 protocol KeychainAccessible {
     func getPassword(for username: String, serviceName: String) throws -> String
-    func setPassword(for username: String, to newValue: String, serviceName: String) throws
+    func setPassword(for username: String, to newValue: String?, serviceName: String) throws
 }

--- a/WordPress/WordPressTest/TestKeychain.swift
+++ b/WordPress/WordPressTest/TestKeychain.swift
@@ -21,7 +21,11 @@ class TestKeychain: KeychainAccessible {
         return keychainItem.password
     }
 
-    func setPassword(for username: String, to newValue: String, serviceName: String) throws {
-        keychain[serviceName] = KeychainItem(username: username, password: newValue)
+    func setPassword(for username: String, to newValue: String?, serviceName: String) throws {
+        if let newValue {
+            keychain[serviceName] = KeychainItem(username: username, password: newValue)
+        } else {
+            keychain[serviceName] = nil
+        }
     }
 }


### PR DESCRIPTION
When removing self-hosted sites, also remove application password (which is stored in the keychain) and cookies.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
