### PR TITLE
Use EmptyStateView to display 'Application Password Required'

### DIFF
--- a/Modules/Sources/WordPressUI/Components/RestApiUpgradePrompt.swift
+++ b/Modules/Sources/WordPressUI/Components/RestApiUpgradePrompt.swift
@@ -11,36 +11,18 @@ public struct RestApiUpgradePrompt: View {
     }
 
     public var body: some View {
-        VStack {
-            let scrollView = ScrollView {
-                VStack(alignment: .leading) {
-                    Text(Strings.title)
-                        .font(.largeTitle)
-                        .fontWeight(.semibold)
-                        .padding(.bottom)
-
-                    Text(Strings.description(localizedFeatureName: localizedFeatureName))
-                        .font(.body)
-                }.padding()
+        EmptyStateView(
+            label: {
+                Text(Strings.title)
+            },
+            description: {
+                Text(Strings.description(localizedFeatureName: localizedFeatureName))
+            },
+            actions: {
+                Button(Strings.getStarted, action: didTapGetStarted)
+                    .buttonStyle(.borderedProminent)
             }
-
-            if #available(iOS 16.4, *) {
-                scrollView.scrollBounceBehavior(.basedOnSize, axes: [.vertical])
-            }
-
-            Spacer()
-            VStack {
-                Button(action: didTapGetStarted, label: {
-                    HStack {
-                        Spacer()
-                        Text(Strings.getStarted)
-                            .font(.headline)
-                            .padding(4)
-                        Spacer()
-                    }
-                }).buttonStyle(.borderedProminent)
-            }.padding()
-        }
+        )
     }
 
     private enum Strings {


### PR DESCRIPTION
As suggested by @kean 

Here is the comparison:

|   | Before | After |
| - | ------ | ----- |
| iPhone | ![iphone-before](https://github.com/user-attachments/assets/739735dc-09e8-4331-b9fb-7cab797601a9) | ![iphone-after](https://github.com/user-attachments/assets/82954d95-3796-4f8a-b608-790fb990354b) |
| iPad | ![ipad-before](https://github.com/user-attachments/assets/022d022b-9c36-4ad9-9995-fb17a2fafa83) | ![ipad-after](https://github.com/user-attachments/assets/ebc4bcc7-886b-44f1-bf2e-20cda945ae88) |


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
