### PR TITLE
Reader: Make it easier to subscribe

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
@@ -11,18 +11,27 @@ struct ReaderPostMenu {
 
     func makeMenu() -> [UIMenuElement] {
         return [
-            makePrimaryActions(),
+            makePrimaryActionsSection(),
+            makeBlogSection(),
             shouldShowReportOrBlockMenu ? makeBlockOrReportActions() : nil
         ].compactMap { $0 }
     }
 
-    private func makePrimaryActions() -> UIMenu {
+    private func makePrimaryActionsSection() -> UIMenu {
         UIMenu(options: [.displayInline], children: [
             share,
             copyPostLink,
             viewPostInBrowser,
-            makeBlogMenu(),
+
         ].compactMap { $0 })
+    }
+
+    private func makeBlogSection() -> UIMenu {
+        var actions = [makeBlogMenu()]
+        if !post.isFollowing {
+            actions.append(subscribe)
+        }
+        return UIMenu(options: [.displayInline], children: actions)
     }
 
     private func makeBlogMenu() -> UIMenuElement {
@@ -35,8 +44,6 @@ struct ReaderPostMenu {
                 actions.append(manageNotifications(for: siteID))
             }
             actions += [ubsubscribe]
-        } else {
-            actions += [subscribe]
         }
         return UIMenu(title: post.blogNameForDisplay() ?? Strings.blogDetails, children: actions)
     }


### PR DESCRIPTION
- Move "Subscribe" to the top level to make it easier to find.
- Put blog-related actions in a separate section

<img width="340" alt="Screenshot 2024-11-12 at 2 01 39 PM" src="https://github.com/user-attachments/assets/da0dee88-9536-48e3-9232-3eaa652849ed">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
