### PR TITLE
Reader: RSS support improvements 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconView.swift
@@ -49,6 +49,7 @@ struct SiteIconView: View {
         switch size {
         case .small: 18
         case .regular: 24
+        case .large: 34
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/SiteIconViewModel.swift
@@ -12,11 +12,13 @@ struct SiteIconViewModel {
     enum Size {
         case small
         case regular
+        case large
 
         var width: CGFloat {
             switch self {
             case .small: 28
             case .regular: 40
+            case .large: 72
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -7,7 +7,7 @@ final class ReaderPostCell: ReaderStreamBaseCell {
 
     private var contentViewConstraints: [NSLayoutConstraint] = []
 
-    static let avatarSize: CGFloat = 28
+    static let avatarSize: CGFloat = SiteIconViewModel.Size.small.width
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
@@ -42,7 +42,7 @@ final class ReaderPostCellViewModel {
             self.avatarURL = post.authorAvatarURL.flatMap(URL.init)
         } else if let avatarURL = post.siteIconForDisplay(ofSize: Int(ReaderPostCell.avatarSize)) {
             self.avatarURL = avatarURL
-        } else if let blogURL = post.blogURL.flatMap(URL.init) {
+        } else if let blogURL = post.blogURL.flatMap(URL.init), post.isExternal {
             if let faviconURL = FaviconService.shared.cachedFavicon(forURL: blogURL) {
                 self.avatarURL = faviconURL
             } else {

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -32,7 +32,7 @@ class ReaderSiteHeaderView: UITableViewHeaderFooterView, ReaderStreamHeader {
             assertionFailure("This header should only be used for site topics.")
             return
         }
-        headerViewModel.imageUrl = siteTopic.siteBlavatar
+        headerViewModel.site = siteTopic
         headerViewModel.title = siteTopic.title
         headerViewModel.siteUrl = URL(string: siteTopic.siteURL)?.host ?? ""
         headerViewModel.siteDetails = siteTopic.siteDescription
@@ -78,19 +78,8 @@ struct ReaderSiteHeader: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            AsyncImage(url: URL(string: viewModel.imageUrl)) { phase in
-                switch phase {
-                case .success(let image):
-                    image
-                        .resizable()
-                        .frame(width: 72.0, height: 72.0)
-                        .clipShape(Circle())
-                default:
-                    Image(Constants.defaultSiteImage)
-                        .resizable()
-                        .frame(width: 72.0, height: 72.0)
-                        .clipShape(Circle())
-                }
+            if let site = viewModel.site {
+                ReaderSiteIconView(site: site, size: .large)
             }
             VStack(alignment: .leading, spacing: 4) {
                 Text(viewModel.title)
@@ -134,7 +123,6 @@ struct ReaderSiteHeader: View {
     }
 
     struct Constants {
-        static let defaultSiteImage = "blavatar-default"
         static let countsFormat = NSLocalizedString("reader.blog.header.values",
                                                     value: "%1$@ posts • %2$@ subscribers",
                                                     comment: "The formatted number of posts and followers for a site. " +
@@ -148,8 +136,7 @@ struct ReaderSiteHeader: View {
 // MARK: - ReaderSiteHeaderViewModel
 
 class ReaderSiteHeaderViewModel: ObservableObject {
-
-    @Published var imageUrl: String
+    @Published var site: ReaderSiteTopic?
     @Published var title: String
     @Published var siteUrl: String
     @Published var siteDetails: String
@@ -161,8 +148,7 @@ class ReaderSiteHeaderViewModel: ObservableObject {
 
     private let onFollowTap: (_ completion: @escaping () -> Void) -> Void
 
-    init(imageUrl: String = "",
-         title: String = "",
+    init(title: String = "",
          siteUrl: String = "",
          siteDetails: String = "",
          postCount: String = "",
@@ -171,7 +157,6 @@ class ReaderSiteHeaderViewModel: ObservableObject {
          isFollowHidden: Bool = false,
          isFollowEnabled: Bool = true,
          onFollowTap: @escaping (_ completion: @escaping () -> Void) -> Void = { _ in }) {
-        self.imageUrl = imageUrl
         self.title = title
         self.siteUrl = siteUrl
         self.siteDetails = siteDetails

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -93,7 +93,9 @@ struct ReaderSiteHeader: View {
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }
-            countsDisplay
+            if viewModel.site?.isExternal == false {
+                countsDisplay
+            }
             if !viewModel.isFollowHidden {
                 ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
                                    isEnabled: viewModel.isFollowEnabled,

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -17,8 +17,7 @@ struct ReaderSidebarSubscriptionsSection: View {
             Label {
                 Text(site.title)
             } icon: {
-                SiteIconView(viewModel: SiteIconViewModel(readerSiteTopic: site, size: .small))
-                    .frame(width: 28, height: 28)
+                ReaderSiteIconView(site: site, size: .small)
             }
             .lineLimit(1)
             .tag(ReaderSidebarItem.subscription(TaggedManagedObjectID(site)))

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -20,9 +20,7 @@ struct ReaderSubscriptionCell: View {
     var body: some View {
         HStack(spacing: 0) {
             HStack(spacing: 16) {
-                let size = SiteIconViewModel.Size.regular
-                SiteIconView(viewModel: .init(readerSiteTopic: site, size: size))
-                    .frame(width: size.width, height: size.width)
+                ReaderSiteIconView(site: site, size: .regular)
                     .padding(.leading, 4)
 
                 VStack(alignment: .leading, spacing: 3) {

--- a/WordPress/Classes/ViewRelated/Reader/Views/ReaderSiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Views/ReaderSiteIconView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ReaderSiteIconView: View, Hashable {
+    let site: ReaderSiteTopic
+    var size: SiteIconViewModel.Size = .small
+
+    var body: some View {
+        _ReaderSiteIconView(viewModel: .init(site: site, size: size))
+            .id(self) // important to ensure @StateObject is re-created if needed
+            .frame(width: size.width, height: size.width)
+    }
+}
+
+private struct _ReaderSiteIconView: View {
+    @StateObject var viewModel: ReaderSiteIconViewModel
+
+    var body: some View {
+        SiteIconView(viewModel: viewModel.icon)
+            .task { await viewModel.refresh() }
+    }
+}
+
+@MainActor
+final class ReaderSiteIconViewModel: ObservableObject {
+    @Published private(set) var icon: SiteIconViewModel
+
+    let site: ReaderSiteTopic
+    let size: SiteIconViewModel.Size
+
+    init(site: ReaderSiteTopic, size: SiteIconViewModel.Size) {
+        self.site = site
+        self.size = size
+        self.icon = SiteIconViewModel(readerSiteTopic: site, size: size)
+    }
+
+    func refresh() async {
+        if icon.imageURL == nil, let siteURL = URL(string: site.siteURL) {
+            if let faviconURL = FaviconService.shared.cachedFavicon(forURL: siteURL) {
+                icon.imageURL = faviconURL
+            } else {
+                icon.imageURL = try? await FaviconService.shared.favicon(forURL: siteURL)
+            }
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Views/ReaderSiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Views/ReaderSiteIconView.swift
@@ -34,7 +34,7 @@ final class ReaderSiteIconViewModel: ObservableObject {
     }
 
     func refresh() async {
-        if icon.imageURL == nil, let siteURL = URL(string: site.siteURL) {
+        if site.isExternal, icon.imageURL == nil, let siteURL = URL(string: site.siteURL) {
             if let faviconURL = FaviconService.shared.cachedFavicon(forURL: siteURL) {
                 icon.imageURL = faviconURL
             } else {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23564.

- Add support for showing favicons in the Reader "Menu" and "Stream" screens
- Stop fetching favicon for non-external sites
- Remove "post count" field from the site headers – API always returns 0, wp.com doesn't show it either

<img width="320" alt="Screenshot 2024-11-01 at 1 13 46 PM" src="https://github.com/user-attachments/assets/822a6dcd-833a-40a0-a0fa-b4b30b92d89b"> <img width="320" alt="Screenshot 2024-11-01 at 1 13 49 PM" src="https://github.com/user-attachments/assets/95e7bc1d-d49d-4f16-a5ea-e7b7c1fc984a">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
