### PR TITLE
Refactor: Remove flipInsetsForRightToLeftLayoutDirection

### DIFF
--- a/WordPress/Classes/Extensions/UIEdgeInsets.swift
+++ b/WordPress/Classes/Extensions/UIEdgeInsets.swift
@@ -5,33 +5,10 @@ extension UIEdgeInsets {
         guard UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft else {
             return self
         }
-
         return flippedForRightToLeftLayoutDirection()
     }
 
     func flippedForRightToLeftLayoutDirection() -> UIEdgeInsets {
         return UIEdgeInsets(top: top, left: right, bottom: bottom, right: left)
-    }
-}
-
-extension UIButton {
-
-    @objc func flipInsetsForRightToLeftLayoutDirection() {
-        guard userInterfaceLayoutDirection() == .rightToLeft else {
-            return
-        }
-        contentEdgeInsets = contentEdgeInsets.flippedForRightToLeftLayoutDirection()
-        imageEdgeInsets = imageEdgeInsets.flippedForRightToLeftLayoutDirection()
-        titleEdgeInsets = titleEdgeInsets.flippedForRightToLeftLayoutDirection()
-    }
-}
-
-// Hack: Since UIEdgeInsets is a struct in ObjC, you can't have methods on it.
-// You can't also export top level functions from Swift.
-// 🙄
-@objc(InsetsHelper)
-class _InsetsHelper: NSObject {
-    @objc static func flipForRightToLeftLayoutDirection(_ insets: UIEdgeInsets) -> UIEdgeInsets {
-        return insets.flippedForRightToLeftLayoutDirection()
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -385,7 +385,6 @@ private extension CommentContentTableViewCell {
         replyButton?.setTitleColor(Style.reactionButtonTextColor, for: .normal)
         replyButton?.setImage(Style.replyIconImage, for: .normal)
         replyButton?.addTarget(self, action: #selector(replyButtonTapped), for: .touchUpInside)
-        replyButton?.flipInsetsForRightToLeftLayoutDirection()
         replyButton?.adjustsImageSizeForAccessibilityContentSizeCategory = true
         adjustImageAndTitleEdgeInsets(for: replyButton)
         replyButton?.sizeToFit()
@@ -397,7 +396,6 @@ private extension CommentContentTableViewCell {
         likeButton?.titleLabel?.adjustsFontForContentSizeCategory = true
         likeButton?.setTitleColor(Style.reactionButtonTextColor, for: .normal)
         likeButton?.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
-        likeButton?.flipInsetsForRightToLeftLayoutDirection()
         likeButton?.adjustsImageSizeForAccessibilityContentSizeCategory = true
         adjustImageAndTitleEdgeInsets(for: likeButton)
         updateLikeButton(liked: false, numberOfLikes: 0)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -78,7 +78,6 @@ class JetpackButton: CircularImageButton {
         imageEdgeInsets = Appearance.iconInsets
         contentEdgeInsets = Appearance.contentInsets
         imageView?.contentMode = .scaleAspectFit
-        flipInsetsForRightToLeftLayoutDirection()
         setImageBackgroundColor(imageBackgroundColor)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -53,8 +53,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
         applyStyles()
 
-        adjustInsetsForTextDirection()
-
         prepareActionButtonsForVoiceOver()
     }
 
@@ -374,17 +372,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         prepareActionButtonsForVoiceOver()
 
         configureActionButtonStyle(saveForLaterButton)
-    }
-
-    private func adjustInsetsForTextDirection() {
-        let buttonsToAdjust: [UIButton] = [
-            likeButton,
-            commentButton,
-            saveForLaterButton,
-            reblogButton]
-        for button in buttonsToAdjust {
-            button.flipInsetsForRightToLeftLayoutDirection()
-        }
     }
 
     fileprivate func configureButtonTitles() {


### PR DESCRIPTION
This PR fixes a few warnings.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
