### PR TITLE
Me Menu: Minor changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -174,36 +174,12 @@ class MeViewController: UITableViewController {
 
                     rows = loggedInRows + rows
                 }
-                return rows + [helpAndSupportIndicator]
-            }()),
-            // middle section
-            ImmuTableSection(rows: {
-                var rows: [ImmuTableRow] = []
-
-                rows.append(ButtonRow(
-                    title: Strings.submitFeedback,
-                    textAlignment: .left,
-                    action: showFeedbackView())
-                )
-
-                rows.append(ButtonRow(
-                    title: ShareAppContentPresenter.RowConstants.buttonTitle,
-                    textAlignment: .left,
-                    isLoading: sharePresenter.isLoading,
-                    action: displayShareFlow())
-                )
-
-                rows.append(ButtonRow(
-                    title: RowTitles.about,
-                    textAlignment: .left,
-                    action: pushAbout(),
-                    accessibilityIdentifier: "About")
-                )
                 return rows
-            }())
+            }()),
+            ImmuTableSection(rows: [helpAndSupportIndicator]),
         ]
 
-        #if IS_JETPACK
+#if IS_JETPACK
         if RemoteFeatureFlag.domainManagement.enabled() && loggedIn && !isSidebarModeEnabled {
             sections.append(.init(rows: [
                 NavigationItemRow(
@@ -220,7 +196,29 @@ class MeViewController: UITableViewController {
             ])
             )
         }
-        #endif
+#endif
+
+        sections.append(
+            ImmuTableSection(rows: [
+                ButtonRow(
+                    title: ShareAppContentPresenter.RowConstants.buttonTitle,
+                    textAlignment: .left,
+                    isLoading: sharePresenter.isLoading,
+                    action: displayShareFlow()
+                ),
+                ButtonRow(
+                    title: Strings.submitFeedback,
+                    textAlignment: .left,
+                    action: showFeedbackView()
+                ),
+                ButtonRow(
+                    title: RowTitles.about,
+                    textAlignment: .left,
+                    action: pushAbout(),
+                    accessibilityIdentifier: "About"
+                )
+            ])
+        )
 
         // last section
         sections.append(


### PR DESCRIPTION
A couple of minor changes to the "Me" menu and where the "Send Feedback" goes based on https://wpmobilep2.wordpress.com/2024/11/18/jetpack-mobile-feedback-is-still-mostly-support-requests/.  It makes it a bit easier to find "Help & Support" and a bit harder to find "Send Feedback".

Here's the before and after.

<img width="320" alt="Screenshot 2024-11-19 at 8 35 14 AM" src="https://github.com/user-attachments/assets/3dd0a8b5-dcc5-4162-85e7-043b5e3bd369">
<img width="320" alt="Screenshot 2024-11-19 at 8 45 09 AM" src="https://github.com/user-attachments/assets/e733da6d-1f68-437f-9000-25e674271468">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
