### PR TITLE
Move Application Passwords entry to user details

### DIFF
--- a/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
+++ b/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
@@ -5,21 +5,21 @@ import WordPressAPI
 
 struct ApplicationTokenListView: View {
 
-    @ObservedObject
+    @StateObject
     private var viewModel: ApplicationTokenListViewModel
 
     fileprivate init(tokens: [ApplicationTokenItem]) {
         let dataProvider = StaticTokenProvider(tokens: .success(tokens))
-        self.init(viewModel: ApplicationTokenListViewModel(dataProvider: dataProvider))
+        self.init(dataProvider: dataProvider)
     }
 
     fileprivate init(error: Error) {
         let dataProvider = StaticTokenProvider(tokens: .failure(error))
-        self.init(viewModel: ApplicationTokenListViewModel(dataProvider: dataProvider))
+        self.init(dataProvider: dataProvider)
     }
 
-    init(viewModel: ApplicationTokenListViewModel) {
-        self.viewModel = viewModel
+    init(dataProvider: ApplicationTokenListDataProvider) {
+        _viewModel = .init(wrappedValue: ApplicationTokenListViewModel(dataProvider: dataProvider))
     }
 
     var body: some View {
@@ -32,7 +32,7 @@ struct ApplicationTokenListView: View {
                 List(viewModel.applicationTokens) { token in
                     ApplicationTokenListItemView(item: token)
                 }
-                .listStyle(.plain)
+                .listStyle(.insetGrouped)
             }
         }
         .navigationTitle(Self.title)
@@ -47,6 +47,7 @@ struct ApplicationTokenListView: View {
     }
 }
 
+@MainActor
 class ApplicationTokenListViewModel: ObservableObject {
 
     @Published
@@ -58,14 +59,13 @@ class ApplicationTokenListViewModel: ObservableObject {
     @Published
     private(set) var applicationTokens: [ApplicationTokenItem]
 
-    private let dataProvider: ApplicationTokenListDataProvider!
+    let dataProvider: ApplicationTokenListDataProvider!
 
     init(dataProvider: ApplicationTokenListDataProvider) {
         self.dataProvider = dataProvider
         self.applicationTokens = []
     }
 
-    @MainActor
     func fetchTokens() async {
         isLoadingData = true
         defer {

--- a/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
+++ b/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
@@ -23,16 +23,23 @@ struct ApplicationTokenListView: View {
     }
 
     var body: some View {
-        VStack {
-            if viewModel.isLoadingData {
-                ProgressView()
-            } else if let error = viewModel.errorMessage {
-                EmptyStateView(Self.errorTitle, systemImage: "exclamationmark.triangle", description: error)
-            } else {
-                List(viewModel.applicationTokens) { token in
-                    ApplicationTokenListItemView(item: token)
+        ZStack {
+            Color(.systemGroupedBackground)
+                .ignoresSafeArea()
+
+            Group {
+                VStack {
+                    if viewModel.isLoadingData {
+                        ProgressView()
+                    } else if let error = viewModel.errorMessage {
+                        EmptyStateView(Self.errorTitle, systemImage: "exclamationmark.triangle", description: error)
+                    } else {
+                        List(viewModel.applicationTokens) { token in
+                            ApplicationTokenListItemView(item: token)
+                        }
+                        .listStyle(.insetGrouped)
+                    }
                 }
-                .listStyle(.insetGrouped)
             }
         }
         .navigationTitle(Self.title)

--- a/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
+++ b/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
@@ -27,18 +27,16 @@ struct ApplicationTokenListView: View {
             Color(.systemGroupedBackground)
                 .ignoresSafeArea()
 
-            Group {
-                VStack {
-                    if viewModel.isLoadingData {
-                        ProgressView()
-                    } else if let error = viewModel.errorMessage {
-                        EmptyStateView(Self.errorTitle, systemImage: "exclamationmark.triangle", description: error)
-                    } else {
-                        List(viewModel.applicationTokens) { token in
-                            ApplicationTokenListItemView(item: token)
-                        }
-                        .listStyle(.insetGrouped)
+            VStack {
+                if viewModel.isLoadingData {
+                    ProgressView()
+                } else if let error = viewModel.errorMessage {
+                    EmptyStateView(Self.errorTitle, systemImage: "exclamationmark.triangle", description: error)
+                } else {
+                    List(viewModel.applicationTokens) { token in
+                        ApplicationTokenListItemView(item: token)
                     }
+                    .listStyle(.insetGrouped)
                 }
             }
         }

--- a/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
+++ b/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
@@ -66,7 +66,7 @@ class ApplicationTokenListViewModel: ObservableObject {
     @Published
     private(set) var applicationTokens: [ApplicationTokenItem]
 
-    let dataProvider: ApplicationTokenListDataProvider!
+    let dataProvider: ApplicationTokenListDataProvider
 
     init(dataProvider: ApplicationTokenListDataProvider) {
         self.dataProvider = dataProvider

--- a/WordPress/Classes/Services/UserService.swift
+++ b/WordPress/Classes/Services/UserService.swift
@@ -65,10 +65,6 @@ actor UserService: UserServiceProtocol {
         await currentUser?.capabilities.keys.contains(capability) == true
     }
 
-    func isCurrentUser(_ user: DisplayUser) async -> Bool {
-        await currentUser?.id == user.id
-    }
-
     func deleteUser(id: Int32, reassigningPostsTo newUserId: Int32) async throws {
         let result = try await client.api.users.delete(
             userId: id,

--- a/WordPress/Classes/Users/Components/UserListItem.swift
+++ b/WordPress/Classes/Users/Components/UserListItem.swift
@@ -9,12 +9,13 @@ struct UserListItem: View {
     var dynamicTypeSize
 
     let user: DisplayUser
+    let isCurrentUser: Bool
     let userService: UserServiceProtocol
     let applicationTokenListDataProvider: ApplicationTokenListDataProvider
 
     var body: some View {
         NavigationLink {
-            UserDetailsView(user: user, userService: userService, applicationTokenListDataProvider: applicationTokenListDataProvider)
+            UserDetailsView(user: user, isCurrentUser: isCurrentUser, userService: userService, applicationTokenListDataProvider: applicationTokenListDataProvider)
         } label: {
             HStack(alignment: .top) {
                 if !dynamicTypeSize.isAccessibilitySize {
@@ -30,5 +31,5 @@ struct UserListItem: View {
 }
 
 #Preview {
-    UserListItem(user: DisplayUser.MockUser, userService: MockUserProvider(), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
+    UserListItem(user: DisplayUser.MockUser, isCurrentUser: true, userService: MockUserProvider(), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
 }

--- a/WordPress/Classes/Users/UserProvider.swift
+++ b/WordPress/Classes/Users/UserProvider.swift
@@ -7,8 +7,6 @@ public protocol UserServiceProtocol: Actor {
 
     func fetchUsers() async throws -> [DisplayUser]
 
-    func isCurrentUser(_ user: DisplayUser) async -> Bool
-
     func isCurrentUserCapableOf(_ capability: String) async -> Bool
 
     func setNewPassword(id: Int32, newPassword: String) async throws
@@ -57,10 +55,6 @@ actor MockUserProvider: UserServiceProtocol {
         case .error:
             throw URLError(.timedOut)
         }
-    }
-
-    func isCurrentUser(_ user: DisplayUser) async -> Bool {
-        true
     }
 
     func isCurrentUserCapableOf(_ capability: String) async -> Bool {

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -4,6 +4,8 @@ struct UserDetailsView: View {
 
     fileprivate let userService: UserServiceProtocol
     let user: DisplayUser
+    let isCurrentUser: Bool
+    let applicationTokenListDataProvider: ApplicationTokenListDataProvider
 
     @State private var presentPasswordAlert: Bool = false {
         didSet {
@@ -20,19 +22,19 @@ struct UserDetailsView: View {
 
     @StateObject
     fileprivate var viewModel: UserDetailViewModel
-    @StateObject
-    fileprivate var applicationTokenListViewModel: ApplicationTokenListViewModel
+
     @StateObject
     fileprivate var deleteUserViewModel: UserDeleteViewModel
 
     @Environment(\.dismiss)
     var dismissAction: DismissAction
 
-    init(user: DisplayUser, userService: UserServiceProtocol, applicationTokenListDataProvider: ApplicationTokenListDataProvider) {
+    init(user: DisplayUser, isCurrentUser: Bool, userService: UserServiceProtocol, applicationTokenListDataProvider: ApplicationTokenListDataProvider) {
         self.user = user
+        self.isCurrentUser = isCurrentUser
         self.userService = userService
+        self.applicationTokenListDataProvider = applicationTokenListDataProvider
         _viewModel = StateObject(wrappedValue: UserDetailViewModel(userService: userService))
-        _applicationTokenListViewModel = StateObject(wrappedValue: ApplicationTokenListViewModel(dataProvider: applicationTokenListDataProvider))
         _deleteUserViewModel = StateObject(wrappedValue: UserDeleteViewModel(user: user, userService: userService))
     }
 
@@ -61,29 +63,29 @@ struct UserDetailsView: View {
                 }
             }
 
-            if !applicationTokenListViewModel.applicationTokens.isEmpty {
-                Section(ApplicationTokenListView.title) {
-                    ForEach(applicationTokenListViewModel.applicationTokens) { token in
-                        ApplicationTokenListItemView(item: token)
-                    }
-                }
-            }
-
-            if viewModel.currentUserCanModifyUsers {
+            if isCurrentUser || viewModel.currentUserCanModifyUsers {
                 Section(Strings.accountManagementSectionTitle) {
-                    Button(Strings.setNewPasswordActionTitle) {
-                        presentPasswordAlert = true
+                    if isCurrentUser {
+                        NavigationLink(ApplicationTokenListView.title) {
+                            ApplicationTokenListView(dataProvider: applicationTokenListDataProvider)
+                        }
                     }
-                    Button(role: .destructive) {
-                        presentUserPicker = true
-                    } label: {
-                        Text(
-                            deleteUserViewModel.isDeletingUser ?
-                                Strings.deletingUserActionTitle
-                                : Strings.deleteUserActionTitle
-                        )
+
+                    if viewModel.currentUserCanModifyUsers {
+                        Button(Strings.setNewPasswordActionTitle) {
+                            presentPasswordAlert = true
+                        }
+                        Button(role: .destructive) {
+                            presentUserPicker = true
+                        } label: {
+                            Text(
+                                deleteUserViewModel.isDeletingUser ?
+                                    Strings.deletingUserActionTitle
+                                    : Strings.deleteUserActionTitle
+                            )
+                        }
+                        .disabled(deleteUserViewModel.isDeletingUser)
                     }
-                    .disabled(deleteUserViewModel.isDeletingUser)
                 }
             }
         }
@@ -115,10 +117,6 @@ struct UserDetailsView: View {
             Task {
                 await viewModel.loadCurrentUserRole()
                 await deleteUserViewModel.fetchOtherUsers()
-
-                if await userService.isCurrentUser(user) {
-                    await applicationTokenListViewModel.fetchTokens()
-                }
             }
         }
     }
@@ -397,6 +395,6 @@ private extension String {
 
 #Preview {
     NavigationStack {
-        UserDetailsView(user: DisplayUser.MockUser, userService: MockUserProvider(), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
+        UserDetailsView(user: DisplayUser.MockUser, isCurrentUser: true, userService: MockUserProvider(), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
     }
 }

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -77,6 +77,11 @@ struct UserDetailsView: View {
                         }
                         Button(role: .destructive) {
                             presentUserPicker = true
+                            Task {
+                                if deleteUserViewModel.otherUsers.isEmpty {
+                                    await deleteUserViewModel.fetchOtherUsers()
+                                }
+                            }
                         } label: {
                             Text(
                                 deleteUserViewModel.isDeletingUser ?
@@ -116,7 +121,6 @@ struct UserDetailsView: View {
         .onAppear() {
             Task {
                 await viewModel.loadCurrentUserRole()
-                await deleteUserViewModel.fetchOtherUsers()
             }
         }
     }

--- a/WordPress/Classes/Users/Views/UserListView.swift
+++ b/WordPress/Classes/Users/Views/UserListView.swift
@@ -5,10 +5,12 @@ public struct UserListView: View {
 
     @StateObject
     private var viewModel: UserListViewModel
+    private let currentUserId: Int32
     private let userService: UserServiceProtocol
     private let applicationTokenListDataProvider: ApplicationTokenListDataProvider
 
-    public init(userService: UserServiceProtocol, applicationTokenListDataProvider: ApplicationTokenListDataProvider) {
+    public init(currentUserId: Int32, userService: UserServiceProtocol, applicationTokenListDataProvider: ApplicationTokenListDataProvider) {
+        self.currentUserId = currentUserId
         self.userService = userService
         self.applicationTokenListDataProvider = applicationTokenListDataProvider
         _viewModel = StateObject(wrappedValue: UserListViewModel(userService: userService))
@@ -34,7 +36,7 @@ public struct UserListView: View {
                                     .listRowBackground(Color.clear)
                             } else {
                                 ForEach(section.users) { user in
-                                    UserListItem(user: user, userService: userService, applicationTokenListDataProvider: applicationTokenListDataProvider)
+                                    UserListItem(user: user, isCurrentUser: user.id == currentUserId, userService: userService, applicationTokenListDataProvider: applicationTokenListDataProvider)
                                 }
                             }
                         }
@@ -73,18 +75,18 @@ public struct UserListView: View {
 
 #Preview("Loading") {
     NavigationView {
-        UserListView(userService: MockUserProvider(), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
+        UserListView(currentUserId: 0, userService: MockUserProvider(), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
     }
 }
 
 #Preview("Error") {
     NavigationView {
-        UserListView(userService: MockUserProvider(scenario: .error), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
+        UserListView(currentUserId: 0, userService: MockUserProvider(scenario: .error), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
     }
 }
 
 #Preview("List") {
     NavigationView {
-        UserListView(userService: MockUserProvider(scenario: .dummyData), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
+        UserListView(currentUserId: 0, userService: MockUserProvider(scenario: .dummyData), applicationTokenListDataProvider: StaticTokenProvider(tokens: .success(.testTokens)))
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -133,7 +133,7 @@ extension BlogDetailsViewController {
         let rootView = ApplicationPasswordRequiredView(blog: self.blog, localizedFeatureName: feature) { client in
             let service = UserService(client: client)
             let applicationPasswordService = ApplicationPasswordService(api: client, currentUserId: userId)
-            return UserListView(userService: service, applicationTokenListDataProvider: applicationPasswordService)
+            return UserListView(currentUserId: Int32(userId), userService: service, applicationTokenListDataProvider: applicationPasswordService)
         }
         presentationDelegate.presentBlogDetailsViewController(UIHostingController(rootView: rootView))
     }

--- a/WordPress/WordPressTest/ApplicationPasswords/ApplicationPasswordsViewModelTests.swift
+++ b/WordPress/WordPressTest/ApplicationPasswords/ApplicationPasswordsViewModelTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @testable import WordPress
 
+@MainActor
 class ApplicationPasswordsViewModelTests: XCTestCase {
 
     func testOrder() async throws {


### PR DESCRIPTION
This is an alternative to https://github.com/wordpress-mobile/WordPress-iOS/pull/23819.

In #23819, application passwords are displayed in the user details view, like wp-admin. But I think @kean 's suggestion in https://github.com/wordpress-mobile/WordPress-iOS/pull/23819#discussion_r1846659725 makes more sense.

<img width=320 src="https://github.com/user-attachments/assets/4d7a46a0-b757-4991-990d-c8023551156d" />

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
