### PR TITLE
Reader: Add context menus

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -53,6 +53,7 @@
 
 - (nullable UISwipeActionsConfiguration *)tableView:(nonnull UITableView *)tableView leadingSwipeActionsConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 - (nullable UISwipeActionsConfiguration *)tableView:(nonnull UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
+- (nullable UIContextMenuConfiguration *)tableView:(nonnull UITableView *)tableView contextMenuConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath point:(CGPoint)point;
 
 #pragma mark - Tracking the removal of views
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -314,6 +314,13 @@ static CGFloat const DefaultCellHeight = 44.0;
     [self.delegate tableView:tableView didSelectRowAtIndexPath:indexPath];
 }
 
+- (UIContextMenuConfiguration *)tableView:(UITableView *)tableView contextMenuConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath point:(CGPoint)point {
+    if ([self.delegate respondsToSelector:@selector(tableView:contextMenuConfigurationForRowAtIndexPath:point:)]) {
+        return [self.delegate tableView:tableView contextMenuConfigurationForRowAtIndexPath:indexPath point:point];
+    }
+    return nil;
+}
+
 
 #pragma mark - Optional Delegate Methods
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
@@ -363,6 +363,13 @@ private class ReaderDiscoverStreamViewController: ReaderStreamViewController {
         super.syncIfAppropriate(forceSync: true)
         tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
     }
+
+    override func getPost(at indexPath: IndexPath) -> ReaderPost? {
+        guard let card: ReaderCard = content.object(at: indexPath) else {
+            return nil
+        }
+        return card.post
+    }
 }
 
 // MARK: - ReaderRecommendedSitesCellDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -1139,6 +1139,10 @@ import AutomatticTracks
             completion?(false)
         })
     }
+
+    func getPost(at indexPath: IndexPath) -> ReaderPost? {
+        content.object(at: indexPath)
+    }
 }
 
 // MARK: - ReaderStreamHeaderDelegate
@@ -1447,6 +1451,20 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         // Do nothing
     }
 
+    func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        guard let post = getPost(at: indexPath) else {
+            return nil
+        }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            guard let self else { return nil }
+            return UIMenu(children: ReaderPostMenu(
+                post: post,
+                topic: readerTopic,
+                anchor: self.tableView.cellForRow(at: indexPath) ?? self.view,
+                viewController: self
+            ).makeMenu())
+        }
+    }
 }
 
 // MARK: - SearchableActivity Conformance


### PR DESCRIPTION
On long-press:

<img width="320" alt="Screenshot 2024-11-14 at 12 24 09 PM" src="https://github.com/user-attachments/assets/f1e8d599-d0a2-4eec-a449-77bd33bc768f">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
