### PR TITLE
[Tooling] Fix `update_appstore_strings` backmerge PR creation

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -614,12 +614,11 @@ def commit_version_and_build_files
   )
 end
 
-def create_backmerge_pr
-  version = release_version_current
-
+def create_backmerge_pr(source_branch: release_branch_name, target_branch: nil)
   pr_url = create_release_backmerge_pull_request(
     repository: GITHUB_REPO,
-    source_branch: release_branch_name(version: version),
+    source_branch: source_branch,
+    target_branches: Array(target_branch),
     labels: ['Releases'],
     milestone_title: release_version_next
   )
@@ -629,8 +628,8 @@ rescue StandardError => e
 
     #{e.message}
 
-    If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
-    Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
+    If this is not the first time you are running the automation that creates a backmerge, the backmerge PR for the `#{source_branch}` branch might have already been previously created.
+    Please close any previous backmerge PR for the `#{source_branch}` branch, delete the previous merge branch, then run the release task again.
   MESSAGE
 
   buildkite_annotate(style: 'error', context: 'error-creating-backmerge', message: error_message) if is_ci


### PR DESCRIPTION
This PR should fix the issue highlighted by @oguzkocer on [this change](https://github.com/wordpress-mobile/WordPress-Android/pull/21229/files#r1800099465), where `update_appstore_strings` wouldn't properly create the PR to merge the `release_notes/{version}` branch to `release/{version}`.

Android counterpart: https://github.com/wordpress-mobile/WordPress-Android/pull/21397

-----

## To Test:

This will be fully tested during the regular release cycle.

It is possible to simulate a similar scenario following the steps below:
1. Create a dummy local branch
2. Create and push a dummy **release** branch with a number far in the future (e.g. `release/500.0`)
3. Create and push a dummy **editorialization** branch for that same release far in the future (e.g. `release_notes/500.0`)
4. Go back to the initial local dummy branch
5. Run the lane with `bundle exec fastlane update_appstore_strings version:"500.0"`
6. A PR from the local branch (which, in a real world scenario, will be the release note branch) should be created.
