### PR TITLE
feat: Enable sharing to non-Jetpack sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 25.6
 -----
 * [*] [internal] Update Gravatar SDK to 3.0.0 [#23701]
+* [*] [Jetpack-only] Enable pubishing to non-Jetpack sites when sharing content to the Jetpack app. [#23778]
 
 25.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,12 +1,12 @@
 25.6
 -----
 * [*] [internal] Update Gravatar SDK to 3.0.0 [#23701]
-* [*] Enable navigating to an individual post's stats from within the "view more" screen for author stats. [#23761]
-* [*] [Jetpack-only] Enable pubishing to non-Jetpack sites when sharing content to the Jetpack app. [#23778]
 
 25.5
 -----
 * [***] Use web-based sign-in flow (hidden under a feature flag) [#23675]
+* [*] Enable navigating to an individual post's stats from within the "view more" screen for author stats. [#23761]
+* [*] [Jetpack-only] Enable pubishing to non-Jetpack sites when sharing content to the Jetpack app. [#23778]
 
 25.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 25.6
 -----
 * [*] [internal] Update Gravatar SDK to 3.0.0 [#23701]
+* [*] Enable navigating to an individual post's stats from within the "view more" screen for author stats. [#23761]
 * [*] [Jetpack-only] Enable pubishing to non-Jetpack sites when sharing content to the Jetpack app. [#23778]
 
 25.5

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -32,7 +32,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
 
     id<AccountServiceRemote> remote = [self remoteForAccount:account];
     
-    BOOL filterJetpackSites = [AppConfiguration showJetpackSitesOnly];
+    BOOL filterJetpackSites = false;
 
     [remote getBlogs:filterJetpackSites success:^(NSArray *blogs) {
         [[[JetpackCapabilitiesService alloc] init] syncWithBlogs:blogs success:^(NSArray<RemoteBlog *> *blogs) {
@@ -404,7 +404,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
 {
     AccountServiceRemoteREST *remote = [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:account.wordPressComRestApi];
     
-    BOOL filterJetpackSites = [AppConfiguration showJetpackSitesOnly];
+    BOOL filterJetpackSites = false;
     
     [remote getBlogs:filterJetpackSites success:^(NSArray *remoteBlogs) {
         [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -9,7 +9,6 @@ import Foundation
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = false
     @objc static let isWordPress: Bool = true
-    @objc static let showJetpackSitesOnly: Bool = false
     @objc static let allowsNewPostShortcut: Bool = true
     @objc static let allowsConnectSite: Bool = true
     @objc static let allowSignUp: Bool = true

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -9,7 +9,6 @@ import Foundation
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = true
     @objc static let isWordPress: Bool = false
-    @objc static let showJetpackSitesOnly: Bool = false
     @objc static let allowsNewPostShortcut: Bool = true
     @objc static let allowsConnectSite: Bool = true
     @objc static let allowSignUp: Bool = true

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -96,10 +96,7 @@ extension AppExtensionsService {
     func fetchSites(onSuccess: @escaping ([RemoteBlog]?) -> (), onFailure: @escaping FailureBlock) {
         let remote = AccountServiceRemoteREST(wordPressComRestApi: simpleRestAPI)
 
-        var filterJetpackSites = false
-        #if IS_JETPACK
-        filterJetpackSites = true
-        #endif
+        let filterJetpackSites = AppConfiguration.showJetpackSitesOnly
 
         remote.getBlogs(filterJetpackSites, success: { blogs in
             guard let blogs = blogs as? [RemoteBlog] else {

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -96,7 +96,7 @@ extension AppExtensionsService {
     func fetchSites(onSuccess: @escaping ([RemoteBlog]?) -> (), onFailure: @escaping FailureBlock) {
         let remote = AccountServiceRemoteREST(wordPressComRestApi: simpleRestAPI)
 
-        let filterJetpackSites = AppConfiguration.showJetpackSitesOnly
+        let filterJetpackSites = false
 
         remote.getBlogs(filterJetpackSites, success: { blogs in
             guard let blogs = blogs as? [RemoteBlog] else {


### PR DESCRIPTION
The Jetpack app is no longer positioned to be a product focused solely on Jetpack sites. Therefore, when sharing content to the Jetpack app, we should allow sharing content to non-Jetpack sites.

Filtering the Jetpack app to include only Jetpack sites was done intentionally in https://github.com/wordpress-mobile/WordPress-iOS/pull/16140. The filtering was reverted in https://github.com/wordpress-mobile/WordPress-iOS/pull/17914, but the changes overlooked the sharing extension. 

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23707.

To test: Perform the steps outlined in https://github.com/wordpress-mobile/WordPress-iOS/issues/23707.

## Regression Notes
1. Potential unintended areas of impact
    Sharing features.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested sharing content to the Jetpack app.
4. What automated tests I added (or what prevented me from doing so)
    Deemed it unnecessary for this small change reverting a previously intentional
    change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
