### PR TITLE
Reader: Resize covers

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -281,11 +281,9 @@ private final class ReaderPostCellView: UIView {
         configureToolbarAccessibility(with: viewModel.toolbar)
     }
 
-    private lazy var mainWindow = UIApplication.shared.mainWindow
-
     private var preferredCoverSize: CGSize? {
-        guard let mainWindow else { return nil }
-        return Self.preferredCoverSize(in: mainWindow, isCompact: isCompact)
+        guard let window = window ?? UIApplication.shared.mainWindow else { return nil }
+        return Self.preferredCoverSize(in: window, isCompact: isCompact)
     }
 
     static func preferredCoverSize(in window: UIWindow, isCompact: Bool) -> CGSize {

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -87,6 +87,7 @@ private final class ReaderPostCellView: UIView {
 
     private var viewModel: ReaderPostCellViewModel? // important: has to retain
     private let coverAspectRatio: CGFloat = 239.0 / 358.0
+    private static let regularCoverWidth: CGFloat = 200
     private var imageViewConstraints: [NSLayoutConstraint] = []
     private var cancellables: [AnyCancellable] = []
 
@@ -202,7 +203,7 @@ private final class ReaderPostCellView: UIView {
         } else {
             imageViewConstraints = [
                 imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: coverAspectRatio),
-                imageView.widthAnchor.constraint(equalToConstant: 200)
+                imageView.widthAnchor.constraint(equalToConstant: Self.regularCoverWidth)
             ]
         }
         NSLayoutConstraint.activate(imageViewConstraints)
@@ -271,12 +272,29 @@ private final class ReaderPostCellView: UIView {
         detailsLabel.text = viewModel.details
 
         imageView.isHidden = viewModel.imageURL == nil
+
         if let imageURL = viewModel.imageURL {
-            imageView.setImage(with: imageURL)
+            imageView.setImage(with: imageURL, size: preferredCoverSize)
         }
 
         configureToolbar(with: viewModel.toolbar)
         configureToolbarAccessibility(with: viewModel.toolbar)
+    }
+
+    private lazy var mainWindow = UIApplication.shared.mainWindow
+
+    private var preferredCoverSize: CGSize? {
+        guard let mainWindow else { return nil }
+        return Self.preferredCoverSize(in: mainWindow, isCompact: isCompact)
+    }
+
+    static func preferredCoverSize(in window: UIWindow, isCompact: Bool) -> CGSize {
+        var coverWidth = Self.regularCoverWidth
+        if isCompact {
+            coverWidth = min(window.bounds.width, window.bounds.height) - ReaderStreamBaseCell.insets.left * 2
+        }
+        return CGSize(width: coverWidth, height: coverWidth)
+            .scaled(by: min(2, window.traitCollection.displayScale))
     }
 
     private func configureToolbar(with viewModel: ReaderPostToolbarViewModel) {


### PR DESCRIPTION
Resize covers to optimize rendering and reduce memory usage.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
