### PR TITLE
Simplify reusing http request Tasks in ImageDownloader

### DIFF
--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -30,7 +30,7 @@ actor ImageDownloader {
         )
     }
 
-    private var tasks: [String: ImageDataTask] = [:]
+    private var tasks: [String: Task<Data, any Error>] = [:]
 
     init(cache: MemoryCacheProtocol = MemoryCache.shared) {
         self.cache = cache
@@ -115,32 +115,22 @@ actor ImageDownloader {
 
     private func data(for request: URLRequest, options: ImageRequestOptions) async throws -> Data {
         let requestKey = request.urlRequest?.url?.absoluteString ?? ""
-        let task = tasks[requestKey] ?? ImageDataTask(key: requestKey, Task {
-            try await self._data(for: request, options: options, key: requestKey)
-        })
-        task.downloader = self
 
-        let subscriptionID = UUID()
-        task.subscriptions.insert(subscriptionID)
-        tasks[requestKey] = task
-
-        return try await task.getData(subscriptionID: subscriptionID)
-    }
-
-    fileprivate nonisolated func unsubscribe(_ subscriptionID: UUID, key: String) {
-        Task {
-            await _unsubscribe(subscriptionID, key: key)
+        let theTask: Task<Data, any Error>
+        if let task = tasks[requestKey] {
+            theTask = task
+        } else {
+            theTask = Task {
+                try await self._data(for: request, options: options, key: requestKey)
+            }
+            tasks[requestKey] = theTask
         }
-    }
 
-    private func _unsubscribe(_ subscriptionID: UUID, key: String) {
-        guard let task = tasks[key],
-              task.subscriptions.remove(subscriptionID) != nil,
-              task.subscriptions.isEmpty else {
-            return
+        return try await withTaskCancellationHandler {
+            try await theTask.value
+        } onCancel: {
+            theTask.cancel()
         }
-        task.task.cancel()
-        tasks[key] = nil
     }
 
     private func _data(for request: URLRequest, options: ImageRequestOptions, key: String) async throws -> Data {
@@ -157,27 +147,6 @@ actor ImageDownloader {
         }
         guard (200..<400).contains(response.statusCode) else {
             throw ImageDownloaderError.unacceptableStatusCode(response.statusCode)
-        }
-    }
-}
-
-private final class ImageDataTask {
-    let key: String
-    var subscriptions = Set<UUID>()
-    let task: Task<Data, Error>
-    weak var downloader: ImageDownloader?
-
-    init(key: String, _ task: Task<Data, Error>) {
-        self.key = key
-        self.task = task
-    }
-
-    func getData(subscriptionID: UUID) async throws -> Data {
-        try await withTaskCancellationHandler {
-            try await task.value
-        } onCancel: { [weak self] in
-            guard let self else { return }
-            self.downloader?.unsubscribe(subscriptionID, key: self.key)
         }
     }
 }

--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -30,7 +30,7 @@ actor ImageDownloader {
         )
     }
 
-    private var tasks: [String: Task<Data, any Error>] = [:]
+    private var tasks: [String: ImageDataTask] = [:]
 
     init(cache: MemoryCacheProtocol = MemoryCache.shared) {
         self.cache = cache
@@ -115,22 +115,32 @@ actor ImageDownloader {
 
     private func data(for request: URLRequest, options: ImageRequestOptions) async throws -> Data {
         let requestKey = request.urlRequest?.url?.absoluteString ?? ""
+        let task = tasks[requestKey] ?? ImageDataTask(key: requestKey, Task {
+            try await self._data(for: request, options: options, key: requestKey)
+        })
+        task.downloader = self
 
-        let theTask: Task<Data, any Error>
-        if let task = tasks[requestKey] {
-            theTask = task
-        } else {
-            theTask = Task {
-                try await self._data(for: request, options: options, key: requestKey)
-            }
-            tasks[requestKey] = theTask
-        }
+        let subscriptionID = UUID()
+        task.subscriptions.insert(subscriptionID)
+        tasks[requestKey] = task
 
-        return try await withTaskCancellationHandler {
-            try await theTask.value
-        } onCancel: {
-            theTask.cancel()
+        return try await task.getData(subscriptionID: subscriptionID)
+    }
+
+    fileprivate nonisolated func unsubscribe(_ subscriptionID: UUID, key: String) {
+        Task {
+            await _unsubscribe(subscriptionID, key: key)
         }
+    }
+
+    private func _unsubscribe(_ subscriptionID: UUID, key: String) {
+        guard let task = tasks[key],
+              task.subscriptions.remove(subscriptionID) != nil,
+              task.subscriptions.isEmpty else {
+            return
+        }
+        task.task.cancel()
+        tasks[key] = nil
     }
 
     private func _data(for request: URLRequest, options: ImageRequestOptions, key: String) async throws -> Data {
@@ -147,6 +157,27 @@ actor ImageDownloader {
         }
         guard (200..<400).contains(response.statusCode) else {
             throw ImageDownloaderError.unacceptableStatusCode(response.statusCode)
+        }
+    }
+}
+
+private final class ImageDataTask {
+    let key: String
+    var subscriptions = Set<UUID>()
+    let task: Task<Data, Error>
+    weak var downloader: ImageDownloader?
+
+    init(key: String, _ task: Task<Data, Error>) {
+        self.key = key
+        self.task = task
+    }
+
+    func getData(subscriptionID: UUID) async throws -> Data {
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            self.downloader?.unsubscribe(subscriptionID, key: self.key)
         }
     }
 }

--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 struct ImageRequestOptions {
     /// Resize the thumbnail to the given size. By default, `nil`.
@@ -30,7 +31,7 @@ actor ImageDownloader {
         )
     }
 
-    private var tasks: [String: ImageDataTask] = [:]
+    private var tasks: [String: AnyPublisher<Result<Data, Error>, Never>] = [:]
 
     init(cache: MemoryCacheProtocol = MemoryCache.shared) {
         self.cache = cache
@@ -115,32 +116,31 @@ actor ImageDownloader {
 
     private func data(for request: URLRequest, options: ImageRequestOptions) async throws -> Data {
         let requestKey = request.urlRequest?.url?.absoluteString ?? ""
-        let task = tasks[requestKey] ?? ImageDataTask(key: requestKey, Task {
-            try await self._data(for: request, options: options, key: requestKey)
-        })
-        task.downloader = self
+        let task = tasks[requestKey] ?? {
+            let subject = CurrentValueSubject<Result<Data, Error>?, Never>(nil)
+            let t = Task {
+                do {
+                    let data = try await self._data(for: request, options: options, key: requestKey)
+                    subject.send(.success(data))
+                } catch {
+                    subject.send(.failure(error))
+                }
+                subject.send(completion: .finished)
+            }
 
-        let subscriptionID = UUID()
-        task.subscriptions.insert(subscriptionID)
+            return subject
+                .handleEvents(receiveCancel: { t.cancel() })
+                .share()
+                .compactMap { $0 }
+                .eraseToAnyPublisher()
+        }()
         tasks[requestKey] = task
 
-        return try await task.getData(subscriptionID: subscriptionID)
-    }
-
-    fileprivate nonisolated func unsubscribe(_ subscriptionID: UUID, key: String) {
-        Task {
-            await _unsubscribe(subscriptionID, key: key)
+        if let result = await task.values.first(where: { _ in true }) {
+            return try result.get()
+        } else {
+            throw CancellationError()
         }
-    }
-
-    private func _unsubscribe(_ subscriptionID: UUID, key: String) {
-        guard let task = tasks[key],
-              task.subscriptions.remove(subscriptionID) != nil,
-              task.subscriptions.isEmpty else {
-            return
-        }
-        task.task.cancel()
-        tasks[key] = nil
     }
 
     private func _data(for request: URLRequest, options: ImageRequestOptions, key: String) async throws -> Data {
@@ -157,27 +157,6 @@ actor ImageDownloader {
         }
         guard (200..<400).contains(response.statusCode) else {
             throw ImageDownloaderError.unacceptableStatusCode(response.statusCode)
-        }
-    }
-}
-
-private final class ImageDataTask {
-    let key: String
-    var subscriptions = Set<UUID>()
-    let task: Task<Data, Error>
-    weak var downloader: ImageDownloader?
-
-    init(key: String, _ task: Task<Data, Error>) {
-        self.key = key
-        self.task = task
-    }
-
-    func getData(subscriptionID: UUID) async throws -> Data {
-        try await withTaskCancellationHandler {
-            try await task.value
-        } onCancel: { [weak self] in
-            guard let self else { return }
-            self.downloader?.unsubscribe(subscriptionID, key: self.key)
         }
     }
 }

--- a/WordPress/WordPressTest/ImageDownloaderTests.swift
+++ b/WordPress/WordPressTest/ImageDownloaderTests.swift
@@ -68,6 +68,51 @@ class ImageDownloaderTests: CoreDataTestCase {
         }
     }
 
+    func testCancelOneOfManySubscribers() async throws {
+        // GIVEN
+        let httpRequestReceived = self.expectation(description: "HTTP request received")
+        let imageURL = try XCTUnwrap(URL(string: "https://example.files.wordpress.com/2023/09/image.jpg"))
+        stub(condition: { _ in true }, response: { _ in
+            httpRequestReceived.fulfill()
+
+            guard let sourceURL = try? XCTUnwrap(Bundle.test.url(forResource: "test-image", withExtension: "jpg")),
+                  let data = try? Data(contentsOf: sourceURL) else {
+                return HTTPStubsResponse(error: URLError(.unknown))
+            }
+
+            return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
+                .responseTime(0.3)
+        })
+
+        // WHEN there are concurrent calls to download the same image and one of those downloads is cancelled
+        let taskCompleted = self.expectation(description: "Image downloaded")
+        taskCompleted.expectedFulfillmentCount = 3
+        for _ in 1...3 {
+            try await Task.sleep(for: .milliseconds(50))
+            Task.detached {
+                do {
+                    _ = try await self.sut.image(from: imageURL)
+                } catch {
+                    XCTFail("Unexpected error: \(error)")
+                }
+                taskCompleted.fulfill()
+            }
+        }
+
+        let taskCancelled = expectation(description: "Task is cancelled")
+        let taskToBeCancelled = Task.detached {
+            do {
+                _ = try await self.sut.image(from: imageURL)
+                XCTFail("Unexpected successful result.")
+            } catch {
+                taskCancelled.fulfill()
+            }
+        }
+        taskToBeCancelled.cancel()
+
+        await fulfillment(of: [httpRequestReceived, taskCompleted, taskCancelled], timeout: 0.5)
+    }
+
     func testMemoryCache() async throws {
         // GIVEN
         let imageURL = try XCTUnwrap(URL(string: "https://example.files.wordpress.com/2023/09/image.jpg"))

--- a/WordPress/WordPressTest/ImageDownloaderTests.swift
+++ b/WordPress/WordPressTest/ImageDownloaderTests.swift
@@ -125,6 +125,40 @@ class ImageDownloaderTests: CoreDataTestCase {
         XCTAssertEqual(image.size, CGSize(width: 1024, height: 680))
     }
 
+    func testReuseHTTPRequest() async throws {
+        // GIVEN
+        let httpRequestReceived = self.expectation(description: "HTTP request received")
+        let imageURL = try XCTUnwrap(URL(string: "https://example.files.wordpress.com/2023/09/image.jpg"))
+        stub(condition: { _ in true }, response: { _ in
+            httpRequestReceived.fulfill()
+
+            guard let sourceURL = try? XCTUnwrap(Bundle.test.url(forResource: "test-image", withExtension: "jpg")),
+                  let data = try? Data(contentsOf: sourceURL) else {
+                return HTTPStubsResponse(error: URLError(.unknown))
+            }
+
+            return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
+                .responseTime(0.3)
+        })
+
+        // WHEN
+        let taskCompleted = self.expectation(description: "Image downloaded")
+        taskCompleted.expectedFulfillmentCount = 3
+        for _ in 1...3 {
+            try await Task.sleep(for: .milliseconds(50))
+            Task.detached {
+                do {
+                    _ = try await self.sut.image(from: imageURL)
+                } catch {
+                    XCTFail("Unexpected error: \(error)")
+                }
+                taskCompleted.fulfill()
+            }
+        }
+
+        await fulfillment(of: [httpRequestReceived, taskCompleted], timeout: 0.5)
+    }
+
     // MARK: - Helpers
 
     /// `Media` is hardcoded to work with a specific direcoty URL managed by `MediaFileManager`

--- a/WordPress/WordPressTest/ImageDownloaderTests.swift
+++ b/WordPress/WordPressTest/ImageDownloaderTests.swift
@@ -64,7 +64,8 @@ class ImageDownloaderTests: CoreDataTestCase {
             let _ = try await task.value
             XCTFail()
         } catch {
-            XCTAssertEqual((error as? URLError)?.code, .cancelled)
+//            XCTAssertEqual((error as? URLError)?.code, .cancelled)
+            XCTAssertTrue(error is CancellationError)
         }
     }
 


### PR DESCRIPTION
@kean I am not sure if the special subscribe and unsubscribe code in `ImageDownloader` is necessary. I don't see any issue in removing that special code and using `Task` directly (`await task.value` to subscribe and `task.cancel` to unsubscribe).

I'm not sure if I have missed anything. Let me know what you think.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
