### PR TITLE
Add unit tests of comparing score of similar searches

### DIFF
--- a/Modules/Tests/WordPressSharedTests/StringRankedSearchTests.swift
+++ b/Modules/Tests/WordPressSharedTests/StringRankedSearchTests.swift
@@ -66,6 +66,35 @@ final class StringRankedSearchTests: XCTestCase {
         XCTAssertLessThan(score("john-appleseed-xxxx", "project"), score("john-appleseed", "project"))
     }
 
+    func testSearchBeginingOrEnd() {
+        XCTAssertEqual(score("AB00", "AB"), score("ABXX", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("4200", "42"), score("42XX", "42"), accuracy: 0.1)
+
+        XCTAssertEqual(score("00AB", "AB"), score("XXAB", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("0042", "42"), score("XX42", "42"), accuracy: 0.1)
+
+        XCTAssertEqual(score("AB_00", "AB"), score("AB_XX", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("42_00", "42"), score("42_XX", "42"), accuracy: 0.1)
+
+        XCTAssertEqual(score("00_AB", "AB"), score("XX_AB", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("00_42", "42"), score("XX_42", "42"), accuracy: 0.1)
+
+        XCTAssertEqual(score("AB/00", "AB"), score("AB/XX", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("42/00", "42"), score("42/XX", "42"), accuracy: 0.1)
+
+        XCTAssertEqual(score("00/AB", "AB"), score("XX/AB", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("00/42", "42"), score("XX/42", "42"), accuracy: 0.1)
+    }
+
+    func testCompareSearchNumbersAndLetters() {
+        XCTAssertEqual(score("42XX", "42"), score("ABXX", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("0042", "42"), score("XXAB", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("42_00", "42"), score("AB_XX", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("00_42", "42"), score("XX_AB", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("42/00", "42"), score("AB/XX", "AB"), accuracy: 0.1)
+        XCTAssertEqual(score("00/42", "42"), score("XX/AB", "AB"), accuracy: 0.1)
+    }
+
     func xtestPerformance() throws {
         measure {
             for _ in 0..<10000 {


### PR DESCRIPTION
This is more of a bug report than a PR.

I noticed that `StringRankedSearch` has inconsistent behavior around searching the beginning or ending part of a string.

@kean Do you mind looking at these test cases? A few of them fail, which IMO is unexpected. For example, search "42" in "0042" produces a score of 0.5, but searching it in "XX42" produces a score of 0.8.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
