### PR TITLE
Pass the expected account email to the WP.com login webpage

### DIFF
--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -89,7 +89,7 @@ struct WordPressDotComAuthenticator {
 
         let token: String
         do {
-            token = try await authenticate(from: viewController, prefersEphemeralWebBrowserSession: hasAlreadySignedIn)
+            token = try await authenticate(from: viewController, prefersEphemeralWebBrowserSession: hasAlreadySignedIn, accountEmail: context.accountEmail(in: coreDataStack.mainContext))
         } catch {
             throw .authentication(error)
         }
@@ -167,19 +167,25 @@ struct WordPressDotComAuthenticator {
     /// - SeeAlso `signIn`
     func authenticate(
         from viewController: UIViewController,
-        prefersEphemeralWebBrowserSession: Bool
+        prefersEphemeralWebBrowserSession: Bool,
+        accountEmail: String? = nil
     ) async throws(AuthenticationError) -> String {
         let clientId = ApiCredentials.client
         let clientSecret = ApiCredentials.secret
         let redirectURI = "x-wordpress-app://oauth2-callback"
 
+        var queries =  [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: "global"),
+        ]
+        if let accountEmail {
+            queries.append(URLQueryItem(name: "user_email", value: accountEmail))
+        }
+
         let authorizeURL = URL(string: "https://public-api.wordpress.com/oauth2/authorize")!
-            .appending(queryItems: [
-                URLQueryItem(name: "client_id", value: clientId),
-                URLQueryItem(name: "redirect_uri", value: redirectURI),
-                URLQueryItem(name: "response_type", value: "code"),
-                URLQueryItem(name: "scope", value: "global"),
-            ])
+            .appending(queryItems: queries)
 
         let callbackURL = try await authorize(from: viewController, url: authorizeURL, prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
 

--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -174,18 +174,21 @@ struct WordPressDotComAuthenticator {
         let clientSecret = ApiCredentials.secret
         let redirectURI = "x-wordpress-app://oauth2-callback"
 
-        var queries =  [
-            URLQueryItem(name: "client_id", value: clientId),
-            URLQueryItem(name: "redirect_uri", value: redirectURI),
-            URLQueryItem(name: "response_type", value: "code"),
-            URLQueryItem(name: "scope", value: "global"),
+        var queries: [String: Any] =  [
+            "client_id": clientId,
+            "redirect_uri": redirectURI,
+            "response_type": "code",
+            "scope": "global",
         ]
         if let accountEmail {
-            queries.append(URLQueryItem(name: "user_email", value: accountEmail))
+            queries["user_email"] =  accountEmail
         }
 
-        let authorizeURL = URL(string: "https://public-api.wordpress.com/oauth2/authorize")!
-            .appending(queryItems: queries)
+        // Using Alamofire instead of URL to encode query string because URL do not encoded "+" (which may present
+        // in user's email) in query. WP.com treat "+" in URL query as a whitespace, which cause the login page to
+        // prepopulate the email address incorrectly, i.e. "foo+bar@baz.com" shows as "foo bar@baz.com"
+        let authorizeURL = try? URLEncoding.queryString.encode(URLRequest(url: URL(string: "https://public-api.wordpress.com/oauth2/authorize")!), with: queries).url
+        guard let authorizeURL else { throw .urlError(URLError(.badURL)) }
 
         let callbackURL = try await authorize(from: viewController, url: authorizeURL, prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
 
@@ -313,7 +316,6 @@ private extension WordPressDotComAuthenticator.SignInError {
 
 private extension WordPressDotComAuthenticator.AuthenticationError {
     var alertMessage: String? {
-        let alertMessage: String
         switch self {
         case .cancelled:
             // `.cancelled` error is thrown when user taps the cancel button in the presented Safari view controller.

--- a/WordPress/WordPressTest/Login/WordPressDotComAuthenticatorTests.swift
+++ b/WordPress/WordPressTest/Login/WordPressDotComAuthenticatorTests.swift
@@ -119,7 +119,7 @@ class WordPressDotComAuthenticatorTests: CoreDataTestCase {
         // Then `mismatchedEmail` error should be returned
         let authenticator = WordPressDotComAuthenticator(coreDataStack: contextManager, authenticator: fakeAuthenticator(callback: ["code": "random"]))
         do {
-            let _ = try await authenticator.attemptSignIn(from: UIViewController(), context: .reAuthentication(.init(account)))
+            let _ = try await authenticator.attemptSignIn(from: UIViewController(), context: .reauthentication(accountEmail: account.email))
             XCTFail("Unexpected successful result")
         } catch let .mismatchedEmail(expectedEmail) {
             XCTAssertEqual(expectedEmail, "test@example.com")

--- a/WordPress/WordPressTest/Login/WordPressDotComAuthenticatorTests.swift
+++ b/WordPress/WordPressTest/Login/WordPressDotComAuthenticatorTests.swift
@@ -105,6 +105,28 @@ class WordPressDotComAuthenticatorTests: CoreDataTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+
+    func testReAuthenticationWithUnexpectedAccount() async throws {
+        // Given the app is already signed in with a WP.com account.
+        let account = AccountBuilder(mainContext).with(email: "test@example.com").with(username: "default_account").with(authToken: "token").build()
+        try mainContext.save()
+        AccountService(coreDataStack: contextManager).setDefaultWordPressComAccount(account)
+
+        // When A different account is authenticated via web login
+        stubTokenExchange()
+        stubGetAccountDetails()
+
+        // Then `mismatchedEmail` error should be returned
+        let authenticator = WordPressDotComAuthenticator(coreDataStack: contextManager, authenticator: fakeAuthenticator(callback: ["code": "random"]))
+        do {
+            let _ = try await authenticator.attemptSignIn(from: UIViewController(), context: .reAuthentication(.init(account)))
+            XCTFail("Unexpected successful result")
+        } catch let .mismatchedEmail(expectedEmail) {
+            XCTAssertEqual(expectedEmail, "test@example.com")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
 }
 
 private extension WordPressDotComAuthenticatorTests {


### PR DESCRIPTION
> [!Note]
> This PR is built on top of #23749 and requires the changes in D165346-code.

When re-authenticating or signing in to a Jetpack site, we expected a specific WP.com account. We already have checks in place to throw an error if users sign in with an unexpected WP.com account. However, from UX perspective, it'd be better to pre-fill the username/email text field on the login page with the expected WP.com account email. That's what this PR does.

## Test Instructions

Use Jetpack login as an example.
1. On desktop browser, fully connect a self-hosted site to Jetpack.
2. On the mobile app, add the self-hosted site.
3. Go to "Stats" in the app, and tap "Log in"

The username/email text field in the login web page should be prepopulated with the email addresses of the account used in step 1.

## Regression Notes
1. Potential unintended areas of impact


5. What I did to test those areas of impact (or what existing automated tests I relied on)


6. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)