### PR TITLE
Site Settings: Fix issue with saving site settings

### DIFF
--- a/WordPress/Classes/Extensions/UIBarButtonItem+Extensions.swift
+++ b/WordPress/Classes/Extensions/UIBarButtonItem+Extensions.swift
@@ -2,7 +2,7 @@ import UIKit
 
 extension UIBarButtonItem {
     /// Returns a bar button item with a spinner activity indicator.
-    static var activityIndicator: UIBarButtonItem {
+    @objc class var activityIndicator: UIBarButtonItem {
         let activityIndicator = UIActivityIndicatorView(style: .medium)
         activityIndicator.sizeToFit()
         activityIndicator.startAnimating()

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -29,6 +29,7 @@ open class DiscussionSettingsViewController: UITableViewController {
 
         tableView.reloadSelectedRow()
         tableView.deselectSelectedRowWithAnimation(true)
+        refreshSettings()
     }
 
     // MARK: - Setup Helpers
@@ -47,6 +48,15 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - Persistance!
+    private func refreshSettings() {
+        let service = BlogService(coreDataStack: ContextManager.shared)
+        service.syncSettings(for: blog, success: { [weak self] in
+            self?.tableView.reloadData()
+            DDLogInfo("Reloaded Settings")
+        }, failure: { (error: Error) in
+            DDLogError("Error while sync'ing blog settings: \(error)")
+        })
+    }
 
     private func setNeedsChangeSettings() {
         isSettingsChangeNeeded = true

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import WordPressShared
 
 /// The purpose of this class is to render the Discussion Settings associated to a site, and
@@ -34,11 +35,11 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - Setup Helpers
-    fileprivate func setupNavBar() {
+    private func setupNavBar() {
         title = NSLocalizedString("Discussion", comment: "Title for the Discussion Settings Screen")
     }
 
-    fileprivate func setupTableView() {
+    private func setupTableView() {
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         tableView.cellLayoutMarginsFollowReadableWidth = true
@@ -48,36 +49,31 @@ open class DiscussionSettingsViewController: UITableViewController {
         clearsSelectionOnViewWillAppear = false
     }
 
-    fileprivate func setupNotificationListeners() {
+    private func setupNotificationListeners() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(DiscussionSettingsViewController.handleContextDidChange(_:)),
-            name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
-            object: settings.managedObjectContext)
+                                       name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+                                       object: settings.managedObjectContext)
     }
 
     // MARK: - Persistance!
-    fileprivate func refreshSettings() {
+    private func refreshSettings() {
         let service = BlogService(coreDataStack: ContextManager.shared)
-        service.syncSettings(for: blog,
-            success: { [weak self] in
-                self?.tableView.reloadData()
-                DDLogInfo("Reloaded Settings")
-            },
-            failure: { (error: Error) in
-                DDLogError("Error while sync'ing blog settings: \(error)")
-            })
+        service.syncSettings(for: blog, success: { [weak self] in
+            self?.tableView.reloadData()
+            DDLogInfo("Reloaded Settings")
+        }, failure: { (error: Error) in
+            DDLogError("Error while sync'ing blog settings: \(error)")
+        })
     }
 
-    fileprivate func saveSettingsIfNeeded() {
+    private func saveSettingsIfNeeded() {
         if !settings.hasChanges {
             return
         }
-
         let service = BlogService(coreDataStack: ContextManager.shared)
-        service.updateSettings(for: blog,
-            success: nil,
-            failure: { (error: Error) -> Void in
-                DDLogError("Error while persisting settings: \(error)")
+        service.updateSettings(for: blog, success: nil, failure: { (error: Error) -> Void in
+            DDLogError("Error while persisting settings: \(error)")
         })
     }
 
@@ -107,7 +103,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         let cell = cellForRow(row, tableView: tableView)
 
         switch row.style {
-        case .Switch:
+        case .switch:
             configureSwitchCell(cell as! SwitchTableViewCell, row: row)
         default:
             configureTextCell(cell as! WPTableViewCell, row: row)
@@ -134,345 +130,323 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - Cell Setup Helpers
-    fileprivate func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+    private func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
         return sections[indexPath.section].rows[indexPath.row]
     }
 
-    fileprivate func cellForRow(_ row: Row, tableView: UITableView) -> UITableViewCell {
+    private func cellForRow(_ row: Row, tableView: UITableView) -> UITableViewCell {
         if let cell = tableView.dequeueReusableCell(withIdentifier: row.style.rawValue) {
             return cell
         }
-
         switch row.style {
-        case .Value1:
+        case .value1:
             return WPTableViewCell(style: .value1, reuseIdentifier: row.style.rawValue)
-        case .Switch:
+        case .switch:
             return SwitchTableViewCell(style: .default, reuseIdentifier: row.style.rawValue)
         }
     }
 
-    fileprivate func configureTextCell(_ cell: WPTableViewCell, row: Row) {
-        cell.textLabel?.text        = row.title ?? String()
-        cell.detailTextLabel?.text  = row.details ?? String()
-        cell.accessoryType          = .disclosureIndicator
+    private func configureTextCell(_ cell: WPTableViewCell, row: Row) {
+        cell.textLabel?.text = row.title ?? String()
+        cell.detailTextLabel?.text = row.details ?? String()
+        cell.accessoryType = .disclosureIndicator
         WPStyleGuide.configureTableViewCell(cell)
     }
 
-    fileprivate func configureSwitchCell(_ cell: SwitchTableViewCell, row: Row) {
-        cell.name                   = row.title ?? String()
-        cell.on                     = row.boolValue ?? true
-        cell.onChange               = { (newValue: Bool) in
+    private func configureSwitchCell(_ cell: SwitchTableViewCell, row: Row) {
+        cell.name = row.title ?? String()
+        cell.on = row.boolValue ?? true
+        cell.onChange = { (newValue: Bool) in
             row.handler?(newValue as AnyObject?)
         }
     }
 
     // MARK: - Row Handlers
-    fileprivate func pressedCommentsAllowed(_ payload: AnyObject?) {
+    private func pressedCommentsAllowed(_ payload: AnyObject?) {
         guard let enabled = payload as? Bool else {
             return
         }
-
         trackSettingsChange(fieldName: "allow_comments", value: enabled as Any)
         settings.commentsAllowed = enabled
     }
 
-    fileprivate func pressedPingbacksInbound(_ payload: AnyObject?) {
+    private func pressedPingbacksInbound(_ payload: AnyObject?) {
         guard let enabled = payload as? Bool else {
             return
         }
-
         trackSettingsChange(fieldName: "receive_pingbacks", value: enabled as Any)
         settings.pingbackInboundEnabled = enabled
     }
 
-    fileprivate func pressedPingbacksOutbound(_ payload: AnyObject?) {
+    private func pressedPingbacksOutbound(_ payload: AnyObject?) {
         guard let enabled = payload as? Bool else {
             return
         }
-
         trackSettingsChange(fieldName: "send_pingbacks", value: enabled as Any)
         settings.pingbackOutboundEnabled = enabled
     }
 
-    fileprivate func pressedRequireNameAndEmail(_ payload: AnyObject?) {
+    private func pressedRequireNameAndEmail(_ payload: AnyObject?) {
         guard let enabled = payload as? Bool else {
             return
         }
-
         trackSettingsChange(fieldName: "require_name_and_email", value: enabled as Any)
         settings.commentsRequireNameAndEmail = enabled
     }
 
-    fileprivate func pressedRequireRegistration(_ payload: AnyObject?) {
+    private func pressedRequireRegistration(_ payload: AnyObject?) {
         guard let enabled = payload as? Bool else {
             return
         }
-
         trackSettingsChange(fieldName: "require_registration", value: enabled as Any)
         settings.commentsRequireRegistration = enabled
     }
 
-    fileprivate func pressedCloseCommenting(_ payload: AnyObject?) {
-        let pickerViewController                = SettingsPickerViewController(style: .insetGrouped)
-        pickerViewController.title              = NSLocalizedString("Close commenting", comment: "Close Comments Title")
-        pickerViewController.switchVisible      = true
-        pickerViewController.switchOn           = settings.commentsCloseAutomatically
-        pickerViewController.switchText         = NSLocalizedString("Automatically Close", comment: "Discussion Settings")
-        pickerViewController.selectionText      = NSLocalizedString("Close after", comment: "Close comments after a given number of days")
-        pickerViewController.selectionFormat    = NSLocalizedString("%d days", comment: "Number of days")
-        pickerViewController.pickerHint         = NSLocalizedString("Automatically close comments on content after a certain number of days.", comment: "Discussion Settings: Comments Auto-close")
-        pickerViewController.pickerFormat       = NSLocalizedString("%d days", comment: "Number of days")
+    private func pressedCloseCommenting(_ payload: AnyObject?) {
+        let pickerViewController = SettingsPickerViewController(style: .insetGrouped)
+        pickerViewController.title = NSLocalizedString("Close commenting", comment: "Close Comments Title")
+        pickerViewController.switchVisible = true
+        pickerViewController.switchOn = settings.commentsCloseAutomatically
+        pickerViewController.switchText = NSLocalizedString("Automatically Close", comment: "Discussion Settings")
+        pickerViewController.selectionText = NSLocalizedString("Close after", comment: "Close comments after a given number of days")
+        pickerViewController.selectionFormat = NSLocalizedString("%d days", comment: "Number of days")
+        pickerViewController.pickerHint = NSLocalizedString("Automatically close comments on content after a certain number of days.", comment: "Discussion Settings: Comments Auto-close")
+        pickerViewController.pickerFormat = NSLocalizedString("%d days", comment: "Number of days")
         pickerViewController.pickerMinimumValue = commentsAutocloseMinimumValue
         pickerViewController.pickerMaximumValue = commentsAutocloseMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsCloseAutomaticallyAfterDays as? Int
-        pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
+        pickerViewController.onChange = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsCloseAutomatically = enabled
             self?.settings.commentsCloseAutomaticallyAfterDays = newValue as NSNumber
 
             let value: Any = enabled ? newValue : "disabled"
             self?.trackSettingsChange(fieldName: "close_commenting", value: value)
         }
-
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
 
-    fileprivate func pressedSortBy(_ payload: AnyObject?) {
-        let settingsViewController              = SettingsSelectionViewController(style: .insetGrouped)
-        settingsViewController.title            = NSLocalizedString("Sort By", comment: "Discussion Settings Title")
-        settingsViewController.currentValue     = settings.commentsSortOrder
-        settingsViewController.titles           = CommentsSorting.allTitles
-        settingsViewController.values           = CommentsSorting.allValues
-        settingsViewController.onItemSelected   = { [weak self] (selected: Any?) in
+    private func pressedSortBy(_ payload: AnyObject?) {
+        let settingsViewController = SettingsSelectionViewController(style: .insetGrouped)
+        settingsViewController.title = NSLocalizedString("Sort By", comment: "Discussion Settings Title")
+        settingsViewController.currentValue = settings.commentsSortOrder
+        settingsViewController.titles = CommentsSorting.allTitles
+        settingsViewController.values = CommentsSorting.allValues
+        settingsViewController.onItemSelected = { [weak self] (selected: Any?) in
             guard let newSortOrder = CommentsSorting(rawValue: selected as! Int) else {
                 return
             }
-
             self?.trackSettingsChange(fieldName: "comments_sort_by", value: selected as Any)
             self?.settings.commentsSorting = newSortOrder
         }
-
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    fileprivate func pressedThreading(_ payload: AnyObject?) {
-        let settingsViewController              = SettingsSelectionViewController(style: .insetGrouped)
-        settingsViewController.title            = NSLocalizedString("Threading", comment: "Discussion Settings Title")
-        settingsViewController.currentValue     = settings.commentsThreading.rawValue as NSObject
-        settingsViewController.titles           = CommentsThreading.allTitles
-        settingsViewController.values           = CommentsThreading.allValues
-        settingsViewController.onItemSelected   = { [weak self] (selected: Any?) in
+    private func pressedThreading(_ payload: AnyObject?) {
+        let settingsViewController = SettingsSelectionViewController(style: .insetGrouped)
+        settingsViewController.title = NSLocalizedString("Threading", comment: "Discussion Settings Title")
+        settingsViewController.currentValue = settings.commentsThreading.rawValue as NSObject
+        settingsViewController.titles = CommentsThreading.allTitles
+        settingsViewController.values = CommentsThreading.allValues
+        settingsViewController.onItemSelected = { [weak self] (selected: Any?) in
             guard let newThreadingDepth = CommentsThreading(rawValue: selected as! Int) else {
                 return
             }
-
             self?.settings.commentsThreading = newThreadingDepth
             self?.trackSettingsChange(fieldName: "comments_threading", value: selected as Any)
         }
-
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    fileprivate func pressedPaging(_ payload: AnyObject?) {
-        let pickerViewController                = SettingsPickerViewController(style: .insetGrouped)
-        pickerViewController.title              = NSLocalizedString("Paging", comment: "Comments Paging")
-        pickerViewController.switchVisible      = true
-        pickerViewController.switchOn           = settings.commentsPagingEnabled
-        pickerViewController.switchText         = NSLocalizedString("Paging", comment: "Discussion Settings")
-        pickerViewController.selectionText      = NSLocalizedString("Comments per page", comment: "A label title.")
-        pickerViewController.pickerHint         = NSLocalizedString("Break comment threads into multiple pages.", comment: "Text snippet summarizing what comment paging does.")
+    private func pressedPaging(_ payload: AnyObject?) {
+        let pickerViewController = SettingsPickerViewController(style: .insetGrouped)
+        pickerViewController.title = NSLocalizedString("Paging", comment: "Comments Paging")
+        pickerViewController.switchVisible = true
+        pickerViewController.switchOn = settings.commentsPagingEnabled
+        pickerViewController.switchText = NSLocalizedString("Paging", comment: "Discussion Settings")
+        pickerViewController.selectionText = NSLocalizedString("Comments per page", comment: "A label title.")
+        pickerViewController.pickerHint = NSLocalizedString("Break comment threads into multiple pages.", comment: "Text snippet summarizing what comment paging does.")
         pickerViewController.pickerMinimumValue = commentsPagingMinimumValue
         pickerViewController.pickerMaximumValue = commentsPagingMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsPageSize as? Int
-        pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
+        pickerViewController.onChange = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsPagingEnabled = enabled
             self?.settings.commentsPageSize = newValue as NSNumber
 
             let value: Any = enabled ? newValue : "disabled"
             self?.trackSettingsChange(fieldName: "comments_paging", value: value)
         }
-
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
 
-    fileprivate func pressedAutomaticallyApprove(_ payload: AnyObject?) {
-        let settingsViewController              = SettingsSelectionViewController(style: .insetGrouped)
-        settingsViewController.title            = NSLocalizedString("Automatically Approve", comment: "Discussion Settings Title")
-        settingsViewController.currentValue     = settings.commentsAutoapproval.rawValue as NSObject
-        settingsViewController.titles           = CommentsAutoapproval.allTitles
-        settingsViewController.values           = CommentsAutoapproval.allValues
-        settingsViewController.hints            = CommentsAutoapproval.allHints
-        settingsViewController.onItemSelected   = { [weak self] (selected: Any?) in
+    private func pressedAutomaticallyApprove(_ payload: AnyObject?) {
+        let settingsViewController = SettingsSelectionViewController(style: .insetGrouped)
+        settingsViewController.title = NSLocalizedString("Automatically Approve", comment: "Discussion Settings Title")
+        settingsViewController.currentValue = settings.commentsAutoapproval.rawValue as NSObject
+        settingsViewController.titles = CommentsAutoapproval.allTitles
+        settingsViewController.values = CommentsAutoapproval.allValues
+        settingsViewController.hints = CommentsAutoapproval.allHints
+        settingsViewController.onItemSelected = { [weak self] (selected: Any?) in
             guard let newApprovalStatus = CommentsAutoapproval(rawValue: selected as! Int) else {
                 return
             }
-
             self?.settings.commentsAutoapproval = newApprovalStatus
             self?.trackSettingsChange(fieldName: "comments_automatically_approve", value: selected as Any)
         }
-
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    fileprivate func pressedLinksInComments(_ payload: AnyObject?) {
-        let pickerViewController                = SettingsPickerViewController(style: .insetGrouped)
-        pickerViewController.title              = NSLocalizedString("Links in comments", comment: "Comments Paging")
-        pickerViewController.switchVisible      = false
-        pickerViewController.selectionText      = NSLocalizedString("Links in comments", comment: "A label title")
-        pickerViewController.pickerHint         = NSLocalizedString("Require manual approval for comments that include more than this number of links.", comment: "An explaination of a setting.")
+    private func pressedLinksInComments(_ payload: AnyObject?) {
+        let pickerViewController = SettingsPickerViewController(style: .insetGrouped)
+        pickerViewController.title = NSLocalizedString("Links in comments", comment: "Comments Paging")
+        pickerViewController.switchVisible = false
+        pickerViewController.selectionText = NSLocalizedString("Links in comments", comment: "A label title")
+        pickerViewController.pickerHint = NSLocalizedString("Require manual approval for comments that include more than this number of links.", comment: "An explaination of a setting.")
         pickerViewController.pickerMinimumValue = commentsLinksMinimumValue
         pickerViewController.pickerMaximumValue = commentsLinksMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int
-        pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
+        pickerViewController.onChange = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsMaximumLinks = newValue as NSNumber
             self?.trackSettingsChange(fieldName: "comments_links", value: newValue as Any)
         }
-
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
 
-    fileprivate func pressedModeration(_ payload: AnyObject?) {
-        let moderationKeys                      = settings.commentsModerationKeys
-        let settingsViewController              = SettingsListEditorViewController(collection: moderationKeys)
-        settingsViewController.title            = NSLocalizedString("Hold for Moderation", comment: "Moderation Keys Title")
-        settingsViewController.insertTitle      = NSLocalizedString("New Moderation Word", comment: "Moderation Keyword Insertion Title")
-        settingsViewController.editTitle        = NSLocalizedString("Edit Moderation Word", comment: "Moderation Keyword Edition Title")
-        settingsViewController.footerText       = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\".",
-                                                                    comment: "Text rendered at the bottom of the Discussion Moderation Keys editor")
-        settingsViewController.onChange         = { [weak self] (updated: Set<String>) in
+    private func pressedModeration(_ payload: AnyObject?) {
+        let moderationKeys = settings.commentsModerationKeys
+        let settingsViewController = SettingsListEditorViewController(collection: moderationKeys)
+        settingsViewController.title = NSLocalizedString("Hold for Moderation", comment: "Moderation Keys Title")
+        settingsViewController.insertTitle = NSLocalizedString("New Moderation Word", comment: "Moderation Keyword Insertion Title")
+        settingsViewController.editTitle = NSLocalizedString("Edit Moderation Word", comment: "Moderation Keyword Edition Title")
+        settingsViewController.footerText = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\".", comment: "Text rendered at the bottom of the Discussion Moderation Keys editor")
+        settingsViewController.onChange = { [weak self] (updated: Set<String>) in
             self?.settings.commentsModerationKeys = updated
             self?.trackSettingsChange(fieldName: "comments_hold_for_moderation", value: updated.count as Any)
         }
-
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    fileprivate func pressedBlocklist(_ payload: AnyObject?) {
-        let blocklistKeys                       = settings.commentsBlocklistKeys
-        let settingsViewController              = SettingsListEditorViewController(collection: blocklistKeys)
-        settingsViewController.title            = NSLocalizedString("Blocklist", comment: "Blocklist Title")
-        settingsViewController.insertTitle      = NSLocalizedString("New Blocklist Word", comment: "Blocklist Keyword Insertion Title")
-        settingsViewController.editTitle        = NSLocalizedString("Edit Blocklist Word", comment: "Blocklist Keyword Edition Title")
-        settingsViewController.footerText       = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress\".",
-                                                                    comment: "Text rendered at the bottom of the Discussion Blocklist Keys editor")
-        settingsViewController.onChange         = { [weak self] (updated: Set<String>) in
+    private func pressedBlocklist(_ payload: AnyObject?) {
+        let blocklistKeys = settings.commentsBlocklistKeys
+        let settingsViewController = SettingsListEditorViewController(collection: blocklistKeys)
+        settingsViewController.title = NSLocalizedString("Blocklist", comment: "Blocklist Title")
+        settingsViewController.insertTitle = NSLocalizedString("New Blocklist Word", comment: "Blocklist Keyword Insertion Title")
+        settingsViewController.editTitle = NSLocalizedString("Edit Blocklist Word", comment: "Blocklist Keyword Edition Title")
+        settingsViewController.footerText = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress\".", comment: "Text rendered at the bottom of the Discussion Blocklist Keys editor")
+        settingsViewController.onChange = { [weak self] (updated: Set<String>) in
             self?.settings.commentsBlocklistKeys = updated
             self?.trackSettingsChange(fieldName: "comments_block_list", value: updated.count as Any)
         }
-
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
     private func trackSettingsChange(fieldName: String, value: Any?) {
-        WPAnalytics.trackSettingsChange(tracksDiscussionSettingsKey,
-                                        fieldName: fieldName,
-                                        value: value)
-
+        WPAnalytics.trackSettingsChange(tracksDiscussionSettingsKey, fieldName: fieldName, value: value)
     }
 
     // MARK: - Computed Properties
-    fileprivate var sections: [Section] {
+    private var sections: [Section] {
         return [postsSection, commentsSection, otherSection]
     }
 
-    fileprivate var postsSection: Section {
+    private var postsSection: Section {
         let headerText = NSLocalizedString("Defaults for New Posts", comment: "Discussion Settings: Posts Section")
         let footerText = NSLocalizedString("You can override these settings for individual posts.", comment: "Discussion Settings: Footer Text")
         let rows = [
-            Row(style: .Switch,
+            Row(style: .switch,
                 title: NSLocalizedString("Allow Comments", comment: "Settings: Comments Enabled"),
                 boolValue: self.settings.commentsAllowed,
-                handler: {  [weak self] in
-                                self?.pressedCommentsAllowed($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedCommentsAllowed($0)
+                }),
 
-            Row(style: .Switch,
+            Row(style: .switch,
                 title: NSLocalizedString("Send Pingbacks", comment: "Settings: Sending Pingbacks"),
                 boolValue: self.settings.pingbackOutboundEnabled,
-                handler: {  [weak self] in
-                                self?.pressedPingbacksOutbound($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedPingbacksOutbound($0)
+                }),
 
-            Row(style: .Switch,
+            Row(style: .switch,
                 title: NSLocalizedString("Receive Pingbacks", comment: "Settings: Receiving Pingbacks"),
                 boolValue: self.settings.pingbackInboundEnabled,
-                handler: {  [weak self] in
-                                self?.pressedPingbacksInbound($0)
-                            })
+                handler: { [weak self] in
+                    self?.pressedPingbacksInbound($0)
+                })
         ]
 
         return Section(headerText: headerText, footerText: footerText, rows: rows)
     }
 
-    fileprivate var commentsSection: Section {
+    private var commentsSection: Section {
         let headerText = NSLocalizedString("Comments", comment: "Settings: Comment Sections")
         let rows = [
-            Row(style: .Switch,
+            Row(style: .switch,
                 title: NSLocalizedString("Require name and email", comment: "Settings: Comments Approval settings"),
                 boolValue: self.settings.commentsRequireNameAndEmail,
-                handler: {  [weak self] in
-                                self?.pressedRequireNameAndEmail($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedRequireNameAndEmail($0)
+                }),
 
-            Row(style: .Switch,
+            Row(style: .switch,
                 title: NSLocalizedString("Require users to log in", comment: "Settings: Comments Approval settings"),
                 boolValue: self.settings.commentsRequireRegistration,
-                handler: {  [weak self] in
-                                self?.pressedRequireRegistration($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedRequireRegistration($0)
+                }),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Close Commenting", comment: "Settings: Close comments after X period"),
                 details: self.detailsForCloseCommenting,
-                handler: {  [weak self] in
-                                self?.pressedCloseCommenting($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedCloseCommenting($0)
+                }),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Sort By", comment: "Settings: Comments Sort Order"),
                 details: self.detailsForSortBy,
-                handler: {  [weak self] in
-                                self?.pressedSortBy($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedSortBy($0)
+                }),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Threading", comment: "Settings: Comments Threading preferences"),
                 details: self.detailsForThreading,
-                handler: {  [weak self] in
-                                self?.pressedThreading($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedThreading($0)
+                }),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Paging", comment: "Settings: Comments Paging preferences"),
                 details: self.detailsForPaging,
-                handler: {  [weak self] in
-                                self?.pressedPaging($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedPaging($0)
+                }),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Automatically Approve", comment: "Settings: Comments Approval settings"),
                 details: self.detailsForAutomaticallyApprove,
-                handler: {  [weak self] in
-                                self?.pressedAutomaticallyApprove($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedAutomaticallyApprove($0)
+                }),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Links in comments", comment: "Settings: Comments Approval settings"),
                 details: self.detailsForLinksInComments,
-                handler: {  [weak self] in
-                                self?.pressedLinksInComments($0)
-                            }),
+                handler: { [weak self] in
+                    self?.pressedLinksInComments($0)
+                }),
         ]
 
         return Section(headerText: headerText, rows: rows)
     }
 
-    fileprivate var otherSection: Section {
+    private var otherSection: Section {
         let rows = [
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Hold for Moderation", comment: "Settings: Comments Moderation"),
                 handler: self.pressedModeration),
 
-            Row(style: .Value1,
+            Row(style: .value1,
                 title: NSLocalizedString("Blocklist", comment: "Settings: Comments Blocklist"),
                 handler: self.pressedBlocklist)
         ]
@@ -481,7 +455,7 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - Row Detail Helpers
-    fileprivate var detailsForCloseCommenting: String {
+    private var detailsForCloseCommenting: String {
         if !settings.commentsCloseAutomatically {
             return NSLocalizedString("Off", comment: "Disabled")
         }
@@ -491,11 +465,11 @@ open class DiscussionSettingsViewController: UITableViewController {
         return String(format: format, numberOfDays)
     }
 
-    fileprivate var detailsForSortBy: String {
+    private var detailsForSortBy: String {
         return settings.commentsSorting.description
     }
 
-    fileprivate var detailsForThreading: String {
+    private var detailsForThreading: String {
         if !settings.commentsThreadingEnabled {
             return NSLocalizedString("Off", comment: "Disabled")
         }
@@ -505,7 +479,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         return String(format: format, levels)
     }
 
-    fileprivate var detailsForPaging: String {
+    private var detailsForPaging: String {
         if !settings.commentsPagingEnabled {
             return NSLocalizedString("None", comment: "Disabled")
         }
@@ -515,7 +489,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         return String(format: format, pageSize)
     }
 
-    fileprivate var detailsForAutomaticallyApprove: String {
+    private var detailsForAutomaticallyApprove: String {
         switch settings.commentsAutoapproval {
         case .disabled:
             return NSLocalizedString("None", comment: "No comment will be autoapproved")
@@ -526,7 +500,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         }
     }
 
-    fileprivate var detailsForLinksInComments: String {
+    private var detailsForLinksInComments: String {
         guard let numberOfLinks = settings.commentsMaximumLinks else {
             return String()
         }
@@ -536,7 +510,7 @@ open class DiscussionSettingsViewController: UITableViewController {
     }
 
     // MARK: - Private Nested Classes
-    fileprivate class Section {
+    private class Section {
         let headerText: String?
         let footerText: String?
         let rows: [Row]
@@ -544,11 +518,11 @@ open class DiscussionSettingsViewController: UITableViewController {
         init(headerText: String? = nil, footerText: String? = nil, rows: [Row]) {
             self.headerText = headerText
             self.footerText = footerText
-            self.rows       = rows
+            self.rows = rows
         }
     }
 
-    fileprivate class Row {
+    private class Row {
         let style: Style
         let title: String?
         let details: String?
@@ -556,39 +530,39 @@ open class DiscussionSettingsViewController: UITableViewController {
         var boolValue: Bool?
 
         init(style: Style, title: String? = nil, details: String? = nil, boolValue: Bool? = nil, handler: Handler? = nil) {
-            self.style      = style
-            self.title      = title
-            self.details    = details
-            self.boolValue  = boolValue
-            self.handler    = handler
+            self.style = style
+            self.title = title
+            self.details = details
+            self.boolValue = boolValue
+            self.handler = handler
         }
 
         typealias Handler = ((AnyObject?) -> Void)
 
         enum Style: String {
-            case Value1     = "Value1"
-            case Switch     = "SwitchCell"
+            case value1 = "Value1"
+            case `switch` = "SwitchCell"
         }
     }
 
     // MARK: - Private Properties
-    fileprivate var blog: Blog!
+    private var blog: Blog!
 
     // MARK: - Computed Properties
-    fileprivate var settings: BlogSettings {
+    private var settings: BlogSettings {
         return blog.settings!
     }
 
     // MARK: - Typealiases
-    fileprivate typealias CommentsSorting           = BlogSettings.CommentsSorting
-    fileprivate typealias CommentsThreading         = BlogSettings.CommentsThreading
-    fileprivate typealias CommentsAutoapproval      = BlogSettings.CommentsAutoapproval
+    private typealias CommentsSorting = BlogSettings.CommentsSorting
+    private typealias CommentsThreading = BlogSettings.CommentsThreading
+    private typealias CommentsAutoapproval = BlogSettings.CommentsAutoapproval
 
     // MARK: - Constants
-    fileprivate let commentsPagingMinimumValue      = 1
-    fileprivate let commentsPagingMaximumValue      = 100
-    fileprivate let commentsLinksMinimumValue       = 1
-    fileprivate let commentsLinksMaximumValue       = 100
-    fileprivate let commentsAutocloseMinimumValue   = 1
-    fileprivate let commentsAutocloseMaximumValue   = 120
+    private let commentsPagingMinimumValue = 1
+    private let commentsPagingMaximumValue = 100
+    private let commentsLinksMinimumValue = 1
+    private let commentsLinksMaximumValue = 100
+    private let commentsAutocloseMinimumValue = 1
+    private let commentsAutocloseMaximumValue = 120
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -7,6 +7,8 @@ import WordPressShared
 ///
 open class DiscussionSettingsViewController: UITableViewController {
     private let tracksDiscussionSettingsKey = "site_settings_discussion"
+    private var isChangingSettings = false
+    private var isSettingsChangeNeeded = false
 
     // MARK: - Initializers / Deinitializers
     @objc public convenience init(blog: Blog) {
@@ -17,21 +19,16 @@ open class DiscussionSettingsViewController: UITableViewController {
     // MARK: - View Lifecycle
     open override func viewDidLoad() {
         super.viewDidLoad()
+
         setupNavBar()
         setupTableView()
-        setupNotificationListeners()
     }
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
         tableView.reloadSelectedRow()
         tableView.deselectSelectedRowWithAnimation(true)
-        refreshSettings()
-    }
-
-    open override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        saveSettingsIfNeeded()
     }
 
     // MARK: - Setup Helpers
@@ -49,44 +46,42 @@ open class DiscussionSettingsViewController: UITableViewController {
         clearsSelectionOnViewWillAppear = false
     }
 
-    private func setupNotificationListeners() {
-        let notificationCenter = NotificationCenter.default
-        notificationCenter.addObserver(self, selector: #selector(DiscussionSettingsViewController.handleContextDidChange(_:)),
-                                       name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
-                                       object: settings.managedObjectContext)
-    }
-
     // MARK: - Persistance!
-    private func refreshSettings() {
-        let service = BlogService(coreDataStack: ContextManager.shared)
-        service.syncSettings(for: blog, success: { [weak self] in
-            self?.tableView.reloadData()
-            DDLogInfo("Reloaded Settings")
-        }, failure: { (error: Error) in
-            DDLogError("Error while sync'ing blog settings: \(error)")
-        })
+
+    private func setNeedsChangeSettings() {
+        isSettingsChangeNeeded = true
+        saveSettingsIfNeeded()
     }
 
     private func saveSettingsIfNeeded() {
-        if !settings.hasChanges {
+        guard !isChangingSettings && isSettingsChangeNeeded else {
             return
         }
+        isChangingSettings = true
+        isSettingsChangeNeeded = false
+        navigationItem.rightBarButtonItem = .activityIndicator
+
         let service = BlogService(coreDataStack: ContextManager.shared)
-        service.updateSettings(for: blog, success: nil, failure: { (error: Error) -> Void in
-            DDLogError("Error while persisting settings: \(error)")
+        service.updateSettings(for: blog, success: { [weak self] in
+            self?.didFinishChangingSettings(nil)
+        }, failure: { [weak self] error -> Void in
+            self?.didFinishChangingSettings(error)
         })
     }
 
-    @objc open func handleContextDidChange(_ note: Foundation.Notification) {
-        guard let context = note.object as? NSManagedObjectContext else {
-            return
+    private func didFinishChangingSettings(_ error: Error?) {
+        isChangingSettings = false
+        if isSettingsChangeNeeded {
+            saveSettingsIfNeeded()
+        } else {
+            navigationItem.rightBarButtonItem = nil
         }
-
-        if !context.updatedObjects.contains(settings) {
-            return
+        if let error {
+            DDLogError("Error while persisting settings: \(error)")
+            let alert = UIAlertController(title: Strings.errorTitle, message: error.localizedDescription, preferredStyle: .alert)
+            alert.addAction(.init(title: SharedStrings.Button.ok, style: .default, handler: nil))
+            present(alert, animated: true)
         }
-
-        saveSettingsIfNeeded()
     }
 
     // MARK: - UITableViewDataSoutce Methods
@@ -166,7 +161,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         guard let enabled = payload as? Bool else {
             return
         }
-        trackSettingsChange(fieldName: "allow_comments", value: enabled as Any)
+        didChangeSetting("allow_comments", value: enabled as Any)
         settings.commentsAllowed = enabled
     }
 
@@ -174,7 +169,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         guard let enabled = payload as? Bool else {
             return
         }
-        trackSettingsChange(fieldName: "receive_pingbacks", value: enabled as Any)
+        didChangeSetting("receive_pingbacks", value: enabled as Any)
         settings.pingbackInboundEnabled = enabled
     }
 
@@ -182,7 +177,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         guard let enabled = payload as? Bool else {
             return
         }
-        trackSettingsChange(fieldName: "send_pingbacks", value: enabled as Any)
+        didChangeSetting("send_pingbacks", value: enabled as Any)
         settings.pingbackOutboundEnabled = enabled
     }
 
@@ -190,7 +185,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         guard let enabled = payload as? Bool else {
             return
         }
-        trackSettingsChange(fieldName: "require_name_and_email", value: enabled as Any)
+        didChangeSetting("require_name_and_email", value: enabled as Any)
         settings.commentsRequireNameAndEmail = enabled
     }
 
@@ -198,7 +193,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         guard let enabled = payload as? Bool else {
             return
         }
-        trackSettingsChange(fieldName: "require_registration", value: enabled as Any)
+        didChangeSetting("require_registration", value: enabled as Any)
         settings.commentsRequireRegistration = enabled
     }
 
@@ -220,7 +215,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             self?.settings.commentsCloseAutomaticallyAfterDays = newValue as NSNumber
 
             let value: Any = enabled ? newValue : "disabled"
-            self?.trackSettingsChange(fieldName: "close_commenting", value: value)
+            self?.didChangeSetting("close_commenting", value: value)
         }
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
@@ -235,7 +230,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             guard let newSortOrder = CommentsSorting(rawValue: selected as! Int) else {
                 return
             }
-            self?.trackSettingsChange(fieldName: "comments_sort_by", value: selected as Any)
+            self?.didChangeSetting("comments_sort_by", value: selected as Any)
             self?.settings.commentsSorting = newSortOrder
         }
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -252,7 +247,7 @@ open class DiscussionSettingsViewController: UITableViewController {
                 return
             }
             self?.settings.commentsThreading = newThreadingDepth
-            self?.trackSettingsChange(fieldName: "comments_threading", value: selected as Any)
+            self?.didChangeSetting("comments_threading", value: selected as Any)
         }
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
@@ -273,7 +268,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             self?.settings.commentsPageSize = newValue as NSNumber
 
             let value: Any = enabled ? newValue : "disabled"
-            self?.trackSettingsChange(fieldName: "comments_paging", value: value)
+            self?.didChangeSetting("comments_paging", value: value)
         }
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
@@ -290,7 +285,7 @@ open class DiscussionSettingsViewController: UITableViewController {
                 return
             }
             self?.settings.commentsAutoapproval = newApprovalStatus
-            self?.trackSettingsChange(fieldName: "comments_automatically_approve", value: selected as Any)
+            self?.didChangeSetting("comments_automatically_approve", value: selected as Any)
         }
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
@@ -306,7 +301,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int
         pickerViewController.onChange = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsMaximumLinks = newValue as NSNumber
-            self?.trackSettingsChange(fieldName: "comments_links", value: newValue as Any)
+            self?.didChangeSetting("comments_links", value: newValue as Any)
         }
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
@@ -320,7 +315,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         settingsViewController.footerText = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\".", comment: "Text rendered at the bottom of the Discussion Moderation Keys editor")
         settingsViewController.onChange = { [weak self] (updated: Set<String>) in
             self?.settings.commentsModerationKeys = updated
-            self?.trackSettingsChange(fieldName: "comments_hold_for_moderation", value: updated.count as Any)
+            self?.didChangeSetting("comments_hold_for_moderation", value: updated.count as Any)
         }
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
@@ -334,13 +329,14 @@ open class DiscussionSettingsViewController: UITableViewController {
         settingsViewController.footerText = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress\".", comment: "Text rendered at the bottom of the Discussion Blocklist Keys editor")
         settingsViewController.onChange = { [weak self] (updated: Set<String>) in
             self?.settings.commentsBlocklistKeys = updated
-            self?.trackSettingsChange(fieldName: "comments_block_list", value: updated.count as Any)
+            self?.didChangeSetting("comments_block_list", value: updated.count as Any)
         }
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    private func trackSettingsChange(fieldName: String, value: Any?) {
+    private func didChangeSetting(_ fieldName: String, value: Any?) {
         WPAnalytics.trackSettingsChange(tracksDiscussionSettingsKey, fieldName: fieldName, value: value)
+        setNeedsChangeSettings()
     }
 
     // MARK: - Computed Properties
@@ -565,4 +561,8 @@ open class DiscussionSettingsViewController: UITableViewController {
     private let commentsLinksMaximumValue = 100
     private let commentsAutocloseMinimumValue = 1
     private let commentsAutocloseMaximumValue = 120
+}
+
+private enum Strings {
+    static let errorTitle = NSLocalizedString("discussionSettings.saveErrorTitle", value: "Failed to save settings", comment: "Error tilte")
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsRelatedPostsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsRelatedPostsView.swift
@@ -6,6 +6,7 @@ import WordPressShared
 struct RelatedPostsSettingsView: View {
     private let blog: Blog
     @ObservedObject private var settings: BlogSettings
+    @State var isSaving = false
 
     var title: String { Strings.title }
 
@@ -34,6 +35,13 @@ struct RelatedPostsSettingsView: View {
         }
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if isSaving {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ProgressView()
+                }
+            }
+        }
     }
 
     private var settingsSection: some View {
@@ -90,7 +98,11 @@ struct RelatedPostsSettingsView: View {
 
     private func save(field: String, value: Any) {
         WPAnalytics.trackSettingsChange("related_posts", fieldName: field, value: value)
-        BlogService(coreDataStack: ContextManager.shared).updateSettings(for: blog, success: nil, failure: { _ in
+        isSaving = true
+        BlogService(coreDataStack: ContextManager.shared).updateSettings(for: blog, success: {
+            isSaving = false
+        }, failure: { _ in
+            isSaving = false
             SVProgressHUD.showDismissibleError(withStatus: Strings.saveFailed)
         })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -1091,14 +1091,35 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     if (!self.blog.settings.hasChanges) {
         return;
     }
-    
+
+    [self showActivityIndicator];
     BlogService *blogService = [[BlogService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     [blogService updateSettingsForBlog:self.blog success:^{
+        [self hideActivityIndicator];
         [NSNotificationCenter.defaultCenter postNotificationName:WPBlogSettingsUpdatedNotification object:nil];
     } failure:^(NSError *error) {
+        [self hideActivityIndicator];
         [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
         DDLogError(@"Error while trying to update BlogSettings: %@", error);
     }];
+}
+
+- (void)showActivityIndicator
+{
+    if ([self isModal]) {
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem.activityIndicator;
+    } else {
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem.activityIndicator;
+    }
+}
+
+- (void)hideActivityIndicator
+{
+    if ([self isModal]) {
+        self.navigationItem.leftBarButtonItem = nil;
+    } else {
+        self.navigationItem.rightBarButtonItem = nil;
+    }
 }
 
 - (BOOL)savingWritingDefaultsIsAvailable


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23787. The app will now use the existing method `didChangeSetting` for tracking changes in `DiscussionSettingsViewController` as a trigger for save. I also made a couple of other changes:

- Fix an issue where if you change settings fairly quickly, the app will send parallel requests
- Add error handling (was completely missing!)
- Add a spinner to the navigation bar to indicate when the save is happening (on iPad shown in the left corner)
- Remove “refresh settings” as it happens on the root screen already. There is no point to do it again here and it might mess with some of the local changes.

**Note**: ignore the first commit https://github.com/wordpress-mobile/WordPress-iOS/pull/23831/commits/b24ddf8d500b7355ff71e76298d9ed9540f621e2 as it simply fixes the formatting.

https://github.com/user-attachments/assets/8148c2f5-5ea1-4aef-939a-c66590085375



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
