### PR TITLE
Extract delete user confirmation sheet into its own view

### DIFF
--- a/WordPress/Classes/Users/Views/DeleteUserConfirmationSheet.swift
+++ b/WordPress/Classes/Users/Views/DeleteUserConfirmationSheet.swift
@@ -15,14 +15,6 @@ struct DeleteUserConfirmationSheet: View {
     var body: some View {
         NavigationView {
             Form {
-                VStack(alignment: .leading) {
-                    Text(Strings.deleteUserAttributionMessage)
-                    Text("ID #\(user.id): \(user.username)")
-                }
-                .frame(maxWidth: .infinity)
-                .listRowBackground(Color.clear)
-                .listRowInsets(.zero)
-
                 Section {
                     if deleteUserViewModel.isFetchingOtherUsers {
                         LabeledContent(Strings.attributeContentToUserLabel) {
@@ -35,6 +27,14 @@ struct DeleteUserConfirmationSheet: View {
                             }
                         }
                     }
+                } header: {
+                    Text(Strings.deleteUserAttributionMessage)
+                        .font(.body)
+                        .textCase(nil)
+                        .foregroundStyle(.primary)
+                        .padding(.bottom, 8)
+                } footer: {
+                    Text(Strings.attributeContentHellpMessage)
                 }
             }
             .navigationTitle(Strings.attributeContentConfirmationTitle)
@@ -70,13 +70,19 @@ struct DeleteUserConfirmationSheet: View {
     enum Strings {
         static let attributeContentToUserLabel = NSLocalizedString(
             "userDetails.alert.attributeContentToUserLabel",
-            value: "Attribute content to user:",
+            value: "Selected user",
             comment: "The label that appears in the alert that appears when deleting a user"
+        )
+
+        static let attributeContentHellpMessage = NSLocalizedString(
+            "userDetails.alert.attributeContentToUserHelpMessage",
+            value: "Pages and posts belonging to the deleted user will have their author changed to the user you select in the provided dropdown.",
+            comment: "The help message for reassigning content to a user after deletion."
         )
 
         static let deleteUserAttributionMessage = NSLocalizedString(
             "userDetails.alert.deleteUserAttributionMessage",
-            value: "You have specified this user for deletion:",
+            value: "Select another user to attribute this content to.",
             comment: "The message that appears when deleting a user."
         )
 
@@ -98,4 +104,8 @@ struct DeleteUserConfirmationSheet: View {
             comment: "The title of the delete button in the confirmation alert that appears when deleting a user"
         )
     }
+}
+
+#Preview {
+    DeleteUserConfirmationSheet(user: .MockUser, deleteUserViewModel: .init(user: .MockUser, userService: MockUserProvider()), didTapDeleteButton: { })
 }

--- a/WordPress/Classes/Users/Views/DeleteUserConfirmationSheet.swift
+++ b/WordPress/Classes/Users/Views/DeleteUserConfirmationSheet.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SwiftUI
+
+struct DeleteUserConfirmationSheet: View {
+    let user: DisplayUser
+
+    @ObservedObject
+    var deleteUserViewModel: UserDeleteViewModel
+
+    let didTapDeleteButton: () -> Void
+
+    @Environment(\.dismiss)
+    private var dismissAction: DismissAction
+
+    var body: some View {
+        NavigationView {
+            Form {
+                VStack(alignment: .leading) {
+                    Text(Strings.deleteUserAttributionMessage)
+                    Text("ID #\(user.id): \(user.username)")
+                }
+                .frame(maxWidth: .infinity)
+                .listRowBackground(Color.clear)
+                .listRowInsets(.zero)
+
+                Section {
+                    if deleteUserViewModel.isFetchingOtherUsers {
+                        LabeledContent(Strings.attributeContentToUserLabel) {
+                            ProgressView()
+                        }
+                    } else {
+                        Picker(Strings.attributeContentToUserLabel, selection: $deleteUserViewModel.selectedUser) {
+                            ForEach(deleteUserViewModel.otherUsers) { user in
+                                Text("\(user.displayName) (\(user.username))").tag(user)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(Strings.attributeContentConfirmationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(role: .cancel) {
+                        dismissAction()
+                    } label: {
+                        Text(Strings.attributeContentConfirmationCancelButton)
+                    }
+                }
+                ToolbarItem(placement: .destructiveAction) {
+                    Button(role: .destructive) {
+                        didTapDeleteButton()
+                    } label: {
+                        Text(Strings.attributeContentConfirmationDeleteButton)
+                    }
+                    .disabled(deleteUserViewModel.deleteButtonIsDisabled)
+                }
+            }
+            .onAppear {
+                Task {
+                    if deleteUserViewModel.otherUsers.isEmpty {
+                        await deleteUserViewModel.fetchOtherUsers()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+
+    enum Strings {
+        static let attributeContentToUserLabel = NSLocalizedString(
+            "userDetails.alert.attributeContentToUserLabel",
+            value: "Attribute content to user:",
+            comment: "The label that appears in the alert that appears when deleting a user"
+        )
+
+        static let deleteUserAttributionMessage = NSLocalizedString(
+            "userDetails.alert.deleteUserAttributionMessage",
+            value: "You have specified this user for deletion:",
+            comment: "The message that appears when deleting a user."
+        )
+
+        static let attributeContentConfirmationTitle = NSLocalizedString(
+            "userDetails.alert.deleteUserConfirmationTitle",
+            value: "Delete Confirmation",
+            comment: "The title of the confirmation alert that appears when deleting a user"
+        )
+
+        static let attributeContentConfirmationCancelButton = NSLocalizedString(
+            "userDetails.alert.deleteUserConfirmationCancelButton",
+            value: "Cancel",
+            comment: "The title of the cancel button in the confirmation alert that appears when deleting a user"
+        )
+
+        static let attributeContentConfirmationDeleteButton = NSLocalizedString(
+            "userDetails.alert.deleteUserConfirmationDeleteButton",
+            value: "Delete",
+            comment: "The title of the delete button in the confirmation alert that appears when deleting a user"
+        )
+    }
+}

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -77,11 +77,6 @@ struct UserDetailsView: View {
                         }
                         Button(role: .destructive) {
                             presentUserPicker = true
-                            Task {
-                                if deleteUserViewModel.otherUsers.isEmpty {
-                                    await deleteUserViewModel.fetchOtherUsers()
-                                }
-                            }
                         } label: {
                             Text(
                                 deleteUserViewModel.isDeletingUser ?
@@ -249,36 +244,6 @@ struct UserDetailsView: View {
             comment: "The title of the OK button in the alert that appears when deleting a user"
         )
 
-        static let deleteUserAttributionMessage = NSLocalizedString(
-            "userDetails.alert.deleteUserAttributionMessage",
-            value: "You have specified this user for deletion:",
-            comment: "The message that appears when deleting a user."
-        )
-
-        static let attributeContentToUserLabel = NSLocalizedString(
-            "userDetails.alert.attributeContentToUserLabel",
-            value: "Attribute content to user:",
-            comment: "The label that appears in the alert that appears when deleting a user"
-        )
-
-        static let attributeContentConfirmationTitle = NSLocalizedString(
-            "userDetails.alert.deleteUserConfirmationTitle",
-            value: "Delete Confirmation",
-            comment: "The title of the confirmation alert that appears when deleting a user"
-        )
-
-        static let attributeContentConfirmationCancelButton = NSLocalizedString(
-            "userDetails.alert.deleteUserConfirmationCancelButton",
-            value: "Cancel",
-            comment: "The title of the cancel button in the confirmation alert that appears when deleting a user"
-        )
-
-        static let attributeContentConfirmationDeleteButton = NSLocalizedString(
-            "userDetails.alert.deleteUserConfirmationDeleteButton",
-            value: "Delete",
-            comment: "The title of the delete button in the confirmation alert that appears when deleting a user"
-        )
-
     }
 }
 
@@ -293,7 +258,9 @@ private extension View {
                 view.presentUserPicker = false
             },
             content: {
-                pickAnotherUser(in: view)
+                DeleteUserConfirmationSheet(user: view.user, deleteUserViewModel: view.deleteUserViewModel) {
+                    view.presentDeleteConfirmation = true
+                }
             }
         )
         .alert(
@@ -332,55 +299,6 @@ private extension View {
                 // TODO: Use appropriate localized error message
                 Text(error.localizedDescription)
             })
-    }
-
-    @ViewBuilder
-    func pickAnotherUser(in view: UserDetailsView) -> some View {
-        NavigationView {
-            Form {
-                VStack(alignment: .leading) {
-                    Text(Strings.deleteUserAttributionMessage)
-                    Text("ID #\(view.user.id): \(view.user.username)")
-                }
-                .frame(maxWidth: .infinity)
-                .listRowBackground(Color.clear)
-                .listRowInsets(.zero)
-
-                Section {
-                    if view.deleteUserViewModel.isFetchingOtherUsers {
-                        LabeledContent(Strings.attributeContentToUserLabel) {
-                            ProgressView()
-                        }
-                    } else {
-                        Picker(Strings.attributeContentToUserLabel, selection: view.$deleteUserViewModel.selectedUser) {
-                            ForEach(view.deleteUserViewModel.otherUsers) { user in
-                                Text("\(user.displayName) (\(user.username))").tag(user)
-                            }
-                        }
-                    }
-                }
-            }
-            .navigationTitle(Strings.attributeContentConfirmationTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(role: .cancel) {
-                        view.presentUserPicker = false
-                    } label: {
-                        Text(Strings.attributeContentConfirmationCancelButton)
-                    }
-                }
-                ToolbarItem(placement: .destructiveAction) {
-                    Button(role: .destructive) {
-                        view.presentDeleteConfirmation = true
-                    } label: {
-                        Text(Strings.attributeContentConfirmationDeleteButton)
-                    }
-                    .disabled(view.deleteUserViewModel.deleteButtonIsDisabled)
-                }
-            }
-        }
-        .presentationDetents([.medium])
     }
 }
 


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/23834.

Nothing too interesting really. Just moving a ViewBuilder function to a View type.


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
