### PR TITLE
Reader: Fix an issue with Reader not showing notification settings for some sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
@@ -122,12 +122,14 @@ enum ReaderSubscriptionNotificationsStatus {
     case none
 
     init?(site: ReaderSiteTopic) {
-        guard let postSubscription = site.postSubscription,
-              let emailSubscription = site.emailSubscription else {
+        guard !site.isExternal else {
             return nil
         }
-        let sendPosts = postSubscription.sendPosts || emailSubscription.sendPosts
-        let sendComments = emailSubscription.sendComments
+        let posts = site.postSubscription
+        let emails = site.emailSubscription
+
+        let sendPosts = (posts?.sendPosts ?? false) || (emails?.sendPosts ?? false)
+        let sendComments = emails?.sendComments ?? false
         if sendPosts && sendComments {
             self = .all
         } else if sendPosts || sendComments {


### PR DESCRIPTION
before / after


<img width="320" alt="Screenshot 2024-11-14 at 1 01 28 PM" src="https://github.com/user-attachments/assets/014d8cde-c623-44e2-8c80-514a59ed2958">

<img width="320" alt="Screenshot 2024-11-14 at 1 05 05 PM" src="https://github.com/user-attachments/assets/82615839-2c30-4990-9959-6f73c53393bb">

Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
