### PR TITLE
Reader: Add like animation in post list

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -245,7 +245,21 @@ private final class ReaderPostCellView: UIView {
     }
 
     @objc private func buttonLikeTapped() {
-        viewModel?.toggleLike()
+        guard let viewModel else {
+            return wpAssertionFailure("missing ViewModel")
+        }
+        if !viewModel.toolbar.isLiked {
+            var toolbar = viewModel.toolbar
+            toolbar.isLiked = true
+            toolbar.likeCount += 1
+            configureToolbar(with: toolbar)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            buttons.like.imageView?.fadeInWithRotationAnimation { _ in
+                viewModel.toggleLike()
+            }
+        } else {
+            viewModel.toggleLike()
+        }
     }
 
     private func makeMoreMenu() -> [UIMenuElement] {
@@ -365,7 +379,7 @@ private func makeAuthorButton() -> UIButton {
 private func makeButton(systemImage: String, font: UIFont = UIFont.preferredFont(forTextStyle: .footnote)) -> UIButton {
     var configuration = UIButton.Configuration.plain()
     configuration.image = UIImage(systemName: systemImage)
-    configuration.imagePadding = 8
+    configuration.imagePadding = 6
     configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
     configuration.baseForegroundColor = .secondaryLabel
     configuration.contentInsets = .init(top: 16, leading: 12, bottom: 14, trailing: 12)

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
@@ -98,7 +98,7 @@ final class ReaderPostCellViewModel {
     }
 
     func toggleLike() {
-        ReaderLikeAction().execute(with: post)
+        ReaderLikeAction().execute(with: post, isFeedbackNeeded: false)
     }
 }
 
@@ -107,8 +107,8 @@ struct ReaderPostToolbarViewModel {
     let isCommentsEnabled: Bool
     let commentCount: Int
     let isLikesEnabled: Bool
-    let likeCount: Int
-    let isLiked: Bool
+    var likeCount: Int
+    var isLiked: Bool
 
     static func make(post: ReaderPost) -> ReaderPostToolbarViewModel {
         ReaderPostToolbarViewModel(

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderLikeAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderLikeAction.swift
@@ -1,12 +1,14 @@
 /// Encapsulates a command to toggle a post's liked status
 final class ReaderLikeAction {
-    func execute(with post: ReaderPost, source: String? = nil, completion: (() -> Void)? = nil) {
+    func execute(with post: ReaderPost, source: String? = nil, isFeedbackNeeded: Bool = true, completion: (() -> Void)? = nil) {
         if !post.isLiked {
             // Consider a like from the list to be enough to push a page view.
             // Solves a long-standing question from folks who ask 'why do I
             // have more likes than page views?'.
             ReaderHelpers.bumpPageViewForPost(post)
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            if isFeedbackNeeded {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
         }
         let service = ReaderPostService(coreDataStack: ContextManager.shared)
         service.toggleLiked(for: post, source: source, success: {


### PR DESCRIPTION
Add like animation to the new cells just like in other parts of the ap.

https://github.com/user-attachments/assets/50c1359c-3891-4958-8564-10289339b904


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
