### PR TITLE
Merge UserDataProvider and UserManagementActionDispatcher into one type

### DIFF
--- a/Modules/Sources/WordPressUI/Views/Users/Components/UserListItem.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Components/UserListItem.swift
@@ -9,18 +9,16 @@ struct UserListItem: View {
     var dynamicTypeSize
 
     private let user: DisplayUser
-    private let userProvider: UserDataProvider
-    private let actionDispatcher: UserManagementActionDispatcher
+    private let userService: UserServiceProtocol
 
-    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
+    init(user: DisplayUser, userService: UserServiceProtocol) {
         self.user = user
-        self.userProvider = userProvider
-        self.actionDispatcher = actionDispatcher
+        self.userService = userService
     }
 
     var body: some View {
         NavigationLink {
-            UserDetailsView(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher)
+            UserDetailsView(user: user, userService: userService)
         } label: {
             HStack(alignment: .top) {
                 if !dynamicTypeSize.isAccessibilitySize {
@@ -36,5 +34,5 @@ struct UserListItem: View {
 }
 
 #Preview {
-    UserListItem(user: DisplayUser.MockUser, userProvider: MockUserProvider(), actionDispatcher: UserManagementActionDispatcher())
+    UserListItem(user: DisplayUser.MockUser, userService: MockUserProvider())
 }

--- a/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
@@ -1,32 +1,19 @@
 import Foundation
+import Combine
 
-public protocol UserDataProvider {
+public protocol UserServiceProtocol {
+    var users: AnyPublisher<Result<[DisplayUser], Error>, Never> { get }
 
-    typealias CachedUserListCallback = ([WordPressUI.DisplayUser]) async -> Void
+    func fetchUsers()
 
-    func fetchCurrentUserCan(_ capability: String) async throws -> Bool
-    func fetchUsers(cachedResults: CachedUserListCallback?) async throws -> [WordPressUI.DisplayUser]
+    func isCurrentUserCapableOf(_ capability: String) async throws -> Bool
 
-    func invalidateCaches() async throws
+    func setNewPassword(id: Int32, newPassword: String) async throws
+
+    func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws
 }
 
-/// Subclass this and register it with the SwiftUI `.environmentObject` method
-/// to perform user management actions.
-///
-/// The default implementation is set up for testing with SwiftUI Previews
-open class UserManagementActionDispatcher: ObservableObject {
-    public init() {}
-
-    open func setNewPassword(id: Int32, newPassword: String) async throws {
-        try await Task.sleep(for: .seconds(2))
-    }
-
-    open func deleteUser(id: Int32, reassigningPostsTo userId: Int32) async throws {
-        try await Task.sleep(for: .seconds(2))
-    }
-}
-
-package struct MockUserProvider: UserDataProvider {
+package class MockUserProvider: UserServiceProtocol {
 
     enum Scenario {
         case infinitLoading
@@ -36,29 +23,46 @@ package struct MockUserProvider: UserDataProvider {
 
     var scenario: Scenario
 
+    private let subject: CurrentValueSubject<Result<[WordPressUI.DisplayUser], any Error>, Never> = .init(.success([]))
+
+    package var users: AnyPublisher<Result<[WordPressUI.DisplayUser], any Error>, Never> {
+        subject.dropFirst().eraseToAnyPublisher()
+    }
+
     init(scenario: Scenario = .dummyData) {
         self.scenario = scenario
     }
 
-    package func fetchUsers(cachedResults: CachedUserListCallback? = nil) async throws -> [WordPressUI.DisplayUser] {
+    package func fetchUsers() {
         switch scenario {
         case .infinitLoading:
-            try await Task.sleep(for: .seconds(1 * 24 * 60 * 60))
-            return []
+            // Do nothing
+            break
         case .dummyData:
-            let dummyDataUrl = URL(string: "https://my.api.mockaroo.com/users.json?key=067c9730")!
-            let response = try await URLSession.shared.data(from: dummyDataUrl)
-            return try JSONDecoder().decode([DisplayUser].self, from: response.0)
+            Task {
+                let dummyDataUrl = URL(string: "https://my.api.mockaroo.com/users.json?key=067c9730")!
+                do {
+                    let response = try await URLSession.shared.data(from: dummyDataUrl)
+                    let users = try JSONDecoder().decode([DisplayUser].self, from: response.0)
+                    subject.send(.success(users))
+                } catch {
+                    subject.send(.failure(error))
+                }
+            }
         case .error:
-            throw URLError(.timedOut)
+            subject.send(.failure(URLError(.timedOut)))
         }
     }
 
-    package func fetchCurrentUserCan(_ capability: String) async throws -> Bool {
+    package func isCurrentUserCapableOf(_ capability: String) async throws -> Bool {
         true
     }
 
-    package func invalidateCaches() async throws {
-        // Do nothing
+    package func setNewPassword(id: Int32, newPassword: String) async throws {
+        // Not used in Preview
+    }
+
+    package func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws {
+        // Not used in Preview
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/UserProvider.swift
@@ -1,10 +1,11 @@
 import Foundation
 import Combine
 
-public protocol UserServiceProtocol {
-    var users: AnyPublisher<Result<[DisplayUser], Error>, Never> { get }
+public protocol UserServiceProtocol: Actor {
+    var users: [DisplayUser]? { get }
+    nonisolated var usersUpdates: AsyncStream<[DisplayUser]> { get }
 
-    func fetchUsers()
+    func fetchUsers() async throws -> [DisplayUser]
 
     func isCurrentUserCapableOf(_ capability: String) async throws -> Bool
 
@@ -13,7 +14,7 @@ public protocol UserServiceProtocol {
     func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws
 }
 
-package class MockUserProvider: UserServiceProtocol {
+package actor MockUserProvider: UserServiceProtocol {
 
     enum Scenario {
         case infinitLoading
@@ -23,34 +24,36 @@ package class MockUserProvider: UserServiceProtocol {
 
     var scenario: Scenario
 
-    private let subject: CurrentValueSubject<Result<[WordPressUI.DisplayUser], any Error>, Never> = .init(.success([]))
+    package nonisolated let usersUpdates: AsyncStream<[DisplayUser]>
+    private let usersUpdatesContinuation: AsyncStream<[DisplayUser]>.Continuation
 
-    package var users: AnyPublisher<Result<[WordPressUI.DisplayUser], any Error>, Never> {
-        subject.dropFirst().eraseToAnyPublisher()
+    package private(set) var users: [DisplayUser]? {
+        didSet {
+            if let users {
+                usersUpdatesContinuation.yield(users)
+            }
+        }
     }
 
     init(scenario: Scenario = .dummyData) {
         self.scenario = scenario
+        (usersUpdates, usersUpdatesContinuation) = AsyncStream<[DisplayUser]>.makeStream()
     }
 
-    package func fetchUsers() {
+    package func fetchUsers() async throws -> [DisplayUser] {
         switch scenario {
         case .infinitLoading:
             // Do nothing
-            break
+            try await Task.sleep(for: .seconds(24 * 60 * 60))
+            return []
         case .dummyData:
-            Task {
-                let dummyDataUrl = URL(string: "https://my.api.mockaroo.com/users.json?key=067c9730")!
-                do {
-                    let response = try await URLSession.shared.data(from: dummyDataUrl)
-                    let users = try JSONDecoder().decode([DisplayUser].self, from: response.0)
-                    subject.send(.success(users))
-                } catch {
-                    subject.send(.failure(error))
-                }
-            }
+            let dummyDataUrl = URL(string: "https://my.api.mockaroo.com/users.json?key=067c9730")!
+            let response = try await URLSession.shared.data(from: dummyDataUrl)
+            let users = try JSONDecoder().decode([DisplayUser].self, from: response.0)
+            self.users = users
+            return users
         case .error:
-            subject.send(.failure(URLError(.timedOut)))
+            throw URLError(.timedOut)
         }
     }
 

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
@@ -13,7 +13,7 @@ public class UserDeleteViewModel: ObservableObject {
     private(set) var error: Error? = nil
 
     @Published
-    var otherUserId: Int32 = 0
+    var selectedUser: DisplayUser? = nil
 
     @Published
     private(set) var otherUsers: [DisplayUser] = []
@@ -21,84 +21,63 @@ public class UserDeleteViewModel: ObservableObject {
     @Published
     private(set) var deleteButtonIsDisabled: Bool = true
 
-    private let userProvider: UserDataProvider
-    private let actionDispatcher: UserManagementActionDispatcher
+    private let userService: UserServiceProtocol
     let user: DisplayUser
 
-    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
+    init(user: DisplayUser, userService: UserServiceProtocol) {
         self.user = user
-        self.userProvider = userProvider
-        self.actionDispatcher = actionDispatcher
-    }
+        self.userService = userService
 
-    func fetchOtherUsers() async {
-        withAnimation {
-            isFetchingOtherUsers = true
-            deleteButtonIsDisabled = true
-        }
+        // Update `otherUsers` whenever there is a successful fetch of users.
+        userService.users.compactMap { [weak self] in
+            guard let self, let users = try? $0.get() else { return nil }
 
-        do {
-            let otherUsers = try await userProvider.fetchUsers { self.didReceiveUsers($0) }
-
-            self.didReceiveUsers(otherUsers)
-        } catch {
-            withAnimation {
-                self.error = error
-                deleteButtonIsDisabled = true
-            }
-        }
-
-        withAnimation {
-            isFetchingOtherUsers = false
-        }
-    }
-
-    func didReceiveUsers(_ users: [DisplayUser]) {
-        withAnimation {
-            if otherUserId == 0 {
-                otherUserId = otherUsers.first?.id ?? 0
-            }
-
-            otherUsers = users
+            return users
                 .filter { $0.id != self.user.id } // Don't allow re-assigning to yourself
                 .sorted(using: KeyPathComparator(\.username))
-            error = nil
-            deleteButtonIsDisabled = false
-            isFetchingOtherUsers = false
         }
+        .assign(to: &$otherUsers)
+
+        // Update `error` whenever there is a failure in fetching users.
+        userService.users.compactMap {
+            if case let .failure(error) = $0 { return error }
+            return nil
+        }
+        .assign(to: &$error)
+
+        // Default `selectedUser` to be the first one in `otherUsers`.
+        // Using Combine here because `didSet` observers don't work with `@Published` properties.
+        //
+        // The implementation is equivalent to `if selectedUser == nil { selectedUser = otherUsers.first }`
+        $otherUsers.combineLatest($selectedUser)
+            .filter { _, selectedUser in selectedUser == nil }
+            .map { others, _ in others.first }
+            .assign(to: &$selectedUser)
+
     }
 
-    func didTapDeleteUser(callback: @escaping () -> Void) {
-        debugPrint("Deleting \(user.username) and re-assigning their content to \(otherUserId)")
+    func fetchOtherUsers() {
+        isFetchingOtherUsers = true
+        deleteButtonIsDisabled = true
 
-        withAnimation {
-            error = nil
-        }
+        userService.fetchUsers()
 
-        Task {
-            await MainActor.run {
-                withAnimation {
-                    isDeletingUser = true
-                }
-            }
+        let fetched = userService.users.first()
 
-            do {
-                try await actionDispatcher.deleteUser(id: user.id, reassigningPostsTo: otherUserId)
-            } catch {
-                debugPrint(error.localizedDescription)
-                await MainActor.run {
-                    withAnimation {
-                        self.error = error
-                    }
-                }
-            }
+        fetched
+            .map { _ in false }
+            .assign(to: &$isFetchingOtherUsers)
+        fetched
+            .map { (try? $0.get()) == nil }
+            .assign(to: &$deleteButtonIsDisabled)
+    }
 
-            await MainActor.run {
-                withAnimation {
-                    isDeletingUser = false
-                    callback()
-                }
-            }
-        }
+    func deleteUser() async throws {
+        guard let otherUserId = selectedUser?.id, otherUserId != user.id else { return }
+
+        isDeletingUser = true
+        defer { isDeletingUser = false }
+
+        try await userService.deleteUser(id: user.id, reassigningPostsTo: otherUserId)
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
@@ -42,7 +42,7 @@ public class UserDeleteViewModel: ObservableObject {
     func fetchOtherUsers() async {
         isFetchingOtherUsers = true
         deleteButtonIsDisabled = true
-        
+
         defer {
             isFetchingOtherUsers = false
             deleteButtonIsDisabled = otherUsers.isEmpty

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDeleteViewModel.swift
@@ -28,23 +28,6 @@ public class UserDeleteViewModel: ObservableObject {
         self.user = user
         self.userService = userService
 
-        // Update `otherUsers` whenever there is a successful fetch of users.
-        userService.users.compactMap { [weak self] in
-            guard let self, let users = try? $0.get() else { return nil }
-
-            return users
-                .filter { $0.id != self.user.id } // Don't allow re-assigning to yourself
-                .sorted(using: KeyPathComparator(\.username))
-        }
-        .assign(to: &$otherUsers)
-
-        // Update `error` whenever there is a failure in fetching users.
-        userService.users.compactMap {
-            if case let .failure(error) = $0 { return error }
-            return nil
-        }
-        .assign(to: &$error)
-
         // Default `selectedUser` to be the first one in `otherUsers`.
         // Using Combine here because `didSet` observers don't work with `@Published` properties.
         //
@@ -56,20 +39,23 @@ public class UserDeleteViewModel: ObservableObject {
 
     }
 
-    func fetchOtherUsers() {
+    func fetchOtherUsers() async {
         isFetchingOtherUsers = true
         deleteButtonIsDisabled = true
+        
+        defer {
+            isFetchingOtherUsers = false
+            deleteButtonIsDisabled = otherUsers.isEmpty
+        }
 
-        userService.fetchUsers()
-
-        let fetched = userService.users.first()
-
-        fetched
-            .map { _ in false }
-            .assign(to: &$isFetchingOtherUsers)
-        fetched
-            .map { (try? $0.get()) == nil }
-            .assign(to: &$deleteButtonIsDisabled)
+        do {
+            let users = try await userService.fetchUsers()
+            self.otherUsers = users
+                .filter { $0.id != self.user.id } // Don't allow re-assigning to yourself
+                .sorted(using: KeyPathComparator(\.username))
+        } catch {
+            self.error = error
+        }
     }
 
     func deleteUser() async throws {

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDetailViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserDetailViewModel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @MainActor
 class UserDetailViewModel: ObservableObject {
-    private let userProvider: UserDataProvider
+    private let userService: UserServiceProtocol
 
     @Published
     private(set) var currentUserCanModifyUsers: Bool = false
@@ -13,30 +13,20 @@ class UserDetailViewModel: ObservableObject {
     @Published
     private(set) var error: Error? = nil
 
-    init(userProvider: UserDataProvider) {
-        self.userProvider = userProvider
+    init(userService: UserServiceProtocol) {
+        self.userService = userService
     }
 
     func loadCurrentUserRole() async {
-        withAnimation {
-            isLoadingCurrentUser = true
-        }
+        error = nil
+
+        isLoadingCurrentUser = true
+        defer { isLoadingCurrentUser = false}
 
         do {
-            let hasPermissions = try await userProvider.fetchCurrentUserCan("edit_users")
-            error = nil
-
-            withAnimation {
-                currentUserCanModifyUsers = hasPermissions
-            }
+            currentUserCanModifyUsers = try await userService.isCurrentUserCapableOf("edit_users")
         } catch {
-            withAnimation {
-                self.error = error
-            }
-        }
-
-        withAnimation {
-            isLoadingCurrentUser = false
+            self.error = error
         }
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import WordPressShared
 
 @MainActor
@@ -11,9 +12,13 @@ class UserListViewModel: ObservableObject {
     }
 
     /// The initial set of users fetched by `fetchItems`
-    private var users: [DisplayUser] = []
-    private let userProvider: UserDataProvider
-
+    private var users: [DisplayUser] = [] {
+        didSet {
+            sortedUsers = self.sortUsers(users)
+        }
+    }
+    private let userService: UserServiceProtocol
+    private var cancellables: Set<AnyCancellable> = []
     private var initialLoad = false
 
     @Published
@@ -37,8 +42,15 @@ class UserListViewModel: ObservableObject {
         }
     }
 
-    init(userProvider: UserDataProvider) {
-        self.userProvider = userProvider
+    init(userService: UserServiceProtocol) {
+        self.userService = userService
+
+        userService.users
+            .compactMap { try? $0.get() }
+            .sink { [weak self] in
+                self?.users = $0
+            }
+            .store(in: &cancellables)
     }
 
     func onAppear() async {
@@ -49,31 +61,14 @@ class UserListViewModel: ObservableObject {
     }
 
     func fetchItems() async {
-        withAnimation {
-            isLoadingItems = true
-        }
-
-        do {
-            let users = try await userProvider.fetchUsers { cachedResults in
-                self.setUsers(cachedResults)
-            }
-            setUsers(users)
-        } catch {
-            self.error = error
-            isLoadingItems = false
-        }
+        isLoadingItems = true
+        userService.fetchUsers()
+        userService.users.first().map { _ in false }.assign(to: &$isLoadingItems)
     }
 
     @Sendable
     func refreshItems() async {
-        do {
-            let users = try await userProvider.fetchUsers { cachedResults in
-                self.setUsers(cachedResults)
-            }
-            setUsers(users)
-        } catch {
-            // Do nothing for now – this should probably show a "Toast" notification or something
-        }
+        userService.fetchUsers()
     }
 
     func setUsers(_ newValue: [DisplayUser]) {

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
@@ -53,14 +53,14 @@ class UserListViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
-    func onAppear() async {
+    func onAppear() {
         if !initialLoad {
             initialLoad = true
-            await fetchItems()
+            fetchItems()
         }
     }
 
-    func fetchItems() async {
+    private func fetchItems() {
         isLoadingItems = true
         userService.fetchUsers()
         userService.users.first().map { _ in false }.assign(to: &$isLoadingItems)

--- a/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/ViewModel/UserListViewModel.swift
@@ -17,8 +17,8 @@ class UserListViewModel: ObservableObject {
             sortedUsers = self.sortUsers(users)
         }
     }
+    private var updateUsersTask: Task<Void, Never>?
     private let userService: UserServiceProtocol
-    private var cancellables: Set<AnyCancellable> = []
     private var initialLoad = false
 
     @Published
@@ -44,31 +44,39 @@ class UserListViewModel: ObservableObject {
 
     init(userService: UserServiceProtocol) {
         self.userService = userService
-
-        userService.users
-            .compactMap { try? $0.get() }
-            .sink { [weak self] in
-                self?.users = $0
-            }
-            .store(in: &cancellables)
     }
 
-    func onAppear() {
+    deinit {
+        updateUsersTask?.cancel()
+    }
+
+    func onAppear() async {
+        if updateUsersTask == nil {
+            updateUsersTask = Task { @MainActor [weak self, usersUpdates = userService.usersUpdates] in
+                for await users in usersUpdates {
+                    guard let self else { break }
+
+                    self.users = users
+                }
+            }
+        }
+
         if !initialLoad {
             initialLoad = true
-            fetchItems()
+            await fetchItems()
         }
     }
 
-    private func fetchItems() {
+    private func fetchItems() async {
         isLoadingItems = true
-        userService.fetchUsers()
-        userService.users.first().map { _ in false }.assign(to: &$isLoadingItems)
+        defer { isLoadingItems = false }
+
+        _ = try? await userService.fetchUsers()
     }
 
     @Sendable
     func refreshItems() async {
-        userService.fetchUsers()
+        _ = try? await userService.fetchUsers()
     }
 
     func setUsers(_ newValue: [DisplayUser]) {

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailsView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailsView.swift
@@ -2,8 +2,7 @@ import SwiftUI
 
 struct UserDetailsView: View {
 
-    fileprivate let userProvider: UserDataProvider
-    fileprivate let actionDispatcher: UserManagementActionDispatcher
+    fileprivate let userService: UserServiceProtocol
     let user: DisplayUser
 
     @State private var presentPasswordAlert: Bool = false {
@@ -16,7 +15,6 @@ struct UserDetailsView: View {
     @State fileprivate var newPasswordConfirmation: String = ""
 
     @State fileprivate var presentUserPicker: Bool = false
-    @State fileprivate var selectedUser: DisplayUser? = nil
     @State fileprivate var presentDeleteConfirmation: Bool = false
     @State fileprivate var presentDeleteUserError: Bool = false
 
@@ -28,12 +26,11 @@ struct UserDetailsView: View {
     @Environment(\.dismiss)
     var dismissAction: DismissAction
 
-    init(user: DisplayUser, userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
+    init(user: DisplayUser, userService: UserServiceProtocol) {
         self.user = user
-        self.userProvider = userProvider
-        self.actionDispatcher = actionDispatcher
-        _viewModel = StateObject(wrappedValue: UserDetailViewModel(userProvider: userProvider))
-        _deleteUserViewModel = StateObject(wrappedValue: UserDeleteViewModel(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher))
+        self.userService = userService
+        _viewModel = StateObject(wrappedValue: UserDetailViewModel(userService: userService))
+        _deleteUserViewModel = StateObject(wrappedValue: UserDeleteViewModel(user: user, userService: userService))
     }
 
     var body: some View {
@@ -87,7 +84,7 @@ struct UserDetailsView: View {
                 SecureField(Strings.newPasswordConfirmationPlaceholder, text: $newPasswordConfirmation)
                 Button(Strings.updatePasswordButton) {
                     Task {
-                        try await self.actionDispatcher.setNewPassword(id: user.id, newPassword: newPassword)
+                        try await self.userService.setNewPassword(id: user.id, newPassword: newPassword)
                     }
                 }
                 .disabled(newPassword.isEmpty || newPassword != newPasswordConfirmation)
@@ -105,7 +102,7 @@ struct UserDetailsView: View {
         .deleteUser(in: self)
         .task {
             await viewModel.loadCurrentUserRole()
-            await deleteUserViewModel.fetchOtherUsers()
+            deleteUserViewModel.fetchOtherUsers()
         }
     }
 
@@ -283,12 +280,15 @@ private extension View {
         .alert(
             UserDetailsView.Strings.deleteUserConfirmationTitle,
             isPresented: view.$presentDeleteConfirmation,
-            presenting: view.selectedUser,
+            presenting: view.deleteUserViewModel.selectedUser,
             actions: { attribution in
                 Button(role: .destructive) {
-                    Task {
-                        view.deleteUserViewModel.didTapDeleteUser {
+                    Task { @MainActor in
+                        do {
+                            try await view.deleteUserViewModel.deleteUser()
                             view.dismissAction()
+                        } catch {
+                            view.presentDeleteUserError = true
                         }
                     }
                 } label: {
@@ -333,7 +333,7 @@ private extension View {
                             ProgressView()
                         }
                     } else {
-                        Picker(Strings.attributeContentToUserLabel, selection: view.$selectedUser) {
+                        Picker(Strings.attributeContentToUserLabel, selection: view.$deleteUserViewModel.selectedUser) {
                             ForEach(view.deleteUserViewModel.otherUsers) { user in
                                 Text("\(user.displayName) (\(user.username))").tag(user)
                             }
@@ -357,7 +357,7 @@ private extension View {
                     } label: {
                         Text(Strings.attributeContentConfirmationDeleteButton)
                     }
-                    .disabled(view.selectedUser == nil)
+                    .disabled(view.deleteUserViewModel.deleteButtonIsDisabled)
                 }
             }
         }
@@ -380,6 +380,6 @@ private extension String {
 
 #Preview {
     NavigationStack {
-        UserDetailsView(user: DisplayUser.MockUser, userProvider: MockUserProvider(), actionDispatcher: UserManagementActionDispatcher())
+        UserDetailsView(user: DisplayUser.MockUser, userService: MockUserProvider())
     }
 }

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailsView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailsView.swift
@@ -100,9 +100,11 @@ struct UserDetailsView: View {
             }
         )
         .deleteUser(in: self)
-        .task {
-            await viewModel.loadCurrentUserRole()
-            await deleteUserViewModel.fetchOtherUsers()
+        .onAppear() {
+            Task {
+                await viewModel.loadCurrentUserRole()
+                await deleteUserViewModel.fetchOtherUsers()
+            }
         }
     }
 

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailsView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserDetailsView.swift
@@ -102,7 +102,7 @@ struct UserDetailsView: View {
         .deleteUser(in: self)
         .task {
             await viewModel.loadCurrentUserRole()
-            deleteUserViewModel.fetchOtherUsers()
+            await deleteUserViewModel.fetchOtherUsers()
         }
     }
 

--- a/Modules/Sources/WordPressUI/Views/Users/Views/UserListView.swift
+++ b/Modules/Sources/WordPressUI/Views/Users/Views/UserListView.swift
@@ -4,13 +4,11 @@ public struct UserListView: View {
 
     @StateObject
     private var viewModel: UserListViewModel
-    private let userProvider: UserDataProvider
-    private let actionDispatcher: UserManagementActionDispatcher
+    private let userService: UserServiceProtocol
 
-    public init(userProvider: UserDataProvider, actionDispatcher: UserManagementActionDispatcher) {
-        self.userProvider = userProvider
-        self.actionDispatcher = actionDispatcher
-        _viewModel = StateObject(wrappedValue: UserListViewModel(userProvider: userProvider))
+    public init(userService: UserServiceProtocol) {
+        self.userService = userService
+        _viewModel = StateObject(wrappedValue: UserListViewModel(userService: userService))
     }
 
     public var body: some View {
@@ -33,7 +31,7 @@ public struct UserListView: View {
                                     .listRowBackground(Color.clear)
                             } else {
                                 ForEach(section.users) { user in
-                                    UserListItem(user: user, userProvider: userProvider, actionDispatcher: actionDispatcher)
+                                    UserListItem(user: user, userService: userService)
                                 }
                             }
                         }
@@ -72,18 +70,18 @@ public struct UserListView: View {
 
 #Preview("Loading") {
     NavigationView {
-        UserListView(userProvider: MockUserProvider(scenario: .infinitLoading), actionDispatcher: UserManagementActionDispatcher())
+        UserListView(userService: MockUserProvider())
     }
 }
 
 #Preview("Error") {
     NavigationView {
-        UserListView(userProvider: MockUserProvider(scenario: .error), actionDispatcher: UserManagementActionDispatcher())
+        UserListView(userService: MockUserProvider(scenario: .error))
     }
 }
 
 #Preview("List") {
     NavigationView {
-        UserListView(userProvider: MockUserProvider(scenario: .dummyData), actionDispatcher: UserManagementActionDispatcher())
+        UserListView(userService: MockUserProvider(scenario: .dummyData))
     }
 }

--- a/WordPress/Classes/Services/UserService.swift
+++ b/WordPress/Classes/Services/UserService.swift
@@ -28,6 +28,7 @@ actor UserService: UserServiceProtocol {
     }
 
     deinit {
+        usersUpdatesContinuation.finish()
         fetchUsersTask?.cancel()
     }
 

--- a/WordPress/Classes/Services/UserService.swift
+++ b/WordPress/Classes/Services/UserService.swift
@@ -5,56 +5,51 @@ import WordPressUI
 
 /// UserService is responsible for fetching user acounts via the .org REST API – it's the replacement for `UsersService` (the XMLRPC-based approach)
 ///
-class UserService: UserServiceProtocol {
+actor UserService: UserServiceProtocol {
     private let client: WordPressClient
 
-    private let fetchUserslock = NSRecursiveLock()
-    private var fetchUsersTask: Task<Void, Error>?
+    private var fetchUsersTask: Task<[DisplayUser], Error>?
 
-    private let usersSubject: CurrentValueSubject<Result<[WordPressUI.DisplayUser], any Error>, Never> = .init(.success([]))
-    var users: AnyPublisher<Result<[WordPressUI.DisplayUser], any Error>, Never> {
-        usersSubject.dropFirst().eraseToAnyPublisher()
+    private(set) var users: [DisplayUser]? {
+        didSet {
+            if let users {
+                usersUpdatesContinuation.yield(users)
+            }
+        }
     }
+    nonisolated let usersUpdates: AsyncStream<[DisplayUser]>
+    private nonisolated let usersUpdatesContinuation: AsyncStream<[DisplayUser]>.Continuation
 
     private var currentUser: UserWithEditContext?
 
     init(client: WordPressClient) {
         self.client = client
+        (usersUpdates, usersUpdatesContinuation) = AsyncStream<[DisplayUser]>.makeStream()
     }
 
     deinit {
         fetchUsersTask?.cancel()
     }
 
-    func fetchUsers() {
-        fetchUserslock.lock()
-        defer { fetchUserslock.unlock() }
-
-        guard fetchUsersTask == nil else { return }
-
-        fetchUsersTask = Task.detached {
-            do {
-                let users: [DisplayUser] = try await self.client
-                    .api
-                    .users
-                    .listWithEditContext(params: UserListParams(perPage: 100))
-                    .compactMap { DisplayUser(user: $0) }
-                self.finishFetchingUsers(.success(users))
-            } catch {
-                self.finishFetchingUsers(.failure(error))
-            }
-        }
+    func fetchUsers() async throws -> [DisplayUser] {
+        let users = try await createFetchUsersTaskIfNeeded().value
+        self.users = users
+        return users
     }
 
-    private func finishFetchingUsers(_ result: Result<[DisplayUser], Error>) {
-        fetchUserslock.lock()
-        defer { fetchUserslock.unlock() }
-
-        fetchUsersTask = nil
-
-        DispatchQueue.main.async {
-            self.usersSubject.send(result)
+    private func createFetchUsersTaskIfNeeded() -> Task<[DisplayUser], Error> {
+        if let fetchUsersTask {
+            return fetchUsersTask
         }
+        let task = Task { [client] in
+            try await client
+                .api
+                .users
+                .listWithEditContext(params: UserListParams(perPage: 100))
+                .compactMap { DisplayUser(user: $0) }
+        }
+        fetchUsersTask = task
+        return task
     }
 
     func isCurrentUserCapableOf(_ capability: String) async throws -> Bool {
@@ -76,13 +71,8 @@ class UserService: UserServiceProtocol {
         )
 
         // Remove the deleted user from the cached users list.
-        if result.deleted {
-            await MainActor.run {
-                if case var .success(fetched) = usersSubject.value, let index = fetched.firstIndex(where: { $0.id == id }) {
-                    fetched.remove(at: index)
-                    usersSubject.send(.success(fetched))
-                }
-            }
+        if result.deleted, let index = users?.firstIndex(where: { $0.id == id }) {
+            users?.remove(at: index)
         }
     }
 

--- a/WordPress/Classes/Services/UserService.swift
+++ b/WordPress/Classes/Services/UserService.swift
@@ -7,7 +7,6 @@ import WordPressUI
 ///
 class UserService: UserServiceProtocol {
     private let client: WordPressClient
-    private let currentUserId: Int
 
     private let fetchUserslock = NSRecursiveLock()
     private var fetchUsersTask: Task<Void, Error>?
@@ -17,9 +16,10 @@ class UserService: UserServiceProtocol {
         usersSubject.dropFirst().eraseToAnyPublisher()
     }
 
-    init(api: WordPressClient, currentUserId: Int) {
-        self.client = api
-        self.currentUserId = currentUserId
+    private var currentUser: UserWithEditContext?
+
+    init(client: WordPressClient) {
+        self.client = client
     }
 
     deinit {
@@ -58,8 +58,15 @@ class UserService: UserServiceProtocol {
     }
 
     func isCurrentUserCapableOf(_ capability: String) async throws -> Bool {
-        // TODO: Cache the current user?
-        try await client.api.users.retrieveMeWithEditContext().capabilities.keys.contains(capability)
+        let currentUser: UserWithEditContext
+        if let cached = self.currentUser {
+            currentUser = cached
+        } else {
+            currentUser = try await self.client.api.users.retrieveMeWithEditContext()
+            self.currentUser = currentUser
+        }
+
+        return currentUser.capabilities.keys.contains(capability)
     }
 
     func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws {

--- a/WordPress/Classes/Services/UserService.swift
+++ b/WordPress/Classes/Services/UserService.swift
@@ -1,107 +1,115 @@
 import Foundation
+import Combine
 import WordPressAPI
 import WordPressUI
 
 /// UserService is responsible for fetching user acounts via the .org REST API – it's the replacement for `UsersService` (the XMLRPC-based approach)
 ///
-struct UserService {
-
-    final class ActionDispatcher: UserManagementActionDispatcher {
-
-        private let client: WordPressClient
-
-        init(client: WordPressClient) {
-            self.client = client
-            super.init()
-        }
-
-        override func setNewPassword(id: Int32, newPassword: String) async throws {
-            _ = try await client.api.users.update(
-                userId: Int32(id),
-                params: UserUpdateParams(password: newPassword)
-            )
-        }
-
-        override func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws {
-            _ = try await client.api.users.delete(
-                userId: id,
-                params: UserDeleteParams(reassign: newUserId)
-            )
-        }
-    }
-
-    final actor UserCache {
-        var users: [DisplayUser] = []
-
-        func setUsers(_ newValue: [DisplayUser]) {
-            self.users = newValue
-        }
-
-        func clear() {
-            self.users = []
-        }
-    }
-
-    private let apiClient: WordPressClient
+class UserService: UserServiceProtocol {
+    private let client: WordPressClient
     private let currentUserId: Int
-    fileprivate let userCache = UserCache()
 
-    let actionDispatcher: ActionDispatcher
+    private let fetchUserslock = NSRecursiveLock()
+    private var fetchUsersTask: Task<Void, Error>?
+
+    private let usersSubject: CurrentValueSubject<Result<[WordPressUI.DisplayUser], any Error>, Never> = .init(.success([]))
+    var users: AnyPublisher<Result<[WordPressUI.DisplayUser], any Error>, Never> {
+        usersSubject.dropFirst().eraseToAnyPublisher()
+    }
 
     init(api: WordPressClient, currentUserId: Int) {
-        self.apiClient = api
+        self.client = api
         self.currentUserId = currentUserId
-        self.actionDispatcher = ActionDispatcher(client: apiClient)
     }
+
+    deinit {
+        fetchUsersTask?.cancel()
+    }
+
+    func fetchUsers() {
+        fetchUserslock.lock()
+        defer { fetchUserslock.unlock() }
+
+        guard fetchUsersTask == nil else { return }
+
+        fetchUsersTask = Task.detached {
+            do {
+                let users: [DisplayUser] = try await self.client
+                    .api
+                    .users
+                    .listWithEditContext(params: UserListParams(perPage: 100))
+                    .compactMap { DisplayUser(user: $0) }
+                self.finishFetchingUsers(.success(users))
+            } catch {
+                self.finishFetchingUsers(.failure(error))
+            }
+        }
+    }
+
+    private func finishFetchingUsers(_ result: Result<[DisplayUser], Error>) {
+        fetchUserslock.lock()
+        defer { fetchUserslock.unlock() }
+
+        fetchUsersTask = nil
+
+        DispatchQueue.main.async {
+            self.usersSubject.send(result)
+        }
+    }
+
+    func isCurrentUserCapableOf(_ capability: String) async throws -> Bool {
+        // TODO: Cache the current user?
+        try await client.api.users.retrieveMeWithEditContext().capabilities.keys.contains(capability)
+    }
+
+    func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws {
+        let result = try await client.api.users.delete(
+            userId: id,
+            params: UserDeleteParams(reassign: newUserId)
+        )
+
+        // Remove the deleted user from the cached users list.
+        if result.deleted {
+            await MainActor.run {
+                if case var .success(fetched) = usersSubject.value, let index = fetched.firstIndex(where: { $0.id == id }) {
+                    fetched.remove(at: index)
+                    usersSubject.send(.success(fetched))
+                }
+            }
+        }
+    }
+
+    func setNewPassword(id: Int32, newPassword: String) async throws {
+        _ = try await client.api.users.update(
+            userId: Int32(id),
+            params: UserUpdateParams(password: newPassword)
+        )
+    }
+
 }
 
-extension UserService: WordPressUI.UserDataProvider {
-
-    func fetchCurrentUserCan(_ capability: String) async throws -> Bool {
-        try await apiClient.api.users.retrieveMeWithEditContext().capabilities.keys.contains(capability)
-    }
-
-    func fetchUsers(cachedResults: CachedUserListCallback? = nil) async throws -> [WordPressUI.DisplayUser] {
-
-        if await !userCache.users.isEmpty {
-            await cachedResults?(await userCache.users)
+private extension DisplayUser {
+    init?(user: UserWithEditContext) {
+        guard let role = user.roles.first else {
+            return nil
         }
 
-        let users: [DisplayUser] = try await apiClient
-            .api
-            .users
-            .listWithEditContext(params: UserListParams(perPage: 100))
-            .compactMap {
-
-             guard let role = $0.roles.first else {
-                 return nil
-             }
-
-             return DisplayUser(
-                 id: $0.id,
-                 handle: $0.slug,
-                 username: $0.username,
-                 firstName: $0.firstName,
-                 lastName: $0.lastName,
-                 displayName: $0.name,
-                 profilePhotoUrl: profilePhotoUrl(for: $0),
-                 role: role,
-                 emailAddress: $0.email,
-                 websiteUrl: $0.link,
-                 biography: $0.description
-             )
-         }
-
-        await userCache.setUsers(users)
-
-        return users
+        self.init(
+            id: user.id,
+            handle: user.slug,
+            username: user.username,
+            firstName: user.firstName,
+            lastName: user.lastName,
+            displayName: user.name,
+            profilePhotoUrl: Self.profilePhotoUrl(for: user),
+            role: role,
+            emailAddress: user.email,
+            websiteUrl: user.link,
+            biography: user.description
+        )
     }
 
-    func invalidateCaches() async throws {
-        await userCache.clear()
-    }
-
-    func profilePhotoUrl(for user: UserWithEditContext) -> URL? {
+    static func profilePhotoUrl(for user: UserWithEditContext) -> URL? {
         // The key is the size of the avatar. Get the largetst one, which is 96x96px.
         // https://github.com/WordPress/wordpress-develop/blob/6.6.2/src/wp-includes/rest-api.php#L1253-L1260
         guard let url = user.avatarUrls?

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -159,13 +159,13 @@ extension BlogDetailsViewController {
     }
 
     @objc func showUsers() {
-        guard let presentationDelegate, let userId = self.blog.userID?.intValue else {
+        guard let presentationDelegate else {
             return
         }
 
         let feature = NSLocalizedString("applicationPasswordRequired.feature.users", value: "User Management", comment: "Feature name for managing users in the app")
         let rootView = ApplicationPasswordRequiredView(blog: self.blog, localizedFeatureName: feature) { client in
-            let service = UserService(api: client, currentUserId: userId)
+            let service = UserService(client: client)
             return UserListView(userService: service)
         }
         presentationDelegate.presentBlogDetailsViewController(UIHostingController(rootView: rootView))

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -166,7 +166,7 @@ extension BlogDetailsViewController {
         let feature = NSLocalizedString("applicationPasswordRequired.feature.users", value: "User Management", comment: "Feature name for managing users in the app")
         let rootView = ApplicationPasswordRequiredView(blog: self.blog, localizedFeatureName: feature) { client in
             let service = UserService(api: client, currentUserId: userId)
-            return UserListView(userProvider: service, actionDispatcher: service.actionDispatcher)
+            return UserListView(userService: service)
         }
         presentationDelegate.presentBlogDetailsViewController(UIHostingController(rootView: rootView))
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -453,6 +453,7 @@
 		4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */; };
 		4A76A4BD29D43BFD00AABF4B /* CommentService+MorderationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */; };
 		4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */; };
+		4A76F9112CE207FA0025F7FA /* UserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76F9102CE207FA0025F7FA /* UserServiceTests.swift */; };
 		4A9314DC297790C300360232 /* PeopleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9314DB297790C300360232 /* PeopleServiceTests.swift */; };
 		4A9948E229714EF1006282A9 /* AccountSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9948E129714EF1006282A9 /* AccountSettingsServiceTests.swift */; };
 		4AA7EE0F2ADF7367007D261D /* PostRepositoryPostsListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA7EE0E2ADF7367007D261D /* PostRepositoryPostsListTests.swift */; };
@@ -2338,6 +2339,7 @@
 		4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+LikesTests.swift"; sourceTree = "<group>"; };
 		4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+MorderationTests.swift"; sourceTree = "<group>"; };
 		4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-success.json"; sourceTree = "<group>"; };
+		4A76F9102CE207FA0025F7FA /* UserServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceTests.swift; sourceTree = "<group>"; };
 		4A9314DB297790C300360232 /* PeopleServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleServiceTests.swift; sourceTree = "<group>"; };
 		4A98A9022C2274E100A2CE58 /* WordPressKitTests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = WordPressKitTests.xcconfig; sourceTree = "<group>"; };
 		4A98A9032C2274E100A2CE58 /* WordPressKit.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = WordPressKit.xcconfig; sourceTree = "<group>"; };
@@ -6404,6 +6406,7 @@
 				4A9314DB297790C300360232 /* PeopleServiceTests.swift */,
 				FEAA6F78298CE4A600ADB44C /* PluginJetpackProxyServiceTests.swift */,
 				1D91080629F847A2003F9A5E /* MediaServiceUpdateTests.m */,
+				4A76F9102CE207FA0025F7FA /* UserServiceTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -10186,6 +10189,7 @@
 				4AB6A3602B7C3EB500769115 /* PinghubWebSocketTests.swift in Sources */,
 				F46546352AF550A20017E3D1 /* AllDomainsListItem+Helpers.swift in Sources */,
 				FEA312842987FB0100FFD405 /* BlogJetpackTests.swift in Sources */,
+				4A76F9112CE207FA0025F7FA /* UserServiceTests.swift in Sources */,
 				0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */,
 				7E8980B922E73F4000C567B0 /* EditorSettingsServiceTests.swift in Sources */,
 				1797373720EBAA4100377B4E /* RouteMatcherTests.swift in Sources */,

--- a/WordPress/WordPressTest/UserServiceTests.swift
+++ b/WordPress/WordPressTest/UserServiceTests.swift
@@ -23,125 +23,59 @@ class UserServiceTests: XCTestCase {
         HTTPStubs.removeAllStubs()
     }
 
-    func testSuccessfulUsersUpdateInTheMainThread() {
+    func testMultipleFetchUsersTriggerOneUpdate() async throws {
         stubSuccessfullUsersFetch()
-        let expectation = XCTestExpectation(description: "Users update in the main thread")
 
-        let cancellable = service.users.sink { _ in
-            if Thread.isMainThread {
+        let expectation = XCTestExpectation(description: "Updated after fetch")
+        let task = Task.detached { [self] in
+            for await _ in self.service.usersUpdates {
                 expectation.fulfill()
             }
         }
 
-        service.fetchUsers()
-
-        wait(for: [expectation], timeout: 0.3)
-    }
-
-    func testSuccessfulUsersUpdateInTheMainThreadWhenFetchFromBackgroundThread() {
-        stubSuccessfullUsersFetch()
-        let expectation = XCTestExpectation(description: "Users update in the main thread")
-
-        let cancellable = service.users.sink { _ in
-            if Thread.isMainThread {
-                expectation.fulfill()
-            }
-        }
-
-        DispatchQueue.global().async {
+        _ = try await [
+            self.service.fetchUsers(),
+            self.service.fetchUsers(),
+            self.service.fetchUsers(),
+            self.service.fetchUsers(),
             self.service.fetchUsers()
-        }
+        ]
 
-        wait(for: [expectation], timeout: 0.3)
+        await fulfillment(of: [expectation], timeout: 0.3)
+        task.cancel()
     }
 
-    func testFailedUsersUpdateInTheMainThread() {
-        stubFailedUsersFetch()
-        let expectation = XCTestExpectation(description: "Users update in the main thread")
-
-        let cancellable = service.users.sink { _ in
-            if Thread.isMainThread {
-                expectation.fulfill()
-            }
-        }
-
-        service.fetchUsers()
-
-        wait(for: [expectation], timeout: 0.3)
-    }
-
-    func testFailedUpdateInTheMainThreadWhenFetchFromBackgroundThread() {
-        stubFailedUsersFetch()
-        let expectation = XCTestExpectation(description: "Users update in the main thread")
-
-        let cancellable = service.users.sink { _ in
-            if Thread.isMainThread {
-                expectation.fulfill()
-            }
-        }
-
-        DispatchQueue.global().async {
-            self.service.fetchUsers()
-        }
-
-        wait(for: [expectation], timeout: 0.3)
-    }
-
-    func testMultipleFetchUsersTriggerOneUpdate() {
+    func testSequentialFetchUsersTriggerOneUpdateForEachFetch() async throws {
         stubSuccessfullUsersFetch()
 
-        let expectation = XCTestExpectation(description: "One update for multiple fetches")
-        let cancellable = service.users.sink { _ in
-            expectation.fulfill()
-        }
-
-        // Only one HTTP request should be sent for all function calls.
-        for _ in 1...10 {
-            service.fetchUsers()
-        }
-
-        wait(for: [expectation], timeout: 0.3)
-    }
-
-    func testSequentialFetchUsersTriggerOneUpdateForEachFetch() {
-        stubSuccessfullUsersFetch()
-
-        for _ in 1...5 {
-            service.fetchUsers()
-
-            let expectation = XCTestExpectation(description: "Updated after fetch")
-            let cancellable = service.users.sink { _ in
+        let expectation = XCTestExpectation(description: "Updated after fetch")
+        expectation.expectedFulfillmentCount = 5
+        let task = Task.detached { [self] in
+            for await _ in self.service.usersUpdates {
                 expectation.fulfill()
             }
-
-            wait(for: [expectation], timeout: 0.3)
         }
+
+        for _ in 1...expectation.expectedFulfillmentCount {
+            _ = try await service.fetchUsers()
+        }
+
+        await fulfillment(of: [expectation], timeout: 0.3)
+
+        task.cancel()
     }
 
     func testDeleteUserTriggersUsersUpdate() async throws {
         stubSuccessfullUsersFetch()
         stubDeleteUser(id: 34)
 
-        var cancellables: Set<AnyCancellable> = []
-
-        var latestUsers: [DisplayUser] = []
-        service.users.sink {
-            if case let .success(users) = $0 {
-                latestUsers = users
-            }
-        }.store(in: &cancellables)
-
-        service.fetchUsers()
-        let expectation = XCTestExpectation(description: "Updated after fetch")
-        let cancellable = service.users.first().sink { _ in
-            expectation.fulfill()
-        }
-        await fulfillment(of: [expectation], timeout: 0.3)
-        XCTAssertTrue(latestUsers.contains { $0.id == 34 })
+        _ = try await service.fetchUsers()
+        let userFetched = await service.users?.contains { $0.id == 34 } == true
+        XCTAssertTrue(userFetched)
 
         try await service.deleteUser(id: 34, reassigningPostsTo: 1)
-
-        XCTAssertFalse(latestUsers.contains { $0.id == 34 })
+        let userDeleted = await service.users?.contains { $0.id == 34 } == false
+        XCTAssertTrue(userDeleted)
     }
 
     private func stubSuccessfullUsersFetch() {

--- a/WordPress/WordPressTest/UserServiceTests.swift
+++ b/WordPress/WordPressTest/UserServiceTests.swift
@@ -65,6 +65,29 @@ class UserServiceTests: XCTestCase {
         task.cancel()
     }
 
+    func testStreamTerminates() async throws {
+        stubSuccessfullUsersFetch()
+
+        let termination = XCTestExpectation(description: "Stream has finished")
+        let task = Task.detached { [self] in
+            for await _ in self.service.usersUpdates {
+                // Do nothing
+            }
+            termination.fulfill()
+        }
+
+        _ = try await service.fetchUsers()
+        _ = try await service.fetchUsers()
+        _ = try await service.fetchUsers()
+
+        // Stream should be terminated once `service` is deallocated.
+        service = nil
+
+        await fulfillment(of: [termination], timeout: 0.3)
+
+        task.cancel()
+    }
+
     func testDeleteUserTriggersUsersUpdate() async throws {
         stubSuccessfullUsersFetch()
         stubDeleteUser(id: 34)

--- a/WordPress/WordPressTest/UserServiceTests.swift
+++ b/WordPress/WordPressTest/UserServiceTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import XCTest
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import Combine
+import WordPressUI
+
+@testable import WordPress
+
+class UserServiceTests: XCTestCase {
+    var service: UserService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let client = try WordPressClient(api: .init(urlSession: .shared, baseUrl: .parse(input: "https://example.com"), authenticationStategy: .none), rootUrl: .parse(input: "https://example.com"))
+        service = UserService(client: client)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        HTTPStubs.removeAllStubs()
+    }
+
+    func testSuccessfulUsersUpdateInTheMainThread() {
+        stubSuccessfullUsersFetch()
+        let expectation = XCTestExpectation(description: "Users update in the main thread")
+
+        let cancellable = service.users.sink { _ in
+            if Thread.isMainThread {
+                expectation.fulfill()
+            }
+        }
+
+        service.fetchUsers()
+
+        wait(for: [expectation], timeout: 0.3)
+    }
+
+    func testSuccessfulUsersUpdateInTheMainThreadWhenFetchFromBackgroundThread() {
+        stubSuccessfullUsersFetch()
+        let expectation = XCTestExpectation(description: "Users update in the main thread")
+
+        let cancellable = service.users.sink { _ in
+            if Thread.isMainThread {
+                expectation.fulfill()
+            }
+        }
+
+        DispatchQueue.global().async {
+            self.service.fetchUsers()
+        }
+
+        wait(for: [expectation], timeout: 0.3)
+    }
+
+    func testFailedUsersUpdateInTheMainThread() {
+        stubFailedUsersFetch()
+        let expectation = XCTestExpectation(description: "Users update in the main thread")
+
+        let cancellable = service.users.sink { _ in
+            if Thread.isMainThread {
+                expectation.fulfill()
+            }
+        }
+
+        service.fetchUsers()
+
+        wait(for: [expectation], timeout: 0.3)
+    }
+
+    func testFailedUpdateInTheMainThreadWhenFetchFromBackgroundThread() {
+        stubFailedUsersFetch()
+        let expectation = XCTestExpectation(description: "Users update in the main thread")
+
+        let cancellable = service.users.sink { _ in
+            if Thread.isMainThread {
+                expectation.fulfill()
+            }
+        }
+
+        DispatchQueue.global().async {
+            self.service.fetchUsers()
+        }
+
+        wait(for: [expectation], timeout: 0.3)
+    }
+
+    func testMultipleFetchUsersTriggerOneUpdate() {
+        stubSuccessfullUsersFetch()
+
+        let expectation = XCTestExpectation(description: "One update for multiple fetches")
+        let cancellable = service.users.sink { _ in
+            expectation.fulfill()
+        }
+
+        // Only one HTTP request should be sent for all function calls.
+        for _ in 1...10 {
+            service.fetchUsers()
+        }
+
+        wait(for: [expectation], timeout: 0.3)
+    }
+
+    func testSequentialFetchUsersTriggerOneUpdateForEachFetch() {
+        stubSuccessfullUsersFetch()
+
+        for _ in 1...5 {
+            service.fetchUsers()
+
+            let expectation = XCTestExpectation(description: "Updated after fetch")
+            let cancellable = service.users.sink { _ in
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: 0.3)
+        }
+    }
+
+    func testDeleteUserTriggersUsersUpdate() async throws {
+        stubSuccessfullUsersFetch()
+        stubDeleteUser(id: 34)
+
+        var cancellables: Set<AnyCancellable> = []
+
+        var latestUsers: [DisplayUser] = []
+        service.users.sink {
+            if case let .success(users) = $0 {
+                latestUsers = users
+            }
+        }.store(in: &cancellables)
+
+        service.fetchUsers()
+        let expectation = XCTestExpectation(description: "Updated after fetch")
+        let cancellable = service.users.first().sink { _ in
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 0.3)
+        XCTAssertTrue(latestUsers.contains { $0.id == 34 })
+
+        try await service.deleteUser(id: 34, reassigningPostsTo: 1)
+
+        XCTAssertFalse(latestUsers.contains { $0.id == 34 })
+    }
+
+    private func stubSuccessfullUsersFetch() {
+        stub(condition: isPath("/wp-json/wp/v2/users")) { _ in
+            let json = #"[{"id":1,"username":"demo","name":"demo","first_name":"","last_name":"","email":"tony.li@automattic.com","url":"https:\/\/yellow-lemming-rail.jurassic.ninja","description":"","link":"https:\/\/yellow-lemming-rail.jurassic.ninja\/author\/demo\/","locale":"en_US","nickname":"demo","slug":"demo","roles":["administrator"],"registered_date":"2024-11-03T21:43:36+00:00","capabilities":{"switch_themes":true,"edit_themes":true,"activate_plugins":true,"edit_plugins":true,"edit_users":true,"edit_files":true,"manage_options":true,"moderate_comments":true,"manage_categories":true,"manage_links":true,"upload_files":true,"import":true,"unfiltered_html":true,"edit_posts":true,"edit_others_posts":true,"edit_published_posts":true,"publish_posts":true,"edit_pages":true,"read":true,"level_10":true,"level_9":true,"level_8":true,"level_7":true,"level_6":true,"level_5":true,"level_4":true,"level_3":true,"level_2":true,"level_1":true,"level_0":true,"edit_others_pages":true,"edit_published_pages":true,"publish_pages":true,"delete_pages":true,"delete_others_pages":true,"delete_published_pages":true,"delete_posts":true,"delete_others_posts":true,"delete_published_posts":true,"delete_private_posts":true,"edit_private_posts":true,"read_private_posts":true,"delete_private_pages":true,"edit_private_pages":true,"read_private_pages":true,"delete_users":true,"create_users":true,"unfiltered_upload":true,"edit_dashboard":true,"update_plugins":true,"delete_plugins":true,"install_plugins":true,"update_themes":true,"install_themes":true,"update_core":true,"list_users":true,"remove_users":true,"promote_users":true,"edit_theme_options":true,"delete_themes":true,"export":true,"administrator":true},"extra_capabilities":{"administrator":true},"avatar_urls":{"24":"https:\/\/secure.gravatar.com\/avatar\/ac05cde1cb014070c625b139e53a2899?s=24&d=mm&r=g","48":"https:\/\/secure.gravatar.com\/avatar\/ac05cde1cb014070c625b139e53a2899?s=48&d=mm&r=g","96":"https:\/\/secure.gravatar.com\/avatar\/ac05cde1cb014070c625b139e53a2899?s=96&d=mm&r=g"},"meta":{"persisted_preferences":{"core":{"isComplementaryAreaVisible":true},"core\/edit-post":{"welcomeGuide":false},"_modified":"2024-11-06T09:23:14.009Z"}},"_links":{"self":[{"href":"https:\/\/yellow-lemming-rail.jurassic.ninja\/wp-json\/wp\/v2\/users\/1"}],"collection":[{"href":"https:\/\/yellow-lemming-rail.jurassic.ninja\/wp-json\/wp\/v2\/users"}]}},{"id":34,"username":"user_1810","name":"User_2718","first_name":"","last_name":"","email":"user_5880@example.com","url":"","description":"","link":"https://yellow-lemming-rail.jurassic.ninja/author/user_1810/","locale":"en_US","nickname":"user_1810","slug":"user_1810","roles":["editor"],"registered_date":"2024-11-05T22:58:27+00:00","capabilities":{"moderate_comments":true,"manage_categories":true,"manage_links":true,"upload_files":true,"unfiltered_html":true,"edit_posts":true,"edit_others_posts":true,"edit_published_posts":true,"publish_posts":true,"edit_pages":true,"read":true,"level_7":true,"level_6":true,"level_5":true,"level_4":true,"level_3":true,"level_2":true,"level_1":true,"level_0":true,"edit_others_pages":true,"edit_published_pages":true,"publish_pages":true,"delete_pages":true,"delete_others_pages":true,"delete_published_pages":true,"delete_posts":true,"delete_others_posts":true,"delete_published_posts":true,"delete_private_posts":true,"edit_private_posts":true,"read_private_posts":true,"delete_private_pages":true,"edit_private_pages":true,"read_private_pages":true,"editor":true},"extra_capabilities":{"editor":true},"avatar_urls":{"24":"https://secure.gravatar.com/avatar/e1cf0e88fb26697102e09f3aa1fd40c7?s=24&d=mm&r=g","48":"https://secure.gravatar.com/avatar/e1cf0e88fb26697102e09f3aa1fd40c7?s=48&d=mm&r=g","96":"https://secure.gravatar.com/avatar/e1cf0e88fb26697102e09f3aa1fd40c7?s=96&d=mm&r=g"},"meta":{"persisted_preferences":[]}}]"#
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+    }
+
+    private func stubFailedUsersFetch() {
+        stub(condition: isPath("/wp-json/wp/v2/users")) { _ in
+            HTTPStubsResponse(error: URLError(.timedOut))
+        }
+    }
+
+    private func stubDeleteUser(id: Int32) {
+        stub(condition: isPath("/wp-json/wp/v2/users/\(id)")) { _ in
+            let json = #"{"deleted":true,"previous":{"id":34,"username":"user_1810","name":"User_2718","first_name":"","last_name":"","email":"user_5880@example.com","url":"","description":"","link":"https://yellow-lemming-rail.jurassic.ninja/author/user_1810/","locale":"en_US","nickname":"user_1810","slug":"user_1810","roles":["editor"],"registered_date":"2024-11-05T22:58:27+00:00","capabilities":{"moderate_comments":true,"manage_categories":true,"manage_links":true,"upload_files":true,"unfiltered_html":true,"edit_posts":true,"edit_others_posts":true,"edit_published_posts":true,"publish_posts":true,"edit_pages":true,"read":true,"level_7":true,"level_6":true,"level_5":true,"level_4":true,"level_3":true,"level_2":true,"level_1":true,"level_0":true,"edit_others_pages":true,"edit_published_pages":true,"publish_pages":true,"delete_pages":true,"delete_others_pages":true,"delete_published_pages":true,"delete_posts":true,"delete_others_posts":true,"delete_published_posts":true,"delete_private_posts":true,"edit_private_posts":true,"read_private_posts":true,"delete_private_pages":true,"edit_private_pages":true,"read_private_pages":true,"editor":true},"extra_capabilities":{"editor":true},"avatar_urls":{"24":"https://secure.gravatar.com/avatar/e1cf0e88fb26697102e09f3aa1fd40c7?s=24&d=mm&r=g","48":"https://secure.gravatar.com/avatar/e1cf0e88fb26697102e09f3aa1fd40c7?s=48&d=mm&r=g","96":"https://secure.gravatar.com/avatar/e1cf0e88fb26697102e09f3aa1fd40c7?s=96&d=mm&r=g"},"meta":{"persisted_preferences":[]}}}"#
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+
+    }
+}


### PR DESCRIPTION
> [!Note]
> This PR is built on top of #23791.

Uses one `UserService` for all user management actions.

The user list is cached in the type, which fixes the issue where deleted users show in the user list.

~I will add unit tests to the service and view model types in a separate PR.~ I have added some unit tests for `UserService`, but not sure what's the best practice/easiest way to test `ObservableObject` (the view models).

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
