### PR TITLE
Reader: Fix broken table reload animations

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -106,6 +106,7 @@
 @property (nonatomic) UITableViewRowAnimation moveRowAnimation;
 @property (nonatomic) UITableViewRowAnimation sectionRowAnimation;
 @property (nonatomic) BOOL listensForContentChanges;
+@property (nonatomic) BOOL disableAnimations;
 
 - (nonnull instancetype)initWithTableView:(nonnull UITableView *)tableView;
 - (void)clearCachedRowHeights;

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -635,6 +635,9 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 
     self.indexPathSelectedBeforeUpdates = [self.tableView indexPathForSelectedRow];
+    if (self.disableAnimations) {
+        [UIView setAnimationsEnabled:NO];
+    }
     [self.tableView beginUpdates];
 }
 
@@ -645,6 +648,9 @@ static CGFloat const DefaultCellHeight = 44.0;
     NSError *error;
     [WPException objcTryBlock:^{
         [self.tableView endUpdates];
+        if (self.disableAnimations) {
+            [UIView setAnimationsEnabled:YES];
+        }
     } error:&error];
     
     if (error) {
@@ -697,7 +703,7 @@ static CGFloat const DefaultCellHeight = 44.0;
         // It seems in some cases newIndexPath can be nil for updates
         newIndexPath = indexPath;
     }
-    
+
     switch(type) {
         case NSFetchedResultsChangeInsert:
         {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderTableContent.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderTableContent.swift
@@ -6,10 +6,14 @@ final class ReaderTableContent {
     private var tableViewHandler: WPTableViewHandler?
 
     func initializeContent(tableView: UITableView, delegate: WPTableViewHandlerDelegate) {
-        tableViewHandler = WPTableViewHandler(tableView: tableView)
-        tableViewHandler?.cacheRowHeights = false
-        tableViewHandler?.updateRowAnimation = .none
-        tableViewHandler?.delegate = delegate
+        let tableViewHandler = WPTableViewHandler(tableView: tableView)
+        tableViewHandler.cacheRowHeights = false
+        tableViewHandler.updateRowAnimation = .none
+        tableViewHandler.moveRowAnimation = .none
+        tableViewHandler.insertRowAnimation = .none
+        tableViewHandler.disableAnimations = true
+        tableViewHandler.delegate = delegate
+        self.tableViewHandler = tableViewHandler
     }
 
     func resetResultsController() {


### PR DESCRIPTION
It looks much better with animations disabled.

https://github.com/user-attachments/assets/f2733cb4-0722-4963-8b82-fdf521f1fe83


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
