### PR TITLE
Reader: Fix WPGlobus plugin support

### DIFF
--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.swift
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.swift
@@ -34,7 +34,7 @@ extension ReaderPostService {
             }
             return (
                 date == Date() ? nil : topic.algorithm,
-                URL(string: topic.path),
+                self.getEndpoint(for: topic),
                 self.numberToSync(for: topic)
             )
         }) else {
@@ -61,6 +61,14 @@ extension ReaderPostService {
         } failure: { error in
             failure?(error)
         }
+    }
+
+    private func getEndpoint(for topic: ReaderAbstractTopic) -> URL? {
+        guard let topic = topic as? ReaderSiteTopic, topic.feedID.intValue > 0 else {
+            return URL(string: topic.path)
+        }
+        let path = "read/feed/\(topic.feedID)/posts"
+        return URL(string: WordPressComRESTAPIVersionedPathBuilder.path(forEndpoint: path, withVersion: ._1_2))
     }
 
     private func processFetchedPostsForTopic(


### PR DESCRIPTION
Fixes an issue with WPGlobus support in Reader.

<img width="320" alt="Screenshot 2024-11-04 at 7 26 13 AM" src="https://github.com/user-attachments/assets/36cf2174-c83a-4d59-aaa1-c9b0be05a314"> <img width="320" alt="Screenshot 2024-11-04 at 9 56 26 AM" src="https://github.com/user-attachments/assets/cc987a40-c1d9-4036-8fd9-1d9d0806272c">

In order to fix it, I switched to `read/feed/{site_id}/posts` API, which is consistent with the web. It does some pre-processing. More details: https://github.com/Automattic/wp-calypso/issues/94936#issuecomment-2405537844.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
