### PR TITLE
Add feature flag for dot com web login flow

### DIFF
--- a/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
+++ b/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
@@ -28,14 +28,6 @@ extension WordPressAuthenticator: WordPressAuthenticatorProtocol {
             return false
         }
 
-        // TODO: Replce with a remote feature flag.
-        // Enable web-based login for debug builds until the remote feature flag is available.
-        #if DEBUG
-        let webLoginEnabled = true
-        #else
-        let webLoginEnabled = false
-        #endif
-
-        return webLoginEnabled
+        return RemoteFeatureFlag.dotComWebLogin.enabled()
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -30,6 +30,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case readingPreferencesFeedback
     case readerAnnouncementCard
     case inAppUpdates
+    case dotComWebLogin
 
     var defaultValue: Bool {
         switch self {
@@ -88,6 +89,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .readerAnnouncementCard:
             return AppConfiguration.isJetpack
         case .inAppUpdates:
+            return false
+        case .dotComWebLogin:
             return false
         }
     }
@@ -151,6 +154,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "reader_announcement_card"
         case .inAppUpdates:
             return "in_app_updates"
+        case .dotComWebLogin:
+            return "jp_wpcom_web_login"
         }
     }
 
@@ -212,6 +217,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Reader Announcement Card"
         case .inAppUpdates:
             return "In-App Updates"
+        case .dotComWebLogin:
+            return "Log in to WordPress.com from web browser"
         }
     }
 


### PR DESCRIPTION
What says in the title.

To test: Uninstall and install the app, tap "Continue With WordPRess.com". The feature flag is set to a 5% rollout percentage. So, you'll need a bit of luck to actually see the web login flow. Alternatively, you can turn the feature flag on from the debug menu.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
