### PR TITLE
Fix an issue with Reader showing duplicated subscriptions after adding one from Search

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderSiteSearchViewController.swift
@@ -152,14 +152,12 @@ class ReaderSiteSearchViewController: UITableViewController {
     }
 
     private func readerStreamViewController(for feed: ReaderFeed) -> ReaderStreamViewController? {
-        if let feedID = feed.feedID, let feedIDValue = Int(feedID) {
-            return ReaderStreamViewController.controllerWithSiteID(feedIDValue as NSNumber,
-                                                                   isFeed: true)
-        } else if let blogID = feed.blogID, let blogIDValue = Int(blogID) {
-            return ReaderStreamViewController.controllerWithSiteID(blogIDValue as NSNumber,
-                                                                   isFeed: false)
+        if let blogID = feed.blogID, let blogIDValue = Int(blogID) {
+            return ReaderStreamViewController.controllerWithSiteID(blogIDValue as NSNumber, isFeed: false)
+        } else if let feedID = feed.feedID, let feedIDValue = Int(feedID) {
+            return ReaderStreamViewController.controllerWithSiteID(feedIDValue as NSNumber, isFeed: true)
         }
-
+        wpAssertionFailure("missing both blogID and feedID")
         return nil
     }
 }


### PR DESCRIPTION
### Steps to reproduce:

- Open Search / Blogs
- Find a site and open its details page
- Follow a site 
- Open the main Reader menu

### Observed result:

- The details page doesn't show the site icon
- The menu shows duplicated subscriptions

<img width="320" alt="Screenshot 2024-10-31 at 11 29 55 AM" src="https://github.com/user-attachments/assets/66a155fc-e9e0-4899-a779-db2a351bbc85">

### RCA

When you open Site Details from Search, it sends the `/read/feed/{id}` request instead of the expected `/read/sites/{id}`.

For some reason, the request succeeds but returns incomplete info (the app expects "ID" for siteID and "icon.img" for an avatar). The format doesn't match what the app expects.

```json
{
  "blog_ID": "59080076",
  "feed_ID": "14846827",
  "name": "Cee's Photo Challenges",
  "URL": "http://ceenphotography.com/",
  "feed_URL": "http://ceenphotography.com",
  "subscribers_count": 12126,
  "is_following": false,
  "last_update": "2024-10-13T23:00:00+00:00",
  "last_checked": "2024-10-13T23:00:15+00:00",
  "marked_for_refresh": false,
  "next_refresh_time": null,
  "organization_id": 0,
  "unseen_count": 0,
  "meta": {
    "links": {
      "self": "https://public-api.wordpress.com/rest/v1.1/read/feed/14846827",
      "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/59080076"
    }
  },
  "image": "http://1.gravatar.com/blavatar/5f6debdacae8b43e3b16b13626819a9ce7f18d918fb392c4a9b7c08f29a35951?s=96&amp;d=http%3A%2F%2Fs0.wp.com%2Fi%2Fbuttonw-com.png",
  "description": "Teaching the art of composition for photography."
}
```

As a result, the app ends up saving this as a separate entity.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
