### PR TITLE
Reader: Local Default Topics

### DIFF
--- a/WordPress/Classes/Models/ReaderDefaultTopic.swift
+++ b/WordPress/Classes/Models/ReaderDefaultTopic.swift
@@ -4,4 +4,28 @@ import Foundation
     override open class var TopicType: String {
         return "default"
     }
+
+    /// - note: Starting with 25.5, the app no longer uses the default topics
+    /// fetched from `/read/menu`. Instead, it uses the topics created locally.
+    /// The only reason these topics are needed is to filter entities in Core Data.
+    static func make(path: Path, in context: NSManagedObjectContext) throws -> ReaderDefaultTopic {
+        if let topic = context.firstObject(ofType: ReaderDefaultTopic.self, matching: NSPredicate(format: "path == %@", path.rawValue)) {
+            return topic
+        }
+        let topic = ReaderDefaultTopic(entity: ReaderDefaultTopic.entity(), insertInto: context)
+        topic.type = TopicType
+        topic.path = path.rawValue
+        topic.title = ""
+        try context.save()
+        return topic
+    }
+
+    enum Path: String {
+        // These are arbitrary values just to identify the entites.
+        case recommended = "/jpios/discover/recommended"
+        case firstPosts = "/jpios/discover/first-posts"
+        case latest = "/jpios/discover/latest"
+        case recent = "/jpios/recent"
+        case liked = "/jpios/liked"
+    }
 }

--- a/WordPress/Classes/Models/ReaderDefaultTopic.swift
+++ b/WordPress/Classes/Models/ReaderDefaultTopic.swift
@@ -25,7 +25,5 @@ import Foundation
         case recommended = "/jpios/discover/recommended"
         case firstPosts = "/jpios/discover/first-posts"
         case latest = "/jpios/discover/latest"
-        case recent = "/jpios/recent"
-        case liked = "/jpios/liked"
     }
 }

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -1,18 +1,12 @@
 #import <Foundation/Foundation.h>
 #import "CoreDataService.h"
 
-extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
-
 @class ReaderAbstractTopic;
 @class ReaderTagTopic;
 @class ReaderSiteTopic;
 @class ReaderSearchTopic;
 
 @interface ReaderTopicService : CoreDataService
-
-- (ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context;
-
-- (void)setCurrentTopic:(ReaderAbstractTopic *)topic;
 
 /**
  Fetches the topics for the reader's menu.

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -10,9 +10,6 @@
 @import WordPressKit;
 @import WordPressShared;
 
-NSString * const ReaderTopicFreshlyPressedPathCommponent = @"freshly-pressed";
-static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTopicPathKey";
-
 @implementation ReaderTopicService
 
 - (void)fetchReaderMenuWithSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure
@@ -41,73 +38,6 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
         } failure:failure];
     } completion:nil onQueue:dispatch_get_main_queue()];
-}
-
-- (ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context
-{
-    ReaderAbstractTopic *topic;
-    topic = [self currentTopicFromSavedPathInContext:context];
-
-    if (!topic) {
-        topic = [self currentTopicFromDefaultTopicInContext:context];
-        [self setCurrentTopic:topic];
-    }
-
-    return topic;
-}
-
-- (ReaderAbstractTopic *)currentTopicFromSavedPathInContext:(NSManagedObjectContext *)context
-{
-    ReaderAbstractTopic *topic;
-    NSString *topicPathString = [[UserPersistentStoreFactory userDefaultsInstance] stringForKey:ReaderTopicCurrentTopicPathKey];
-    if (topicPathString) {
-        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderAbstractTopic classNameWithoutNamespaces]];
-        request.predicate = [NSPredicate predicateWithFormat:@"path = %@", topicPathString];
-
-        NSError *error;
-        topic = [[context executeFetchRequest:request error:&error] firstObject];
-        if (error) {
-            DDLogError(@"%@ error fetching topic: %@", NSStringFromSelector(_cmd), error);
-        }
-    }
-    return topic;
-}
-
-- (ReaderAbstractTopic *)currentTopicFromDefaultTopicInContext:(NSManagedObjectContext *)context
-{
-    // Return the default topic
-    ReaderAbstractTopic *topic;
-    NSError *error;
-    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderDefaultTopic classNameWithoutNamespaces]];
-    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"title" ascending:YES];
-    request.sortDescriptors = @[sortDescriptor];
-    NSArray *topics = [context executeFetchRequest:request error:&error];
-    if (error) {
-        DDLogError(@"%@ error fetching topic: %@", NSStringFromSelector(_cmd), error);
-        return nil;
-    }
-
-    if ([topics count] == 0) {
-        return nil;
-    }
-
-    NSArray *matches = [topics filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"path CONTAINS[cd] %@", ReaderTopicFreshlyPressedPathCommponent]];
-    if ([matches count]) {
-        topic = matches[0];
-    } else {
-        topic = topics[0];
-    }
-
-    return topic;
-}
-
-- (void)setCurrentTopic:(ReaderAbstractTopic *)topic
-{
-    if (!topic) {
-        [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:ReaderTopicCurrentTopicPathKey];
-    } else {
-        [[UserPersistentStoreFactory userDefaultsInstance] setObject:topic.path forKey:ReaderTopicCurrentTopicPathKey];
-    }
 }
 
 - (void)deleteAllSearchTopics
@@ -862,10 +792,7 @@ array are marked as being unfollowed in Core Data.
         if ([currentTopics count] > 0) {
             for (ReaderAbstractTopic *topic in currentTopics) {
                 if (![topic isKindOfClass:[ReaderSiteTopic class]] && ![topicsToKeep containsObject:topic]) {
-                    
-                    if ([topic isEqual:[self currentTopicInContext:context]]) {
-                        self.currentTopic = nil;
-                    }
+
                     if (topic.inUse) {
                         if (!ReaderHelpers.isLoggedIn && [topic isKindOfClass:ReaderTagTopic.class]) {
                             DDLogInfo(@"Not unfollowing a locally saved topic: %@", topic.title);

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -106,7 +106,6 @@
 - (void)deleteAllTopics
 {
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-        [self setCurrentTopic:nil];
         NSArray *currentTopics = [ReaderAbstractTopic lookupAllInContext:context error:nil];
         for (ReaderAbstractTopic *topic in currentTopics) {
             DDLogInfo(@"Deleting topic: %@", topic.title);
@@ -235,8 +234,6 @@
             NSDictionary *properties = @{@"tag":topicName, @"source":source};
             [WPAnalytics trackReaderStat:WPAnalyticsStatReaderTagFollowed properties:properties];
             [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-                [self selectTopicWithID:topicID inContext:context];
-
                 // mark tag topic as followed
                 ReaderTagTopic *tag = [ReaderTagTopic lookupWithTagID:topicID inContext:context];
                 if (tag) {
@@ -525,16 +522,6 @@
         api = [self apiForRequestInContext:context];
     }];
     return api;
-}
-
-/**
- Finds an existing topic matching the specified topicID and, if found, makes it the
- selected topic.
- */
-- (void)selectTopicWithID:(NSNumber *)topicID inContext:(NSManagedObjectContext *)context
-{
-    ReaderAbstractTopic *topic = [ReaderTagTopic lookupWithTagID:topicID inContext:context];
-    [self setCurrentTopic:topic];
 }
 
 /**

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -117,15 +117,20 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
 
     private func makeViewController(for screen: ReaderStaticScreen) -> UIViewController {
         switch screen {
-        case .recent, .discover, .likes:
-            if screen == .discover {
-                return ReaderDiscoverViewController()
+        case .discover:
+            return ReaderDiscoverViewController()
+        case .recent:
+            // TODO: (tech debt) Fix an issue where this fails if opened before the menus are fetched for the first time
+            if let topic = sidebarViewModel.getRecentTopic() {
+                return ReaderStreamViewController.controllerWithTopic(topic)
             } else {
-                if let topic = screen.topicType.flatMap(sidebarViewModel.getTopic) {
-                    return ReaderStreamViewController.controllerWithTopic(topic)
-                } else {
-                    return makeErrorViewController() // This should never happen
-                }
+                return makeErrorViewController()
+            }
+        case .likes:
+            if let topic = sidebarViewModel.getLikesTopic() {
+                return ReaderStreamViewController.controllerWithTopic(topic)
+            } else {
+                return makeErrorViewController()
             }
         case .saved:
             return ReaderStreamViewController.controllerForContentType(.saved)

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -118,14 +118,14 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
     private func makeViewController(for screen: ReaderStaticScreen) -> UIViewController {
         switch screen {
         case .recent, .discover, .likes:
-            if let topic = screen.topicType.flatMap(sidebarViewModel.getTopic) {
-                if screen == .discover {
-                    return ReaderDiscoverViewController(topic: topic)
-                } else {
-                    return ReaderStreamViewController.controllerWithTopic(topic)
-                }
+            if screen == .discover {
+                return ReaderDiscoverViewController()
             } else {
-                return makeErrorViewController() // This should never happen
+                if let topic = screen.topicType.flatMap(sidebarViewModel.getTopic) {
+                    return ReaderStreamViewController.controllerWithTopic(topic)
+                } else {
+                    return makeErrorViewController() // This should never happen
+                }
             }
         case .saved:
             return ReaderStreamViewController.controllerForContentType(.saved)

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
@@ -7,7 +7,6 @@ import WordPressShared
 class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDelegate {
     private let headerView = ReaderDiscoverHeaderView()
     private var selectedChannel: ReaderDiscoverChannel = .recommended
-    private let topic: ReaderAbstractTopic
     private var streamVC: ReaderStreamViewController?
     private weak var selectInterestsVC: ReaderSelectInterestsViewController?
     private let selectInterestsCoordinator = ReaderSelectInterestsCoordinator()
@@ -15,10 +14,8 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
     private let viewContext: NSManagedObjectContext
     private var cancellables: [AnyCancellable] = []
 
-    init(topic: ReaderAbstractTopic) {
-        wpAssert(ReaderHelpers.topicIsDiscover(topic))
+    init() {
         self.viewContext = ContextManager.shared.mainContext
-        self.topic = topic
         self.tags = ManagedObjectsObserver(
             predicate: ReaderSidebarTagsSection.predicate,
             sortDescriptors: [SortDescriptor(\.title, order: .forward)],
@@ -40,6 +37,8 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
         configureStream(for: selectedChannel)
 
         showSelectInterestsIfNeeded()
+
+        WPAnalytics.trackReaderEvent(.readerDiscoverShown, properties: [:])
     }
 
     private func setupNavigation() {
@@ -66,22 +65,30 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
     // MARK: - Selected Stream
 
     private func configureStream(for channel: ReaderDiscoverChannel) {
-        showStreamViewController(makeViewController(for: channel))
+        do {
+            showStreamViewController(try makeViewController(for: channel))
+        } catch {
+            wpAssertionFailure("failed to show stream", userInfo: ["error": "\(error)"])
+        }
     }
 
-    private func makeViewController(for channel: ReaderDiscoverChannel) -> ReaderStreamViewController {
+    private func makeViewController(for channel: ReaderDiscoverChannel) throws -> ReaderStreamViewController {
         switch channel {
         case .recommended:
-            ReaderDiscoverStreamViewController(topic: topic)
+            ReaderDiscoverStreamViewController(topic: try makeTopic(path: .recommended))
         case .firstPosts:
-            ReaderDiscoverStreamViewController(topic: topic, stream: .firstPosts, sorting: .date)
+            ReaderDiscoverStreamViewController(topic: try makeTopic(path: .firstPosts), stream: .firstPosts, sorting: .date)
         case .latest:
-            ReaderDiscoverStreamViewController(topic: topic, sorting: .date)
+            ReaderDiscoverStreamViewController(topic: try makeTopic(path: .latest), sorting: .date)
         case .dailyPrompts:
             ReaderStreamViewController.controllerWithTagSlug(ReaderTagTopic.dailyPromptTag)
         case .tag(let tag):
             ReaderStreamViewController.controllerWithTopic(tag)
         }
+    }
+
+    private func makeTopic(path: ReaderDefaultTopic.Path) throws -> ReaderDefaultTopic {
+        try ReaderDefaultTopic.make(path: path, in: viewContext)
     }
 
     private func showStreamViewController(_ streamVC: ReaderStreamViewController) {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
@@ -230,38 +230,6 @@ struct ReaderNotificationKeys {
         Blog.lookup(withID: siteID, in: ContextManager.sharedInstance().mainContext)?.isAdmin ?? false
     }
 
-    // convenience method that returns the topic type
-    class func topicType(_ topic: ReaderAbstractTopic?) -> ReaderTopicType {
-        guard let topic = topic else {
-            return .noTopic
-        }
-        if topicIsDiscover(topic) {
-            return .discover
-        }
-        if topicIsFollowing(topic) {
-            return .following
-        }
-        if topicIsLiked(topic) {
-            return .likes
-        }
-        if isTopicList(topic) {
-            return .list
-        }
-        if isTopicSearchTopic(topic) {
-            return .search
-        }
-        if isTopicSite(topic) {
-            return .site
-        }
-        if isTopicTag(topic) {
-            return .tag
-        }
-        if topic is ReaderTeamTopic {
-            return .organization
-        }
-        return .noTopic
-    }
-
     // MARK: Logged in helper
 
     @objc open class func isLoggedIn() -> Bool {
@@ -495,19 +463,6 @@ struct ReaderNotificationKeys {
                 """
         )
     }
-}
-
-/// Typed topic type
-enum ReaderTopicType {
-    case discover
-    case following
-    case likes
-    case list
-    case search
-    case site
-    case tag
-    case organization
-    case noTopic
 }
 
 @objc enum SiteOrganizationType: Int {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
@@ -106,17 +106,6 @@ struct ReaderNotificationKeys {
         return topic.isKind(of: ReaderSearchTopic.self)
     }
 
-    /// Check if the specified topic is for Discover
-    ///
-    /// - Parameters:
-    ///     - topic: A ReaderAbstractTopic
-    ///
-    /// - Returns: True if the topic is for Discover
-    ///
-    @objc open class func topicIsDiscover(_ topic: ReaderAbstractTopic) -> Bool {
-        return topic.path.contains("/read/sites/53424024/posts")
-    }
-
     /// Check if the specified topic is for Following
     ///
     /// - Parameters:

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
@@ -106,17 +106,6 @@ struct ReaderNotificationKeys {
         return topic.isKind(of: ReaderSearchTopic.self)
     }
 
-    /// Check if the specified topic is for Freshly Pressed
-    ///
-    /// - Parameters:
-    ///     - topic: A ReaderAbstractTopic
-    ///
-    /// - Returns: True if the topic is for Freshly Pressed
-    ///
-    @objc open class func topicIsFreshlyPressed(_ topic: ReaderAbstractTopic) -> Bool {
-        return topic.path.hasSuffix("/freshly-pressed")
-    }
-
     /// Check if the specified topic is for Discover
     ///
     /// - Parameters:
@@ -155,10 +144,7 @@ struct ReaderNotificationKeys {
     class func trackLoadedTopic(_ topic: ReaderAbstractTopic, withProperties properties: [AnyHashable: Any]) {
         var stat: WPAnalyticsStat?
 
-        if topicIsFreshlyPressed(topic) {
-            stat = .readerFreshlyPressedLoaded
-
-        } else if topicIsFollowing(topic) {
+        if topicIsFollowing(topic) {
             WPAnalytics.trackReader(.readerFollowingShown, properties: properties)
 
         } else if topicIsLiked(topic) {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
@@ -167,16 +167,11 @@ struct ReaderNotificationKeys {
         } else if isTopicSite(topic) {
             WPAnalytics.trackReader(.readerBlogPreviewed, properties: properties)
 
-        } else if isTopicDefault(topic) && topicIsDiscover(topic) {
-            // Tracks Discover only if it was one of the default menu items.
-            WPAnalytics.trackReaderEvent(.readerDiscoverShown, properties: properties)
-
         } else if isTopicList(topic) {
             stat = .readerListLoaded
 
         } else if isTopicTag(topic) {
             stat = .readerTagLoaded
-
         } else if let teamTopic = topic as? ReaderTeamTopic {
             WPAnalytics.trackReader(teamTopic.shownTrackEvent, properties: properties)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
@@ -161,10 +161,10 @@ struct ReaderPostMenu {
         guard let topic else {
             return false
         }
-        return ReaderHelpers.isTopicTag(topic) ||
-            ReaderHelpers.topicIsDiscover(topic) ||
-            ReaderHelpers.topicIsFreshlyPressed(topic) ||
-            ReaderHelpers.topicIsFollowing(topic)
+        if ReaderHelpers.isTopicTag(topic) {
+            return true
+        }
+        return (topic is ReaderDefaultTopic) && !ReaderHelpers.topicIsLiked(topic)
     }
 
     // MARK: Helpers

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -215,11 +215,6 @@ import AutomatticTracks
     /// - Returns: An instance of the controller
     ///
     @objc class func controllerWithTopic(_ topic: ReaderAbstractTopic) -> ReaderStreamViewController {
-        // if a default discover topic is provided, treat it as a site to retrieve the header
-        if ReaderHelpers.topicIsDiscover(topic) {
-            return controllerWithSiteID(ReaderHelpers.discoverSiteID, isFeed: false)
-        }
-
         let controller = ReaderStreamViewController()
         controller.readerTopic = topic
         return controller
@@ -238,7 +233,6 @@ import AutomatticTracks
         let controller = ReaderStreamViewController()
         controller.isFeed = isFeed
         controller.siteID = siteID
-
         return controller
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -181,15 +181,8 @@ extension ReaderTagsTableViewModel {
         let generator = UINotificationFeedbackGenerator()
         generator.prepare()
 
-        service.followTagNamed(tagName, withSuccess: { [weak self] in
+        service.followTagNamed(tagName, withSuccess: {
             generator.notificationOccurred(.success)
-
-            guard let self else { return }
-
-            // A successful follow makes the new tag the currentTopic.
-            if let tag = service.currentTopic(in: self.context) as? ReaderTagTopic {
-                self.scrollToTag(tag)
-            }
         }, failure: { (error) in
             DDLogError("Could not follow topic named \(tagName) : \(String(describing: error))")
 
@@ -218,17 +211,6 @@ extension ReaderTagsTableViewModel {
             alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))
             alert.presentFromRootViewController()
         }
-    }
-
-    /// Scrolls the tableView so the specified tag is in view and flashes that row
-    ///
-    /// - Parameters:
-    ///     - tag: The tag to scroll into view.
-    private func scrollToTag(_ tag: ReaderTagTopic) {
-        guard let indexPath = tableViewHandler.resultsController?.indexPath(forObject: tag) else {
-            return
-        }
-        tableView?.flashRowAtIndexPath(tableViewHandler.adjustedToTable(indexPath: indexPath), scrollPosition: .middle, completion: {})
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewModel.swift
@@ -34,6 +34,16 @@ final class ReaderSidebarViewModel: ObservableObject {
         }
     }
 
+    func getRecentTopic() -> ReaderAbstractTopic? {
+        try? ReaderAbstractTopic.lookupAllMenus(in: contextManager.mainContext)
+            .first(where: ReaderHelpers.topicIsFollowing)
+    }
+
+    func getLikesTopic() -> ReaderAbstractTopic? {
+        try? ReaderAbstractTopic.lookupAllMenus(in: contextManager.mainContext)
+            .first(where: ReaderHelpers.topicIsLiked)
+    }
+
     func getTopic(for topicType: ReaderTopicType) -> ReaderAbstractTopic? {
         return try? ReaderAbstractTopic.lookupAllMenus(in: contextManager.mainContext).first {
             ReaderHelpers.topicType($0) == topicType

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewModel.swift
@@ -44,12 +44,6 @@ final class ReaderSidebarViewModel: ObservableObject {
             .first(where: ReaderHelpers.topicIsLiked)
     }
 
-    func getTopic(for topicType: ReaderTopicType) -> ReaderAbstractTopic? {
-        return try? ReaderAbstractTopic.lookupAllMenus(in: contextManager.mainContext).first {
-            ReaderHelpers.topicType($0) == topicType
-        }
-    }
-
     func onAppear() {
         reloadMenuIfNeeded()
     }
@@ -114,16 +108,6 @@ enum ReaderStaticScreen: String, CaseIterable, Identifiable, Hashable {
         case .saved: "bookmark"
         case .likes: "star"
         case .search: "magnifyingglass"
-        }
-    }
-
-    var topicType: ReaderTopicType? {
-        switch self {
-        case .recent: .following
-        case .discover: .discover
-        case .saved: nil
-        case .likes: .likes
-        case .search: nil
         }
     }
 

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -306,40 +306,6 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
     }
 
     /**
-    Ensure that a default topic can be set and retrieved.
-    */
-    func testGettingSettingCurrentTopic() {
-        let remoteTopics = remoteAndDefaultTopicForTests()
-
-        // Setup
-        let expect = expectation(description: "topics saved expectation")
-        let service = ReaderTopicService(coreDataStack: contextManager)
-        service.setCurrentTopic(nil)
-
-        // Current topic is not nil after a sync
-        service.mergeMenuTopics(remoteTopics, withSuccess: { () -> Void in
-            expect.fulfill()
-        })
-        waitForExpectations(timeout: expectationTimeout, handler: nil)
-
-        XCTAssertNotNil(service.currentTopic, "The current topic was nil.")
-
-        let sortDescriptor = NSSortDescriptor(key: "title", ascending: true)
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderAbstractTopic.classNameWithoutNamespaces())
-        request.sortDescriptors = [sortDescriptor]
-
-        let results = try! mainContext.fetch(request)
-
-        var topic = results.last as! ReaderAbstractTopic
-        XCTAssertEqual(service.currentTopic(in: mainContext).type, ReaderDefaultTopic.TopicType, "The curent topic should have been a default topic")
-
-        topic = results.first as! ReaderAbstractTopic
-        service.setCurrentTopic(topic)
-
-        XCTAssertEqual(service.currentTopic(in: mainContext).path, topic.path, "The current topic did not match the topic we assiged to it")
-    }
-
-    /**
     Ensure all topics are deleted when an account is changed.
     */
     func testDeleteAllTopics() {


### PR DESCRIPTION
## Background

When you open the Reader, it fetches `/read/menu` that contains the following fields:

```swift
  "default": {
    "discover": {
      "URL": "https://public-api.wordpress.com/rest/v1.2/read/sites/53424024/posts",
      "title": "Discover"
    },
    "following": {
      "URL": "https://public-api.wordpress.com/rest/v1.2/read/following",
      "title": "Followed Sites"
    },
    "liked": {
      "URL": "https://public-api.wordpress.com/rest/v1.2/read/liked",
      "title": "My Likes"
    },
  },
```

For each of these menu items, the app creates a `ReaderDefaultTopic` instance of Core Data. The main role of these topics is to be used in predicates for caching posts: `NSPredicate(format: "topic = %@)`.

There are two main issue with this approach:

- The app can't open any of these menus until it successfully fetches `/read/menu`
- The app [hardcodes](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift#L129) this path (`read/sites/53424024/posts`) for Discover. If the path ever changes on the backend, Discover will completely stop working in the app.

With Discover, the app uses neither the `URL` nor the `title` field from the response, so it's a pretty easy update to no longer rely on this value. This is not the case for "Followed Sites" and "My Likes" where the app actually uses the `path` in multiple ways, including for fetching the respective feeds.

## Changes

- Create `ReaderDefaultTopic` for "Discover" locally
- Remove `currentTopic` (no longer used)
- Remove `ReaderTopicType` (not needed anymore)

## To test:

- Set a network breakpoint on `/read/menu`
- Open the app for the first time
- Open Reader
- Tap Discover
- Verify that the screen opens and loads the channels ("Recommended", "Latest", etc)

## Future Changes

- Update "Recent" and "Likes" to also stop relying on the `/read/menu`. This is a larger change and I decided not to make it in the scope of this PR.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
