### PR TITLE
Self-hosted site user management

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -60,7 +60,7 @@ let package = Package(
         .target(name: "WordPressFlux"),
         .target(name: "WordPressSharedObjC", resources: [.process("Resources")]),
         .target(name: "WordPressShared", dependencies: [.target(name: "WordPressSharedObjC")], resources: [.process("Resources")]),
-        .target(name: "WordPressUI", resources: [.process("Resources")]),
+        .target(name: "WordPressUI", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")]),
         .testTarget(name: "JetpackStatsWidgetsCoreTests", dependencies: [.target(name: "JetpackStatsWidgetsCore")]),
         .testTarget(name: "DesignSystemTests", dependencies: [.target(name: "DesignSystem")]),
         .testTarget(name: "WordPressFluxTests", dependencies: ["WordPressFlux"]),

--- a/Modules/Sources/WordPressShared/Utility/StringRankedSearch.swift
+++ b/Modules/Sources/WordPressShared/Utility/StringRankedSearch.swift
@@ -120,3 +120,14 @@ extension StringRankedSearch {
         .map(\.0)
     }
 }
+
+/// Objects conforming to `StringRankedSearchable` can be searched by calling `search(query:)` on a collection of them
+public protocol StringRankedSearchable {
+    var searchString: String { get }
+}
+
+public extension Collection where Iterator.Element: StringRankedSearchable {
+    func search(query: String, minScore: Double = 0.7) -> [Iterator.Element] {
+        StringRankedSearch(searchTerm: query).search(in: self, minScore: minScore) { $0.searchString }
+    }
+}

--- a/Modules/Sources/WordPressUI/Extensions/SwiftUI+Extensions.swift
+++ b/Modules/Sources/WordPressUI/Extensions/SwiftUI+Extensions.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+public extension EdgeInsets {
+    static let zero = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+}

--- a/Modules/Sources/WordPressUI/Views/Users/Components/UserListItem.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Components/UserListItem.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct UserListItem: View {
+
+    @ScaledMetric(relativeTo: .headline)
+    var height: CGFloat = 48
+
+    @Environment(\.sizeCategory)
+    var sizeCategory
+
+    var user: DisplayUser
+
+    var body: some View {
+        NavigationLink {
+            UserDetailView(user: user)
+        } label: {
+            HStack(alignment: .top) {
+                if !sizeCategory.isAccessibilityCategory {
+                    if let profilePhotoUrl = user.profilePhotoUrl {
+                        UserProfileImage(size: CGSize(width: height, height: height), url: profilePhotoUrl)
+                    }
+                }
+                VStack(alignment: .leading) {
+                    Text(user.displayName).font(.headline)
+                    Text(user.handle).font(.body).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    UserListItem(user: DisplayUser.MockUser)
+}

--- a/Modules/Sources/WordPressUI/Views/Users/Components/UserListItem.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Components/UserListItem.swift
@@ -8,11 +8,19 @@ struct UserListItem: View {
     @Environment(\.sizeCategory)
     var sizeCategory
 
-    var user: DisplayUser
+    private let user: DisplayUser
+    private let userProvider: UserDataProvider
+    private let actionDispatcher: UserManagementActionDispatcher
+
+    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
+        self.user = user
+        self.userProvider = userProvider
+        self.actionDispatcher = actionDispatcher
+    }
 
     var body: some View {
         NavigationLink {
-            UserDetailView(user: user)
+            UserDetailView(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher)
         } label: {
             HStack(alignment: .top) {
                 if !sizeCategory.isAccessibilityCategory {
@@ -30,5 +38,5 @@ struct UserListItem: View {
 }
 
 #Preview {
-    UserListItem(user: DisplayUser.MockUser)
+    UserListItem(user: DisplayUser.MockUser, userProvider: MockUserProvider(), actionDispatcher: UserManagementActionDispatcher())
 }

--- a/Modules/Sources/WordPressUI/Views/Users/Components/UserProfileImage.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Components/UserProfileImage.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct UserProfileImage: View {
+
+    private let size: CGSize
+
+    private let url: URL
+
+    init(size: CGSize, email: String) {
+        self.size = size
+        self.url = URL(string: "https://gravatar.com/avatar/58fc51586c9a1f9895ac70e3ca60886e?size=256")!
+    }
+
+    init(size: CGSize, url: URL) {
+        self.size = size
+        self.url = url
+    }
+
+    var body: some View {
+        AsyncImage(
+            url: self.url,
+            content: { image in
+                image.resizable()
+                    .frame(width: size.height, height: size.height)
+                    .aspectRatio(contentMode: .fit)
+                    .clipShape(.rect(cornerRadius: 4.0))
+            },
+            placeholder: {
+                ProgressView().frame(width: size.height, height: size.height)
+            }
+        )
+    }
+}
+
+#Preview {
+    UserProfileImage(size: CGSize(width: 64, height: 64), email: "test@example.com")
+}

--- a/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public protocol UserDataProvider {
+
+    typealias CachedUserListCallback = ([WordPressUI.DisplayUser]) async -> Void
+
+    func fetchCurrentUserCan(_ capability: String) async throws -> Bool
+    func fetchUsers(cachedResults: CachedUserListCallback?) async throws -> [WordPressUI.DisplayUser]
+
+    func invalidateCaches() async throws
+}
+
+@MainActor
+public struct UserObjectResolver {
+    public static var userProvider: UserDataProvider = MockUserProvider()
+    public static var actionDispatcher: UserManagementActionDispatcher = UserManagementActionDispatcher()
+}
+
+/// Subclass this and register it with the SwiftUI `.environmentObject` method
+/// to perform user management actions.
+///
+/// The default implementation is set up for testing with SwiftUI Previews
+open class UserManagementActionDispatcher: ObservableObject {
+    public init() {}
+
+    open func setNewPassword(id: Int32, newPassword: String) async throws {
+        try await Task.sleep(for: .seconds(2))
+    }
+
+    open func deleteUser(id: Int32, reassigningPostsTo userId: Int32) async throws {
+        try await Task.sleep(for: .seconds(2))
+    }
+}
+
+package struct MockUserProvider: UserDataProvider {
+
+    let dummyDataUrl = URL(string: "https://my.api.mockaroo.com/users.json?key=067c9730")!
+
+    package func fetchUsers(cachedResults: CachedUserListCallback? = nil) async throws -> [WordPressUI.DisplayUser] {
+        let response = try await URLSession.shared.data(from: dummyDataUrl)
+        return try JSONDecoder().decode([DisplayUser].self, from: response.0)
+    }
+
+    package func fetchCurrentUserCan(_ capability: String) async throws -> Bool {
+        true
+    }
+
+    package func invalidateCaches() async throws {
+        // Do nothing
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
@@ -10,12 +10,6 @@ public protocol UserDataProvider {
     func invalidateCaches() async throws
 }
 
-@MainActor
-public struct UserObjectResolver {
-    public static var userProvider: UserDataProvider = MockUserProvider()
-    public static var actionDispatcher: UserManagementActionDispatcher = UserManagementActionDispatcher()
-}
-
 /// Subclass this and register it with the SwiftUI `.environmentObject` method
 /// to perform user management actions.
 ///

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/DisplayUser.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/DisplayUser.swift
@@ -1,0 +1,76 @@
+import Foundation
+import WordPressShared
+
+public struct DisplayUser: Identifiable, Codable {
+    public let id: Int32
+    public let handle: String
+    public let username: String
+    public let firstName: String
+    public let lastName: String
+    public let displayName: String
+    public let profilePhotoUrl: URL?
+    public let role: String
+
+    public let emailAddress: String
+    public let websiteUrl: String?
+
+    public let biography: String?
+
+    public init(
+        id: Int32,
+        handle: String,
+        username: String,
+        firstName: String,
+        lastName: String,
+        displayName: String,
+        profilePhotoUrl: URL?,
+        role: String,
+        emailAddress: String,
+        websiteUrl: String?,
+        biography: String?
+    ) {
+        self.id = id
+        self.handle = handle
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.displayName = displayName
+        self.profilePhotoUrl = profilePhotoUrl
+        self.role = role
+        self.emailAddress = emailAddress
+        self.websiteUrl = websiteUrl
+        self.biography = biography
+    }
+
+    static package let MockUser = DisplayUser(
+        id: 16,
+        handle: "@person",
+        username: "example",
+        firstName: "John",
+        lastName: "Smith",
+        displayName: "John Smith",
+        profilePhotoUrl: URL(string: "https://gravatar.com/avatar/58fc51586c9a1f9895ac70e3ca60886e?size=256"),
+        role: "administrator",
+        emailAddress: "john@example.com",
+        websiteUrl: "",
+        biography: ""
+    )
+}
+
+extension DisplayUser: StringRankedSearchable {
+    public var searchString: String {
+
+        // These are in ranked order – the higher something is in the list, the more heavily it's weighted
+        [
+            handle,
+            username,
+            firstName,
+            lastName,
+            emailAddress,
+            displayName,
+            emailAddress,
+        ]
+            .compactMap { $0 }
+            .joined(separator: " ")
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserChangePasswordViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserChangePasswordViewModel.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+public class UserChangePasswordViewModel: ObservableObject {
+
+    public enum Errors: LocalizedError {
+        case passwordMustNotBeEmpty
+
+        public var errorDescription: String? {
+            switch self {
+                case .passwordMustNotBeEmpty: NSLocalizedString(
+                    "userchangepassword.error.empty",
+                    value: "Password must not be empty",
+                    comment: "An error message that appears when an empty password has been entered"
+                )
+            }
+        }
+    }
+
+    @Published
+    var password: String = ""
+
+    @Published
+    var isChangingPassword: Bool = false
+
+    @Published
+    var error: Error? = nil
+
+    @Environment(\.dismiss)
+    var dismissAction
+
+    let user: DisplayUser
+
+    init(user: DisplayUser) {
+        self.user = user
+    }
+
+    func didTapChangePassword(callback: @escaping () -> Void) {
+
+        if password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            withAnimation {
+                error = Errors.passwordMustNotBeEmpty
+            }
+            return
+        }
+
+        withAnimation {
+            error = nil
+        }
+
+        Task {
+            await MainActor.run {
+                withAnimation {
+                    self.isChangingPassword = true
+                }
+            }
+
+            do {
+                try await UserObjectResolver.actionDispatcher.setNewPassword(id: user.id, newPassword: password)
+            } catch {
+                self.error = error
+            }
+
+            await MainActor.run {
+                withAnimation {
+                    self.isChangingPassword = false
+                }
+            }
+
+            await MainActor.run {
+                callback()
+            }
+        }
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserChangePasswordViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserChangePasswordViewModel.swift
@@ -28,10 +28,12 @@ public class UserChangePasswordViewModel: ObservableObject {
     @Environment(\.dismiss)
     var dismissAction
 
+    private let actionDispatcher: UserManagementActionDispatcher
     let user: DisplayUser
 
-    init(user: DisplayUser) {
+    init(user: DisplayUser, actionDispatcher: UserManagementActionDispatcher) {
         self.user = user
+        self.actionDispatcher = actionDispatcher
     }
 
     func didTapChangePassword(callback: @escaping () -> Void) {
@@ -55,7 +57,7 @@ public class UserChangePasswordViewModel: ObservableObject {
             }
 
             do {
-                try await UserObjectResolver.actionDispatcher.setNewPassword(id: user.id, newPassword: password)
+                try await actionDispatcher.setNewPassword(id: user.id, newPassword: password)
             } catch {
                 self.error = error
             }

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+
+@MainActor
+public class UserDeleteViewModel: ObservableObject {
+
+    @Published
+    var isFetchingOtherUsers: Bool = false
+
+    @Published
+    var isDeletingUser: Bool = false
+
+    @Published
+    var error: Error? = nil
+
+    @Published
+    var otherUserId: Int32 = 0
+
+    @Published
+    var otherUsers: [DisplayUser] = []
+
+    @Published
+    var deleteButtonIsDisabled: Bool = true
+
+    let user: DisplayUser
+
+    init(user: DisplayUser) {
+        self.user = user
+    }
+
+    func fetchOtherUsers() async {
+        withAnimation {
+            isFetchingOtherUsers = true
+            deleteButtonIsDisabled = true
+        }
+
+        do {
+            let otherUsers = try await UserObjectResolver.userProvider
+                .fetchUsers { self.didReceiveUsers($0) }
+
+            self.didReceiveUsers(otherUsers)
+        } catch {
+            withAnimation {
+                self.error = error
+                deleteButtonIsDisabled = true
+            }
+        }
+
+        withAnimation {
+            isFetchingOtherUsers = false
+        }
+    }
+
+    func didReceiveUsers(_ users: [DisplayUser]) {
+        withAnimation {
+            if otherUserId == 0 {
+                otherUserId = otherUsers.first?.id ?? 0
+            }
+
+            otherUsers = users
+                .filter { $0.id != self.user.id } // Don't allow re-assigning to yourself
+                .sorted(using: KeyPathComparator(\.username))
+            error = nil
+            deleteButtonIsDisabled = false
+            isFetchingOtherUsers = false
+        }
+    }
+
+    func didTapDeleteUser(callback: @escaping () -> Void) {
+        debugPrint("Deleting \(user.username) and re-assigning their content to \(otherUserId)")
+
+        withAnimation {
+            error = nil
+        }
+
+        Task {
+            await MainActor.run {
+                withAnimation {
+                    isDeletingUser = true
+                }
+            }
+
+            do {
+                try await UserObjectResolver.actionDispatcher.deleteUser(id: user.id, reassigningPostsTo: otherUserId)
+            } catch {
+                debugPrint(error.localizedDescription)
+                await MainActor.run {
+                    withAnimation {
+                        self.error = error
+                    }
+                }
+            }
+
+            await MainActor.run {
+                withAnimation {
+                    isDeletingUser = false
+                    callback()
+                }
+            }
+        }
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
@@ -21,10 +21,14 @@ public class UserDeleteViewModel: ObservableObject {
     @Published
     var deleteButtonIsDisabled: Bool = true
 
+    private let userProvider: UserDataProvider
+    private let actionDispatcher: UserManagementActionDispatcher
     let user: DisplayUser
 
-    init(user: DisplayUser) {
+    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
         self.user = user
+        self.userProvider = userProvider
+        self.actionDispatcher = actionDispatcher
     }
 
     func fetchOtherUsers() async {
@@ -34,8 +38,7 @@ public class UserDeleteViewModel: ObservableObject {
         }
 
         do {
-            let otherUsers = try await UserObjectResolver.userProvider
-                .fetchUsers { self.didReceiveUsers($0) }
+            let otherUsers = try await userProvider.fetchUsers { self.didReceiveUsers($0) }
 
             self.didReceiveUsers(otherUsers)
         } catch {
@@ -80,7 +83,7 @@ public class UserDeleteViewModel: ObservableObject {
             }
 
             do {
-                try await UserObjectResolver.actionDispatcher.deleteUser(id: user.id, reassigningPostsTo: otherUserId)
+                try await actionDispatcher.deleteUser(id: user.id, reassigningPostsTo: otherUserId)
             } catch {
                 debugPrint(error.localizedDescription)
                 await MainActor.run {

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDetailViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDetailViewModel.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+@MainActor
+class UserDetailViewModel: ObservableObject {
+
+    @Published
+    var currentUserCanModifyUsers: Bool = false
+
+    @Published
+    var isLoadingCurrentUser: Bool = false
+
+    @Published
+    var error: Error? = nil
+
+    func loadCurrentUserRole() async {
+        withAnimation {
+            isLoadingCurrentUser = true
+        }
+
+        do {
+            let hasPermissions = try await UserObjectResolver.userProvider.fetchCurrentUserCan("edit_users")
+            error = nil
+
+            withAnimation {
+                currentUserCanModifyUsers = hasPermissions
+            }
+        } catch {
+            withAnimation {
+                self.error = error
+            }
+        }
+
+        withAnimation {
+            isLoadingCurrentUser = false
+        }
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDetailViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDetailViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @MainActor
 class UserDetailViewModel: ObservableObject {
+    private let userProvider: UserDataProvider
 
     @Published
     var currentUserCanModifyUsers: Bool = false
@@ -12,13 +13,17 @@ class UserDetailViewModel: ObservableObject {
     @Published
     var error: Error? = nil
 
+    init(userProvider: UserDataProvider) {
+        self.userProvider = userProvider
+    }
+
     func loadCurrentUserRole() async {
         withAnimation {
             isLoadingCurrentUser = true
         }
 
         do {
-            let hasPermissions = try await UserObjectResolver.userProvider.fetchCurrentUserCan("edit_users")
+            let hasPermissions = try await userProvider.fetchCurrentUserCan("edit_users")
             error = nil
 
             withAnimation {

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import WordPressShared
+
+@MainActor
+class UserListViewModel: ObservableObject {
+
+    struct Section: Identifiable {
+        var id: String { role }
+        let role: String
+        let users: [DisplayUser]
+    }
+
+    /// The initial set of users fetched by `fetchItems`
+    private var users: [DisplayUser] = []
+
+    @Published
+    var sortedUsers: [Section] = []
+
+    @Published
+    var error: Error? = nil
+
+    @Published
+    var isLoadingItems: Bool = true
+
+    @Published
+    var searchTerm: String = "" {
+        didSet {
+            if searchTerm.trimmingCharacters(in: .whitespacesAndNewlines) == "" {
+                setSearchResults(sortUsers(users))
+            } else {
+                let searchResults = users.search(query: searchTerm)
+                setSearchResults([Section(role: "Search Results", users: searchResults)])
+            }
+        }
+    }
+
+    func fetchItems() async {
+        withAnimation {
+            isLoadingItems = true
+        }
+
+        do {
+            let users = try await UserObjectResolver.userProvider.fetchUsers { cachedResults in
+                self.setUsers(cachedResults)
+            }
+            setUsers(users)
+        } catch {
+            self.error = error
+            isLoadingItems = false
+        }
+    }
+
+    @Sendable
+    func refreshItems() async {
+        do {
+            let users = try await UserObjectResolver.userProvider.fetchUsers { cachedResults in
+                self.setUsers(cachedResults)
+            }
+            setUsers(users)
+        } catch {
+            // Do nothing for now – this should probably show a "Toast" notification or something
+        }
+    }
+
+    func setUsers(_ newValue: [DisplayUser]) {
+        withAnimation {
+            self.users = newValue
+            self.sortedUsers = sortUsers(newValue)
+            isLoadingItems = false
+        }
+    }
+
+    func setSearchResults(_ newValue: [Section]) {
+        withAnimation {
+            self.sortedUsers = newValue
+        }
+    }
+
+    private func sortUsers(_ users: [DisplayUser]) -> [Section] {
+        Dictionary(grouping: users, by: { $0.role })
+            .map { Section(role: $0.key, users: $0.value.sorted(by: { $0.username < $1.username })) }
+            .sorted { $0.role < $1.role }
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
@@ -12,6 +12,7 @@ class UserListViewModel: ObservableObject {
 
     /// The initial set of users fetched by `fetchItems`
     private var users: [DisplayUser] = []
+    private let userProvider: UserDataProvider
 
     @Published
     var sortedUsers: [Section] = []
@@ -34,13 +35,17 @@ class UserListViewModel: ObservableObject {
         }
     }
 
+    init(userProvider: UserDataProvider) {
+        self.userProvider = userProvider
+    }
+
     func fetchItems() async {
         withAnimation {
             isLoadingItems = true
         }
 
         do {
-            let users = try await UserObjectResolver.userProvider.fetchUsers { cachedResults in
+            let users = try await userProvider.fetchUsers { cachedResults in
                 self.setUsers(cachedResults)
             }
             setUsers(users)
@@ -53,7 +58,7 @@ class UserListViewModel: ObservableObject {
     @Sendable
     func refreshItems() async {
         do {
-            let users = try await UserObjectResolver.userProvider.fetchUsers { cachedResults in
+            let users = try await userProvider.fetchUsers { cachedResults in
                 self.setUsers(cachedResults)
             }
             setUsers(users)

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserChangePasswordView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserChangePasswordView.swift
@@ -52,7 +52,7 @@ struct UserChangePasswordView: View {
 
 struct UserChangePasswordViewPreviews: PreviewProvider {
 
-    static let viewModel = UserChangePasswordViewModel(user: DisplayUser.MockUser)
+    static let viewModel = UserChangePasswordViewModel(user: DisplayUser.MockUser, actionDispatcher: UserManagementActionDispatcher())
 
     static var previews: some View {
         NavigationStack {

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserChangePasswordView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserChangePasswordView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct UserChangePasswordView: View {
+
+    @ObservedObject
+    var viewModel: UserChangePasswordViewModel
+
+    @Environment(\.dismiss)
+    var dismiss
+
+    var body: some View {
+        Form {
+
+            if let error = viewModel.error {
+                Section {
+                    Text(error.localizedDescription)
+                        .font(.headline)
+                        .foregroundStyle(.red)
+                }
+                .listRowBackground(Color.clear)
+                .listRowInsets(.zero)
+            }
+
+            Section {
+                SecureField("New Password", text: $viewModel.password)
+            }
+
+            Section {
+                Button(action: {
+                    viewModel.didTapChangePassword {
+                        self.dismiss()
+                    }
+                }, label: {
+                    HStack {
+                        Spacer()
+                        Text("Save Changes")
+                            .font(.headline)
+                            .padding(4)
+                        Spacer()
+                        if viewModel.isChangingPassword {
+                            ProgressView().tint(.white)
+                        }
+                    }
+                }).buttonStyle(.borderedProminent)
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(.zero)
+        }
+        .navigationTitle("Change Password")
+    }
+}
+
+struct UserChangePasswordViewPreviews: PreviewProvider {
+
+    static let viewModel = UserChangePasswordViewModel(user: DisplayUser.MockUser)
+
+    static var previews: some View {
+        NavigationStack {
+            UserChangePasswordView(viewModel: viewModel)
+        }
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDeleteView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDeleteView.swift
@@ -3,15 +3,19 @@ import SwiftUI
 struct UserDeleteView: View {
 
     @StateObject
-    var viewModel: UserDeleteViewModel
+    private var viewModel: UserDeleteViewModel
+    private let userProvider: UserDataProvider
+    private let actionDispatcher: UserManagementActionDispatcher
 
     @Environment(\.dismiss)
     var dismissAction: DismissAction
 
     var parentDismissAction: DismissAction?
 
-    init(user: DisplayUser, dismiss: DismissAction? = nil) {
-        _viewModel = StateObject(wrappedValue: UserDeleteViewModel(user: user))
+    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher, dismiss: DismissAction? = nil) {
+        self.userProvider = userProvider
+        self.actionDispatcher = actionDispatcher
+        _viewModel = StateObject(wrappedValue: UserDeleteViewModel(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher))
         parentDismissAction = dismiss
     }
 
@@ -61,6 +65,6 @@ struct UserDeleteView: View {
 
 #Preview {
     NavigationStack {
-        UserDeleteView(user: .MockUser)
+        UserDeleteView(user: .MockUser, userProvider: MockUserProvider(), actionDispatcher: UserManagementActionDispatcher())
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDeleteView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDeleteView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct UserDeleteView: View {
+
+    @StateObject
+    var viewModel: UserDeleteViewModel
+
+    @Environment(\.dismiss)
+    var dismissAction: DismissAction
+
+    var parentDismissAction: DismissAction?
+
+    init(user: DisplayUser, dismiss: DismissAction? = nil) {
+        _viewModel = StateObject(wrappedValue: UserDeleteViewModel(user: user))
+        parentDismissAction = dismiss
+    }
+
+    var body: some View {
+        Form {
+            if let error = viewModel.error {
+                Text(error.localizedDescription)
+            }
+            else if viewModel.isFetchingOtherUsers {
+                LabeledContent("Attribute all content to:") {
+                    ProgressView()
+                }
+            } else {
+                Picker("Attribute all content to:", selection: $viewModel.otherUserId.animation()) {
+                    ForEach(viewModel.otherUsers) { user in
+                        Text(user.username).tag(user.id)
+                    }
+                }
+            }
+            Section {
+                Button(role: .destructive) {
+                    viewModel.didTapDeleteUser {
+                        self.dismissAction()
+                        self.parentDismissAction?()
+                    }
+                } label: {
+                    HStack {
+                        Spacer()
+                        Text("Delete User")
+                            .font(.headline)
+                            .padding(4)
+                        Spacer()
+                        if viewModel.isDeletingUser {
+                            ProgressView().tint(.white)
+                        }
+                    }
+                }.buttonStyle(.borderedProminent)
+                .disabled(viewModel.deleteButtonIsDisabled)
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(.zero)
+        }
+        .navigationTitle("Delete User")
+        .task { await viewModel.fetchOtherUsers() }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        UserDeleteView(user: .MockUser)
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+struct UserDetailView: View {
+
+    let user: DisplayUser
+
+    @StateObject
+    var viewModel = UserDetailViewModel()
+
+    @Environment(\.dismiss)
+    var dismissAction: DismissAction
+
+    var body: some View {
+        Form {
+            Section(Strings.nameSectionTitle) {
+                LabeledContent(Strings.roleFieldTitle, value: user.role)
+                LabeledContent(Strings.firstNameFieldTitle, value: user.firstName)
+                LabeledContent(Strings.lastNameFieldTitle, value: user.lastName)
+                LabeledContent(Strings.nicknameFieldTitle, value: user.handle)
+                LabeledContent(Strings.displayNameFieldTitle, value: user.displayName)
+            }
+
+            Section(Strings.contactInfoSectionTitle) {
+                LabeledContent(Strings.emailAddressFieldTitle, value: user.emailAddress)
+                if let website = user.websiteUrl {
+                    LabeledContent(Strings.websiteFieldTitle, value: website)
+                }
+            }
+
+            Section(Strings.aboutUserSectionTitle) {
+                LabeledContent(Strings.bioFieldTitle, value: user.biography ?? "")
+                if let profilePhotoUrl = user.profilePhotoUrl {
+                    LabeledContent(Strings.profilePictureFieldTitle) {
+                        UserProfileImage(size: CGSize(width: 96, height: 96), url: profilePhotoUrl)
+                    }
+                }
+            }
+
+            if viewModel.currentUserCanModifyUsers {
+                Section(Strings.accountManagementSectionTitle) {
+                    NavigationLink {
+                        UserChangePasswordView(viewModel: passwordChangeViewModel)
+                    } label: {
+                        Text(Strings.setNewPasswordActionTitle)
+                    }
+
+                    NavigationLink {
+                        // Pass this view's dismiss action, because if we delete a user, we want that screen *and* this one gone
+                        UserDeleteView(user: user, dismiss: dismissAction)
+                    } label: {
+                        Text(Strings.deleteUserActionTitle)
+                    }
+                }
+            }
+        }
+        .navigationTitle(user.displayName)
+        .task {
+            await viewModel.loadCurrentUserRole()
+        }
+    }
+
+    var passwordChangeViewModel: UserChangePasswordViewModel {
+        UserChangePasswordViewModel(user: user)
+    }
+
+    enum Strings {
+        static let nameSectionTitle = NSLocalizedString(
+            "userdetail.name-section-title",
+            value: "Name",
+            comment: "The 'Name' section of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let contactInfoSectionTitle = NSLocalizedString(
+            "userdetail.contact-info-section-title",
+            value: "Contact Info",
+            comment: "The 'Contact Info' section of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let aboutUserSectionTitle = NSLocalizedString(
+            "userdetail.about-user-section-title",
+            value: "About the User",
+            comment: "The 'About the user' section of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let accountManagementSectionTitle = NSLocalizedString(
+            "userdetail.account-management-section-title",
+            value: "Account Management",
+            comment: "The 'Account Management' section of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let roleFieldTitle = NSLocalizedString(
+            "userdetail.role-field-title",
+            value: "Role",
+            comment: "The 'Role' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let firstNameFieldTitle = NSLocalizedString(
+            "userdetail.first-name-field-title",
+            value: "First Name",
+            comment: "The 'First Name' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let lastNameFieldTitle = NSLocalizedString(
+            "userdetail.last-name-field-title",
+            value: "Last Name",
+            comment: "The 'Last Name' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let nicknameFieldTitle = NSLocalizedString(
+            "userdetail.nickname-field-title",
+            value: "Nickname",
+            comment: "The 'Nickname' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let displayNameFieldTitle = NSLocalizedString(
+            "userdetail.displayname-field-title",
+            value: "Display Name",
+            comment: "The 'Display Name publicly as' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let emailAddressFieldTitle = NSLocalizedString(
+            "userdetail.email-address-field-title",
+            value: "Email Address",
+            comment: "The 'Email' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let websiteFieldTitle = NSLocalizedString(
+            "userdetail.website-field-title",
+            value: "Website",
+            comment: "The 'Website' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let bioFieldTitle = NSLocalizedString(
+            "userdetail.bio-field-title",
+            value: "Biographical Info",
+            comment: "The 'Biographical Info' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let profilePictureFieldTitle = NSLocalizedString(
+            "userdetail.profile-picture-field-title",
+            value: "Profile Picture",
+            comment: "The 'Profile Picture' field of the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let setNewPasswordActionTitle  = NSLocalizedString(
+            "userdetail.set-new-password-action-title",
+            value: "Set New Password",
+            comment: "The 'Set New Password' button on the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let sendPasswordResetEmailActionTitle  = NSLocalizedString(
+            "userdetail.send-password-reset-email-action-title",
+            value: "Send Password Reset Email",
+            comment: "The 'Send Password Reset Email' button on the user profile – matches what's in /wp-admin/profile.php"
+        )
+
+        static let deleteUserActionTitle  = NSLocalizedString(
+            "userdetail.delete-user-action-title",
+            value: "Delete User",
+            comment: "The 'Delete User' button on the user profile – matches what's in /wp-admin/profile.php"
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        UserDetailView(user: DisplayUser.MockUser)
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailView.swift
@@ -2,13 +2,22 @@ import SwiftUI
 
 struct UserDetailView: View {
 
+    private let userProvider: UserDataProvider
+    private let actionDispatcher: UserManagementActionDispatcher
     let user: DisplayUser
 
     @StateObject
-    var viewModel = UserDetailViewModel()
+    var viewModel: UserDetailViewModel
 
     @Environment(\.dismiss)
     var dismissAction: DismissAction
+
+    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
+        self.user = user
+        self.userProvider = userProvider
+        self.actionDispatcher = actionDispatcher
+        _viewModel = StateObject(wrappedValue: UserDetailViewModel(userProvider: userProvider))
+    }
 
     var body: some View {
         Form {
@@ -46,7 +55,7 @@ struct UserDetailView: View {
 
                     NavigationLink {
                         // Pass this view's dismiss action, because if we delete a user, we want that screen *and* this one gone
-                        UserDeleteView(user: user, dismiss: dismissAction)
+                        UserDeleteView(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher, dismiss: dismissAction)
                     } label: {
                         Text(Strings.deleteUserActionTitle)
                     }
@@ -60,7 +69,7 @@ struct UserDetailView: View {
     }
 
     var passwordChangeViewModel: UserChangePasswordViewModel {
-        UserChangePasswordViewModel(user: user)
+        UserChangePasswordViewModel(user: user, actionDispatcher: actionDispatcher)
     }
 
     enum Strings {
@@ -164,6 +173,6 @@ struct UserDetailView: View {
 
 #Preview {
     NavigationStack {
-        UserDetailView(user: DisplayUser.MockUser)
+        UserDetailView(user: DisplayUser.MockUser, userProvider: MockUserProvider(), actionDispatcher: UserManagementActionDispatcher())
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserListView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserListView.swift
@@ -3,9 +3,15 @@ import SwiftUI
 public struct UserListView: View {
 
     @StateObject
-    var viewModel = UserListViewModel()
+    private var viewModel: UserListViewModel
+    private let userProvider: UserDataProvider
+    private let actionDispatcher: UserManagementActionDispatcher
 
-    public init() {}
+    public init(userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
+        self.userProvider = userProvider
+        self.actionDispatcher = actionDispatcher
+        _viewModel = StateObject(wrappedValue: UserListViewModel(userProvider: userProvider))
+    }
 
     public var body: some View {
         Group {
@@ -23,7 +29,7 @@ public struct UserListView: View {
                                 .listRowBackground(Color.clear)
                         } else {
                             ForEach(section.users) { user in
-                                UserListItem(user: user)
+                                UserListItem(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher)
                             }
                         }
                     }
@@ -61,6 +67,6 @@ public struct UserListView: View {
 
 #Preview {
     NavigationView {
-        UserListView()
+        UserListView(userProvider: MockUserProvider(), actionDispatcher: UserManagementActionDispatcher())
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserListView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserListView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+public struct UserListView: View {
+
+    @StateObject
+    var viewModel = UserListViewModel()
+
+    public init() {}
+
+    public var body: some View {
+        Group {
+            if let error = viewModel.error {
+                EmptyStateView(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
+            } else if viewModel.isLoadingItems {
+                ProgressView()
+            } else {
+                List(viewModel.sortedUsers) { section in
+                    Section(section.role) {
+                        if section.users.isEmpty {
+                            Text(Strings.noUsersFound)
+                                .font(.body)
+                                .foregroundStyle(Color.secondary)
+                                .listRowBackground(Color.clear)
+                        } else {
+                            ForEach(section.users) { user in
+                                UserListItem(user: user)
+                            }
+                        }
+                    }
+                }
+                .searchable(text: $viewModel.searchTerm, prompt: Text(Strings.searchPrompt))
+                    .disableAutocorrection(true)
+                    .textInputAutocapitalization(.never)
+                .refreshable(action: viewModel.refreshItems)
+            }
+        }
+        .navigationTitle(Strings.usersListTitle)
+        .task { await viewModel.fetchItems() }
+    }
+
+    enum Strings {
+        static let searchPrompt = NSLocalizedString(
+            "userlist.searchprompt",
+            value: "Search",
+            comment: "An instruction for the user to tap to start searching"
+        )
+
+        static let usersListTitle = NSLocalizedString(
+            "userlist.title",
+            value: "Users",
+            comment: "The heading at the top of the user list"
+        )
+
+        static let noUsersFound = NSLocalizedString(
+            "userlist.nousersfound",
+            value: "No users found",
+            comment: "Shown when the user list is empty"
+        )
+    }
+}
+
+#Preview {
+    NavigationView {
+        UserListView()
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 25.6
 -----
 * [*] [internal] Update Gravatar SDK to 3.0.0 [#23701]
+* [*] (Hidden under a feature flag) User Management for self-hosted sites. [#23768]
 
 25.5
 -----

--- a/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
@@ -152,6 +152,10 @@ extension Blog {
     func setSiteIdentifier(_ newValue: SiteIdentifier) {
         self.apiKey = newValue
     }
+
+    @objc var isSelfHosted: Bool {
+        self.account == nil
+    }
 }
 
 extension WpApiApplicationPasswordDetails {

--- a/WordPress/Classes/Services/UserService.swift
+++ b/WordPress/Classes/Services/UserService.swift
@@ -1,0 +1,111 @@
+import Foundation
+import WordPressAPI
+import WordPressUI
+
+/// UserService is responsible for fetching user acounts via the .org REST API – it's the replacement for `UsersService` (the XMLRPC-based approach)
+///
+struct UserService {
+
+    final class ActionDispatcher: UserManagementActionDispatcher {
+
+        private let client: WordPressClient
+
+        init(client: WordPressClient) {
+            self.client = client
+            super.init()
+        }
+
+        override func setNewPassword(id: Int32, newPassword: String) async throws {
+            _ = try await client.api.users.update(
+                userId: Int32(id),
+                params: UserUpdateParams(password: newPassword)
+            )
+        }
+
+        override func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws {
+            _ = try await client.api.users.delete(
+                userId: id,
+                params: UserDeleteParams(reassign: newUserId)
+            )
+        }
+    }
+
+    final actor UserCache {
+        var users: [DisplayUser] = []
+
+        func setUsers(_ newValue: [DisplayUser]) {
+            self.users = newValue
+        }
+
+        func clear() {
+            self.users = []
+        }
+    }
+
+    private let apiClient: WordPressClient
+    private let currentUserId: Int
+    fileprivate let userCache = UserCache()
+
+    let actionDispatcher: ActionDispatcher
+
+    init(api: WordPressClient, currentUserId: Int) {
+        self.apiClient = api
+        self.currentUserId = currentUserId
+        self.actionDispatcher = ActionDispatcher(client: apiClient)
+    }
+}
+
+extension UserService: WordPressUI.UserDataProvider {
+
+    func fetchCurrentUserCan(_ capability: String) async throws -> Bool {
+        try await apiClient.api.users.retrieveMeWithEditContext().capabilities.keys.contains(capability)
+    }
+
+    func fetchUsers(cachedResults: CachedUserListCallback? = nil) async throws -> [WordPressUI.DisplayUser] {
+
+        if await !userCache.users.isEmpty {
+            await cachedResults?(await userCache.users)
+        }
+
+        let users: [DisplayUser] = try await apiClient
+            .api
+            .users
+            .listWithEditContext(params: UserListParams(perPage: 100))
+            .compactMap {
+
+             guard let role = $0.roles.first else {
+                 return nil
+             }
+
+             return DisplayUser(
+                 id: $0.id,
+                 handle: $0.slug,
+                 username: $0.username,
+                 firstName: $0.firstName,
+                 lastName: $0.lastName,
+                 displayName: $0.username,
+                 profilePhotoUrl: profilePhotoUrl(for: $0),
+                 role: role,
+                 emailAddress: $0.email,
+                 websiteUrl: $0.link,
+                 biography: $0.description
+             )
+         }
+
+        await userCache.setUsers(users)
+
+        return users
+    }
+
+    func invalidateCaches() async throws {
+        await userCache.clear()
+    }
+
+    func profilePhotoUrl(for user: UserWithEditContext) -> URL? {
+        guard let rawUrl = user.avatarUrls?.first?.value else { // This results in a very low-res avatar
+            return nil
+        }
+
+        return URL(string: rawUrl)
+    }
+}

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -16,6 +16,7 @@ enum FeatureFlag: Int, CaseIterable {
     case newGutenberg
     case newGutenbergThemeStyles
     case newGutenbergPlugins
+    case selfHostedSiteUserManagement
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -51,6 +52,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .newGutenbergThemeStyles:
             return false
         case .newGutenbergPlugins:
+            return false
+        case .selfHostedSiteUserManagement:
             return false
         }
     }
@@ -88,6 +91,7 @@ extension FeatureFlag {
         case .newGutenberg: "Experimental Block Editor"
         case .newGutenbergThemeStyles: "Experimental Block Editor Styles"
         case .newGutenbergPlugins: "Experimental Block Editor Plugins"
+        case .selfHostedSiteUserManagement: "Self-hosted Site User Management"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -166,9 +166,7 @@ extension BlogDetailsViewController {
         let feature = NSLocalizedString("applicationPasswordRequired.feature.users", value: "User Management", comment: "Feature name for managing users in the app")
         let rootView = ApplicationPasswordRequiredView(blog: self.blog, localizedFeatureName: feature) { client in
             let service = UserService(api: client, currentUserId: userId)
-            UserObjectResolver.userProvider = service
-            UserObjectResolver.actionDispatcher = service.actionDispatcher
-            return UserListView()
+            return UserListView(userProvider: service, actionDispatcher: service.actionDispatcher)
         }
         presentationDelegate.presentBlogDetailsViewController(UIHostingController(rootView: rootView))
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -112,6 +112,10 @@ extension BlogDetailsViewController {
         return blog.supports(.people)
     }
 
+    @objc func shouldAddUsersRow() -> Bool {
+        blog.isSelfHosted
+    }
+
     @objc func shouldAddPluginsRow() -> Bool {
         return blog.supports(.pluginManagement)
     }
@@ -150,6 +154,21 @@ extension BlogDetailsViewController {
             let service = ApplicationPasswordService(api: client, currentUserId: userId)
             let viewModel = ApplicationTokenListViewModel(dataProvider: service)
             return ApplicationTokenListView(viewModel: viewModel)
+        }
+        presentationDelegate.presentBlogDetailsViewController(UIHostingController(rootView: rootView))
+    }
+
+    @objc func showUsers() {
+        guard let presentationDelegate, let userId = self.blog.userID?.intValue else {
+            return
+        }
+
+        let feature = NSLocalizedString("applicationPasswordRequired.feature.users", value: "User Management", comment: "Feature name for managing users in the app")
+        let rootView = ApplicationPasswordRequiredView(blog: self.blog, localizedFeatureName: feature) { client in
+            let service = UserService(api: client, currentUserId: userId)
+            UserObjectResolver.userProvider = service
+            UserObjectResolver.actionDispatcher = service.actionDispatcher
+            return UserListView()
         }
         presentationDelegate.presentBlogDetailsViewController(UIHostingController(rootView: rootView))
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -113,7 +113,7 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldAddUsersRow() -> Bool {
-        blog.isSelfHosted
+        FeatureFlag.selfHostedSiteUserManagement.enabled && blog.isSelfHosted
     }
 
     @objc func shouldAddPluginsRow() -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -511,6 +511,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
                                             animated:NO
                                       scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
                 [self showPeople];
+            } else if ([self.blog selfHostedSiteRestApi]) {
+                self.restorableSelectedIndexPath = indexPath;
+                [self.tableView selectRowAtIndexPath:indexPath
+                                            animated:NO
+                                      scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+                [self showUsers];
             }
             break;
         case BlogDetailsSubsectionPlugins:
@@ -833,6 +839,20 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     return row;
 }
 
+- (BlogDetailsRow *)usersRow
+{
+    __weak __typeof(self) weakSelf = self;
+    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Users", @"Noun. Title. Links to the user management feature.")
+                                        accessibilityIdentifier:@"User Row"
+                                                          image:[UIImage imageNamed:@"site-menu-people"]
+                                                       callback:^{
+        if (@available(iOS 16.4, *)) {
+            [weakSelf showUsers];
+        }
+    }];
+    return row;
+}
+
 - (BlogDetailsRow *)pluginsRow
 {
     __weak __typeof(self) weakSelf = self;
@@ -1105,6 +1125,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     // The 2nd section
     if ([self shouldAddPeopleRow]) {
         [secondSectionRows addObject:[self peopleRow]];
+    }
+    if ([self shouldAddUsersRow]) {
+        [secondSectionRows addObject:[self usersRow]];
     }
     if ([self shouldAddPluginsRow]) {
         [secondSectionRows addObject:[self pluginsRow]];


### PR DESCRIPTION
The majority of code in this PR is taken from #23572. See the first comment.

I added some minor changes in the following two commits: Removing a couple of global static variables and adding a feature flag for the new User Management feature.

I will make more changes to fine-tune both the UI and the implementation.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
