### PR TITLE
Fix crash in UserProfileSheetViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -919,10 +919,11 @@ private extension NotificationDetailsViewController {
     func displayUserProfile(_ user: LikeUser, from indexPath: IndexPath) {
         let userProfileVC = UserProfileSheetViewController(user: user)
         userProfileVC.blogUrlPreviewedSource = "notif_like_list_user_profile"
-        let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
-
-        let sourceView = tableView.cellForRow(at: indexPath) ?? view
-        bottomSheet.show(from: self, sourceView: sourceView)
+        userProfileVC.modalPresentationStyle = .popover
+        userProfileVC.popoverPresentationController?.sourceView = tableView.cellForRow(at: indexPath) ?? view
+        userProfileVC.popoverPresentationController?.adaptiveSheetPresentationController.prefersGrabberVisible = true
+        userProfileVC.popoverPresentationController?.adaptiveSheetPresentationController.detents = [.medium()]
+        present(userProfileVC, animated: true)
 
         WPAnalytics.track(.userProfileSheetShown, properties: ["source": "like_notification_list"])
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -55,9 +55,12 @@ private extension ReaderDetailLikesListController {
     func displayUserProfile(_ user: LikeUser, from indexPath: IndexPath) {
         let userProfileVC = UserProfileSheetViewController(user: user)
         userProfileVC.blogUrlPreviewedSource = "reader_like_list_user_profile"
-        let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
-        let sourceView = tableView.cellForRow(at: indexPath) ?? view
-        bottomSheet.show(from: self, sourceView: sourceView)
+        userProfileVC.modalPresentationStyle = .popover
+        userProfileVC.popoverPresentationController?.sourceView = tableView.cellForRow(at: indexPath) ?? view
+        userProfileVC.popoverPresentationController?.adaptiveSheetPresentationController.prefersGrabberVisible = true
+        userProfileVC.popoverPresentationController?.adaptiveSheetPresentationController.detents = [.medium()]
+        present(userProfileVC, animated: true)
+
         WPAnalytics.track(.userProfileSheetShown, properties: ["source": "like_reader_list"])
     }
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -32,46 +32,20 @@ class UserProfileSheetViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         configureTable()
         registerTableCells()
+
+        tableView.contentInset.top = 24 // For grabber and extra inset in popover
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
         var size = tableView.contentSize
-
-        // Apply a slight padding to the bottom of the view to give it some space to breathe
-        // when being presented in a popover or bottom sheet
-        let bottomPadding = WPDeviceIdentification.isiPad() ? Constants.iPadBottomPadding : Constants.iPhoneBottomPadding
-        size.height += bottomPadding
-
+        size.height += tableView.contentInset.top
         preferredContentSize = size
     }
-}
-
-// MARK: - DrawerPresentable Extension
-
-extension UserProfileSheetViewController: DrawerPresentable {
-
-    var collapsedHeight: DrawerHeight {
-        if traitCollection.verticalSizeClass == .compact {
-            return .maxHeight
-        }
-
-        // Force the table layout to update so the Bottom Sheet gets the right height.
-        tableView.layoutIfNeeded()
-        return .intrinsicHeight
-    }
-
-    var scrollableView: UIScrollView? {
-        return tableView
-    }
-
-    var allowsUserTransition: Bool {
-        false
-    }
-
 }
 
 // MARK: - UITableViewDataSource methods
@@ -212,8 +186,5 @@ private extension UserProfileSheetViewController {
     enum Constants {
         static let userInfoSection = 0
         static let siteSectionTitle = NSLocalizedString("Site", comment: "Header for a single site, shown in Notification user profile.").localizedUppercase
-        static let iPadBottomPadding: CGFloat = 10
-        static let iPhoneBottomPadding: CGFloat = 40
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21084 (https://a8c.sentry.io/issues/3804144050/?environment=appStore&project=5716771&query=release%3Acom.automattic.jetpack%4025.4.2%2B25.4.2.0&referrer=release-issue-stream). It is a pretty common crash. I hope it only affects this screen, and it does seem to be the case based on the callstacks.

<img width="320" alt="Screenshot 2024-11-19 at 6 33 53 PM" src="https://github.com/user-attachments/assets/d50ee459-e095-4480-915b-ab55c77479bd">
<img width="1316" alt="Screenshot 2024-11-19 at 6 39 03 PM" src="https://github.com/user-attachments/assets/a3c84ac8-022d-45e5-9bdd-d75ac0cea01b">



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
