### PR TITLE
Fixes for 24.5.2

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -34,12 +34,12 @@ extension UINavigationController {
             self.pushViewController(viewController, animated: animated)
         }
 
-        if UIAccessibility.isReduceMotionEnabled && !self.splitViewControllerIsHorizontallyCompact {
-            splitViewController.view.hideWithBlankingSnapshot(afterScreenUpdates: true)
-            performTransition(false)
-        } else {
+//        if UIAccessibility.isReduceMotionEnabled && !self.splitViewControllerIsHorizontallyCompact {
+//            splitViewController.view.hideWithBlankingSnapshot(afterScreenUpdates: true)
+//            performTransition(false)
+//        } else {
             performTransition(animated)
-        }
+//        }
     }
 }
 

--- a/WordPress/Classes/System/SplitViewRootPresenter+Welcome.swift
+++ b/WordPress/Classes/System/SplitViewRootPresenter+Welcome.swift
@@ -15,8 +15,6 @@ class WelcomeSplitViewContent: SplitViewDisplayable {
         let noSitesVC = UIHostingController(rootView: noSiteView)
         noSitesVC.view.backgroundColor = .systemBackground
         secondary = UINavigationController(rootViewController: noSitesVC)
-
-        supplementary.isNavigationBarHidden = true
     }
 
     func displayed(in splitVC: UISplitViewController) {

--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -3,10 +3,6 @@ import ColorStudio
 import SwiftUI
 
 struct UIAppColor {
-    static func primary(_ shade: ColorStudioShade) -> UIColor {
-        CSColor.Blue.shade(shade)
-    }
-
     static func accent(_ shade: ColorStudioShade) -> UIColor {
         CSColor.Pink.shade(shade)
     }
@@ -91,19 +87,33 @@ struct UIAppColor {
 
 #if IS_JETPACK
     static let tint = UIColor.label
+
     static let brand = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
 
     static func brand(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.JetpackGreen.shade(shade)
+    }
+
+    static let primary = CSColor.JetpackGreen.base
+
+    static func primary(_ shade: ColorStudioShade) -> UIColor {
         CSColor.JetpackGreen.shade(shade)
     }
 #endif
 
 #if IS_WORDPRESS
     static let tint = brand
+
     static let brand = CSColor.WordPressBlue.base
 
     static func brand(_ shade: ColorStudioShade) -> UIColor {
         CSColor.WordPressBlue.shade(shade)
+    }
+
+    static let primary = CSColor.Blue.base
+
+    static func primary(_ shade: ColorStudioShade) -> UIColor {
+        CSColor.Blue.shade(shade)
     }
 #endif
 
@@ -111,9 +121,6 @@ struct UIAppColor {
     static let error = CSColor.Red.base
     static let gray = CSColor.Gray.base
     static let blue = CSColor.Blue.base
-
-    /// - warning: soft-deprecated, use `UIAppColor.tint`.
-    static let primary = brand
 
     static let success = CSColor.Green.base
     static let text = CSColor.Gray.shade(.shade80)

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -286,7 +286,7 @@ import Gridicons
                                                                       comment: "Accessibility Label for the enter full screen button on the comment reply text view")
 
         // Reply button
-        replyButton.setTitleColor(Style.replyButtonColor, for: .normal)
+        replyButton.setTitleColor(UIAppColor.brand, for: .normal)
         replyButton.titleLabel?.text = NSLocalizedString("Reply", comment: "Reply to a comment.")
         replyButton.accessibilityIdentifier = "reply-button"
         replyButton.accessibilityLabel = NSLocalizedString("Reply", comment: "Accessibility label for the reply button")

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -362,8 +362,8 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                                                         views:views]];
 
     [NSLayoutConstraint activateConstraints:@[
-        [self.replyTextView.leadingAnchor constraintEqualToAnchor:self.replyTextView.leadingAnchor],
-        [self.replyTextView.trailingAnchor constraintEqualToAnchor:self.replyTextView.trailingAnchor],
+        [self.replyTextView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.replyTextView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
         [self.view.keyboardLayoutGuide.topAnchor constraintEqualToAnchor:self.replyTextView.bottomAnchor]
     ]];
 


### PR DESCRIPTION
This PR contains four fixes for the patch 25.4.2:

-  Fix an issue with posts not opening in Reader with motion reduction enabled https://github.com/wordpress-mobile/WordPress-iOS/issues/23652
- Fix an issue with a “Reply” button missing in Notifications / Comments on iPad https://github.com/wordpress-mobile/WordPress-iOS/pull/23710
- Fix an issue with missing Sidebar button when you have no sites https://github.com/wordpress-mobile/WordPress-iOS/pull/23711
- Fix bar graph colors mismatched across light and dark modes https://github.com/wordpress-mobile/WordPress-iOS/pull/23712

These changes are either cherry-picks from `trunk` or were fixed in `trunk` in a different way.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
