### PR TITLE
Reader: Fix site header background in dark mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -82,7 +82,6 @@ private struct ReaderSiteHeader: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(EdgeInsets(top: 8, leading: 0, bottom: 16, trailing: 0))
-        .background(Color(UIColor.secondarySystemGroupedBackground))
     }
 
     private var countsDisplay: some View {


### PR DESCRIPTION
before/after (public blog)

<img width="320" alt="Screenshot 2024-11-19 at 9 17 35 AM" src="https://github.com/user-attachments/assets/4438eb13-22c7-40da-9260-402ec5d3d3b9">
<img width="320" alt="Screenshot 2024-11-19 at 9 22 46 AM" src="https://github.com/user-attachments/assets/d45f964d-c2af-4334-871a-1942bca8f978">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
