### PR TITLE
Reader: Minor issue with subscritpions

### DIFF
--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -74,16 +74,4 @@ extern NSString * const ReaderSiteServiceErrorDomain;
  */
 - (void)syncPostsForFollowedSites;
 
-/**
- Returns a ReaderSiteTopic for the given site URL.
- 
- @param siteURL The URL of the site.
- @param success block called on a successful fetch containing the ReaderSiteTopic.
- @param failure block called if there is any error. `error` can be any underlying network error.
- */
-- (void)topicWithSiteURL:(NSURL *)siteURL
-                 success:(void (^)(ReaderSiteTopic *topic))success
-                 failure:(void(^)(NSError *error))failure;
-
-
 @end

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -160,20 +160,6 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     }];
 }
 
-- (void)topicWithSiteURL:(NSURL *)siteURL success:(void (^)(ReaderSiteTopic *topic))success failure:(void(^)(NSError *error))failure
-{
-    WordPressComRestApi *api = [self apiForRequest];
-    ReaderSiteServiceRemote *service = [[ReaderSiteServiceRemote alloc] initWithWordPressComRestApi:api];
-    
-    [service findSiteIDForURL:siteURL success:^(NSUInteger siteID) {
-        NSNumber *site = [NSNumber numberWithUnsignedLong:siteID];
-        ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:site inContext:self.coreDataStack.mainContext];
-        success(topic);
-    } failure:^(NSError *error) {
-        failure(error);
-    }];
-}
-
 #pragma mark - Private Methods
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
@@ -8,8 +8,6 @@ import AutomatticTracks
 extension NSNotification.Name {
     // Sent when a site or a tag is unfollowed via Reader Manage screen.
     static let ReaderTopicUnfollowed = NSNotification.Name(rawValue: "ReaderTopicUnfollowed")
-    // Sent when a site is followed via Reader Manage screen.
-    static let ReaderSiteFollowed = NSNotification.Name(rawValue: "ReaderSiteFollowed")
     // Sent when a post's seen state has been toggled.
     static let ReaderPostSeenToggled = NSNotification.Name(rawValue: "ReaderPostSeenToggled")
     // Sent when a site is blocked.

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -21,7 +21,7 @@ struct ReaderSubscriptionCell: View {
         HStack(spacing: 0) {
             HStack(spacing: 16) {
                 ReaderSiteIconView(site: site, size: .regular)
-                    .padding(.leading, 4)
+                    .padding(.leading, horizontalSizeClass == .compact ? 0 : 4)
 
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
@@ -6,12 +6,8 @@ struct ReaderSubscriptionHelper {
     // MARK: Subscribe
 
     func toggleSiteSubscription(forPost post: ReaderPost) {
-        let siteURL = post.blogURL.flatMap(URL.init)
         ReaderFollowAction().execute(with: post, context: ContextManager.shared.mainContext, completion: { isFollowing in
             UINotificationFeedbackGenerator().notificationOccurred(.success)
-            if isFollowing, let siteURL {
-                postSiteFollowedNotification(siteURL: siteURL)
-            }
             ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: isFollowing, success: true)
         }, failure: { _, _ in
             UINotificationFeedbackGenerator().notificationOccurred(.error)
@@ -33,7 +29,7 @@ struct ReaderSubscriptionHelper {
             let service = ReaderSiteService(coreDataStack: contextManager)
             service.followSite(by: url, success: {
                 ReaderTopicService(coreDataStack: contextManager)
-                    .fetchAllFollowedSites(success: {}, failure: {})
+                    .fetchAllFollowedSites(success: {}, failure: { _ in })
                 generator.notificationOccurred(.success)
                 continuation.resume(returning: ())
             }, failure: { error in

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
@@ -32,7 +32,8 @@ struct ReaderSubscriptionHelper {
         try await withUnsafeThrowingContinuation { continuation in
             let service = ReaderSiteService(coreDataStack: contextManager)
             service.followSite(by: url, success: {
-                postSiteFollowedNotification(siteURL: url)
+                ReaderTopicService(coreDataStack: contextManager)
+                    .fetchAllFollowedSites(success: {}, failure: {})
                 generator.notificationOccurred(.success)
                 continuation.resume(returning: ())
             }, failure: { error in
@@ -41,17 +42,6 @@ struct ReaderSubscriptionHelper {
                 continuation.resume(throwing: error ?? URLError(.unknown))
             })
         }
-    }
-
-    private func postSiteFollowedNotification(siteURL: URL) {
-        let service = ReaderSiteService(coreDataStack: contextManager)
-        service.topic(withSiteURL: siteURL, success: { topic in
-            if let topic = topic {
-                NotificationCenter.default.post(name: .ReaderSiteFollowed, object: nil, userInfo: [ReaderNotificationKeys.topic: topic])
-            }
-        }, failure: { error in
-            DDLogError("Unable to find topic by siteURL: \(String(describing: error?.localizedDescription))")
-        })
     }
 
     // MARK: Subscribe/Unsubscribe (ReaderSiteTopic)


### PR DESCRIPTION
- Fix list not refreshing after adding a subscription 
- Fix leading inset in the list

## To test:

- Open Reader / Subscriptions
- Tap "+" and add an RSS feed
- **Verify** that the list got refreshed

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
