### PR TITLE
Reader: Fix scroll-to-top in Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
@@ -46,6 +46,14 @@ final class ReaderSidebarViewController: UIHostingController<AnyView> {
     }
 }
 
+extension ReaderSidebarViewController: ScrollableViewController {
+    func scrollViewToTop() {
+        if let scrollView = contentScrollView(for: .top) {
+            scrollView.scrollToTop(animated: true)
+        }
+    }
+}
+
 private struct ReaderSidebarView: View {
     @ObservedObject var viewModel: ReaderSidebarViewModel
 


### PR DESCRIPTION
To test:

- Open Reader main menu
- Scroll to bottom
- Tap the "Reader" tab bar item
- **Verify** that it scrolls to top

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
