### PR TITLE
Remove unused code from WPTabBarController

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -2,12 +2,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const WPNewPostURLParamContentKey;
-extern NSString * const WPNewPostURLParamTagsKey;
 extern NSString * const WPTabBarCurrentlySelectedScreenSites;
 extern NSString * const WPTabBarCurrentlySelectedScreenReader;
 extern NSString * const WPTabBarCurrentlySelectedScreenNotifications;
-extern NSNotificationName const WPTabBarHeightChangedNotification;
 
 @class AbstractPost;
 @class Blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -14,20 +14,11 @@
 @import WordPressShared;
 @import WordPressUI;
 
-static NSString * const WPTabBarButtonClassname = @"UITabBarButton";
 static NSString * const WPApplicationIconBadgeNumberKeyPath = @"applicationIconBadgeNumber";
-
-NSString * const WPNewPostURLParamTitleKey = @"title";
-NSString * const WPNewPostURLParamContentKey = @"content";
-NSString * const WPNewPostURLParamTagsKey = @"tags";
-NSString * const WPNewPostURLParamImageKey = @"image";
 
 NSString * const WPTabBarCurrentlySelectedScreenSites = @"Blog List";
 NSString * const WPTabBarCurrentlySelectedScreenReader = @"Reader";
 NSString * const WPTabBarCurrentlySelectedScreenNotifications = @"Notifications";
-
-NSNotificationName const WPTabBarHeightChangedNotification = @"WPTabBarHeightChangedNotification";
-static NSString * const WPTabBarFrameKeyPath = @"frame";
 
 static NSInteger const WPTabBarIconOffsetiPad = 7;
 static NSInteger const WPTabBarIconOffsetiPhone = 5;
@@ -52,8 +43,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 @property (nonatomic, strong) UIImage *meTabBarImage;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadUnselected;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadSelected;
-
-@property (nonatomic, assign) CGFloat tabBarHeight;
 
 @end
 
@@ -101,11 +90,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                                                options:NSKeyValueObservingOptionNew
                                                context:nil];
 
-        [self.tabBar addObserver:self
-                      forKeyPath:WPTabBarFrameKeyPath
-                         options:NSKeyValueObservingOptionNew
-                         context:nil];
-
         [self observeGravatarImageUpdate];
     }
     return self;
@@ -118,7 +102,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)dealloc
 {
-    [self.tabBar removeObserver:self forKeyPath:WPTabBarFrameKeyPath];
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
 }
 
@@ -403,22 +386,8 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if (object == self.tabBar && [keyPath isEqualToString:WPTabBarFrameKeyPath]) {
-        [self notifyOfTabBarHeightChangedIfNeeded];
-    }
-
     if (object == [UIApplication sharedApplication] && [keyPath isEqualToString:WPApplicationIconBadgeNumberKeyPath]) {
         [self updateNotificationBadgeVisibility];
-    }
-}
-
-- (void)notifyOfTabBarHeightChangedIfNeeded
-{
-    CGFloat newTabBarHeight = self.tabBar.frame.size.height;
-    if (newTabBarHeight != self.tabBarHeight) {
-        self.tabBarHeight = newTabBarHeight;
-        [[NSNotificationCenter defaultCenter] postNotificationName:WPTabBarHeightChangedNotification
-                                                            object:nil];
     }
 }
 


### PR DESCRIPTION
I found this code when working on another change.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
